### PR TITLE
Add mips-zkm-zkvm-elf triple

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1679,6 +1679,7 @@ supported_targets! {
 
     ("mips-unknown-linux-uclibc", mips_unknown_linux_uclibc),
     ("mipsel-unknown-linux-uclibc", mipsel_unknown_linux_uclibc),
+    ("mips-zkm-zkvm-elf", mips_zkm_zkvm_elf),
 
     ("i686-linux-android", i686_linux_android),
     ("x86_64-linux-android", x86_64_linux_android),

--- a/compiler/rustc_target/src/spec/targets/mips_zkm_zkvm_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/mips_zkm_zkvm_elf.rs
@@ -22,13 +22,7 @@ pub(crate) fn target() -> Target {
             endian: Endian::Big,
             cpu: "mips32r2".into(),
 
-            // Some crates (*cough* crossbeam) assume you have 64 bit
-            // atomics if the target name is not in a hardcoded list.
-            // Since zkvm is singlethreaded and all operations are
-            // atomic, I guess we can just say we support 64-bit
-            // atomics.
-            max_atomic_width: Some(64),
-            atomic_cas: true,
+            max_atomic_width: Some(32),
 
             features: "+mips32r2,+soft-float,+noabicalls".into(),
             executables: true,

--- a/compiler/rustc_target/src/spec/targets/mips_zkm_zkvm_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/mips_zkm_zkvm_elf.rs
@@ -1,0 +1,43 @@
+use crate::abi::Endian;
+use crate::spec::{Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, Target, TargetOptions};
+
+pub(crate) fn target() -> Target {
+    Target {
+        data_layout: "E-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".into(),
+        llvm_target: "mips".into(),
+        metadata: crate::spec::TargetMetadata {
+            description: Some("ZKM's zero-knowledge Virtual Machine (MIPS32r2 ISA)".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: None, // ?
+        },
+        pointer_width: 32,
+        arch: "mips".into(),
+
+        options: TargetOptions {
+            os: "zkvm".into(),
+            vendor: "zkm".into(),
+            linker_flavor: LinkerFlavor::Gnu(Cc::No, Lld::Yes),
+            linker: Some("rust-lld".into()),
+            endian: Endian::Big,
+            cpu: "mips32r2".into(),
+
+            // Some crates (*cough* crossbeam) assume you have 64 bit
+            // atomics if the target name is not in a hardcoded list.
+            // Since zkvm is singlethreaded and all operations are
+            // atomic, I guess we can just say we support 64-bit
+            // atomics.
+            max_atomic_width: Some(64),
+            atomic_cas: true,
+
+            features: "+mips32r2,+soft-float,+noabicalls".into(),
+            executables: true,
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Static,
+            emit_debug_gdb_scripts: false,
+            eh_frame_header: false,
+            singlethread: true,
+            ..Default::default()
+        },
+    }
+}

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -128,6 +128,7 @@ static TARGETS: &[&str] = &[
     "mipsisa64r6el-unknown-linux-gnuabi64",
     "mipsel-unknown-linux-gnu",
     "mipsel-unknown-linux-musl",
+    "mips-zkm-zkvm-elf",
     "nvptx64-nvidia-cuda",
     "powerpc-unknown-linux-gnu",
     "powerpc64-unknown-linux-gnu",

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -285,6 +285,9 @@
 //@ revisions: mips_unknown_linux_uclibc
 //@ [mips_unknown_linux_uclibc] compile-flags: --target mips-unknown-linux-uclibc
 //@ [mips_unknown_linux_uclibc] needs-llvm-components: mips
+//@ revisions: mips_zkm_zkvm_elf
+//@ [mips_unknown_linux_uclibc] compile-flags: --target mips-zkm-zkvm-elf
+//@ [mips_unknown_linux_uclibc] needs-llvm-components: mips
 //@ revisions: mipsel_sony_psp
 //@ [mipsel_sony_psp] compile-flags: --target mipsel-sony-psp
 //@ [mipsel_sony_psp] needs-llvm-components: mips

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -286,8 +286,8 @@
 //@ [mips_unknown_linux_uclibc] compile-flags: --target mips-unknown-linux-uclibc
 //@ [mips_unknown_linux_uclibc] needs-llvm-components: mips
 //@ revisions: mips_zkm_zkvm_elf
-//@ [mips_unknown_linux_uclibc] compile-flags: --target mips-zkm-zkvm-elf
-//@ [mips_unknown_linux_uclibc] needs-llvm-components: mips
+//@ [mips_zkm_zkvm_elf] compile-flags: --target mips-zkm-zkvm-elf
+//@ [mips_zkm_zkvm_elf] needs-llvm-components: mips
 //@ revisions: mipsel_sony_psp
 //@ [mipsel_sony_psp] compile-flags: --target mipsel-sony-psp
 //@ [mipsel_sony_psp] needs-llvm-components: mips

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -230,7 +230,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_vendor = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_vendor` are: `apple`, `espressif`, `fortanix`, `ibm`, `kmc`, `nintendo`, `nvidia`, `pc`, `risc0`, `sony`, `sun`, `unikraft`, `unknown`, `uwp`, `win7`, and `wrs`
+   = note: expected values for `target_vendor` are: `apple`, `espressif`, `fortanix`, `ibm`, `kmc`, `nintendo`, `nvidia`, `pc`, `risc0`, `sony`, `sun`, `unikraft`, `unknown`, `uwp`, `win7`, `wrs` and `zkm`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->


[We](zkm.io) are trying to add a new target `mips-zkm-zkvm-elf` into rustc. 

We have implemented a MIPS zkVM(zero knowledge virtual machine) to generate validity/ZK proof for general purpose computing.  It allows the dev to compile the rust program into MIPS ELF, and the it proves the MIPS emulator/VM and generate a succinct proof to tell the verifier that the computing has been executed as expected. 

This new target can significantly reduce the installation overhead for Rust dev. 