### PR TITLE
ci: Cleanup docker build logs in CI

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -76,8 +76,9 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
     # Include cache version. Can be used to manually bust the Docker cache.
     echo "2" >> $hash_key
 
-    echo "Image input"
+    echo "::group::Image checksum input"
     cat $hash_key
+    echo "::endgroup::"
 
     cksum=$(sha512sum $hash_key | \
     awk '{print $1}')


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Cleaning up the CI logs to make reviewing CI failures easier. This PR adds a `::group` around the docker tag hash input which is pretty large (250+ lines) and is probably not relevant for most people.

Related to #134910 , see this [comment](https://github.com/rust-lang/rust/issues/134910#issuecomment-2565612463) 


