### PR TITLE
Fix mistake in windows file open

### DIFF
--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -323,7 +323,7 @@ impl File {
                     let alloc = c::FILE_ALLOCATION_INFO { AllocationSize: 0 };
                     let result = c::SetFileInformationByHandle(
                         handle.as_raw_handle(),
-                        c::FileEndOfFileInfo,
+                        c::FileAllocationInfo,
                         (&raw const alloc).cast::<c_void>(),
                         mem::size_of::<c::FILE_ALLOCATION_INFO>() as u32,
                     );


### PR DESCRIPTION
In #134722 this should have been `c::FileAllocationInfo` not `c::FileEndOfFileInfo`. Oops.