### PR TITLE
Correctly note item kind in `NonConstFunctionCall` error message

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -253,7 +253,7 @@ const_eval_non_const_fmt_macro_call =
     cannot call non-const formatting macro in {const_eval_const_context}s
 
 const_eval_non_const_fn_call =
-    cannot call non-const fn `{$def_path_str}` in {const_eval_const_context}s
+    cannot call non-const {$def_descr} `{$def_path_str}` in {const_eval_const_context}s
 
 const_eval_non_const_impl =
     impl defined here, but it is not `const`

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -304,6 +304,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
             }
             _ => ccx.dcx().create_err(errors::NonConstFnCall {
                 span,
+                def_descr: ccx.tcx.def_descr(callee),
                 def_path_str: ccx.tcx.def_path_str_with_args(callee, args),
                 kind: ccx.const_kind(),
             }),

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -192,6 +192,7 @@ pub(crate) struct NonConstFnCall {
     #[primary_span]
     pub span: Span,
     pub def_path_str: String,
+    pub def_descr: &'static str,
     pub kind: ConstContext,
 }
 

--- a/compiler/rustc_error_codes/src/error_codes/E0015.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0015.md
@@ -7,7 +7,7 @@ fn create_some() -> Option<u8> {
     Some(1)
 }
 
-// error: cannot call non-const fn `create_some` in constants
+// error: cannot call non-const function `create_some` in constants
 const FOO: Option<u8> = create_some();
 ```
 

--- a/tests/run-make/const-trait-stable-toolchain/const-super-trait-nightly-disabled.stderr
+++ b/tests/run-make/const-trait-stable-toolchain/const-super-trait-nightly-disabled.stderr
@@ -52,7 +52,7 @@ help: enable `#![feature(const_trait_impl)]` in your crate and mark `Bar` as `#[
 LL | #[const_trait] trait Bar: ~const Foo {}
    | ++++++++++++++
 
-error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> const-super-trait.rs:10:7
    |
 LL |     x.a();

--- a/tests/run-make/const-trait-stable-toolchain/const-super-trait-nightly-enabled.stderr
+++ b/tests/run-make/const-trait-stable-toolchain/const-super-trait-nightly-enabled.stderr
@@ -32,7 +32,7 @@ help: mark `Bar` as `#[const_trait]` to allow it to have `const` implementations
 LL | #[const_trait] trait Bar: ~const Foo {}
    | ++++++++++++++
 
-error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> const-super-trait.rs:10:7
    |
 LL |     x.a();

--- a/tests/run-make/const-trait-stable-toolchain/const-super-trait-stable-disabled.stderr
+++ b/tests/run-make/const-trait-stable-toolchain/const-super-trait-stable-disabled.stderr
@@ -50,7 +50,7 @@ note: `Bar` can't be used with `~const` because it isn't annotated with `#[const
 7 | trait Bar: ~const Foo {}
   | ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> const-super-trait.rs:10:7
    |
 10 |     x.a();

--- a/tests/run-make/const-trait-stable-toolchain/const-super-trait-stable-enabled.stderr
+++ b/tests/run-make/const-trait-stable-toolchain/const-super-trait-stable-enabled.stderr
@@ -40,7 +40,7 @@ note: `Bar` can't be used with `~const` because it isn't annotated with `#[const
 7 | trait Bar: ~const Foo {}
   | ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> const-super-trait.rs:10:7
    |
 10 |     x.a();

--- a/tests/ui/asm/non-const.rs
+++ b/tests/ui/asm/non-const.rs
@@ -8,4 +8,4 @@ fn main() {}
 fn non_const_fn(x: i32) -> i32 { x }
 
 global_asm!("/* {} */", const non_const_fn(0));
-//~^ERROR: cannot call non-const fn
+//~^ERROR: cannot call non-const function

--- a/tests/ui/asm/non-const.stderr
+++ b/tests/ui/asm/non-const.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `non_const_fn` in constants
+error[E0015]: cannot call non-const function `non_const_fn` in constants
   --> $DIR/non-const.rs:10:31
    |
 LL | global_asm!("/* {} */", const non_const_fn(0));

--- a/tests/ui/borrowck/issue-64453.rs
+++ b/tests/ui/borrowck/issue-64453.rs
@@ -2,7 +2,7 @@ struct Project;
 struct Value;
 
 static settings_dir: String = format!("");
-//~^ ERROR cannot call non-const fn
+//~^ ERROR cannot call non-const function
 
 fn from_string(_: String) -> Value {
     Value

--- a/tests/ui/borrowck/issue-64453.stderr
+++ b/tests/ui/borrowck/issue-64453.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `format` in statics
+error[E0015]: cannot call non-const function `format` in statics
   --> $DIR/issue-64453.rs:4:31
    |
 LL | static settings_dir: String = format!("");

--- a/tests/ui/const-generics/nested-type.full.stderr
+++ b/tests/ui/const-generics/nested-type.full.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `Foo::{constant#0}::Foo::<17>::value` in constants
+error[E0015]: cannot call non-const associated function `Foo::{constant#0}::Foo::<17>::value` in constants
   --> $DIR/nested-type.rs:15:5
    |
 LL |     Foo::<17>::value()

--- a/tests/ui/const-generics/nested-type.min.stderr
+++ b/tests/ui/const-generics/nested-type.min.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `Foo::{constant#0}::Foo::<17>::value` in constants
+error[E0015]: cannot call non-const associated function `Foo::{constant#0}::Foo::<17>::value` in constants
   --> $DIR/nested-type.rs:15:5
    |
 LL |     Foo::<17>::value()

--- a/tests/ui/const-generics/nested-type.rs
+++ b/tests/ui/const-generics/nested-type.rs
@@ -13,7 +13,7 @@ struct Foo<const N: [u8; {
     }
 
     Foo::<17>::value()
-    //~^ ERROR cannot call non-const fn
+    //~^ ERROR cannot call non-const associated function
 }]>;
 //[min]~^^^^^^^^^^^^ ERROR `[u8; {
 

