### PR TITLE
fix(rustdoc): print the `doc(hidden)` attribute the same as others

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -760,6 +760,11 @@ impl Item {
                 }
             })
             .collect();
+
+        if !keep_as_is && self.is_doc_hidden() {
+            attrs.push("#[doc(hidden)]".into());
+        }
+
         if !keep_as_is
             && let Some(def_id) = self.def_id()
             && let ItemType::Struct | ItemType::Enum | ItemType::Union = self.type_()
@@ -822,6 +827,7 @@ impl Item {
                 attrs.push(format!("#[repr({})]", out.join(", ")));
             }
         }
+
         attrs
     }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1610,14 +1610,7 @@ pub(crate) fn visibility_print_with_space<'a, 'tcx: 'a>(
         }
     };
 
-    let is_doc_hidden = item.is_doc_hidden();
-    display_fn(move |f| {
-        if is_doc_hidden {
-            f.write_str("#[doc(hidden)] ")?;
-        }
-
-        f.write_str(&vis)
-    })
+    display_fn(move |f| f.write_str(&vis))
 }
 
 pub(crate) trait PrintWithSpace {

--- a/tests/rustdoc/display-hidden-items.rs
+++ b/tests/rustdoc/display-hidden-items.rs
@@ -7,24 +7,28 @@
 //@ has 'foo/index.html'
 //@ has - '//*[@class="item-name"]/span[@title="Hidden item"]' '👻'
 
-//@ has - '//*[@id="reexport.hidden_reexport"]/code' '#[doc(hidden)] pub use hidden::inside_hidden as hidden_reexport;'
+//@ has - '//*[@id="reexport.hidden_reexport"]/code' 'pub use hidden::inside_hidden as hidden_reexport;'
 #[doc(hidden)]
 pub use hidden::inside_hidden as hidden_reexport;
 
 //@ has - '//*[@class="item-name"]/a[@class="trait"]' 'TraitHidden'
-//@ has 'foo/trait.TraitHidden.html'
-//@ has - '//code' '#[doc(hidden)] pub trait TraitHidden'
+//@ has 'foo/trait.TraitHidden.html' '//*[@class="rust item-decl"]/code' '#[doc(hidden)]'
 #[doc(hidden)]
 pub trait TraitHidden {}
 
 //@ has 'foo/index.html' '//*[@class="item-name"]/a[@class="trait"]' 'Trait'
 pub trait Trait {
     //@ has 'foo/trait.Trait.html'
-    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' '#[doc(hidden)] const BAR: u32 = 0u32'
+    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
     #[doc(hidden)]
     const BAR: u32 = 0;
 
-    //@ has - '//*[@id="method.foo"]/*[@class="code-header"]' 'fn foo()'
+    #[doc(hidden)]
+    //@ has 'foo/trait.Trait.html'
+    //@ has - '//*[@id="associatedtype.Baz"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+    type Baz;
+
+    //@ has - '//*[@id="method.foo"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
     #[doc(hidden)]
     fn foo() {}
 }
@@ -32,27 +36,40 @@ pub trait Trait {
 //@ has 'foo/index.html' '//*[@class="item-name"]/a[@class="struct"]' 'Struct'
 //@ has 'foo/struct.Struct.html'
 pub struct Struct {
-    //@ has - '//*[@id="structfield.a"]/code' 'a: u32'
+    // FIXME: display attrs on fields in the Fields section
+    //@ !has - '//*[@id="structfield.a"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
     #[doc(hidden)]
     pub a: u32,
 }
 
 impl Struct {
-    //@ has - '//*[@id="method.new"]/*[@class="code-header"]' 'pub fn new() -> Self'
+    //@ has - '//*[@id="method.new"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
     #[doc(hidden)]
     pub fn new() -> Self { Self { a: 0 } }
 }
 
 impl Trait for Struct {
-    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]' '#[doc(hidden)] const BAR: u32 = 0u32'
-    //@ has - '//*[@id="method.foo"]/*[@class="code-header"]' '#[doc(hidden)] fn foo()'
+    //@ has - '//*[@id="associatedconstant.BAR"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+    //@ has - '//*[@id="method.foo"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+    // NOTE: feature(associated_type_defaults) is unstable so users have to set a type for trait associated items:
+    // we don't want to hide it if they don't ask for it explicitely in the impl.
+    //@ !has - '//*[@id="associatedtype.Baz"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+
+    type Baz = ();
 }
 //@ has - '//*[@id="impl-TraitHidden-for-Struct"]/*[@class="code-header"]' 'impl TraitHidden for Struct'
 impl TraitHidden for Struct {}
 
+//@ has 'foo/index.html' '//*[@class="item-name"]/a[@class="struct"]' 'TupleStruct'
+pub struct TupleStruct(
+    // FIXME: display attrs on fields in the Fields section
+    //@ !has 'foo/struct.TupleStruct.html' '//*[@id="structfield.0"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+    #[doc(hidden)]
+    ()
+);
+
 //@ has 'foo/index.html' '//*[@class="item-name"]/a[@class="enum"]' 'HiddenEnum'
-//@ has 'foo/enum.HiddenEnum.html'
-//@ has - '//code' '#[doc(hidden)] pub enum HiddenEnum'
+//@ has 'foo/enum.HiddenEnum.html' '//*[@class="rust item-decl"]/code' '#[doc(hidden)]'
 #[doc(hidden)]
 pub enum HiddenEnum {
     A,
@@ -60,9 +77,11 @@ pub enum HiddenEnum {
 
 //@ has 'foo/index.html' '//*[@class="item-name"]/a[@class="enum"]' 'Enum'
 pub enum Enum {
-    //@ has 'foo/enum.Enum.html' '//*[@id="variant.A"]/*[@class="code-header"]' 'A'
+    //@ has 'foo/enum.Enum.html' '//*[@id="variant.A"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
     #[doc(hidden)]
     A,
+    //@ has 'foo/enum.Enum.html' '//*[@id="variant.B"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+    B(#[doc(hidden)] ())
 }
 
 //@ has 'foo/index.html' '//*[@class="item-name"]/a[@class="mod"]' 'hidden'
@@ -73,3 +92,22 @@ pub mod hidden {
     //@ has 'foo/hidden/fn.inside_hidden.html'
     pub fn inside_hidden() {}
 }
+
+//@ has 'foo/index.html' '//*[@class="item-name"]/a[@class="union"]' 'Union'
+//@ has 'foo/union.Union.html' '//*[@class="rust item-decl"]/code' '#[doc(hidden)]'
+#[doc(hidden)]
+pub union Union {
+    // FIXME: display attrs on fields in the Fields section
+    //@ !has 'foo/union.Union.html' '//*[@id="structfield.a"]/*[@class="code-header"]/*[@class="code-attribute"]' '#[doc(hidden)]'
+    #[doc(hidden)]
+    pub a: u8,
+}
+
+//@ has 'foo/index.html' '//*[@class="item-name"]/a[@class="macro"]' 'macro_rule'
+//@ has 'foo/macro.macro_rule.html' '//*[@class="rust item-decl"]/code' '#[doc(hidden)]'
+#[doc(hidden)]
+#[macro_export]
+macro_rules! macro_rule {
+    () => {};
+}
+


### PR DESCRIPTION
Closes #132304

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

| Before | After |
|--------|--------|
| <img width="416" alt="Before: doc hidden is in white, on the same line as the struct def" src="https://github.com/user-attachments/assets/e6db05a5-3d3e-49bc-b225-d3db2f4b108e" /> | <img width="297" alt="After: doc(hidden) is in gray, like the repr(transparent) attribute below it" src="https://github.com/user-attachments/assets/f9092129-9fdb-47cd-a082-132f76ca84a8" /> |
