### PR TITLE
Account for type parameters in bound suggestion

### DIFF
--- a/tests/ui/methods/suggest-restriction-involving-type-param.fixed
+++ b/tests/ui/methods/suggest-restriction-involving-type-param.fixed
@@ -1,0 +1,31 @@
+//@ run-rustfix
+
+#[derive(Clone)]
+struct A {
+    x: String
+}
+
+struct B {
+    x: String
+}
+
+impl From<A> for B {
+    fn from(a: A) -> Self {
+        B { x: a.x }
+    }
+}
+
+impl B {
+    pub fn from_many<T: Into<B> + Clone>(v: Vec<T>) -> Self where B: From<T> {
+        B { x: v.iter().map(|e| B::from(e.clone()).x).collect::<Vec<String>>().join(" ") }
+        //~^ ERROR the trait bound `B: From<T>` is not satisfied
+    }
+}
+
+fn main() {
+    let _b: B = B { x: "foobar".to_string() };
+    let a: A = A { x: "frob".to_string() };
+    let ab: B = a.into();
+    println!("Hello, {}!", ab.x);
+    let _c: B = B::from_many(vec![A { x: "x".to_string() }]);
+}

--- a/tests/ui/methods/suggest-restriction-involving-type-param.rs
+++ b/tests/ui/methods/suggest-restriction-involving-type-param.rs
@@ -1,0 +1,31 @@
+//@ run-rustfix
+
+#[derive(Clone)]
+struct A {
+    x: String
+}
+
+struct B {
+    x: String
+}
+
+impl From<A> for B {
+    fn from(a: A) -> Self {
+        B { x: a.x }
+    }
+}
+
+impl B {
+    pub fn from_many<T: Into<B> + Clone>(v: Vec<T>) -> Self {
+        B { x: v.iter().map(|e| B::from(e.clone()).x).collect::<Vec<String>>().join(" ") }
+        //~^ ERROR the trait bound `B: From<T>` is not satisfied
+    }
+}
+
+fn main() {
+    let _b: B = B { x: "foobar".to_string() };
+    let a: A = A { x: "frob".to_string() };
+    let ab: B = a.into();
+    println!("Hello, {}!", ab.x);
+    let _c: B = B::from_many(vec![A { x: "x".to_string() }]);
+}

--- a/tests/ui/methods/suggest-restriction-involving-type-param.stderr
+++ b/tests/ui/methods/suggest-restriction-involving-type-param.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `B: From<T>` is not satisfied
+  --> $DIR/suggest-restriction-involving-type-param.rs:20:33
+   |
+LL |         B { x: v.iter().map(|e| B::from(e.clone()).x).collect::<Vec<String>>().join(" ") }
+   |                                 ^ the trait `From<T>` is not implemented for `B`
+   |
+help: consider further restricting the type
+   |
+LL |     pub fn from_many<T: Into<B> + Clone>(v: Vec<T>) -> Self where B: From<T> {
+   |                                                             ++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
When encountering a missing bound that involves a type parameter, on associated functions we look at the generics to see if the type parameter is present. If so, we suggest the bound on the associated function instead of on the impl/trait. At the impl/trait doesn't have another type parameter of that name, then we don't suggest the bound at that item level.

```
error[E0277]: the trait bound `B: From<T>` is not satisfied
  --> $DIR/suggest-restriction-involving-type-param.rs:20:33
   |
LL |         B { x: v.iter().map(|e| B::from(e.clone()).x).collect::<Vec<String>>().join(" ") }
   |                                 ^ the trait `From<T>` is not implemented for `B`
   |
help: consider further restricting the type
   |
LL |     pub fn from_many<T: Into<B> + Clone>(v: Vec<T>) -> Self where B: From<T> {
   |                                                             ++++++++++++++++
```

Fix #104089.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
