### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -213,7 +213,9 @@ impl<'a> State<'a> {
 
     fn print_expr_call(&mut self, func: &ast::Expr, args: &[P<ast::Expr>], fixup: FixupContext) {
         let needs_paren = match func.kind {
-            ast::ExprKind::Field(..) => true,
+            // In order to call a named field, needs parens: `(self.fun)()`
+            // But not for an unnamed field: `self.0()`
+            ast::ExprKind::Field(_, name) => !name.is_numeric(),
             _ => func.precedence() < ExprPrecedence::Unambiguous,
         };
 

--- a/compiler/rustc_ast_pretty/src/pprust/state/fixup.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/fixup.rs
@@ -138,6 +138,20 @@ impl FixupContext {
         }
     }
 
+    /// Transform this fixup into the one that should apply when printing a
+    /// leftmost subexpression followed by a `.` or `?` token, which confer
+    /// different statement boundary rules compared to other leftmost
+    /// subexpressions.
+    pub(crate) fn leftmost_subexpression_with_dot(self) -> Self {
+        FixupContext {
+            stmt: self.stmt || self.leftmost_subexpression_in_stmt,
+            leftmost_subexpression_in_stmt: false,
+            match_arm: self.match_arm || self.leftmost_subexpression_in_match_arm,
+            leftmost_subexpression_in_match_arm: false,
+            ..self
+        }
+    }
+
     /// Transform this fixup into the one that should apply when printing any
     /// subexpression that is neither a leftmost subexpression nor surrounded in
     /// delimiters.

