### PR TITLE
make -Csoft-float have an effect on all ARM targets

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -189,7 +189,7 @@ pub(crate) fn target_machine_factory(
     let reloc_model = to_llvm_relocation_model(sess.relocation_model());
 
     let (opt_level, _) = to_llvm_opt_settings(optlvl);
-    let use_softfp = if sess.target.arch == "arm" && sess.target.abi == "eabihf" {
+    let use_softfp = if sess.target.arch == "arm" {
         sess.opts.cg.soft_float
     } else {
         // `validate_commandline_args_with_session_available` has already warned about this being

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1320,7 +1320,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     }
 
     if sess.opts.cg.soft_float {
-        if sess.target.arch == "arm" && sess.target.abi == "eabihf" {
+        if sess.target.arch == "arm" {
             sess.dcx().emit_warn(errors::SoftFloatDeprecated);
         } else {
             // All `use_softfp` does is the equivalent of `-mfloat-abi` in GCC/clang, which only exists on ARM targets.


### PR DESCRIPTION
See the discussion [on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/187780-t-compiler.2Fwg-llvm/topic/Softfloat.20ABI.2C.20hardfloat.20instructions): apparently `-float-abi=soft` is how one can force "use soffloat ABI but hardware FP instructions" on ARM-32. Our version of that is `-Csoft-float` but I made that one a NOP on all targets except for ARM eabihf (see https://github.com/rust-lang/rust/pull/129897)... which now make experimentation on what we actually want to do here a lot harder. So, let's unlock the flag on all ARM targets while we are still figuring out our long-term plans here.

Cc @workingjubilee 