### PR TITLE
Run Python formatting check in tidy on CI

### DIFF
--- a/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
@@ -35,4 +35,4 @@ COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
 # NOTE: intentionally uses python2 for x.py so we can test it still works.
 # validate-toolstate only runs in our CI, so it's ok for it to only support python3.
 ENV SCRIPT TIDY_PRINT_DIFF=1 python2.7 ../x.py test \
-           --stage 0 src/tools/tidy tidyselftest --extra-checks=py:lint,cpp:fmt
+           --stage 0 src/tools/tidy tidyselftest --extra-checks=py,cpp

--- a/src/ci/scripts/upload-build-metrics.py
+++ b/src/ci/scripts/upload-build-metrics.py
@@ -51,13 +51,23 @@ def upload_datadog_measure(name: str, value: float):
     print(f"Metric {name}: {value:.4f}")
 
     cmd = "npx"
-    if os.getenv("GITHUB_ACTIONS") is not None and sys.platform.lower().startswith("win"):
+    if os.getenv("GITHUB_ACTIONS") is not None and sys.platform.lower().startswith(
+        "win"
+    ):
         # Due to weird interaction of MSYS2 and Python, we need to use an absolute path,
         # and also specify the ".cmd" at the end. See https://github.com/rust-lang/rust/pull/125771.
         cmd = "C:\\Program Files\\nodejs\\npx.cmd"
 
     subprocess.run(
-        [cmd, "datadog-ci", "measure", "--level", "job", "--measures", f"{name}:{value}"],
+        [
+            cmd,
+            "datadog-ci",
+            "measure",
+            "--level",
+            "job",
+            "--measures",
+            f"{name}:{value}",
+        ],
         check=False,
     )
 


### PR DESCRIPTION
I don't think that there's a reason why we should ignore Python formatting on CI, when we already check Python lints and C++ formatting.

r? @onur-ozkan