### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -553,6 +553,9 @@ Simon Sapin <simon@exyr.org> <simon.sapin@exyr.org>
 Simonas Kazlauskas <git@kazlauskas.me> Simonas Kazlauskas <github@kazlauskas.me>
 Simonas Kazlauskas <git@kazlauskas.me> <simonas+t-compiler@kazlauskas.me>
 Siva Prasad <sivaauturic@gmail.com>
+Skgland <3877590+Skgland@users.noreply.github.com>
+Skgland <3877590+Skgland@users.noreply.github.com> <bb-github@t-online.de>
+Skgland <3877590+Skgland@users.noreply.github.com> <bennet.blessmann+github@googlemail.com>
 Smittyvb <me@smitop.com>
 Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com>
 Stanislav Tkach <stanislav.tkach@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -48,6 +48,7 @@ Andrew Poelstra <asp11@sfu.ca> <apoelstra@wpsoftware.net>
 Anhad Singh <andypythonappdeveloper@gmail.com>
 Antoine Plaskowski <antoine.plaskowski@epitech.eu>
 Anton Löfgren <anton.lofgren@gmail.com> <alofgren@op5.com>
+apiraino <apiraino@users.noreply.github.com> <apiraino@protonmail.com>
 Araam Borhanian <avborhanian@gmail.com>
 Araam Borhanian <avborhanian@gmail.com> <dobbybabee@gmail.com>
 Areski Belaid <areski@gmail.com> areski <areski@gmail.com>
@@ -62,7 +63,10 @@ Austin Seipp <mad.one@gmail.com> <as@hacks.yi.org>
 Ayaz Hafiz <ayaz.hafiz.1@gmail.com>
 Aydin Kim <ladinjin@hanmail.net> aydin.kim <aydin.kim@samsung.com>
 Ayush Mishra <ayushmishra2005@gmail.com>
+Ashley Mannix <kodraus@hey.com> <ashleymannix@live.com.au>
 asrar <aszenz@gmail.com>
+b-naber <bn263@gmx.de>
+b-naber <bn263@gmx.de> <b_naber@gmx.de>
 BaoshanPang <pangbw@gmail.com>
 Barosl Lee <vcs@barosl.com> Barosl LEE <github@barosl.com>
 Bastian Kersting <bastian@cmbt.de>
@@ -98,6 +102,8 @@ Caleb Cartwright <caleb.cartwright@outlook.com>
 Caleb Jones <code@calebjones.net>
 Noah Lev <camelidcamel@gmail.com>
 Noah Lev <camelidcamel@gmail.com> <37223377+camelid@users.noreply.github.com>
+Catherine <catherine3.flores@gmail.com>
+Catherine <catherine3.flores@gmail.com> <catherine.3.flores@gmail.com>
 cameron1024 <cameron.studdstreet@gmail.com>
 Camille Gillot <gillot.camille@gmail.com>
 Carl-Anton Ingmarsson <mail@carlanton.se> <ca.ingmarsson@gmail.com>
@@ -133,11 +139,13 @@ Clement Miao <clementmiao@gmail.com>
 Clément Renault <renault.cle@gmail.com>
 Cliff Dyer <jcd@sdf.org>
 Clinton Ryan <clint.ryan3@gmail.com>
+Taylor Cramer <cramertaylorj@gmail.com> <cramertj@google.com>
 ember arlynx <ember@lunar.town> <corey@octayn.net>
 Crazycolorz5 <Crazycolorz5@gmail.com>
 csmoe <35686186+csmoe@users.noreply.github.com>
 Cyryl Płotnicki <cyplo@cyplo.net>
 Damien Schoof <damien.schoof@gmail.com>
+Dan Gohman <dev@sunfishcode.online> <sunfish@mozilla.com>
 Dan Robertson <danlrobertson89@gmail.com>
 Daniel Campoverde <alx741@riseup.net>
 Daniel J Rollins <drollins@financialforce.com>
@@ -179,10 +187,14 @@ Eduardo Bautista <me@eduardobautista.com> <=>
 Eduardo Bautista <me@eduardobautista.com> <mail@eduardobautista.com>
 Eduardo Broto <ebroto@tutanota.com>
 Edward Shen <code@eddie.sh> <xes@meta.com>
+Jacob Finkelman <eh2406@wayne.edu>
+Jacob Finkelman <eh2406@wayne.edu> <YeomanYaacov@gmail.com>
 Elliott Slaughter <elliottslaughter@gmail.com> <eslaughter@mozilla.com>
 Elly Fong-Jones <elly@leptoquark.net>
 Eric Holk <eric.holk@gmail.com> <eholk@cs.indiana.edu>
 Eric Holk <eric.holk@gmail.com> <eholk@mozilla.com>
