### PR TITLE
Add more `begin_panic` normalizations to panic backtrace tests

### DIFF
--- a/tests/ui/panics/issue-47429-short-backtraces.rs
+++ b/tests/ui/panics/issue-47429-short-backtraces.rs
@@ -9,6 +9,8 @@
 // This is needed to avoid test output differences across std being built with v0 symbols vs legacy
 // symbols.
 //@ normalize-stderr-test: "begin_panic::<&str>" -> "begin_panic"
+// This variant occurs on macOS with `rust.debuginfo-level = "line-tables-only"` (#133997)
+//@ normalize-stderr-test: " begin_panic<&str>" -> " std::panicking::begin_panic"
 // And this is for differences between std with and without debuginfo.
 //@ normalize-stderr-test: "\n +at [^\n]+" -> ""
 

--- a/tests/ui/panics/issue-47429-short-backtraces.run.stderr
+++ b/tests/ui/panics/issue-47429-short-backtraces.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/issue-47429-short-backtraces.rs:24:5:
+thread 'main' panicked at $DIR/issue-47429-short-backtraces.rs:26:5:
 explicit panic
 stack backtrace:
    0: std::panicking::begin_panic

--- a/tests/ui/panics/runtime-switch.rs
+++ b/tests/ui/panics/runtime-switch.rs
@@ -9,6 +9,8 @@
 // This is needed to avoid test output differences across std being built with v0 symbols vs legacy
 // symbols.
 //@ normalize-stderr-test: "begin_panic::<&str>" -> "begin_panic"
+// This variant occurs on macOS with `rust.debuginfo-level = "line-tables-only"` (#133997)
+//@ normalize-stderr-test: " begin_panic<&str>" -> " std::panicking::begin_panic"
 // And this is for differences between std with and without debuginfo.
 //@ normalize-stderr-test: "\n +at [^\n]+" -> ""
 

--- a/tests/ui/panics/runtime-switch.run.stderr
+++ b/tests/ui/panics/runtime-switch.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/runtime-switch.rs:27:5:
+thread 'main' panicked at $DIR/runtime-switch.rs:29:5:
 explicit panic
 stack backtrace:
    0: std::panicking::begin_panic

--- a/tests/ui/panics/short-ice-remove-middle-frames-2.rs
+++ b/tests/ui/panics/short-ice-remove-middle-frames-2.rs
@@ -12,6 +12,8 @@
 // This is needed to avoid test output differences across std being built with v0 symbols vs legacy
 // symbols.
 //@ normalize-stderr-test: "begin_panic::<&str>" -> "begin_panic"
+// This variant occurs on macOS with `rust.debuginfo-level = "line-tables-only"` (#133997)
+//@ normalize-stderr-test: " begin_panic<&str>" -> " std::panicking::begin_panic"
 // And this is for differences between std with and without debuginfo.
 //@ normalize-stderr-test: "\n +at [^\n]+" -> ""
 

--- a/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/short-ice-remove-middle-frames-2.rs:61:5:
+thread 'main' panicked at $DIR/short-ice-remove-middle-frames-2.rs:63:5:
 debug!!!
 stack backtrace:
    0: std::panicking::begin_panic

--- a/tests/ui/panics/short-ice-remove-middle-frames.rs
+++ b/tests/ui/panics/short-ice-remove-middle-frames.rs
@@ -13,6 +13,8 @@
 // This is needed to avoid test output differences across std being built with v0 symbols vs legacy
 // symbols.
 //@ normalize-stderr-test: "begin_panic::<&str>" -> "begin_panic"
+// This variant occurs on macOS with `rust.debuginfo-level = "line-tables-only"` (#133997)
+//@ normalize-stderr-test: " begin_panic<&str>" -> " std::panicking::begin_panic"
 // And this is for differences between std with and without debuginfo.
 //@ normalize-stderr-test: "\n +at [^\n]+" -> ""
 

--- a/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/short-ice-remove-middle-frames.rs:57:5:
+thread 'main' panicked at $DIR/short-ice-remove-middle-frames.rs:59:5:
 debug!!!
 stack backtrace:
    0: std::panicking::begin_panic


### PR DESCRIPTION
Since #123244, these tests have started failing locally on some systems (#133997) due to minor variations in how `begin_panic` is printed in the backtrace.

The variation appears to occur on macOS when `rust.debuginfo-level = "line-tables-only"` is set, which is the default in `config.compiler.toml`. It does not occur when the debuginfo level is set to 1.

The variation doesn't seem relevant to these tests, so this PR simply adds another custom normalization rule to account for the variation.

---

Will conflict with #134759.