### PR TITLE
Fix typos in comments across layout.rs and lib.rs files

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -636,7 +636,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                     // same ABI as the scalar variant with the reserved niche.
                     BackendRepr::Scalar(_) => BackendRepr::Scalar(niche_scalar),
                     BackendRepr::ScalarPair(first, second) => {
-                        // Only the niche is guaranteed to be initialised,
+                        // Only the niche is guaranteed to be initialized,
                         // so use union layouts for the other primitive.
                         if niche_offset == Size::ZERO {
                             BackendRepr::ScalarPair(niche_scalar, second.to_union())
@@ -777,7 +777,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
             panic!(
                 "layout decided on a larger discriminant type ({min_ity:?}) than typeck ({typeck_ity:?})"
             );
-            // However, it is fine to make discr type however large (as an optimisation)
+            // However, it is fine to make discr type however large (as an optimization)
             // after this point – we’ll just truncate the value we load in codegen.
         }
 
@@ -883,7 +883,7 @@ impl<Cx: HasDataLayout> LayoutCalculator<Cx> {
                         break;
                     }
                     // This is pretty conservative. We could go fancier
-                    // by realising that (u8, u8) could just cohabit with
+                    // by realizing that (u8, u8) could just cohabit with
                     // u16 or even u32.
                     let new_prim = match (old_prim, prim) {
                         // Allow all identical primitives.

--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -95,7 +95,7 @@ bitflags! {
         // Other flags can still inhibit reordering and thus randomization.
         // The seed stored in `ReprOptions.field_shuffle_seed`.
         const RANDOMIZE_LAYOUT   = 1 << 4;
-        // Any of these flags being set prevent field reordering optimisation.
+        // Any of these flags being set prevent field reordering optimization.
         const FIELD_ORDER_UNOPTIMIZABLE   = ReprFlags::IS_C.bits()
                                  | ReprFlags::IS_SIMD.bits()
                                  | ReprFlags::IS_LINEAR.bits();
@@ -204,7 +204,7 @@ impl ReprOptions {
         !self.inhibit_struct_field_reordering() && self.flags.contains(ReprFlags::RANDOMIZE_LAYOUT)
     }
 
-    /// Returns `true` if this `#[repr()]` should inhibit union ABI optimisations.
+    /// Returns `true` if this `#[repr()]` should inhibit union ABI optimizations.
     pub fn inhibits_union_abi_opt(&self) -> bool {
         self.c()
     }


### PR DESCRIPTION
Corrected spelling errors in comments to improve clarity and maintain consistency in terminology. Changes include:
- "initialised" to "initialized"
- "optimisation" to "optimization"
- "realising" to "realizing"

These updates enhance the readability of the code without altering functionality.