### PR TITLE
tests: add basic test coverage for stable `--crate-type` flag

### DIFF
--- a/tests/ui/invalid-compile-flags/crate-type-flag.empty_crate_type.stderr
+++ b/tests/ui/invalid-compile-flags/crate-type-flag.empty_crate_type.stderr
@@ -1,0 +1,2 @@
+error: unknown crate type: ``
+

--- a/tests/ui/invalid-compile-flags/crate-type-flag.proc_underscore_macro.stderr
+++ b/tests/ui/invalid-compile-flags/crate-type-flag.proc_underscore_macro.stderr
@@ -1,0 +1,2 @@
+error: unknown crate type: `proc_macro`
+

--- a/tests/ui/invalid-compile-flags/crate-type-flag.rs
+++ b/tests/ui/invalid-compile-flags/crate-type-flag.rs
@@ -1,0 +1,61 @@
+//! Check that `rustc`'s `--crate-type` flag accepts `--crate-type=<valid_type>` as well as the
+//! multi-value version `--crate-type=<valid_type_1>,<valid_type_2>`.
+//!
+//! This test does not try to check if the output artifacts are valid.
+
+// FIXME(#132309): add a proper `supports-crate-type` directive.
+
+// Single valid crate types should pass
+//@ revisions: lib rlib staticlib dylib cdylib bin proc_dash_macro
+
+//@[lib] compile-flags: --crate-type=lib
+//@[lib] check-pass
+
+//@[rlib] compile-flags: --crate-type=rlib
+//@[rlib] check-pass
+
+//@[staticlib] compile-flags: --crate-type=staticlib
+//@[staticlib] check-pass
+
+//@[dylib] ignore-musl (dylibs are not supported)
+//@[dylib] ignore-wasm (dylibs are not supported)
+//@[dylib] compile-flags: --crate-type=dylib
+//@[dylib] check-pass
+
+//@[cdylib] ignore-musl (cdylibs are not supported)
+//@[cdylib] compile-flags: --crate-type=cdylib
+//@[cdylib] check-pass
+
+//@[bin] compile-flags: --crate-type=bin
+//@[bin] check-pass
+
+//@[proc_dash_macro] ignore-wasm (proc-macro is not supported)
+//@[proc_dash_macro] compile-flags: --crate-type=proc-macro
+//@[proc_dash_macro] check-pass
+
+//@ revisions: multivalue multivalue_combined
+
+//@[multivalue] compile-flags: --crate-type=lib,rlib,staticlib
+//@[multivalue] check-pass
+
+//@[multivalue_combined] ignore-musl (dylibs are not supported)
+//@[multivalue_combined] ignore-wasm (dylibs are not supported)
+//@[multivalue_combined] compile-flags: --crate-type=lib,rlib,staticlib --crate-type=dylib
+//@[multivalue_combined] check-pass
+
+// `proc-macro` is accepted, but `proc_macro` is not.
+//@ revisions: proc_underscore_macro
+//@[proc_underscore_macro] compile-flags: --crate-type=proc_macro
+//@[proc_underscore_macro] error-pattern: "unknown crate type: `proc_macro`"
+
+// Empty `--crate-type` not accepted.
+//@ revisions: empty_crate_type
+//@[empty_crate_type] compile-flags: --crate-type=
+//@[empty_crate_type] error-pattern: "unknown crate type: ``"
+
+// Random unknown crate type. Also check that we can handle non-ASCII.
+//@ revisions: unknown
+//@[unknown] compile-flags: --crate-type=🤡
+//@[unknown] error-pattern: "unknown crate type: `🤡`"
+
+fn main() {}

--- a/tests/ui/invalid-compile-flags/crate-type-flag.unknown.stderr
+++ b/tests/ui/invalid-compile-flags/crate-type-flag.unknown.stderr
@@ -1,0 +1,2 @@
+error: unknown crate type: `🤡`
+


### PR DESCRIPTION
I experimented locally with making the compiler panic if multiple crate types are passed to a single `--crate-type` flag, and it turns out not only does the compiler successfully bootstrap, only two ui tests failed:

```
failures:
    [ui] tests/ui/sepcomp/sepcomp-lib.rs
    [ui] tests/ui/sepcomp/sepcomp-lib-lto.rs

test result: FAILED. 4 passed; 2 failed; 18181 ignored; 0 measured; 0 filtered out; finished in 364.55ms
```

These are not specific tests for the `--crate-type` flag, only their auxiliary *happens* to use a `--crate-type` with two crate types:

```rs
//@ compile-flags: -C codegen-units=3 --crate-type=rlib,dylib -g
```

I was not able to find a specific test in run-make test suite either.

So this PR tries to add some basic test coverage for the stable `--crate-type` flag's interface (including to check that `--crate-type` accepts multiple crate types), since I imagine it might be slightly awkward if we accidentally regressed this.

r? compiler