### PR TITLE
Avoid ICE: Account for `for<'a>` types when checking for non-structural type in constant as pattern

### DIFF
--- a/tests/ui/consts/const_in_pattern/non_structural_with_escaping_bounds.rs
+++ b/tests/ui/consts/const_in_pattern/non_structural_with_escaping_bounds.rs
@@ -1,0 +1,15 @@
+#![feature(structural_match)]
+impl<T: ?Sized> std::marker::StructuralPartialEq for O<T> { }
+
+enum O<T: ?Sized> {
+    Some(*const T),
+    None,
+}
+
+const C: O<dyn for<'a> Fn(Box<dyn Fn(&'a u8)>)> = O::None;
+
+fn main() {
+    match O::None {
+        C => (), //~ ERROR constant of non-structural type
+    }
+}

--- a/tests/ui/consts/const_in_pattern/non_structural_with_escaping_bounds.stderr
+++ b/tests/ui/consts/const_in_pattern/non_structural_with_escaping_bounds.stderr
@@ -1,0 +1,15 @@
+error: constant of non-structural type `O<dyn for<'a> Fn(Box<dyn Fn(&'a u8)>)>` in a pattern
+  --> $DIR/non_structural_with_escaping_bounds.rs:13:9
+   |
+LL | const C: O<dyn for<'a> Fn(Box<dyn Fn(&'a u8)>)> = O::None;
+   | ----------------------------------------------- constant defined here
+...
+LL |         C => (),
+   |         ^ constant of non-structural type
+   |
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details
+   = note: `std::alloc::Global` must be annotated with `#[derive(PartialEq)]` to be usable in patterns
+   = note: `std::alloc::Global` must be annotated with `#[derive(PartialEq)]` to be usable in patterns
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/consts/const_in_pattern/non_structural_with_escaping_bounds.stderr
+++ b/tests/ui/consts/const_in_pattern/non_structural_with_escaping_bounds.stderr
@@ -8,7 +8,6 @@ LL |         C => (),
    |         ^ constant of non-structural type
    |
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details
-   = note: `std::alloc::Global` must be annotated with `#[derive(PartialEq)]` to be usable in patterns
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const_in_pattern/non_structural_with_escaping_bounds.stderr
+++ b/tests/ui/consts/const_in_pattern/non_structural_with_escaping_bounds.stderr
@@ -9,7 +9,6 @@ LL |         C => (),
    |
    = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details
    = note: `std::alloc::Global` must be annotated with `#[derive(PartialEq)]` to be usable in patterns
-   = note: `std::alloc::Global` must be annotated with `#[derive(PartialEq)]` to be usable in patterns
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
When we encounter a constant in a pattern, we check if it is non-structural. If so, we check if the type implements `PartialEq`, but for types with escaping bound vars the check would be incorrect as is, so we break early. This is ok because these types would be filtered anyways.

Slight tweak to output to remove unnecessary context as a drive-by.

Fix #134764.