### PR TITLE
add .mailmap entry for myself

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -553,6 +553,9 @@ Simon Sapin <simon@exyr.org> <simon.sapin@exyr.org>
 Simonas Kazlauskas <git@kazlauskas.me> Simonas Kazlauskas <github@kazlauskas.me>
 Simonas Kazlauskas <git@kazlauskas.me> <simonas+t-compiler@kazlauskas.me>
 Siva Prasad <sivaauturic@gmail.com>
+Skgland <3877590+Skgland@users.noreply.github.com>
+Skgland <3877590+Skgland@users.noreply.github.com> <bb-github@t-online.de>
+Skgland <3877590+Skgland@users.noreply.github.com> <bennet.blessmann+github@googlemail.com>
 Smittyvb <me@smitop.com>
 Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com>
 Stanislav Tkach <stanislav.tkach@gmail.com>


### PR DESCRIPTION
Seeing #132474 in the bors queue I decided to check myself and noticed I was listed four times.
This fixed that by cannonicalizing all entries to use my username and the github no-reply email address, rather than some combination of name or username and different email addresses.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
