### PR TITLE
docs: fix typos

### DIFF
--- a/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-gnu.md
@@ -122,7 +122,7 @@ limactl shell riscv
 
 Using [Docker (with BuildKit)](https://docs.docker.com/build/buildkit/) the
 [`riscv64/ubuntu`](https://hub.docker.com/r/riscv64/ubuntu) image can be used
-to buiild or run `riscv64gc-unknown-linux-gnu` binaries.
+to build or run `riscv64gc-unknown-linux-gnu` binaries.
 
 ```bash
 docker run --platform linux/riscv64 -ti --rm --mount "type=bind,src=$(pwd),dst=/checkout" riscv64/ubuntu bash

--- a/src/doc/rustc/src/targets/custom.md
+++ b/src/doc/rustc/src/targets/custom.md
@@ -21,10 +21,10 @@ To use a custom target, see the (unstable) [`build-std` feature](../../cargo/ref
 When `rustc` is given an option `--target=TARGET` (where `TARGET` is any string), it uses the following logic:
 1. if `TARGET` is the name of a built-in target, use that
 2. if `TARGET` is a path to a file, read that file as a json target
-3. otherwise, search the colon-seperated list of directories found
+3. otherwise, search the colon-separated list of directories found
    in the `RUST_TARGET_PATH` environment variable from left to right
    for a file named `TARGET.json`.
 
-These steps are tried in order, so if there are multple potentially valid
+These steps are tried in order, so if there are multiple potentially valid
 interpretations for a target, whichever is found first will take priority.
 If none of these methods find a target, an error is thrown.

--- a/src/doc/rustdoc/src/write-documentation/documentation-tests.md
+++ b/src/doc/rustdoc/src/write-documentation/documentation-tests.md
@@ -412,7 +412,7 @@ In some cases, doctests cannot be merged. For example, if you have:
 ```
 
 The problem with this code is that, if you change any other doctests, it'll likely break when
-runing `rustdoc --test`, making it tricky to maintain.
+running `rustdoc --test`, making it tricky to maintain.
 
 This is where the `standalone_crate` attribute comes in: it tells `rustdoc` that a doctest
 should not be merged with the others. So the previous code should use it:


### PR DESCRIPTION
Fix typos in docs. Thank you.