### PR TITLE
Revert #119515 single line where clause style guide

### DIFF
--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -46,7 +46,6 @@ include:
 - Miscellaneous `rustfmt` bugfixes.
 - Use version-sort (sort `x8`, `x16`, `x32`, `x64`, `x128` in that order).
 - Change "ASCIIbetical" sort to Unicode-aware "non-lowercase before lowercase".
-- Format single associated type `where` clauses on the same line if they fit.
 
 ## Rust 2015/2018/2021 style edition
 

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -295,18 +295,8 @@ Prefer to use single-letter names for generic parameters.
 
 These rules apply for `where` clauses on any item.
 
-If a where clause is short, and appears on a short one-line function
-declaration with no body or on a short type with no `=`, format it on
-the same line as the declaration:
-
-```rust
-fn new(&self) -> Self where Self: Sized;
-
-type Item<'a>: SomeTrait where Self: 'a;
-```
-
-Otherwise, if immediately following a closing bracket of any kind, write the
-keyword `where` on the same line, with a space before it.
+If immediately following a closing bracket of any kind, write the keyword
+`where` on the same line, with a space before it.
 
 Otherwise, put `where` on a new line at the same indentation level. Put each
 component of a `where` clause on its own line, block-indented. Use a trailing
@@ -357,7 +347,7 @@ where
 ```
 
 If a `where` clause is very short, prefer using an inline bound on the type
-parameter if possible.
+parameter.
 
 If a component of a `where` clause does not fit and contains `+`, break it
 before each `+` and block-indent the continuation lines. Put each bound on its
@@ -431,20 +421,8 @@ Format associated types like type aliases. Where an associated type has a
 bound, put a space after the colon but not before:
 
 ```rust
-type Foo: Bar;
+pub type Foo: Bar;
 ```
-
-If an associated type is short, has no `=`, and has a `where` clause with only
-one entry, format the entire type declaration including the `where` clause on
-the same line if it fits:
-
-```rust
-type Item<'a> where Self: 'a;
-type Item<'a>: PartialEq + Send where Self: 'a;
-```
-
-If the associated type has a `=`, or if the `where` clause contains multiple
-entries, format it across multiple lines as with a type alias.
 
 ## extern items
 


### PR DESCRIPTION
This did not get implemented for the style edition in 2024, so this PR removes it from the documentation.
See tracking issue https://github.com/rust-lang/rust/issues/132381.

This can be added back in the next edition if it gets implemented. I'm a little unclear on what the style team intends for how future changes are documented. For example, the current style-guide documented behavior that rustfmt does not support. I'm not sure who the audience for this document is, or how this is intended to stay in sync with rustfmt. For example, if I read this and assume this is how it is supposed to work, and then rustfmt breaks that, it seems like that is confusing. Similarly, if I'm staying on an older edition, this documentation would be incorrect for my crate.

Perhaps changes like this could be "teed-up" in a PR, but not merged until the edition is stabilized (similar to how the reference works)? And include notes for parts that are edition-specific (so if I am using an older edition, I can see that something is different). In general, I'm a little confused on how this is intended to work.

Reverts:

- https://github.com/rust-lang/rust/pull/119515