+Eric Holk <eric.holk@gmail.com> <eric@theincredibleholk.org>
+Eric Holk <eric.holk@gmail.com> <ericholk@microsoft.com>
 Eric Holmes <eric@ejholmes.net>
 Eric Reed <ecreed@cs.washington.edu> <ereed@mozilla.com>
 Erick Tryzelaar <erick.tryzelaar@gmail.com> <etryzelaar@iqt.org>
@@ -206,6 +218,7 @@ Felix S. Klock II <pnkfelix@pnkfx.org> <pnkfelix@mozilla.com>
 Félix Saparelli <felix@passcod.name>
 Flaper Fesp <flaper87@gmail.com>
 Florian Berger <fbergr@gmail.com>
+Florian Gilcher <florian.gilcher@asquera.de> <flo@andersground.net>
 Florian Wilkens <mrfloya_github@outlook.com> Florian Wilkens <floya@live.de>
 François Mockers <mockersf@gmail.com>
 Frank Steffahn <fdsteffahn@gmail.com> <frank.steffahn@stu.uni-kiel.de>
@@ -240,6 +253,8 @@ Herman J. Radtke III <herman@hermanradtke.com> Herman J. Radtke III <hermanradtk
 Hirochika Matsumoto <git@hkmatsumoto.com> <matsujika@gmail.com>
 Hrvoje Nikšić <hniksic@gmail.com>
 Hsiang-Cheng Yang <rick68@users.noreply.github.com>
+Huon Wilson <dbau.pp@gmail.com>
+Huon Wilson <dbau.pp@gmail.com> <wilson.huon@gmail.com>
 Ian Jackson <ijackson@chiark.greenend.org.uk> <ian.jackson@citrix.com>
 Ian Jackson <ijackson@chiark.greenend.org.uk> <ijackson+github@slimy.greenend.org.uk>
 Ian Jackson <ijackson@chiark.greenend.org.uk> <iwj@xenproject.org>
@@ -252,9 +267,13 @@ ivan tkachenko <me@ratijas.tk>
 J. J. Weber <jjweber@gmail.com>
 Jack Huey <jack.huey@umassmed.edu> <jackh726@gmail.com>
 Jacob <jacob.macritchie@gmail.com>
+Jacob Hoffman-Andrews <rust@hoffman-andrews.com> <github@hoffman-andrews.com>
 Jacob Greenfield <xales@naveria.com>
 Jacob Pratt <jacob@jhpratt.dev> <the.z.cuber@gmail.com>
 Jacob Pratt <jacob@jhpratt.dev> <jacopratt@tesla.com>
+Jake Goulding <jake.goulding@integer32.com>
+Jake Goulding <jake.goulding@integer32.com> <jake.goulding@gmail.com> 
+Jake Goulding <jake.goulding@integer32.com> <shepmaster@mac.com>
 Jake Vossen <jake@vossen.dev>
 Jakob Degen <jakob.e.degen@gmail.com> <jakob@degen.com>
 Jakob Lautrup Nysom <jako3047@gmail.com>
@@ -287,6 +306,7 @@ Jerry Hardee <hardeejj9@gmail.com>
 Jesús Rubio <jesusprubio@gmail.com>
 Jethro Beekman <github@jbeekman.nl>
 Jian Zeng <knight42@mail.ustc.edu.cn>
+Jieyou Xu <jieyouxu@outlook.com>
 Jieyou Xu <jieyouxu@outlook.com> <39484203+jieyouxu@users.noreply.github.com>
 Jihyun Yu <j.yu@navercorp.com> <yjh0502@gmail.com>
 Jihyun Yu <j.yu@navercorp.com> jihyun <jihyun@nablecomm.com>
@@ -322,9 +342,12 @@ Josh Holmer <jholmer.in@gmail.com>
 Josh Stone <cuviper@gmail.com> <jistone@redhat.com>
 Josh Stone <cuviper@gmail.com> <jistone@fedoraproject.org>
 Julia Ryan <juliaryan3.14@gmail.com> <josephryan3.14@gmail.com>
+Jubilee Young <workingjubilee@gmail.com> <46493976+workingjubilee@users.noreply.github.com>
+Jubilee Young <workingjubilee@gmail.com>
 Julian Knodt <julianknodt@gmail.com>
 jumbatm <jumbatm@gmail.com> <30644300+jumbatm@users.noreply.github.com>
 Junyoung Cho <june0.cho@samsung.com>
+Jynn Nelson <github@jyn.dev> <rust@jyn.dev>
 Jynn Nelson <github@jyn.dev> <jyn514@gmail.com>
 Jynn Nelson <github@jyn.dev> <joshua@yottadb.com>
 Jynn Nelson <github@jyn.dev> <jyn.nelson@redjack.com>
@@ -385,12 +408,14 @@ Marcell Pardavi <marcell.pardavi@gmail.com>
 Marcus Klaas de Vries <mail@marcusklaas.nl>
 Margaret Meyerhofer <mmeyerho@andrew.cmu.edu> <mmeyerho@andrew>
 Mark Mansi <markm@cs.wisc.edu>