--- a/compiler/rustc_borrowck/src/diagnostics/opaque_suggestions.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/opaque_suggestions.rs
@@ -31,7 +31,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         diag: &mut Diag<'_>,
     ) {
         // We look at all the locals. Why locals? Because it's the best thing
-        // I could think of that's correlated with the *instantiated* higer-ranked
+        // I could think of that's correlated with the *instantiated* higher-ranked
         // binder for calls, since we don't really store those anywhere else.
         for ty in self.body.local_decls.iter().map(|local| local.ty) {
             if !ty.has_opaque_types() {

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -140,6 +140,12 @@ pub(crate) fn type_check<'a, 'tcx>(
         &mut constraints,
     );
 
+    let pre_obligations = infcx.take_registered_region_obligations();
+    assert!(
+        pre_obligations.is_empty(),
+        "there should be no incoming region obligations = {pre_obligations:#?}",
+    );
+
     debug!(?normalized_inputs_and_output);
 
     let mut typeck = TypeChecker {

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -299,10 +299,6 @@ impl<'tcx> RegionConstraintCollector<'_, 'tcx> {
         self.storage.var_infos.len()
     }
 
-    pub fn region_constraint_data(&self) -> &RegionConstraintData<'tcx> {
-        &self.storage.data
-    }
-
     /// Takes (and clears) the current set of constraints. Note that
     /// the set of variables remains intact, but all relationships
     /// between them are reset. This is used during NLL checking to

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -220,7 +220,7 @@ fn main() {
     let mut cmd = Command::new(&llvm_config);
     cmd.arg(llvm_link_arg).arg("--libs");
 
-    // Don't link system libs if cross-compiling unless targetting Windows.
+    // Don't link system libs if cross-compiling unless targeting Windows.
     // On Windows system DLLs aren't linked directly, instead import libraries are used.
     // These import libraries are independent of the host.
     if !is_crossed || target.contains("windows") {

--- a/compiler/rustc_mir_build/src/check_tail_calls.rs
+++ b/compiler/rustc_mir_build/src/check_tail_calls.rs
@@ -117,7 +117,7 @@ impl<'tcx> TailCallCkVisitor<'_, 'tcx> {
                 self.report_arguments_mismatch(expr.span, caller_sig, callee_sig);
             }
 
-            // FIXME(explicit_tail_calls): this currenly fails for cases where opaques are used.
+            // FIXME(explicit_tail_calls): this currently fails for cases where opaques are used.
             // e.g.
             // ```
             // fn a() -> impl Sized { become b() } // ICE

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1336,7 +1336,7 @@ impl<'a> Parser<'a> {
     ) -> bool {
         if let ExprKind::Binary(op, l1, r1) = &inner_op.kind {
             if let ExprKind::Field(_, ident) = l1.kind
-                && ident.as_str().parse::<i32>().is_err()
+                && !ident.is_numeric()
                 && !matches!(r1.kind, ExprKind::Lit(_))
             {
                 // The parser has encountered `foo.bar<baz`, the likelihood of the turbofish

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2707,6 +2707,12 @@ impl Ident {
     pub fn is_raw_guess(self) -> bool {
         self.name.can_be_raw() && self.is_reserved()
     }
+
+    /// Whether this would be the identifier for a tuple field like `self.0`, as
+    /// opposed to a named field like `self.thing`.
+    pub fn is_numeric(self) -> bool {
+        !self.name.is_empty() && self.as_str().bytes().all(|b| b.is_ascii_digit())
+    }
 }
 
 /// Collect all the keywords in a given edition into a vector.

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -161,8 +161,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
         let outlives_env = OutlivesEnvironment::new(full_env);
         let _ = infcx.process_registered_region_obligations(&outlives_env, |ty, _| Ok(ty));
 
-        let region_data =
-            infcx.inner.borrow_mut().unwrap_region_constraints().region_constraint_data().clone();
+        let region_data = infcx.inner.borrow_mut().unwrap_region_constraints().data().clone();
 
         let vid_to_region = self.map_vid_to_region(&region_data);
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1843,7 +1843,7 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
         // a global and a non-global where-clause.
         //
         // Our handling of where-bounds is generally fairly messy but necessary for backwards
-        // compatability, see #50825 for why we need to handle global where-bounds like this.
+        // compatibility, see #50825 for why we need to handle global where-bounds like this.
         let is_global = |c: ty::PolyTraitPredicate<'tcx>| c.is_global() && !c.has_bound_vars();
         let param_candidates = candidates
             .iter()

--- a/library/alloc/tests/sort/tests.rs
+++ b/library/alloc/tests/sort/tests.rs
@@ -33,7 +33,7 @@ fn check_is_sorted<T: Ord + Clone + Debug, S: Sort>(v: &mut [T]) {
             known_good_stable_sort::sort(known_good_sorted_vec.as_mut_slice());
 
             if is_small_test {
-                eprintln!("Orginal:  {:?}", v_orig);
+                eprintln!("Original:  {:?}", v_orig);
                 eprintln!("Expected: {:?}", known_good_sorted_vec);
                 eprintln!("Got:      {:?}", v);
             } else {

--- a/library/core/benches/num/int_pow/mod.rs
+++ b/library/core/benches/num/int_pow/mod.rs
@@ -25,7 +25,7 @@ macro_rules! pow_bench_template {
                 let mut exp_iter = black_box(&exp_array).into_iter();
 
                 (0..ITERATIONS).fold((0 as IntType, false), |acc, _| {
-                    // Sometimes constants don't propogate all the way to the
+                    // Sometimes constants don't propagate all the way to the
                     // inside of the loop, so we call a custom expression every cycle
                     // rather than iter::repeat(CONST)
                     let base: IntType = $base_macro!(base_iter);

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -110,8 +110,8 @@ static EXPRS: &[&str] = &[
     "{ (loop {}) - 1 }",
     "match 2 { _ => (loop {}) - 1 }",
     // No eager statement boundary if followed by `.` or `?`.
-    "{ (loop {}).to_string() - 1 }",  // FIXME: no parenthesis needed.
-    "match 2 { _ => (loop {}).to_string() - 1 }",  // FIXME: no parenthesis needed.
+    "{ loop {}.to_string() - 1 }",
+    "match 2 { _ => loop {}.to_string() - 1 }",
     // Angle bracket is eagerly parsed as a path's generic argument list.
     "(2 as T) < U",
     "(2 as T<U>) < V", // FIXME: no parentheses needed.

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -77,6 +77,9 @@ static EXPRS: &[&str] = &[
     // These mean different things.
     "if let _ = true && false {}",
     "if let _ = (true && false) {}",
+    // Parentheses to call a named field, but not an unnamed field.
+    "(self.fun)()",
+    "(self.0)()",  // FIXME: no parenthesis needed.
     // Conditions end at the first curly brace, so struct expressions need to be
     // parenthesized. Except in a match guard, where conditions end at arrow.
     "if let _ = (Struct {}) {}",

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -108,6 +108,10 @@ static EXPRS: &[&str] = &[
     "{ (match 2 {})() - 1 }",
     "{ (match 2 {})[0] - 1 }",
     "{ (loop {}) - 1 }",
+    "match 2 { _ => (loop {}) - 1 }",
+    // No eager statement boundary if followed by `.` or `?`.
+    "{ (loop {}).to_string() - 1 }",  // FIXME: no parenthesis needed.
+    "match 2 { _ => (loop {}).to_string() - 1 }",  // FIXME: no parenthesis needed.
     // Angle bracket is eagerly parsed as a path's generic argument list.
     "(2 as T) < U",
     "(2 as T<U>) < V", // FIXME: no parentheses needed.

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -79,7 +79,7 @@ static EXPRS: &[&str] = &[
     "if let _ = (true && false) {}",
     // Parentheses to call a named field, but not an unnamed field.
     "(self.fun)()",
-    "(self.0)()",  // FIXME: no parenthesis needed.
+    "self.0()",
     // Conditions end at the first curly brace, so struct expressions need to be
     // parenthesized. Except in a match guard, where conditions end at arrow.
     "if let _ = (Struct {}) {}",


### PR DESCRIPTION
Successful merges:

 - #134823 (Fix typos)
 - #134827 (Some random region tweaks)
 - #134833 (Skip parenthesis if `.` makes statement boundary unambiguous)
 - #134834 (Skip parenthesis around tuple struct field calls)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134823,134827,134833,134834)
<!-- homu-ignore:end -->