### PR TITLE
Revert #134209

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1320,31 +1320,7 @@ impl Config {
 
         // Set flags.
         config.paths = std::mem::take(&mut flags.paths);
-        config.skip = flags
-            .skip
-            .into_iter()
-            .chain(flags.exclude)
-            .map(|p| {
-                let p = if cfg!(windows) {
-                    PathBuf::from(p.to_str().unwrap().replace('/', "\\"))
-                } else {
-                    p
-                };
-
-                // Jump to top-level project path to support passing paths
-                // from sub directories.
-                let top_level_path = config.src.join(&p);
-                if !config.src.join(&top_level_path).exists() {
-                    eprintln!("WARNING: '{}' does not exist.", top_level_path.display());
-                }
-
-                // Never return top-level path here as it would break `--skip`
-                // logic on rustc's internal test framework which is utilized
-                // by compiletest.
-                p
-            })
-            .collect();
-
+        config.skip = flags.skip.into_iter().chain(flags.exclude).collect();
         config.include_default_paths = flags.include_default_paths;
         config.rustc_error_format = flags.rustc_error_format;
         config.json_output = flags.json_output;


### PR DESCRIPTION
Reverts [validate --skip and --exclude paths #134209](https://github.com/rust-lang/rust/pull/134209).

Reopens https://github.com/rust-lang/rust/issues/134198.

Unfortunately, the present logic is not quite right because `Step`s are allowed to register arbitrary *aliases* (e.g. `library/test` is aliased to `test`), which means that we incorrectly warn on

```
./x test --exclude test
```

producing

```
WARNING: '/home/joe/repos/rust/test' does not exist.
```

even though this alias (`test`) is indeed a known and handled `--exclude` filter.

A proper fix will need to do something like "collect all eligible `Step`s then check `should_run(exclude)`" in order to determine if the exclude filter will trigger for the steps. (Courtesy of jyn pointing this out.)

I don't quite have the time to investigate the proper fix atm, so I am posting a revert for now (unless someone wants to look at it).

This reverts commit 6cf13b00368f68f5cdad155e4fa919d4041db667, reversing changes made to 2846699366ac9eac997c037a8552b994daddf8bf.

r? @onur-ozkan