+Mark Mansi <markm@cs.wisc.edu> <m.mim95@gmail.com>
 Mark Rousskov <mark.simulacrum@gmail.com>
 Mark Sinclair <mark.edward.x@gmail.com>
 Mark Sinclair <mark.edward.x@gmail.com> =Mark Sinclair <=125axel125@gmail.com>
 Markus Legner <markus@legner.ch>
 Markus Westerlind <marwes91@gmail.com> Markus <marwes91@gmail.com>
 Martin Carton <cartonmartin+git@gmail.com>
+Martin Carton <cartonmartin+git@gmail.com> <cartonmartin@gmail.com>
 Martin Habovštiak <martin.habovstiak@gmail.com>
 Martin Hafskjold Thoresen <martinhath@gmail.com>
 Martin Nordholts <martin.nordholts@codetale.se> <enselic@gmail.com>
@@ -415,6 +440,7 @@ Melody Horn <melody@boringcactus.com> <mathphreak@gmail.com>
 Mendes <pedro.mendes.26@gmail.com>
 mental <m3nta1@yahoo.com>
 mibac138 <5672750+mibac138@users.noreply.github.com>
+Michael Howell <michael@notriddle.com> <notriddle+rust-mod@protonmail.com>
 Michael Williams <m.t.williams@live.com>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@gmail>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@gmail.com>
@@ -431,6 +457,7 @@ Ms2ger <ms2ger@gmail.com> <Ms2ger@gmail.com>
 msizanoen1 <qtmlabs@protonmail.com>
 Mukilan Thiagarajan <mukilanthiagarajan@gmail.com>
 Nadrieril Feneanar <Nadrieril@users.noreply.github.com>
+Nadrieril Feneanar <Nadrieril@users.noreply.github.com> <nadrieril+rust@gmail.com>
 Nadrieril Feneanar <Nadrieril@users.noreply.github.com> <nadrieril+git@gmail.com>
 NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm@gmail.com>
 NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm+github@gmail.com>
@@ -447,15 +474,23 @@ Nicholas Bishop <nbishop@nbishop.net> <nicholasbishop@gmail.com>
 Nicholas Bishop <nbishop@nbishop.net> <nicholasbishop@google.com>
 Nicholas Nethercote <n.nethercote@gmail.com> <nnethercote@apple.com>
 Nicholas Nethercote <n.nethercote@gmail.com> <nnethercote@mozilla.com>
+Nick Cameron <nrc@ncameron.org> <ncameron@mozilla.com>
+Nick Fitzgerald <fitzgen@gmail.com> <nfitzgerald@mozilla.com>
 Nick Platt <platt.nicholas@gmail.com>
 Niclas Schwarzlose <15schnic@gmail.com>
 Nicolas Abram <abramlujan@gmail.com>
 Nicole Mazzuca <npmazzuca@gmail.com>
+Niko Matsakis <rust@nikomatsakis.com>
+Niko Matsakis <rust@nikomatsakis.com> <niko@alum.mit.edu>
+Noratrieb <48135649+Noratrieb@users.noreply.github.com>
 Noratrieb <48135649+Noratrieb@users.noreply.github.com> <48135649+Nilstrieb@users.noreply.github.com>
 Noratrieb <48135649+Noratrieb@users.noreply.github.com> <nilstrieb@gmail.com>
+Noratrieb <48135649+Noratrieb@users.noreply.github.com> <rust@noratrieb.dev>
 Noratrieb <48135649+Noratrieb@users.noreply.github.com> <nora@noratrieb.dev>
 Nif Ward <nif.ward@gmail.com>
 Nika Layzell <nika@thelayzells.com> <michael@thelayzells.com>
+Nikita Popov <nikita.ppv@gmail.com>
+Nikita Popov <nikita.ppv@gmail.com> <npopov@redhat.com>
 NODA Kai <nodakai@gmail.com>
 Oğuz Ağcayazı <oguz.agcayazi@gmail.com> <oguz.agcayazi@gmail.com>
 Oğuz Ağcayazı <oguz.agcayazi@gmail.com> <ouz.agz@gmail.com>
@@ -516,6 +551,7 @@ Ricky Hosfelt <ricky@hosfelt.io>
 Ritiek Malhotra <ritiekmalhotra123@gmail.com>
 Rob Arnold <robarnold@cs.cmu.edu>
 Rob Arnold <robarnold@cs.cmu.edu> Rob Arnold <robarnold@68-26-94-7.pools.spcsdns.net>
+Robert Collins <robertc@robertcollins.net> <robertc+rust@robertcollins.net>
 Robert Foss <dev@robertfoss.se> robertfoss <dev@robertfoss.se>
 Robert Gawdzik <rgawdzik@hotmail.com> Robert Gawdzik ☢ <rgawdzik@hotmail.com>
 Robert Habermeier <rphmeier@gmail.com>
