### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/src/doc/unstable-book/src/language-features/rustc-private.md
+++ b/src/doc/unstable-book/src/language-features/rustc-private.md
@@ -6,6 +6,9 @@ The tracking issue for this feature is: [#27812]
 
 ------------------------
 
-This feature allows access to unstable internal compiler crates.
+This feature allows access to unstable internal compiler crates such as `rustc_driver`.
 
-Additionally it changes the linking behavior of crates which have this feature enabled. It will prevent linking to a dylib if there's a static variant of it already statically linked into another dylib dependency. This is required to successfully link to `rustc_driver`.
+The presence of this feature changes the way the linkage format for dylibs is calculated in a way
+that is necessary for linking against dylibs that statically link `std` (such as `rustc_driver`).
+This makes this feature "viral" in linkage; its use in a given crate makes its use required in
+dependent crates which link to it (including integration tests, which are built as separate crates).

--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -59,14 +59,8 @@ impl TestCx<'_> {
             return;
         }
 
-        let prefixes = {
-            static PREFIXES: &[&str] = &["cdb", "cdbg"];
-            // No "native rust support" variation for CDB yet.
-            PREFIXES
-        };
-
         // Parse debugger commands etc from test files
-        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, self.config, prefixes)
+        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, self.config, &["cdb"])
             .unwrap_or_else(|e| self.fatal(&e));
 
         // https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-commands

--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -60,7 +60,7 @@ impl TestCx<'_> {
         }
 
         // Parse debugger commands etc from test files
-        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, self.config, &["cdb"])
+        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, self.config, "cdb")
             .unwrap_or_else(|e| self.fatal(&e));
 
         // https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-commands
@@ -131,7 +131,7 @@ impl TestCx<'_> {
     }
 
     fn run_debuginfo_gdb_test_no_opt(&self) {
-        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, self.config, &["gdb"])
+        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, self.config, "gdb")
             .unwrap_or_else(|e| self.fatal(&e));
         let mut cmds = dbg_cmds.commands.join("\n");
 
@@ -397,7 +397,7 @@ impl TestCx<'_> {
         }
 
         // Parse debugger commands etc from test files
-        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, self.config, &["lldb"])
+        let dbg_cmds = DebuggerCommands::parse_from(&self.testpaths.file, self.config, "lldb")
             .unwrap_or_else(|e| self.fatal(&e));
 
         // Write debugger script:

--- a/tests/codegen/const-array.rs
+++ b/tests/codegen/const-array.rs
@@ -1,0 +1,15 @@
+//@ compile-flags: -O
+
+#![crate_type = "lib"]
+
+const LUT: [u8; 2] = [1, 1];
+
+// CHECK-LABEL: @decode
+#[no_mangle]
+pub fn decode(i: u8) -> u8 {
+    // CHECK: start:
+    // CHECK-NEXT: icmp
+    // CHECK-NEXT: select
+    // CHECK-NEXT: ret
+    if i < 2 { LUT[i as usize] } else { 2 }
+}


### PR DESCRIPTION
Successful merges:

 - #134849 (compiletest: Slightly simplify the handling of debugger directive prefixes)
 - #134850 (Document virality of `feature(rustc_private)`)
 - #134852 (Added a codegen test for optimization with const arrays)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134849,134850,134852)
<!-- homu-ignore:end -->