### PR TITLE
Include arguments to the precondition check in failure messages

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -133,7 +133,7 @@ impl Layout {
         assert_unsafe_precondition!(
             check_library_ub,
             "Layout::from_size_align_unchecked requires that align is a power of 2 \
-            and the rounded-up allocation size does not exceed isize::MAX",
+            and the rounded-up allocation size does not exceed isize::MAX (size:{size}, align:{align})",
             (
                 size: usize = size,
                 align: usize = align,

--- a/library/core/src/ascii/ascii_char.rs
+++ b/library/core/src/ascii/ascii_char.rs
@@ -521,7 +521,7 @@ impl AsciiChar {
     pub const unsafe fn digit_unchecked(d: u8) -> Self {
         assert_unsafe_precondition!(
             check_library_ub,
-            "`ascii::Char::digit_unchecked` input cannot exceed 9.",
+            "`ascii::Char::digit_unchecked` input cannot exceed 9. (d:{d})",
             (d: u8 = d) => d < 10
         );
 

--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -28,7 +28,7 @@ pub(super) const unsafe fn from_u32_unchecked(i: u32) -> char {
     unsafe {
         assert_unsafe_precondition!(
             check_language_ub,
-            "invalid value for `char`",
+            "invalid value for `char` ({i})",
             (i: u32 = i) => char_try_from_u32(i).is_ok()
         );
         transmute(i)

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1859,8 +1859,9 @@ impl char {
     pub const unsafe fn as_ascii_unchecked(&self) -> ascii::Char {
         assert_unsafe_precondition!(
             check_library_ub,
-            "as_ascii_unchecked requires that the char is valid ASCII",
-            (it: &char = self) => it.is_ascii()
+            "as_ascii_unchecked requires that the char is valid ASCII \
+            (self:{it})",
+            (it: char = *self) => it.is_ascii()
         );
 
         // SAFETY: the caller promised that this char is ASCII.

--- a/library/core/src/displaywrapper.rs
+++ b/library/core/src/displaywrapper.rs
@@ -1,0 +1,111 @@
+use core::fmt::{Display, Formatter, Result};
+use core::num::NonZeroU128;
+
+#[allow(missing_debug_implementations)]
+pub struct DisplayWrapper<T>(pub T);
+
+macro_rules! display_int {
+    ($ty:ty) => {
+        impl Display for DisplayWrapper<$ty> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+                let n = self.0;
+                let is_negative = n < 0;
+                let n = (!(n as u128)).wrapping_add(1);
+                display_int(n, is_negative, f)
+            }
+        }
+    };
+}
+
+display_int!(i8);
+display_int!(i16);
+display_int!(i32);
+display_int!(i64);
+display_int!(i128);
+display_int!(isize);
+
+macro_rules! display_uint {
+    ($ty:ty) => {
+        impl Display for DisplayWrapper<$ty> {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+                display_int(self.0 as u128, false, f)
+            }
+        }
+    };
+}
+
+display_uint!(u8);
+display_uint!(u16);
+display_uint!(u32);
+display_uint!(u64);
+display_uint!(u128);
+display_uint!(usize);
+
+impl Display for DisplayWrapper<*const ()> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        format_ptr(self.0.addr(), f)
+    }
+}
+impl Display for DisplayWrapper<*mut ()> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        format_ptr(self.0.addr(), f)
+    }
+}
+
+impl Display for DisplayWrapper<char> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let mut buf = [0u8; 4];
+        let s = self.0.encode_utf8(&mut buf);
+        f.write_str(s)
+    }
+}
+
+impl Display for DisplayWrapper<bool> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let s = match self.0 {
+            true => "true",
+            false => "false",
+        };
+        f.write_str(s)
+    }
+}
+
+const ALPHABET: &[u8; 16] = b"0123456789abcdef";
+
+fn format_with_radix(mut n: u128, buf: &mut [u8], radix: NonZeroU128) -> usize {
+    let mut cur = buf.len();
+    while n >= radix.get() {
+        let d = n % radix;
+        n /= radix;
+        cur = cur.wrapping_sub(1);
+        buf[cur] = ALPHABET[d as usize];
+    }
+    cur = cur.wrapping_sub(1);
+    buf[cur] = ALPHABET[n as usize];
+    cur
+}
+
+pub fn format_ptr(addr: usize, f: &mut Formatter<'_>) -> Result {
+    let mut buf = [b'0'; 42];
+    let mut cur =
+        format_with_radix(addr as u128, &mut buf, const { NonZeroU128::new(16).unwrap() });
+
+    cur = cur.wrapping_sub(1);
+    buf[cur] = b'x';
+    cur = cur.wrapping_sub(1);
+
+    // SAFETY: The buffer is initially ASCII and we only write ASCII bytes to it.
+    let s = unsafe { core::str::from_utf8_unchecked(&buf[cur..]) };
+    f.write_str(s)
+}
+
+pub fn display_int(n: u128, is_negative: bool, f: &mut Formatter<'_>) -> Result {
+    let mut buf = [b'-'; 42];
+    let mut cur = format_with_radix(n, &mut buf, const { NonZeroU128::new(10).unwrap() });
+    if is_negative {
+        cur = cur.wrapping_sub(1);
+    }
+    // SAFETY: The buffer is initially ASCII and we only write ASCII bytes to it.
+    let s = unsafe { core::str::from_utf8_unchecked(&buf[cur..]) };
+    f.write_str(s)
+}

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2096,6 +2096,7 @@ impl<'a> Formatter<'a> {
     /// assert_eq!(format!("{Foo:0>8}"), "Foo");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     pub fn write_str(&mut self, data: &str) -> Result {
         self.buf.write_str(data)
     }

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2424,7 +2424,7 @@ where
 /// macro supports setting attributes for those functions. Both functions are marked as `#[inline]`.
 ///
 /// See [`const_eval_select()`] for the rules and requirements around that intrinsic.