@@ -554,6 +590,11 @@ Simonas Kazlauskas <git@kazlauskas.me> Simonas Kazlauskas <github@kazlauskas.me>
 Simonas Kazlauskas <git@kazlauskas.me> <simonas+t-compiler@kazlauskas.me>
 Siva Prasad <sivaauturic@gmail.com>
 Smittyvb <me@smitop.com>
+Sophia June Turner <547158+sophiajt@users.noreply.github.com>
+Sophia June Turner <547158+sophiajt@users.noreply.github.com> <547158+jntrnr@users.noreply.github.com>
+Sophia June Turner <547158+sophiajt@users.noreply.github.com> <jonathandturner@users.noreply.github.com>
+Sophia June Turner <547158+sophiajt@users.noreply.github.com> <jturner@mozilla.com>
+Sophia June Turner <547158+sophiajt@users.noreply.github.com> <jonathan.d.turner@gmail.com>
 Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com>
 Stanislav Tkach <stanislav.tkach@gmail.com>
 startling <tdixon51793@gmail.com>
@@ -586,8 +627,10 @@ Tim Diekmann <t.diekmann.3dv@gmail.com>
 Tim Hutt <tdhutt@gmail.com>
 Tim JIANG <p90eri@gmail.com>
 Tim Joseph Dumol <tim@timdumol.com>
+Tim Neumann <mail@timnn.me> <timnn@google.com>
 Timothy Maloney <tmaloney@pdx.edu>
 Tomas Koutsky <tomas@stepnivlk.net>
+Tomasz Miąsko <tomasz.miasko@gmail.com>
 Torsten Weber <TorstenWeber12@gmail.com>
 Torsten Weber <TorstenWeber12@gmail.com> <torstenweber12@gmail.com>
 Trevor Gross <tmgross@umich.edu> <t.gross35@gmail.com>
@@ -607,7 +650,7 @@ Valerii Lashmanov <vflashm@gmail.com>
 Vitali Haravy <HumaneProgrammer@gmail.com> Vitali Haravy <humaneprogrammer@gmail.com>
 Vitaly Shukela <vi0oss@gmail.com>
 Waffle Lapkin <waffle.lapkin@gmail.com>
-Waffle Lapkin <waffle.lapkin@tasking.com>
+Waffle Lapkin <waffle.lapkin@gmail.com> <waffle.lapkin@tasking.com>
 Wesley Wiser <wwiser@gmail.com> <wesleywiser@microsoft.com>
 whitequark <whitequark@whitequark.org>
 William Ting <io@williamting.com> <william.h.ting@gmail.com>

--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -46,7 +46,6 @@ include:
 - Miscellaneous `rustfmt` bugfixes.
 - Use version-sort (sort `x8`, `x16`, `x32`, `x64`, `x128` in that order).
 - Change "ASCIIbetical" sort to Unicode-aware "non-lowercase before lowercase".
-- Format single associated type `where` clauses on the same line if they fit.
 
 ## Rust 2015/2018/2021 style edition
 

--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -40,8 +40,6 @@ include:
   of a delimited expression, delimited expressions are generally combinable,
   regardless of the number of members. Previously only applied with exactly
   one member (except for closures with explicit blocks).
-- When line-breaking a binary operator, if the first operand spans multiple
-  lines, use the base indentation of the last line.
 - Miscellaneous `rustfmt` bugfixes.
 - Use version-sort (sort `x8`, `x16`, `x32`, `x64`, `x128` in that order).
 - Change "ASCIIbetical" sort to Unicode-aware "non-lowercase before lowercase".

--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -40,9 +40,8 @@ include:
   of a delimited expression, delimited expressions are generally combinable,
   regardless of the number of members. Previously only applied with exactly
   one member (except for closures with explicit blocks).
-- When line-breaking an assignment operator, if the left-hand side spans
-  multiple lines, use the base indentation of the last line of the left-hand
-  side to indent the right-hand side.
+- When line-breaking a binary operator, if the first operand spans multiple
+  lines, use the base indentation of the last line.
 - Miscellaneous `rustfmt` bugfixes.
 - Use version-sort (sort `x8`, `x16`, `x32`, `x64`, `x128` in that order).
 - Change "ASCIIbetical" sort to Unicode-aware "non-lowercase before lowercase".

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -328,37 +328,6 @@ foo_bar
 Prefer line-breaking at an assignment operator (either `=` or `+=`, etc.) rather
 than at other binary operators.
 
