### PR TITLE
rustdoc: treat `allowed_through_unstable_modules` as deprecation

### DIFF
--- a/src/librustdoc/passes/propagate_stability.rs
+++ b/src/librustdoc/passes/propagate_stability.rs
@@ -110,8 +110,7 @@ fn merge_stability(
     } else if let Some(mut own_stab) = own_stability
         && let StabilityLevel::Stable { since, allowed_through_unstable_modules: true } =
             own_stab.level
-        && let Some(parent_stab) = parent_stability
-        && parent_stab.is_stable()
+        && parent_stability.is_some_and(|stab| stab.is_stable())
     {
         // this property does not apply transitively through re-exports
         own_stab.level = StabilityLevel::Stable { since, allowed_through_unstable_modules: false };

--- a/src/librustdoc/passes/propagate_stability.rs
+++ b/src/librustdoc/passes/propagate_stability.rs
@@ -107,6 +107,15 @@ fn merge_stability(
             || parent_stab.stable_since().is_some_and(|parent_since| parent_since > own_since))
     {
         parent_stability
+    } else if let Some(mut own_stab) = own_stability
+        && let StabilityLevel::Stable { since, allowed_through_unstable_modules: true } =
+            own_stab.level
+        && let Some(parent_stab) = parent_stability
+        && parent_stab.is_stable()
+    {
+        // this property does not apply transitively through re-exports
+        own_stab.level = StabilityLevel::Stable { since, allowed_through_unstable_modules: false };
+        Some(own_stab)
     } else {
         own_stability
     }

--- a/tests/rustdoc-js-std/core-transmute.js
+++ b/tests/rustdoc-js-std/core-transmute.js
@@ -1,0 +1,11 @@
+const FILTER_CRATE = "core";
+const EXPECTED = [
+    {
+        'query': 'generic:T -> generic:U',
+        'others': [
+            { 'path': 'core::intrinsics::simd', 'name': 'simd_as' },
+            { 'path': 'core::intrinsics::simd', 'name': 'simd_cast' },
+            { 'path': 'core::mem', 'name': 'transmute' },
+        ],
+    },
+];

--- a/tests/rustdoc-js-std/transmute-fail.js
+++ b/tests/rustdoc-js-std/transmute-fail.js
@@ -1,4 +1,5 @@
 // should-fail
+const FILTER_CRATE = "std";
 const EXPECTED = [
     {
         // Keep this test case identical to `transmute`, except the
@@ -7,7 +8,7 @@ const EXPECTED = [
         'others': [
             { 'path': 'std::intrinsics::simd', 'name': 'simd_as' },
             { 'path': 'std::intrinsics::simd', 'name': 'simd_cast' },
-            { 'path': 'std::intrinsics', 'name': 'transmute' },
+            { 'path': 'std::mem', 'name': 'transmute' },
         ],
     },
 ];

--- a/tests/rustdoc-js-std/transmute.js
+++ b/tests/rustdoc-js-std/transmute.js
@@ -1,3 +1,4 @@
+const FILTER_CRATE = "std";
 const EXPECTED = [
     {
         // Keep this test case identical to `transmute-fail`, except the
@@ -6,7 +7,7 @@ const EXPECTED = [
         'others': [
             { 'path': 'std::intrinsics::simd', 'name': 'simd_as' },
             { 'path': 'std::intrinsics::simd', 'name': 'simd_cast' },
-            { 'path': 'std::intrinsics', 'name': 'transmute' },
+            { 'path': 'std::mem', 'name': 'transmute' },
         ],
     },
 ];


### PR DESCRIPTION
This ensures `std::intrinsics::transmute` is deemphasized in the search engine and other UI, by cleaning it into a deprecation without propagating it through reexports when the parent module is stable.

Fixes #131676

Related to #135003

r? @GuillaumeGomez 

@RalfJung @workingjubilee 