### PR TITLE
Make sure to scrape region constraints from deeply normalizing type outlives assumptions in borrowck

### DIFF
--- a/tests/ui/traits/next-solver/known-type-outlives-has-constraints.rs
+++ b/tests/ui/traits/next-solver/known-type-outlives-has-constraints.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+trait Norm {
+    type Out;
+}
+impl<'a, T: 'a> Norm for &'a T {
+    type Out = T;
+}
+
+fn hello<'a, T: 'a>() where <&'a T as Norm>::Out: 'a {}
+
+fn main() {}


### PR DESCRIPTION
Otherwise we're just randomly registering these region relations into the infcx which isn't good

r? lcnr