### PR TITLE
Detect `mut arg: &Ty` meant to be `arg: &mut Ty` and provide structured suggestion

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -85,6 +85,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         self.annotate_expected_due_to_let_ty(err, expr, error);
         self.annotate_loop_expected_due_to_inference(err, expr, error);
+        if self.annotate_mut_binding_to_immutable_binding(err, expr, error) {
+            return;
+        }
 
         // FIXME(#73154): For now, we do leak check when coercing function
         // pointers in typeck, instead of only during borrowck. This can lead
@@ -793,6 +796,108 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             _ => {}
         }
+    }
+
+    /// Detect the following case
+    ///
+    /// ```text
+    /// fn change_object(mut a: &Ty) {
+    ///     let a = Ty::new();
+    ///     b = a;
+    /// }
+    /// ```
+    ///
+    /// where the user likely meant to modify the value behind there reference, use `a` as an out
+    /// parameter, instead of mutating the local binding. When encountering this we suggest:
+    ///
+    /// ```text
+    /// fn change_object(a: &'_ mut Ty) {
+    ///     let a = Ty::new();
+    ///     *b = a;
+    /// }
+    /// ```
+    fn annotate_mut_binding_to_immutable_binding(
+        &self,
+        err: &mut Diag<'_>,
+        expr: &hir::Expr<'_>,
+        error: Option<TypeError<'tcx>>,
+    ) -> bool {
+        let Some(TypeError::Sorts(ExpectedFound { expected, found })) = error else { return false };
+        let ty::Ref(_, inner, hir::Mutability::Not) = expected.kind() else { return false };
+        if !self.can_eq(self.param_env, *inner, found) {
+            // The difference between the expected and found values isn't one level of borrowing.
+            return false;
+        }
+        // We have an `ident = expr;` assignment.
+        let hir::Node::Expr(hir::Expr { kind: hir::ExprKind::Assign(lhs, rhs, _), .. }) =
+            self.tcx.parent_hir_node(expr.hir_id)
+        else {
+            return false;
+        };
+        if rhs.hir_id != expr.hir_id || expected.is_closure() {
+            return false;
+        }
+        // We are assigning to some binding.
+        let hir::ExprKind::Path(hir::QPath::Resolved(
+            None,
+            hir::Path { res: hir::def::Res::Local(hir_id), .. },
+        )) = lhs.kind
+        else {
+            return false;
+        };
+        let hir::Node::Pat(pat) = self.tcx.hir_node(*hir_id) else { return false };
+        // The pattern we have is an fn argument.
+        let hir::Node::Param(hir::Param { ty_span, .. }) = self.tcx.parent_hir_node(pat.hir_id)
+        else {
+            return false;
+        };
+        let item = self.tcx.hir().get_parent_item(pat.hir_id);
+        let item = self.tcx.hir_owner_node(item);
+        let Some(fn_decl) = item.fn_decl() else { return false };
+
+        // We have a mutable binding in the argument.
+        let hir::PatKind::Binding(hir::BindingMode::MUT, _hir_id, ident, _) = pat.kind else {
+            return false;
+        };
+
+        // Look for the type corresponding to the argument pattern we have in the argument list.
+        let Some(ty_sugg) = fn_decl
+            .inputs
+            .iter()
+            .filter_map(|ty| {
+                if ty.span == *ty_span
+                    && let hir::TyKind::Ref(lt, mut_ty) = ty.kind
+                {
+                    // `&'name Ty` -> `&'name mut Ty` or `&Ty` -> `&mut Ty`
+                    Some((
+                        mut_ty.ty.span.shrink_to_lo(),
+                        format!(
+                            "{}mut ",
+                            if lt.ident.span.lo() == lt.ident.span.hi() { "" } else { " " }
+                        ),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .next()
+        else {
+            return false;
+        };
+        let sugg = vec![
+            ty_sugg,
+            (pat.span.until(ident.span), String::new()),
+            (lhs.span.shrink_to_lo(), "*".to_string()),
+        ];
+        // We suggest changing the argument from `mut ident: &Ty` to `ident: &'_ mut Ty` and the
+        // assignment from `ident = val;` to `*ident = val;`.
+        err.multipart_suggestion_verbose(
+            "you might have meant to mutate the pointed at value being passed in, instead of \
+             changing the reference in the local binding",
+            sugg,
+            Applicability::MaybeIncorrect,
+        );
+        return true;
     }
 
     fn annotate_alternative_method_deref(

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -799,6 +799,9 @@ passes_unused_assign = value assigned to `{$name}` is never read
 passes_unused_assign_passed = value passed to `{$name}` is never read
     .help = maybe it is overwritten before being read?
 
+passes_unused_assign_suggestion =
+    you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
+
 passes_unused_capture_maybe_capture_ref = value captured by `{$name}` is never read
     .help = did you mean to capture by reference instead?
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1787,9 +1787,26 @@ pub(crate) struct IneffectiveUnstableImpl;
 
 #[derive(LintDiagnostic)]
 #[diag(passes_unused_assign)]
-#[help]
 pub(crate) struct UnusedAssign {
     pub name: String,
+    #[subdiagnostic]
+    pub suggestion: Option<UnusedAssignSuggestion>,
+    #[help]
+    pub help: bool,
+}
+
+#[derive(Subdiagnostic)]
+#[multipart_suggestion(passes_unused_assign_suggestion, applicability = "maybe-incorrect")]
+pub(crate) struct UnusedAssignSuggestion {
+    pub pre: &'static str,
+    #[suggestion_part(code = "{pre}mut ")]
+    pub ty_span: Span,
+    #[suggestion_part(code = "")]
+    pub ty_ref_span: Span,
+    #[suggestion_part(code = "*")]
+    pub ident_span: Span,
+    #[suggestion_part(code = "")]
+    pub expr_ref_span: Span,
 }
 
 #[derive(LintDiagnostic)]

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.fixed
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.fixed
@@ -2,15 +2,15 @@
 #![deny(unused_assignments, unused_variables)]
 struct Object;
 
-fn change_object(mut object: &Object) { //~ HELP you might have meant to mutate
+fn change_object(object: &mut Object) { //~ HELP you might have meant to mutate
     let object2 = Object;
-    object = object2; //~ ERROR mismatched types
+    *object = object2; //~ ERROR mismatched types
 }
 
-fn change_object2(mut object: &Object) { //~ ERROR variable `object` is assigned to, but never used
+fn change_object2(object: &mut Object) { //~ ERROR variable `object` is assigned to, but never used
     //~^ HELP you might have meant to mutate
     let object2 = Object;
-    object = &object2;
+    *object = object2;
     //~^ ERROR `object2` does not live long enough
     //~| ERROR value assigned to `object` is never read
 }

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs
@@ -1,0 +1,20 @@
+#![deny(unused_assignments, unused_variables)]
+struct Object;
+
+fn change_object(mut object: &Object) {
+    let object2 = Object;
+    object = object2; //~ ERROR mismatched types
+}
+
+fn change_object2(mut object: &Object) { //~ ERROR variable `object` is assigned to, but never used
+    let object2 = Object;
+    object = &object2;
+    //~^ ERROR `object2` does not live long enough
+    //~| ERROR value assigned to `object` is never read
+}
+
+fn main() {
+    let object = Object;
+    change_object(&object);
+    change_object2(&object);
+}

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
@@ -20,12 +20,17 @@ error: value assigned to `object` is never read
 LL |     object = &object2;
    |     ^^^^^^
    |
-   = help: maybe it is overwritten before being read?
 note: the lint level is defined here
   --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:1:9
    |
 LL | #![deny(unused_assignments, unused_variables)]
    |         ^^^^^^^^^^^^^^^^^^
+help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
+   |
+LL ~ fn change_object2(object: &mut Object) {
+LL |     let object2 = Object;
+LL ~     *object = object2;
+   |
 
 error: variable `object` is assigned to, but never used
   --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:9:23

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
@@ -7,10 +7,12 @@ LL |     let object2 = Object;
 LL |     object = object2;
    |              ^^^^^^^ expected `&Object`, found `Object`
    |
-help: consider borrowing here
+help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
    |
-LL |     object = &object2;
-   |              +
+LL ~ fn change_object(object: &mut Object) {
+LL |     let object2 = Object;
+LL ~     *object = object2;
+   |
 
 error: value assigned to `object` is never read
   --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:11:5

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:6:14
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:7:14
    |
 LL | fn change_object(mut object: &Object) {
    |                              ------- expected due to this parameter type
@@ -15,41 +15,43 @@ LL ~     *object = object2;
    |
 
 error: value assigned to `object` is never read
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:11:5
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:13:5
    |
 LL |     object = &object2;
    |     ^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:1:9
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:2:9
    |
 LL | #![deny(unused_assignments, unused_variables)]
    |         ^^^^^^^^^^^^^^^^^^
 help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
    |
 LL ~ fn change_object2(object: &mut Object) {
+LL |
 LL |     let object2 = Object;
 LL ~     *object = object2;
    |
 
 error: variable `object` is assigned to, but never used
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:9:23
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:10:23
    |
 LL | fn change_object2(mut object: &Object) {
    |                       ^^^^^^
    |
    = note: consider using `_object` instead
 note: the lint level is defined here
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:1:29
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:2:29
    |
 LL | #![deny(unused_assignments, unused_variables)]
    |                             ^^^^^^^^^^^^^^^^
 
 error[E0597]: `object2` does not live long enough
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:11:14
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:13:14
    |
 LL | fn change_object2(mut object: &Object) {
    |                               - let's call the lifetime of this reference `'1`
+LL |
 LL |     let object2 = Object;
    |         ------- binding `object2` declared here
 LL |     object = &object2;

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
@@ -1,0 +1,60 @@
+error[E0308]: mismatched types
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:6:14
+   |
+LL | fn change_object(mut object: &Object) {
+   |                              ------- expected due to this parameter type
+LL |     let object2 = Object;
+LL |     object = object2;
+   |              ^^^^^^^ expected `&Object`, found `Object`
+   |
+help: consider borrowing here
+   |
+LL |     object = &object2;
+   |              +
+
+error: value assigned to `object` is never read
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:11:5
+   |
+LL |     object = &object2;
+   |     ^^^^^^
+   |
+   = help: maybe it is overwritten before being read?
+note: the lint level is defined here
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:1:9
+   |
+LL | #![deny(unused_assignments, unused_variables)]
+   |         ^^^^^^^^^^^^^^^^^^
+
+error: variable `object` is assigned to, but never used
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:9:23
+   |
+LL | fn change_object2(mut object: &Object) {
+   |                       ^^^^^^
+   |
+   = note: consider using `_object` instead
+note: the lint level is defined here
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:1:29
+   |
+LL | #![deny(unused_assignments, unused_variables)]
+   |                             ^^^^^^^^^^^^^^^^
+
+error[E0597]: `object2` does not live long enough
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:11:14
+   |
+LL | fn change_object2(mut object: &Object) {
+   |                               - let's call the lifetime of this reference `'1`
+LL |     let object2 = Object;
+   |         ------- binding `object2` declared here
+LL |     object = &object2;
+   |     ---------^^^^^^^^
+   |     |        |
+   |     |        borrowed value does not live long enough
+   |     assignment requires that `object2` is borrowed for `'1`
+...
+LL | }
+   | - `object2` dropped here while still borrowed
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0308, E0597.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
When a newcomer attempts to use an "out parameter" using borrows, they sometimes get confused and instead of mutating the borrow they try to mutate the function-local binding instead. This leads to either type errors (due to assigning an owned value to a mutable binding of reference type) or a multitude of lifetime errors and unused binding warnings.

This change adds a suggestion to the type error

```
error[E0308]: mismatched types
  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:6:14
   |
LL | fn change_object(mut object: &Object) {
   |                              ------- expected due to this parameter type
LL |     let object2 = Object;
LL |     object = object2;
   |              ^^^^^^^ expected `&Object`, found `Object`
   |
help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
   |
LL ~ fn change_object(object: &mut Object) {
LL |     let object2 = Object;
LL ~     *object = object2;
   |
```
and to the unused assignment lint
```
error: value assigned to `object` is never read
  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:11:5
   |
LL |     object = &object2;
   |     ^^^^^^
   |
note: the lint level is defined here
  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:1:9
   |
LL | #![deny(unused_assignments, unused_variables)]
   |         ^^^^^^^^^^^^^^^^^^
help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
   |
LL ~ fn change_object2(object: &mut Object) {
LL |     let object2 = Object;
LL ~     *object = object2;
   |
```

Fix #112357.