### PR TITLE
Update x

### DIFF
--- a/x
+++ b/x
@@ -32,7 +32,7 @@ for SEARCH_PYTHON in py python3 python python2; do
         else
             extra_arg=""
         fi
-        exec "$python" $extra_arg "$xpy" "$@"
+        exec "$python" "$extra_arg" "$xpy" "$@"
     fi
 done
 


### PR DESCRIPTION
Ensure that the exec command properly handles arguments when using exec "$python" $extra_arg "$xpy" "$@". The problem with this approach is that $extra_arg is unquoted, which could cause issues if it contains spaces or other special characters, especially when passing the arguments to python. To fix this, the exec command should be properly quoted to prevent any such issues.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
