### PR TITLE
Make Boxy UwU

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -84,7 +84,8 @@ boolean_coercion <booleancoercion@gmail.com>
 Boris Egorov <jightuse@gmail.com> <egorov@linux.com>
 bors <bors@rust-lang.org> bors[bot] <26634292+bors[bot]@users.noreply.github.com>
 bors <bors@rust-lang.org> bors[bot] <bors[bot]@users.noreply.github.com>
-Boxy <rust@boxyuwu.dev> <supbscripter@gmail.com>
+BoxyUwU <rust@boxyuwu.dev>
+BoxyUwU <rust@boxyuwu.dev> <supbscripter@gmail.com>
 Braden Nelson <moonheart08@users.noreply.github.com>
 Brandon Sanderson <singingboyo@gmail.com> Brandon Sanderson <singingboyo@hotmail.com>
 Brett Cannon <brett@python.org> Brett Cannon <brettcannon@users.noreply.github.com>


### PR DESCRIPTION
as requested by

r? @BoxyUwU

, supersedes #129906

We need 2 entries here, the first one tells us that this email and this name is canonical for you, the second entry maps that email to your canonical email (and name).