### PR TITLE
Fix doc for pointer's validity in zst operation

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -15,7 +15,7 @@
 //! The precise rules for validity are not determined yet. The guarantees that are
 //! provided at this point are very minimal:
 //!
-//! * For operations of [size zero][zst], *every* pointer is valid, including the [null] pointer.
+//! * For operations of [size zero][zst], *every* pointer is valid, except the [null] pointer.
 //!   The following points are only concerned with non-zero-sized accesses.
 //! * A [null] pointer is *never* valid.
 //! * For a pointer to be valid, it is necessary, but not always sufficient, that the pointer be


### PR DESCRIPTION
### PR Description
This pr addresses a discrepancy in the documentation regarding pointer validity for zero-sized types (ZSTs). 

According to the documentation on [core::ptr](https://doc.rust-lang.org/core/ptr/index.html), it states that 
> For operations of size zero, every pointer is valid, including the null pointer.

However, this is contradicted by the documentation on [core::ptr::read](https://doc.rust-lang.org/core/ptr/fn.read.html), which specifies that 
> even if T has size 0, the pointer must be non-null and properly aligned.

This creates a contradiction, as `core::ptr::read` explicitly states that pointers to ZSTs must be non-null, while the `core::ptr` documentation implies that null pointers are valid for ZSTs.

###  Suggestion 
Besides, I would like to suggest a revision to the following sentence in the [core::ptr](https://doc.rust-lang.org/core/ptr/index.html) documentation:

> We say that a pointer is “dangling” if it is not valid for any non-zero-sized accesses. This means out-of-bounds pointers, pointers to freed memory, null pointers, and pointers created with NonNull::dangling are all dangling.

The term "dangling" traditionally refers to a pointer that still exists but points to memory that has been freed or is otherwise invalid. In contrast, a null pointer is not considered a "dangling" pointer, but rather an invalid pointer by definition. 

So in this context, I think replacing "dangling"  with "invalid" would be better?