### PR TITLE
docs: inline `alloc::ffi::c_str` types to `alloc::ffi`

### DIFF
--- a/library/alloc/src/ffi/mod.rs
+++ b/library/alloc/src/ffi/mod.rs
@@ -83,7 +83,7 @@
 #[doc(inline)]
 #[stable(feature = "alloc_c_string", since = "1.64.0")]
 pub use self::c_str::CString;
-#[doc(no_inline)]
+#[doc(inline)]
 #[stable(feature = "alloc_c_string", since = "1.64.0")]
 pub use self::c_str::{FromVecWithNulError, IntoStringError, NulError};
 


### PR DESCRIPTION
like https://github.com/rust-lang/rust/pull/134791 but for `alloc`

r? @tgross35 @notriddle 