### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -5,11 +5,11 @@ from rust_types import RustType, classify_struct, classify_union
 
 
 # BACKCOMPAT: rust 1.35
-def is_hashbrown_hashmap(hash_map):
+def is_hashbrown_hashmap(hash_map: lldb.SBValue) -> bool:
     return len(hash_map.type.fields) == 1
 
 
-def classify_rust_type(type):
+def classify_rust_type(type: lldb.SBType) -> str:
     type_class = type.GetTypeClass()
     if type_class == lldb.eTypeClassStruct:
         return classify_struct(type.name, type.fields)
@@ -19,106 +19,104 @@ def classify_rust_type(type):
     return RustType.OTHER
 
 
-def summary_lookup(valobj, dict):
-    # type: (SBValue, dict) -> str
+def summary_lookup(valobj: lldb.SBValue, _dict: LLDBOpaque) -> str:
     """Returns the summary provider for the given value"""
     rust_type = classify_rust_type(valobj.GetType())
 
     if rust_type == RustType.STD_STRING:
-        return StdStringSummaryProvider(valobj, dict)
+        return StdStringSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_OS_STRING:
-        return StdOsStringSummaryProvider(valobj, dict)
+        return StdOsStringSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_STR:
-        return StdStrSummaryProvider(valobj, dict)
+        return StdStrSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_VEC:
-        return SizeSummaryProvider(valobj, dict)
+        return SizeSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_VEC_DEQUE:
-        return SizeSummaryProvider(valobj, dict)
+        return SizeSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_SLICE:
-        return SizeSummaryProvider(valobj, dict)
+        return SizeSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_HASH_MAP:
-        return SizeSummaryProvider(valobj, dict)
+        return SizeSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_HASH_SET:
-        return SizeSummaryProvider(valobj, dict)
+        return SizeSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_RC:
-        return StdRcSummaryProvider(valobj, dict)
+        return StdRcSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_ARC:
-        return StdRcSummaryProvider(valobj, dict)
+        return StdRcSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_REF:
-        return StdRefSummaryProvider(valobj, dict)
+        return StdRefSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_REF_MUT:
-        return StdRefSummaryProvider(valobj, dict)
+        return StdRefSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_REF_CELL:
-        return StdRefSummaryProvider(valobj, dict)
+        return StdRefSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_NONZERO_NUMBER:
-        return StdNonZeroNumberSummaryProvider(valobj, dict)
+        return StdNonZeroNumberSummaryProvider(valobj, _dict)
 
     if rust_type == RustType.STD_PATHBUF:
-        return StdPathBufSummaryProvider(valobj, dict)
+        return StdPathBufSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_PATH:
-        return StdPathSummaryProvider(valobj, dict)
+        return StdPathSummaryProvider(valobj, _dict)
 
     return ""
 
 
-def synthetic_lookup(valobj, dict):
-    # type: (SBValue, dict) -> object
+def synthetic_lookup(valobj: lldb.SBValue, _dict: LLDBOpaque) -> object:
     """Returns the synthetic provider for the given value"""
     rust_type = classify_rust_type(valobj.GetType())
 
     if rust_type == RustType.STRUCT:
-        return StructSyntheticProvider(valobj, dict)
+        return StructSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STRUCT_VARIANT:
-        return StructSyntheticProvider(valobj, dict, is_variant=True)
+        return StructSyntheticProvider(valobj, _dict, is_variant=True)
     if rust_type == RustType.TUPLE:
-        return TupleSyntheticProvider(valobj, dict)
+        return TupleSyntheticProvider(valobj, _dict)
     if rust_type == RustType.TUPLE_VARIANT:
-        return TupleSyntheticProvider(valobj, dict, is_variant=True)
+        return TupleSyntheticProvider(valobj, _dict, is_variant=True)
     if rust_type == RustType.EMPTY:
-        return EmptySyntheticProvider(valobj, dict)
+        return EmptySyntheticProvider(valobj, _dict)
     if rust_type == RustType.REGULAR_ENUM:
         discriminant = valobj.GetChildAtIndex(0).GetChildAtIndex(0).GetValueAsUnsigned()
-        return synthetic_lookup(valobj.GetChildAtIndex(discriminant), dict)
+        return synthetic_lookup(valobj.GetChildAtIndex(discriminant), _dict)
     if rust_type == RustType.SINGLETON_ENUM:
