### PR TITLE
Enable more tests on Windows

### DIFF
--- a/tests/codegen/debug-column.rs
+++ b/tests/codegen/debug-column.rs
@@ -1,6 +1,6 @@
 // Verify that debuginfo column numbers are 1-based byte offsets.
 //
-//@ ignore-windows
+//@ ignore-msvc
 //@ compile-flags: -C debuginfo=2
 
 #[rustfmt::skip]

--- a/tests/codegen/force-no-unwind-tables.rs
+++ b/tests/codegen/force-no-unwind-tables.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -C no-prepopulate-passes -C panic=abort -C force-unwind-tables=n
-//@ ignore-windows
+//@ ignore-windows: unwind tables are required for panics on Windows
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/thread-local.rs
+++ b/tests/codegen/thread-local.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -O
 //@ aux-build:thread_local_aux.rs
-//@ ignore-windows FIXME(#84933)
+//@ ignore-windows FIXME(#134939)
 //@ ignore-wasm globals are used instead of thread locals
 //@ ignore-emscripten globals are used instead of thread locals
 //@ ignore-android does not use #[thread_local]

--- a/tests/crashes/132981.rs
+++ b/tests/crashes/132981.rs
@@ -2,6 +2,10 @@
 //@compile-flags: -Clink-dead-code=true --crate-type lib
 //@ only-x86_64
 //@ ignore-windows
+// The set of targets this crashes on is really fiddly, because it is deep in our ABI logic. It
+// crashes on x86_64-unknown-linux-gnu, and i686-pc-windows-msvc, but not on
+// x86_64-pc-windows-msvc. If you are trying to fix this crash, don't pay too much attention to the
+// directives.
 
 #![feature(rust_cold_cc)]
 pub extern "rust-cold" fn foo(_: [usize; 3]) {}

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
@@ -1,4 +1,4 @@
-//@ ignore-windows
+//@ ignore-windows different error message
 //@ revisions: edition2015 edition2024
 //@[edition2015]edition:2015
 //@[edition2015]check-fail

--- a/tests/ui-fulldeps/stable-mir/check_abi.rs
+++ b/tests/ui-fulldeps/stable-mir/check_abi.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 
 #![feature(rustc_private)]
 #![feature(assert_matches)]

--- a/tests/ui-fulldeps/stable-mir/check_allocation.rs
+++ b/tests/ui-fulldeps/stable-mir/check_allocation.rs
@@ -5,7 +5,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/check_attribute.rs
+++ b/tests/ui-fulldeps/stable-mir/check_attribute.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 
 #![feature(rustc_private)]
 

--- a/tests/ui-fulldeps/stable-mir/check_binop.rs
+++ b/tests/ui-fulldeps/stable-mir/check_binop.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 
 #![feature(rustc_private)]
 

--- a/tests/ui-fulldeps/stable-mir/check_crate_defs.rs
+++ b/tests/ui-fulldeps/stable-mir/check_crate_defs.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 
 #![feature(rustc_private)]
 #![feature(assert_matches)]

--- a/tests/ui-fulldeps/stable-mir/check_def_ty.rs
+++ b/tests/ui-fulldeps/stable-mir/check_def_ty.rs
@@ -5,7 +5,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/check_defs.rs
+++ b/tests/ui-fulldeps/stable-mir/check_defs.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/check_foreign.rs
+++ b/tests/ui-fulldeps/stable-mir/check_foreign.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/check_instance.rs
+++ b/tests/ui-fulldeps/stable-mir/check_instance.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/check_intrinsics.rs
+++ b/tests/ui-fulldeps/stable-mir/check_intrinsics.rs
@@ -8,7 +8,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 
 #![feature(rustc_private)]
 #![feature(assert_matches)]

--- a/tests/ui-fulldeps/stable-mir/check_item_kind.rs
+++ b/tests/ui-fulldeps/stable-mir/check_item_kind.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/check_normalization.rs
+++ b/tests/ui-fulldeps/stable-mir/check_normalization.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/check_trait_queries.rs
+++ b/tests/ui-fulldeps/stable-mir/check_trait_queries.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/check_transform.rs
+++ b/tests/ui-fulldeps/stable-mir/check_transform.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 
 #![feature(rustc_private)]
 #![feature(assert_matches)]

