### PR TITLE
Make `ty::Error` implement all auto traits

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -819,7 +819,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         candidates.vec.push(AutoImplCandidate)
                     }
                 }
-                ty::Error(_) => {} // do not add an auto trait impl for `ty::Error` for now.
+                ty::Error(_) => {
+                    candidates.vec.push(AutoImplCandidate);
+                }
             }
         }
     }

--- a/tests/ui/consts/error-is-freeze.rs
+++ b/tests/ui/consts/error-is-freeze.rs
@@ -1,0 +1,14 @@
+// Make sure we treat the error type as freeze to suppress useless errors.
+
+struct MyStruct {
+    foo: Option<UndefinedType>,
+    //~^ ERROR cannot find type `UndefinedType` in this scope
+}
+impl MyStruct {
+    pub const EMPTY_REF: &'static Self = &Self::EMPTY;
+    pub const EMPTY: Self = Self {
+        foo: None,
+    };
+}
+
+fn main() {}

--- a/tests/ui/consts/error-is-freeze.stderr
+++ b/tests/ui/consts/error-is-freeze.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `UndefinedType` in this scope
+  --> $DIR/error-is-freeze.rs:4:17
+   |
+LL |     foo: Option<UndefinedType>,
+   |                 ^^^^^^^^^^^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | struct MyStruct<UndefinedType> {
+   |                +++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/impl-trait/auto-trait-contains-err.rs
+++ b/tests/ui/impl-trait/auto-trait-contains-err.rs
@@ -1,9 +1,9 @@
-//@ known-bug: #131050
 //@ compile-flags: --edition=2021
 
 use std::future::Future;
 
 fn invalid_future() -> impl Future {}
+//~^ ERROR `()` is not a future
 
 fn create_complex_future() -> impl Future<Output = impl ReturnsSend> {
     async { &|| async { invalid_future().await } }
@@ -21,3 +21,5 @@ where
     R: Send,
 {
 }
+
+fn main() {}

--- a/tests/ui/impl-trait/auto-trait-contains-err.stderr
+++ b/tests/ui/impl-trait/auto-trait-contains-err.stderr
@@ -1,0 +1,11 @@
+error[E0277]: `()` is not a future
+  --> $DIR/auto-trait-contains-err.rs:5:24
+   |
+LL | fn invalid_future() -> impl Future {}
+   |                        ^^^^^^^^^^^ `()` is not a future
+   |
+   = help: the trait `Future` is not implemented for `()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
I have no idea what's up with the crashes test I fixed--I really don't want to look into it since it has to do something with borrowck and multiple layers of opaques. I think the underlying idea of allowing error types to implement all auto traits is justified though.

Fixes #134796
Fixes #131050

r? lcnr