### PR TITLE
Add test ensuring correct suggestion for pattern dereference

### DIFF
--- a/tests/ui/pattern/suggest-dereferencing-through-Deref.fixed
+++ b/tests/ui/pattern/suggest-dereferencing-through-Deref.fixed
@@ -1,0 +1,29 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
+enum A {
+    V1(u8),
+    V2(u32),
+}
+
+fn foo() {
+    let a = Some(Box::new(A::V1(1u8)));
+    
+    if let Some(b) = a.as_ref() {
+        if let A::V1(v) = &**b { //~ ERROR mismatched types
+            println!("{:?}", v);
+        }
+    }
+}
+
+fn bar() {
+    let a = Some(Box::new(A::V1(1u8)));
+    
+    if let Some(b) = a.as_ref() {
+        if let A::V1(v) = **b { //~ ERROR mismatched types
+            println!("{:?}", v);
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/pattern/suggest-dereferencing-through-Deref.rs
+++ b/tests/ui/pattern/suggest-dereferencing-through-Deref.rs
@@ -1,0 +1,29 @@
+//@ run-rustfix
+#![allow(dead_code)]
+
+enum A {
+    V1(u8),
+    V2(u32),
+}
+
+fn foo() {
+    let a = Some(Box::new(A::V1(1u8)));
+    
+    if let Some(b) = a.as_ref() {
+        if let A::V1(v) = b { //~ ERROR mismatched types
+            println!("{:?}", v);
+        }
+    }
+}
+
+fn bar() {
+    let a = Some(Box::new(A::V1(1u8)));
+    
+    if let Some(b) = a.as_ref() {
+        if let A::V1(v) = *b { //~ ERROR mismatched types
+            println!("{:?}", v);
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/pattern/suggest-dereferencing-through-Deref.stderr
+++ b/tests/ui/pattern/suggest-dereferencing-through-Deref.stderr
@@ -1,0 +1,33 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-dereferencing-through-Deref.rs:13:16
+   |
+LL |         if let A::V1(v) = b {
+   |                ^^^^^^^^   - this expression has type `&Box<A>`
+   |                |
+   |                expected `Box<A>`, found `A`
+   |
+   = note: expected struct `Box<A>`
+                found enum `A`
+help: consider dereferencing to access the inner value using the Deref trait
+   |
+LL |         if let A::V1(v) = &**b {
+   |                           ~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-dereferencing-through-Deref.rs:23:16
+   |
+LL |         if let A::V1(v) = *b {
+   |                ^^^^^^^^   -- this expression has type `Box<A>`
+   |                |
+   |                expected `Box<A>`, found `A`
+   |
+   = note: expected struct `Box<A>`
+                found enum `A`
+help: consider dereferencing the boxed value
+   |
+LL |         if let A::V1(v) = **b {
+   |                           ~~~
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
```
error[E0308]: mismatched types
  --> $DIR/suggest-dereferencing-through-Deref.rs:13:16
   |
LL |         if let A::V1(v) = b {
   |                ^^^^^^^^   - this expression has type `&Box<A>`
   |                |
   |                expected `Box<A>`, found `A`
   |
   = note: expected struct `Box<A>`
                found enum `A`
help: consider dereferencing to access the inner value using the Deref trait
   |
LL |         if let A::V1(v) = &**b {
   |                           ~~~~

error[E0308]: mismatched types
  --> $DIR/suggest-dereferencing-through-Deref.rs:23:16
   |
LL |         if let A::V1(v) = *b {
   |                ^^^^^^^^   -- this expression has type `Box<A>`
   |                |
   |                expected `Box<A>`, found `A`
   |
   = note: expected struct `Box<A>`
                found enum `A`
help: consider dereferencing the boxed value
   |
LL |         if let A::V1(v) = **b {
   |                           ~~~
```

Fix #68628

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