-        return synthetic_lookup(valobj.GetChildAtIndex(0), dict)
+        return synthetic_lookup(valobj.GetChildAtIndex(0), _dict)
     if rust_type == RustType.ENUM:
-        return ClangEncodedEnumProvider(valobj, dict)
+        return ClangEncodedEnumProvider(valobj, _dict)
     if rust_type == RustType.STD_VEC:
-        return StdVecSyntheticProvider(valobj, dict)
+        return StdVecSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_VEC_DEQUE:
-        return StdVecDequeSyntheticProvider(valobj, dict)
+        return StdVecDequeSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_SLICE or rust_type == RustType.STD_STR:
-        return StdSliceSyntheticProvider(valobj, dict)
+        return StdSliceSyntheticProvider(valobj, _dict)
 
     if rust_type == RustType.STD_HASH_MAP:
         if is_hashbrown_hashmap(valobj):
-            return StdHashMapSyntheticProvider(valobj, dict)
+            return StdHashMapSyntheticProvider(valobj, _dict)
         else:
-            return StdOldHashMapSyntheticProvider(valobj, dict)
+            return StdOldHashMapSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_HASH_SET:
         hash_map = valobj.GetChildAtIndex(0)
         if is_hashbrown_hashmap(hash_map):
-            return StdHashMapSyntheticProvider(valobj, dict, show_values=False)
+            return StdHashMapSyntheticProvider(valobj, _dict, show_values=False)
         else:
-            return StdOldHashMapSyntheticProvider(hash_map, dict, show_values=False)
+            return StdOldHashMapSyntheticProvider(hash_map, _dict, show_values=False)
 
     if rust_type == RustType.STD_RC:
-        return StdRcSyntheticProvider(valobj, dict)
+        return StdRcSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_ARC:
-        return StdRcSyntheticProvider(valobj, dict, is_atomic=True)
+        return StdRcSyntheticProvider(valobj, _dict, is_atomic=True)
 
     if rust_type == RustType.STD_CELL:
-        return StdCellSyntheticProvider(valobj, dict)
+        return StdCellSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_REF:
-        return StdRefSyntheticProvider(valobj, dict)
+        return StdRefSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_REF_MUT:
-        return StdRefSyntheticProvider(valobj, dict)
+        return StdRefSyntheticProvider(valobj, _dict)
     if rust_type == RustType.STD_REF_CELL:
-        return StdRefSyntheticProvider(valobj, dict, is_cell=True)
+        return StdRefSyntheticProvider(valobj, _dict, is_cell=True)
 
-    return DefaultSyntheticProvider(valobj, dict)
+    return DefaultSyntheticProvider(valobj, _dict)

--- a/src/etc/rust_types.py
+++ b/src/etc/rust_types.py
@@ -1,3 +1,4 @@
+from typing import List
 import re
 
 
@@ -85,12 +86,11 @@ STD_TYPE_TO_REGEX = {
 }
 
 
-def is_tuple_fields(fields):
-    # type: (list) -> bool
+def is_tuple_fields(fields: List) -> bool:
     return all(TUPLE_ITEM_REGEX.match(str(field.name)) for field in fields)
 
 
-def classify_struct(name, fields):
+def classify_struct(name: str, fields: List) -> str:
     if len(fields) == 0:
         return RustType.EMPTY
 
@@ -111,7 +111,7 @@ def classify_struct(name, fields):
     return RustType.STRUCT
 
 
-def classify_union(fields):
+def classify_union(fields: List) -> str:
     if len(fields) == 0:
         return RustType.EMPTY
 

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -900,7 +900,8 @@ fn get_index_type_id(
         | clean::Generic(_)
         | clean::SelfTy
         | clean::ImplTrait(_)
-        | clean::Infer => None,
+        | clean::Infer
+        | clean::UnsafeBinder(_) => None,
     }
 }
 

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -573,7 +573,7 @@ impl FromClean<clean::Type> for Type {
     fn from_clean(ty: clean::Type, renderer: &JsonRenderer<'_>) -> Self {
         use clean::Type::{
             Array, BareFunction, BorrowedRef, Generic, ImplTrait, Infer, Primitive, QPath,
-            RawPointer, SelfTy, Slice, Tuple,
+            RawPointer, SelfTy, Slice, Tuple, UnsafeBinder,
         };
 
         match ty {
@@ -613,6 +613,8 @@ impl FromClean<clean::Type> for Type {
                 self_type: Box::new(self_type.into_json(renderer)),
                 trait_: trait_.map(|trait_| trait_.into_json(renderer)),
             },
+            // FIXME(unsafe_binder): Implement rustdoc-json.
+            UnsafeBinder(_) => todo!(),
         }
     }
 }