-If line-breaking at a binary operator (including assignment operators) where the
-first operand spans multiple lines, use the base indentation of the *last*
-line of the first operand, and indent relative to that:
-
-```rust
-impl SomeType {
-    fn method(&mut self) {
-        self.array[array_index as usize]
-            .as_mut()
-            .expect("thing must exist")
-            .extra_info =
-                long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
-
-        self.array[array_index as usize]
-            .as_mut()
-            .expect("thing must exist")
-            .extra_info
-                + long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
-
-        self.array[array_index as usize]
-            .as_mut()
-            .expect("thing must exist")
-            .extra_info = Some(ExtraInfo {
-                parent,
-                count: count as u16,
-                children: children.into_boxed_slice(),
-            });
-    }
-}
-```
-
 ### Casts (`as`)
 
 Format `as` casts like a binary operator. In particular, always include spaces

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -328,9 +328,9 @@ foo_bar
 Prefer line-breaking at an assignment operator (either `=` or `+=`, etc.) rather
 than at other binary operators.
 
-If line-breaking an assignment operator where the left-hand side spans multiple
-lines, use the base indentation of the *last* line of the left-hand side, and
-indent the right-hand side relative to that:
+If line-breaking at a binary operator (including assignment operators) where the
+first operand spans multiple lines, use the base indentation of the *last*
+line of the first operand, and indent relative to that:
 
 ```rust
 impl SomeType {
@@ -340,6 +340,12 @@ impl SomeType {
             .expect("thing must exist")
             .extra_info =
                 long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
+
+        self.array[array_index as usize]
+            .as_mut()
+            .expect("thing must exist")
+            .extra_info
+                + long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
 
         self.array[array_index as usize]
             .as_mut()

--- a/src/doc/style-guide/src/items.md
+++ b/src/doc/style-guide/src/items.md
@@ -295,18 +295,8 @@ Prefer to use single-letter names for generic parameters.
 
 These rules apply for `where` clauses on any item.
 
-If a where clause is short, and appears on a short one-line function
-declaration with no body or on a short type with no `=`, format it on
-the same line as the declaration:
-
-```rust
-fn new(&self) -> Self where Self: Sized;
-
-type Item<'a>: SomeTrait where Self: 'a;
-```
-
-Otherwise, if immediately following a closing bracket of any kind, write the
-keyword `where` on the same line, with a space before it.
+If immediately following a closing bracket of any kind, write the keyword
+`where` on the same line, with a space before it.
 
 Otherwise, put `where` on a new line at the same indentation level. Put each
 component of a `where` clause on its own line, block-indented. Use a trailing
@@ -357,7 +347,7 @@ where
 ```
 
 If a `where` clause is very short, prefer using an inline bound on the type
-parameter if possible.
+parameter.
 
 If a component of a `where` clause does not fit and contains `+`, break it
 before each `+` and block-indent the continuation lines. Put each bound on its
@@ -431,20 +421,8 @@ Format associated types like type aliases. Where an associated type has a
 bound, put a space after the colon but not before:
 
 ```rust
-type Foo: Bar;
+pub type Foo: Bar;
 ```
-
-If an associated type is short, has no `=`, and has a `where` clause with only
-one entry, format the entire type declaration including the `where` clause on
-the same line if it fits:
-
-```rust
-type Item<'a> where Self: 'a;
-type Item<'a>: PartialEq + Send where Self: 'a;
-```
-
-If the associated type has a `=`, or if the `where` clause contains multiple
-entries, format it across multiple lines as with a type alias.
 
 ## extern items
 

--- a/src/tools/tidy/src/ext_tool_checks.rs
+++ b/src/tools/tidy/src/ext_tool_checks.rs
@@ -154,6 +154,9 @@ fn check_impl(
             args.insert(0, "--diff".as_ref());
             let _ = py_runner(py_path.as_ref().unwrap(), true, None, "ruff", &args);
         }
+        if res.is_err() && !bless {
+            eprintln!("rerun tidy with `--extra-checks=py:fmt --bless` to reformat Python code");
+        }
         // Rethrow error
         let _ = res?;
     }

--- a/tests/rustdoc-gui/item-info.goml
+++ b/tests/rustdoc-gui/item-info.goml
@@ -45,3 +45,26 @@ compare-elements-css: (
     "#main-content > .item-info .stab:nth-of-type(2)",
     ["height"],
 )
+
+// Now checking the text color and the links color.
+show-text: true
+include: "utils.goml"
+go-to: "file://" + |DOC_PATH| + "/lib2/trait.Trait.html"
+
+call-function: ("switch-theme", {"theme": "ayu"})
+assert-css: (".item-info .stab", {"color": "rgb(197, 197, 197)"}, ALL)
+assert-css: (".item-info .stab strong", {"color": "rgb(197, 197, 197)"}, ALL)
+assert-css: (".item-info .stab span", {"color": "rgb(197, 197, 197)"}, ALL)
+assert-css: (".item-info .stab a", {"color": "rgb(57, 175, 215)"}, ALL)
+
+call-function: ("switch-theme", {"theme": "dark"})
+assert-css: (".item-info .stab", {"color": "rgb(221, 221, 221)"}, ALL)
+assert-css: (".item-info .stab strong", {"color": "rgb(221, 221, 221)"}, ALL)
+assert-css: (".item-info .stab span", {"color": "rgb(221, 221, 221)"}, ALL)
+assert-css: (".item-info .stab a", {"color": "rgb(210, 153, 29)"}, ALL)
+
+call-function: ("switch-theme", {"theme": "light"})
+assert-css: (".item-info .stab", {"color": "rgb(0, 0, 0)"}, ALL)
+assert-css: (".item-info .stab strong", {"color": "rgb(0, 0, 0)"}, ALL)
+assert-css: (".item-info .stab span", {"color": "rgb(0, 0, 0)"}, ALL)
+assert-css: (".item-info .stab a", {"color": "rgb(56, 115, 173)"}, ALL)

