### PR TITLE
rustc_codegen_ssa: Buffer file writes in link_rlib

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::error::Error;
 use std::ffi::OsString;
 use std::fs::{self, File};
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use ar_archive_writer::{
@@ -493,7 +493,6 @@ impl<'a> ArArchiveBuilder<'a> {
                 perms: 0o644,
             })
         }
-
         // Write to a temporary file first before atomically renaming to the final name.
         // This prevents programs (including rustc) from attempting to read a partial archive.
         // It also enables writing an archive with the same filename as a dependency on Windows as
@@ -509,9 +508,9 @@ impl<'a> ArArchiveBuilder<'a> {
                 io_error_context("couldn't create a directory for the temp file", err)
             })?;
         let archive_tmpfile_path = archive_tmpdir.path().join("tmp.a");
-        let mut archive_tmpfile = File::create_new(&archive_tmpfile_path)
+        let archive_tmpfile = File::create_new(&archive_tmpfile_path)
             .map_err(|err| io_error_context("couldn't create the temp file", err))?;
-
+        let mut archive_tmpfile = BufWriter::new(archive_tmpfile);
         write_archive_to_stream(
             &mut archive_tmpfile,
             &entries,
@@ -519,7 +518,8 @@ impl<'a> ArArchiveBuilder<'a> {
             false,
             /* is_ec = */ self.sess.target.arch == "arm64ec",
         )?;
-
+        archive_tmpfile.flush()?;
+        drop(archive_tmpfile);
         let any_entries = !entries.is_empty();
         drop(entries);
         // Drop src_archives to unmap all input archives, which is necessary if we want to write the

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -493,6 +493,7 @@ impl<'a> ArArchiveBuilder<'a> {
                 perms: 0o644,
             })
         }
+
         // Write to a temporary file first before atomically renaming to the final name.
         // This prevents programs (including rustc) from attempting to read a partial archive.
         // It also enables writing an archive with the same filename as a dependency on Windows as
@@ -510,6 +511,7 @@ impl<'a> ArArchiveBuilder<'a> {
         let archive_tmpfile_path = archive_tmpdir.path().join("tmp.a");
         let archive_tmpfile = File::create_new(&archive_tmpfile_path)
             .map_err(|err| io_error_context("couldn't create the temp file", err))?;
+
         let mut archive_tmpfile = BufWriter::new(archive_tmpfile);
         write_archive_to_stream(
             &mut archive_tmpfile,
@@ -520,6 +522,7 @@ impl<'a> ArArchiveBuilder<'a> {
         )?;
         archive_tmpfile.flush()?;
         drop(archive_tmpfile);
+
         let any_entries = !entries.is_empty();
         drop(entries);
         // Drop src_archives to unmap all input archives, which is necessary if we want to write the


### PR DESCRIPTION
This makes this step take ~25ms on my machine (M3 Max 64GB) for Zed repo instead of ~150ms (on editor crate). Additionally it takes down the time needed for a clean cargo build of ripgrep from ~6.1s to 5.9s. 

This change is mostly relevant for dev builds of crates with multiple large CGUs.
I imagine it could be quite relevant for dev scenarios on Windows, but sadly I have no way to measure that myself.
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