--- a/tests/rustdoc-ui/doctest/non-local-defs-impl.rs
+++ b/tests/rustdoc-ui/doctest/non-local-defs-impl.rs
@@ -21,7 +21,7 @@
 /// }
 /// ```
 ///
-/// But this shoudln't produce a warning:
+/// But this shouldn't produce a warning:
 /// ```rust,no_run
 /// # extern crate pub_trait;
 /// # use pub_trait::Trait;

--- a/tests/rustdoc/auxiliary/unsafe-binder-dep.rs
+++ b/tests/rustdoc/auxiliary/unsafe-binder-dep.rs
@@ -1,0 +1,4 @@
+#![feature(unsafe_binders)]
+#![allow(incomplete_features)]
+
+pub fn woof() -> unsafe<'a> &'a str { todo!() }

--- a/tests/rustdoc/unsafe-binder.rs
+++ b/tests/rustdoc/unsafe-binder.rs
@@ -1,0 +1,15 @@
+//@ aux-build:unsafe-binder-dep.rs
+
+#![feature(unsafe_binders)]
+#![allow(incomplete_features)]
+
+extern crate unsafe_binder_dep;
+
+//@ has 'unsafe_binder/fn.woof.html' //pre "fn woof() -> unsafe<'a> &'a str"
+pub use unsafe_binder_dep::woof;
+
+//@ has 'unsafe_binder/fn.meow.html' //pre "fn meow() -> unsafe<'a> &'a str"
+pub fn meow() -> unsafe<'a> &'a str { todo!() }
+
+//@ has 'unsafe_binder/fn.meow_squared.html' //pre "fn meow_squared() -> unsafe<'b, 'a> &'a &'b str"
+pub fn meow_squared() -> unsafe<'b, 'a> &'a &'b str { todo!() }

--- a/tests/ui/closures/2229_closure_analysis/issue-118144.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-118144.rs
@@ -6,7 +6,7 @@ fn func(func_arg: &mut V) {
     || {
         // Declaring `x` separately instead of using
         // a destructuring binding like `let V(x) = ...`
-        // becaue only `V(x) = ...` triggers the ICE
+        // because only `V(x) = ...` triggers the ICE
         let x;
         V(x) = func_arg; //~ ERROR: mismatched types
         func_arg.0 = 0;

--- a/tests/ui/coroutine/issue-53548.rs
+++ b/tests/ui/coroutine/issue-53548.rs
@@ -6,7 +6,7 @@
 // to process this `'r` region bound. In particular, to be WF, the
 // region bound must meet the requirements of the trait, and hence we
 // got `for<'r> { 'r: 'static }`. This would ICE because the `Binder`
-// constructor we were using was assering that no higher-ranked
+// constructor we were using was asserting that no higher-ranked
 // regions were involved (because the WF code is supposed to skip
 // those). The error (if debug-asserions were disabled) came because
 // we obviously cannot prove that `'r: 'static` for any region `'r`.

--- a/tests/ui/panics/default-backtrace-ice.rs
+++ b/tests/ui/panics/default-backtrace-ice.rs
@@ -17,7 +17,7 @@
 // `__rust_{begin,end}_short_backtrace` markers, which only appear in full
 // backtraces. The rest of the backtrace is filtered out.
 //
-// Ignored on msvc becaue the `__rust_{begin,end}_short_backtrace` symbols
+// Ignored on msvc because the `__rust_{begin,end}_short_backtrace` symbols
 // aren't reliable.
 
 fn main() { missing_ident; }


### PR DESCRIPTION
Successful merges:

 - #134291 (Use python built in type annotations in LLDB visualizer scripts)
 - #134857 (Unsafe binder support in rustdoc)
 - #134957 (chore: fix some typos)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134291,134857,134957)
<!-- homu-ignore:end -->