### PR TITLE
compiletest: Deny usage of special FileCheck suffixes as revision names

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -951,10 +951,12 @@ impl Config {
                         raw,
                         testfile.display()
                     );
-                } else if FORBIDDEN_REVISION_NAMES.contains(&revision.as_str()) {
+                } else if matches!(self.mode, Mode::Assembly | Mode::Codegen | Mode::MirOpt)
+                    && FORBIDDEN_REVISION_NAMES.contains(&revision.as_str())
+                {
                     panic!(
-                        "invalid revision: `{}` in line `{}`: {}",
-                        revision,
+                        "revision name `{revision}` is not permitted in a test suite that uses `FileCheck` annotations\n\
+                         as it is confusing when used as custom `FileCheck` prefix: `{revision}` in line `{}`: {}",
                         raw,
                         testfile.display()
                     );

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -934,6 +934,9 @@ fn iter_header(
 
 impl Config {
     fn parse_and_update_revisions(&self, testfile: &Path, line: &str, existing: &mut Vec<String>) {
+        const FORBIDDEN_REVISION_NAMES: [&str; 9] =
+            ["CHECK", "COM", "NEXT", "SAME", "EMPTY", "NOT", "COUNT", "DAG", "LABEL"];
+
         if let Some(raw) = self.parse_name_value_directive(line, "revisions") {
             if self.mode == Mode::RunMake {
                 panic!("`run-make` tests do not support revisions: {}", testfile.display());
@@ -944,6 +947,13 @@ impl Config {
                 if !duplicates.insert(revision.clone()) {
                     panic!(
                         "duplicate revision: `{}` in line `{}`: {}",
+                        revision,
+                        raw,
+                        testfile.display()
+                    );
+                } else if FORBIDDEN_REVISION_NAMES.contains(&revision.as_str()) {
+                    panic!(
+                        "invalid revision: `{}` in line `{}`: {}",
                         revision,
                         raw,
                         testfile.display()

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -554,6 +554,21 @@ fn test_duplicate_revisions() {
 }
 
 #[test]
+fn test_forbidden_revisions() {
+    let config: Config = cfg().build();
+    let revisions = ["CHECK", "COM", "NEXT", "SAME", "EMPTY", "NOT", "COUNT", "DAG", "LABEL"];
+    for rev in revisions {
+        let res = std::panic::catch_unwind(|| {
+            parse_rs(&config, format!("//@ revisions: {rev}").as_str());
+        });
+        assert!(res.is_err());
+        if let Some(msg) = res.unwrap_err().downcast_ref::<String>() {
+            assert!(msg.contains(format!("invalid revision: `{rev}` in line ` {rev}`").as_str()))
+        }
+    }
+}
+
+#[test]
 fn ignore_arch() {
     let archs = [
         ("x86_64-unknown-linux-gnu", "x86_64"),


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Adds a check that ensures special FileCheck suffixes are not used as revision names.

Fix #130982 
