### PR TITLE
Normalize each signature input/output in `typeck_with_fallback` with its own span

### DIFF
--- a/tests/ui/associated-types/associated-types-for-unimpl-trait.stderr
+++ b/tests/ui/associated-types/associated-types-for-unimpl-trait.stderr
@@ -10,11 +10,12 @@ LL |     fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: S
    |                                                                                +++++++++++
 
 error[E0277]: the trait bound `Self: Get` is not satisfied
-  --> $DIR/associated-types-for-unimpl-trait.rs:11:81
+  --> $DIR/associated-types-for-unimpl-trait.rs:11:41
    |
 LL |     fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Sized {}
-   |                                                                                 ^^ the trait `Get` is not implemented for `Self`
+   |                                         ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider further restricting `Self`
    |
 LL |     fn uhoh<U: Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Sized, Self: Get {}

--- a/tests/ui/associated-types/associated-types-no-suitable-bound.stderr
+++ b/tests/ui/associated-types/associated-types-no-suitable-bound.stderr
@@ -10,11 +10,12 @@ LL |     fn uhoh<T: Get>(foo: <T as Get>::Value) {}
    |              +++++
 
 error[E0277]: the trait bound `T: Get` is not satisfied
-  --> $DIR/associated-types-no-suitable-bound.rs:11:40
+  --> $DIR/associated-types-no-suitable-bound.rs:11:21
    |
 LL |     fn uhoh<T>(foo: <T as Get>::Value) {}
-   |                                        ^^ the trait `Get` is not implemented for `T`
+   |                     ^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `T`
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider restricting type parameter `T` with trait `Get`
    |
 LL |     fn uhoh<T: Get>(foo: <T as Get>::Value) {}

--- a/tests/ui/associated-types/associated-types-no-suitable-supertrait-2.stderr
+++ b/tests/ui/associated-types/associated-types-no-suitable-supertrait-2.stderr
@@ -10,11 +10,12 @@ LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Ge
    |                                                              +++++++++++++++
 
 error[E0277]: the trait bound `Self: Get` is not satisfied
-  --> $DIR/associated-types-no-suitable-supertrait-2.rs:17:62
+  --> $DIR/associated-types-no-suitable-supertrait-2.rs:17:40
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
-   |                                                              ^^ the trait `Get` is not implemented for `Self`
+   |                                        ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider further restricting `Self`
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}

--- a/tests/ui/associated-types/associated-types-no-suitable-supertrait.stderr
+++ b/tests/ui/associated-types/associated-types-no-suitable-supertrait.stderr
@@ -34,27 +34,29 @@ LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Ge
    |                                                              +++++++++++++++
 
 error[E0277]: the trait bound `Self: Get` is not satisfied
-  --> $DIR/associated-types-no-suitable-supertrait.rs:17:62
+  --> $DIR/associated-types-no-suitable-supertrait.rs:17:40
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) {}
-   |                                                              ^^ the trait `Get` is not implemented for `Self`
+   |                                        ^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `Self`
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider further restricting `Self`
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <Self as Get>::Value) where Self: Get {}
    |                                                              +++++++++++++++
 
 error[E0277]: the trait bound `(T, U): Get` is not satisfied
-  --> $DIR/associated-types-no-suitable-supertrait.rs:23:64
+  --> $DIR/associated-types-no-suitable-supertrait.rs:23:40
    |
 LL |     fn uhoh<U:Get>(&self, foo: U, bar: <(T, U) as Get>::Value) {}