--- a/tests/rustdoc/type-alias/deeply-nested-112515.rs
+++ b/tests/rustdoc/type-alias/deeply-nested-112515.rs
@@ -1,6 +1,6 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/112515>.
 // It's to ensure that this code doesn't have infinite loop in rustdoc when
-// trying to retrive type alias implementations.
+// trying to retrieve type alias implementations.
 
 // ignore-tidy-linelength
 

--- a/tests/ui/duplicate/multiple-types-with-same-name-and-derive.rs
+++ b/tests/ui/duplicate/multiple-types-with-same-name-and-derive.rs
@@ -1,6 +1,6 @@
 // Here, there are two types with the same name. One of these has a `derive` annotation, but in the
 // expansion these `impl`s are associated to the the *other* type. There is a suggestion to remove
-// unneded type parameters, but because we're now point at a type with no type parameters, the
+// unneeded type parameters, but because we're now point at a type with no type parameters, the
 // suggestion would suggest removing code from an empty span, which would ICE in nightly.
 //
 // issue: rust-lang/rust#108748

--- a/tests/ui/incoherent-inherent-impls/no-other-unrelated-errors.rs
+++ b/tests/ui/incoherent-inherent-impls/no-other-unrelated-errors.rs
@@ -1,4 +1,4 @@
-// E0116 caused other unrelated errors, so check no unrelated errors are emmitted.
+// E0116 caused other unrelated errors, so check no unrelated errors are emitted.
 
 fn main() {
     let x = "hello";

--- a/tests/ui/indexing/indexing-spans-caller-location.rs
+++ b/tests/ui/indexing/indexing-spans-caller-location.rs
@@ -20,7 +20,7 @@ impl std::ops::Index<usize> for A {
     type Output = ();
 
     fn index(&self, _idx: usize) -> &() {
-        // Use the relative number to make it resistent to header changes.
+        // Use the relative number to make it resistant to header changes.
         assert_eq!(caller_line(), self.prev_line + 2);
         &()
     }

--- a/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.rs
+++ b/tests/ui/inference/need_type_info/issue-107745-avoid-expr-from-macro-expansion.rs
@@ -2,7 +2,7 @@
 
 // Regression test for #107745.
 // Previously need_type_info::update_infer_source will consider expressions originating from
-// macro expressions as candiate "previous sources". This unfortunately can mean that
+// macro expressions as candidate "previous sources". This unfortunately can mean that
 // for macros expansions such as `format!()` internal implementation details can leak, such as:
 //
 // ```

--- a/tests/ui/issues/issue-12567.stderr
+++ b/tests/ui/issues/issue-12567.stderr
@@ -11,14 +11,16 @@ LL |         (&[hd1, ..], &[hd2, ..])
    |                        --- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |         (&[], &[ref hd, ..]) | (&[hd, ..], &[])
-   |                 +++
-help: consider borrowing the pattern binding
+LL -         (&[], &[hd, ..]) | (&[hd, ..], &[])
+LL +         (&[], [hd, ..]) | (&[hd, ..], &[])
    |
-LL |         (&[hd1, ..], &[ref hd2, ..])
-   |                        +++
+help: consider removing the borrow
+   |
+LL -         (&[hd1, ..], &[hd2, ..])
+LL +         (&[hd1, ..], [hd2, ..])
+   |
 
 error[E0508]: cannot move out of type `[T]`, a non-copy slice
   --> $DIR/issue-12567.rs:2:11
@@ -33,14 +35,16 @@ LL |         (&[hd1, ..], &[hd2, ..])
    |            --- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |         (&[], &[ref hd, ..]) | (&[hd, ..], &[])
-   |                 +++
-help: consider borrowing the pattern binding
+LL -         (&[], &[hd, ..]) | (&[hd, ..], &[])
+LL +         (&[], [hd, ..]) | (&[hd, ..], &[])
    |
-LL |         (&[ref hd1, ..], &[hd2, ..])
-   |            +++
+help: consider removing the borrow
+   |
+LL -         (&[hd1, ..], &[hd2, ..])
+LL +         ([hd1, ..], &[hd2, ..])
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail2.stderr
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail2.stderr
@@ -7,10 +7,11 @@ LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       data moved here
    |                       move occurs because `x` has type `&mut u32`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |     if let Some(&Some(ref x)) = Some(&Some(&mut 0)) {
-   |                       +++
+LL -     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
+LL +     if let Some(Some(x)) = Some(&Some(&mut 0)) {
+   |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/ref_pat_eat_one_layer_2024_fail2.rs:11:10

--- a/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.fixed
+++ b/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.fixed
@@ -1,0 +1,10 @@
+//@ run-rustfix
+//! diagnostic test for #132806: make sure the suggestion to bind by-reference in patterns doesn't
+//! erroneously remove the wrong `&`
+
+use std::collections::HashMap;
+
+fn main() {
+    let _ = HashMap::<String, i32>::new().iter().filter(|&(_k, &_v)| { true });
+    //~^ ERROR cannot move out of a shared reference
+}

--- a/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.rs
+++ b/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.rs
@@ -1,0 +1,10 @@
+//@ run-rustfix
+//! diagnostic test for #132806: make sure the suggestion to bind by-reference in patterns doesn't
+//! erroneously remove the wrong `&`
+
+use std::collections::HashMap;
+
+fn main() {
+    let _ = HashMap::<String, i32>::new().iter().filter(|&(&_k, &_v)| { true });
+    //~^ ERROR cannot move out of a shared reference
+}

--- a/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.stderr
+++ b/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.stderr
@@ -1,0 +1,18 @@
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/do-not-suggest-removing-wrong-ref-pattern-issue-132806.rs:8:58
+   |
+LL |     let _ = HashMap::<String, i32>::new().iter().filter(|&(&_k, &_v)| { true });
+   |                                                          ^^^--^^^^^^
+   |                                                             |
+   |                                                             data moved here
+   |                                                             move occurs because `_k` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     let _ = HashMap::<String, i32>::new().iter().filter(|&(&_k, &_v)| { true });
+LL +     let _ = HashMap::<String, i32>::new().iter().filter(|&(_k, &_v)| { true });
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/nll/move-errors.stderr
+++ b/tests/ui/nll/move-errors.stderr
@@ -209,10 +209,11 @@ LL |         (D(s), &t) => (),
    |                 data moved here
    |                 move occurs because `t` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |         (D(s), &ref t) => (),
-   |                 +++
+LL -         (D(s), &t) => (),
+LL +         (D(s), t) => (),
+   |
 
 error[E0509]: cannot move out of type `F`, which implements the `Drop` trait
   --> $DIR/move-errors.rs:102:11

--- a/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.stderr
+++ b/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.stderr
@@ -9,6 +9,11 @@ LL |         deref!(x) => x,
    |                |
    |                data moved here
    |                move occurs because `x` has type `Struct`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         deref!(ref x) => x,
+   |                +++
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/cant_move_out_of_pattern.rs:17:11
@@ -21,6 +26,11 @@ LL |         deref!(x) => x,
    |                |
    |                data moved here
    |                move occurs because `x` has type `Struct`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         deref!(ref x) => x,
+   |                +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/dont-suggest-ref/simple.rs
+++ b/tests/ui/suggestions/dont-suggest-ref/simple.rs
@@ -219,42 +219,42 @@ pub fn main() {
 
     let (&X(_t),) = (&x.clone(),);
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the borrow
     if let (&Either::One(_t),) = (&e.clone(),) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the borrow
     while let (&Either::One(_t),) = (&e.clone(),) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the borrow
     match (&e.clone(),) {
         //~^ ERROR cannot move
         (&Either::One(_t),)
-        //~^ HELP consider borrowing the pattern binding
+        //~^ HELP consider removing the borrow
         | (&Either::Two(_t),) => (),
     }
     fn f3((&X(_t),): (&X,)) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the borrow
 
     let (&mut X(_t),) = (&mut xm.clone(),);
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the mutable borrow
     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the mutable borrow
     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the mutable borrow
     match (&mut em.clone(),) {
         //~^ ERROR cannot move
         (&mut Either::One(_t),) => (),
-        //~^ HELP consider borrowing the pattern binding
+        //~^ HELP consider removing the mutable borrow
         (&mut Either::Two(_t),) => (),
-        //~^ HELP consider borrowing the pattern binding
+        //~^ HELP consider removing the mutable borrow
     }
     fn f4((&mut X(_t),): (&mut X,)) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the mutable borrow
 
     // move from &Either/&X value
 

--- a/tests/ui/suggestions/dont-suggest-ref/simple.stderr
+++ b/tests/ui/suggestions/dont-suggest-ref/simple.stderr
@@ -578,10 +578,11 @@ LL |     let (&X(_t),) = (&x.clone(),);
    |             data moved here
    |             move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |     let (&X(ref _t),) = (&x.clone(),);
-   |             +++
+LL -     let (&X(_t),) = (&x.clone(),);
+LL +     let (X(_t),) = (&x.clone(),);
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/simple.rs:223:34
@@ -592,10 +593,11 @@ LL |     if let (&Either::One(_t),) = (&e.clone(),) { }
    |                          data moved here
    |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |     if let (&Either::One(ref _t),) = (&e.clone(),) { }
-   |                          +++
+LL -     if let (&Either::One(_t),) = (&e.clone(),) { }
+LL +     if let (Either::One(_t),) = (&e.clone(),) { }
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/simple.rs:226:37
@@ -606,10 +608,11 @@ LL |     while let (&Either::One(_t),) = (&e.clone(),) { }
    |                             data moved here
    |                             move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |     while let (&Either::One(ref _t),) = (&e.clone(),) { }
-   |                             +++
+LL -     while let (&Either::One(_t),) = (&e.clone(),) { }
+LL +     while let (Either::One(_t),) = (&e.clone(),) { }
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/simple.rs:229:11
@@ -623,10 +626,11 @@ LL |         (&Either::One(_t),)
    |                       data moved here
    |                       move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |         (&Either::One(ref _t),)
-   |                       +++
+LL -         (&Either::One(_t),)
+LL +         (Either::One(_t),)
+   |
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/simple.rs:239:25
@@ -637,10 +641,11 @@ LL |     let (&mut X(_t),) = (&mut xm.clone(),);
    |                 data moved here
    |                 move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the mutable borrow
    |
-LL |     let (&mut X(ref _t),) = (&mut xm.clone(),);
-   |                 +++
+LL -     let (&mut X(_t),) = (&mut xm.clone(),);
+LL +     let (X(_t),) = (&mut xm.clone(),);
+   |
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/simple.rs:242:38
@@ -651,10 +656,11 @@ LL |     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                              data moved here
    |                              move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the mutable borrow
    |
-LL |     if let (&mut Either::One(ref _t),) = (&mut em.clone(),) { }
-   |                              +++
+LL -     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
+LL +     if let (Either::One(_t),) = (&mut em.clone(),) { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/simple.rs:245:41
@@ -665,10 +671,11 @@ LL |     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                                 data moved here
    |                                 move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the mutable borrow
    |
-LL |     while let (&mut Either::One(ref _t),) = (&mut em.clone(),) { }
-   |                                 +++
+LL -     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
+LL +     while let (Either::One(_t),) = (&mut em.clone(),) { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/simple.rs:248:11
@@ -683,14 +690,16 @@ LL |         (&mut Either::Two(_t),) => (),
    |                           -- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing the pattern binding
+help: consider removing the mutable borrow
    |
-LL |         (&mut Either::One(ref _t),) => (),
-   |                           +++
-help: consider borrowing the pattern binding
+LL -         (&mut Either::One(_t),) => (),
+LL +         (Either::One(_t),) => (),
    |
-LL |         (&mut Either::Two(ref _t),) => (),
-   |                           +++
+help: consider removing the mutable borrow
+   |
+LL -         (&mut Either::Two(_t),) => (),
+LL +         (Either::Two(_t),) => (),
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/simple.rs:261:18
@@ -947,10 +956,11 @@ LL |     fn f3((&X(_t),): (&X,)) { }
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |     fn f3((&X(ref _t),): (&X,)) { }
-   |               +++
+LL -     fn f3((&X(_t),): (&X,)) { }
+LL +     fn f3((X(_t),): (&X,)) { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/simple.rs:255:11
@@ -961,10 +971,11 @@ LL |     fn f4((&mut X(_t),): (&mut X,)) { }
    |                   data moved here
    |                   move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the mutable borrow
    |
-LL |     fn f4((&mut X(ref _t),): (&mut X,)) { }
-   |                   +++
+LL -     fn f4((&mut X(_t),): (&mut X,)) { }
+LL +     fn f4((X(_t),): (&mut X,)) { }
+   |
 
 error[E0507]: cannot move out of `a.a` as enum variant `Some` which is behind a shared reference
   --> $DIR/simple.rs:331:20

--- a/tests/ui/suggestions/option-content-move-from-tuple-match.stderr
+++ b/tests/ui/suggestions/option-content-move-from-tuple-match.stderr
@@ -10,10 +10,11 @@ LL |         (None, &c) => &c.unwrap(),
    |                 data moved here
    |                 move occurs because `c` has type `Option<String>`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |         (None, &ref c) => &c.unwrap(),
-   |                 +++
+LL -         (None, &c) => &c.unwrap(),
+LL +         (None, c) => &c.unwrap(),
+   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - #132474 (Add more mailmap entries)
 - #133486 (borrowck diagnostics: make `add_move_error_suggestions` use the HIR rather than `SourceMap`)
 - #134861 (Add GUI test for item info elements color)
 - #134968 (Print how to rebless Python formatting in tidy)
 - #134971 (chore: fix typos)
 - #134972 (add .mailmap entry for myself)
 - #134974 (Revert #119515 single line where clause style guide)
 - #134975 (Revert style guide rhs break)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=132474,133486,134861,134968,134971,134972,134974,134975)
<!-- homu-ignore:end -->