### PR TITLE
Suppress host effect predicates if underlying trait doesn't hold

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -114,7 +114,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         //
                         // We rely on a few heuristics to identify cases where this root
                         // obligation is more important than the leaf obligation:
-                        let (main_trait_predicate, o) = if let ty::PredicateKind::Clause(
+                        let (main_trait_predicate, main_obligation) = if let ty::PredicateKind::Clause(
                             ty::ClauseKind::Trait(root_pred)
                         ) = root_obligation.predicate.kind().skip_binder()
                             && !leaf_trait_predicate.self_ty().skip_binder().has_escaping_bound_vars()
@@ -199,7 +199,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             notes,
                             parent_label,
                             append_const_msg,
-                        } = self.on_unimplemented_note(main_trait_predicate, o, &mut long_ty_file);
+                        } = self.on_unimplemented_note(main_trait_predicate, main_obligation, &mut long_ty_file);
 
                         let have_alt_message = message.is_some() || label.is_some();
                         let is_try_conversion = self.is_try_conversion(span, main_trait_ref.def_id());

--- a/tests/ui/traits/const-traits/double-error-for-unimplemented-trait.rs
+++ b/tests/ui/traits/const-traits/double-error-for-unimplemented-trait.rs
@@ -1,0 +1,22 @@
+// Make sure we don't issue *two* error messages for the trait predicate *and* host predicate.
+
+#![feature(const_trait_impl)]
+
+#[const_trait]
+trait Trait {
+  type Out;
+}
+
+const fn needs_const<T: ~const Trait>(_: &T) {}
+
+const IN_CONST: () = {
+  needs_const(&());
+  //~^ ERROR the trait bound `(): Trait` is not satisfied
+};
+
+const fn conditionally_const() {
+  needs_const(&());
+  //~^ ERROR the trait bound `(): Trait` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/traits/const-traits/double-error-for-unimplemented-trait.stderr
+++ b/tests/ui/traits/const-traits/double-error-for-unimplemented-trait.stderr
@@ -1,0 +1,41 @@
+error[E0277]: the trait bound `(): Trait` is not satisfied
+  --> $DIR/double-error-for-unimplemented-trait.rs:13:15
+   |
+LL |   needs_const(&());
+   |   ----------- ^^^ the trait `Trait` is not implemented for `()`
+   |   |
+   |   required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/double-error-for-unimplemented-trait.rs:6:1
+   |
+LL | trait Trait {
+   | ^^^^^^^^^^^
+note: required by a bound in `needs_const`
+  --> $DIR/double-error-for-unimplemented-trait.rs:10:25
+   |
+LL | const fn needs_const<T: ~const Trait>(_: &T) {}
+   |                         ^^^^^^^^^^^^ required by this bound in `needs_const`
+
+error[E0277]: the trait bound `(): Trait` is not satisfied
+  --> $DIR/double-error-for-unimplemented-trait.rs:18:15
+   |
+LL |   needs_const(&());
+   |   ----------- ^^^ the trait `Trait` is not implemented for `()`
+   |   |
+   |   required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/double-error-for-unimplemented-trait.rs:6:1
+   |
+LL | trait Trait {
+   | ^^^^^^^^^^^
+note: required by a bound in `needs_const`
+  --> $DIR/double-error-for-unimplemented-trait.rs:10:25
+   |
+LL | const fn needs_const<T: ~const Trait>(_: &T) {}
+   |                         ^^^^^^^^^^^^ required by this bound in `needs_const`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Don't report two errors for when the (`HostEffectPredicate`) `T: const Trait` isn't implemented because (`TraitPredicate`) `T: Trait` doesn't even hold.