### PR TITLE
Unsafe binder support in rustdoc

### DIFF
--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -900,7 +900,8 @@ fn get_index_type_id(
         | clean::Generic(_)
         | clean::SelfTy
         | clean::ImplTrait(_)
-        | clean::Infer => None,
+        | clean::Infer
+        | clean::UnsafeBinder(_) => None,
     }
 }
 

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -573,7 +573,7 @@ impl FromClean<clean::Type> for Type {
     fn from_clean(ty: clean::Type, renderer: &JsonRenderer<'_>) -> Self {
         use clean::Type::{
             Array, BareFunction, BorrowedRef, Generic, ImplTrait, Infer, Primitive, QPath,
-            RawPointer, SelfTy, Slice, Tuple,
+            RawPointer, SelfTy, Slice, Tuple, UnsafeBinder,
         };
 
         match ty {
@@ -613,6 +613,8 @@ impl FromClean<clean::Type> for Type {
                 self_type: Box::new(self_type.into_json(renderer)),
                 trait_: trait_.map(|trait_| trait_.into_json(renderer)),
             },
+            // FIXME(unsafe_binder): Implement rustdoc-json.
+            UnsafeBinder(_) => todo!(),
         }
     }
 }

--- a/tests/rustdoc/auxiliary/unsafe-binder-dep.rs
+++ b/tests/rustdoc/auxiliary/unsafe-binder-dep.rs
@@ -1,0 +1,4 @@
+#![feature(unsafe_binders)]
+#![allow(incomplete_features)]
+
+pub fn woof() -> unsafe<'a> &'a str { todo!() }

--- a/tests/rustdoc/unsafe-binder.rs
+++ b/tests/rustdoc/unsafe-binder.rs
@@ -1,0 +1,15 @@
+//@ aux-build:unsafe-binder-dep.rs
+
+#![feature(unsafe_binders)]
+#![allow(incomplete_features)]
+
+extern crate unsafe_binder_dep;
+
+//@ has 'unsafe_binder/fn.woof.html' //pre "fn woof() -> unsafe<'a> &'a str"
+pub use unsafe_binder_dep::woof;
+
+//@ has 'unsafe_binder/fn.meow.html' //pre "fn meow() -> unsafe<'a> &'a str"
+pub fn meow() -> unsafe<'a> &'a str { todo!() }
+
+//@ has 'unsafe_binder/fn.meow_squared.html' //pre "fn meow_squared() -> unsafe<'b, 'a> &'a &'b str"
+pub fn meow_squared() -> unsafe<'b, 'a> &'a &'b str { todo!() }


### PR DESCRIPTION
Adds rustdoc support for unsafe binder types: `unsafe<'a> Foo<'a>`. Doesn't add json support yet.

Tracking:
* https://github.com/rust-lang/rust/issues/130516