--- a/tests/ui-fulldeps/stable-mir/check_ty_fold.rs
+++ b/tests/ui-fulldeps/stable-mir/check_ty_fold.rs
@@ -5,7 +5,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/compilation-result.rs
+++ b/tests/ui-fulldeps/stable-mir/compilation-result.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/crate-info.rs
+++ b/tests/ui-fulldeps/stable-mir/crate-info.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/projections.rs
+++ b/tests/ui-fulldeps/stable-mir/projections.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/smir_internal.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_internal.rs
@@ -5,7 +5,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/smir_serde.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_serde.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui-fulldeps/stable-mir/smir_visitor.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_visitor.rs
@@ -4,7 +4,6 @@
 //@ ignore-stage1
 //@ ignore-cross-compile
 //@ ignore-remote
-//@ ignore-windows-gnu mingw has troubles with linking https://github.com/rust-lang/rust/pull/116837
 //@ edition: 2021
 
 #![feature(rustc_private)]

--- a/tests/ui/abi/abi-sysv64-arg-passing.rs
+++ b/tests/ui/abi/abi-sysv64-arg-passing.rs
@@ -29,7 +29,8 @@
 //@ ignore-aarch64
 //@ ignore-windows
 
-// note: windows is ignored as rust_test_helpers does not have the sysv64 abi on windows
+// Windows is ignored because bootstrap doesn't yet know to compile rust_test_helpers with
+// the sysv64 ABI on Windows.
 
 #[allow(dead_code)]
 #[allow(improper_ctypes)]

--- a/tests/ui/abi/large-byval-align.rs
+++ b/tests/ui/abi/large-byval-align.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: -Copt-level=0
 //@ only-x86_64
-//@ ignore-windows
 //@ min-llvm-version: 19
 //@ build-pass
 

--- a/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.rs
@@ -1,4 +1,4 @@
-//@ ignore-windows
+//@ ignore-windows FIXME(134939): thread_local + no_mangle doesn't work on Windows
 //@ aux-build:cfg-target-thread-local.rs
 
 #![feature(thread_local)]