-   |                                                                ^^ the trait `Get` is not implemented for `(T, U)`
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `(T, U)`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/associated-types-no-suitable-supertrait.rs:12:1
    |
 LL | trait Get {
    | ^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -65,16 +65,17 @@ LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
 
 error[E0277]: the trait bound `(): Foo` is not satisfied
-  --> $DIR/issue-59324.rs:23:52
+  --> $DIR/issue-59324.rs:23:29
    |
 LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
-   |                                                    ^^ the trait `Foo` is not implemented for `()`
+   |                             ^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `()`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-59324.rs:3:1
    |
 LL | pub trait Foo: NotFoo {
    | ^^^^^^^^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the size for values of type `(dyn ThriftService<(), AssocType = _> + 'static)` cannot be known at compilation time
   --> $DIR/issue-59324.rs:23:29

--- a/tests/ui/auto-traits/issue-83857-ub.stderr
+++ b/tests/ui/auto-traits/issue-83857-ub.stderr
@@ -18,16 +18,10 @@ LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i
    |                                                                                +++++++++++++++++++++
 
 error[E0277]: `Foo<T, U>` cannot be sent between threads safely
-  --> $DIR/issue-83857-ub.rs:21:80
+  --> $DIR/issue-83857-ub.rs:21:35
    |
-LL |   fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i32) {
-   |  ________________________________________________________________________________^
-LL | |
-LL | |
-LL | |     f(foo(v));
-LL | |
-LL | | }
-   | |_^ `Foo<T, U>` cannot be sent between threads safely
+LL | fn generic<T, U>(v: Foo<T, U>, f: fn(<Foo<T, U> as WithAssoc>::Output) -> i32) {
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo<T, U>` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `Foo<T, U>`
 note: required for `Foo<T, U>` to implement `WithAssoc`

--- a/tests/ui/error-codes/E0229.stderr
+++ b/tests/ui/error-codes/E0229.stderr
@@ -48,10 +48,10 @@ LL | fn baz<I: Foo>(x: &<I as Foo<A = Bar>>::A) {}
    |         +++++
 
 error[E0277]: the trait bound `I: Foo` is not satisfied
-  --> $DIR/E0229.rs:13:39
+  --> $DIR/E0229.rs:13:14
    |
 LL | fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
-   |                                       ^^ the trait `Foo` is not implemented for `I`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `I`
    |
 help: consider restricting type parameter `I` with trait `Foo`
    |

--- a/tests/ui/issues/issue-18611.stderr
+++ b/tests/ui/issues/issue-18611.stderr
@@ -11,19 +11,17 @@ LL | trait HasState {
    | ^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `isize: HasState` is not satisfied
-  --> $DIR/issue-18611.rs:1:46
+  --> $DIR/issue-18611.rs:1:18
    |
-LL |   fn add_state(op: <isize as HasState>::State) {
-   |  ______________________________________________^
-...  |
-LL | | }
-   | |_^ the trait `HasState` is not implemented for `isize`
+LL | fn add_state(op: <isize as HasState>::State) {
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HasState` is not implemented for `isize`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-18611.rs:6:1
    |
 LL | trait HasState {
    | ^^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-35570.stderr
+++ b/tests/ui/issues/issue-35570.stderr
@@ -11,15 +11,10 @@ LL | trait Trait2<'a> {
    | ^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `for<'a> (): Trait2<'a>` is not satisfied
-  --> $DIR/issue-35570.rs:8:66
+  --> $DIR/issue-35570.rs:8:16
    |
-LL |   fn _ice(param: Box<dyn for <'a> Trait1<<() as Trait2<'a>>::Ty>>) {
-   |  __________________________________________________________________^
-LL | |
-LL | |
-LL | |     let _e: (usize, usize) = unsafe{mem::transmute(param)};
-LL | | }
-   | |_^ the trait `for<'a> Trait2<'a>` is not implemented for `()`
+LL | fn _ice(param: Box<dyn for <'a> Trait1<<() as Trait2<'a>>::Ty>>) {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Trait2<'a>` is not implemented for `()`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/issue-35570.rs:4:1

--- a/tests/ui/proc-macro/bad-projection.stderr
+++ b/tests/ui/proc-macro/bad-projection.stderr
@@ -48,16 +48,17 @@ LL | trait Project {
    | ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(): Project` is not satisfied
-  --> $DIR/bad-projection.rs:14:40
+  --> $DIR/bad-projection.rs:14:17
    |
 LL | pub fn uwu() -> <() as Project>::Assoc {}
-   |                                        ^^ the trait `Project` is not implemented for `()`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ the trait `Project` is not implemented for `()`
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/bad-projection.rs:9:1
    |
 LL | trait Project {
    | ^^^^^^^^^^^^^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.rs
+++ b/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.rs
@@ -20,8 +20,8 @@ trait Trait2<'a, 'b> {
 // do not infer that.
 fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
     //~^ ERROR the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
+    //~| ERROR the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
 {
-    //~^ ERROR the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
 }
 
 fn main() { }

--- a/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
+++ b/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
@@ -10,12 +10,10 @@ LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1< <T 
    |                    ++++++++++++++++++++++++
 
 error[E0277]: the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
-  --> $DIR/regions-implied-bounds-projection-gap-hr-1.rs:23:1
+  --> $DIR/regions-implied-bounds-projection-gap-hr-1.rs:21:25
    |
-LL | / {
-LL | |
-LL | | }
-   | |_^ the trait `for<'z> Trait2<'y, 'z>` is not implemented for `T`
+LL | fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'z> Trait2<'y, 'z>` is not implemented for `T`
    |
 help: consider restricting type parameter `T` with trait `Trait2`
    |

--- a/tests/ui/specialization/min_specialization/issue-79224.stderr
+++ b/tests/ui/specialization/min_specialization/issue-79224.stderr
@@ -35,13 +35,10 @@ LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
 
 error[E0277]: the trait bound `B: Clone` is not satisfied
-  --> $DIR/issue-79224.rs:30:62
+  --> $DIR/issue-79224.rs:30:12
    |
-LL |       fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-   |  ______________________________________________________________^
-...  |
-LL | |     }
-   | |_____^ the trait `Clone` is not implemented for `B`
+LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+   |            ^^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
 help: consider further restricting type parameter `B` with trait `Clone`

--- a/tests/ui/type-alias-impl-trait/generic_underconstrained.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_underconstrained.stderr
@@ -15,21 +15,17 @@ LL | fn underconstrain<T: Trait>(_: T) -> Underconstrained<T> {
    |                    +++++++
 
 error[E0277]: the trait bound `T: Trait` is not satisfied
-  --> $DIR/generic_underconstrained.rs:9:51
+  --> $DIR/generic_underconstrained.rs:9:31
    |
-LL |   fn underconstrain<T>(_: T) -> Underconstrained<T> {
-   |  ___________________________________________________^
-LL | |
-LL | |
-LL | |     unimplemented!()
-LL | | }
-   | |_^ the trait `Trait` is not implemented for `T`
+LL | fn underconstrain<T>(_: T) -> Underconstrained<T> {
+   |                               ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
    |
 note: required by a bound on the type alias `Underconstrained`
   --> $DIR/generic_underconstrained.rs:6:26
    |
 LL | type Underconstrained<T: Trait> = impl Send;
    |                          ^^^^^ required by this bound
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | fn underconstrain<T: Trait>(_: T) -> Underconstrained<T> {

--- a/tests/ui/type-alias-impl-trait/generic_underconstrained2.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_underconstrained2.stderr
@@ -31,42 +31,34 @@ LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained
    |                          +++++++++++++++++
 
 error[E0277]: `U` doesn't implement `Debug`
-  --> $DIR/generic_underconstrained2.rs:8:53
+  --> $DIR/generic_underconstrained2.rs:8:33
    |
-LL |   fn underconstrained<U>(_: U) -> Underconstrained<U> {
-   |  _____________________________________________________^
-LL | |
-LL | |
-LL | |     5u32
-LL | | }
-   | |_^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+LL | fn underconstrained<U>(_: U) -> Underconstrained<U> {
+   |                                 ^^^^^^^^^^^^^^^^^^^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
 note: required by a bound on the type alias `Underconstrained`
   --> $DIR/generic_underconstrained2.rs:5:26
    |
 LL | type Underconstrained<T: std::fmt::Debug> = impl Send;
    |                          ^^^^^^^^^^^^^^^ required by this bound
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider restricting type parameter `U` with trait `Debug`
    |
 LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
    |                      +++++++++++++++++
 
 error[E0277]: `V` doesn't implement `Debug`
-  --> $DIR/generic_underconstrained2.rs:17:64
+  --> $DIR/generic_underconstrained2.rs:17:43
    |
-LL |   fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
-   |  ________________________________________________________________^
-LL | |
-LL | |
-LL | |     5u32
-LL | | }
-   | |_^ `V` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+LL | fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
+   |                                           ^^^^^^^^^^^^^^^^^^^^ `V` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
 note: required by a bound on the type alias `Underconstrained2`
   --> $DIR/generic_underconstrained2.rs:14:27
    |
 LL | type Underconstrained2<T: std::fmt::Debug> = impl Send;
    |                           ^^^^^^^^^^^^^^^ required by this bound
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider restricting type parameter `V` with trait `Debug`
    |
 LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {


### PR DESCRIPTION
Applies the same hack as #106582 but to the args in typeck. Greatly improves normalization error spans from a signature.