### PR TITLE
Disable `backtrace-debuginfo.rs` on windows-gnu

### DIFF
--- a/tests/ui/runtime/backtrace-debuginfo.rs
+++ b/tests/ui/runtime/backtrace-debuginfo.rs
@@ -13,6 +13,10 @@
 //@ ignore-sgx no processes
 //@ ignore-fuchsia Backtrace not symbolized, trace different line alignment
 
+// FIXME(#117097): backtrace (possibly unwinding mechanism) seems to be different on at least
+// `i686-mingw` (32-bit windows-gnu)? cc #128911.
+//@ ignore-windows-gnu
+
 use std::env;
 
 #[path = "backtrace-debuginfo-aux.rs"] mod aux;


### PR DESCRIPTION
This test appears still flaky cf. #117097 on `i686-mingw` as observed in https://github.com/rust-lang/rust/pull/131244#issuecomment-2564086577.

r? compiler (or anyone, really)