### PR TITLE
Add FileCheck annotations to mir-opt/issues

### DIFF
--- a/tests/mir-opt/issues/issue_75439.rs
+++ b/tests/mir-opt/issues/issue_75439.rs
@@ -1,10 +1,14 @@
-// skip-filecheck
 // EMIT_MIR issue_75439.foo.MatchBranchSimplification.diff
 //@ ignore-endian-big
 
 use std::mem::transmute;
 
 pub fn foo(bytes: [u8; 16]) -> Option<[u8; 4]> {
+    // CHECK-LABEL: fn foo(
+    // CHECK: bb2: {
+    // CHECK-NEXT: 0: [[bb:bb[0-9]+]],
+    // CHECK-SAME: {{[0-9]+}}: [[bb]],
+
     // big endian `u32`s
     let dwords: [u32; 4] = unsafe { transmute(bytes) };
     const FF: u32 = 0x0000_ffff_u32.to_be();


### PR DESCRIPTION
This resolves a part of #116971 .

The directory `tests/mir-opt/issues` has only one test issue_75439.rs which should add FileCheck annotations.

Originally it was introduced in #75580 to confirm that there were duplicated basic blocks against or-patterns, but in #123067 the duplication was resolved. So FileCheck should ensure that there is no such duplication any more.
