### PR TITLE
Stabilize `style_edition = "2024"` in-tree

### DIFF
--- a/src/tools/rustfmt/src/bin/main.rs
+++ b/src/tools/rustfmt/src/bin/main.rs
@@ -568,10 +568,6 @@ impl GetOptsOptions {
                 if let Some(ref file_lines) = matches.opt_str("file-lines") {
                     options.file_lines = file_lines.parse()?;
                 }
-                if let Some(ref edition_str) = matches.opt_str("style-edition") {
-                    options.style_edition =
-                        Some(style_edition_from_style_edition_str(edition_str)?);
-                }
             } else {
                 let mut unstable_options = vec![];
                 if matches.opt_present("skip-children") {
@@ -582,9 +578,6 @@ impl GetOptsOptions {
                 }
                 if matches.opt_present("file-lines") {
                     unstable_options.push("`--file-lines`");
-                }
-                if matches.opt_present("style-edition") {
-                    unstable_options.push("`--style-edition`");
                 }
                 if !unstable_options.is_empty() {
                     let s = if unstable_options.len() == 1 { "" } else { "s" };
@@ -659,6 +652,10 @@ impl GetOptsOptions {
                 Ok(color) => options.color = Some(color),
                 _ => return Err(format_err!("Invalid color: {}", color)),
             }
+        }
+
+        if let Some(ref edition_str) = matches.opt_str("style-edition") {
+            options.style_edition = Some(style_edition_from_style_edition_str(edition_str)?);
         }
 
         Ok(options)

--- a/src/tools/rustfmt/src/config/mod.rs
+++ b/src/tools/rustfmt/src/config/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod style_edition;
 // This macro defines configuration options used in rustfmt. Each option
 // is defined as follows:
 //
-// `name: value type, default value, is stable, description;`
+// `name: value type, is stable, description;`
 create_config! {
     // Fundamental stuff
     max_width: MaxWidth, true, "Maximum width of each line";
@@ -149,7 +149,7 @@ create_config! {
     blank_lines_lower_bound: BlankLinesLowerBound, false,
         "Minimum number of blank lines which must be put between items";
     edition: EditionConfig, true, "The edition of the parser (RFC 2052)";
-    style_edition: StyleEditionConfig, false, "The edition of the Style Guide (RFC 3338)";
+    style_edition: StyleEditionConfig, true, "The edition of the Style Guide (RFC 3338)";
     version: VersionConfig, false, "Version of formatting rules";
     inline_attribute_width: InlineAttributeWidth, false,
         "Write an item and its attribute on the same line \

--- a/src/tools/rustfmt/src/config/options.rs
+++ b/src/tools/rustfmt/src/config/options.rs
@@ -511,7 +511,6 @@ pub enum StyleEdition {
     Edition2021,
     #[value = "2024"]
     #[doc_hint = "2024"]
-    #[unstable_variant]
     /// [Edition 2024]().
     Edition2024,
 }


### PR DESCRIPTION
This PR stabilizes the `style_edition` flag in rustfmt.

**Why am I doing this in-tree?** The beta release cut is imminent (according to forge, on January 3) and this is the most lightweight approach to getting this flag stable on nightly. It's imperative (as far as I can tell -- @traviscross can verify or disagree) that we stabilize the `style_edition` flag so that users can control their style edition separately from the edition.

I'm happy to move this PR to the rustfmt repo and subsequently prepare a subtree sync if someone on @rust-lang/rustfmt believes that we should get this landed on the rustfmt side then synced. If this is the right recourse, I'd like to note that this is still quite time-sensitive. However, I'm happy to dedicate time to get this done if necessary, since I'd really like to un-jeopardize the style edition.

Tracking:

- https://github.com/rust-lang/rust/issues/123799