--- a/tests/ui/consts/const-call.rs
+++ b/tests/ui/consts/const-call.rs
@@ -4,5 +4,5 @@ fn f(x: usize) -> usize {
 
 fn main() {
     let _ = [0; f(2)];
-    //~^ ERROR cannot call non-const fn
+    //~^ ERROR cannot call non-const function
 }

--- a/tests/ui/consts/const-call.stderr
+++ b/tests/ui/consts/const-call.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `f` in constants
+error[E0015]: cannot call non-const function `f` in constants
   --> $DIR/const-call.rs:6:17
    |
 LL |     let _ = [0; f(2)];

--- a/tests/ui/consts/const-eval/format.rs
+++ b/tests/ui/consts/const-eval/format.rs
@@ -1,14 +1,14 @@
 const fn failure() {
     panic!("{:?}", 0);
     //~^ ERROR cannot call non-const formatting macro in constant functions
-    //~| ERROR cannot call non-const fn `Arguments::<'_>::new_v1::<1, 1>` in constant functions
+    //~| ERROR cannot call non-const associated function `Arguments::<'_>::new_v1::<1, 1>` in constant functions
 }
 
 const fn print() {
     println!("{:?}", 0);
     //~^ ERROR cannot call non-const formatting macro in constant functions
-    //~| ERROR cannot call non-const fn `Arguments::<'_>::new_v1::<2, 1>` in constant functions
-    //~| ERROR cannot call non-const fn `_print` in constant functions
+    //~| ERROR cannot call non-const associated function `Arguments::<'_>::new_v1::<2, 1>` in constant functions
+    //~| ERROR cannot call non-const function `_print` in constant functions
 }
 
 fn main() {}

--- a/tests/ui/consts/const-eval/format.stderr
+++ b/tests/ui/consts/const-eval/format.stderr
@@ -7,7 +7,7 @@ LL |     panic!("{:?}", 0);
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `Arguments::<'_>::new_v1::<1, 1>` in constant functions
+error[E0015]: cannot call non-const associated function `Arguments::<'_>::new_v1::<1, 1>` in constant functions
   --> $DIR/format.rs:2:5
    |
 LL |     panic!("{:?}", 0);
@@ -25,7 +25,7 @@ LL |     println!("{:?}", 0);
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `Arguments::<'_>::new_v1::<2, 1>` in constant functions
+error[E0015]: cannot call non-const associated function `Arguments::<'_>::new_v1::<2, 1>` in constant functions
   --> $DIR/format.rs:8:5
    |
 LL |     println!("{:?}", 0);
@@ -34,7 +34,7 @@ LL |     println!("{:?}", 0);
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `_print` in constant functions
+error[E0015]: cannot call non-const function `_print` in constant functions
   --> $DIR/format.rs:8:5
    |
 LL |     println!("{:?}", 0);

--- a/tests/ui/consts/const-eval/ub-slice-get-unchecked.stderr
+++ b/tests/ui/consts/const-eval/ub-slice-get-unchecked.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `core::slice::<impl [()]>::get_unchecked::<std::ops::Range<usize>>` in constants
+error[E0015]: cannot call non-const method `core::slice::<impl [()]>::get_unchecked::<std::ops::Range<usize>>` in constants
   --> $DIR/ub-slice-get-unchecked.rs:7:29
    |
 LL | const B: &[()] = unsafe { A.get_unchecked(3..1) };

--- a/tests/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.rs
+++ b/tests/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.rs
@@ -5,7 +5,7 @@ extern "C" {
 const extern "C" fn bar() {
     unsafe {
         regular_in_block();
-        //~^ ERROR: cannot call non-const fn
+        //~^ ERROR: cannot call non-const function
     }
 }
 
@@ -14,7 +14,7 @@ extern "C" fn regular() {}
 const extern "C" fn foo() {
     unsafe {
         regular();
-        //~^ ERROR: cannot call non-const fn
+        //~^ ERROR: cannot call non-const function
     }
 }
 

--- a/tests/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.stderr
+++ b/tests/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `regular_in_block` in constant functions
+error[E0015]: cannot call non-const function `regular_in_block` in constant functions
   --> $DIR/const-extern-fn-call-extern-fn.rs:7:9
    |
 LL |         regular_in_block();
@@ -6,7 +6,7 @@ LL |         regular_in_block();
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const fn `regular` in constant functions
+error[E0015]: cannot call non-const function `regular` in constant functions
   --> $DIR/const-extern-fn-call-extern-fn.rs:16:9
    |
 LL |         regular();

--- a/tests/ui/consts/const-fn-not-safe-for-const.stderr
+++ b/tests/ui/consts/const-fn-not-safe-for-const.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `random` in constant functions
+error[E0015]: cannot call non-const function `random` in constant functions
   --> $DIR/const-fn-not-safe-for-const.rs:14:5
    |
 LL |     random()

--- a/tests/ui/consts/control-flow/issue-46843.rs
+++ b/tests/ui/consts/control-flow/issue-46843.rs
@@ -8,7 +8,7 @@ fn non_const() -> Thing {
 }
 
 pub const Q: i32 = match non_const() {
-    //~^ ERROR cannot call non-const fn
+    //~^ ERROR cannot call non-const function
     Thing::This => 1,
     Thing::That => 0
 };

--- a/tests/ui/consts/control-flow/issue-46843.stderr
+++ b/tests/ui/consts/control-flow/issue-46843.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `non_const` in constants
+error[E0015]: cannot call non-const function `non_const` in constants
   --> $DIR/issue-46843.rs:10:26
    |
 LL | pub const Q: i32 = match non_const() {

--- a/tests/ui/consts/issue-16538.stderr
+++ b/tests/ui/consts/issue-16538.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `Y::foo` in statics
+error[E0015]: cannot call non-const function `Y::foo` in statics
   --> $DIR/issue-16538.rs:11:23
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);

--- a/tests/ui/consts/issue-32829-2.rs
+++ b/tests/ui/consts/issue-32829-2.rs
@@ -8,7 +8,7 @@ const bad : u32 = {
 const bad_two : u32 = {
     {
         invalid();
-        //~^ ERROR: cannot call non-const fn `invalid`
+        //~^ ERROR: cannot call non-const function `invalid`
         0
     }
 };
@@ -30,7 +30,7 @@ static bad_four : u32 = {
 static bad_five : u32 = {
     {
         invalid();
-        //~^ ERROR: cannot call non-const fn `invalid`
+        //~^ ERROR: cannot call non-const function `invalid`
         0
     }
 };
@@ -52,7 +52,7 @@ static mut bad_seven : u32 = {
 static mut bad_eight : u32 = {
     {
         invalid();
-        //~^ ERROR: cannot call non-const fn `invalid`
+        //~^ ERROR: cannot call non-const function `invalid`
         0
     }
 };

--- a/tests/ui/consts/issue-32829-2.stderr
+++ b/tests/ui/consts/issue-32829-2.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `invalid` in constants
+error[E0015]: cannot call non-const function `invalid` in constants
   --> $DIR/issue-32829-2.rs:10:9
    |
 LL |         invalid();
@@ -6,7 +6,7 @@ LL |         invalid();
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const fn `invalid` in statics
+error[E0015]: cannot call non-const function `invalid` in statics
   --> $DIR/issue-32829-2.rs:32:9
    |
 LL |         invalid();
@@ -15,7 +15,7 @@ LL |         invalid();
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
 
-error[E0015]: cannot call non-const fn `invalid` in statics
+error[E0015]: cannot call non-const function `invalid` in statics
   --> $DIR/issue-32829-2.rs:54:9
    |
 LL |         invalid();

--- a/tests/ui/consts/issue-43105.rs
+++ b/tests/ui/consts/issue-43105.rs
@@ -1,7 +1,7 @@
 fn xyz() -> u8 { 42 }
 
 const NUM: u8 = xyz();
-//~^ ERROR cannot call non-const fn
+//~^ ERROR cannot call non-const function
 
 fn main() {
     match 1 {

--- a/tests/ui/consts/issue-43105.stderr
+++ b/tests/ui/consts/issue-43105.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `xyz` in constants
+error[E0015]: cannot call non-const function `xyz` in constants
   --> $DIR/issue-43105.rs:3:17
    |
 LL | const NUM: u8 = xyz();

--- a/tests/ui/consts/min_const_fn/bad_const_fn_body_ice.rs
+++ b/tests/ui/consts/min_const_fn/bad_const_fn_body_ice.rs
@@ -1,7 +1,7 @@
 const fn foo(a: i32) -> Vec<i32> {
     vec![1, 2, 3]
     //~^ ERROR allocations are not allowed
-    //~| ERROR cannot call non-const fn
+    //~| ERROR cannot call non-const method
 }
 
 fn main() {}

--- a/tests/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
+++ b/tests/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
@@ -6,7 +6,7 @@ LL |     vec![1, 2, 3]
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `slice::<impl [i32]>::into_vec::<std::alloc::Global>` in constant functions
+error[E0015]: cannot call non-const method `slice::<impl [i32]>::into_vec::<std::alloc::Global>` in constant functions
   --> $DIR/bad_const_fn_body_ice.rs:2:5
    |
 LL |     vec![1, 2, 3]

--- a/tests/ui/consts/mir_check_nonconst.rs
+++ b/tests/ui/consts/mir_check_nonconst.rs
@@ -6,6 +6,6 @@ fn bar() -> Foo {
 }
 
 static foo: Foo = bar();
-//~^ ERROR cannot call non-const fn
+//~^ ERROR cannot call non-const function
 
 fn main() {}

--- a/tests/ui/consts/mir_check_nonconst.stderr
+++ b/tests/ui/consts/mir_check_nonconst.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `bar` in statics
+error[E0015]: cannot call non-const function `bar` in statics
   --> $DIR/mir_check_nonconst.rs:8:19
    |
 LL | static foo: Foo = bar();

--- a/tests/ui/error-codes/E0010-teach.rs
+++ b/tests/ui/error-codes/E0010-teach.rs
@@ -3,5 +3,5 @@
 #![allow(warnings)]
 
 const CON: Vec<i32> = vec![1, 2, 3]; //~ ERROR E0010
-//~| ERROR cannot call non-const fn
+//~| ERROR cannot call non-const method
 fn main() {}

--- a/tests/ui/error-codes/E0010-teach.stderr
+++ b/tests/ui/error-codes/E0010-teach.stderr
@@ -7,7 +7,7 @@ LL | const CON: Vec<i32> = vec![1, 2, 3];
    = note: The runtime heap is not yet available at compile-time, so no runtime heap allocations can be created.
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `slice::<impl [i32]>::into_vec::<std::alloc::Global>` in constants
+error[E0015]: cannot call non-const method `slice::<impl [i32]>::into_vec::<std::alloc::Global>` in constants
   --> $DIR/E0010-teach.rs:5:23
    |
 LL | const CON: Vec<i32> = vec![1, 2, 3];

--- a/tests/ui/error-codes/E0010.rs
+++ b/tests/ui/error-codes/E0010.rs
@@ -1,5 +1,5 @@
 #![allow(warnings)]
 
 const CON: Vec<i32> = vec![1, 2, 3]; //~ ERROR E0010
-//~| ERROR cannot call non-const fn
+//~| ERROR cannot call non-const method
 fn main() {}

--- a/tests/ui/error-codes/E0010.stderr
+++ b/tests/ui/error-codes/E0010.stderr
@@ -6,7 +6,7 @@ LL | const CON: Vec<i32> = vec![1, 2, 3];
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `slice::<impl [i32]>::into_vec::<std::alloc::Global>` in constants
+error[E0015]: cannot call non-const method `slice::<impl [i32]>::into_vec::<std::alloc::Global>` in constants
   --> $DIR/E0010.rs:3:23
    |
 LL | const CON: Vec<i32> = vec![1, 2, 3];

--- a/tests/ui/error-codes/E0015.rs
+++ b/tests/ui/error-codes/E0015.rs
@@ -3,6 +3,6 @@ fn create_some() -> Option<u8> {
 }
 
 const FOO: Option<u8> = create_some();
-//~^ ERROR cannot call non-const fn `create_some` in constants [E0015]
+//~^ ERROR cannot call non-const function `create_some` in constants [E0015]
 
 fn main() {}

--- a/tests/ui/error-codes/E0015.stderr
+++ b/tests/ui/error-codes/E0015.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `create_some` in constants
+error[E0015]: cannot call non-const function `create_some` in constants
   --> $DIR/E0015.rs:5:25
    |
 LL | const FOO: Option<u8> = create_some();

--- a/tests/ui/explicit-tail-calls/constck.rs
+++ b/tests/ui/explicit-tail-calls/constck.rs
@@ -4,14 +4,14 @@
 const fn f() {
     if false {
         become not_const();
-        //~^ error: cannot call non-const fn `not_const` in constant functions
+        //~^ error: cannot call non-const function `not_const` in constant functions
     }
 }
 
 const fn g((): ()) {
     if false {
         become yes_const(not_const());
-        //~^ error: cannot call non-const fn `not_const` in constant functions
+        //~^ error: cannot call non-const function `not_const` in constant functions
     }
 }
 

--- a/tests/ui/explicit-tail-calls/constck.stderr
+++ b/tests/ui/explicit-tail-calls/constck.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `not_const` in constant functions
+error[E0015]: cannot call non-const function `not_const` in constant functions
   --> $DIR/constck.rs:6:16
    |
 LL |         become not_const();
@@ -6,7 +6,7 @@ LL |         become not_const();
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const fn `not_const` in constant functions
+error[E0015]: cannot call non-const function `not_const` in constant functions
   --> $DIR/constck.rs:13:26
    |
 LL |         become yes_const(not_const());

--- a/tests/ui/issues/issue-7364.rs
+++ b/tests/ui/issues/issue-7364.rs
@@ -3,6 +3,6 @@ use std::cell::RefCell;
 // Regression test for issue 7364
 static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));
 //~^ ERROR `RefCell<isize>` cannot be shared between threads safely [E0277]
-//~| ERROR cannot call non-const fn
+//~| ERROR cannot call non-const associated function
 
 fn main() { }

--- a/tests/ui/issues/issue-7364.stderr
+++ b/tests/ui/issues/issue-7364.stderr
@@ -11,7 +11,7 @@ note: required because it appears within the type `Box<RefCell<isize>>`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
    = note: shared static variables must have a type that implements `Sync`
 
-error[E0015]: cannot call non-const fn `Box::<RefCell<isize>>::new` in statics
+error[E0015]: cannot call non-const associated function `Box::<RefCell<isize>>::new` in statics
   --> $DIR/issue-7364.rs:4:37
    |
 LL | static boxed: Box<RefCell<isize>> = Box::new(RefCell::new(0));

--- a/tests/ui/resolve/issue-39559-2.stderr
+++ b/tests/ui/resolve/issue-39559-2.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `<Dim3 as Dim>::dim` in constants
+error[E0015]: cannot call non-const associated function `<Dim3 as Dim>::dim` in constants
   --> $DIR/issue-39559-2.rs:14:24
    |
 LL |     let array: [usize; Dim3::dim()]
@@ -6,7 +6,7 @@ LL |     let array: [usize; Dim3::dim()]
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const fn `<Dim3 as Dim>::dim` in constants
+error[E0015]: cannot call non-const associated function `<Dim3 as Dim>::dim` in constants
   --> $DIR/issue-39559-2.rs:16:15
    |
 LL |         = [0; Dim3::dim()];

--- a/tests/ui/static/static-mut-not-constant.rs
+++ b/tests/ui/static/static-mut-not-constant.rs
@@ -1,4 +1,4 @@
 static mut a: Box<isize> = Box::new(3);
-//~^ ERROR cannot call non-const fn
+//~^ ERROR cannot call non-const associated function
 
 fn main() {}

--- a/tests/ui/static/static-mut-not-constant.stderr
+++ b/tests/ui/static/static-mut-not-constant.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `Box::<isize>::new` in statics
+error[E0015]: cannot call non-const associated function `Box::<isize>::new` in statics
   --> $DIR/static-mut-not-constant.rs:1:28
    |
 LL | static mut a: Box<isize> = Box::new(3);

--- a/tests/ui/static/static-vec-repeat-not-constant.stderr
+++ b/tests/ui/static/static-vec-repeat-not-constant.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `foo` in statics
+error[E0015]: cannot call non-const function `foo` in statics
   --> $DIR/static-vec-repeat-not-constant.rs:3:25
    |
 LL | static a: [isize; 2] = [foo(); 2];

--- a/tests/ui/statics/check-values-constraints.rs
+++ b/tests/ui/statics/check-values-constraints.rs
@@ -89,7 +89,7 @@ static mut STATIC13: SafeStruct =
 
 static mut STATIC14: SafeStruct = SafeStruct {
     field1: SafeEnum::Variant1,
-    field2: SafeEnum::Variant4("str".to_string()), //~ ERROR cannot call non-const fn
+    field2: SafeEnum::Variant4("str".to_string()), //~ ERROR cannot call non-const method
 };
 
 static STATIC15: &'static [Vec<MyOwned>] = &[

--- a/tests/ui/statics/check-values-constraints.stderr
+++ b/tests/ui/statics/check-values-constraints.stderr
@@ -19,7 +19,7 @@ LL | static STATIC11: Vec<MyOwned> = vec![MyOwned];
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
+error[E0015]: cannot call non-const method `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:81:33
    |
 LL | static STATIC11: Vec<MyOwned> = vec![MyOwned];
@@ -29,7 +29,7 @@ LL | static STATIC11: Vec<MyOwned> = vec![MyOwned];
    = note: consider wrapping this expression in `std::sync::LazyLock::new(|| ...)`
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `<str as ToString>::to_string` in statics
+error[E0015]: cannot call non-const method `<str as ToString>::to_string` in statics
   --> $DIR/check-values-constraints.rs:92:38
    |
 LL |     field2: SafeEnum::Variant4("str".to_string()),
@@ -46,7 +46,7 @@ LL |     vec![MyOwned],
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
+error[E0015]: cannot call non-const method `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:96:5
    |
 LL |     vec![MyOwned],
@@ -64,7 +64,7 @@ LL |     vec![MyOwned],
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
+error[E0015]: cannot call non-const method `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:98:5
    |
 LL |     vec![MyOwned],
@@ -82,7 +82,7 @@ LL |     &vec![MyOwned],
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
+error[E0015]: cannot call non-const method `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:103:6
    |
 LL |     &vec![MyOwned],
@@ -100,7 +100,7 @@ LL |     &vec![MyOwned],
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
+error[E0015]: cannot call non-const method `slice::<impl [MyOwned]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:105:6
    |
 LL |     &vec![MyOwned],
@@ -118,7 +118,7 @@ LL | static STATIC19: Vec<isize> = vec![3];
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `slice::<impl [isize]>::into_vec::<std::alloc::Global>` in statics
+error[E0015]: cannot call non-const method `slice::<impl [isize]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:111:31
    |
 LL | static STATIC19: Vec<isize> = vec![3];
@@ -136,7 +136,7 @@ LL |         static x: Vec<isize> = vec![3];
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `slice::<impl [isize]>::into_vec::<std::alloc::Global>` in statics
+error[E0015]: cannot call non-const method `slice::<impl [isize]>::into_vec::<std::alloc::Global>` in statics
   --> $DIR/check-values-constraints.rs:117:32
    |
 LL |         static x: Vec<isize> = vec![3];

--- a/tests/ui/traits/const-traits/call-const-trait-method-pass.stderr
+++ b/tests/ui/traits/const-traits/call-const-trait-method-pass.stderr
@@ -7,7 +7,7 @@ LL | impl const PartialEq for Int {
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
 
-error[E0015]: cannot call non-const fn `<Int as PartialEq>::eq` in constant functions
+error[E0015]: cannot call non-const method `<Int as PartialEq>::eq` in constant functions
   --> $DIR/call-const-trait-method-pass.rs:20:15
    |
 LL |         !self.eq(other)

--- a/tests/ui/traits/const-traits/call-generic-in-impl.stderr
+++ b/tests/ui/traits/const-traits/call-generic-in-impl.stderr
@@ -17,7 +17,7 @@ note: `PartialEq` can't be used with `~const` because it isn't annotated with `#
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0015]: cannot call non-const fn `<T as PartialEq>::eq` in constant functions
+error[E0015]: cannot call non-const method `<T as PartialEq>::eq` in constant functions
   --> $DIR/call-generic-in-impl.rs:12:9
    |
 LL |         PartialEq::eq(self, other)

--- a/tests/ui/traits/const-traits/call-generic-method-chain.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-chain.stderr
@@ -53,7 +53,7 @@ LL |     *t == *t
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const fn `<S as PartialEq>::eq` in constant functions
+error[E0015]: cannot call non-const method `<S as PartialEq>::eq` in constant functions
   --> $DIR/call-generic-method-chain.rs:16:15
    |
 LL |         !self.eq(other)

--- a/tests/ui/traits/const-traits/call-generic-method-dup-bound.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-dup-bound.stderr
@@ -53,7 +53,7 @@ LL |     *t == *t
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const fn `<S as PartialEq>::eq` in constant functions
+error[E0015]: cannot call non-const method `<S as PartialEq>::eq` in constant functions
   --> $DIR/call-generic-method-dup-bound.rs:14:15
    |
 LL |         !self.eq(other)

--- a/tests/ui/traits/const-traits/call-generic-method-pass.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-pass.stderr
@@ -34,7 +34,7 @@ LL |     *t == *t
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const fn `<S as PartialEq>::eq` in constant functions
+error[E0015]: cannot call non-const method `<S as PartialEq>::eq` in constant functions
   --> $DIR/call-generic-method-pass.rs:16:15
    |
 LL |         !self.eq(other)

--- a/tests/ui/traits/const-traits/const-check-fns-in-const-impl.rs
+++ b/tests/ui/traits/const-traits/const-check-fns-in-const-impl.rs
@@ -12,7 +12,7 @@ fn non_const() {}
 
 impl const T for S {
     fn foo() { non_const() }
-    //~^ ERROR cannot call non-const fn
+    //~^ ERROR cannot call non-const function
 }
 
 fn main() {}

--- a/tests/ui/traits/const-traits/const-check-fns-in-const-impl.stderr
+++ b/tests/ui/traits/const-traits/const-check-fns-in-const-impl.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `non_const` in constant functions
+error[E0015]: cannot call non-const function `non_const` in constant functions
   --> $DIR/const-check-fns-in-const-impl.rs:14:16
    |
 LL |     fn foo() { non_const() }

--- a/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.rs
+++ b/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.rs
@@ -12,6 +12,6 @@ impl Foo for () {
 
 fn main() {
     (const || { (()).foo() })();
-    //~^ ERROR: cannot call non-const fn `<() as Foo>::foo` in constant functions
+    //~^ ERROR: cannot call non-const method `<() as Foo>::foo` in constant functions
     // FIXME(const_trait_impl) this should probably say constant closures
 }

--- a/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.stderr
+++ b/tests/ui/traits/const-traits/const_closure-const_trait_impl-ice-113381.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `<() as Foo>::foo` in constant functions
+error[E0015]: cannot call non-const method `<() as Foo>::foo` in constant functions
   --> $DIR/const_closure-const_trait_impl-ice-113381.rs:14:22
    |
 LL |     (const || { (()).foo() })();

--- a/tests/ui/traits/const-traits/const_derives/derive-const-non-const-type.stderr
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-non-const-type.stderr
@@ -8,7 +8,7 @@ LL | #[derive_const(Default)]
    = note: adding a non-const method body in the future would be a breaking change
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `<A as Default>::default` in constant functions
+error[E0015]: cannot call non-const associated function `<A as Default>::default` in constant functions
   --> $DIR/derive-const-non-const-type.rs:11:14
    |
 LL | #[derive_const(Default)]

--- a/tests/ui/traits/const-traits/const_derives/derive-const-use.stderr
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-use.stderr
@@ -48,7 +48,7 @@ LL | #[derive_const(Default, PartialEq)]
    = note: adding a non-const method body in the future would be a breaking change
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `<S as Default>::default` in constants
+error[E0015]: cannot call non-const associated function `<S as Default>::default` in constants
   --> $DIR/derive-const-use.rs:18:35
    |
 LL | const _: () = assert!(S((), A) == S::default());
@@ -64,7 +64,7 @@ LL | const _: () = assert!(S((), A) == S::default());
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const fn `<() as Default>::default` in constant functions
+error[E0015]: cannot call non-const associated function `<() as Default>::default` in constant functions
   --> $DIR/derive-const-use.rs:16:14
    |
 LL | #[derive_const(Default, PartialEq)]
@@ -75,7 +75,7 @@ LL | pub struct S((), A);
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `<A as Default>::default` in constant functions
+error[E0015]: cannot call non-const associated function `<A as Default>::default` in constant functions
   --> $DIR/derive-const-use.rs:16:18
    |
 LL | #[derive_const(Default, PartialEq)]

--- a/tests/ui/traits/const-traits/ice-112822-expected-type-for-param.rs
+++ b/tests/ui/traits/const-traits/ice-112822-expected-type-for-param.rs
@@ -10,7 +10,7 @@ const fn test() -> impl ~const Fn() {
         match sl {
             [first, remainder @ ..] => {
                 assert_eq!(first, &b'f');
-                //~^ ERROR cannot call non-const fn
+                //~^ ERROR cannot call non-const function
                 //~| ERROR cannot call non-const operator
             }
             [] => panic!(),

--- a/tests/ui/traits/const-traits/ice-112822-expected-type-for-param.stderr
+++ b/tests/ui/traits/const-traits/ice-112822-expected-type-for-param.stderr
@@ -46,7 +46,7 @@ LL |                 assert_eq!(first, &b'f');
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: cannot call non-const fn `core::panicking::assert_failed::<&u8, &u8>` in constant functions
+error[E0015]: cannot call non-const function `core::panicking::assert_failed::<&u8, &u8>` in constant functions
   --> $DIR/ice-112822-expected-type-for-param.rs:12:17
    |
 LL |                 assert_eq!(first, &b'f');

--- a/tests/ui/traits/const-traits/inline-incorrect-early-bound-in-ctfe.rs
+++ b/tests/ui/traits/const-traits/inline-incorrect-early-bound-in-ctfe.rs
@@ -24,7 +24,7 @@ impl Trait for () {
 
 const fn foo() {
     ().foo();
-    //~^ ERROR cannot call non-const fn `<() as Trait>::foo` in constant functions
+    //~^ ERROR cannot call non-const method `<() as Trait>::foo` in constant functions
 }
 
 const UWU: () = foo();

--- a/tests/ui/traits/const-traits/inline-incorrect-early-bound-in-ctfe.stderr
+++ b/tests/ui/traits/const-traits/inline-incorrect-early-bound-in-ctfe.stderr
@@ -7,7 +7,7 @@ LL |     fn foo(self);
 LL |     fn foo<T>(self) {
    |            ^ found 1 type parameter
 
-error[E0015]: cannot call non-const fn `<() as Trait>::foo` in constant functions
+error[E0015]: cannot call non-const method `<() as Trait>::foo` in constant functions
   --> $DIR/inline-incorrect-early-bound-in-ctfe.rs:26:8
    |
 LL |     ().foo();

--- a/tests/ui/traits/const-traits/issue-79450.rs
+++ b/tests/ui/traits/const-traits/issue-79450.rs
@@ -6,7 +6,7 @@ trait Tr {
     fn req(&self);
 
     fn prov(&self) {
-        println!("lul"); //~ ERROR: cannot call non-const fn `_print` in constant functions
+        println!("lul"); //~ ERROR: cannot call non-const function `_print` in constant functions
         self.req();
     }
 }

--- a/tests/ui/traits/const-traits/issue-79450.stderr
+++ b/tests/ui/traits/const-traits/issue-79450.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `_print` in constant functions
+error[E0015]: cannot call non-const function `_print` in constant functions
   --> $DIR/issue-79450.rs:9:9
    |
 LL |         println!("lul");

--- a/tests/ui/traits/const-traits/issue-88155.rs
+++ b/tests/ui/traits/const-traits/issue-88155.rs
@@ -9,7 +9,7 @@ pub trait A {
 pub const fn foo<T: A>() -> bool {
     T::assoc()
     //FIXME ~^ ERROR the trait bound
-    //FIXME ~| ERROR cannot call non-const fn
+    //FIXME ~| ERROR cannot call non-const function
 }
 
 fn main() {}

--- a/tests/ui/traits/const-traits/issue-88155.stderr
+++ b/tests/ui/traits/const-traits/issue-88155.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `<T as A>::assoc` in constant functions
+error[E0015]: cannot call non-const associated function `<T as A>::assoc` in constant functions
   --> $DIR/issue-88155.rs:10:5
    |
 LL |     T::assoc()

--- a/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.rs
+++ b/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.rs
@@ -11,5 +11,5 @@ impl Foo for () {
 
 fn main() {
     (const || { (()).foo() })();
-    //~^ ERROR: cannot call non-const fn
+    //~^ ERROR: cannot call non-const method
 }

--- a/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.stderr
+++ b/tests/ui/traits/const-traits/non-const-op-const-closure-non-const-outer.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `<() as Foo>::foo` in constant functions
+error[E0015]: cannot call non-const method `<() as Foo>::foo` in constant functions
   --> $DIR/non-const-op-const-closure-non-const-outer.rs:13:22
    |
 LL |     (const || { (()).foo() })();

--- a/tests/ui/traits/const-traits/non-const-op-in-closure-in-const.stderr
+++ b/tests/ui/traits/const-traits/non-const-op-in-closure-in-const.stderr
@@ -17,7 +17,7 @@ note: `From` can't be used with `~const` because it isn't annotated with `#[cons
   --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0015]: cannot call non-const fn `<B as From<A>>::from` in constant functions
+error[E0015]: cannot call non-const associated function `<B as From<A>>::from` in constant functions
   --> $DIR/non-const-op-in-closure-in-const.rs:12:9
    |
 LL |         B::from(self)

--- a/tests/ui/traits/const-traits/std-impl-gate.gated.stderr
+++ b/tests/ui/traits/const-traits/std-impl-gate.gated.stderr
@@ -4,7 +4,7 @@ error[E0635]: unknown feature `const_default_impls`
 LL | #![cfg_attr(gated, feature(const_trait_impl, const_default_impls))]
    |                                              ^^^^^^^^^^^^^^^^^^^
 
-error[E0015]: cannot call non-const fn `<Vec<usize> as Default>::default` in constant functions
+error[E0015]: cannot call non-const associated function `<Vec<usize> as Default>::default` in constant functions
   --> $DIR/std-impl-gate.rs:13:5
    |
 LL |     Default::default()

--- a/tests/ui/traits/const-traits/std-impl-gate.rs
+++ b/tests/ui/traits/const-traits/std-impl-gate.rs
@@ -11,7 +11,7 @@ fn non_const_context() -> Vec<usize> {
 
 const fn const_context() -> Vec<usize> {
     Default::default()
-    //[stock]~^ ERROR cannot call non-const fn
+    //[stock]~^ ERROR cannot call non-const associated function
 }
 
 fn main() {

--- a/tests/ui/traits/const-traits/std-impl-gate.stock.stderr
+++ b/tests/ui/traits/const-traits/std-impl-gate.stock.stderr
@@ -1,4 +1,4 @@
-error[E0015]: cannot call non-const fn `<Vec<usize> as Default>::default` in constant functions
+error[E0015]: cannot call non-const associated function `<Vec<usize> as Default>::default` in constant functions
   --> $DIR/std-impl-gate.rs:13:5
    |
 LL |     Default::default()

--- a/tests/ui/traits/const-traits/super-traits-fail-2.nn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.nn.stderr
@@ -45,7 +45,7 @@ help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
 LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
-error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> $DIR/super-traits-fail-2.rs:20:7
    |
 LL |     x.a();

--- a/tests/ui/traits/const-traits/super-traits-fail-2.ny.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.ny.stderr
@@ -57,7 +57,7 @@ help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
 LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
-error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> $DIR/super-traits-fail-2.rs:20:7
    |
 LL |     x.a();

--- a/tests/ui/traits/const-traits/super-traits-fail-2.rs
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.rs
@@ -19,7 +19,7 @@ trait Bar: ~const Foo {}
 const fn foo<T: Bar>(x: &T) {
     x.a();
     //[yy,yn]~^ ERROR the trait bound `T: ~const Foo`
-    //[nn,ny]~^^ ERROR cannot call non-const fn `<T as Foo>::a` in constant functions
+    //[nn,ny]~^^ ERROR cannot call non-const method `<T as Foo>::a` in constant functions
 }
 
 fn main() {}

--- a/tests/ui/traits/const-traits/super-traits-fail-3.nnn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.nnn.stderr
@@ -88,7 +88,7 @@ help: enable `#![feature(const_trait_impl)]` in your crate and mark `Bar` as `#[
 LL | #[const_trait] trait Bar: ~const Foo {}
    | ++++++++++++++
 
-error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> $DIR/super-traits-fail-3.rs:36:7
    |
 LL |     x.a();

--- a/tests/ui/traits/const-traits/super-traits-fail-3.nny.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.nny.stderr
@@ -88,7 +88,7 @@ help: enable `#![feature(const_trait_impl)]` in your crate and mark `Bar` as `#[
 LL | #[const_trait] trait Bar: ~const Foo {}
    | ++++++++++++++
 
-error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> $DIR/super-traits-fail-3.rs:36:7
    |
 LL |     x.a();

--- a/tests/ui/traits/const-traits/super-traits-fail-3.rs
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.rs
@@ -35,7 +35,7 @@ const fn foo<T: ~const Bar>(x: &T) {
     //[nyy,nyn,nny,nnn]~^^^ ERROR: const trait impls are experimental
     x.a();
     //[yyn]~^ ERROR: the trait bound `T: ~const Foo` is not satisfied
-    //[ynn,yny,nny,nnn]~^^ ERROR: cannot call non-const fn `<T as Foo>::a` in constant functions
+    //[ynn,yny,nny,nnn]~^^ ERROR: cannot call non-const method `<T as Foo>::a` in constant functions
     //[nyy,nyn]~^^^ ERROR: cannot call conditionally-const method `<T as Foo>::a` in constant functions
 }
 

--- a/tests/ui/traits/const-traits/super-traits-fail-3.ynn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.ynn.stderr
@@ -68,7 +68,7 @@ help: mark `Bar` as `#[const_trait]` to allow it to have `const` implementations
 LL | #[const_trait] trait Bar: ~const Foo {}
    | ++++++++++++++
 
-error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> $DIR/super-traits-fail-3.rs:36:7
    |
 LL |     x.a();

--- a/tests/ui/traits/const-traits/super-traits-fail-3.yny.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.yny.stderr
@@ -57,7 +57,7 @@ help: mark `Foo` as `#[const_trait]` to allow it to have `const` implementations
 LL | #[const_trait] trait Foo {
    | ++++++++++++++
 
-error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+error[E0015]: cannot call non-const method `<T as Foo>::a` in constant functions
   --> $DIR/super-traits-fail-3.rs:36:7
    |
 LL |     x.a();

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -668,7 +668,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     type F: std::ops::Fn(_);
    |                          ^ not allowed in type signatures
 
-error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:230:29: 230:32}>` in constants
+error[E0015]: cannot call non-const method `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:230:29: 230:32}>` in constants
   --> $DIR/typeck_type_placeholder_item.rs:230:22
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
@@ -676,7 +676,7 @@ LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const fn `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:230:29: 230:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:230:49: 230:52}>` in constants
+error[E0015]: cannot call non-const method `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:230:29: 230:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:230:49: 230:52}>` in constants
   --> $DIR/typeck_type_placeholder_item.rs:230:45
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);


### PR DESCRIPTION
Don't just call everything a "`fn`". This is more consistent with the error message we give for conditionally-const items, which do note the item's def kind.

r? fmease, this is a prerequisite for making those `~const PartialEq` error messages better. Re-roll if you're busy or don't want to review this.