### PR TITLE
fix default-backtrace-ice test

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1388,7 +1388,9 @@ pub fn install_ice_hook(
     // opt in to less-verbose backtraces by manually setting "RUST_BACKTRACE"
     // (e.g. `RUST_BACKTRACE=1`)
     if env::var_os("RUST_BACKTRACE").is_none() {
-        if env!("CFG_RELEASE_CHANNEL") == "dev" {
+        // HACK: this check is extremely dumb, but we don't really need it to be smarter since this should only happen in the test suite anyway.
+        let ui_testing = std::env::args().any(|arg| arg == "-Zui-testing");
+        if env!("CFG_RELEASE_CHANNEL") == "dev" && !ui_testing {
             panic::set_backtrace_style(panic::BacktraceStyle::Short);
         } else {
             panic::set_backtrace_style(panic::BacktraceStyle::Full);

--- a/tests/ui/panics/default-backtrace-ice.rs
+++ b/tests/ui/panics/default-backtrace-ice.rs
@@ -1,6 +1,8 @@
 //@ unset-rustc-env:RUST_BACKTRACE
 //@ compile-flags:-Z treat-err-as-bug=1
 //@ error-pattern:stack backtrace:
+// Verify this is a full backtrace, not a short backtrace.
+//@ error-pattern:__rust_begin_short_backtrace
 //@ failure-status:101
 //@ ignore-msvc
 //@ normalize-stderr-test: "note: .*" -> ""

--- a/tests/ui/panics/default-backtrace-ice.stderr
+++ b/tests/ui/panics/default-backtrace-ice.stderr
@@ -1,5 +1,5 @@
 error: internal compiler error[E0425]: cannot find value `missing_ident` in this scope
-  --> $DIR/default-backtrace-ice.rs:21:13
+  --> $DIR/default-backtrace-ice.rs:23:13
    |
 LL | fn main() { missing_ident; }
    |             ^^^^^^^^^^^^^ not found in this scope


### PR DESCRIPTION
when running `tests/ui/panics/default-backtrace-ice.rs locally it gave this error:
```
failures:

---- [ui] tests/ui/panics/default-backtrace-ice.rs stdout ----
Saved the actual stderr to "/home/jyn/src/rust3/build/x86_64-unknown-linux-gnu/test/ui/panics/default-backtrace-ice/default-backtrace-ice.stderr"
diff of stderr:

7
8	aborting due to `-Z treat-err-as-bug=1`
9	stack backtrace:
-	(end_short_backtrace)
-	(begin_short_backtrace)
-	(end_short_backtrace)
-	(begin_short_backtrace)
+	      [... omitted 22 frames ...]
+
```
(note that you must *not* use --bless; we previously did not have an error annotation to verify it was a full backtrace instead of a short backtrace.)

this is a regression from setting RUST_BACKTRACE=1 by default in https://github.com/rust-lang/rust/pull/134743. we need to turn off the new behavior when running UI tests so that they reflect our dist compiler. normally that's done by checking `sess.unstable_opts.ui_testing`, but this happens extremely early in the compiler before we've expanded arg files. do an extremely simple hack that doesn't work in all cases - we don't need it to work in all cases, only when running UI tests.

cc https://github.com/rust-lang/rust/pull/129658#issuecomment-2561988081

r? @jieyouxu 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
