### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1388,7 +1388,9 @@ pub fn install_ice_hook(
     // opt in to less-verbose backtraces by manually setting "RUST_BACKTRACE"
     // (e.g. `RUST_BACKTRACE=1`)
     if env::var_os("RUST_BACKTRACE").is_none() {
-        if env!("CFG_RELEASE_CHANNEL") == "dev" {
+        // HACK: this check is extremely dumb, but we don't really need it to be smarter since this should only happen in the test suite anyway.
+        let ui_testing = std::env::args().any(|arg| arg == "-Zui-testing");
+        if env!("CFG_RELEASE_CHANNEL") == "dev" && !ui_testing {
             panic::set_backtrace_style(panic::BacktraceStyle::Short);
         } else {
             panic::set_backtrace_style(panic::BacktraceStyle::Full);

--- a/src/tools/miri/CONTRIBUTING.md
+++ b/src/tools/miri/CONTRIBUTING.md
@@ -212,6 +212,15 @@ Miri comes with a few benchmarks; you can run `./miri bench` to run them with th
 Miri. Note: this will run `./miri install` as a side-effect. Also requires `hyperfine` to be
 installed (`cargo install hyperfine`).
 
+To compare the benchmark results with a baseline, do the following:
+- Before applying your changes, run `./miri bench --save-baseline=baseline.json`.
+- Then do your changes.
+- Then run `./miri bench --load-baseline=baseline.json`; the results will include
+  a comparison with the baseline.
+
+You can run only some of the benchmarks by listing them, e.g. `./miri bench mse`.
+The names refer to the folders in `bench-cargo-miri`.
+
 ## Configuring `rust-analyzer`
 
 To configure `rust-analyzer` and the IDE for working on Miri, copy one of the provided

--- a/src/tools/miri/README.md
+++ b/src/tools/miri/README.md
@@ -160,14 +160,14 @@ Certain parts of the execution are picked randomly by Miri, such as the exact ba
 allocations are stored at and the interleaving of concurrently executing threads. Sometimes, it can
 be useful to explore multiple different execution, e.g. to make sure that your code does not depend
 on incidental "super-alignment" of new allocations and to test different thread interleavings.
-This can be done with the `--many-seeds` flag:
+This can be done with the `-Zmiri-many-seeds` flag:
 
 ```
-cargo miri test --many-seeds # tries the seeds in 0..64
-cargo miri test --many-seeds=0..16
+MIRIFLAGS="-Zmiri-many-seeds" cargo miri test # tries the seeds in 0..64
+MIRIFLAGS="-Zmiri-many-seeds=0..16" cargo miri test
 ```
 
-The default of 64 different seeds is quite slow, so you probably want to specify a smaller range.
+The default of 64 different seeds can be quite slow, so you often want to specify a smaller range.
 
 ### Running Miri on CI
 
@@ -317,6 +317,12 @@ environment variable. We first document the most relevant and most commonly used
   execution with a "permission denied" error being returned to the program.
   `warn` prints a full backtrace each time that happens; `warn-nobacktrace` is less
   verbose and shown at most once per operation. `hide` hides the warning entirely.
+* `-Zmiri-many-seeds=[<from>]..<to>` runs the program multiple times with different seeds for Miri's
+  RNG. With different seeds, Miri will make different choices to resolve non-determinism such as the
+  order in which concurrent threads are scheduled, or the exact addresses assigned to allocations.
+  This is useful to find bugs that only occur under particular interleavings of concurrent threads,
+  or that otherwise depend on non-determinism. If the `<from>` part is skipped, it defaults to `0`.
+  Can be used without a value; in that case the range defaults to `0..64`.
 * `-Zmiri-num-cpus` states the number of available CPUs to be reported by miri. By default, the
   number of available CPUs is `1`. Note that this flag does not affect how miri handles threads in
   any way.

--- a/src/tools/miri/README.md
+++ b/src/tools/miri/README.md
@@ -347,8 +347,8 @@ environment variable. We first document the most relevant and most commonly used
   can increase test coverage by running Miri multiple times with different seeds.
 * `-Zmiri-strict-provenance` enables [strict
   provenance](https://github.com/rust-lang/rust/issues/95228) checking in Miri. This means that
-  casting an integer to a pointer yields a result with 'invalid' provenance, i.e., with provenance
-  that cannot be used for any memory access.
+  casting an integer to a pointer will stop execution because the provenance of the pointer
+  cannot be determined.
 * `-Zmiri-symbolic-alignment-check` makes the alignment check more strict.  By default, alignment is
   checked by casting the pointer to an integer, and making sure that is a multiple of the alignment.
   This can lead to cases where a program passes the alignment check by pure chance, because things
@@ -437,6 +437,8 @@ to Miri failing to detect cases of undefined behavior in a program.
   of Rust will be stricter than Tree Borrows. In other words, if you use Tree Borrows,
   even if your code is accepted today, it might be declared UB in the future.
   This is much less likely with Stacked Borrows.
+  Using Tree Borrows currently implies `-Zmiri-strict-provenance` because integer-to-pointer
+  casts are not supported in this mode, but that may change in the future.
 * `-Zmiri-force-page-size=<num>` overrides the default page size for an architecture, in multiples of 1k.
   `4` is default for most targets. This value should always be a power of 2 and nonzero.
 * `-Zmiri-unique-is-unique` performs additional aliasing checks for `core::ptr::Unique` to ensure

--- a/src/tools/miri/README.md
+++ b/src/tools/miri/README.md
@@ -294,9 +294,10 @@ environment variable. We first document the most relevant and most commonly used
   will always fail and `0.0` means it will never fail. Note that setting it to
   `1.0` will likely cause hangs, since it means programs using
   `compare_exchange_weak` cannot make progress.
-* `-Zmiri-disable-isolation` disables host isolation.  As a consequence,
+* `-Zmiri-disable-isolation` disables host isolation. As a consequence,
   the program has access to host resources such as environment variables, file
   systems, and randomness.
+  This overwrites a previous `-Zmiri-isolation-error`.
 * `-Zmiri-disable-leak-backtraces` disables backtraces reports for memory leaks. By default, a
   backtrace is captured for every allocation when it is created, just in case it leaks. This incurs
   some memory overhead to store data that is almost never used. This flag is implied by
@@ -317,6 +318,7 @@ environment variable. We first document the most relevant and most commonly used
   execution with a "permission denied" error being returned to the program.
   `warn` prints a full backtrace each time that happens; `warn-nobacktrace` is less
   verbose and shown at most once per operation. `hide` hides the warning entirely.
+  This overwrites a previous `-Zmiri-disable-isolation`.
 * `-Zmiri-many-seeds=[<from>]..<to>` runs the program multiple times with different seeds for Miri's
   RNG. With different seeds, Miri will make different choices to resolve non-determinism such as the
   order in which concurrent threads are scheduled, or the exact addresses assigned to allocations.

--- a/src/tools/miri/README.md
+++ b/src/tools/miri/README.md
@@ -323,6 +323,8 @@ environment variable. We first document the most relevant and most commonly used
   This is useful to find bugs that only occur under particular interleavings of concurrent threads,
   or that otherwise depend on non-determinism. If the `<from>` part is skipped, it defaults to `0`.
   Can be used without a value; in that case the range defaults to `0..64`.
+* `-Zmiri-many-seeds-keep-going` tells Miri to really try all the seeds in the given range, even if
+  a failing seed has already been found. This is useful to determine which fraction of seeds fails.
 * `-Zmiri-num-cpus` states the number of available CPUs to be reported by miri. By default, the
   number of available CPUs is `1`. Note that this flag does not affect how miri handles threads in
   any way.

--- a/src/tools/miri/ci/ci.sh
+++ b/src/tools/miri/ci/ci.sh
@@ -66,9 +66,9 @@ function run_tests {
     time MIRIFLAGS="${MIRIFLAGS-} -O -Zmir-opt-level=4 -Cdebug-assertions=yes" MIRI_SKIP_UI_CHECKS=1 ./miri test $TARGET_FLAG tests/{pass,panic}
   fi
   if [ -n "${MANY_SEEDS-}" ]; then
-    # Also run some many-seeds tests. (Also tests `./miri run`.)
+    # Run many-seeds tests. (Also tests `./miri run`.)
     time for FILE in tests/many-seeds/*.rs; do
-      ./miri run "--many-seeds=0..$MANY_SEEDS" $TARGET_FLAG "$FILE"
+      ./miri run "-Zmiri-many-seeds=0..$MANY_SEEDS" $TARGET_FLAG "$FILE"
     done
   fi
   if [ -n "${TEST_BENCH-}" ]; then

--- a/src/tools/miri/miri-script/Cargo.lock
+++ b/src/tools/miri/miri-script/Cargo.lock
@@ -250,6 +250,8 @@ dependencies = [
  "itertools",
  "path_macro",
  "rustc_version",
+ "serde",
+ "serde_derive",
  "serde_json",
  "shell-words",
  "tempfile",

--- a/src/tools/miri/miri-script/Cargo.toml
+++ b/src/tools/miri/miri-script/Cargo.toml
@@ -23,6 +23,8 @@ xshell = "0.2.6"
 rustc_version = "0.4"
 dunce = "1.0.4"
 directories = "5"
+serde = "1"
 serde_json = "1"
+serde_derive = "1"
 tempfile = "3.13.0"
 clap = { version = "4.5.21", features = ["derive"] }

--- a/src/tools/miri/miri-script/src/main.rs
+++ b/src/tools/miri/miri-script/src/main.rs
@@ -121,6 +121,10 @@ pub enum Command {
         /// as the baseline for a future run.
         #[arg(long)]
         save_baseline: Option<String>,
+        /// Load previous stored benchmark results as baseline, and print an analysis of how the
+        /// current run compares.
+        #[arg(long)]
+        load_baseline: Option<String>,
         /// List of benchmarks to run (default: run all benchmarks).
         benches: Vec<String>,
     },

--- a/src/tools/miri/miri-script/src/main.rs
+++ b/src/tools/miri/miri-script/src/main.rs
@@ -4,28 +4,8 @@ mod commands;
 mod coverage;
 mod util;
 
-use std::ops::Range;
-
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
-
-/// Parses a seed range
-///
-/// This function is used for the `--many-seeds` flag. It expects the range in the form
-/// `<from>..<to>`. `<from>` is inclusive, `<to>` is exclusive. `<from>` can be omitted,
-/// in which case it is assumed to be `0`.
-fn parse_range(val: &str) -> anyhow::Result<Range<u32>> {
-    let (from, to) = val
-        .split_once("..")
-        .ok_or_else(|| anyhow!("invalid format for `--many-seeds`: expected `from..to`"))?;
-    let from: u32 = if from.is_empty() {
-        0
-    } else {
-        from.parse().context("invalid `from` in `--many-seeds=from..to")?
-    };
-    let to: u32 = to.parse().context("invalid `to` in `--many-seeds=from..to")?;
-    Ok(from..to)
-}
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum Command {
@@ -81,9 +61,6 @@ pub enum Command {
         /// Show build progress.
         #[arg(long, short)]
         verbose: bool,
-        /// Run the driver with the seeds in the given range (`..to` or `from..to`, default: `0..64`).
-        #[arg(long, value_parser = parse_range)]
-        many_seeds: Option<Range<u32>>,
         /// The cross-interpretation target.
         #[arg(long)]
         target: Option<String>,

--- a/src/tools/miri/miri-script/src/main.rs
+++ b/src/tools/miri/miri-script/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_question_mark)]
+#![allow(clippy::needless_question_mark, rustc::internal)]
 
 mod commands;
 mod coverage;
@@ -117,6 +117,10 @@ pub enum Command {
         /// When `true`, skip the `./miri install` step.
         #[arg(long)]
         no_install: bool,
+        /// Store the benchmark result in the given file, so it can be used
+        /// as the baseline for a future run.
+        #[arg(long)]
+        save_baseline: Option<String>,
         /// List of benchmarks to run (default: run all benchmarks).
         benches: Vec<String>,
     },

--- a/src/tools/miri/miri-script/src/util.rs
+++ b/src/tools/miri/miri-script/src/util.rs
@@ -1,9 +1,7 @@
 use std::ffi::{OsStr, OsString};
 use std::io::BufRead;
-use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::{env, iter, thread};
+use std::{env, iter};
 
 use anyhow::{Context, Result, anyhow, bail};
 use dunce::canonicalize;
@@ -29,7 +27,6 @@ pub fn flagsplit(flags: &str) -> Vec<String> {
 }
 
 /// Some extra state we track for building Miri, such as the right RUSTFLAGS.
-#[derive(Clone)]
 pub struct MiriEnv {
     /// miri_dir is the root of the miri repository checkout we are working in.
     pub miri_dir: PathBuf,
@@ -239,54 +236,5 @@ impl MiriEnv {
         }
 
         Ok(())
-    }
-
-    /// Run the given closure many times in parallel with access to the shell, once for each value in the `range`.
-    pub fn run_many_times(
-        &self,
-        range: Range<u32>,
-        run: impl Fn(&Self, u32) -> Result<()> + Sync,
-    ) -> Result<()> {
-        // `next` is atomic so threads can concurrently fetch their next value to run.
-        let next = AtomicU32::new(range.start);
-        let end = range.end; // exclusive!
-        let failed = AtomicBool::new(false);
-        thread::scope(|s| {
-            let mut handles = Vec::new();
-            // Spawn one worker per core.
-            for _ in 0..thread::available_parallelism()?.get() {
-                // Create a copy of the environment for this thread.
-                let local_miri = self.clone();
-                let handle = s.spawn(|| -> Result<()> {
-                    let local_miri = local_miri; // move the copy into this thread.
-                    // Each worker thread keeps asking for numbers until we're all done.
-                    loop {
-                        let cur = next.fetch_add(1, Ordering::Relaxed);
-                        if cur >= end {
-                            // We hit the upper limit and are done.
-                            break;
-                        }
-                        // Run the command with this seed.
-                        run(&local_miri, cur).inspect_err(|_| {
-                            // If we failed, tell everyone about this.
-                            failed.store(true, Ordering::Relaxed);
-                        })?;
-                        // Check if some other command failed (in which case we'll stop as well).
-                        if failed.load(Ordering::Relaxed) {
-                            return Ok(());
-                        }
-                    }
-                    Ok(())
-                });
-                handles.push(handle);
-            }
-            // Wait for all workers to be done.
-            for handle in handles {
-                handle.join().unwrap()?;
-            }
-            // If all workers succeeded, we can't have failed.
-            assert!(!failed.load(Ordering::Relaxed));
-            Ok(())
-        })
     }
 }

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -549,11 +549,6 @@ fn main() {
             miri_config.check_alignment = miri::AlignmentCheck::None;
         } else if arg == "-Zmiri-symbolic-alignment-check" {
             miri_config.check_alignment = miri::AlignmentCheck::Symbolic;
-        } else if arg == "-Zmiri-disable-abi-check" {
-            eprintln!(
-                "WARNING: the flag `-Zmiri-disable-abi-check` no longer has any effect; \
-                    ABI checks cannot be disabled any more"
-            );
         } else if arg == "-Zmiri-disable-isolation" {
             if matches!(isolation_enabled, Some(true)) {
                 show_error!(
@@ -623,10 +618,6 @@ fn main() {
             many_seeds = Some(0..64);
         } else if arg == "-Zmiri-many-seeds-keep-going" {
             many_seeds_keep_going = true;
-        } else if let Some(_param) = arg.strip_prefix("-Zmiri-env-exclude=") {
-            show_error!(
-                "`-Zmiri-env-exclude` has been removed; unset env vars before starting Miri instead"
-            );
         } else if let Some(param) = arg.strip_prefix("-Zmiri-env-forward=") {
             miri_config.forwarded_env_vars.push(param.to_owned());
         } else if let Some(param) = arg.strip_prefix("-Zmiri-env-set=") {

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -26,11 +26,17 @@ extern crate rustc_span;
 
 use std::env::{self, VarError};
 use std::num::NonZero;
+use std::ops::Range;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use miri::{BacktraceStyle, BorrowTrackerMethod, ProvenanceMode, RetagFields, ValidationMode};
+use miri::{
+    BacktraceStyle, BorrowTrackerMethod, MiriConfig, ProvenanceMode, RetagFields, ValidationMode,
+};
 use rustc_abi::ExternAbi;
+use rustc_data_structures::sync;
 use rustc_data_structures::sync::Lrc;
 use rustc_driver::Compilation;
 use rustc_hir::def_id::LOCAL_CRATE;
@@ -52,7 +58,64 @@ use rustc_span::def_id::DefId;
 use tracing::debug;
 
 struct MiriCompilerCalls {
-    miri_config: miri::MiriConfig,
+    miri_config: Option<MiriConfig>,
+    many_seeds: Option<Range<u32>>,
+}
+
+impl MiriCompilerCalls {
+    fn new(miri_config: MiriConfig, many_seeds: Option<Range<u32>>) -> Self {
+        Self { miri_config: Some(miri_config), many_seeds }
+    }
+}
+
+fn entry_fn(tcx: TyCtxt<'_>) -> (DefId, EntryFnType) {
+    if let Some(entry_def) = tcx.entry_fn(()) {
+        return entry_def;
+    }
+    // Look for a symbol in the local crate named `miri_start`, and treat that as the entry point.
+    let sym = tcx.exported_symbols(LOCAL_CRATE).iter().find_map(|(sym, _)| {
+        if sym.symbol_name_for_local_instance(tcx).name == "miri_start" { Some(sym) } else { None }
+    });
+    if let Some(ExportedSymbol::NonGeneric(id)) = sym {
+        let start_def_id = id.expect_local();
+        let start_span = tcx.def_span(start_def_id);
+
+        let expected_sig = ty::Binder::dummy(tcx.mk_fn_sig(
+            [tcx.types.isize, Ty::new_imm_ptr(tcx, Ty::new_imm_ptr(tcx, tcx.types.u8))],
+            tcx.types.isize,
+            false,
+            hir::Safety::Safe,
+            ExternAbi::Rust,
+        ));
+
+        let correct_func_sig = check_function_signature(
+            tcx,
+            ObligationCause::new(start_span, start_def_id, ObligationCauseCode::Misc),
+            *id,
+            expected_sig,
+        )
+        .is_ok();
+
+        if correct_func_sig {
+            (*id, EntryFnType::Start)
+        } else {
+            tcx.dcx().fatal(
+                "`miri_start` must have the following signature:\n\
+                        fn miri_start(argc: isize, argv: *const *const u8) -> isize",
+            );
+        }
+    } else {
+        tcx.dcx().fatal(
+            "Miri can only run programs that have a main function.\n\
+            Alternatively, you can export a `miri_start` function:\n\
+            \n\
+            #[cfg(miri)]\n\
+            #[no_mangle]\n\
+            fn miri_start(argc: isize, argv: *const *const u8) -> isize {\
+            \n    // Call the actual start function that your project implements, based on your target's conventions.\n\
+            }"
+        );
+    }
 }
 
 impl rustc_driver::Callbacks for MiriCompilerCalls {
@@ -87,7 +150,7 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
         }
 
         let (entry_def_id, entry_type) = entry_fn(tcx);
-        let mut config = self.miri_config.clone();
+        let mut config = self.miri_config.take().expect("after_analysis must only be called once");
 
         // Add filename to `miri` arguments.
         config.args.insert(0, tcx.sess.io.input.filestem().to_string());
@@ -111,12 +174,31 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
                     optimizations is usually marginal at best.");
         }
 
-        if let Some(return_code) = miri::eval_entry(tcx, entry_def_id, entry_type, config) {
-            std::process::exit(i32::try_from(return_code).expect("Return value was too large!"));
+        if let Some(many_seeds) = self.many_seeds.take() {
+            assert!(config.seed.is_none());
+            sync::par_for_each_in(many_seeds, |seed| {
+                let mut config = config.clone();
+                config.seed = Some(seed.into());
+                eprintln!("Trying seed: {seed}");
+                let return_code = miri::eval_entry(tcx, entry_def_id, entry_type, config)
+                    .unwrap_or(rustc_driver::EXIT_FAILURE);
+                if return_code != rustc_driver::EXIT_SUCCESS {
+                    eprintln!("FAILING SEED: {seed}");
+                    tcx.dcx().abort_if_errors(); // exits with a different error message
+                    std::process::exit(return_code);
+                }
+            });
+            std::process::exit(rustc_driver::EXIT_SUCCESS);
+        } else {
+            let return_code = miri::eval_entry(tcx, entry_def_id, entry_type, config)
+                .unwrap_or_else(|| {
+                    tcx.dcx().abort_if_errors();
+                    rustc_driver::EXIT_FAILURE
+                });
+            std::process::exit(return_code);
         }
-        tcx.dcx().abort_if_errors();
 
-        Compilation::Stop
+        // Unreachable.
     }
 }
 
@@ -241,21 +323,28 @@ fn rustc_logger_config() -> rustc_log::LoggerConfig {
     cfg
 }
 
+/// The global logger can only be set once per process, so track
+/// whether that already happened.
+static LOGGER_INITED: AtomicBool = AtomicBool::new(false);
+
 fn init_early_loggers(early_dcx: &EarlyDiagCtxt) {
     // Now for rustc. We only initialize `rustc` if the env var is set (so the user asked for it).
     // If it is not set, we avoid initializing now so that we can initialize later with our custom
     // settings, and *not* log anything for what happens before `miri` gets started.
     if env::var_os("RUSTC_LOG").is_some() {
         rustc_driver::init_logger(early_dcx, rustc_logger_config());
+        assert!(!LOGGER_INITED.swap(true, Ordering::AcqRel));
     }
 }
 
 fn init_late_loggers(early_dcx: &EarlyDiagCtxt, tcx: TyCtxt<'_>) {
-    // If `RUSTC_LOG` is not set, then `init_early_loggers` did not call
-    // `rustc_driver::init_logger`, so we have to do this now.
-    if env::var_os("RUSTC_LOG").is_none() {
+    // If the logger is not yet initialized, initialize it.
+    if !LOGGER_INITED.swap(true, Ordering::AcqRel) {
         rustc_driver::init_logger(early_dcx, rustc_logger_config());
     }
+    // There's a little race condition here in many-seeds mode, where we don't wait for the thread
+    // that is doing the initializing. But if you want to debug things with extended logging you
+    // probably won't use many-seeds mode anyway.
 
     // If `MIRI_BACKTRACE` is set and `RUSTC_CTFE_BACKTRACE` is not, set `RUSTC_CTFE_BACKTRACE`.
     // Do this late, so we ideally only apply this to Miri's errors.
@@ -270,25 +359,14 @@ fn init_late_loggers(early_dcx: &EarlyDiagCtxt, tcx: TyCtxt<'_>) {
 }
 
 /// Execute a compiler with the given CLI arguments and callbacks.
-fn run_compiler(
-    mut args: Vec<String>,
-    target_crate: bool,
+fn run_compiler_and_exit(
+    args: &[String],
     callbacks: &mut (dyn rustc_driver::Callbacks + Send),
-    using_internal_features: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    using_internal_features: Arc<std::sync::atomic::AtomicBool>,
 ) -> ! {
-    // Don't insert `MIRI_DEFAULT_ARGS`, in particular, `--cfg=miri`, if we are building
-    // a "host" crate. That may cause procedural macros (and probably build scripts) to
-    // depend on Miri-only symbols, such as `miri_resolve_frame`:
-    // https://github.com/rust-lang/miri/issues/1760
-    if target_crate {
-        // Some options have different defaults in Miri than in plain rustc; apply those by making
-        // them the first arguments after the binary name (but later arguments can overwrite them).
-        args.splice(1..1, miri::MIRI_DEFAULT_ARGS.iter().map(ToString::to_string));
-    }
-
     // Invoke compiler, and handle return code.
     let exit_code = rustc_driver::catch_with_exit_code(move || {
-        rustc_driver::RunCompiler::new(&args, callbacks)
+        rustc_driver::RunCompiler::new(args, callbacks)
             .set_using_internal_features(using_internal_features)
             .run();
         Ok(())
@@ -309,6 +387,18 @@ fn parse_rate(input: &str) -> Result<f64, &'static str> {
         Ok(_) => Err("must be between `0.0` and `1.0`"),
         Err(_) => Err("requires a `f64` between `0.0` and `1.0`"),
     }
+}
+
+/// Parses a seed range
+///
+/// This function is used for the `-Zmiri-many-seeds` flag. It expects the range in the form
+/// `<from>..<to>`. `<from>` is inclusive, `<to>` is exclusive. `<from>` can be omitted,
+/// in which case it is assumed to be `0`.
+fn parse_range(val: &str) -> Result<Range<u32>, &'static str> {
+    let (from, to) = val.split_once("..").ok_or("expected `from..to`")?;
+    let from: u32 = if from.is_empty() { 0 } else { from.parse().map_err(|_| "invalid `from`")? };
+    let to: u32 = to.parse().map_err(|_| "invalid `to`")?;
+    Ok(from..to)
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -349,56 +439,6 @@ fn jemalloc_magic() {
     }
 }
 
-fn entry_fn(tcx: TyCtxt<'_>) -> (DefId, EntryFnType) {
-    if let Some(entry_def) = tcx.entry_fn(()) {
-        return entry_def;
-    }
-    // Look for a symbol in the local crate named `miri_start`, and treat that as the entry point.
-    let sym = tcx.exported_symbols(LOCAL_CRATE).iter().find_map(|(sym, _)| {
-        if sym.symbol_name_for_local_instance(tcx).name == "miri_start" { Some(sym) } else { None }
-    });
-    if let Some(ExportedSymbol::NonGeneric(id)) = sym {
-        let start_def_id = id.expect_local();
-        let start_span = tcx.def_span(start_def_id);
-
-        let expected_sig = ty::Binder::dummy(tcx.mk_fn_sig(
-            [tcx.types.isize, Ty::new_imm_ptr(tcx, Ty::new_imm_ptr(tcx, tcx.types.u8))],
-            tcx.types.isize,
-            false,
-            hir::Safety::Safe,
-            ExternAbi::Rust,
-        ));
-
-        let correct_func_sig = check_function_signature(
-            tcx,
-            ObligationCause::new(start_span, start_def_id, ObligationCauseCode::Misc),
-            *id,
-            expected_sig,
-        )
-        .is_ok();
-
-        if correct_func_sig {
-            (*id, EntryFnType::Start)
-        } else {
-            tcx.dcx().fatal(
-                "`miri_start` must have the following signature:\n\
-                        fn miri_start(argc: isize, argv: *const *const u8) -> isize",
-            );
-        }
-    } else {
-        tcx.dcx().fatal(
-            "Miri can only run programs that have a main function.\n\
-            Alternatively, you can export a `miri_start` function:\n\
-            \n\
-            #[cfg(miri)]\n\
-            #[no_mangle]\n\
-            fn miri_start(argc: isize, argv: *const *const u8) -> isize {\
-            \n    // Call the actual start function that your project implements, based on your target's conventions.\n\
-            }"
-        );
-    }
-}
-
 fn main() {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     jemalloc_magic();
@@ -431,10 +471,21 @@ fn main() {
             panic!("invalid `MIRI_BE_RUSTC` value: {crate_kind:?}")
         };
 
-        // We cannot use `rustc_driver::main` as we need to adjust the CLI arguments.
-        run_compiler(
-            args,
-            target_crate,
+        let mut args = args;
+        // Don't insert `MIRI_DEFAULT_ARGS`, in particular, `--cfg=miri`, if we are building
+        // a "host" crate. That may cause procedural macros (and probably build scripts) to
+        // depend on Miri-only symbols, such as `miri_resolve_frame`:
+        // https://github.com/rust-lang/miri/issues/1760
+        if target_crate {
+            // Splice in the default arguments after the program name.
+            // Some options have different defaults in Miri than in plain rustc; apply those by making
+            // them the first arguments after the binary name (but later arguments can overwrite them).
+            args.splice(1..1, miri::MIRI_DEFAULT_ARGS.iter().map(ToString::to_string));
+        }
+
+        // We cannot use `rustc_driver::main` as we want it to use `args` as the CLI arguments.
+        run_compiler_and_exit(
+            &args,
             &mut MiriBeRustCompilerCalls { target_crate },
             using_internal_features,
         )
@@ -448,7 +499,8 @@ fn main() {
     init_early_loggers(&early_dcx);
 
     // Parse our arguments and split them across `rustc` and `miri`.
-    let mut miri_config = miri::MiriConfig::default();
+    let mut many_seeds: Option<Range<u32>> = None;
+    let mut miri_config = MiriConfig::default();
     miri_config.env = env_snapshot;
 
     let mut rustc_args = vec![];
@@ -463,6 +515,8 @@ fn main() {
         if rustc_args.is_empty() {
             // Very first arg: binary name.
             rustc_args.push(arg);
+            // Also add the default arguments.
+            rustc_args.extend(miri::MIRI_DEFAULT_ARGS.iter().map(ToString::to_string));
         } else if after_dashdash {
             // Everything that comes after `--` is forwarded to the interpreted crate.
             miri_config.args.push(arg);
@@ -544,13 +598,19 @@ fn main() {
                 _ => show_error!("`-Zmiri-retag-fields` can only be `all`, `none`, or `scalar`"),
             };
         } else if let Some(param) = arg.strip_prefix("-Zmiri-seed=") {
-            if miri_config.seed.is_some() {
-                show_error!("Cannot specify -Zmiri-seed multiple times!");
-            }
             let seed = param.parse::<u64>().unwrap_or_else(|_| {
                 show_error!("-Zmiri-seed must be an integer that fits into u64")
             });
             miri_config.seed = Some(seed);
+        } else if let Some(param) = arg.strip_prefix("-Zmiri-many-seeds=") {
+            let range = parse_range(param).unwrap_or_else(|err| {
+                show_error!(
+                    "-Zmiri-many-seeds requires a range in the form `from..to` or `..to`: {err}"
+                )
+            });
+            many_seeds = Some(range);
+        } else if arg == "-Zmiri-many-seeds" {
+            many_seeds = Some(0..64);
         } else if let Some(_param) = arg.strip_prefix("-Zmiri-env-exclude=") {
             show_error!(
                 "`-Zmiri-env-exclude` has been removed; unset env vars before starting Miri instead"
@@ -665,13 +725,23 @@ fn main() {
             "Tree Borrows does not support integer-to-pointer casts, and is hence not compatible with permissive provenance"
         );
     }
+    // You can set either one seed or many.
+    if many_seeds.is_some() && miri_config.seed.is_some() {
+        show_error!("Only one of `-Zmiri-seed` and `-Zmiri-many-seeds can be set");
+    }
+    if many_seeds.is_some() && !rustc_args.iter().any(|arg| arg.starts_with("-Zthreads=")) {
+        // Ensure we have parallelism for many-seeds mode.
+        rustc_args.push(format!(
+            "-Zthreads={}",
+            std::thread::available_parallelism().map_or(1, |n| n.get())
+        ));
+    }
 
     debug!("rustc arguments: {:?}", rustc_args);
     debug!("crate arguments: {:?}", miri_config.args);
-    run_compiler(
-        rustc_args,
-        /* target_crate: */ true,
-        &mut MiriCompilerCalls { miri_config },
+    run_compiler_and_exit(
+        &rustc_args,
+        &mut MiriCompilerCalls::new(miri_config, many_seeds),
         using_internal_features,
     )
 }

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -514,8 +514,6 @@ fn main() {
 
     let mut rustc_args = vec![];
     let mut after_dashdash = false;
-    // If user has explicitly enabled/disabled isolation
-    let mut isolation_enabled: Option<bool> = None;
 
     // Note that we require values to be given with `=`, not with a space.
     // This matches how rustc parses `-Z`.
@@ -550,13 +548,6 @@ fn main() {
         } else if arg == "-Zmiri-symbolic-alignment-check" {
             miri_config.check_alignment = miri::AlignmentCheck::Symbolic;
         } else if arg == "-Zmiri-disable-isolation" {
-            if matches!(isolation_enabled, Some(true)) {
-                show_error!(
-                    "-Zmiri-disable-isolation cannot be used along with -Zmiri-isolation-error"
-                );
-            } else {
-                isolation_enabled = Some(false);
-            }
             miri_config.isolated_op = miri::IsolatedOp::Allow;
         } else if arg == "-Zmiri-disable-leak-backtraces" {
             miri_config.collect_leak_backtraces = false;
@@ -565,14 +556,6 @@ fn main() {
         } else if arg == "-Zmiri-track-weak-memory-loads" {
             miri_config.track_outdated_loads = true;
         } else if let Some(param) = arg.strip_prefix("-Zmiri-isolation-error=") {
-            if matches!(isolation_enabled, Some(false)) {
-                show_error!(
-                    "-Zmiri-isolation-error cannot be used along with -Zmiri-disable-isolation"
-                );
-            } else {
-                isolation_enabled = Some(true);
-            }
-
             miri_config.isolated_op = match param {
                 "abort" => miri::IsolatedOp::Reject(miri::RejectOpWith::Abort),
                 "hide" => miri::IsolatedOp::Reject(miri::RejectOpWith::NoWarning),

--- a/src/tools/miri/src/diagnostics.rs
+++ b/src/tools/miri/src/diagnostics.rs
@@ -12,7 +12,7 @@ use crate::*;
 /// Details of premature program termination.
 pub enum TerminationInfo {
     Exit {
-        code: i64,
+        code: i32,
         leak_check: bool,
     },
     Abort(String),
@@ -214,7 +214,7 @@ pub fn prune_stacktrace<'tcx>(
 pub fn report_error<'tcx>(
     ecx: &InterpCx<'tcx, MiriMachine<'tcx>>,
     e: InterpErrorInfo<'tcx>,
-) -> Option<(i64, bool)> {
+) -> Option<(i32, bool)> {
     use InterpErrorKind::*;
     use UndefinedBehaviorInfo::*;
 

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -1,6 +1,4 @@
-use std::collections::BTreeSet;
 use std::num::NonZero;
-use std::sync::Mutex;
 use std::time::Duration;
 use std::{cmp, iter};
 
@@ -641,11 +639,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         match reject_with {
             RejectOpWith::Abort => isolation_abort_error(op_name),
             RejectOpWith::WarningWithoutBacktrace => {
-                // This exists to reduce verbosity; make sure we emit the warning at most once per
-                // operation.
-                static EMITTED_WARNINGS: Mutex<BTreeSet<String>> = Mutex::new(BTreeSet::new());
-
-                let mut emitted_warnings = EMITTED_WARNINGS.lock().unwrap();
+                let mut emitted_warnings = this.machine.reject_in_isolation_warned.borrow_mut();
                 if !emitted_warnings.contains(op_name) {
                     // First time we are seeing this.
                     emitted_warnings.insert(op_name.to_owned());
@@ -653,6 +647,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         .dcx()
                         .warn(format!("{op_name} was made to return an error due to isolation"));
                 }
+
                 interp_ok(())
             }
             RejectOpWith::Warning => {

--- a/src/tools/miri/src/helpers.rs
+++ b/src/tools/miri/src/helpers.rs
@@ -332,19 +332,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         base: &P,
         name: &str,
     ) -> InterpResult<'tcx, P> {
-        if let Some(field) = self.try_project_field_named(base, name)? {
-            return interp_ok(field);
-        }
-        bug!("No field named {} in type {}", name, base.layout().ty);
-    }
-
-    /// Search if `base` (which must be a struct or union type) contains the `name` field.
-    fn projectable_has_field<P: Projectable<'tcx, Provenance>>(
-        &self,
-        base: &P,
-        name: &str,
-    ) -> bool {
-        self.try_project_field_named(base, name).unwrap().is_some()
+        interp_ok(
+            self.try_project_field_named(base, name)?
+                .unwrap_or_else(|| bug!("no field named {} in type {}", name, base.layout().ty)),
+        )
     }
 
     /// Write an int of the appropriate size to `dest`. The target type may be signed or unsigned,

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -428,7 +428,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "exit" => {
                 let [code] = this.check_shim(abi, Conv::C, link_name, args)?;
                 let code = this.read_scalar(code)?.to_i32()?;
-                throw_machine_stop!(TerminationInfo::Exit { code: code.into(), leak_check: false });
+                throw_machine_stop!(TerminationInfo::Exit { code, leak_check: false });
             }
             "abort" => {
                 let [] = this.check_shim(abi, Conv::C, link_name, args)?;

--- a/src/tools/miri/src/shims/native_lib.rs
+++ b/src/tools/miri/src/shims/native_lib.rs
@@ -173,7 +173,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     // Wildcard pointer, whatever it points to must be already exposed.
                     continue;
                 };
-                // The first time this happens at a particular location, print a warning.
+                // The first time this happens, print a warning.
                 thread_local! {
                     static HAVE_WARNED: RefCell<bool> = const { RefCell::new(false) };
                 }

--- a/src/tools/miri/src/shims/native_lib.rs
+++ b/src/tools/miri/src/shims/native_lib.rs
@@ -1,5 +1,4 @@
 //! Implements calling functions from a native library.
-use std::cell::RefCell;
 use std::ops::Deref;
 
 use libffi::high::call as ffi;
@@ -174,16 +173,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     continue;
                 };
                 // The first time this happens, print a warning.
-                thread_local! {
-                    static HAVE_WARNED: RefCell<bool> = const { RefCell::new(false) };
+                if !this.machine.native_call_mem_warned.replace(true) {
+                    // Newly set, so first time we get here.
+                    this.emit_diagnostic(NonHaltingDiagnostic::NativeCallSharedMem);
                 }
-                HAVE_WARNED.with_borrow_mut(|have_warned| {
-                    if !*have_warned {
-                        // Newly inserted, so first time we see this span.
-                        this.emit_diagnostic(NonHaltingDiagnostic::NativeCallSharedMem);
-                        *have_warned = true;
-                    }
-                });
 
                 this.prepare_for_native_call(alloc_id, prov)?;
             }

--- a/src/tools/miri/src/shims/windows/foreign_items.rs
+++ b/src/tools/miri/src/shims/windows/foreign_items.rs
@@ -552,8 +552,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Miscellaneous
             "ExitProcess" => {
                 let [code] = this.check_shim(abi, sys_conv, link_name, args)?;
-                let code = this.read_scalar(code)?.to_u32()?;
-                throw_machine_stop!(TerminationInfo::Exit { code: code.into(), leak_check: false });
+                // Windows technically uses u32, but we unify everything to a Unix-style i32.
+                let code = this.read_scalar(code)?.to_i32()?;
+                throw_machine_stop!(TerminationInfo::Exit { code, leak_check: false });
             }
             "SystemFunction036" => {
                 // used by getrandom 0.1

--- a/src/tools/miri/tests/pass/0weak_memory_consistency.rs
+++ b/src/tools/miri/tests/pass/0weak_memory_consistency.rs
@@ -40,7 +40,7 @@ fn static_atomic_bool(val: bool) -> &'static AtomicBool {
     Box::leak(Box::new(AtomicBool::new(val)))
 }
 
-// Spins until it acquires a pre-determined value.
+/// Spins until it acquires a pre-determined value.
 fn loads_value(loc: &AtomicI32, ord: Ordering, val: i32) -> i32 {
     while loc.load(ord) != val {
         std::hint::spin_loop();
@@ -186,31 +186,6 @@ fn test_mixed_access() {
     assert_eq!(r2, 2);
 }
 
-// The following two tests are taken from Repairing Sequential Consistency in C/C++11
-// by Lahav et al.
-// https://plv.mpi-sws.org/scfix/paper.pdf
-
-// Test case SB
-fn test_sc_store_buffering() {
-    let x = static_atomic(0);
-    let y = static_atomic(0);
-
-    let j1 = spawn(move || {
-        x.store(1, SeqCst);
-        y.load(SeqCst)
-    });
-
-    let j2 = spawn(move || {
-        y.store(1, SeqCst);
-        x.load(SeqCst)
-    });
-
-    let a = j1.join().unwrap();
-    let b = j2.join().unwrap();
-
-    assert_ne!((a, b), (0, 0));
-}
-
 fn test_single_thread() {
     let x = AtomicI32::new(42);
 
@@ -257,178 +232,6 @@ fn test_sync_through_rmw_and_fences() {
     assert_ne!((a, b), (0, 0));
 }
 
-// Test case by @SabrinaJewson
-// https://github.com/rust-lang/miri/issues/2301#issuecomment-1221502757
-// Demonstrating C++20 SC access changes
-fn test_iriw_sc_rlx() {
-    let x = static_atomic_bool(false);
-    let y = static_atomic_bool(false);
-
-    let a = spawn(move || x.store(true, Relaxed));
-    let b = spawn(move || y.store(true, Relaxed));
-    let c = spawn(move || {
-        while !x.load(SeqCst) {}
-        y.load(SeqCst)
-    });
-    let d = spawn(move || {
-        while !y.load(SeqCst) {}
-        x.load(SeqCst)
-    });
-
-    a.join().unwrap();
-    b.join().unwrap();
-    let c = c.join().unwrap();
-    let d = d.join().unwrap();
-
-    assert!(c || d);
-}
-
-// Similar to `test_iriw_sc_rlx` but with fences instead of SC accesses.
-fn test_cpp20_sc_fence_fix() {
-    let x = static_atomic_bool(false);
-    let y = static_atomic_bool(false);
-
-    let thread1 = spawn(|| {
-        let a = x.load(Relaxed);
-        fence(SeqCst);
-        let b = y.load(Relaxed);
-        (a, b)
-    });
-
-    let thread2 = spawn(|| {
-        x.store(true, Relaxed);
-    });
-    let thread3 = spawn(|| {
-        y.store(true, Relaxed);
-    });
-
-    let thread4 = spawn(|| {
-        let c = y.load(Relaxed);
-        fence(SeqCst);
-        let d = x.load(Relaxed);
-        (c, d)
-    });
-
-    let (a, b) = thread1.join().unwrap();
-    thread2.join().unwrap();
-    thread3.join().unwrap();
-    let (c, d) = thread4.join().unwrap();
-    let bad = a == true && b == false && c == true && d == false;
-    assert!(!bad);
-}
-
-// https://plv.mpi-sws.org/scfix/paper.pdf
-// 2.2 Second Problem: SC Fences are Too Weak
-fn test_cpp20_rwc_syncs() {
-    /*
-    int main() {
-        atomic_int x = 0;
-        atomic_int y = 0;
-        {{{ x.store(1,mo_relaxed);
-        ||| { r1=x.load(mo_relaxed).readsvalue(1);
-              fence(mo_seq_cst);
-              r2=y.load(mo_relaxed); }
-        ||| { y.store(1,mo_relaxed);
-              fence(mo_seq_cst);
-              r3=x.load(mo_relaxed); }
-        }}}
-        return 0;
-    }
-    */
-    let x = static_atomic(0);
-    let y = static_atomic(0);
-
-    let j1 = spawn(move || {
-        x.store(1, Relaxed);
-    });
-
-    let j2 = spawn(move || {
-        loads_value(&x, Relaxed, 1);
-        fence(SeqCst);
-        y.load(Relaxed)
-    });
-
-    let j3 = spawn(move || {
-        y.store(1, Relaxed);
-        fence(SeqCst);
-        x.load(Relaxed)
-    });
-
-    j1.join().unwrap();
-    let b = j2.join().unwrap();
-    let c = j3.join().unwrap();
-
-    assert!((b, c) != (0, 0));
-}
-
-/// This checks that the *last* thing the SC fence does is act like a release fence.
-/// See <https://github.com/rust-lang/miri/pull/4057#issuecomment-2522296601>.
-fn test_sc_fence_release() {
-    let x = static_atomic(0);
-    let y = static_atomic(0);
-    let z = static_atomic(0);
-    let k = static_atomic(0);
-
-    let j1 = spawn(move || {
-        x.store(1, Relaxed);
-        fence(SeqCst);
-        k.store(1, Relaxed);
-    });
-    let j2 = spawn(move || {
-        y.store(1, Relaxed);
-        fence(SeqCst);
-        z.store(1, Relaxed);
-    });
-
-    let j3 = spawn(move || {
-        let kval = k.load(Acquire);
-        let yval = y.load(Relaxed);
-        (kval, yval)
-    });
-    let j4 = spawn(move || {
-        let zval = z.load(Acquire);
-        let xval = x.load(Relaxed);
-        (zval, xval)
-    });
-
-    j1.join().unwrap();
-    j2.join().unwrap();
-    let (kval, yval) = j3.join().unwrap();
-    let (zval, xval) = j4.join().unwrap();
-
-    let bad = kval == 1 && yval == 0 && zval == 1 && xval == 0;
-    assert!(!bad);
-}
-
-/// Test that SC fences and accesses sync correctly with each other.
-fn test_sc_fence_access() {
-    /*
-        Wx1 sc
-        Ry0 sc
-        ||
-        Wy1 rlx
-        SC-fence
-        Rx0 rlx
-    */
-    let x = static_atomic(0);
-    let y = static_atomic(0);
-
-    let j1 = spawn(move || {
-        x.store(1, SeqCst);
-        y.load(SeqCst)
-    });
-    let j2 = spawn(move || {
-        y.store(1, Relaxed);
-        fence(SeqCst);
-        x.load(Relaxed)
-    });
-
-    let v1 = j1.join().unwrap();
-    let v2 = j2.join().unwrap();
-    let bad = v1 == 0 && v2 == 0;
-    assert!(!bad);
-}
-
 pub fn main() {
     for _ in 0..50 {
         test_single_thread();
@@ -437,12 +240,6 @@ pub fn main() {
         test_message_passing();
         test_wrc();
         test_corr();
-        test_sc_store_buffering();
         test_sync_through_rmw_and_fences();
-        test_iriw_sc_rlx();
-        test_cpp20_sc_fence_fix();
-        test_cpp20_rwc_syncs();
-        test_sc_fence_release();
-        test_sc_fence_access();
     }
 }

--- a/src/tools/miri/tests/pass/0weak_memory_consistency_sc.rs
+++ b/src/tools/miri/tests/pass/0weak_memory_consistency_sc.rs
@@ -1,0 +1,354 @@
+//@compile-flags: -Zmiri-ignore-leaks -Zmiri-disable-stacked-borrows -Zmiri-disable-validation -Zmiri-provenance-gc=10000
+// This test's runtime explodes if the GC interval is set to 1 (which we do in CI), so we
+// override it internally back to the default frequency.
+
+// The following tests check whether our weak memory emulation produces
+// any inconsistent execution outcomes
+// This file here focuses on SC accesses and fences.
+
+use std::sync::atomic::Ordering::*;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering, fence};
+use std::thread::spawn;
+
+// We can't create static items because we need to run each test
+// multiple times
+fn static_atomic(val: i32) -> &'static AtomicI32 {
+    Box::leak(Box::new(AtomicI32::new(val)))
+}
+fn static_atomic_bool(val: bool) -> &'static AtomicBool {
+    Box::leak(Box::new(AtomicBool::new(val)))
+}
+
+/// Spins until it acquires a pre-determined value.
+fn loads_value(loc: &AtomicI32, ord: Ordering, val: i32) -> i32 {
+    while loc.load(ord) != val {
+        std::hint::spin_loop();
+    }
+    val
+}
+
+// Test case SB taken from Repairing Sequential Consistency in C/C++11
+// by Lahav et al.
+// https://plv.mpi-sws.org/scfix/paper.pdf
+fn test_sc_store_buffering() {
+    let x = static_atomic(0);
+    let y = static_atomic(0);
+
+    let j1 = spawn(move || {
+        x.store(1, SeqCst);
+        y.load(SeqCst)
+    });
+
+    let j2 = spawn(move || {
+        y.store(1, SeqCst);
+        x.load(SeqCst)
+    });
+
+    let a = j1.join().unwrap();
+    let b = j2.join().unwrap();
+
+    assert_ne!((a, b), (0, 0));
+}
+
+// Test case by @SabrinaJewson
+// https://github.com/rust-lang/miri/issues/2301#issuecomment-1221502757
+// Demonstrating C++20 SC access changes
+fn test_iriw_sc_rlx() {
+    let x = static_atomic_bool(false);
+    let y = static_atomic_bool(false);
+
+    let a = spawn(move || x.store(true, Relaxed));
+    let b = spawn(move || y.store(true, Relaxed));
+    let c = spawn(move || {
+        while !x.load(SeqCst) {}
+        y.load(SeqCst)
+    });
+    let d = spawn(move || {
+        while !y.load(SeqCst) {}
+        x.load(SeqCst)
+    });
+
+    a.join().unwrap();
+    b.join().unwrap();
+    let c = c.join().unwrap();
+    let d = d.join().unwrap();
+
+    assert!(c || d);
+}
+
+// Similar to `test_iriw_sc_rlx` but with fences instead of SC accesses.
+fn test_cpp20_sc_fence_fix() {
+    let x = static_atomic_bool(false);
+    let y = static_atomic_bool(false);
+
+    let thread1 = spawn(|| {
+        let a = x.load(Relaxed);
+        fence(SeqCst);
+        let b = y.load(Relaxed);
+        (a, b)
+    });
+
+    let thread2 = spawn(|| {
+        x.store(true, Relaxed);
+    });
+    let thread3 = spawn(|| {
+        y.store(true, Relaxed);
+    });
+
+    let thread4 = spawn(|| {
+        let c = y.load(Relaxed);
+        fence(SeqCst);
+        let d = x.load(Relaxed);
+        (c, d)
+    });
+
+    let (a, b) = thread1.join().unwrap();
+    thread2.join().unwrap();
+    thread3.join().unwrap();
+    let (c, d) = thread4.join().unwrap();
+    let bad = a == true && b == false && c == true && d == false;
+    assert!(!bad);
+}
+
+// https://plv.mpi-sws.org/scfix/paper.pdf
+// 2.2 Second Problem: SC Fences are Too Weak
+fn test_cpp20_rwc_syncs() {
+    /*
+    int main() {
+        atomic_int x = 0;
+        atomic_int y = 0;
+        {{{ x.store(1,mo_relaxed);
+        ||| { r1=x.load(mo_relaxed).readsvalue(1);
+              fence(mo_seq_cst);
+              r2=y.load(mo_relaxed); }
+        ||| { y.store(1,mo_relaxed);
+              fence(mo_seq_cst);
+              r3=x.load(mo_relaxed); }
+        }}}
+        return 0;
+    }
+    */
+    let x = static_atomic(0);
+    let y = static_atomic(0);
+
+    let j1 = spawn(move || {
+        x.store(1, Relaxed);
+    });
+
+    let j2 = spawn(move || {
+        loads_value(&x, Relaxed, 1);
+        fence(SeqCst);
+        y.load(Relaxed)
+    });
+
+    let j3 = spawn(move || {
+        y.store(1, Relaxed);
+        fence(SeqCst);
+        x.load(Relaxed)
+    });
+
+    j1.join().unwrap();
+    let b = j2.join().unwrap();
+    let c = j3.join().unwrap();
+
+    assert!((b, c) != (0, 0));
+}
+
+/// This checks that the *last* thing the SC fence does is act like a release fence.
+/// See <https://github.com/rust-lang/miri/pull/4057#issuecomment-2522296601>.
+/// Test by Ori Lahav.
+fn test_sc_fence_release() {
+    let x = static_atomic(0);
+    let y = static_atomic(0);
+    let z = static_atomic(0);
+    let k = static_atomic(0);
+
+    let j1 = spawn(move || {
+        x.store(1, Relaxed);
+        fence(SeqCst);
+        k.store(1, Relaxed);
+    });
+    let j2 = spawn(move || {
+        y.store(1, Relaxed);
+        fence(SeqCst);
+        z.store(1, Relaxed);
+    });
+
+    let j3 = spawn(move || {
+        let kval = k.load(Acquire); // bad case: loads 1
+        let yval = y.load(Relaxed); // bad case: loads 0
+        (kval, yval)
+    });
+    let j4 = spawn(move || {
+        let zval = z.load(Acquire); // bad case: loads 1
+        let xval = x.load(Relaxed); // bad case: loads 0
+        (zval, xval)
+    });
+
+    j1.join().unwrap();
+    j2.join().unwrap();
+    let (kval, yval) = j3.join().unwrap();
+    let (zval, xval) = j4.join().unwrap();
+
+    let bad = kval == 1 && yval == 0 && zval == 1 && xval == 0;
+    assert!(!bad);
+}
+
+/// Test that SC fences and accesses sync correctly with each other.
+/// Test by Ori Lahav.
+fn test_sc_fence_access() {
+    /*
+        Wx1 sc
+        Ry0 sc
+        ||
+        Wy1 rlx
+        SC-fence
+        Rx0 rlx
+    */
+    let x = static_atomic(0);
+    let y = static_atomic(0);
+
+    let j1 = spawn(move || {
+        x.store(1, SeqCst);
+        y.load(SeqCst)
+    });
+    let j2 = spawn(move || {
+        y.store(1, Relaxed);
+        fence(SeqCst);
+        // If this sees a 0, the fence must have been *before* the x.store(1).
+        x.load(Relaxed)
+    });
+
+    let yval = j1.join().unwrap();
+    let xval = j2.join().unwrap();
+    let bad = yval == 0 && xval == 0;
+    assert!(!bad);
+}
+
+/// Test that SC fences and accesses sync correctly with each other
+/// when mediated by a release-acquire pair.
+/// Test by Ori Lahav (https://github.com/rust-lang/miri/pull/4057#issuecomment-2525268730).
+fn test_sc_fence_access_relacq() {
+    let x = static_atomic(0);
+    let y = static_atomic(0);
+    let z = static_atomic(0);
+
+    let j1 = spawn(move || {
+        x.store(1, SeqCst);
+        y.load(SeqCst) // bad case: loads 0
+    });
+    let j2 = spawn(move || {
+        y.store(1, Relaxed);
+        z.store(1, Release)
+    });
+    let j3 = spawn(move || {
+        let zval = z.load(Acquire); // bad case: loads 1
+        // If we see 1 here, the rel-acq pair makes the fence happen after the z.store(1).
+        fence(SeqCst);
+        // If this sees a 0, the fence must have been *before* the x.store(1).
+        let xval = x.load(Relaxed); // bad case: loads 0
+        (zval, xval)
+    });
+
+    let yval = j1.join().unwrap();
+    j2.join().unwrap();
+    let (zval, xval) = j3.join().unwrap();
+    let bad = yval == 0 && zval == 1 && xval == 0;
+    assert!(!bad);
+}
+
+/// A test that involves multiple SC fences and accesses.
+/// Test by Ori Lahav (https://github.com/rust-lang/miri/pull/4057#issuecomment-2525268730).
+fn test_sc_multi_fence() {
+    let x = static_atomic(0);
+    let y = static_atomic(0);
+    let z = static_atomic(0);
+
+    let j1 = spawn(move || {
+        x.store(1, SeqCst);
+        y.load(SeqCst) // bad case: loads 0
+    });
+    let j2 = spawn(move || {
+        y.store(1, Relaxed);
+        // In the bad case this fence is *after* the j1 y.load, since
+        // otherwise that load would pick up the 1 we just stored.
+        fence(SeqCst);
+        z.load(Relaxed) // bad case: loads 0
+    });
+    let j3 = spawn(move || {
+        z.store(1, Relaxed);
+    });
+    let j4 = spawn(move || {
+        let zval = z.load(Relaxed); // bad case: loads 1
+        // In the bad case this fence is *after* the one above since
+        // otherwise, the j2 load of z would load 1.
+        fence(SeqCst);
+        // Since that fence is in turn after the j1 y.load, our fence is
+        // after the j1 x.store, which means we must pick up that store.
+        let xval = x.load(Relaxed); // bad case: loads 0
+        (zval, xval)
+    });
+
+    let yval = j1.join().unwrap();
+    let zval1 = j2.join().unwrap();
+    j3.join().unwrap();
+    let (zval2, xval) = j4.join().unwrap();
+    let bad = yval == 0 && zval1 == 0 && zval2 == 1 && xval == 0;
+    assert!(!bad);
+}
+
+fn test_sc_relaxed() {
+    /*
+    y:=1 rlx
+    Fence sc
+    a:=x rlx
+    Fence acq
+    b:=z rlx // 0
+    ||
+    z:=1 rlx
+    x:=1 sc
+    c:=y sc // 0
+    */
+
+    let x = static_atomic(0);
+    let y = static_atomic(0);
+    let z = static_atomic(0);
+
+    let j1 = spawn(move || {
+        y.store(1, Relaxed);
+        fence(SeqCst);
+        // If the relaxed load here is removed, then the "bad" behavior becomes allowed
+        // by C++20 (and by RC11 / scfix as well).
+        let _a = x.load(Relaxed);
+        fence(Acquire);
+        // If we see 0 here this means in some sense we are "before" the store to z below.
+        let b = z.load(Relaxed);
+        b
+    });
+    let j2 = spawn(move || {
+        z.store(1, Relaxed);
+        x.store(1, SeqCst);
+        // If we see 0 here, this means in some sense we are "before" the store to y above.
+        let c = y.load(SeqCst);
+        c
+    });
+
+    let b = j1.join().unwrap();
+    let c = j2.join().unwrap();
+    let bad = b == 0 && c == 0;
+    assert!(!bad);
+}
+
+pub fn main() {
+    for _ in 0..50 {
+        test_sc_store_buffering();
+        test_iriw_sc_rlx();
+        test_cpp20_sc_fence_fix();
+        test_cpp20_rwc_syncs();
+        test_sc_fence_release();
+        test_sc_fence_access();
+        test_sc_fence_access_relacq();
+        test_sc_multi_fence();
+        test_sc_relaxed();
+    }
+}

--- a/src/tools/miri/tests/pass/ptr_int_casts.rs
+++ b/src/tools/miri/tests/pass/ptr_int_casts.rs
@@ -1,7 +1,4 @@
-//@revisions: stack tree
-// Tree Borrows doesn't support int2ptr casts, but let's make sure we don't immediately crash either.
-//@[tree]compile-flags: -Zmiri-tree-borrows
-//@[stack]compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 use std::{mem, ptr};
 
 fn eq_ref<T>(x: &T, y: &T) -> bool {

--- a/src/tools/miri/tests/pass/ptr_int_from_exposed.rs
+++ b/src/tools/miri/tests/pass/ptr_int_from_exposed.rs
@@ -1,7 +1,4 @@
-//@revisions: stack tree
-// Tree Borrows doesn't support int2ptr casts, but let's make sure we don't immediately crash either.
-//@[tree]compile-flags: -Zmiri-tree-borrows
-//@[stack]compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 use std::ptr;
 

--- a/tests/ui/error-emitter/multiline-removal-suggestion.rs
+++ b/tests/ui/error-emitter/multiline-removal-suggestion.rs
@@ -1,0 +1,57 @@
+// Make sure suggestion for removal of a span that covers multiple lines is properly highlighted.
+//@ compile-flags: --error-format=human --color=always
+//@ edition:2018
+// ignore-tidy-tab
+// We use `\t` instead of spaces for indentation to ensure that the highlighting logic properly
+// accounts for replaced characters (like we do for `\t` with `    `). The naïve way of highlighting
+// could be counting chars of the original code, instead of operating on the code as it is being
+// displayed.
+use std::collections::{HashMap, HashSet};
+fn foo() -> Vec<(bool, HashSet<u8>)> {
+	let mut hm = HashMap::<bool, Vec<HashSet<u8>>>::new();
+	hm.into_iter()
+		.map(|(is_true, ts)| {
+			ts.into_iter()
+				.map(|t| {
+					(
+						is_true,
+						t,
+					)
+				}).flatten()
+		})
+		.flatten()
+		.collect()
+}
+fn bar() -> Vec<(bool, HashSet<u8>)> {
+	let mut hm = HashMap::<bool, Vec<HashSet<u8>>>::new();
+	hm.into_iter()
+		.map(|(is_true, ts)| {
+			ts.into_iter()
+				.map(|t| (is_true, t))
+				.flatten()
+		})
+		.flatten()
+		.collect()
+}
+fn baz() -> Vec<(bool, HashSet<u8>)> {
+	let mut hm = HashMap::<bool, Vec<HashSet<u8>>>::new();
+	hm.into_iter()
+		.map(|(is_true, ts)| {
+			ts.into_iter().map(|t| {
+				(is_true, t)
+			}).flatten()
+		})
+		.flatten()
+		.collect()
+}
+fn bay() -> Vec<(bool, HashSet<u8>)> {
+	let mut hm = HashMap::<bool, Vec<HashSet<u8>>>::new();
+	hm.into_iter()
+		.map(|(is_true, ts)| {
+			ts.into_iter()
+				.map(|t| (is_true, t)).flatten()
+		})
+		.flatten()
+		.collect()
+}
+fn main() {}

--- a/tests/ui/error-emitter/multiline-removal-suggestion.svg
+++ b/tests/ui/error-emitter/multiline-removal-suggestion.svg
@@ -1,0 +1,504 @@
+<svg width="1902px" height="4322px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-ansi256-009 { fill: #FF5555 }
+    .fg-ansi256-010 { fill: #55FF55 }
+    .fg-ansi256-012 { fill: #5555FF }
+    .fg-ansi256-014 { fill: #55FFFF }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:20:8</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 }).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                    </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: consider removing this method call, as the receiver has type `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;` and `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;: Iterator` trivially holds</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>            ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                 .map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                     (</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                         is_true,</tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                         t,</tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                     )</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                 })</tspan><tspan>.flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>            ts.into_iter().flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="388px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="406px">
+</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:12:2</tspan>
+</tspan>
+    <tspan x="10px" y="460px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="496px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="514px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="532px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 .map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="550px"><tspan class="fg-ansi256-012 bold">...</tspan><tspan>  </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="568px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 }).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="586px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         })</tspan>
+</tspan>
+    <tspan x="10px" y="604px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|__________^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="622px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="640px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="658px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="676px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `Flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="712px">
+</tspan>
+    <tspan x="10px" y="730px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:13:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+</tspan>
+    <tspan x="10px" y="748px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:23:4</tspan>
+</tspan>
+    <tspan x="10px" y="766px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="784px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="802px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="820px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="838px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 .map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="856px"><tspan class="fg-ansi256-012 bold">...</tspan><tspan>  </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="874px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="892px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .collect()</tspan>
+</tspan>
+    <tspan x="10px" y="910px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">method cannot be called due to unsatisfied trait bounds</tspan>
+</tspan>
+    <tspan x="10px" y="928px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|_________|</tspan>
+</tspan>
+    <tspan x="10px" y="946px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="964px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="982px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
+</tspan>
+    <tspan x="10px" y="1000px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:15:10: 15:13}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+</tspan>
+    <tspan x="10px" y="1018px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:13:8: 13:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1036px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:15:10: 15:13}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+</tspan>
+    <tspan x="10px" y="1054px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:13:8: 13:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1072px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:15:10: 15:13}&gt;&gt;: IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1090px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:13:8: 13:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1108px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:13:8: 13:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1126px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:13:8: 13:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1144px">
+</tspan>
+    <tspan x="10px" y="1162px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="1180px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:31:6</tspan>
+</tspan>
+    <tspan x="10px" y="1198px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1216px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="1234px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="1252px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1270px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="1288px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1306px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="1324px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="1342px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: consider removing this method call, as the receiver has type `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;` and `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;: Iterator` trivially holds</tspan>
+</tspan>
+    <tspan x="10px" y="1360px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1378px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>            ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1396px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                 .map(|t| (is_true, t))</tspan>
+</tspan>
+    <tspan x="10px" y="1414px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>            ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1432px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1450px">
+</tspan>
+    <tspan x="10px" y="1468px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="1486px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:27:2</tspan>
+</tspan>
+    <tspan x="10px" y="1504px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1522px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1540px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="1558px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1576px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 .map(|t| (is_true, t))</tspan>
+</tspan>
+    <tspan x="10px" y="1594px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="1612px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         })</tspan>
+</tspan>
+    <tspan x="10px" y="1630px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|__________^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="1648px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1666px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="1684px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1702px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `Flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="1720px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="1738px">
+</tspan>
+    <tspan x="10px" y="1756px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:28:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+</tspan>
+    <tspan x="10px" y="1774px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:34:4</tspan>
+</tspan>
+    <tspan x="10px" y="1792px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1810px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1828px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="1846px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1864px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 .map(|t| (is_true, t))</tspan>
+</tspan>
+    <tspan x="10px" y="1882px"><tspan class="fg-ansi256-012 bold">...</tspan><tspan>  </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1900px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="1918px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .collect()</tspan>
+</tspan>
+    <tspan x="10px" y="1936px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">method cannot be called due to unsatisfied trait bounds</tspan>
+</tspan>
+    <tspan x="10px" y="1954px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|_________|</tspan>
+</tspan>
+    <tspan x="10px" y="1972px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1990px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2008px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
+</tspan>
+    <tspan x="10px" y="2026px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:30:10: 30:13}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+</tspan>
+    <tspan x="10px" y="2044px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:28:8: 28:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2062px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:30:10: 30:13}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+</tspan>
+    <tspan x="10px" y="2080px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:28:8: 28:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2098px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:30:10: 30:13}&gt;&gt;: IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2116px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:28:8: 28:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2134px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:28:8: 28:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2152px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:28:8: 28:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2170px">
+</tspan>
+    <tspan x="10px" y="2188px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="2206px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:42:7</tspan>
+</tspan>
+    <tspan x="10px" y="2224px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2242px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             }).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="2260px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="2278px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2296px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="2314px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2332px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="2350px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="2368px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: consider removing this method call, as the receiver has type `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;` and `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;: Iterator` trivially holds</tspan>
+</tspan>
+    <tspan x="10px" y="2386px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2404px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>            ts.into_iter()</tspan><tspan class="fg-ansi256-009">.map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="2422px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                 (is_true, t)</tspan>
+</tspan>
+    <tspan x="10px" y="2440px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-             })</tspan><tspan>.flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="2458px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>            ts.into_iter().flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="2476px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2494px">
+</tspan>
+    <tspan x="10px" y="2512px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="2530px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:38:2</tspan>
+</tspan>
+    <tspan x="10px" y="2548px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2566px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="2584px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="2602px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>             ts.into_iter().map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="2620px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 (is_true, t)</tspan>
+</tspan>
+    <tspan x="10px" y="2638px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>             }).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="2656px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         })</tspan>
+</tspan>
+    <tspan x="10px" y="2674px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|__________^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="2692px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2710px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="2728px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2746px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `Flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="2764px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="2782px">
+</tspan>
+    <tspan x="10px" y="2800px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:39:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+</tspan>
+    <tspan x="10px" y="2818px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:45:4</tspan>
+</tspan>
+    <tspan x="10px" y="2836px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2854px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="2872px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="2890px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             ts.into_iter().map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="2908px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 (is_true, t)</tspan>
+</tspan>
+    <tspan x="10px" y="2926px"><tspan class="fg-ansi256-012 bold">...</tspan><tspan>  </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2944px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="2962px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .collect()</tspan>
+</tspan>
+    <tspan x="10px" y="2980px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">method cannot be called due to unsatisfied trait bounds</tspan>
+</tspan>
+    <tspan x="10px" y="2998px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|_________|</tspan>
+</tspan>
+    <tspan x="10px" y="3016px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3034px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3052px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
+</tspan>
+    <tspan x="10px" y="3070px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:23: 40:26}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+</tspan>
+    <tspan x="10px" y="3088px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:39:8: 39:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3106px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:23: 40:26}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+</tspan>
+    <tspan x="10px" y="3124px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:39:8: 39:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3142px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:23: 40:26}&gt;&gt;: IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3160px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:39:8: 39:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3178px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:39:8: 39:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3196px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:39:8: 39:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3214px">
+</tspan>
+    <tspan x="10px" y="3232px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="3250px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:52:28</tspan>
+</tspan>
+    <tspan x="10px" y="3268px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3286px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 .map(|t| (is_true, t)).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3304px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                                        </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="3322px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3340px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="3358px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3376px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="3394px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="3412px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: consider removing this method call, as the receiver has type `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;` and `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;: Iterator` trivially holds</tspan>
+</tspan>
+    <tspan x="10px" y="3430px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3448px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>            ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="3466px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                 .map(|t| (is_true, t))</tspan><tspan>.flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3484px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>            ts.into_iter().flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3502px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3520px">
+</tspan>
+    <tspan x="10px" y="3538px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="3556px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:49:2</tspan>
+</tspan>
+    <tspan x="10px" y="3574px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3592px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="3610px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="3628px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="3646px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 .map(|t| (is_true, t)).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3664px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         })</tspan>
+</tspan>
+    <tspan x="10px" y="3682px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|__________^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="3700px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3718px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="3736px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3754px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `Flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="3772px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="3790px">
+</tspan>
+    <tspan x="10px" y="3808px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:50:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+</tspan>
+    <tspan x="10px" y="3826px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:55:4</tspan>
+</tspan>
+    <tspan x="10px" y="3844px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3862px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="3880px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="3898px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="3916px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 .map(|t| (is_true, t)).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3934px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         })</tspan>
+</tspan>
+    <tspan x="10px" y="3952px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3970px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .collect()</tspan>
+</tspan>
+    <tspan x="10px" y="3988px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">method cannot be called due to unsatisfied trait bounds</tspan>
+</tspan>
+    <tspan x="10px" y="4006px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|_________|</tspan>
+</tspan>
+    <tspan x="10px" y="4024px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4042px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4060px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
+</tspan>
+    <tspan x="10px" y="4078px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:52:10: 52:13}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+</tspan>
+    <tspan x="10px" y="4096px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:50:8: 50:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4114px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:52:10: 52:13}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+</tspan>
+    <tspan x="10px" y="4132px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:50:8: 50:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4150px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:52:10: 52:13}&gt;&gt;: IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4168px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:50:8: 50:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4186px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:50:8: 50:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4204px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:50:8: 50:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4222px">
+</tspan>
+    <tspan x="10px" y="4240px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 12 previous errors</tspan>
+</tspan>
+    <tspan x="10px" y="4258px">
+</tspan>
+    <tspan x="10px" y="4276px"><tspan class="bold">Some errors have detailed explanations: E0277, E0599.</tspan>
+</tspan>
+    <tspan x="10px" y="4294px"><tspan class="bold">For more information about an error, try `rustc --explain E0277`.</tspan>
+</tspan>
+    <tspan x="10px" y="4312px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/ui/panics/default-backtrace-ice.rs
+++ b/tests/ui/panics/default-backtrace-ice.rs
@@ -1,6 +1,8 @@
 //@ unset-rustc-env:RUST_BACKTRACE
 //@ compile-flags:-Z treat-err-as-bug=1
 //@ error-pattern:stack backtrace:
+// Verify this is a full backtrace, not a short backtrace.
+//@ error-pattern:__rust_begin_short_backtrace
 //@ failure-status:101
 //@ ignore-msvc
 //@ normalize-stderr-test: "note: .*" -> ""

--- a/tests/ui/panics/default-backtrace-ice.stderr
+++ b/tests/ui/panics/default-backtrace-ice.stderr
@@ -1,5 +1,5 @@
 error: internal compiler error[E0425]: cannot find value `missing_ident` in this scope
-  --> $DIR/default-backtrace-ice.rs:21:13
+  --> $DIR/default-backtrace-ice.rs:23:13
    |
 LL | fn main() { missing_ident; }
    |             ^^^^^^^^^^^^^ not found in this scope

--- a/tests/ui/panics/issue-47429-short-backtraces.rs
+++ b/tests/ui/panics/issue-47429-short-backtraces.rs
@@ -9,6 +9,8 @@
 // This is needed to avoid test output differences across std being built with v0 symbols vs legacy
 // symbols.
 //@ normalize-stderr-test: "begin_panic::<&str>" -> "begin_panic"
+// This variant occurs on macOS with `rust.debuginfo-level = "line-tables-only"` (#133997)
+//@ normalize-stderr-test: " begin_panic<&str>" -> " std::panicking::begin_panic"
 // And this is for differences between std with and without debuginfo.
 //@ normalize-stderr-test: "\n +at [^\n]+" -> ""
 

--- a/tests/ui/panics/issue-47429-short-backtraces.run.stderr
+++ b/tests/ui/panics/issue-47429-short-backtraces.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/issue-47429-short-backtraces.rs:24:5:
+thread 'main' panicked at $DIR/issue-47429-short-backtraces.rs:26:5:
 explicit panic
 stack backtrace:
    0: std::panicking::begin_panic

--- a/tests/ui/panics/runtime-switch.rs
+++ b/tests/ui/panics/runtime-switch.rs
@@ -9,6 +9,8 @@
 // This is needed to avoid test output differences across std being built with v0 symbols vs legacy
 // symbols.
 //@ normalize-stderr-test: "begin_panic::<&str>" -> "begin_panic"
+// This variant occurs on macOS with `rust.debuginfo-level = "line-tables-only"` (#133997)
+//@ normalize-stderr-test: " begin_panic<&str>" -> " std::panicking::begin_panic"
 // And this is for differences between std with and without debuginfo.
 //@ normalize-stderr-test: "\n +at [^\n]+" -> ""
 

--- a/tests/ui/panics/runtime-switch.run.stderr
+++ b/tests/ui/panics/runtime-switch.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/runtime-switch.rs:27:5:
+thread 'main' panicked at $DIR/runtime-switch.rs:29:5:
 explicit panic
 stack backtrace:
    0: std::panicking::begin_panic

--- a/tests/ui/panics/short-ice-remove-middle-frames-2.rs
+++ b/tests/ui/panics/short-ice-remove-middle-frames-2.rs
@@ -12,6 +12,8 @@
 // This is needed to avoid test output differences across std being built with v0 symbols vs legacy
 // symbols.
 //@ normalize-stderr-test: "begin_panic::<&str>" -> "begin_panic"
+// This variant occurs on macOS with `rust.debuginfo-level = "line-tables-only"` (#133997)
+//@ normalize-stderr-test: " begin_panic<&str>" -> " std::panicking::begin_panic"
 // And this is for differences between std with and without debuginfo.
 //@ normalize-stderr-test: "\n +at [^\n]+" -> ""
 

--- a/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames-2.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/short-ice-remove-middle-frames-2.rs:61:5:
+thread 'main' panicked at $DIR/short-ice-remove-middle-frames-2.rs:63:5:
 debug!!!
 stack backtrace:
    0: std::panicking::begin_panic

--- a/tests/ui/panics/short-ice-remove-middle-frames.rs
+++ b/tests/ui/panics/short-ice-remove-middle-frames.rs
@@ -13,6 +13,8 @@
 // This is needed to avoid test output differences across std being built with v0 symbols vs legacy
 // symbols.
 //@ normalize-stderr-test: "begin_panic::<&str>" -> "begin_panic"
+// This variant occurs on macOS with `rust.debuginfo-level = "line-tables-only"` (#133997)
+//@ normalize-stderr-test: " begin_panic<&str>" -> " std::panicking::begin_panic"
 // And this is for differences between std with and without debuginfo.
 //@ normalize-stderr-test: "\n +at [^\n]+" -> ""
 

--- a/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
+++ b/tests/ui/panics/short-ice-remove-middle-frames.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at $DIR/short-ice-remove-middle-frames.rs:57:5:
+thread 'main' panicked at $DIR/short-ice-remove-middle-frames.rs:59:5:
 debug!!!
 stack backtrace:
    0: std::panicking::begin_panic


### PR DESCRIPTION
Successful merges:

 - #134664 (Account for removal of multiline span in suggestion)
 - #134774 (fix default-backtrace-ice test)
 - #134781 (Add more `begin_panic` normalizations to panic backtrace tests)
 - #134784 (Miri subtree update)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134664,134774,134781,134784)
<!-- homu-ignore:end -->