### PR TITLE
Skip parenthesis around tuple struct field calls

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -213,7 +213,9 @@ impl<'a> State<'a> {
 
     fn print_expr_call(&mut self, func: &ast::Expr, args: &[P<ast::Expr>], fixup: FixupContext) {
         let needs_paren = match func.kind {
-            ast::ExprKind::Field(..) => true,
+            // In order to call a named field, needs parens: `(self.fun)()`
+            // But not for an unnamed field: `self.0()`
+            ast::ExprKind::Field(_, name) => !name.is_numeric(),
             _ => func.precedence() < ExprPrecedence::Unambiguous,
         };
 

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1336,7 +1336,7 @@ impl<'a> Parser<'a> {
     ) -> bool {
         if let ExprKind::Binary(op, l1, r1) = &inner_op.kind {
             if let ExprKind::Field(_, ident) = l1.kind
-                && ident.as_str().parse::<i32>().is_err()
+                && !ident.is_numeric()
                 && !matches!(r1.kind, ExprKind::Lit(_))
             {
                 // The parser has encountered `foo.bar<baz`, the likelihood of the turbofish

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2707,6 +2707,12 @@ impl Ident {
     pub fn is_raw_guess(self) -> bool {
         self.name.can_be_raw() && self.is_reserved()
     }
+
+    /// Whether this would be the identifier for a tuple field like `self.0`, as
+    /// opposed to a named field like `self.thing`.
+    pub fn is_numeric(self) -> bool {
+        !self.name.is_empty() && self.as_str().bytes().all(|b| b.is_ascii_digit())
+    }
 }
 
 /// Collect all the keywords in a given edition into a vector.

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -77,6 +77,9 @@ static EXPRS: &[&str] = &[
     // These mean different things.
     "if let _ = true && false {}",
     "if let _ = (true && false) {}",
+    // Parentheses to call a named field, but not an unnamed field.
+    "(self.fun)()",
+    "(self.0)()",  // FIXME: no parenthesis needed.
     // Conditions end at the first curly brace, so struct expressions need to be
     // parenthesized. Except in a match guard, where conditions end at arrow.
     "if let _ = (Struct {}) {}",

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -79,7 +79,7 @@ static EXPRS: &[&str] = &[
     "if let _ = (true && false) {}",
     // Parentheses to call a named field, but not an unnamed field.
     "(self.fun)()",
-    "(self.0)()",  // FIXME: no parenthesis needed.
+    "self.0()",
     // Conditions end at the first curly brace, so struct expressions need to be
     // parenthesized. Except in a match guard, where conditions end at arrow.
     "if let _ = (Struct {}) {}",


### PR DESCRIPTION
The pretty-printer previously did not distinguish between named vs unnamed fields when printing a function call containing a struct field. It would print the call as `(self.fun)()` for a named field which is correct, and `(self.0)()` for an unnamed field which is redundant.

This PR changes function calls of tuple struct fields to print without parens.

**Before:**

```rust
struct Tuple(fn());

fn main() {
    let tuple = Tuple(|| {});
    (tuple.0)();
}
```

**After:**

```rust
struct Tuple(fn());

fn main() {
    let tuple = Tuple(|| {});
    tuple.0();
}
```