### PR TITLE
Convert some `Into` impls into `From` impls

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -241,15 +241,15 @@ impl AngleBracketedArg {
     }
 }
 
-impl Into<P<GenericArgs>> for AngleBracketedArgs {
-    fn into(self) -> P<GenericArgs> {
-        P(GenericArgs::AngleBracketed(self))
+impl From<AngleBracketedArgs> for P<GenericArgs> {
+    fn from(val: AngleBracketedArgs) -> Self {
+        P(GenericArgs::AngleBracketed(val))
     }
 }
 
-impl Into<P<GenericArgs>> for ParenthesizedArgs {
-    fn into(self) -> P<GenericArgs> {
-        P(GenericArgs::Parenthesized(self))
+impl From<ParenthesizedArgs> for P<GenericArgs> {
+    fn from(val: ParenthesizedArgs) -> Self {
+        P(GenericArgs::Parenthesized(val))
     }
 }
 

--- a/compiler/rustc_ast/src/ptr.rs
+++ b/compiler/rustc_ast/src/ptr.rs
@@ -158,9 +158,9 @@ impl<T> From<Vec<T>> for P<[T]> {
     }
 }
 
-impl<T> Into<Vec<T>> for P<[T]> {
-    fn into(self) -> Vec<T> {
-        self.into_vec()
+impl<T> From<P<[T]>> for Vec<T> {
+    fn from(val: P<[T]>) -> Self {
+        val.into_vec()
     }
 }
 

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -357,9 +357,9 @@ impl From<Cow<'static, str>> for DiagMessage {
 /// subdiagnostic derive refers to typed identifiers that are `DiagMessage`s, so need to be
 /// able to convert between these, as much as they'll be converted back into `DiagMessage`
 /// using `with_subdiagnostic_message` eventually. Don't use this other than for the derive.
-impl Into<SubdiagMessage> for DiagMessage {
-    fn into(self) -> SubdiagMessage {
-        match self {
+impl From<DiagMessage> for SubdiagMessage {
+    fn from(val: DiagMessage) -> Self {
+        match val {
             DiagMessage::Str(s) => SubdiagMessage::Str(s),
             DiagMessage::Translated(s) => SubdiagMessage::Translated(s),
             DiagMessage::FluentIdentifier(id, None) => SubdiagMessage::FluentIdentifier(id),

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -156,9 +156,9 @@ impl IntoDiagArg for DiagArgValue {
     }
 }
 
-impl Into<FluentValue<'static>> for DiagArgValue {
-    fn into(self) -> FluentValue<'static> {
-        match self {
+impl From<DiagArgValue> for FluentValue<'static> {
+    fn from(val: DiagArgValue) -> Self {
+        match val {
             DiagArgValue::Str(s) => From::from(s),
             DiagArgValue::Number(n) => From::from(n),
             DiagArgValue::StrListSepByAnd(l) => fluent_value_from_str_list_sep_by_and(l),

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -4072,33 +4072,33 @@ impl<'hir> OwnerNode<'hir> {
     }
 }
 
-impl<'hir> Into<OwnerNode<'hir>> for &'hir Item<'hir> {
-    fn into(self) -> OwnerNode<'hir> {
-        OwnerNode::Item(self)
+impl<'hir> From<&'hir Item<'hir>> for OwnerNode<'hir> {
+    fn from(val: &'hir Item<'hir>) -> Self {
+        OwnerNode::Item(val)
     }
 }
 
-impl<'hir> Into<OwnerNode<'hir>> for &'hir ForeignItem<'hir> {
-    fn into(self) -> OwnerNode<'hir> {
-        OwnerNode::ForeignItem(self)
+impl<'hir> From<&'hir ForeignItem<'hir>> for OwnerNode<'hir> {
+    fn from(val: &'hir ForeignItem<'hir>) -> Self {
+        OwnerNode::ForeignItem(val)
     }
 }
 
-impl<'hir> Into<OwnerNode<'hir>> for &'hir ImplItem<'hir> {
-    fn into(self) -> OwnerNode<'hir> {
-        OwnerNode::ImplItem(self)
+impl<'hir> From<&'hir ImplItem<'hir>> for OwnerNode<'hir> {
+    fn from(val: &'hir ImplItem<'hir>) -> Self {
+        OwnerNode::ImplItem(val)
     }
 }
 
-impl<'hir> Into<OwnerNode<'hir>> for &'hir TraitItem<'hir> {
-    fn into(self) -> OwnerNode<'hir> {
-        OwnerNode::TraitItem(self)
+impl<'hir> From<&'hir TraitItem<'hir>> for OwnerNode<'hir> {
+    fn from(val: &'hir TraitItem<'hir>) -> Self {
+        OwnerNode::TraitItem(val)
     }
 }
 
-impl<'hir> Into<Node<'hir>> for OwnerNode<'hir> {
-    fn into(self) -> Node<'hir> {
-        match self {
+impl<'hir> From<OwnerNode<'hir>> for Node<'hir> {
+    fn from(val: OwnerNode<'hir>) -> Self {
+        match val {
             OwnerNode::Item(n) => Node::Item(n),
             OwnerNode::ForeignItem(n) => Node::ForeignItem(n),
             OwnerNode::ImplItem(n) => Node::ImplItem(n),

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -303,9 +303,9 @@ pub(crate) struct RawDefId {
     index: u32,
 }
 
-impl Into<RawDefId> for DefId {
-    fn into(self) -> RawDefId {
-        RawDefId { krate: self.krate.as_u32(), index: self.index.as_u32() }
+impl From<DefId> for RawDefId {
+    fn from(val: DefId) -> Self {
+        RawDefId { krate: val.krate.as_u32(), index: val.index.as_u32() }
     }
 }
 

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -88,10 +88,10 @@ impl ReportedErrorInfo {
     }
 }
 
-impl Into<ErrorGuaranteed> for ReportedErrorInfo {
+impl From<ReportedErrorInfo> for ErrorGuaranteed {
     #[inline]
-    fn into(self) -> ErrorGuaranteed {
-        self.error
+    fn from(val: ReportedErrorInfo) -> Self {
+        val.error
     }
 }
 

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -249,9 +249,9 @@ pub enum AdtKind {
     Enum,
 }
 
-impl Into<DataTypeKind> for AdtKind {
-    fn into(self) -> DataTypeKind {
-        match self {
+impl From<AdtKind> for DataTypeKind {
+    fn from(val: AdtKind) -> Self {
+        match val {
             AdtKind::Struct => DataTypeKind::Struct,
             AdtKind::Union => DataTypeKind::Union,
             AdtKind::Enum => DataTypeKind::Enum,

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -45,12 +45,12 @@ pub enum TypeAnnotationNeeded {
     E0284,
 }
 
-impl Into<ErrCode> for TypeAnnotationNeeded {
-    fn into(self) -> ErrCode {
-        match self {
-            Self::E0282 => E0282,
-            Self::E0283 => E0283,
-            Self::E0284 => E0284,
+impl From<TypeAnnotationNeeded> for ErrCode {
+    fn from(val: TypeAnnotationNeeded) -> Self {
+        match val {
+            TypeAnnotationNeeded::E0282 => E0282,
+            TypeAnnotationNeeded::E0283 => E0283,
+            TypeAnnotationNeeded::E0284 => E0284,
         }
     }
 }


### PR DESCRIPTION
From the [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) docs:

> One should always prefer implementing `From` over [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) because implementing `From` automatically provides one with an implementation of [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) thanks to the blanket implementation in the standard library.
>
> Only implement [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) when targeting a version prior to Rust 1.41 and converting to a type outside the current crate. `From` was not able to do these types of conversions in earlier versions because of Rust’s orphaning rules. See [Into](https://doc.rust-lang.org/std/convert/trait.Into.html) for more details.

Some of these impls are likely from before 1.41, and then some others were probably just mistakes. Building nightly rust is definitely not supported on 1.41, so let's modernize these impls :D