### PR TITLE
compiletest: Remove empty 'expected' files when blessing

### DIFF
--- a/src/tools/compiletest/src/runtest/coverage.rs
+++ b/src/tools/compiletest/src/runtest/coverage.rs
@@ -39,16 +39,16 @@ impl<'test> TestCx<'test> {
         let expected_coverage_dump = self.load_expected_output(kind);
         let actual_coverage_dump = self.normalize_output(&proc_res.stdout, &[]);
 
-        let coverage_dump_errors = self.compare_output(
+        let coverage_dump_compare_outcome = self.compare_output(
             kind,
             &actual_coverage_dump,
             &proc_res.stdout,
             &expected_coverage_dump,
         );
 
-        if coverage_dump_errors > 0 {
+        if coverage_dump_compare_outcome.should_error() {
             self.fatal_proc_rec(
-                &format!("{coverage_dump_errors} errors occurred comparing coverage output."),
+                &format!("an error occurred comparing coverage output."),
                 &proc_res,
             );
         }
@@ -139,16 +139,16 @@ impl<'test> TestCx<'test> {
                 self.fatal_proc_rec(&err, &proc_res);
             });
 
-        let coverage_errors = self.compare_output(
+        let coverage_dump_compare_outcome = self.compare_output(
             kind,
             &normalized_actual_coverage,
             &proc_res.stdout,
             &expected_coverage,
         );
 
-        if coverage_errors > 0 {
+        if coverage_dump_compare_outcome.should_error() {
             self.fatal_proc_rec(
-                &format!("{} errors occurred comparing coverage output.", coverage_errors),
+                &format!("an error occurred comparing coverage output."),
                 &proc_res,
             );
         }

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -100,7 +100,12 @@ impl TestCx<'_> {
                 )
             });
 
-            errors += self.compare_output("fixed", &fixed_code, &fixed_code, &expected_fixed);
+            if self
+                .compare_output("fixed", &fixed_code, &fixed_code, &expected_fixed)
+                .should_error()
+            {
+                errors += 1;
+            }
         } else if !expected_fixed.is_empty() {
             panic!(
                 "the `//@ run-rustfix` directive wasn't found but a `*.fixed` \


### PR DESCRIPTION
Fixes #134793
Fixes #134196

This also refactors `compare_output` to return an enum; returning a usize was done for convenience but is misleading