### PR TITLE
add suggestion for wrongly ordered format parameters

### DIFF
--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -197,6 +197,8 @@ builtin_macros_format_redundant_args = redundant {$n ->
 
 builtin_macros_format_remove_raw_ident = remove the `r#`
 
+builtin_macros_format_reorder_format_parameter = did you mean `{$replacement}`?
+
 builtin_macros_format_requires_string = requires at least a format string argument
 
 builtin_macros_format_string_invalid = invalid format string: {$desc}

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -618,6 +618,17 @@ pub(crate) enum InvalidFormatStringSuggestion {
         #[primary_span]
         span: Span,
     },
+    #[suggestion(
+        builtin_macros_format_reorder_format_parameter,
+        code = "{replacement}",
+        style = "verbose",
+        applicability = "machine-applicable"
+    )]
+    ReorderFormatParameter {
+        #[primary_span]
+        span: Span,
+        replacement: String,
+    },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -316,6 +316,13 @@ fn make_format_args(
                     e.sugg_ = Some(errors::InvalidFormatStringSuggestion::RemoveRawIdent { span })
                 }
             }
+            parse::Suggestion::ReorderFormatParameter(span, replacement) => {
+                let span = fmt_span.from_inner(InnerSpan::new(span.start, span.end));
+                e.sugg_ = Some(errors::InvalidFormatStringSuggestion::ReorderFormatParameter {
+                    span,
+                    replacement,
+                });
+            }
         }
         let guar = ecx.dcx().emit_err(e);
         return ExpandResult::Ready(Err(guar));

--- a/tests/ui/fmt/suggest-wrongly-order-format-parameter.fixed
+++ b/tests/ui/fmt/suggest-wrongly-order-format-parameter.fixed
@@ -1,0 +1,25 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/129966
+//!
+//! Ensure we provide suggestion for wrongly ordered format parameters.
+
+//@ run-rustfix
+#![allow(dead_code)]
+
+#[derive(Debug)]
+struct Foo(u8, u8);
+
+fn main() {
+    let f = Foo(1, 2);
+
+    println!("{f:#?}");
+    //~^ ERROR invalid format string: expected `}`, found `#`
+    //~| HELP did you mean `#?`?
+
+    println!("{f:x?}");
+    //~^ ERROR invalid format string: expected `}`, found `x`
+    //~| HELP did you mean `x?`?
+
+    println!("{f:X?}");
+    //~^ ERROR invalid format string: expected `}`, found `X`
+    //~| HELP did you mean `X?`?
+}

--- a/tests/ui/fmt/suggest-wrongly-order-format-parameter.rs
+++ b/tests/ui/fmt/suggest-wrongly-order-format-parameter.rs
@@ -1,0 +1,25 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/129966
+//!
+//! Ensure we provide suggestion for wrongly ordered format parameters.
+
+//@ run-rustfix
+#![allow(dead_code)]
+
+#[derive(Debug)]
+struct Foo(u8, u8);
+
+fn main() {
+    let f = Foo(1, 2);
+
+    println!("{f:?#}");
+    //~^ ERROR invalid format string: expected `}`, found `#`
+    //~| HELP did you mean `#?`?
+
+    println!("{f:?x}");
+    //~^ ERROR invalid format string: expected `}`, found `x`
+    //~| HELP did you mean `x?`?
+
+    println!("{f:?X}");
+    //~^ ERROR invalid format string: expected `}`, found `X`
+    //~| HELP did you mean `X?`?
+}

--- a/tests/ui/fmt/suggest-wrongly-order-format-parameter.stderr
+++ b/tests/ui/fmt/suggest-wrongly-order-format-parameter.stderr
@@ -1,0 +1,35 @@
+error: invalid format string: expected `}`, found `#`
+  --> $DIR/suggest-wrongly-order-format-parameter.rs:14:19
+   |
+LL |     println!("{f:?#}");
+   |                   ^ expected `'}'` in format string
+   |
+help: did you mean `#?`?
+   |
+LL |     println!("{f:#?}");
+   |                  ~~
+
+error: invalid format string: expected `}`, found `x`
+  --> $DIR/suggest-wrongly-order-format-parameter.rs:18:19
+   |
+LL |     println!("{f:?x}");
+   |                   ^ expected `'}'` in format string
+   |
+help: did you mean `x?`?
+   |
+LL |     println!("{f:x?}");
+   |                  ~~
+
+error: invalid format string: expected `}`, found `X`
+  --> $DIR/suggest-wrongly-order-format-parameter.rs:22:19
+   |
+LL |     println!("{f:?X}");
+   |                   ^ expected `'}'` in format string
+   |
+help: did you mean `X?`?
+   |
+LL |     println!("{f:X?}");
+   |                  ~~
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Add suggestion for wrongly ordered format parameters like `?#`.

Supersedes #131004 
Fix #129966
