### PR TITLE
Skip parenthesis if `.` makes statement boundary unambiguous

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state/fixup.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/fixup.rs
@@ -138,6 +138,20 @@ impl FixupContext {
         }
     }
 
+    /// Transform this fixup into the one that should apply when printing a
+    /// leftmost subexpression followed by a `.` or `?` token, which confer
+    /// different statement boundary rules compared to other leftmost
+    /// subexpressions.
+    pub(crate) fn leftmost_subexpression_with_dot(self) -> Self {
+        FixupContext {
+            stmt: self.stmt || self.leftmost_subexpression_in_stmt,
+            leftmost_subexpression_in_stmt: false,
+            match_arm: self.match_arm || self.leftmost_subexpression_in_match_arm,
+            leftmost_subexpression_in_match_arm: false,
+            ..self
+        }
+    }
+
     /// Transform this fixup into the one that should apply when printing any
     /// subexpression that is neither a leftmost subexpression nor surrounded in
     /// delimiters.

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -110,8 +110,8 @@ static EXPRS: &[&str] = &[
     "{ (loop {}) - 1 }",
     "match 2 { _ => (loop {}) - 1 }",
     // No eager statement boundary if followed by `.` or `?`.
-    "{ (loop {}).to_string() - 1 }",  // FIXME: no parenthesis needed.
-    "match 2 { _ => (loop {}).to_string() - 1 }",  // FIXME: no parenthesis needed.
+    "{ loop {}.to_string() - 1 }",
+    "match 2 { _ => loop {}.to_string() - 1 }",
     // Angle bracket is eagerly parsed as a path's generic argument list.
     "(2 as T) < U",
     "(2 as T<U>) < V", // FIXME: no parentheses needed.

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -108,6 +108,10 @@ static EXPRS: &[&str] = &[
     "{ (match 2 {})() - 1 }",
     "{ (match 2 {})[0] - 1 }",
     "{ (loop {}) - 1 }",
+    "match 2 { _ => (loop {}) - 1 }",
+    // No eager statement boundary if followed by `.` or `?`.
+    "{ (loop {}).to_string() - 1 }",  // FIXME: no parenthesis needed.
+    "match 2 { _ => (loop {}).to_string() - 1 }",  // FIXME: no parenthesis needed.
     // Angle bracket is eagerly parsed as a path's generic argument list.
     "(2 as T) < U",
     "(2 as T<U>) < V", // FIXME: no parentheses needed.


### PR DESCRIPTION
There is a rule in the parser that statements and match-arms never end in front of a `.` or `?` token (except when the `.` is really `..` or `..=` or `...`). So some of the leading subexpressions that need parentheses inserted when followed by some other operator like `-` or `+`, do not need parentheses when followed by `.` or `?`.

Example:

```rust
fn main() {
    loop {}.to_string() + "";
    match () {
        _ => loop {}.to_string() + "",
    };
}
```

`-Zunpretty=expanded` before:

```console
#![feature(prelude_import)]
#[prelude_import]
use std::prelude::rust_2021::*;
#[macro_use]
extern crate std;
fn main() {
    (loop {}).to_string() + "";
    match () { _ => (loop {}).to_string() + "", };
}
```

After:

```console
#![feature(prelude_import)]
#[prelude_import]
use std::prelude::rust_2021::*;
#[macro_use]
extern crate std;
fn main() {
    loop {}.to_string() + "";
    match () { _ => loop {}.to_string() + "", };
}
```