### PR TITLE
bootstrap: flip `compile::Rustc` vs `compile::Assemble`

### DIFF
--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -825,8 +825,12 @@ impl<'a> Builder<'a> {
         match kind {
             Kind::Build => describe!(
                 compile::Std,
-                compile::Rustc,
+                // FIXME(#135022): `compile::Assemble` **must** come before `compile::Rustc` after
+                // `PathSet` also permits prefix-matching, because `compile::Rustc` can consume the
+                // `"compiler"` path filter first, causing `compile::Assemble` to no longer run when
+                // the user writes `./x build compiler --stage 0`.
                 compile::Assemble,
+                compile::Rustc,
                 compile::CodegenBackend,
                 compile::StartupObjects,
                 tool::BuildManifest,


### PR DESCRIPTION
The `PathSet` prefix matching unfortunately also has implications for `./x build compiler --stage 0`, because the path filter `"compiler"` gets consumed by `compile::Rustc` step first after `PathSet` prefix matching, whereas before `PathSet` prefix matching, `compile::Rustc` would not have consumed `"compiler"`.

This merely papers over #134970 to unblock contributors from using `./x build compiler --stage 0`.

The `PathSet` prefix matching behavior is tracked in #135022.

Closes #134970.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
