### PR TITLE
bootstrap: drop warning for top-level test suite path check due to false positives

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1325,23 +1325,14 @@ impl Config {
             .into_iter()
             .chain(flags.exclude)
             .map(|p| {
-                let p = if cfg!(windows) {
-                    PathBuf::from(p.to_str().unwrap().replace('/', "\\"))
-                } else {
-                    p
-                };
-
-                // Jump to top-level project path to support passing paths
-                // from sub directories.
-                let top_level_path = config.src.join(&p);
-                if !config.src.join(&top_level_path).exists() {
-                    eprintln!("WARNING: '{}' does not exist.", top_level_path.display());
-                }
-
                 // Never return top-level path here as it would break `--skip`
                 // logic on rustc's internal test framework which is utilized
                 // by compiletest.
-                p
+                if cfg!(windows) {
+                    PathBuf::from(p.to_str().unwrap().replace('/', "\\"))
+                } else {
+                    p
+                }
             })
             .collect();
 


### PR DESCRIPTION
The current top-level test suite directory does not exist warning logic doesn't quite handle the more exotic path suffix matches that test filters seem to accept (e.g. `library/test` can be matched with `--exclude test`), so avoid warning on non-existent top-level test suites for now. To avoid false positives, we probably need to query test `Step`s for their `should_run(exclude_filter)` logic.

This retains the fix for the Windows path handling (unlike #134843).

r? @onur-ozkan 
