### PR TITLE
Pass objcopy args for stripping on OSX

### DIFF
--- a/tests/run-make/strip/hello.rs
+++ b/tests/run-make/strip/hello.rs
@@ -1,0 +1,8 @@
+fn main() {
+    hey_i_get_compiled();
+}
+
+#[inline(never)]
+fn hey_i_get_compiled() {
+    println!("Hi! Do or do not strip me, your choice.");
+}

--- a/tests/run-make/strip/rmake.rs
+++ b/tests/run-make/strip/rmake.rs
@@ -1,0 +1,42 @@
+//@ ignore-windows Windows does not actually strip
+
+// Test that -Cstrip correctly strips/preserves debuginfo and symbols.
+
+use run_make_support::{bin_name, is_darwin, llvm_dwarfdump, llvm_nm, rustc};
+
+fn main() {
+    // We use DW_ (the start of any DWARF name) to check that some debuginfo is present.
+    let dwarf_indicator = "DW_";
+
+    let test_symbol = "hey_i_get_compiled";
+    let binary = &bin_name("hello");
+
+    // Avoid checking debuginfo on darwin, because it is not actually affected by strip.
+    // Darwin *never* puts debuginfo in the main binary (-Csplit-debuginfo=off just removes it),
+    // so we never actually have any debuginfo in there, so we can't check that it's present.
+    let do_debuginfo_check = !is_darwin();
+
+    // Additionally, use -Cdebuginfo=2 to make the test independent of the amount of debuginfo
+    // for std.
+
+    // -Cstrip=none should preserve symbols and debuginfo.
+    rustc().arg("hello.rs").arg("-Cdebuginfo=2").arg("-Cstrip=none").run();
+    llvm_nm().input(binary).run().assert_stdout_contains(test_symbol);
+    if do_debuginfo_check {
+        llvm_dwarfdump().input(binary).run().assert_stdout_contains(dwarf_indicator);
+    }
+
+    // -Cstrip=debuginfo should preserve symbols and strip debuginfo.
+    rustc().arg("hello.rs").arg("-Cdebuginfo=2").arg("-Cstrip=debuginfo").run();
+    llvm_nm().input(binary).run().assert_stdout_contains(test_symbol);
+    if do_debuginfo_check {
+        llvm_dwarfdump().input(binary).run().assert_stdout_not_contains(dwarf_indicator);
+    }
+
+    // -Cstrip=symbols should strip symbols and strip debuginfo.
+    rustc().arg("hello.rs").arg("-Cdebuginfo=2").arg("-Cstrip=symbols").run();
+    llvm_nm().input(binary).run().assert_stderr_not_contains(test_symbol);
+    if do_debuginfo_check {
+        llvm_dwarfdump().input(binary).run().assert_stdout_not_contains(dwarf_indicator);
+    }
+}


### PR DESCRIPTION
When `-Cstrip` was changed in #131405 to use the bundled rust-objcopy instead of /usr/bin/strip on OSX, strip-like arguments were preserved.

But strip and objcopy are, while being the same binary, different, they have different defaults depending on which binary they are. Notably, strip strips everything by default, and objcopy doesn't strip anything by default.

Additionally, `-S` actually means `--strip-all`, so debuginfo stripped everything and symbols didn't strip anything.

We now correctly pass `--strip-debug` and `--strip-all`.

fixes #135028

try-job: aarch64-apple
try-job: dist-aarch64-apple