### PR TITLE
Display valid crate types in error message for --crate-type flag

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2709,7 +2709,12 @@ pub fn parse_crate_types_from_list(list_list: Vec<String>) -> Result<Vec<CrateTy
                 "cdylib" => CrateType::Cdylib,
                 "bin" => CrateType::Executable,
                 "proc-macro" => CrateType::ProcMacro,
-                _ => return Err(format!("unknown crate type: `{part}`")),
+                _ => {
+                    return Err(format!(
+                        "unknown crate type: `{part}`, expected one of: \
+                        `lib`, `rlib`, `staticlib`, `dylib`, `cdylib`, `bin`, `proc-macro`",
+                    ));
+                }
             };
             if !crate_types.contains(&new_part) {
                 crate_types.push(new_part)

--- a/tests/ui/crate_type_flag.rs
+++ b/tests/ui/crate_type_flag.rs
@@ -1,0 +1,4 @@
+//@ compile-flags: --crate-type dynlib
+//@ error-pattern: unknown crate type: `dynlib`, expected one of: `lib`, `rlib`, `staticlib`, `dylib`, `cdylib`, `bin`, `proc-macro`
+
+fn main() {}

--- a/tests/ui/crate_type_flag.stderr
+++ b/tests/ui/crate_type_flag.stderr
@@ -1,0 +1,2 @@
+error: unknown crate type: `dynlib`, expected one of: `lib`, `rlib`, `staticlib`, `dylib`, `cdylib`, `bin`, `proc-macro`
+

--- a/tests/ui/invalid-compile-flags/crate-type-flag.empty_crate_type.stderr
+++ b/tests/ui/invalid-compile-flags/crate-type-flag.empty_crate_type.stderr
@@ -1,2 +1,2 @@
-error: unknown crate type: ``
+error: unknown crate type: ``, expected one of: `lib`, `rlib`, `staticlib`, `dylib`, `cdylib`, `bin`, `proc-macro`
 

--- a/tests/ui/invalid-compile-flags/crate-type-flag.proc_underscore_macro.stderr
+++ b/tests/ui/invalid-compile-flags/crate-type-flag.proc_underscore_macro.stderr
@@ -1,2 +1,2 @@
-error: unknown crate type: `proc_macro`
+error: unknown crate type: `proc_macro`, expected one of: `lib`, `rlib`, `staticlib`, `dylib`, `cdylib`, `bin`, `proc-macro`
 

--- a/tests/ui/invalid-compile-flags/crate-type-flag.rs
+++ b/tests/ui/invalid-compile-flags/crate-type-flag.rs
@@ -45,16 +45,16 @@
 // `proc-macro` is accepted, but `proc_macro` is not.
 //@ revisions: proc_underscore_macro
 //@[proc_underscore_macro] compile-flags: --crate-type=proc_macro
-//@[proc_underscore_macro] error-pattern: "unknown crate type: `proc_macro`"
+//@[proc_underscore_macro] error-pattern: unknown crate type: `proc_macro`
 
 // Empty `--crate-type` not accepted.
 //@ revisions: empty_crate_type
 //@[empty_crate_type] compile-flags: --crate-type=
-//@[empty_crate_type] error-pattern: "unknown crate type: ``"
+//@[empty_crate_type] error-pattern: unknown crate type: ``
 
 // Random unknown crate type. Also check that we can handle non-ASCII.
 //@ revisions: unknown
 //@[unknown] compile-flags: --crate-type=🤡
-//@[unknown] error-pattern: "unknown crate type: `🤡`"
+//@[unknown] error-pattern: unknown crate type: `🤡`
 
 fn main() {}

--- a/tests/ui/invalid-compile-flags/crate-type-flag.unknown.stderr
+++ b/tests/ui/invalid-compile-flags/crate-type-flag.unknown.stderr
@@ -1,2 +1,2 @@
-error: unknown crate type: `🤡`
+error: unknown crate type: `🤡`, expected one of: `lib`, `rlib`, `staticlib`, `dylib`, `cdylib`, `bin`, `proc-macro`
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This PR improves the error message for the --crate-type flag. When an invalid crate type is provided, the compiler will now show a list of valid options.

### Before
![image](https://github.com/user-attachments/assets/4922e4e5-eeca-40cd-ac1c-1c6319a81aee)

### After
![image](https://github.com/user-attachments/assets/67ea1f35-aa41-4e4f-8691-47c273d0cff9)

I based the implementation on `OutputType::shorthands_display`

Closes #70183