### PR TITLE
Don't ice on bad transmute in typeck in new solver

### DIFF
--- a/tests/ui/traits/next-solver/dont-ice-on-bad-transmute-in-typeck.rs
+++ b/tests/ui/traits/next-solver/dont-ice-on-bad-transmute-in-typeck.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -Znext-solver
+
+trait Trait<'a> {
+    type Assoc;
+}
+
+fn foo(x: for<'a> fn(<() as Trait<'a>>::Assoc)) {
+    //~^ ERROR the trait bound `for<'a> (): Trait<'a>` is not satisfied
+    //~| ERROR the trait bound `for<'a> (): Trait<'a>` is not satisfied
+    //~| ERROR the trait bound `for<'a> (): Trait<'a>` is not satisfied
+    unsafe { std::mem::transmute::<_, ()>(x); }
+    //~^ ERROR the trait bound `for<'a> (): Trait<'a>` is not satisfied
+    //~| ERROR the trait bound `for<'a> (): Trait<'a>` is not satisfied
+    //~| ERROR the trait bound `for<'a> (): Trait<'a>` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/traits/next-solver/dont-ice-on-bad-transmute-in-typeck.stderr
+++ b/tests/ui/traits/next-solver/dont-ice-on-bad-transmute-in-typeck.stderr
@@ -1,0 +1,75 @@
+error[E0277]: the trait bound `for<'a> (): Trait<'a>` is not satisfied
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:7:11
+   |
+LL | fn foo(x: for<'a> fn(<() as Trait<'a>>::Assoc)) {
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Trait<'a>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:3:1
+   |
+LL | trait Trait<'a> {
+   | ^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `for<'a> (): Trait<'a>` is not satisfied
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:7:8
+   |
+LL | fn foo(x: for<'a> fn(<() as Trait<'a>>::Assoc)) {
+   |        ^ the trait `for<'a> Trait<'a>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:3:1
+   |
+LL | trait Trait<'a> {
+   | ^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `for<'a> (): Trait<'a>` is not satisfied
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:11:14
+   |
+LL |     unsafe { std::mem::transmute::<_, ()>(x); }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Trait<'a>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:3:1
+   |
+LL | trait Trait<'a> {
+   | ^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `for<'a> (): Trait<'a>` is not satisfied
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:11:36
+   |
+LL |     unsafe { std::mem::transmute::<_, ()>(x); }
+   |                                    ^ the trait `for<'a> Trait<'a>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:3:1
+   |
+LL | trait Trait<'a> {
+   | ^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `for<'a> (): Trait<'a>` is not satisfied
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:11:43
+   |
+LL |     unsafe { std::mem::transmute::<_, ()>(x); }
+   |                                           ^ the trait `for<'a> Trait<'a>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:3:1
+   |
+LL | trait Trait<'a> {
+   | ^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `for<'a> (): Trait<'a>` is not satisfied
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:7:1
+   |
+LL | fn foo(x: for<'a> fn(<() as Trait<'a>>::Assoc)) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Trait<'a>` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/dont-ice-on-bad-transmute-in-typeck.rs:3:1
+   |
+LL | trait Trait<'a> {
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Old trait solver ends up getting its infcx tainted because we try to normalize the type, but the new trait solver doesn't. This means we try to compute the stalled transmute obligations, which tries to normalize a type an ICEs. Let's make this a delayed bug.

r? lcnr