### PR TITLE
Fix doc for missing Box allocator consistency

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1045,6 +1045,8 @@ impl<T: ?Sized> Box<T> {
     /// memory problems. For example, a double-free may occur if the
     /// function is called twice on the same raw pointer.
     ///
+    /// The raw pointer must point to a block of memory allocated by the global allocator.
+    ///
     /// The safety conditions are described in the [memory layout] section.
     ///
     /// # Examples
@@ -1148,6 +1150,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// memory problems. For example, a double-free may occur if the
     /// function is called twice on the same raw pointer.
     ///
+    /// The raw pointer must point to a block of memory allocated by `alloc`
     ///
     /// # Examples
     ///


### PR DESCRIPTION
### Description:
This PR addresses missing document regarding consistency of `Box::from_raw` and `Box::from_raw_in`.

- [from_raw](https://doc.rust-lang.org/nightly/std/boxed/struct.Box.html#method.from_raw): The document now misses the raw pointer passed to `Box::from_raw` must point to a block of memory allocated by the `Global Allocator` (specified in source code).

- [from_raw_in](https://doc.rust-lang.org/nightly/std/boxed/struct.Box.html#method.from_raw_in): The safety conditions don't include the allocator consistency.

Besides, [Boxed Memory Layout](https://doc.rust-lang.org/nightly/std/boxed/index.html#memory-layout) doesn't explicitly cover the allocator consistency issue.

This change builds upon the improvements made in [PR #134496](https://github.com/rust-lang/rust/pull/134496).