### PR TITLE
Redo the swap code for better tail & padding handling

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -504,6 +504,12 @@ pub fn check_intrinsic_type(
             sym::typed_swap_nonoverlapping => {
                 (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)); 2], tcx.types.unit)
             }
+            sym::untyped_swap_nonoverlapping => (
+                1,
+                0,
+                vec![Ty::new_mut_ptr(tcx, Ty::new_maybe_uninit(tcx, param(0))); 2],
+                tcx.types.unit,
+            ),
 
             sym::discriminant_value => {
                 let assoc_items = tcx.associated_item_def_ids(

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2142,6 +2142,7 @@ symbols! {
                           unstable location; did you mean to load this crate \
                           from crates.io via `Cargo.toml` instead?",
         untagged_unions,
+        untyped_swap_nonoverlapping,
         unused_imports,
         unwind,
         unwind_attributes,

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -376,6 +376,7 @@ pub mod alloc;
 // note: does not need to be public
 mod bool;
 mod escape;
+pub(crate) mod swapping;
 mod tuple;
 mod unit;
 

--- a/library/core/src/swapping.rs
+++ b/library/core/src/swapping.rs
@@ -1,0 +1,182 @@
+use crate::{hint, intrinsics, mem, ptr};
+
+//#[rustc_const_stable_indirect]
+//#[rustc_allow_const_fn_unstable(const_eval_select)]
+#[rustc_const_unstable(feature = "const_swap_nonoverlapping", issue = "133668")]
+#[inline]
+pub(crate) const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
+    intrinsics::const_eval_select!(
+        @capture[T] { x: *mut T, y: *mut T, count: usize }:
+        if const {
+            // At compile-time we want to always copy this in chunks of `T`, to ensure that if there
+            // are pointers inside `T` we will copy them in one go rather than trying to copy a part
+            // of a pointer (which would not work).
+            // SAFETY: Same preconditions as this function
+            unsafe { swap_nonoverlapping_const(x, y, count) }
+        } else {
+            // At runtime we want to make sure not to swap byte-for-byte for types like [u8; 15],
+            // and swapping as `MaybeUninit<T>` doesn't actually work as untyped for things like
+            // T = (u16, u8), so we type-erase to raw bytes and swap that way.
+            // SAFETY: Same preconditions as this function
+            unsafe { swap_nonoverlapping_runtime(x, y, count) }
+        }
+    )
+}
+
+/// Same behavior and safety conditions as [`swap_nonoverlapping`]
+#[rustc_const_stable_indirect]
+#[inline]
+const unsafe fn swap_nonoverlapping_const<T>(x: *mut T, y: *mut T, count: usize) {
+    let x = x.cast::<mem::MaybeUninit<T>>();
+    let y = y.cast::<mem::MaybeUninit<T>>();
+    let mut i = 0;
+    while i < count {
+        // SAFETY: By precondition, `i` is in-bounds because it's below `n`
+        // and because the two input ranges are non-overlapping and read/writeable,
+        // these individual items inside them are too.
+        unsafe {
+            intrinsics::untyped_swap_nonoverlapping::<T>(x.add(i), y.add(i));
+        }
+
+        i += 1;
+    }
+}
+
+// Scale the monomorphizations with the size of the machine, roughly.
+const MAX_ALIGN: usize = align_of::<usize>().pow(2);
+
+/// Same behavior and safety conditions as [`swap_nonoverlapping`]
+#[inline]
+unsafe fn swap_nonoverlapping_runtime<T>(x: *mut T, y: *mut T, count: usize) {
+    let bytes = {
+        let slice = ptr::slice_from_raw_parts(x, count);
+        // SAFETY: Because they both exist in memory and don't overlap, they
+        // must be legal slice sizes (below `isize::MAX` bytes).
+        unsafe { mem::size_of_val_raw(slice) }
+    };
+
+    // Generating *untyped* loops for every type is silly, so we polymorphize away
+    // the actual type, but we want to take advantage of alignment if possible,
+    // so monomorphize for a restricted set of possible alignments.
+    macro_rules! delegate_by_alignment {
+        ($($p:pat => $align:expr,)+) => {{
+            #![allow(unreachable_patterns)]
+            match const { align_of::<T>() } {
+                $(
+                    $p => {
+                        swap_nonoverlapping_bytes::<$align>(x.cast(), y.cast(), bytes);
+                    }
+                )+
+            }
+        }};
+    }
+
+    // SAFETY:
+    unsafe {
+        delegate_by_alignment! {
+            MAX_ALIGN.. => MAX_ALIGN,
+            64.. => 64,
+            32.. => 32,
+            16.. => 16,
+            8.. => 8,
+            4.. => 4,
+            2.. => 2,
+            _ => 1,
+        }
+    }
+}
+
+/// # Safety:
+/// - `x` and `y` must be aligned to `ALIGN`
+/// - `bytes` must be a multiple of `ALIGN`
+/// - They must be readable, writable, and non-overlapping for `bytes` bytes
+#[inline]
+unsafe fn swap_nonoverlapping_bytes<const ALIGN: usize>(
+    x: *mut mem::MaybeUninit<u8>,
+    y: *mut mem::MaybeUninit<u8>,
+    bytes: usize,
+) {
+    // SAFETY: Two legal non-overlapping regions can't be bigger than this.
+    // (And they couldn't have made allocations any bigger either anyway.)
+    // FIXME: Would be nice to have a type for this instead of the assume.
+    unsafe { hint::assert_unchecked(bytes < isize::MAX as usize) };
+
+    let mut i = 0;
+    macro_rules! swap_next_n {
+        ($n:expr) => {{
+            let x: *mut mem::MaybeUninit<[u8; $n]> = x.add(i).cast();
+            let y: *mut mem::MaybeUninit<[u8; $n]> = y.add(i).cast();
+            swap_nonoverlapping_aligned_chunk::<ALIGN, [u8; $n]>(
+                x.as_mut_unchecked(),
+                y.as_mut_unchecked(),
+            );
+            i += $n;
+        }};
+    }
+
+    while bytes - i >= MAX_ALIGN {
+        const { assert!(MAX_ALIGN >= ALIGN) };
+        // SAFETY: the const-assert above confirms we're only ever called with
+        // an alignment equal to or smaller than max align, so this is necessarily
+        // aligned, and the while loop ensures there's enough read/write memory.
+        unsafe {
+            swap_next_n!(MAX_ALIGN);
+        }
+    }
+
+    macro_rules! handle_tail {
+        ($($n:literal)+) => {$(
+            if const { $n % ALIGN == 0 } {
+                // Checking this way simplifies the block end to just add+test,
+                // rather than needing extra math before the check.
+                if (bytes & $n) != 0 {
+                    // SAFETY: The above swaps were bigger, so could not have
+                    // impacted the `$n`-relevant bit, so checking `bytes & $n`
+                    // was equivalent to `bytes - i >= $n`, and thus we have
+                    // enough space left to swap another `$n` bytes.
+                    unsafe {
+                        swap_next_n!($n);
+                    }
+                }
+            }
+        )+};
+    }
+    const { assert!(MAX_ALIGN <= 64) };
+    handle_tail!(32 16 8 4 2 1);
+
+    debug_assert_eq!(i, bytes);
+}
+
+/// Swaps the `C` behind `x` and `y` as untyped memory
+///
+/// # Safety
+///
+/// Both `x` and `y` must be aligned to `ALIGN`, in addition to their normal alignment.
+/// They must be readable and writeable for `sizeof(C)` bytes, as usual for `&mut`s.
+///
+/// (The actual instantiations are usually `C = [u8; _]`, so we get the alignment
+/// information from the loads by `assume`ing the passed-in alignment.)
+// Don't let MIR inline this, because we really want it to keep its noalias metadata
+#[rustc_no_mir_inline]
+#[inline]
+unsafe fn swap_nonoverlapping_aligned_chunk<const ALIGN: usize, C>(
+    x: &mut mem::MaybeUninit<C>,
+    y: &mut mem::MaybeUninit<C>,
+) {
+    assert!(size_of::<C>() % ALIGN == 0);
+
+    let x = ptr::from_mut(x);
+    let y = ptr::from_mut(y);
+
+    // SAFETY: One of our preconditions.
+    unsafe {
+        hint::assert_unchecked(x.is_aligned_to(ALIGN));
+        hint::assert_unchecked(y.is_aligned_to(ALIGN));
+    }
+
+    // SAFETY: The memory is readable and writable because these were passed to
+    // us as mutable references, and the untyped swap doesn't need validity.
+    unsafe {
+        intrinsics::untyped_swap_nonoverlapping::<C>(x, y);
+    }
+}

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -992,3 +992,32 @@ fn test_ptr_metadata_in_const() {
     assert_eq!(SLICE_META, 3);
     assert_eq!(DYN_META.size_of(), 42);
 }
+
+// See <https://github.com/rust-lang/rust/issues/134713>
+#[test]
+fn test_ptr_swap_nonoverlapping_swaps_padding() {
+    #[repr(C)]
+    struct Foo(usize, u8);
+
+    let buf1: [usize; 2] = [1000, 2000];
+    let buf2: [usize; 2] = [3000, 4000];
+
+    // Foo and [usize; 2] have the same size and alignment,
+    // so swap_nonoverlapping should treat them the same
+    assert_eq!(size_of::<Foo>(), size_of::<[usize; 2]>());
+    assert_eq!(align_of::<Foo>(), align_of::<[usize; 2]>());
+
+    let mut b1 = buf1;
+    let mut b2 = buf2;
+    // Safety: b1 and b2 are distinct local variables,
+    // with the same size and alignment as Foo.
+    unsafe {
+        std::ptr::swap_nonoverlapping(
+            b1.as_mut_ptr().cast::<Foo>(),
+            b2.as_mut_ptr().cast::<Foo>(),
+            1,
+        );
+    }
+    assert_eq!(b1, buf2);
+    assert_eq!(b2, buf1);
+}

--- a/tests/assembly/x86_64-typed-swap.rs
+++ b/tests/assembly/x86_64-typed-swap.rs
@@ -51,3 +51,35 @@ pub fn swap_simd(x: &mut __m128, y: &mut __m128) {
     // CHECK: retq
     swap(x, y)
 }
+
+// CHECK-LABEL: swap_string:
+#[no_mangle]
+pub fn swap_string(x: &mut String, y: &mut String) {
+    // CHECK: movups (%[[ARG1]]), %[[T1a:xmm.]]
+    // CHECK: movups (%[[ARG2]]), %[[T2a:xmm.]]
+    // CHECK: movups %[[T2a]], (%[[ARG1]])
+    // CHECK: movups %[[T1a]], (%[[ARG2]])
+    // CHECK: movq   16(%[[ARG1]]), %[[T1b:r.+]]
+    // CHECK: movq   16(%[[ARG2]]), %[[T2b:r.+]]
+    // CHECK: movq   %[[T2b]], 16(%[[ARG1]])
+    // CHECK: movq   %[[T1b]], 16(%[[ARG2]])
+    // CHECK: retq
+    swap(x, y)
+}
+
+// CHECK-LABEL: swap_44_bytes:
+#[no_mangle]
+pub fn swap_44_bytes(x: &mut [u8; 44], y: &mut [u8; 44]) {
+    // Ensure we do better than a long run of byte copies,
+    // see <https://github.com/rust-lang/rust/issues/134946>
+
+    // CHECK-NOT: movb
+    // CHECK-COUNT-8: movups{{.+}}xmm
+    // CHECK-NOT: movb
+    // CHECK-COUNT-4: movq
+    // CHECK-NOT: movb
+    // CHECK-COUNT-4: movl
+    // CHECK-NOT: movb
+    // CHECK: retq
+    swap(x, y)
+}

--- a/tests/codegen/simd/swap-simd-types.rs
+++ b/tests/codegen/simd/swap-simd-types.rs
@@ -23,8 +23,19 @@ pub fn swap_single_m256(x: &mut __m256, y: &mut __m256) {
 #[no_mangle]
 pub fn swap_m256_slice(x: &mut [__m256], y: &mut [__m256]) {
     // CHECK-NOT: alloca
-    // CHECK: load <8 x float>{{.+}}align 32
-    // CHECK: store <8 x float>{{.+}}align 32
+
+    // CHECK-NOT: load i128
+    // CHECK-NOT: load i64
+    // CHECK-NOT: load i32
+
+    // CHECK: [[A:%.+]] = load i256{{.+}}align 32
+    // CHECK: [[B:%.+]] = load i256{{.+}}align 32
+    // CHECK: store i256 [[B]]{{.+}}align 32
+    // CHECK: store i256 [[A]]{{.+}}align 32
+
+    // CHECK-NOT: load i128
+    // CHECK-NOT: load i64
+    // CHECK-NOT: load i32
     if x.len() == y.len() {
         x.swap_with_slice(y);
     }
@@ -34,7 +45,18 @@ pub fn swap_m256_slice(x: &mut [__m256], y: &mut [__m256]) {
 #[no_mangle]
 pub fn swap_bytes32(x: &mut [u8; 32], y: &mut [u8; 32]) {
     // CHECK-NOT: alloca
-    // CHECK: load <32 x i8>{{.+}}align 1
-    // CHECK: store <32 x i8>{{.+}}align 1
+
+    // CHECK-NOT: load i128
+    // CHECK-NOT: load i64
+    // CHECK-NOT: load i32
+
+    // CHECK: [[A:%.+]] = load i256{{.+}}align 1
+    // CHECK: [[B:%.+]] = load i256{{.+}}align 1
+    // CHECK: store i256 [[B]]{{.+}}align 1
+    // CHECK: store i256 [[A]]{{.+}}align 1
+
+    // CHECK-NOT: load i128
+    // CHECK-NOT: load i64
+    // CHECK-NOT: load i32
     swap(x, y)
 }


### PR DESCRIPTION
A couple of parts here

## Fixes #134713

Actually using the type passed to `ptr::swap_nonoverlapping` for anything other than its size + align turns out to not work, so this redo goes back to *always* swapping via not-`!noundef` integers.

(Except in `const`, which keeps doing the same thing as before to preserve @RalfJung's fix from #134689)

## Fixes #134946

I'd previously moved the swapping to use auto-vectorization, but someone pointed out on Discord that the tail loop handling from that left a whole bunch of byte-by-byte swapping around.  This PR goes back to a manual chunk, with at most logarithmic more instructions for the tail.

(There are other ways that could potentially handle the tail even better, but this seems to be pretty good, since it's how LLVM ends up lowering operations on types like `i56`.)

## Polymorphization

Since it's silly to have separate copies of swapping -- especially *untyped* swapping! -- for `u32`, `i32`, `f32`, `[u16; 2]`, etc, this sends everything to byte versions, but still mono'd by alignment.  That should make it more ok that the code is somewhat more complex, since we only get 7 monomorphizations of the complicated bit.

(One day we'll be able to remove some of the hacks by being able to just call `foo::<{align_of::<T>()}>`, but since alignments are only powers of two, the manual dispatch out isn't a big deal.)