--- a/tests/ui/inference/issue-71584.rs
+++ b/tests/ui/inference/issue-71584.rs
@@ -1,4 +1,4 @@
-//@ ignore-windows different list of satisfying impls
+//@ ignore-windows FIXME: We get an extra E0283 on Windows
 fn main() {
     let n: u32 = 1;
     let mut d: u64 = 2;

--- a/tests/ui/linkage-attr/linkage-attr-does-not-panic-llvm-issue-33992.rs
+++ b/tests/ui/linkage-attr/linkage-attr-does-not-panic-llvm-issue-33992.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-//@ ignore-windows
 //@ ignore-apple
 //@ ignore-wasm32 common linkage not implemented right now
 
@@ -11,9 +10,11 @@ pub static TEST2: bool = true;
 #[linkage = "internal"]
 pub static TEST3: bool = true;
 
+#[cfg(not(target_env = "msvc"))]
 #[linkage = "linkonce"]
 pub static TEST4: bool = true;
 
+#[cfg(not(target_env = "msvc"))]
 #[linkage = "linkonce_odr"]
 pub static TEST5: bool = true;
 

--- a/tests/ui/linkage-attr/propagate-generic-issue-18804/main.rs
+++ b/tests/ui/linkage-attr/propagate-generic-issue-18804/main.rs
@@ -3,7 +3,6 @@
 // functions. Failure results in a linker error.
 
 //@ ignore-emscripten no weak symbol support
-//@ ignore-windows no extern_weak linkage
 //@ ignore-apple no extern_weak linkage
 
 //@ aux-build:lib.rs

--- a/tests/ui/logging-only-prints-once.rs
+++ b/tests/ui/logging-only-prints-once.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-//@ ignore-windows
 //@ needs-threads
 
 use std::cell::Cell;

--- a/tests/ui/lto/weak-works.rs
+++ b/tests/ui/lto/weak-works.rs
@@ -1,7 +1,8 @@
 //@ run-pass
 
 //@ compile-flags: -C codegen-units=8 -Z thinlto
-//@ ignore-windows
+//@ ignore-i686-pc-windows-gnu
+//@ ignore-x86_64-pc-windows-gnu
 
 #![feature(linkage)]
 

--- a/tests/ui/parser/mod_file_not_exist.rs
+++ b/tests/ui/parser/mod_file_not_exist.rs
@@ -1,5 +1,3 @@
-//@ ignore-windows
-
 mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
 //~^ HELP to create the module `not_a_real_file`, create file
 

--- a/tests/ui/parser/mod_file_not_exist.stderr
+++ b/tests/ui/parser/mod_file_not_exist.stderr
@@ -1,5 +1,5 @@
 error[E0583]: file not found for module `not_a_real_file`
-  --> $DIR/mod_file_not_exist.rs:3:1
+  --> $DIR/mod_file_not_exist.rs:1:1
    |
 LL | mod not_a_real_file;
    | ^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | mod not_a_real_file;
    = note: if there is a `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::...` instead
 
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
-  --> $DIR/mod_file_not_exist.rs:7:16
+  --> $DIR/mod_file_not_exist.rs:5:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
    |                ^^^^^^^^^^^^ use of unresolved module or unlinked crate `mod_file_aux`

--- a/tests/ui/suggestions/missing-lifetime-specifier.rs
+++ b/tests/ui/suggestions/missing-lifetime-specifier.rs
@@ -1,6 +1,5 @@
 // The specific errors produced depend the thread-local implementation.
 // Run only on platforms with "fast" TLS.
-//@ ignore-windows FIXME(#84933)
 //@ ignore-wasm globals are used instead of thread locals
 //@ ignore-emscripten globals are used instead of thread locals
 //@ ignore-android does not use #[thread_local]

--- a/tests/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/tests/ui/suggestions/missing-lifetime-specifier.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:28:44
+  --> $DIR/missing-lifetime-specifier.rs:27:44
    |
 LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ expected 2 lifetime parameters
@@ -11,7 +11,7 @@ LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo<'static, 'static>>>>> = RefC
    |                                               ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:32:44
+  --> $DIR/missing-lifetime-specifier.rs:31:44
    |
 LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
    |                                            ^^^^ expected 2 lifetime parameters
@@ -25,7 +25,7 @@ LL |     static b: RefCell<HashMap<i32, Vec<Vec<&'static Bar<'static, 'static>>>
    |                                             +++++++    ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:36:47
+  --> $DIR/missing-lifetime-specifier.rs:35:47
    |
 LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
    |                                               ^ expected 2 lifetime parameters
@@ -37,7 +37,7 @@ LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:40:44
+  --> $DIR/missing-lifetime-specifier.rs:39:44
    |
 LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^   ^ expected 2 lifetime parameters
@@ -51,7 +51,7 @@ LL |     static d: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, 'static, i
    |                                             +++++++     +++++++++++++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:49:44
+  --> $DIR/missing-lifetime-specifier.rs:48:44
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^ expected named lifetime parameter
@@ -63,7 +63,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> =
    |                                             +++++++
 
 error[E0107]: union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:45:44
+  --> $DIR/missing-lifetime-specifier.rs:44:44
    |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^^^ ------- supplied 1 lifetime argument
@@ -71,7 +71,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell:
    |                                            expected 2 lifetime arguments
    |
 note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:21:11
+  --> $DIR/missing-lifetime-specifier.rs:20:11
    |
 LL | pub union Qux<'t, 'k, I> {
    |           ^^^ --  --
@@ -81,7 +81,7 @@ LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                       +++++++++
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:49:45
+  --> $DIR/missing-lifetime-specifier.rs:48:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -89,7 +89,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell
    |                                             expected 2 lifetime arguments
    |
 note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:25:7
+  --> $DIR/missing-lifetime-specifier.rs:24:7
    |
 LL | trait Tar<'t, 'k, I> {}
    |       ^^^ --  --

--- a/tests/ui/threads-sendsync/spawning-with-debug.rs
+++ b/tests/ui/threads-sendsync/spawning-with-debug.rs
@@ -1,7 +1,6 @@
 //@ run-pass
 #![allow(unused_must_use)]
 #![allow(unused_mut)]
-//@ ignore-windows
 //@ exec-env:RUST_LOG=debug
 //@ needs-threads
 

--- a/tests/ui/threads-sendsync/thread-local-extern-static.rs
+++ b/tests/ui/threads-sendsync/thread-local-extern-static.rs
@@ -1,5 +1,5 @@
 //@ run-pass
-//@ ignore-windows
+//@ ignore-windows FIXME(134939): thread_local + no_mangle doesn't work on Windows
 //@ aux-build:thread-local-extern-static.rs
 
 #![feature(cfg_target_thread_local, thread_local)]

--- a/tests/ui/traits/issue-77982.rs
+++ b/tests/ui/traits/issue-77982.rs
@@ -1,5 +1,6 @@
-//@ ignore-windows different list of satisfying impls
-//@ ignore-arm different list of satisfying impls
+//@ ignore-windows FIXME: We get an extra E0283 on Windows
+//@ ignore-arm extra satisfying impls
+
 use std::collections::HashMap;
 
 fn what() {

--- a/tests/ui/traits/issue-77982.stderr
+++ b/tests/ui/traits/issue-77982.stderr
@@ -1,5 +1,5 @@
 error[E0283]: type annotations needed
-  --> $DIR/issue-77982.rs:10:10
+  --> $DIR/issue-77982.rs:11:10
    |
 LL |     opts.get(opt.as_ref());
    |          ^^^ ------------ type must be known at this point
@@ -18,7 +18,7 @@ LL |     opts.get::<Q>(opt.as_ref());
    |             +++++
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-77982.rs:10:10
+  --> $DIR/issue-77982.rs:11:10
    |
 LL |     opts.get(opt.as_ref());
    |          ^^^     ------ type must be known at this point
@@ -36,7 +36,7 @@ LL |     opts.get::<Q>(opt.as_ref());
    |             +++++
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-77982.rs:15:59
+  --> $DIR/issue-77982.rs:16:59
    |
 LL |     let ips: Vec<_> = (0..100_000).map(|_| u32::from(0u32.into())).collect();
    |                                            ---            ^^^^
@@ -56,13 +56,13 @@ LL |     let ips: Vec<_> = (0..100_000).map(|_| u32::from(<u32 as Into<T>>::into
    |                                                      +++++++++++++++++++++++    ~
 
 error[E0283]: type annotations needed for `Box<_>`
-  --> $DIR/issue-77982.rs:38:9
+  --> $DIR/issue-77982.rs:39:9
    |
 LL |     let _ = ().foo();
    |         ^      --- type must be known at this point
    |
 note: multiple `impl`s satisfying `(): Foo<'_, _>` found
-  --> $DIR/issue-77982.rs:31:1
+  --> $DIR/issue-77982.rs:32:1
    |
 LL | impl Foo<'static, u32> for () {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,13 +74,13 @@ LL |     let _: Box<T> = ().foo();
    |          ++++++++
 
 error[E0283]: type annotations needed for `Box<_>`
-  --> $DIR/issue-77982.rs:42:9
+  --> $DIR/issue-77982.rs:43:9
    |
 LL |     let _ = (&()).bar();
    |         ^         --- type must be known at this point
    |
 note: multiple `impl`s satisfying `&(): Bar<'_, _>` found
-  --> $DIR/issue-77982.rs:34:1
+  --> $DIR/issue-77982.rs:35:1
    |
 LL | impl<'a> Bar<'static, u32> for &'a () {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/typeck/issue-43189.rs
+++ b/tests/ui/typeck/issue-43189.rs
@@ -1,7 +1,6 @@
 // Issue 46112: An extern crate pub re-exporting libcore was causing
 // paths rooted from `std` to be misrendered in the diagnostic output.
 
-//@ ignore-windows
 //@ aux-build:xcrate-issue-43189-a.rs
 //@ aux-build:xcrate-issue-43189-b.rs
 

--- a/tests/ui/typeck/issue-43189.stderr
+++ b/tests/ui/typeck/issue-43189.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `a` found for unit type `()` in the current scope
-  --> $DIR/issue-43189.rs:10:8
+  --> $DIR/issue-43189.rs:9:8
    |
 LL |     ().a();
    |        ^ method not found in `()`

--- a/tests/ui/typeck/issue-46112.rs
+++ b/tests/ui/typeck/issue-46112.rs
@@ -1,7 +1,6 @@
 // Issue 46112: An extern crate pub re-exporting libcore was causing
 // paths rooted from `std` to be misrendered in the diagnostic output.
 
-//@ ignore-windows
 //@ aux-build:xcrate-issue-46112-rexport-core.rs
 
 extern crate xcrate_issue_46112_rexport_core;

--- a/tests/ui/typeck/issue-46112.stderr
+++ b/tests/ui/typeck/issue-46112.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-46112.rs:9:21
+  --> $DIR/issue-46112.rs:8:21
    |
 LL | fn main() { test(Ok(())); }
    |                  -- ^^ expected `Option<()>`, found `()`
@@ -9,7 +9,7 @@ LL | fn main() { test(Ok(())); }
    = note:   expected enum `Option<()>`
            found unit type `()`
 help: the type constructed contains `()` due to the type of the argument passed
-  --> $DIR/issue-46112.rs:9:18
+  --> $DIR/issue-46112.rs:8:18
    |
 LL | fn main() { test(Ok(())); }
    |                  ^^^--^


### PR DESCRIPTION
As part of the discussion of https://github.com/rust-lang/compiler-team/issues/822 on Zulip, it was mentioned that problems with the i686-pc-windows-gnu target may have resulted in tests being disabled on Windows.

So in this PR, I've ripped out all our `//@ ignore-windows` directives, then re-added all the ones that are definitely required based on the outcome of try-builds, and in some cases I've improved the justification or tightened the directives to `//@ ignore-msvc` or ignoring specific targets.