-pub(crate) macro const_eval_select {
+pub macro const_eval_select {
     (
         @capture$([$($binders:tt)*])? { $($arg:ident : $ty:ty = $val:expr),* $(,)? } $( -> $ret:ty )? :
         if const

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -347,6 +347,9 @@ pub mod alloc;
 
 // note: does not need to be public
 mod bool;
+#[doc(hidden)]
+#[unstable(feature = "ub_checks", issue = "none")]
+pub mod displaywrapper;
 mod escape;
 mod tuple;
 mod unit;

--- a/library/core/src/mem/alignment.rs
+++ b/library/core/src/mem/alignment.rs
@@ -188,7 +188,8 @@ impl Alignment {
     pub const unsafe fn new_unchecked(align: usize) -> Self {
         assert_unsafe_precondition!(
             check_language_ub,
-            "Alignment::new_unchecked requires a power of two",
+            "Alignment::new_unchecked requires a power of two \
+            (align:{align})",
             (align: usize = align) => align.is_power_of_two()
         );
 

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -651,7 +651,7 @@ impl u8 {
         assert_unsafe_precondition!(
             check_library_ub,
             "as_ascii_unchecked requires that the byte is valid ASCII",
-            (it: &u8 = self) => it.is_ascii()
+            (it: u8 = *self) => it.is_ascii()
         );
 
         // SAFETY: the caller promised that this byte is ASCII.

--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -24,7 +24,8 @@ impl IndexRange {
     pub(crate) const unsafe fn new_unchecked(start: usize, end: usize) -> Self {
         ub_checks::assert_unsafe_precondition!(
             check_library_ub,
-            "IndexRange::new_unchecked requires `start <= end`",
+            "IndexRange::new_unchecked requires `start <= end` \
+            (start:{start}, end:{end})",
             (start: usize = start, end: usize = end) => start <= end,
         );
         IndexRange { start, end }

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -377,7 +377,8 @@ impl<T: PointeeSized> *const T {
 
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::offset requires the address calculation to not overflow",
+            "ptr::offset requires the address calculation to not overflow \
+            (ptr:{this}, count:{count}, size:{size})",
             (
                 this: *const () = self as *const (),
                 count: isize = count,
@@ -721,7 +722,8 @@ impl<T: PointeeSized> *const T {
 
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::offset_from_unsigned requires `self >= origin`",
+            "ptr::offset_from_unsigned requires `self >= origin` \
+            (self:{this}, origin:{origin})",
             (
                 this: *const () = self as *const (),
                 origin: *const () = origin as *const (),
@@ -860,7 +862,8 @@ impl<T: PointeeSized> *const T {
         #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::add requires that the address calculation does not overflow",
+            "ptr::add requires that the address calculation does not overflow \
+            (self:{this}, count:{count}, size:{size})",
             (
                 this: *const () = self as *const (),
                 count: usize = count,
@@ -938,7 +941,8 @@ impl<T: PointeeSized> *const T {
         #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::sub requires that the address calculation does not overflow",
+            "ptr::sub requires that the address calculation does not overflow \
+            (self:{this}, count:{count}, size:{size})",
             (
                 this: *const () = self as *const (),
                 count: usize = count,

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -531,7 +531,8 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
     ub_checks::assert_unsafe_precondition!(
         check_language_ub,
         "ptr::copy_nonoverlapping requires that both pointer arguments are aligned and non-null \
-        and the specified memory ranges do not overlap",
+        and the specified memory ranges do not overlap \
+        (src{src}, dst:{dst}, size:{size}, align:{align}, count:{count})",
         (
             src: *const () = src as *const (),
             dst: *mut () = dst as *mut (),
@@ -629,7 +630,8 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     unsafe {
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::copy requires that both pointer arguments are aligned and non-null",
+            "ptr::copy requires that both pointer arguments are aligned and non-null \
+            (src{src}, dst:{dst}, align:{align})",
             (
                 src: *const () = src as *const (),
                 dst: *mut () = dst as *mut (),
@@ -703,7 +705,8 @@ pub const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize) {
     unsafe {
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::write_bytes requires that the destination pointer is aligned and non-null",
+            "ptr::write_bytes requires that the destination pointer is aligned and non-null \
+            (dst:{addr}, align:{align})",
             (
                 addr: *const () = dst as *const (),
                 align: usize = align_of::<T>(),
@@ -1381,7 +1384,8 @@ pub const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
     ub_checks::assert_unsafe_precondition!(
         check_library_ub,
         "ptr::swap_nonoverlapping requires that both pointer arguments are aligned and non-null \
-        and the specified memory ranges do not overlap",
+        and the specified memory ranges do not overlap \
+        (x:{x}, y:{y}, size:{size}, align:{align}, count:{count})",
         (
             x: *mut () = x as *mut (),
             y: *mut () = y as *mut (),
@@ -1564,7 +1568,8 @@ pub const unsafe fn replace<T>(dst: *mut T, src: T) -> T {
     unsafe {
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::replace requires that the pointer argument is aligned and non-null",
+            "ptr::replace requires that the pointer argument is aligned and non-null \
+            (dst:{addr}, (align:{align}))",
             (
                 addr: *const () = dst as *const (),
                 align: usize = align_of::<T>(),
@@ -1723,7 +1728,8 @@ pub const unsafe fn read<T>(src: *const T) -> T {
         #[cfg(debug_assertions)] // Too expensive to always enable (for now?)
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::read requires that the pointer argument is aligned and non-null",
+            "ptr::read requires that the pointer argument is aligned and non-null \
+            (src:{addr}, align:{align})",
             (
                 addr: *const () = src as *const (),
                 align: usize = align_of::<T>(),
@@ -1923,7 +1929,8 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
         #[cfg(debug_assertions)] // Too expensive to always enable (for now?)
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::write requires that the pointer argument is aligned and non-null",
+            "ptr::write requires that the pointer argument is aligned and non-null \
+            (dst:{addr}, align:{align})",
             (
                 addr: *mut () = dst as *mut (),
                 align: usize = align_of::<T>(),
@@ -2113,7 +2120,8 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
     unsafe {
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::read_volatile requires that the pointer argument is aligned",
+            "ptr::read_volatile requires that the pointer argument is aligned \
+            (src:{addr}, align:{align})",
             (
                 addr: *const () = src as *const (),
                 align: usize = align_of::<T>(),
@@ -2215,7 +2223,8 @@ pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
     unsafe {
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::write_volatile requires that the pointer argument is aligned",
+            "ptr::write_volatile requires that the pointer argument is aligned \
+            (dst:{addr}, align:{align})",
             (
                 addr: *mut () = dst as *mut (),
                 align: usize = align_of::<T>(),

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -380,7 +380,8 @@ impl<T: PointeeSized> *mut T {
 
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::offset requires the address calculation to not overflow",
+            "ptr::offset requires the address calculation to not overflow \
+            (self:{this}, count:{count}, size:{size})",
             (
                 this: *const () = self as *const (),
                 count: isize = count,
@@ -958,7 +959,8 @@ impl<T: PointeeSized> *mut T {
         #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::add requires that the address calculation does not overflow",
+            "ptr::add requires that the address calculation does not overflow \
+            (self:{this}, count:{count}, size:{size})",
             (
                 this: *const () = self as *const (),
                 count: usize = count,
@@ -1036,7 +1038,8 @@ impl<T: PointeeSized> *mut T {
         #[cfg(debug_assertions)] // Expensive, and doesn't catch much in the wild.
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "ptr::sub requires that the address calculation does not overflow",
+            "ptr::sub requires that the address calculation does not overflow \
+            (self:{this}, count:{count}, size:{size})",
             (
                 this: *const () = self as *const (),
                 count: usize = count,

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -232,7 +232,7 @@ impl<T: PointeeSized> NonNull<T> {
         unsafe {
             assert_unsafe_precondition!(
                 check_language_ub,
-                "NonNull::new_unchecked requires that the pointer is non-null",
+                "NonNull::new_unchecked requires that the pointer is non-null (ptr:{ptr})",
                 (ptr: *mut () = ptr as *mut ()) => !ptr.is_null()
             );
             transmute(ptr)

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -198,9 +198,10 @@ const unsafe impl<T> SliceIndex<[T]> for usize {
     #[track_caller]
     unsafe fn get_unchecked(self, slice: *const [T]) -> *const T {
         assert_unsafe_precondition!(
-            check_language_ub, // okay because of the `assume` below
-            "slice::get_unchecked requires that the index is within the slice",
-            (this: usize = self, len: usize = slice.len()) => this < len
+            check_language_ub,
+            "slice::get_unchecked requires that the index is within the slice \
+            (index:{index}, len:{len})",
+            (index: usize = self, len: usize = slice.len()) => index < len
         );
         // SAFETY: the caller guarantees that `slice` is not dangling, so it
         // cannot be longer than `isize::MAX`. They also guarantee that
@@ -219,8 +220,9 @@ const unsafe impl<T> SliceIndex<[T]> for usize {
     unsafe fn get_unchecked_mut(self, slice: *mut [T]) -> *mut T {
         assert_unsafe_precondition!(
             check_library_ub,
-            "slice::get_unchecked_mut requires that the index is within the slice",
-            (this: usize = self, len: usize = slice.len()) => this < len
+            "slice::get_unchecked_mut requires that the index is within the slice \
+            (index:{index}, len:{len})",
+            (index: usize = self, len: usize = slice.len()) => index < len
         );
         // SAFETY: see comments for `get_unchecked` above.
         unsafe { slice_get_unchecked(slice, self) }
@@ -270,7 +272,8 @@ const unsafe impl<T> SliceIndex<[T]> for ops::IndexRange {
     unsafe fn get_unchecked(self, slice: *const [T]) -> *const [T] {
         assert_unsafe_precondition!(
             check_library_ub,
-            "slice::get_unchecked requires that the index is within the slice",
+            "slice::get_unchecked requires that the index is within the slice \
+            (end:{end}, len:{len})",
             (end: usize = self.end(), len: usize = slice.len()) => end <= len
         );
         // SAFETY: the caller guarantees that `slice` is not dangling, so it
@@ -285,7 +288,8 @@ const unsafe impl<T> SliceIndex<[T]> for ops::IndexRange {
     unsafe fn get_unchecked_mut(self, slice: *mut [T]) -> *mut [T] {
         assert_unsafe_precondition!(
             check_library_ub,
-            "slice::get_unchecked_mut requires that the index is within the slice",
+            "slice::get_unchecked_mut requires that the index is within the slice \
+            (end:{end}, len:{len})",
             (end: usize = self.end(), len: usize = slice.len()) => end <= len
         );
 
@@ -352,7 +356,8 @@ const unsafe impl<T> SliceIndex<[T]> for ops::Range<usize> {
     unsafe fn get_unchecked(self, slice: *const [T]) -> *const [T] {
         assert_unsafe_precondition!(
             check_library_ub,
-            "slice::get_unchecked requires that the range is within the slice",
+            "slice::get_unchecked requires that the range is within the slice \
+            (range:{start}..{end}, len:{len})",
             (
                 start: usize = self.start,
                 end: usize = self.end,
@@ -377,7 +382,8 @@ const unsafe impl<T> SliceIndex<[T]> for ops::Range<usize> {
     unsafe fn get_unchecked_mut(self, slice: *mut [T]) -> *mut [T] {
         assert_unsafe_precondition!(
             check_library_ub,
-            "slice::get_unchecked_mut requires that the range is within the slice",
+            "slice::get_unchecked_mut requires that the range is within the slice \
+            (range:{start}..{end}, len:{len})",
             (
                 start: usize = self.start,
                 end: usize = self.end,

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -951,7 +951,8 @@ impl<T> [T] {
     pub const unsafe fn swap_unchecked(&mut self, a: usize, b: usize) {
         assert_unsafe_precondition!(
             check_library_ub,
-            "slice::swap_unchecked requires that the indices are within the slice",
+            "slice::swap_unchecked requires that the indices are within the slice \
+            (a:{a}, b:{b}, len:{len})",
             (
                 len: usize = self.len(),
                 a: usize = a,
@@ -1341,7 +1342,8 @@ impl<T> [T] {
     pub const unsafe fn as_chunks_unchecked<const N: usize>(&self) -> &[[T; N]] {
         assert_unsafe_precondition!(
             check_language_ub,
-            "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks",
+            "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks \
+            (N:{n}, len:{len})",
             (n: usize = N, len: usize = self.len()) => n != 0 && len.is_multiple_of(n),
         );
         // SAFETY: Caller must guarantee that `N` is nonzero and exactly divides the slice length
@@ -1501,7 +1503,8 @@ impl<T> [T] {
     pub const unsafe fn as_chunks_unchecked_mut<const N: usize>(&mut self) -> &mut [[T; N]] {
         assert_unsafe_precondition!(
             check_language_ub,
-            "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks",
+            "slice::as_chunks_unchecked requires `N != 0` and the slice to split exactly into `N`-element chunks \
+            (N:{n}, len:{len})",
             (n: usize = N, len: usize = self.len()) => n != 0 && len.is_multiple_of(n)
         );
         // SAFETY: Caller must guarantee that `N` is nonzero and exactly divides the slice length
@@ -2048,7 +2051,8 @@ impl<T> [T] {
 
         assert_unsafe_precondition!(
             check_library_ub,
-            "slice::split_at_unchecked requires the index to be within the slice",
+            "slice::split_at_unchecked requires the index to be within the slice \
+            (mid:{mid}, len:{len})",
             (mid: usize = mid, len: usize = len) => mid <= len,
         );
 
@@ -2098,7 +2102,8 @@ impl<T> [T] {
 
         assert_unsafe_precondition!(
             check_library_ub,
-            "slice::split_at_mut_unchecked requires the index to be within the slice",
+            "slice::split_at_mut_unchecked requires the index to be within the slice \
+            (mid:{mid}, len:{len})",
             (mid: usize = mid, len: usize = len) => mid <= len,
         );
 

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -126,7 +126,8 @@ pub const unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T]
     unsafe {
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`",
+            "slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX` \
+            (data:{data}, size:{size}, align:{align}, len:{len})",
             (
                 data: *mut () = data as *mut (),
                 size: usize = size_of::<T>(),
@@ -181,7 +182,8 @@ pub const unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a m
     unsafe {
         ub_checks::assert_unsafe_precondition!(
             check_language_ub,
-            "slice::from_raw_parts_mut requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`",
+            "slice::from_raw_parts_mut requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX` \
+            (data:{data}, size:{size}, align:{align}, len:{len})",
             (
                 data: *mut () = data as *mut (),
                 size: usize = size_of::<T>(),

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2825,6 +2825,7 @@ impl str {
     #[must_use]
     #[inline]
     pub const unsafe fn as_ascii_unchecked(&self) -> &[ascii::Char] {
+        // FIXME: Add &str support to DisplayWrapper
         assert_unsafe_precondition!(
             check_library_ub,
             "as_ascii_unchecked requires that the string is valid ASCII",

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -207,7 +207,8 @@ const unsafe impl SliceIndex<str> for ops::Range<usize> {
             // `str::get_unchecked` without adding a special function
             // to `SliceIndex` just for this.
             check_library_ub,
-            "str::get_unchecked requires that the range is within the string slice",
+            "str::get_unchecked requires that the range is within the string slice \
+            (range:{start}..{end}, len:{len})",
             (
                 start: usize = self.start,
                 end: usize = self.end,
@@ -229,7 +230,8 @@ const unsafe impl SliceIndex<str> for ops::Range<usize> {
 
         assert_unsafe_precondition!(
             check_library_ub,
-            "str::get_unchecked_mut requires that the range is within the string slice",
+            "str::get_unchecked_mut requires that the range is within the string slice \
+            (range:{start}..{end}, len:{len})",
             (
                 start: usize = self.start,
                 end: usize = self.end,
@@ -291,7 +293,8 @@ const unsafe impl SliceIndex<str> for range::Range<usize> {
             // `str::get_unchecked` without adding a special function
             // to `SliceIndex` just for this.
             check_library_ub,
-            "str::get_unchecked requires that the range is within the string slice",
+            "str::get_unchecked requires that the range is within the string slice \
+            (range:{start}..{end}, len:{len})",
             (
                 start: usize = self.start,
                 end: usize = self.end,
@@ -313,7 +316,8 @@ const unsafe impl SliceIndex<str> for range::Range<usize> {
 
         assert_unsafe_precondition!(
             check_library_ub,
-            "str::get_unchecked_mut requires that the range is within the string slice",
+            "str::get_unchecked_mut requires that the range is within the string slice \
+            (range:{start}..{end}, len:{len})",
             (
                 start: usize = self.start,
                 end: usize = self.end,

--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -65,13 +65,20 @@ macro_rules! assert_unsafe_precondition {
             #[inline]
             #[rustc_nounwind]
             #[track_caller]
+            #[rustc_allow_const_fn_unstable(const_eval_select)]
             const fn precondition_check($($name:$ty),*) {
-                if !$e {
-                    let msg = concat!("unsafe precondition(s) violated: ", $message,
-                        "\n\nThis indicates a bug in the program. \
-                        This Undefined Behavior check is optional, and cannot be relied on for safety.");
-                    ::core::panicking::panic_nounwind_fmt(::core::fmt::Arguments::from_str(msg), false);
-                }
+                if $e { return; }
+                ::core::intrinsics::const_eval_select!(
+                    @capture { $($name: $ty),* }:
+                    if const {
+                        ::core::panicking::panic_nounwind($message);
+                    } else #[allow(unused)] {
+                        $(
+                            let $name = ::core::displaywrapper::DisplayWrapper($name);
+                        )*
+                        ::core::panicking::panic_nounwind_fmt(format_args!($message), false);
+                    }
+                )
             }
 
             if ::core::ub_checks::$kind() {

--- a/src/tools/miri/tests/fail/ptr_swap_nonoverlapping.stderr
+++ b/src/tools/miri/tests/fail/ptr_swap_nonoverlapping.stderr
@@ -1,8 +1,6 @@
 
-thread 'main' ($TID) panicked at tests/fail/ptr_swap_nonoverlapping.rs:LL:CC:
-unsafe precondition(s) violated: ptr::swap_nonoverlapping requires that both pointer arguments are aligned and non-null and the specified memory ranges do not overlap
-
-This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
+thread 'main' ($TID) panicked at RUSTLIB/core/src/ptr/mod.rs:LL:CC:
+ptr::swap_nonoverlapping requires that both pointer arguments are aligned and non-null and the specified memory ranges do not overlap (x:$HEX, y:$HEX, size:8, align:8, count:1)
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 note: in Miri, you may have to set `MIRIFLAGS=-Zmiri-env-forward=RUST_BACKTRACE` for the environment variable to have an effect
 thread caused non-unwinding panic. aborting.

--- a/tests/ui/consts/const-eval/ub-slice-get-unchecked.stderr
+++ b/tests/ui/consts/const-eval/ub-slice-get-unchecked.stderr
@@ -1,10 +1,18 @@
-error[E0080]: evaluation panicked: unsafe precondition(s) violated: slice::get_unchecked requires that the range is within the slice
-              
-              This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
+error[E0080]: evaluation panicked: slice::get_unchecked requires that the range is within the slice (range:{start}..{end}, len:{len})
   --> $DIR/ub-slice-get-unchecked.rs:7:27
    |
 LL | const B: &[()] = unsafe { A.get_unchecked(3..1) };
-   |                           ^^^^^^^^^^^^^^^^^^^^^ evaluation of `B` failed here
+   |                           ^^^^^^^^^^^^^^^^^^^^^ evaluation of `B` failed inside this call
+   |
+note: inside `<std::ops::Range<usize> as SliceIndex<[T]>>::get_unchecked::precondition_check::compiletime`
+  --> $SRC_DIR/core/src/ub_checks.rs:LL:COL
+  --> $SRC_DIR/core/src/slice/index.rs:LL:COL
+  ::: $SRC_DIR/core/src/slice/index.rs:LL:COL
+   |
+   = note: in this macro invocation
+note: inside `core::panicking::panic_nounwind`
+  --> $SRC_DIR/core/src/panicking.rs:LL:COL
+   = note: this error originates in the macro `assert_unsafe_precondition` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/precondition-checks/alignment.rs
+++ b/tests/ui/precondition-checks/alignment.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: Alignment::new_unchecked requires
+//@ error-pattern: Alignment::new_unchecked requires
 
 #![feature(ptr_alignment_type)]
 

--- a/tests/ui/precondition-checks/as_ascii_unchecked.rs
+++ b/tests/ui/precondition-checks/as_ascii_unchecked.rs
@@ -1,0 +1,17 @@
+//@ run-crash
+//@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
+//@ error-pattern: as_ascii_unchecked requires that the
+//@ revisions: char str
+
+#![feature(ascii_char)]
+
+use std::ascii::Char;
+
+fn main() {
+    unsafe {
+        #[cfg(char)]
+        let _c: Char = '🦀'.as_ascii_unchecked();
+        #[cfg(str)]
+        let _c: &[Char] = "🦀".as_ascii_unchecked();
+    }
+}

--- a/tests/ui/precondition-checks/ascii-char-digit_unchecked.rs
+++ b/tests/ui/precondition-checks/ascii-char-digit_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: `ascii::Char::digit_unchecked` input cannot exceed 9
+//@ error-pattern: `ascii::Char::digit_unchecked` input cannot exceed 9
 
 #![feature(ascii_char)]
 

--- a/tests/ui/precondition-checks/assert_unchecked.rs
+++ b/tests/ui/precondition-checks/assert_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: hint::assert_unchecked must never be called when the condition is false
+//@ error-pattern: hint::assert_unchecked must never be called when the condition is false
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/char-from_u32_unchecked.rs
+++ b/tests/ui/precondition-checks/char-from_u32_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: invalid value for `char`
+//@ error-pattern: invalid value for `char`
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/copy-nonoverlapping.rs
+++ b/tests/ui/precondition-checks/copy-nonoverlapping.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::copy_nonoverlapping requires
+//@ error-pattern: ptr::copy_nonoverlapping requires
 //@ revisions: null_src null_dst misaligned_src misaligned_dst overlapping
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/copy.rs
+++ b/tests/ui/precondition-checks/copy.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::copy requires
+//@ error-pattern: ptr::copy requires
 //@ revisions: null_src null_dst misaligned_src misaligned_dst
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/layout.rs
+++ b/tests/ui/precondition-checks/layout.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: Layout::from_size_align_unchecked requires
+//@ error-pattern: Layout::from_size_align_unchecked requires
 //@ revisions: toolarge badalign
 
 fn main() {

--- a/tests/ui/precondition-checks/nonnull.rs
+++ b/tests/ui/precondition-checks/nonnull.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: NonNull::new_unchecked requires
+//@ error-pattern: NonNull::new_unchecked requires
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/nonzero-from_mut_unchecked.rs
+++ b/tests/ui/precondition-checks/nonzero-from_mut_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: NonZero::from_mut_unchecked requires
+//@ error-pattern: NonZero::from_mut_unchecked requires
 
 #![feature(nonzero_from_mut)]
 

--- a/tests/ui/precondition-checks/nonzero-new_unchecked.rs
+++ b/tests/ui/precondition-checks/nonzero-new_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: NonZero::new_unchecked requires
+//@ error-pattern: NonZero::new_unchecked requires
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/read.rs
+++ b/tests/ui/precondition-checks/read.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::read requires
+//@ error-pattern: ptr::read requires
 //@ revisions: null misaligned
 //@ ignore-test (unimplemented)
 

--- a/tests/ui/precondition-checks/read_volatile.rs
+++ b/tests/ui/precondition-checks/read_volatile.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::read_volatile requires
+//@ error-pattern: ptr::read_volatile requires
 //@ revisions: misaligned
 
 use std::ptr;

--- a/tests/ui/precondition-checks/replace.rs
+++ b/tests/ui/precondition-checks/replace.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::replace requires
+//@ error-pattern: ptr::replace requires
 //@ revisions: null misaligned
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/slice-from-raw-parts-mut.rs
+++ b/tests/ui/precondition-checks/slice-from-raw-parts-mut.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: slice::from_raw_parts_mut requires
+//@ error-pattern: slice::from_raw_parts_mut requires
 //@ revisions: null misaligned toolarge
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/slice-from-raw-parts.rs
+++ b/tests/ui/precondition-checks/slice-from-raw-parts.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: slice::from_raw_parts requires
+//@ error-pattern: slice::from_raw_parts requires
 //@ revisions: null misaligned toolarge
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/slice-get_unchecked.rs
+++ b/tests/ui/precondition-checks/slice-get_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: slice::get_unchecked requires
+//@ error-pattern: slice::get_unchecked requires
 //@ revisions: usize range range_to range_from backwards_range
 
 fn main() {

--- a/tests/ui/precondition-checks/slice-get_unchecked_mut.rs
+++ b/tests/ui/precondition-checks/slice-get_unchecked_mut.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: slice::get_unchecked_mut requires
+//@ error-pattern: slice::get_unchecked_mut requires
 //@ revisions: usize range range_to range_from backwards_range
 
 fn main() {

--- a/tests/ui/precondition-checks/str-get_unchecked.rs
+++ b/tests/ui/precondition-checks/str-get_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: str::get_unchecked requires
+//@ error-pattern: str::get_unchecked requires
 //@ revisions: range range_to range_from backwards_range
 
 fn main() {

--- a/tests/ui/precondition-checks/str-get_unchecked_mut.rs
+++ b/tests/ui/precondition-checks/str-get_unchecked_mut.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: str::get_unchecked_mut requires
+//@ error-pattern: str::get_unchecked_mut requires
 //@ revisions: range range_to range_from backwards_range
 
 fn main() {

--- a/tests/ui/precondition-checks/swap-nonoverlapping.rs
+++ b/tests/ui/precondition-checks/swap-nonoverlapping.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::swap_nonoverlapping requires
+//@ error-pattern: ptr::swap_nonoverlapping requires
 //@ revisions: null_src null_dst misaligned_src misaligned_dst overlapping
 
 #![allow(invalid_null_arguments)]

--- a/tests/ui/precondition-checks/unchecked_add.rs
+++ b/tests/ui/precondition-checks/unchecked_add.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: u8::unchecked_add cannot overflow
+//@ error-pattern: u8::unchecked_add cannot overflow
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/unchecked_mul.rs
+++ b/tests/ui/precondition-checks/unchecked_mul.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: u8::unchecked_add cannot overflow
+//@ error-pattern: u8::unchecked_add cannot overflow
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/unchecked_shl.rs
+++ b/tests/ui/precondition-checks/unchecked_shl.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: u8::unchecked_shl cannot overflow
+//@ error-pattern: u8::unchecked_shl cannot overflow
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/unchecked_shr.rs
+++ b/tests/ui/precondition-checks/unchecked_shr.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: u8::unchecked_shr cannot overflow
+//@ error-pattern: u8::unchecked_shr cannot overflow
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/unchecked_sub.rs
+++ b/tests/ui/precondition-checks/unchecked_sub.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: u8::unchecked_sub cannot overflow
+//@ error-pattern: u8::unchecked_sub cannot overflow
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/unreachable_unchecked.rs
+++ b/tests/ui/precondition-checks/unreachable_unchecked.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: hint::unreachable_unchecked must never be reached
+//@ error-pattern: hint::unreachable_unchecked must never be reached
 
 fn main() {
     unsafe {

--- a/tests/ui/precondition-checks/vec-from-parts.rs
+++ b/tests/ui/precondition-checks/vec-from-parts.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Cdebug-assertions=yes
-//@ error-pattern: unsafe precondition(s) violated: Vec::from_parts_in requires that length <= capacity
+//@ error-pattern: Vec::from_parts_in requires that length <= capacity
 #![feature(allocator_api)]
 
 use std::ptr::NonNull;

--- a/tests/ui/precondition-checks/vec-from-raw-parts.rs
+++ b/tests/ui/precondition-checks/vec-from-raw-parts.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Cdebug-assertions=yes
-//@ error-pattern: unsafe precondition(s) violated: Vec::from_raw_parts_in requires that length <= capacity
+//@ error-pattern: Vec::from_raw_parts_in requires that length <= capacity
 //@ revisions: vec_from_raw_parts vec_from_raw_parts_in string_from_raw_parts
 
 #![feature(allocator_api)]

--- a/tests/ui/precondition-checks/vec-set-len.rs
+++ b/tests/ui/precondition-checks/vec-set-len.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Cdebug-assertions=yes
-//@ error-pattern: unsafe precondition(s) violated: Vec::set_len requires that new_len <= capacity()
+//@ error-pattern: Vec::set_len requires that new_len <= capacity()
 
 fn main() {
     let mut vec: Vec<i32> = Vec::with_capacity(5);

--- a/tests/ui/precondition-checks/write.rs
+++ b/tests/ui/precondition-checks/write.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::write requires
+//@ error-pattern: ptr::write requires
 //@ revisions: null misaligned
 //@ ignore-test (unimplemented)
 

--- a/tests/ui/precondition-checks/write_bytes.rs
+++ b/tests/ui/precondition-checks/write_bytes.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::write requires
+//@ error-pattern: ptr::write requires
 //@ revisions: null misaligned
 //@ ignore-test (unimplemented)
 

--- a/tests/ui/precondition-checks/write_volatile.rs
+++ b/tests/ui/precondition-checks/write_volatile.rs
@@ -1,6 +1,6 @@
 //@ run-crash
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
-//@ error-pattern: unsafe precondition(s) violated: ptr::write_volatile requires
+//@ error-pattern: ptr::write_volatile requires
 //@ revisions: misaligned
 
 use std::ptr;


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/134938)*
<!-- homu-ignore:end -->

Trying to format the types we want using the built-in Display/Debug impls creates a lot of calls from compiler-builtins to core.

My solution for that is to provide a different Display impl though a wrapper type. It is easy to make the entire implementation to get monomorphized in compiler-builtins, which is some serious hoop-jumping because https://github.com/rust-lang/rust/pull/122580 patches our call to `panic_nounwind_fmt` during codegen to just `llvm.trap`. So we're actually just making sure that dead code can't cause a linker error.