### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -755,7 +755,7 @@ impl<'a> Parser<'a> {
         // When there are a few keywords in the last ten elements of `self.expected_token_types`
         // and the current token is an identifier, it's probably a misspelled keyword. This handles
         // code like `async Move {}`, misspelled `if` in match guard, misspelled `else` in
-        // `if`-`else` and mispelled `where` in a where clause.
+        // `if`-`else` and misspelled `where` in a where clause.
         if !expected_keywords.is_empty()
             && !curr_ident.is_used_keyword()
             && let Some(misspelled_kw) = find_similar_kw(curr_ident, &expected_keywords)

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -420,7 +420,7 @@ impl<A: Allocator> RawVecInner<A> {
         match Self::try_allocate_in(capacity, AllocInit::Uninitialized, alloc, elem_layout) {
             Ok(this) => {
                 unsafe {
-                    // Make it more obvious that a subsquent Vec::reserve(capacity) will not allocate.
+                    // Make it more obvious that a subsequent Vec::reserve(capacity) will not allocate.
                     hint::assert_unchecked(!this.needs_to_grow(0, capacity, elem_layout));
                 }
                 this

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -595,7 +595,7 @@
 //! [drop-impl]: self#implementing-drop-for-types-with-address-sensitive-states
 //!
 //! The [`drop`] function takes [`&mut self`], but this is called *even if that `self` has been
-//! pinned*! Implementing [`Drop`] for a type with address-sensitive states, because if `self` was
+//! pinned*! Implementing [`Drop`] for a type with address-sensitive states requires some care, because if `self` was
 //! indeed in an address-sensitive state before [`drop`] was called, it is as if the compiler
 //! automatically called [`Pin::get_unchecked_mut`].
 //!

--- a/library/std/src/thread/current.rs
+++ b/library/std/src/thread/current.rs
@@ -136,7 +136,7 @@ pub(crate) fn set_current(thread: Thread) -> Result<(), Thread> {
 /// one thread and is guaranteed not to call the global allocator.
 #[inline]
 pub(crate) fn current_id() -> ThreadId {
-    // If accessing the persistant thread ID takes multiple TLS accesses, try
+    // If accessing the persistent thread ID takes multiple TLS accesses, try
     // to retrieve it from the current thread handle, which will only take one
     // TLS access.
     if !id::CHEAP {

--- a/src/ci/docker/README.md
+++ b/src/ci/docker/README.md
@@ -26,6 +26,12 @@ DEPLOY=1 ./src/ci/docker/run.sh x86_64-gnu
 while locally, to the `obj/$image_name` directory. This is primarily to prevent
 strange linker errors when using multiple Docker images.
 
+For some Linux workflows (for example `x86_64-gnu-llvm-18-N`), the process is more involved. You will need to see which script is executed for the given workflow inside the [`jobs.yml`](../github-actions/jobs.yml) file and pass it through the `DOCKER_SCRIPT` environment variable. For example, to reproduce the `x86_64-gnu-llvm-18-3` workflow, you can run the following script:
+
+```
+DOCKER_SCRIPT=x86_64-gnu-llvm3.sh ./src/ci/docker/run.sh x86_64-gnu-llvm-18
+```
+
 ## Local Development
 
 Refer to the [dev guide](https://rustc-dev-guide.rust-lang.org/tests/docker.html) for more information on testing locally.

--- a/src/doc/rustc/src/platform-support/android.md
+++ b/src/doc/rustc/src/platform-support/android.md
@@ -65,4 +65,4 @@ Currently the `riscv64-linux-android` target requires the following architecture
 ### aarch64-linux-android on Nightly compilers
 
 As soon as `-Zfixed-x18` compiler flag is supplied, the [`ShadowCallStack` sanitizer](https://releases.llvm.org/7.0.1/tools/clang/docs/ShadowCallStack.html)
-instrumentation is also made avaiable by supplying the second compiler flag `-Zsanitizer=shadow-call-stack`.
+instrumentation is also made available by supplying the second compiler flag `-Zsanitizer=shadow-call-stack`.

--- a/tests/codegen/slice-indexing.rs
+++ b/tests/codegen/slice-indexing.rs
@@ -60,3 +60,40 @@ pub unsafe fn str_get_unchecked_mut_by_range(x: &mut str, r: Range<usize>) -> &m
     // CHECK: sub nuw i64
     x.get_unchecked_mut(r)
 }
+
+// CHECK-LABEL: @slice_repeated_indexing(
+#[no_mangle]
+pub fn slice_repeated_indexing(dst: &mut [u8], offset: usize) {
+    let mut i = offset;
+    // CHECK: panic_bounds_check
+    dst[i] = 1;
+    i += 1;
+    // CHECK: panic_bounds_check
+    dst[i] = 2;
+    i += 1;
+    // CHECK: panic_bounds_check
+    dst[i] = 3;
+    i += 1;
+    // CHECK: panic_bounds_check
+    dst[i] = 4;
+}
+
+// CHECK-LABEL: @slice_repeated_indexing_coalesced(
+#[no_mangle]
+pub fn slice_repeated_indexing_coalesced(dst: &mut [u8], offset: usize) {
+    let mut i = offset;
+    if i.checked_add(4).unwrap() <= dst.len() {
+        // CHECK-NOT: panic_bounds_check
+        dst[i] = 1;
+        i += 1;
+        // CHECK-NOT: panic_bounds_check
+        dst[i] = 2;
+        i += 1;
+        // CHECK-NOT: panic_bounds_check
+        dst[i] = 3;
+        i += 1;
+        // CHECK-NOT: panic_bounds_check
+        dst[i] = 4;
+    }
+    // CHECK: ret
+}


### PR DESCRIPTION
Successful merges:

 - #134870 (Fix sentence fragment in `pin` module docs)
 - #134884 (Fix typos)
 - #134892 (Added codegen test for elidings bounds check when indexes are manually checked)
 - #134894 (Document how to run the split Docker pipelines)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134870,134884,134892,134894)
<!-- homu-ignore:end -->