### PR TITLE
Improve default target options for x86_64-unknown-linux-none

### DIFF
--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_none.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_none.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target, base};
+use crate::spec::{Cc, LinkerFlavor, Lld, PanicStrategy, StackProbeType, Target, base};
 
 pub(crate) fn target() -> Target {
     let mut base = base::linux::opts();
@@ -7,6 +7,7 @@ pub(crate) fn target() -> Target {
     base.stack_probes = StackProbeType::Inline;
     base.linker_flavor = LinkerFlavor::Gnu(Cc::No, Lld::Yes);
     base.linker = Some("rust-lld".into());
+    base.panic_strategy = PanicStrategy::Abort;
 
     Target {
         llvm_target: "x86_64-unknown-linux-none".into(),
@@ -14,7 +15,7 @@ pub(crate) fn target() -> Target {
             description: None,
             tier: None,
             host_tools: None,
-            std: Some(true),
+            std: Some(false),
         },
         pointer_width: 64,
         data_layout:

--- a/src/doc/rustc/src/platform-support/x86_64-unknown-linux-none.md
+++ b/src/doc/rustc/src/platform-support/x86_64-unknown-linux-none.md
@@ -14,6 +14,11 @@ This target is cross compiled and can be built from any host.
 
 This target has no support for host tools, std, or alloc.
 
+One of the primary motivations of the target is to write a dynamic linker and libc in Rust.
+For that, the target defaults to position-independent code and position-independent executables (PIE) by default.
+PIE binaries need relocation at runtime. This is usually done by the dynamic linker or libc.
+You can use `-Crelocation-model=static` to create a position-dependent binary that does not need relocation at runtime.
+
 ## Building the target
 
 The target can be built by enabling it for a `rustc` build:


### PR DESCRIPTION
Without a standard library, we cannot unwind, so it should be panic=abort by default.

Additionally, it does not have std because while it is Linux, it cannot use libc, which std uses today for Linux.

Using PIE by default may be surprising to users, as shown in #134763, so I've documented it explicitly. I'm not sure if we want to count that as fixing the issue or not.

cc @morr0ne, as you added the target (and are the maintainer), and @Noratrieb, who reviewed that PR (:D).