### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -575,7 +575,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         // ---------- place
                         self.err.multipart_suggestions(
                             format!(
-                                "to modify a `{}`, use `.get_mut()`, `.insert()` or the entry API",
+                                "use `.insert()` to insert a value into a `{}`, `.get_mut()` to modify it, or the entry API for more flexibility",
                                 self.ty,
                             ),
                             vec![

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -624,7 +624,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         self.suggested = true;
                     } else if let hir::ExprKind::MethodCall(_path, receiver, _, sp) = expr.kind
                         && let hir::ExprKind::Index(val, index, _) = receiver.kind
-                        && expr.span == self.assign_span
+                        && receiver.span == self.assign_span
                     {
                         // val[index].path(args..);
                         self.err.multipart_suggestion(
@@ -639,7 +639,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                                     index.span.shrink_to_hi().with_hi(receiver.span.hi()),
                                     ") { val".to_string(),
                                 ),
-                                (sp.shrink_to_hi(), "); }".to_string()),
+                                (sp.shrink_to_hi(), "; }".to_string()),
                             ],
                             Applicability::MachineApplicable,
                         );

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -575,7 +575,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         // ---------- place
                         self.err.multipart_suggestions(
                             format!(
-                                "use `.insert()` to insert a value into a `{}`, `.get_mut()` to modify it, or the entry API for more flexibility",
+                                "use `.insert()` to insert a value into a `{}`, `.get_mut()` \
+                                to modify it, or the entry API for more flexibility",
                                 self.ty,
                             ),
                             vec![
@@ -592,16 +593,17 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                                     (rv.span.shrink_to_hi(), ")".to_string()),
                                 ],
                                 vec![
-                                    // val.get_mut(index).map(|v| { *v = rv; });
+                                    // if let Some(v) = val.get_mut(index) { *v = rv; }
+                                    (val.span.shrink_to_lo(), "if let Some(val) = ".to_string()),
                                     (
                                         val.span.shrink_to_hi().with_hi(index.span.lo()),
                                         ".get_mut(".to_string(),
                                     ),
                                     (
                                         index.span.shrink_to_hi().with_hi(place.span.hi()),
-                                        ").map(|val| { *val".to_string(),
+                                        ") { *val".to_string(),
                                     ),
-                                    (rv.span.shrink_to_hi(), "; })".to_string()),
+                                    (rv.span.shrink_to_hi(), "; }".to_string()),
                                 ],
                                 vec![
                                     // let x = val.entry(index).or_insert(rv);
@@ -628,15 +630,16 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         self.err.multipart_suggestion(
                             format!("to modify a `{}` use `.get_mut()`", self.ty),
                             vec![
+                                (val.span.shrink_to_lo(), "if let Some(val) = ".to_string()),
                                 (
                                     val.span.shrink_to_hi().with_hi(index.span.lo()),
                                     ".get_mut(".to_string(),
                                 ),
                                 (
                                     index.span.shrink_to_hi().with_hi(receiver.span.hi()),
-                                    ").map(|val| val".to_string(),
+                                    ") { val".to_string(),
                                 ),
-                                (sp.shrink_to_hi(), ")".to_string()),
+                                (sp.shrink_to_hi(), "); }".to_string()),
                             ],
                             Applicability::MachineApplicable,
                         );

--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -197,6 +197,8 @@ builtin_macros_format_redundant_args = redundant {$n ->
 
 builtin_macros_format_remove_raw_ident = remove the `r#`
 
+builtin_macros_format_reorder_format_parameter = did you mean `{$replacement}`?
+
 builtin_macros_format_requires_string = requires at least a format string argument
 
 builtin_macros_format_string_invalid = invalid format string: {$desc}

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -618,6 +618,17 @@ pub(crate) enum InvalidFormatStringSuggestion {
         #[primary_span]
         span: Span,
     },
+    #[suggestion(
+        builtin_macros_format_reorder_format_parameter,
+        code = "{replacement}",
+        style = "verbose",
+        applicability = "machine-applicable"
+    )]
+    ReorderFormatParameter {
+        #[primary_span]
+        span: Span,
+        replacement: String,
+    },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -316,6 +316,13 @@ fn make_format_args(
                     e.sugg_ = Some(errors::InvalidFormatStringSuggestion::RemoveRawIdent { span })
                 }
             }
