### PR TITLE
bootstrap: Fix `./x check bootstrap` by moving `shared_helpers::tests`

### DIFF
--- a/src/bootstrap/src/utils/mod.rs
+++ b/src/bootstrap/src/utils/mod.rs
@@ -14,3 +14,5 @@ pub(crate) mod metrics;
 pub(crate) mod render_tests;
 pub(crate) mod shared_helpers;
 pub(crate) mod tarball;
+#[cfg(test)]
+mod tests;

--- a/src/bootstrap/src/utils/shared_helpers.rs
+++ b/src/bootstrap/src/utils/shared_helpers.rs
@@ -13,8 +13,9 @@ use std::io::Write;
 use std::process::Command;
 use std::str::FromStr;
 
-#[cfg(test)]
-mod tests;
+// If we were to declare a tests submodule here, the shim binaries that include this
+// module via `#[path]` would fail to find it, which breaks `./x check bootstrap`.
+// So instead the unit tests for this module are in `super::tests::shared_helpers_tests`.
 
 /// Returns the environment variable which the dynamic library lookup path
 /// resides in for this platform.

--- a/src/bootstrap/src/utils/tests/mod.rs
+++ b/src/bootstrap/src/utils/tests/mod.rs
@@ -1,0 +1,1 @@
+mod shared_helpers_tests;

--- a/src/bootstrap/src/utils/tests/shared_helpers_tests.rs
+++ b/src/bootstrap/src/utils/tests/shared_helpers_tests.rs
@@ -1,4 +1,11 @@
-use super::parse_value_from_args;
+//! The `shared_helpers` module can't have its own tests submodule, because
+//! that would cause problems for the shim binaries that include it via
+//! `#[path]`, so instead those unit tests live here.
+//!
+//! To prevent tidy from complaining about this file not being named `tests.rs`,
+//! it lives inside a submodule directory named `tests`.
+
+use crate::utils::shared_helpers::parse_value_from_args;
 
 #[test]
 fn test_parse_value_from_args() {


### PR DESCRIPTION
Running `./x check bootstrap` currently doesn't work, because it builds the bootstrap shim binaries with `cfg(test)`, and those binaries can't find a `tests` submodule when they include `shared_helpers.rs` via `#[path]`.

This PR fixes that by taking the tests module and moving it to `super::tests::shared_helpers_tests` instead.

(The extra `tests` submodule prevents tidy from complaining about unit tests that aren't in a dedicated tests module.)

---

It would be nice to also run `./x check bootstrap compiletest` in CI, so that this and #134848 don't regress, but I didn't want to bundle that change with this fix.