### PR TITLE
Run `tests/ui/backtrace/std-backtrace.rs` on MSVC.

### DIFF
--- a/tests/ui/backtrace/std-backtrace.rs
+++ b/tests/ui/backtrace/std-backtrace.rs
@@ -3,7 +3,6 @@
 //@ ignore-wasm32 spawning processes is not supported
 //@ ignore-openbsd no support for libbacktrace without filename
 //@ ignore-sgx no processes
-//@ ignore-msvc see #62897 and `backtrace-debuginfo.rs` test
 //@ ignore-fuchsia Backtraces not symbolized
 //@ compile-flags:-g
 //@ compile-flags:-Cstrip=none


### PR DESCRIPTION
The original PR which disabled these, https://github.com/rust-lang/rust/pull/62897, only mentions them being broken on i686. ~~let's still make sure the rest of windows is supported.~~ Let's see if we can enable this for msvc now (32-bit and 64-bit).

r? @jieyouxu 

try-job: x86_64-msvc
try-job: i686-msvc
try-job: i686-mingw
try-job: x86_64-mingw-1
try-job: x86_64-mingw-2
try-job: dist-x86_64-msvc
try-job: dist-i686-msvc