+            parse::Suggestion::ReorderFormatParameter(span, replacement) => {
+                let span = fmt_span.from_inner(InnerSpan::new(span.start, span.end));
+                e.sugg_ = Some(errors::InvalidFormatStringSuggestion::ReorderFormatParameter {
+                    span,
+                    replacement,
+                });
+            }
         }
         let guar = ecx.dcx().emit_err(e);
         return ExpandResult::Ready(Err(guar));

--- a/compiler/rustc_lint/src/default_could_be_derived.rs
+++ b/compiler/rustc_lint/src/default_could_be_derived.rs
@@ -1,9 +1,11 @@
 use rustc_data_structures::fx::FxHashMap;
-use rustc_errors::Diag;
+use rustc_errors::{Applicability, Diag};
 use rustc_hir as hir;
 use rustc_middle::ty;
+use rustc_middle::ty::TyCtxt;
 use rustc_session::{declare_lint, impl_lint_pass};
 use rustc_span::Symbol;
+use rustc_span::def_id::DefId;
 use rustc_span::symbol::sym;
 
 use crate::{LateContext, LateLintPass};
@@ -149,13 +151,16 @@ impl<'tcx> LateLintPass<'tcx> for DefaultCouldBeDerived {
         let hir_id = cx.tcx.local_def_id_to_hir_id(local);
         let hir::Node::Item(item) = cx.tcx.hir_node(hir_id) else { return };
         cx.tcx.node_span_lint(DEFAULT_OVERRIDES_DEFAULT_FIELDS, hir_id, item.span, |diag| {
-            mk_lint(diag, orig_fields, fields);
+            mk_lint(cx.tcx, diag, type_def_id, parent, orig_fields, fields);
         });
     }
 }
 
 fn mk_lint(
+    tcx: TyCtxt<'_>,
     diag: &mut Diag<'_, ()>,
+    type_def_id: DefId,
+    impl_def_id: DefId,
     orig_fields: FxHashMap<Symbol, &hir::FieldDef<'_>>,
     fields: &[hir::ExprField<'_>],
 ) {
@@ -175,11 +180,24 @@ fn mk_lint(
         }
     }
 
-    diag.help(if removed_all_fields {
-        "to avoid divergence in behavior between `Struct { .. }` and \
-         `<Struct as Default>::default()`, derive the `Default`"
+    if removed_all_fields {
+        let msg = "to avoid divergence in behavior between `Struct { .. }` and \
+                   `<Struct as Default>::default()`, derive the `Default`";
+        if let Some(hir::Node::Item(impl_)) = tcx.hir().get_if_local(impl_def_id) {
+            diag.multipart_suggestion_verbose(
+                msg,
+                vec![
+                    (tcx.def_span(type_def_id).shrink_to_lo(), "#[derive(Default)] ".to_string()),
+                    (impl_.span, String::new()),
+                ],
+                Applicability::MachineApplicable,
+            );
+        } else {
+            diag.help(msg);
+        }
     } else {
-        "use the default values in the `impl` with `Struct { mandatory_field, .. }` to avoid them \
-         diverging over time"
-    });
+        let msg = "use the default values in the `impl` with `Struct { mandatory_field, .. }` to \
+                   avoid them diverging over time";
+        diag.help(msg);
+    }
 }

--- a/library/panic_unwind/src/seh.rs
+++ b/library/panic_unwind/src/seh.rs
@@ -288,8 +288,6 @@ cfg_if::cfg_if! {
    }
 }
 
-// FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
-#[allow(static_mut_refs)]
 pub unsafe fn panic(data: Box<dyn Any + Send>) -> u32 {
     use core::intrinsics::atomic_store_seqcst;
 

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -402,7 +402,6 @@ impl Step for RustAnalyzer {
 macro_rules! tool_check_step {
     (
         $name:ident,
-        $display_name:literal,
         $path:literal,
         $($alias:literal, )*
         $source_type:path
@@ -429,7 +428,7 @@ macro_rules! tool_check_step {
 
             fn run(self, builder: &Builder<'_>) {
                 let Self { target } = self;
-                run_tool_check_step(builder, target, stringify!($name), $display_name, $path, $source_type);
+                run_tool_check_step(builder, target, stringify!($name), $path, $source_type);
             }
         }
     }
@@ -440,10 +439,10 @@ fn run_tool_check_step(
     builder: &Builder<'_>,
     target: TargetSelection,
     step_type_name: &str,
-    display_name: &str,
     path: &str,
     source_type: SourceType,
 ) {
+    let display_name = path.rsplit('/').next().unwrap();
     let compiler = builder.compiler(builder.top_stage, builder.config.build);
 
     builder.ensure(Rustc::new(target, builder));
@@ -473,33 +472,23 @@ fn run_tool_check_step(
     run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
 }
 
-tool_check_step!(Rustdoc, "rustdoc", "src/tools/rustdoc", "src/librustdoc", SourceType::InTree);
+tool_check_step!(Rustdoc, "src/tools/rustdoc", "src/librustdoc", SourceType::InTree);
 // Clippy, miri and Rustfmt are hybrids. They are external tools, but use a git subtree instead
 // of a submodule. Since the SourceType only drives the deny-warnings
 // behavior, treat it as in-tree so that any new warnings in clippy will be
 // rejected.
-tool_check_step!(Clippy, "clippy", "src/tools/clippy", SourceType::InTree);
-tool_check_step!(Miri, "miri", "src/tools/miri", SourceType::InTree);
-tool_check_step!(CargoMiri, "cargo-miri", "src/tools/miri/cargo-miri", SourceType::InTree);
-tool_check_step!(Rls, "rls", "src/tools/rls", SourceType::InTree);
-tool_check_step!(Rustfmt, "rustfmt", "src/tools/rustfmt", SourceType::InTree);
-tool_check_step!(
-    MiroptTestTools,
-    "miropt-test-tools",
-    "src/tools/miropt-test-tools",
-    SourceType::InTree
-);
-tool_check_step!(
-    TestFloatParse,
-    "test-float-parse",
-    "src/etc/test-float-parse",
-    SourceType::InTree
-);
+tool_check_step!(Clippy, "src/tools/clippy", SourceType::InTree);
+tool_check_step!(Miri, "src/tools/miri", SourceType::InTree);
+tool_check_step!(CargoMiri, "src/tools/miri/cargo-miri", SourceType::InTree);
+tool_check_step!(Rls, "src/tools/rls", SourceType::InTree);
+tool_check_step!(Rustfmt, "src/tools/rustfmt", SourceType::InTree);
+tool_check_step!(MiroptTestTools, "src/tools/miropt-test-tools", SourceType::InTree);
+tool_check_step!(TestFloatParse, "src/etc/test-float-parse", SourceType::InTree);
 
-tool_check_step!(Bootstrap, "bootstrap", "src/bootstrap", SourceType::InTree, false);
+tool_check_step!(Bootstrap, "src/bootstrap", SourceType::InTree, false);
 // Compiletest is implicitly "checked" when it gets built in order to run tests,
 // so this is mainly for people working on compiletest to run locally.
-tool_check_step!(Compiletest, "compiletest", "src/tools/compiletest", SourceType::InTree, false);
+tool_check_step!(Compiletest, "src/tools/compiletest", SourceType::InTree, false);
 
 /// Cargo's output path for the standard library in a given stage, compiled
 /// by a particular compiler for the specified target.

--- a/src/bootstrap/src/core/build_steps/check.rs
+++ b/src/bootstrap/src/core/build_steps/check.rs
@@ -401,10 +401,13 @@ impl Step for RustAnalyzer {
 
 macro_rules! tool_check_step {
     (
-        $name:ident,
-        $path:literal
-        $(, alt_path: $alt_path:literal )*
-        $(, default: $default:literal )?
+        $name:ident {
+            // The part of this path after the final '/' is also used as a display name.
+            path: $path:literal
+            $(, alt_path: $alt_path:literal )*
+            $(, default: $default:literal )?
+            $( , )?
+        }
     ) => {
         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
         pub struct $name {
@@ -474,23 +477,23 @@ fn run_tool_check_step(
     run_cargo(builder, cargo, builder.config.free_args.clone(), &stamp, vec![], true, false);
 }
 
-tool_check_step!(Rustdoc, "src/tools/rustdoc", alt_path: "src/librustdoc");
+tool_check_step!(Rustdoc { path: "src/tools/rustdoc", alt_path: "src/librustdoc" });
 // Clippy, miri and Rustfmt are hybrids. They are external tools, but use a git subtree instead
 // of a submodule. Since the SourceType only drives the deny-warnings
 // behavior, treat it as in-tree so that any new warnings in clippy will be
 // rejected.
-tool_check_step!(Clippy, "src/tools/clippy");
-tool_check_step!(Miri, "src/tools/miri");
-tool_check_step!(CargoMiri, "src/tools/miri/cargo-miri");
-tool_check_step!(Rls, "src/tools/rls");
-tool_check_step!(Rustfmt, "src/tools/rustfmt");
-tool_check_step!(MiroptTestTools, "src/tools/miropt-test-tools");
-tool_check_step!(TestFloatParse, "src/etc/test-float-parse");
+tool_check_step!(Clippy { path: "src/tools/clippy" });
+tool_check_step!(Miri { path: "src/tools/miri" });
+tool_check_step!(CargoMiri { path: "src/tools/miri/cargo-miri" });
+tool_check_step!(Rls { path: "src/tools/rls" });
+tool_check_step!(Rustfmt { path: "src/tools/rustfmt" });
+tool_check_step!(MiroptTestTools { path: "src/tools/miropt-test-tools" });
+tool_check_step!(TestFloatParse { path: "src/etc/test-float-parse" });
 
-tool_check_step!(Bootstrap, "src/bootstrap", default: false);
+tool_check_step!(Bootstrap { path: "src/bootstrap", default: false });
 // Compiletest is implicitly "checked" when it gets built in order to run tests,
 // so this is mainly for people working on compiletest to run locally.
-tool_check_step!(Compiletest, "src/tools/compiletest", default: false);
+tool_check_step!(Compiletest { path: "src/tools/compiletest", default: false });
 
 /// Cargo's output path for the standard library in a given stage, compiled
 /// by a particular compiler for the specified target.

--- a/tests/ui/borrowck/index-mut-help.stderr
+++ b/tests/ui/borrowck/index-mut-help.stderr
@@ -14,7 +14,7 @@ LL |     map["peter"] = "0".to_string();
    |     ^^^^^^^^^^^^ cannot assign
    |
    = help: trait `IndexMut` is required to modify indexed content, but it is not implemented for `HashMap<&str, String>`
-help: to modify a `HashMap<&str, String>`, use `.get_mut()`, `.insert()` or the entry API
+help: use `.insert()` to insert a value into a `HashMap<&str, String>`, `.get_mut()` to modify it, or the entry API for more flexibility
    |
 LL |     map.insert("peter", "0".to_string());
    |        ~~~~~~~~       ~                +

--- a/tests/ui/borrowck/index-mut-help.stderr
+++ b/tests/ui/borrowck/index-mut-help.stderr
@@ -18,8 +18,8 @@ help: use `.insert()` to insert a value into a `HashMap<&str, String>`, `.get_mu
    |
 LL |     map.insert("peter", "0".to_string());
    |        ~~~~~~~~       ~                +
-LL |     map.get_mut("peter").map(|val| { *val = "0".to_string(); });
-   |        ~~~~~~~~~       ~~~~~~~~~~~~~~~~~~                  ++++
+LL |     if let Some(val) = map.get_mut("peter") { *val = "0".to_string(); };
+   |     ++++++++++++++++++    ~~~~~~~~~       ~~~~~~~~                  +++
 LL |     let val = map.entry("peter").or_insert("0".to_string());
    |     +++++++++    ~~~~~~~       ~~~~~~~~~~~~               +
 

--- a/tests/ui/borrowck/index-mut-help.stderr
+++ b/tests/ui/borrowck/index-mut-help.stderr
@@ -5,7 +5,10 @@ LL |     map["peter"].clear();
    |     ^^^^^^^^^^^^ cannot borrow as mutable
    |
    = help: trait `IndexMut` is required to modify indexed content, but it is not implemented for `HashMap<&str, String>`
-   = help: to modify a `HashMap<&str, String>`, use `.get_mut()`, `.insert()` or the entry API
+help: to modify a `HashMap<&str, String>` use `.get_mut()`
+   |
+LL |     if let Some(val) = map.get_mut("peter") { val.clear(); };
+   |     ++++++++++++++++++    ~~~~~~~~~       ~~~~~~~        +++
 
 error[E0594]: cannot assign to data in an index of `HashMap<&str, String>`
   --> $DIR/index-mut-help.rs:11:5

--- a/tests/ui/btreemap/btreemap-index-mut-2.stderr
+++ b/tests/ui/btreemap/btreemap-index-mut-2.stderr
@@ -5,7 +5,7 @@ LL |         map[&0] = 1;
    |         ^^^^^^^^^^^ cannot assign
    |
    = help: trait `IndexMut` is required to modify indexed content, but it is not implemented for `BTreeMap<u32, u32>`
-help: to modify a `BTreeMap<u32, u32>`, use `.get_mut()`, `.insert()` or the entry API
+help: use `.insert()` to insert a value into a `BTreeMap<u32, u32>`, `.get_mut()` to modify it, or the entry API for more flexibility
    |
 LL |         map.insert(&0, 1);
    |            ~~~~~~~~  ~  +

--- a/tests/ui/btreemap/btreemap-index-mut-2.stderr
+++ b/tests/ui/btreemap/btreemap-index-mut-2.stderr
@@ -9,8 +9,8 @@ help: use `.insert()` to insert a value into a `BTreeMap<u32, u32>`, `.get_mut()
    |
 LL |         map.insert(&0, 1);
    |            ~~~~~~~~  ~  +
-LL |         map.get_mut(&0).map(|val| { *val = 1; });
-   |            ~~~~~~~~~  ~~~~~~~~~~~~~~~~~~    ++++
+LL |         if let Some(val) = map.get_mut(&0) { *val = 1; };
+   |         ++++++++++++++++++    ~~~~~~~~~  ~~~~~~~~    +++
 LL |         let val = map.entry(&0).or_insert(1);
    |         +++++++++    ~~~~~~~  ~~~~~~~~~~~~ +
 

--- a/tests/ui/btreemap/btreemap-index-mut.stderr
+++ b/tests/ui/btreemap/btreemap-index-mut.stderr
@@ -5,7 +5,7 @@ LL |     map[&0] = 1;
    |     ^^^^^^^^^^^ cannot assign
    |
    = help: trait `IndexMut` is required to modify indexed content, but it is not implemented for `BTreeMap<u32, u32>`
-help: to modify a `BTreeMap<u32, u32>`, use `.get_mut()`, `.insert()` or the entry API
+help: use `.insert()` to insert a value into a `BTreeMap<u32, u32>`, `.get_mut()` to modify it, or the entry API for more flexibility
    |
 LL |     map.insert(&0, 1);
    |        ~~~~~~~~  ~  +

--- a/tests/ui/btreemap/btreemap-index-mut.stderr
+++ b/tests/ui/btreemap/btreemap-index-mut.stderr
@@ -9,8 +9,8 @@ help: use `.insert()` to insert a value into a `BTreeMap<u32, u32>`, `.get_mut()
    |
 LL |     map.insert(&0, 1);
    |        ~~~~~~~~  ~  +
-LL |     map.get_mut(&0).map(|val| { *val = 1; });
-   |        ~~~~~~~~~  ~~~~~~~~~~~~~~~~~~    ++++
+LL |     if let Some(val) = map.get_mut(&0) { *val = 1; };
+   |     ++++++++++++++++++    ~~~~~~~~~  ~~~~~~~~    +++
 LL |     let val = map.entry(&0).or_insert(1);
    |     +++++++++    ~~~~~~~  ~~~~~~~~~~~~ +
 

--- a/tests/ui/fmt/suggest-wrongly-order-format-parameter.fixed
+++ b/tests/ui/fmt/suggest-wrongly-order-format-parameter.fixed
@@ -1,0 +1,25 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/129966
+//!
+//! Ensure we provide suggestion for wrongly ordered format parameters.
+
+//@ run-rustfix
+#![allow(dead_code)]
+
+#[derive(Debug)]
+struct Foo(u8, u8);
+
+fn main() {
+    let f = Foo(1, 2);
+
+    println!("{f:#?}");
+    //~^ ERROR invalid format string: expected `}`, found `#`
+    //~| HELP did you mean `#?`?
+
+    println!("{f:x?}");
+    //~^ ERROR invalid format string: expected `}`, found `x`
+    //~| HELP did you mean `x?`?
+
+    println!("{f:X?}");
+    //~^ ERROR invalid format string: expected `}`, found `X`
+    //~| HELP did you mean `X?`?
+}

--- a/tests/ui/fmt/suggest-wrongly-order-format-parameter.rs
+++ b/tests/ui/fmt/suggest-wrongly-order-format-parameter.rs
@@ -1,0 +1,25 @@
+//! Regression test for https://github.com/rust-lang/rust/issues/129966
+//!
+//! Ensure we provide suggestion for wrongly ordered format parameters.
+
+//@ run-rustfix
+#![allow(dead_code)]
+
+#[derive(Debug)]
+struct Foo(u8, u8);
+
+fn main() {
+    let f = Foo(1, 2);
+
+    println!("{f:?#}");
+    //~^ ERROR invalid format string: expected `}`, found `#`
+    //~| HELP did you mean `#?`?
+
+    println!("{f:?x}");
+    //~^ ERROR invalid format string: expected `}`, found `x`
+    //~| HELP did you mean `x?`?
+
+    println!("{f:?X}");
+    //~^ ERROR invalid format string: expected `}`, found `X`
+    //~| HELP did you mean `X?`?
+}

--- a/tests/ui/fmt/suggest-wrongly-order-format-parameter.stderr
+++ b/tests/ui/fmt/suggest-wrongly-order-format-parameter.stderr
@@ -1,0 +1,35 @@
+error: invalid format string: expected `}`, found `#`
+  --> $DIR/suggest-wrongly-order-format-parameter.rs:14:19
+   |
+LL |     println!("{f:?#}");
+   |                   ^ expected `'}'` in format string
+   |
+help: did you mean `#?`?
+   |
+LL |     println!("{f:#?}");
+   |                  ~~
+
+error: invalid format string: expected `}`, found `x`
+  --> $DIR/suggest-wrongly-order-format-parameter.rs:18:19
+   |
+LL |     println!("{f:?x}");
+   |                   ^ expected `'}'` in format string
+   |
+help: did you mean `x?`?
+   |
+LL |     println!("{f:x?}");
+   |                  ~~
+
+error: invalid format string: expected `}`, found `X`
+  --> $DIR/suggest-wrongly-order-format-parameter.rs:22:19
+   |
+LL |     println!("{f:?X}");
+   |                   ^ expected `'}'` in format string
+   |
+help: did you mean `X?`?
+   |
+LL |     println!("{f:X?}");
+   |                  ~~
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/hashmap/hashmap-index-mut.stderr
+++ b/tests/ui/hashmap/hashmap-index-mut.stderr
@@ -5,7 +5,7 @@ LL |     map[&0] = 1;
    |     ^^^^^^^^^^^ cannot assign
    |
    = help: trait `IndexMut` is required to modify indexed content, but it is not implemented for `HashMap<u32, u32>`
-help: to modify a `HashMap<u32, u32>`, use `.get_mut()`, `.insert()` or the entry API
+help: use `.insert()` to insert a value into a `HashMap<u32, u32>`, `.get_mut()` to modify it, or the entry API for more flexibility
    |
 LL |     map.insert(&0, 1);
    |        ~~~~~~~~  ~  +

--- a/tests/ui/hashmap/hashmap-index-mut.stderr
+++ b/tests/ui/hashmap/hashmap-index-mut.stderr
@@ -9,8 +9,8 @@ help: use `.insert()` to insert a value into a `HashMap<u32, u32>`, `.get_mut()`
    |
 LL |     map.insert(&0, 1);
    |        ~~~~~~~~  ~  +
-LL |     map.get_mut(&0).map(|val| { *val = 1; });
-   |        ~~~~~~~~~  ~~~~~~~~~~~~~~~~~~    ++++
+LL |     if let Some(val) = map.get_mut(&0) { *val = 1; };
+   |     ++++++++++++++++++    ~~~~~~~~~  ~~~~~~~~    +++
 LL |     let val = map.entry(&0).or_insert(1);
    |     +++++++++    ~~~~~~~  ~~~~~~~~~~~~ +
 

--- a/tests/ui/issues/issue-41726.stderr
+++ b/tests/ui/issues/issue-41726.stderr
@@ -5,7 +5,10 @@ LL |         things[src.as_str()].sort();
    |         ^^^^^^^^^^^^^^^^^^^^ cannot borrow as mutable
    |
    = help: trait `IndexMut` is required to modify indexed content, but it is not implemented for `HashMap<String, Vec<String>>`
-   = help: to modify a `HashMap<String, Vec<String>>`, use `.get_mut()`, `.insert()` or the entry API
+help: to modify a `HashMap<String, Vec<String>>` use `.get_mut()`
+   |
+LL |         if let Some(val) = things.get_mut(src.as_str()) { val.sort(); };
+   |         ++++++++++++++++++       ~~~~~~~~~            ~~~~~~~       +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/no_send-rc.stderr
+++ b/tests/ui/no_send-rc.stderr
@@ -12,6 +12,10 @@ note: required by a bound in `bar`
    |
 LL | fn bar<T: Send>(_: T) {}
    |           ^^^^ required by this bound in `bar`
+help: consider dereferencing here
+   |
+LL |     bar(*x);
+   |         +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -31,7 +31,10 @@ LL | |             y: 0,
 LL | | }
    | |_^
    |
-   = help: to avoid divergence in behavior between `Struct { .. }` and `<Struct as Default>::default()`, derive the `Default`
+help: to avoid divergence in behavior between `Struct { .. }` and `<Struct as Default>::default()`, derive the `Default`
+   |
+LL ~ #[derive(Default)] struct B {
+   |
 
 error: `Default` impl doesn't use the declared default field values
   --> $DIR/manual-default-impl-could-be-derived.rs:43:1

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -86,6 +86,10 @@ note: required by a bound in `f_send`
    |
 LL | fn f_send<T: Send>(t: T) {}
    |              ^^^^ required by this bound in `f_send`
+help: consider dereferencing here
+   |
+LL |     f_send(*rc);
+   |            +
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/traits/suggest-dereferences/deref-argument.fixed
+++ b/tests/ui/traits/suggest-dereferences/deref-argument.fixed
@@ -1,0 +1,37 @@
+//@ run-rustfix
+//! diagnostic test for #90997.
+//! test that E0277 suggests dereferences to satisfy bounds when the referent is `Copy` or boxed.
+use std::ops::Deref;
+
+trait Test {
+    fn test(self);
+}
+fn consume_test(x: impl Test) { x.test() }
+
+impl Test for u32 {
+    fn test(self) {}
+}
+struct MyRef(u32);
+impl Deref for MyRef {
+    type Target = u32;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+struct NonCopy;
+impl Test for NonCopy {
+    fn test(self) {}
+}
+
+fn main() {
+    let my_ref = MyRef(0);
+    consume_test(*my_ref);
+    //~^ ERROR the trait bound `MyRef: Test` is not satisfied
+    //~| SUGGESTION *
+
+    let nested_box = Box::new(Box::new(Box::new(NonCopy)));
+    consume_test(***nested_box);
+    //~^ ERROR the trait bound `Box<Box<Box<NonCopy>>>: Test` is not satisfied
+    //~| SUGGESTION ***
+}

--- a/tests/ui/traits/suggest-dereferences/deref-argument.rs
+++ b/tests/ui/traits/suggest-dereferences/deref-argument.rs
@@ -1,0 +1,37 @@
+//@ run-rustfix
+//! diagnostic test for #90997.
+//! test that E0277 suggests dereferences to satisfy bounds when the referent is `Copy` or boxed.
+use std::ops::Deref;
+
+trait Test {
+    fn test(self);
+}
+fn consume_test(x: impl Test) { x.test() }
+
+impl Test for u32 {
+    fn test(self) {}
+}
+struct MyRef(u32);
+impl Deref for MyRef {
+    type Target = u32;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+struct NonCopy;
+impl Test for NonCopy {
+    fn test(self) {}
+}
+
+fn main() {
+    let my_ref = MyRef(0);
+    consume_test(my_ref);
+    //~^ ERROR the trait bound `MyRef: Test` is not satisfied
+    //~| SUGGESTION *
+
+    let nested_box = Box::new(Box::new(Box::new(NonCopy)));
+    consume_test(nested_box);
+    //~^ ERROR the trait bound `Box<Box<Box<NonCopy>>>: Test` is not satisfied
+    //~| SUGGESTION ***
+}

--- a/tests/ui/traits/suggest-dereferences/deref-argument.stderr
+++ b/tests/ui/traits/suggest-dereferences/deref-argument.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the trait bound `MyRef: Test` is not satisfied
+  --> $DIR/deref-argument.rs:29:18
+   |
+LL |     consume_test(my_ref);
+   |     ------------ ^^^^^^ the trait `Test` is not implemented for `MyRef`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `consume_test`
+  --> $DIR/deref-argument.rs:9:25
+   |
+LL | fn consume_test(x: impl Test) { x.test() }
+   |                         ^^^^ required by this bound in `consume_test`
+help: consider dereferencing here
+   |
+LL |     consume_test(*my_ref);
+   |                  +
+
+error[E0277]: the trait bound `Box<Box<Box<NonCopy>>>: Test` is not satisfied
+  --> $DIR/deref-argument.rs:34:18
+   |
+LL |     consume_test(nested_box);
+   |     ------------ ^^^^^^^^^^ the trait `Test` is not implemented for `Box<Box<Box<NonCopy>>>`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `consume_test`
+  --> $DIR/deref-argument.rs:9:25
+   |
+LL | fn consume_test(x: impl Test) { x.test() }
+   |                         ^^^^ required by this bound in `consume_test`
+help: consider dereferencing here
+   |
+LL |     consume_test(***nested_box);
+   |                  +++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #131439 (Remove allowing static_mut_refs lint)
 - #133292 (E0277: suggest dereferencing function arguments in more cases)
 - #134877 (add suggestion for wrongly ordered format parameters)
 - #134945 (Some small nits to the borrowck suggestions for mutating a map through index)
 - #134950 (bootstrap: Overhaul and simplify the `tool_check_step!` macro)
 - #134979 (Provide structured suggestion for `impl Default` of type where all fields have defaults)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131439,133292,134877,134945,134950,134979)
<!-- homu-ignore:end -->