### PR TITLE
Revert style guide rhs break

### DIFF
--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -40,8 +40,6 @@ include:
   of a delimited expression, delimited expressions are generally combinable,
   regardless of the number of members. Previously only applied with exactly
   one member (except for closures with explicit blocks).
-- When line-breaking a binary operator, if the first operand spans multiple
-  lines, use the base indentation of the last line.
 - Miscellaneous `rustfmt` bugfixes.
 - Use version-sort (sort `x8`, `x16`, `x32`, `x64`, `x128` in that order).
 - Change "ASCIIbetical" sort to Unicode-aware "non-lowercase before lowercase".

--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -40,9 +40,8 @@ include:
   of a delimited expression, delimited expressions are generally combinable,
   regardless of the number of members. Previously only applied with exactly
   one member (except for closures with explicit blocks).
-- When line-breaking an assignment operator, if the left-hand side spans
-  multiple lines, use the base indentation of the last line of the left-hand
-  side to indent the right-hand side.
+- When line-breaking a binary operator, if the first operand spans multiple
+  lines, use the base indentation of the last line.
 - Miscellaneous `rustfmt` bugfixes.
 - Use version-sort (sort `x8`, `x16`, `x32`, `x64`, `x128` in that order).
 - Change "ASCIIbetical" sort to Unicode-aware "non-lowercase before lowercase".

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -328,37 +328,6 @@ foo_bar
 Prefer line-breaking at an assignment operator (either `=` or `+=`, etc.) rather
 than at other binary operators.
 
-If line-breaking at a binary operator (including assignment operators) where the
-first operand spans multiple lines, use the base indentation of the *last*
-line of the first operand, and indent relative to that:
-
-```rust
-impl SomeType {
-    fn method(&mut self) {
-        self.array[array_index as usize]
-            .as_mut()
-            .expect("thing must exist")
-            .extra_info =
-                long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
-
-        self.array[array_index as usize]
-            .as_mut()
-            .expect("thing must exist")
-            .extra_info
-                + long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
-
-        self.array[array_index as usize]
-            .as_mut()
-            .expect("thing must exist")
-            .extra_info = Some(ExtraInfo {
-                parent,
-                count: count as u16,
-                children: children.into_boxed_slice(),
-            });
-    }
-}
-```
-
 ### Casts (`as`)
 
 Format `as` casts like a binary operator. In particular, always include spaces

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -328,9 +328,9 @@ foo_bar
 Prefer line-breaking at an assignment operator (either `=` or `+=`, etc.) rather
 than at other binary operators.
 
-If line-breaking an assignment operator where the left-hand side spans multiple
-lines, use the base indentation of the *last* line of the left-hand side, and
-indent the right-hand side relative to that:
+If line-breaking at a binary operator (including assignment operators) where the
+first operand spans multiple lines, use the base indentation of the *last*
+line of the first operand, and indent relative to that:
 
 ```rust
 impl SomeType {
@@ -340,6 +340,12 @@ impl SomeType {
             .expect("thing must exist")
             .extra_info =
                 long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
+
+        self.array[array_index as usize]
+            .as_mut()
+            .expect("thing must exist")
+            .extra_info
+                + long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
 
         self.array[array_index as usize]
             .as_mut()


### PR DESCRIPTION
This reverts https://github.com/rust-lang/rust/pull/132369 and https://github.com/rust-lang/rust/pull/119838. The style-guide change for indentation of rhs was not implemented in time for the 2024 style edition. 
See tracking issue https://github.com/rust-lang/rust/issues/132380.

cc #134974 for the other style guide change in 2024.

r? @compiler-errors 
