### PR TITLE
Improve infer (`_`) suggestions in `const`s and `static`s

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2031,11 +2031,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     fn lower_array_length_to_const_arg(&mut self, c: &AnonConst) -> &'hir hir::ConstArg<'hir> {
         match c.value.kind {
             ExprKind::Underscore => {
-                if self.tcx.features().generic_arg_infer() {
-                    let ct_kind = hir::ConstArgKind::Infer(self.lower_span(c.value.span));
-                    self.arena
-                        .alloc(hir::ConstArg { hir_id: self.lower_node_id(c.id), kind: ct_kind })
-                } else {
+                if !self.tcx.features().generic_arg_infer() {
                     feature_err(
                         &self.tcx.sess,
                         sym::generic_arg_infer,
@@ -2043,8 +2039,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         fluent_generated::ast_lowering_underscore_array_length_unstable,
                     )
                     .stash(c.value.span, StashKey::UnderscoreForArrayLengths);
-                    self.lower_anon_const_to_const_arg(c)
                 }
+                let ct_kind = hir::ConstArgKind::Infer(self.lower_span(c.value.span));
+                self.arena.alloc(hir::ConstArg { hir_id: self.lower_node_id(c.id), kind: ct_kind })
             }
             _ => self.lower_anon_const_to_const_arg(c),
         }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -3387,7 +3387,7 @@ impl<'hir> FnRetTy<'hir> {
         }
     }
 
-    pub fn get_infer_ret_ty(&self) -> Option<&'hir Ty<'hir>> {
+    pub fn is_suggestable_infer_ty(&self) -> Option<&'hir Ty<'hir>> {
         if let Self::Return(ty) = self {
             if ty.is_suggestable_infer_ty() {
                 return Some(*ty);

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -131,19 +131,25 @@ pub struct ItemCtxt<'tcx> {
 ///////////////////////////////////////////////////////////////////////////
 
 #[derive(Default)]
-pub(crate) struct HirPlaceholderCollector(pub(crate) Vec<Span>);
+pub(crate) struct HirPlaceholderCollector {
+    pub spans: Vec<Span>,
+    // If any of the spans points to a const infer var, then suppress any messages
+    // that may try to turn that const infer into a type parameter.
+    pub may_contain_const_infer: bool,
+}
 
 impl<'v> Visitor<'v> for HirPlaceholderCollector {
     fn visit_ty(&mut self, t: &'v hir::Ty<'v>) {
         if let hir::TyKind::Infer = t.kind {
-            self.0.push(t.span);
+            self.spans.push(t.span);
         }
         intravisit::walk_ty(self, t)
     }
     fn visit_generic_arg(&mut self, generic_arg: &'v hir::GenericArg<'v>) {
         match generic_arg {
             hir::GenericArg::Infer(inf) => {
-                self.0.push(inf.span);
+                self.spans.push(inf.span);
+                self.may_contain_const_infer = true;
                 intravisit::walk_inf(self, inf);
             }
             hir::GenericArg::Type(t) => self.visit_ty(t),
@@ -152,7 +158,8 @@ impl<'v> Visitor<'v> for HirPlaceholderCollector {
     }
     fn visit_const_arg(&mut self, const_arg: &'v hir::ConstArg<'v>) {
         if let hir::ConstArgKind::Infer(span) = const_arg.kind {
-            self.0.push(span);
+            self.may_contain_const_infer = true;
+            self.spans.push(span);
         }
         intravisit::walk_const_arg(self, const_arg)
     }
@@ -277,8 +284,8 @@ fn reject_placeholder_type_signatures_in_item<'tcx>(
     placeholder_type_error(
         icx.lowerer(),
         Some(generics),
-        visitor.0,
-        suggest,
+        visitor.spans,
+        suggest && !visitor.may_contain_const_infer,
         None,
         item.kind.descr(),
     );
@@ -607,16 +614,16 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
             hir::FnRetTy::DefaultReturn(..) => tcx.types.unit,
         };
 
-        if !(visitor.0.is_empty() && infer_replacements.is_empty()) {
+        if !(visitor.spans.is_empty() && infer_replacements.is_empty()) {
             // We check for the presence of
             // `ident_span` to not emit an error twice when we have `fn foo(_: fn() -> _)`.
 
             let mut diag = crate::collect::placeholder_type_error_diag(
                 self,
                 generics,
-                visitor.0,
+                visitor.spans,
                 infer_replacements.iter().map(|(s, _)| *s).collect(),
-                true,
+                !visitor.may_contain_const_infer,
                 hir_ty,
                 "function",
             );
@@ -712,7 +719,7 @@ fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
                         placeholder_type_error(
                             icx.lowerer(),
                             None,
-                            visitor.0,
+                            visitor.spans,
                             false,
                             None,
                             "static variable",
@@ -780,7 +787,7 @@ fn lower_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
                 placeholder_type_error(
                     icx.lowerer(),
                     None,
-                    visitor.0,
+                    visitor.spans,
                     false,
                     None,
                     it.kind.descr(),
@@ -822,7 +829,7 @@ fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
                 placeholder_type_error(
                     icx.lowerer(),
                     None,
-                    visitor.0,
+                    visitor.spans,
                     false,
                     None,
                     "associated constant",
@@ -837,7 +844,14 @@ fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
             // Account for `type T = _;`.
             let mut visitor = HirPlaceholderCollector::default();
             visitor.visit_trait_item(trait_item);
-            placeholder_type_error(icx.lowerer(), None, visitor.0, false, None, "associated type");
+            placeholder_type_error(
+                icx.lowerer(),
+                None,
+                visitor.spans,
+                false,
+                None,
+                "associated type",
+            );
         }
 
         hir::TraitItemKind::Type(_, None) => {
@@ -848,7 +862,14 @@ fn lower_trait_item(tcx: TyCtxt<'_>, trait_item_id: hir::TraitItemId) {
             let mut visitor = HirPlaceholderCollector::default();
             visitor.visit_trait_item(trait_item);
 
-            placeholder_type_error(icx.lowerer(), None, visitor.0, false, None, "associated type");
+            placeholder_type_error(
+                icx.lowerer(),
+                None,
+                visitor.spans,
+                false,
+                None,
+                "associated type",
+            );
         }
     };
 
@@ -872,7 +893,14 @@ fn lower_impl_item(tcx: TyCtxt<'_>, impl_item_id: hir::ImplItemId) {
             let mut visitor = HirPlaceholderCollector::default();
             visitor.visit_impl_item(impl_item);
 
-            placeholder_type_error(icx.lowerer(), None, visitor.0, false, None, "associated type");
+            placeholder_type_error(
+                icx.lowerer(),
+                None,
+                visitor.spans,
+                false,
+                None,
+                "associated type",
+            );
         }
         hir::ImplItemKind::Const(ty, _) => {
             // Account for `const T: _ = ..;`
@@ -882,7 +910,7 @@ fn lower_impl_item(tcx: TyCtxt<'_>, impl_item_id: hir::ImplItemId) {
                 placeholder_type_error(
                     icx.lowerer(),
                     None,
-                    visitor.0,
+                    visitor.spans,
                     false,
                     None,
                     "associated constant",
@@ -1422,7 +1450,7 @@ fn recover_infer_ret_ty<'tcx>(
     let mut visitor = HirPlaceholderCollector::default();
     visitor.visit_ty(infer_ret_ty);
 
-    let mut diag = bad_placeholder(icx.lowerer(), visitor.0, "return type");
+    let mut diag = bad_placeholder(icx.lowerer(), visitor.spans, "return type");
     let ret_ty = fn_sig.output();
 
     // Don't leak types into signatures unless they're nameable!

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1371,7 +1371,7 @@ fn lower_fn_sig_recovering_infer_ret_ty<'tcx>(
     generics: &'tcx hir::Generics<'tcx>,
     def_id: LocalDefId,
 ) -> ty::PolyFnSig<'tcx> {
-    if let Some(infer_ret_ty) = sig.decl.output.get_infer_ret_ty() {
+    if let Some(infer_ret_ty) = sig.decl.output.is_suggestable_infer_ty() {
         return recover_infer_ret_ty(icx, infer_ret_ty, generics, def_id);
     }
 

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -453,16 +453,17 @@ fn infer_placeholder_type<'tcx>(
                 visitor.visit_ty(ty);
             }
             // If we have just one span, let's try to steal a const `_` feature error.
-            let try_steal_span = if !tcx.features().generic_arg_infer() && visitor.0.len() == 1 {
-                visitor.0.first().copied()
+            let try_steal_span = if !tcx.features().generic_arg_infer() && visitor.spans.len() == 1
+            {
+                visitor.spans.first().copied()
             } else {
                 None
             };
-            // If we didn't find any infer tys, then just fallback to `span``.
-            if visitor.0.is_empty() {
-                visitor.0.push(span);
+            // If we didn't find any infer tys, then just fallback to `span`.
+            if visitor.spans.is_empty() {
+                visitor.spans.push(span);
             }
-            let mut diag = bad_placeholder(cx, visitor.0, kind);
+            let mut diag = bad_placeholder(cx, visitor.spans, kind);
 
             if !ty.references_error() {
                 if let Some(ty) = ty.make_suggestable(tcx, false, None) {

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -412,7 +412,7 @@ fn infer_placeholder_type<'tcx>(
     kind: &'static str,
 ) -> Ty<'tcx> {
     let tcx = cx.tcx();
-    let ty = tcx.diagnostic_only_typeck(def_id).node_type(body_id.hir_id);
+    let ty = tcx.typeck(def_id).node_type(body_id.hir_id);
 
     // If this came from a free `const` or `static mut?` item,
     // then the user may have written e.g. `const A = 42;`.

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -467,9 +467,9 @@ fn infer_placeholder_type<'tcx>(
 
             if !ty.references_error() {
                 if let Some(ty) = ty.make_suggestable(tcx, false, None) {
-                    diag.span_suggestion(
+                    diag.span_suggestion_verbose(
                         span,
-                        "replace with the correct type",
+                        "replace this with a fully-specified type",
                         ty,
                         Applicability::MachineApplicable,
                     );

--- a/compiler/rustc_hir_analysis/src/collect/type_of/opaque.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of/opaque.rs
@@ -187,7 +187,7 @@ impl TaitConstraintLocator<'_> {
             "foreign items cannot constrain opaque types",
         );
         if let Some(hir_sig) = hir_node.fn_sig()
-            && hir_sig.decl.output.get_infer_ret_ty().is_some()
+            && hir_sig.decl.output.is_suggestable_infer_ty().is_some()
         {
             let guar = self.tcx.dcx().span_delayed_bug(
                 hir_sig.decl.output.span(),

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1774,7 +1774,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let Some((
             _,
             hir::Node::LetStmt(hir::LetStmt { ty: Some(ty), .. })
-            | hir::Node::Item(hir::Item { kind: hir::ItemKind::Const(ty, _, _), .. }),
         )) = parent_node
         else {
             return;

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1771,11 +1771,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let parent_node = self.tcx.hir().parent_iter(expr.hir_id).find(|(_, node)| {
             !matches!(node, hir::Node::Expr(hir::Expr { kind: hir::ExprKind::AddrOf(..), .. }))
         });
-        let Some((
-            _,
-            hir::Node::LetStmt(hir::LetStmt { ty: Some(ty), .. })
-        )) = parent_node
-        else {
+        let Some((_, hir::Node::LetStmt(hir::LetStmt { ty: Some(ty), .. }))) = parent_node else {
             return;
         };
         if let hir::TyKind::Array(_, ct) = ty.peel_refs().kind {

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -150,7 +150,7 @@ fn typeck_with_fallback<'tcx>(
     let mut fcx = FnCtxt::new(&root_ctxt, param_env, def_id);
 
     if let Some(hir::FnSig { header, decl, .. }) = node.fn_sig() {
-        let fn_sig = if decl.output.get_infer_ret_ty().is_some() {
+        let fn_sig = if decl.output.is_suggestable_infer_ty().is_some() {
             fcx.lowerer().lower_fn_ty(id, header.safety, header.abi, decl, None, None)
         } else {
             tcx.fn_sig(def_id).instantiate_identity()

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -87,21 +87,7 @@ fn used_trait_imports(tcx: TyCtxt<'_>, def_id: LocalDefId) -> &UnordSet<LocalDef
 }
 
 fn typeck<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
-    let fallback = move || tcx.type_of(def_id.to_def_id()).instantiate_identity();
-    typeck_with_fallback(tcx, def_id, fallback, None)
-}
-
-/// Used only to get `TypeckResults` for type inference during error recovery.
-/// Currently only used for type inference of `static`s and `const`s to avoid type cycle errors.
-fn diagnostic_only_typeck<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    def_id: LocalDefId,
-) -> &'tcx ty::TypeckResults<'tcx> {
-    let fallback = move || {
-        let span = tcx.hir().span(tcx.local_def_id_to_hir_id(def_id));
-        Ty::new_error_with_message(tcx, span, "diagnostic only typeck table used")
-    };
-    typeck_with_fallback(tcx, def_id, fallback, None)
+    typeck_with_fallback(tcx, def_id, None)
 }
 
 /// Same as `typeck` but `inspect` is invoked on evaluation of each root obligation.
@@ -113,15 +99,13 @@ pub fn inspect_typeck<'tcx>(
     def_id: LocalDefId,
     inspect: ObligationInspector<'tcx>,
 ) -> &'tcx ty::TypeckResults<'tcx> {
-    let fallback = move || tcx.type_of(def_id.to_def_id()).instantiate_identity();
-    typeck_with_fallback(tcx, def_id, fallback, Some(inspect))
+    typeck_with_fallback(tcx, def_id, Some(inspect))
 }
 
-#[instrument(level = "debug", skip(tcx, fallback, inspector), ret)]
+#[instrument(level = "debug", skip(tcx, inspector), ret)]
 fn typeck_with_fallback<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: LocalDefId,
-    fallback: impl Fn() -> Ty<'tcx> + 'tcx,
     inspector: Option<ObligationInspector<'tcx>>,
 ) -> &'tcx ty::TypeckResults<'tcx> {
     // Closures' typeck results come from their outermost function,
@@ -151,6 +135,10 @@ fn typeck_with_fallback<'tcx>(
 
     if let Some(hir::FnSig { header, decl, .. }) = node.fn_sig() {
         let fn_sig = if decl.output.is_suggestable_infer_ty().is_some() {
+            // In the case that we're recovering `fn() -> W<_>` or some other return
+            // type that has an infer in it, lower the type directly so that it'll
+            // be correctly filled with infer. We'll use this inference to provide
+            // a suggestion later on.
             fcx.lowerer().lower_fn_ty(id, header.safety, header.abi, decl, None, None)
         } else {
             tcx.fn_sig(def_id).instantiate_identity()
@@ -164,8 +152,19 @@ fn typeck_with_fallback<'tcx>(
 
         check_fn(&mut fcx, fn_sig, None, decl, def_id, body, tcx.features().unsized_fn_params());
     } else {
-        let expected_type = infer_type_if_missing(&fcx, node);
-        let expected_type = expected_type.unwrap_or_else(fallback);
+        let expected_type = if let Some(infer_ty) = infer_type_if_missing(&fcx, node) {
+            infer_ty
+        } else if let Some(ty) = node.ty()
+            && ty.is_suggestable_infer_ty()
+        {
+            // In the case that we're recovering `const X: [T; _]` or some other
+            // type that has an infer in it, lower the type directly so that it'll
+            // be correctly filled with infer. We'll use this inference to provide
+            // a suggestion later on.
+            fcx.lowerer().lower_ty(ty)
+        } else {
+            tcx.type_of(def_id).instantiate_identity()
+        };
 
         let expected_type = fcx.normalize(body.value.span, expected_type);
 
@@ -506,5 +505,5 @@ fn fatally_break_rust(tcx: TyCtxt<'_>, span: Span) -> ! {
 
 pub fn provide(providers: &mut Providers) {
     method::provide(providers);
-    *providers = Providers { typeck, diagnostic_only_typeck, used_trait_imports, ..*providers };
+    *providers = Providers { typeck, used_trait_imports, ..*providers };
 }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1100,9 +1100,6 @@ rustc_queries! {
         desc { |tcx| "type-checking `{}`", tcx.def_path_str(key) }
         cache_on_disk_if(tcx) { !tcx.is_typeck_child(key.to_def_id()) }
     }
-    query diagnostic_only_typeck(key: LocalDefId) -> &'tcx ty::TypeckResults<'tcx> {
-        desc { |tcx| "type-checking `{}`", tcx.def_path_str(key) }
-    }
 
     query used_trait_imports(key: LocalDefId) -> &'tcx UnordSet<LocalDefId> {
         desc { |tcx| "finding used_trait_imports `{}`", tcx.def_path_str(key) }

--- a/compiler/rustc_ty_utils/src/sig_types.rs
+++ b/compiler/rustc_ty_utils/src/sig_types.rs
@@ -31,7 +31,7 @@ pub fn walk_types<'tcx, V: SpannedTypeVisitor<'tcx>>(
             // If the type of the item uses `_`, we're gonna error out anyway, but
             // typeck (which type_of invokes below), will call back into opaque_types_defined_by
             // causing a cycle. So we just bail out in this case.
-            if hir_sig.output.get_infer_ret_ty().is_some() {
+            if hir_sig.output.is_suggestable_infer_ty().is_some() {
                 return V::Result::output();
             }
             let ty_sig = tcx.fn_sig(item).instantiate_identity();

--- a/tests/ui/array-slice-vec/suggest-array-length.fixed
+++ b/tests/ui/array-slice-vec/suggest-array-length.fixed
@@ -3,24 +3,21 @@
 
 fn main() {
     const Foo: [i32; 3] = [1, 2, 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
     const REF_FOO: &[u8; 1] = &[1];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    static Statik: [i32; 3] = [1, 2, 3];
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for static variables
+    static REF_STATIK: &[u8; 1] = &[1];
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for static variables
     let foo: [i32; 3] = [1, 2, 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR using `_` for array lengths is unstable
     let bar: [i32; 3] = [0; 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR using `_` for array lengths is unstable
     let ref_foo: &[i32; 3] = &[1, 2, 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR using `_` for array lengths is unstable
     let ref_bar: &[i32; 3] = &[0; 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR using `_` for array lengths is unstable
     let multiple_ref_foo: &&[i32; 3] = &&[1, 2, 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR using `_` for array lengths is unstable
 }

--- a/tests/ui/array-slice-vec/suggest-array-length.rs
+++ b/tests/ui/array-slice-vec/suggest-array-length.rs
@@ -3,24 +3,21 @@
 
 fn main() {
     const Foo: [i32; _] = [1, 2, 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
     const REF_FOO: &[u8; _] = &[1];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+    static Statik: [i32; _] = [1, 2, 3];
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for static variables
+    static REF_STATIK: &[u8; _] = &[1];
+    //~^ ERROR the placeholder `_` is not allowed within types on item signatures for static variables
     let foo: [i32; _] = [1, 2, 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR using `_` for array lengths is unstable
     let bar: [i32; _] = [0; 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR using `_` for array lengths is unstable
     let ref_foo: &[i32; _] = &[1, 2, 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR using `_` for array lengths is unstable
     let ref_bar: &[i32; _] = &[0; 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR using `_` for array lengths is unstable
     let multiple_ref_foo: &&[i32; _] = &&[1, 2, 3];
-    //~^ ERROR in expressions, `_` can only be used on the left-hand side of an assignment
-    //~| ERROR using `_` for array lengths is unstable
+    //~^ ERROR using `_` for array lengths is unstable
 }

--- a/tests/ui/array-slice-vec/suggest-array-length.stderr
+++ b/tests/ui/array-slice-vec/suggest-array-length.stderr
@@ -1,67 +1,41 @@
-error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/suggest-array-length.rs:11:20
-   |
-LL |     let foo: [i32; _] = [1, 2, 3];
-   |                    ^ `_` not allowed here
-
-error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/suggest-array-length.rs:14:20
-   |
-LL |     let bar: [i32; _] = [0; 3];
-   |                    ^ `_` not allowed here
-
-error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/suggest-array-length.rs:17:25
-   |
-LL |     let ref_foo: &[i32; _] = &[1, 2, 3];
-   |                         ^ `_` not allowed here
-
-error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/suggest-array-length.rs:20:25
-   |
-LL |     let ref_bar: &[i32; _] = &[0; 3];
-   |                         ^ `_` not allowed here
-
-error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/suggest-array-length.rs:23:35
-   |
-LL |     let multiple_ref_foo: &&[i32; _] = &&[1, 2, 3];
-   |                                   ^ `_` not allowed here
-
-error: in expressions, `_` can only be used on the left-hand side of an assignment
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/suggest-array-length.rs:5:22
    |
 LL |     const Foo: [i32; _] = [1, 2, 3];
-   |                      ^ `_` not allowed here
+   |                ------^-
+   |                |     |
+   |                |     not allowed in type signatures
+   |                help: replace with the correct type: `[i32; 3]`
 
-error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/suggest-array-length.rs:8:26
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+  --> $DIR/suggest-array-length.rs:7:26
    |
 LL |     const REF_FOO: &[u8; _] = &[1];
-   |                          ^ `_` not allowed here
+   |                    ------^-
+   |                    |     |
+   |                    |     not allowed in type signatures
+   |                    help: replace with the correct type: `&[u8; 1]`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
+  --> $DIR/suggest-array-length.rs:9:26
+   |
+LL |     static Statik: [i32; _] = [1, 2, 3];
+   |                    ------^-
+   |                    |     |
+   |                    |     not allowed in type signatures
+   |                    help: replace with the correct type: `[i32; 3]`
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
+  --> $DIR/suggest-array-length.rs:11:30
+   |
+LL |     static REF_STATIK: &[u8; _] = &[1];
+   |                        ------^-
+   |                        |     |
+   |                        |     not allowed in type signatures
+   |                        help: replace with the correct type: `&[u8; 1]`
 
 error[E0658]: using `_` for array lengths is unstable
-  --> $DIR/suggest-array-length.rs:5:22
-   |
-LL |     const Foo: [i32; _] = [1, 2, 3];
-   |                      ^ help: consider specifying the array length: `3`
-   |
-   = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
-   = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: using `_` for array lengths is unstable
-  --> $DIR/suggest-array-length.rs:8:26
-   |
-LL |     const REF_FOO: &[u8; _] = &[1];
-   |                          ^ help: consider specifying the array length: `1`
-   |
-   = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
-   = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: using `_` for array lengths is unstable
-  --> $DIR/suggest-array-length.rs:11:20
+  --> $DIR/suggest-array-length.rs:13:20
    |
 LL |     let foo: [i32; _] = [1, 2, 3];
    |                    ^ help: consider specifying the array length: `3`
@@ -71,7 +45,7 @@ LL |     let foo: [i32; _] = [1, 2, 3];
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: using `_` for array lengths is unstable
-  --> $DIR/suggest-array-length.rs:14:20
+  --> $DIR/suggest-array-length.rs:15:20
    |
 LL |     let bar: [i32; _] = [0; 3];
    |                    ^ help: consider specifying the array length: `3`
@@ -91,7 +65,7 @@ LL |     let ref_foo: &[i32; _] = &[1, 2, 3];
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: using `_` for array lengths is unstable
-  --> $DIR/suggest-array-length.rs:20:25
+  --> $DIR/suggest-array-length.rs:19:25
    |
 LL |     let ref_bar: &[i32; _] = &[0; 3];
    |                         ^ help: consider specifying the array length: `3`
@@ -101,7 +75,7 @@ LL |     let ref_bar: &[i32; _] = &[0; 3];
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: using `_` for array lengths is unstable
-  --> $DIR/suggest-array-length.rs:23:35
+  --> $DIR/suggest-array-length.rs:21:35
    |
 LL |     let multiple_ref_foo: &&[i32; _] = &&[1, 2, 3];
    |                                   ^ help: consider specifying the array length: `3`
@@ -110,6 +84,7 @@ LL |     let multiple_ref_foo: &&[i32; _] = &&[1, 2, 3];
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 14 previous errors
+error: aborting due to 9 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+Some errors have detailed explanations: E0121, E0658.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/array-slice-vec/suggest-array-length.stderr
+++ b/tests/ui/array-slice-vec/suggest-array-length.stderr
@@ -2,37 +2,45 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/suggest-array-length.rs:5:22
    |
 LL |     const Foo: [i32; _] = [1, 2, 3];
-   |                ------^-
-   |                |     |
-   |                |     not allowed in type signatures
-   |                help: replace with the correct type: `[i32; 3]`
+   |                      ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     const Foo: [i32; 3] = [1, 2, 3];
+   |                ~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/suggest-array-length.rs:7:26
    |
 LL |     const REF_FOO: &[u8; _] = &[1];
-   |                    ------^-
-   |                    |     |
-   |                    |     not allowed in type signatures
-   |                    help: replace with the correct type: `&[u8; 1]`
+   |                          ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     const REF_FOO: &[u8; 1] = &[1];
+   |                    ~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/suggest-array-length.rs:9:26
    |
 LL |     static Statik: [i32; _] = [1, 2, 3];
-   |                    ------^-
-   |                    |     |
-   |                    |     not allowed in type signatures
-   |                    help: replace with the correct type: `[i32; 3]`
+   |                          ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     static Statik: [i32; 3] = [1, 2, 3];
+   |                    ~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/suggest-array-length.rs:11:30
    |
 LL |     static REF_STATIK: &[u8; _] = &[1];
-   |                        ------^-
-   |                        |     |
-   |                        |     not allowed in type signatures
-   |                        help: replace with the correct type: `&[u8; 1]`
+   |                              ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     static REF_STATIK: &[u8; 1] = &[1];
+   |                        ~~~~~~~~
 
 error[E0658]: using `_` for array lengths is unstable
   --> $DIR/suggest-array-length.rs:13:20

--- a/tests/ui/async-await/issues/issue-95307.rs
+++ b/tests/ui/async-await/issues/issue-95307.rs
@@ -5,8 +5,8 @@
 
 pub trait C {
     async fn new() -> [u8; _];
-    //~^ ERROR: using `_` for array lengths is unstable
-    //~| ERROR: in expressions, `_` can only be used on the left-hand side of an assignment
+    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for functions
+    //~| ERROR using `_` for array lengths is unstable
 }
 
 fn main() {}

--- a/tests/ui/async-await/issues/issue-95307.stderr
+++ b/tests/ui/async-await/issues/issue-95307.stderr
@@ -1,8 +1,13 @@
-error: in expressions, `_` can only be used on the left-hand side of an assignment
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/issue-95307.rs:7:28
    |
 LL |     async fn new() -> [u8; _];
-   |                            ^ `_` not allowed here
+   |                            ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL |     async fn new<T>() -> [u8; T];
+   |                 +++           ~
 
 error[E0658]: using `_` for array lengths is unstable
   --> $DIR/issue-95307.rs:7:28
@@ -16,4 +21,5 @@ LL |     async fn new() -> [u8; _];
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+Some errors have detailed explanations: E0121, E0658.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/async-await/issues/issue-95307.stderr
+++ b/tests/ui/async-await/issues/issue-95307.stderr
@@ -3,11 +3,6 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
    |
 LL |     async fn new() -> [u8; _];
    |                            ^ not allowed in type signatures
-   |
-help: use type parameters instead
-   |
-LL |     async fn new<T>() -> [u8; T];
-   |                 +++           ~
 
 error[E0658]: using `_` for array lengths is unstable
   --> $DIR/issue-95307.rs:7:28

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
@@ -30,13 +30,19 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/in-signature.rs:22:15
    |
 LL | const ARR_CT: [u8; _] = [0; 3];
-   |               ^^^^^^^ not allowed in type signatures
+   |               ^^^^^^^
+   |               |
+   |               not allowed in type signatures
+   |               help: replace with the correct type: `[u8; 3]`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/in-signature.rs:24:20
    |
 LL | static ARR_STATIC: [u8; _] = [0; 3];
-   |                    ^^^^^^^ not allowed in type signatures
+   |                    ^^^^^^^
+   |                    |
+   |                    not allowed in type signatures
+   |                    help: replace with the correct type: `[u8; 3]`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/in-signature.rs:26:14

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
@@ -30,57 +30,71 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/in-signature.rs:22:20
    |
 LL | const ARR_CT: [u8; _] = [0; 3];
-   |               -----^-
-   |               |    |
-   |               |    not allowed in type signatures
-   |               help: replace with the correct type: `[u8; 3]`
+   |                    ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | const ARR_CT: [u8; 3] = [0; 3];
+   |               ~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/in-signature.rs:24:25
    |
 LL | static ARR_STATIC: [u8; _] = [0; 3];
-   |                    -----^-
-   |                    |    |
-   |                    |    not allowed in type signatures
-   |                    help: replace with the correct type: `[u8; 3]`
+   |                         ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | static ARR_STATIC: [u8; 3] = [0; 3];
+   |                    ~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/in-signature.rs:26:23
    |
 LL | const TY_CT: Bar<i32, _> = Bar::<i32, 3>(0);
-   |              ---------^-
-   |              |        |
-   |              |        not allowed in type signatures
-   |              help: replace with the correct type: `Bar<i32, 3>`
+   |                       ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | const TY_CT: Bar<i32, 3> = Bar::<i32, 3>(0);
+   |              ~~~~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/in-signature.rs:28:28
    |
 LL | static TY_STATIC: Bar<i32, _> = Bar::<i32, 3>(0);
-   |                   ---------^-
-   |                   |        |
-   |                   |        not allowed in type signatures
-   |                   help: replace with the correct type: `Bar<i32, 3>`
+   |                            ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | static TY_STATIC: Bar<i32, 3> = Bar::<i32, 3>(0);
+   |                   ~~~~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/in-signature.rs:30:24
    |
 LL | const TY_CT_MIXED: Bar<_, _> = Bar::<i32, 3>(0);
-   |                    ----^--^-
-   |                    |   |  |
-   |                    |   |  not allowed in type signatures
-   |                    |   not allowed in type signatures
-   |                    help: replace with the correct type: `Bar<i32, 3>`
+   |                        ^  ^ not allowed in type signatures
+   |                        |
+   |                        not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | const TY_CT_MIXED: Bar<i32, 3> = Bar::<i32, 3>(0);
+   |                    ~~~~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/in-signature.rs:32:29
    |
 LL | static TY_STATIC_MIXED: Bar<_, _> = Bar::<i32, 3>(0);
-   |                         ----^--^-
-   |                         |   |  |
-   |                         |   |  not allowed in type signatures
-   |                         |   not allowed in type signatures
-   |                         help: replace with the correct type: `Bar<i32, 3>`
+   |                             ^  ^ not allowed in type signatures
+   |                             |
+   |                             not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | static TY_STATIC_MIXED: Bar<i32, 3> = Bar::<i32, 3>(0);
+   |                         ~~~~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types
   --> $DIR/in-signature.rs:51:23

--- a/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/in-signature.stderr
@@ -27,57 +27,59 @@ LL | fn ty_fn_mixed() -> Bar<_, _> {
    |                     help: replace with the correct return type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/in-signature.rs:22:15
+  --> $DIR/in-signature.rs:22:20
    |
 LL | const ARR_CT: [u8; _] = [0; 3];
-   |               ^^^^^^^
-   |               |
-   |               not allowed in type signatures
+   |               -----^-
+   |               |    |
+   |               |    not allowed in type signatures
    |               help: replace with the correct type: `[u8; 3]`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/in-signature.rs:24:20
+  --> $DIR/in-signature.rs:24:25
    |
 LL | static ARR_STATIC: [u8; _] = [0; 3];
-   |                    ^^^^^^^
-   |                    |
-   |                    not allowed in type signatures
+   |                    -----^-
+   |                    |    |
+   |                    |    not allowed in type signatures
    |                    help: replace with the correct type: `[u8; 3]`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/in-signature.rs:26:14
+  --> $DIR/in-signature.rs:26:23
    |
 LL | const TY_CT: Bar<i32, _> = Bar::<i32, 3>(0);
-   |              ^^^^^^^^^^^
-   |              |
-   |              not allowed in type signatures
+   |              ---------^-
+   |              |        |
+   |              |        not allowed in type signatures
    |              help: replace with the correct type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/in-signature.rs:28:19
+  --> $DIR/in-signature.rs:28:28
    |
 LL | static TY_STATIC: Bar<i32, _> = Bar::<i32, 3>(0);
-   |                   ^^^^^^^^^^^
-   |                   |
-   |                   not allowed in type signatures
+   |                   ---------^-
+   |                   |        |
+   |                   |        not allowed in type signatures
    |                   help: replace with the correct type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/in-signature.rs:30:20
+  --> $DIR/in-signature.rs:30:24
    |
 LL | const TY_CT_MIXED: Bar<_, _> = Bar::<i32, 3>(0);
-   |                    ^^^^^^^^^
-   |                    |
-   |                    not allowed in type signatures
+   |                    ----^--^-
+   |                    |   |  |
+   |                    |   |  not allowed in type signatures
+   |                    |   not allowed in type signatures
    |                    help: replace with the correct type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/in-signature.rs:32:25
+  --> $DIR/in-signature.rs:32:29
    |
 LL | static TY_STATIC_MIXED: Bar<_, _> = Bar::<i32, 3>(0);
-   |                         ^^^^^^^^^
-   |                         |
-   |                         not allowed in type signatures
+   |                         ----^--^-
+   |                         |   |  |
+   |                         |   |  not allowed in type signatures
+   |                         |   not allowed in type signatures
    |                         help: replace with the correct type: `Bar<i32, 3>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated types

--- a/tests/ui/consts/issue-104768.rs
+++ b/tests/ui/consts/issue-104768.rs
@@ -1,4 +1,5 @@
 const A: &_ = 0_u32;
 //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for constants
+//~| ERROR: mismatched types
 
 fn main() {}

--- a/tests/ui/consts/issue-104768.stderr
+++ b/tests/ui/consts/issue-104768.stderr
@@ -15,10 +15,12 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/issue-104768.rs:1:11
    |
 LL | const A: &_ = 0_u32;
-   |          -^
-   |          ||
-   |          |not allowed in type signatures
-   |          help: replace with the correct type: `u32`
+   |           ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | const A: u32 = 0_u32;
+   |          ~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/issue-104768.stderr
+++ b/tests/ui/consts/issue-104768.stderr
@@ -1,3 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-104768.rs:1:15
+   |
+LL | const A: &_ = 0_u32;
+   |               ^^^^^ expected `&_`, found `u32`
+   |
+   = note: expected reference `&'static _`
+                   found type `u32`
+help: consider borrowing here
+   |
+LL | const A: &_ = &0_u32;
+   |               +
+
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/issue-104768.rs:1:10
    |
@@ -7,6 +20,7 @@ LL | const A: &_ = 0_u32;
    |          not allowed in type signatures
    |          help: replace with the correct type: `u32`
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0121`.
+Some errors have detailed explanations: E0121, E0308.
+For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/consts/issue-104768.stderr
+++ b/tests/ui/consts/issue-104768.stderr
@@ -12,12 +12,12 @@ LL | const A: &_ = &0_u32;
    |               +
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/issue-104768.rs:1:10
+  --> $DIR/issue-104768.rs:1:11
    |
 LL | const A: &_ = 0_u32;
-   |          ^^
-   |          |
-   |          not allowed in type signatures
+   |          -^
+   |          ||
+   |          |not allowed in type signatures
    |          help: replace with the correct type: `u32`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/error-codes/E0121.stderr
+++ b/tests/ui/error-codes/E0121.stderr
@@ -11,10 +11,12 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/E0121.rs:3:13
    |
 LL | static BAR: _ = "test";
-   |             ^
-   |             |
-   |             not allowed in type signatures
-   |             help: replace with the correct type: `&str`
+   |             ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | static BAR: &str = "test";
+   |             ~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-generic_arg_infer.normal.stderr
+++ b/tests/ui/feature-gates/feature-gate-generic_arg_infer.normal.stderr
@@ -1,17 +1,5 @@
-error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/feature-gate-generic_arg_infer.rs:11:27
-   |
-LL |     let _x: [u8; 3] = [0; _];
-   |                           ^ `_` not allowed here
-
-error: in expressions, `_` can only be used on the left-hand side of an assignment
-  --> $DIR/feature-gate-generic_arg_infer.rs:14:18
-   |
-LL |     let _y: [u8; _] = [0; 3];
-   |                  ^ `_` not allowed here
-
 error[E0658]: using `_` for array lengths is unstable
-  --> $DIR/feature-gate-generic_arg_infer.rs:14:18
+  --> $DIR/feature-gate-generic_arg_infer.rs:13:18
    |
 LL |     let _y: [u8; _] = [0; 3];
    |                  ^ help: consider specifying the array length: `3`
@@ -21,7 +9,7 @@ LL |     let _y: [u8; _] = [0; 3];
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0747]: type provided when a constant was expected
-  --> $DIR/feature-gate-generic_arg_infer.rs:20:20
+  --> $DIR/feature-gate-generic_arg_infer.rs:18:20
    |
 LL |     let _x = foo::<_>([1,2]);
    |                    ^
@@ -42,7 +30,7 @@ LL |     let _x: [u8; 3] = [0; _];
    = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0658, E0747.
 For more information about an error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-generic_arg_infer.rs
+++ b/tests/ui/feature-gates/feature-gate-generic_arg_infer.rs
@@ -10,10 +10,8 @@ fn foo<const N: usize>(_: [u8; N]) -> [u8; N] {
 fn bar() {
     let _x: [u8; 3] = [0; _];
     //[normal]~^ ERROR: using `_` for array lengths is unstable
-    //[normal]~| ERROR: in expressions, `_` can only be used on the left-hand side of an assignment
     let _y: [u8; _] = [0; 3];
     //[normal]~^ ERROR: using `_` for array lengths is unstable
-    //[normal]~| ERROR: in expressions, `_` can only be used on the left-hand side of an assignment
 }
 
 fn main() {

--- a/tests/ui/generic-const-items/assoc-const-missing-type.rs
+++ b/tests/ui/generic-const-items/assoc-const-missing-type.rs
@@ -12,7 +12,6 @@ impl Trait for () {
     const K<T> = ();
     //~^ ERROR missing type for `const` item
     //~| ERROR mismatched types
-    //~| ERROR mismatched types
     const Q = "";
     //~^ ERROR missing type for `const` item
     //~| ERROR lifetime parameters or bounds on const `Q` do not match the trait declaration

--- a/tests/ui/generic-const-items/assoc-const-missing-type.stderr
+++ b/tests/ui/generic-const-items/assoc-const-missing-type.stderr
@@ -16,7 +16,7 @@ LL |     const K<T> = ();
    |               ^ help: provide a type for the associated constant: `()`
 
 error[E0195]: lifetime parameters or bounds on const `Q` do not match the trait declaration
-  --> $DIR/assoc-const-missing-type.rs:16:12
+  --> $DIR/assoc-const-missing-type.rs:15:12
    |
 LL |     const Q<'a>: &'a str;
    |            ---- lifetimes in impl do not match this const in trait
@@ -25,24 +25,12 @@ LL |     const Q = "";
    |            ^ lifetimes do not match const in trait
 
 error: missing type for `const` item
-  --> $DIR/assoc-const-missing-type.rs:16:12
+  --> $DIR/assoc-const-missing-type.rs:15:12
    |
 LL |     const Q = "";
    |            ^ help: provide a type for the associated constant: `: &str`
 
-error[E0308]: mismatched types
-  --> $DIR/assoc-const-missing-type.rs:12:18
-   |
-LL |     const K<T> = ();
-   |             -    ^^ expected type parameter `T`, found `()`
-   |             |
-   |             expected this type parameter
-   |
-   = note: expected type parameter `T`
-                   found unit type `()`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0195, E0308.
 For more information about an error, try `rustc --explain E0195`.

--- a/tests/ui/macros/issue-69396-const-no-type-in-macro.rs
+++ b/tests/ui/macros/issue-69396-const-no-type-in-macro.rs
@@ -4,7 +4,7 @@ macro_rules! suite {
             const A = "A".$fn();
             //~^ ERROR the name `A` is defined multiple times
             //~| ERROR missing type for `const` item
-            //~| ERROR the placeholder `_` is not allowed within types on item signatures for constants
+            //~| ERROR missing type for item
         )*
     }
 }

--- a/tests/ui/macros/issue-69396-const-no-type-in-macro.stderr
+++ b/tests/ui/macros/issue-69396-const-no-type-in-macro.stderr
@@ -31,10 +31,7 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/issue-69396-const-no-type-in-macro.rs:4:20
    |
 LL |               const A = "A".$fn();
-   |                      ^
-   |                      |
-   |                      not allowed in type signatures
-   |                      help: replace with the correct type: `bool`
+   |                      ^ not allowed in type signatures
 ...
 LL | / suite! {
 LL | |     len;
@@ -43,6 +40,10 @@ LL | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `suite` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: replace this with a fully-specified type
+   |
+LL |             const Abool = "A".$fn();
+   |                    ++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/macros/issue-69396-const-no-type-in-macro.stderr
+++ b/tests/ui/macros/issue-69396-const-no-type-in-macro.stderr
@@ -27,7 +27,7 @@ LL | | }
    |
    = note: this error originates in the macro `suite` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
+error[E0121]: missing type for item
   --> $DIR/issue-69396-const-no-type-in-macro.rs:4:20
    |
 LL |               const A = "A".$fn();
@@ -40,10 +40,6 @@ LL | | }
    | |_- in this macro invocation
    |
    = note: this error originates in the macro `suite` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: replace this with a fully-specified type
-   |
-LL |             const Abool = "A".$fn();
-   |                    ++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/issues/issue-89574.rs
+++ b/tests/ui/parser/issues/issue-89574.rs
@@ -2,5 +2,4 @@ fn main() {
     const EMPTY_ARRAY = [];
     //~^ missing type for `const` item
     //~| ERROR type annotations needed
-    //~| ERROR type annotations needed
 }

--- a/tests/ui/parser/issues/issue-89574.stderr
+++ b/tests/ui/parser/issues/issue-89574.stderr
@@ -15,14 +15,6 @@ help: provide a type for the item
 LL |     const EMPTY_ARRAY: <type> = [];
    |                      ++++++++
 
-error[E0282]: type annotations needed
-  --> $DIR/issue-89574.rs:2:25
-   |
-LL |     const EMPTY_ARRAY = [];
-   |                         ^^ cannot infer type
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/suggestions/unnamable-types.rs
+++ b/tests/ui/suggestions/unnamable-types.rs
@@ -10,7 +10,7 @@ const A = 5;
 static B: _ = "abc";
 //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for static variables
 //~| NOTE: not allowed in type signatures
-//~| HELP: replace with the correct type
+//~| HELP: replace this with a fully-specified type
 
 
 // FIXME: this should also suggest a function pointer, as the closure is non-capturing

--- a/tests/ui/suggestions/unnamable-types.stderr
+++ b/tests/ui/suggestions/unnamable-types.stderr
@@ -8,10 +8,12 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/unnamable-types.rs:10:11
    |
 LL | static B: _ = "abc";
-   |           ^
-   |           |
-   |           not allowed in type signatures
-   |           help: replace with the correct type: `&str`
+   |           ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | static B: &str = "abc";
+   |           ~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/unnamable-types.rs:17:10

--- a/tests/ui/typeck/issue-79040.rs
+++ b/tests/ui/typeck/issue-79040.rs
@@ -1,6 +1,6 @@
 fn main() {
-    const FOO = "hello" + 1; //~ ERROR cannot add `{integer}` to `&str`
-    //~^ missing type for `const` item
-    //~| ERROR cannot add `{integer}` to `&str`
+    const FOO = "hello" + 1;
+    //~^ ERROR cannot add `{integer}` to `&str`
+    //~| missing type for `const` item
     println!("{}", FOO);
 }

--- a/tests/ui/typeck/issue-79040.stderr
+++ b/tests/ui/typeck/issue-79040.stderr
@@ -17,16 +17,6 @@ help: provide a type for the item
 LL |     const FOO: <type> = "hello" + 1;
    |              ++++++++
 
-error[E0369]: cannot add `{integer}` to `&str`
-  --> $DIR/issue-79040.rs:2:25
-   |
-LL |     const FOO = "hello" + 1;
-   |                 ------- ^ - {integer}
-   |                 |
-   |                 &str
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0369`.

--- a/tests/ui/typeck/typeck_type_placeholder_item.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_item.rs
@@ -221,6 +221,7 @@ fn value() -> Option<&'static _> {
 
 const _: Option<_> = map(value);
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for constants
+//~| ERROR cannot call non-const function `map::<u8>` in constants
 
 fn evens_squared(n: usize) -> _ {
 //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -82,12 +82,13 @@ LL | static TEST4: _ = 145;
    |               help: replace with the correct type: `i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:19:15
+  --> $DIR/typeck_type_placeholder_item.rs:19:16
    |
 LL | static TEST5: (_, _) = (1, 2);
-   |               ^^^^^^
-   |               |
-   |               not allowed in type signatures
+   |               -^--^-
+   |               ||  |
+   |               ||  not allowed in type signatures
+   |               |not allowed in type signatures
    |               help: replace with the correct type: `(i32, i32)`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
@@ -229,12 +230,12 @@ LL |     static B: _ = 42;
    |               help: replace with the correct type: `i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:77:15
+  --> $DIR/typeck_type_placeholder_item.rs:77:22
    |
 LL |     static C: Option<_> = Some(42);
-   |               ^^^^^^^^^
-   |               |
-   |               not allowed in type signatures
+   |               -------^-
+   |               |      |
+   |               |      not allowed in type signatures
    |               help: replace with the correct type: `Option<i32>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
@@ -275,12 +276,13 @@ LL |     static FN_TEST4: _ = 145;
    |                      help: replace with the correct type: `i32`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
-  --> $DIR/typeck_type_placeholder_item.rs:91:22
+  --> $DIR/typeck_type_placeholder_item.rs:91:23
    |
 LL |     static FN_TEST5: (_, _) = (1, 2);
-   |                      ^^^^^^
-   |                      |
-   |                      not allowed in type signatures
+   |                      -^--^-
+   |                      ||  |
+   |                      ||  not allowed in type signatures
+   |                      |not allowed in type signatures
    |                      help: replace with the correct type: `(i32, i32)`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
@@ -578,12 +580,12 @@ LL | fn value() -> Option<&'static _> {
    |               help: replace with the correct return type: `Option<&'static u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:222:10
+  --> $DIR/typeck_type_placeholder_item.rs:222:17
    |
 LL | const _: Option<_> = map(value);
-   |          ^^^^^^^^^
-   |          |
-   |          not allowed in type signatures
+   |          -------^-
+   |          |      |
+   |          |      not allowed in type signatures
    |          help: replace with the correct type: `Option<u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -67,29 +67,36 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:13:15
    |
 LL | static TEST3: _ = "test";
-   |               ^
-   |               |
-   |               not allowed in type signatures
-   |               help: replace with the correct type: `&str`
+   |               ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | static TEST3: &str = "test";
+   |               ~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:16:15
    |
 LL | static TEST4: _ = 145;
-   |               ^
-   |               |
-   |               not allowed in type signatures
-   |               help: replace with the correct type: `i32`
+   |               ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | static TEST4: i32 = 145;
+   |               ~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:19:16
    |
 LL | static TEST5: (_, _) = (1, 2);
-   |               -^--^-
-   |               ||  |
-   |               ||  not allowed in type signatures
-   |               |not allowed in type signatures
-   |               help: replace with the correct type: `(i32, i32)`
+   |                ^  ^ not allowed in type signatures
+   |                |
+   |                not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | static TEST5: (i32, i32) = (1, 2);
+   |               ~~~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:22:13
@@ -224,19 +231,23 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:75:15
    |
 LL |     static B: _ = 42;
-   |               ^
-   |               |
-   |               not allowed in type signatures
-   |               help: replace with the correct type: `i32`
+   |               ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     static B: i32 = 42;
+   |               ~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:77:22
    |
 LL |     static C: Option<_> = Some(42);
-   |               -------^-
-   |               |      |
-   |               |      not allowed in type signatures
-   |               help: replace with the correct type: `Option<i32>`
+   |                      ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     static C: Option<i32> = Some(42);
+   |               ~~~~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:79:21
@@ -261,29 +272,36 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:85:22
    |
 LL |     static FN_TEST3: _ = "test";
-   |                      ^
-   |                      |
-   |                      not allowed in type signatures
-   |                      help: replace with the correct type: `&str`
+   |                      ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     static FN_TEST3: &str = "test";
+   |                      ~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:88:22
    |
 LL |     static FN_TEST4: _ = 145;
-   |                      ^
-   |                      |
-   |                      not allowed in type signatures
-   |                      help: replace with the correct type: `i32`
+   |                      ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     static FN_TEST4: i32 = 145;
+   |                      ~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for static variables
   --> $DIR/typeck_type_placeholder_item.rs:91:23
    |
 LL |     static FN_TEST5: (_, _) = (1, 2);
-   |                      -^--^-
-   |                      ||  |
-   |                      ||  not allowed in type signatures
-   |                      |not allowed in type signatures
-   |                      help: replace with the correct type: `(i32, i32)`
+   |                       ^  ^ not allowed in type signatures
+   |                       |
+   |                       not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     static FN_TEST5: (i32, i32) = (1, 2);
+   |                      ~~~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:94:20
@@ -550,10 +568,12 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:194:14
    |
 LL |     const D: _ = 42;
-   |              ^
-   |              |
-   |              not allowed in type signatures
-   |              help: replace with the correct type: `i32`
+   |              ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     const D: i32 = 42;
+   |              ~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/typeck_type_placeholder_item.rs:209:14
@@ -583,10 +603,12 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:222:17
    |
 LL | const _: Option<_> = map(value);
-   |          -------^-
-   |          |      |
-   |          |      not allowed in type signatures
-   |          help: replace with the correct type: `Option<u8>`
+   |                 ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | const _: Option<u8> = map(value);
+   |          ~~~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:226:31

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -85,7 +85,10 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:19:15
    |
 LL | static TEST5: (_, _) = (1, 2);
-   |               ^^^^^^ not allowed in type signatures
+   |               ^^^^^^
+   |               |
+   |               not allowed in type signatures
+   |               help: replace with the correct type: `(i32, i32)`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:22:13
@@ -229,7 +232,10 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:77:15
    |
 LL |     static C: Option<_> = Some(42);
-   |               ^^^^^^^^^ not allowed in type signatures
+   |               ^^^^^^^^^
+   |               |
+   |               not allowed in type signatures
+   |               help: replace with the correct type: `Option<i32>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:79:21
@@ -272,7 +278,10 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:91:22
    |
 LL |     static FN_TEST5: (_, _) = (1, 2);
-   |                      ^^^^^^ not allowed in type signatures
+   |                      ^^^^^^
+   |                      |
+   |                      not allowed in type signatures
+   |                      help: replace with the correct type: `(i32, i32)`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item.rs:94:20
@@ -578,7 +587,7 @@ LL | const _: Option<_> = map(value);
    |          help: replace with the correct type: `Option<u8>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/typeck_type_placeholder_item.rs:225:31
+  --> $DIR/typeck_type_placeholder_item.rs:226:31
    |
 LL | fn evens_squared(n: usize) -> _ {
    |                               ^
@@ -587,13 +596,13 @@ LL | fn evens_squared(n: usize) -> _ {
    |                               help: replace with an appropriate return type: `impl Iterator<Item = usize>`
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
-  --> $DIR/typeck_type_placeholder_item.rs:230:10
+  --> $DIR/typeck_type_placeholder_item.rs:231:10
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |          ^ not allowed in type signatures
    |
-note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:230:29}>, {closure@typeck_type_placeholder_item.rs:230:49}>` cannot be named
-  --> $DIR/typeck_type_placeholder_item.rs:230:14
+note: however, the inferred type `Map<Filter<Range<i32>, {closure@typeck_type_placeholder_item.rs:231:29}>, {closure@typeck_type_placeholder_item.rs:231:49}>` cannot be named
+  --> $DIR/typeck_type_placeholder_item.rs:231:14
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -668,23 +677,31 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
 LL |     type F: std::ops::Fn(_);
    |                          ^ not allowed in type signatures
 
-error[E0015]: cannot call non-const method `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:230:29: 230:32}>` in constants
-  --> $DIR/typeck_type_placeholder_item.rs:230:22
+error[E0015]: cannot call non-const function `map::<u8>` in constants
+  --> $DIR/typeck_type_placeholder_item.rs:222:22
+   |
+LL | const _: Option<_> = map(value);
+   |                      ^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+
+error[E0015]: cannot call non-const method `<std::ops::Range<i32> as Iterator>::filter::<{closure@$DIR/typeck_type_placeholder_item.rs:231:29: 231:32}>` in constants
+  --> $DIR/typeck_type_placeholder_item.rs:231:22
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |                      ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const method `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:230:29: 230:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:230:49: 230:52}>` in constants
-  --> $DIR/typeck_type_placeholder_item.rs:230:45
+error[E0015]: cannot call non-const method `<Filter<std::ops::Range<i32>, {closure@$DIR/typeck_type_placeholder_item.rs:231:29: 231:32}> as Iterator>::map::<i32, {closure@$DIR/typeck_type_placeholder_item.rs:231:49: 231:52}>` in constants
+  --> $DIR/typeck_type_placeholder_item.rs:231:45
    |
 LL | const _: _ = (1..10).filter(|x| x % 2 == 0).map(|x| x * x);
    |                                             ^^^^^^^^^^^^^^
    |
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error: aborting due to 74 previous errors
+error: aborting due to 75 previous errors
 
 Some errors have detailed explanations: E0015, E0046, E0121, E0282, E0403.
 For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -11,19 +11,23 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item_help.rs:7:14
    |
 LL | const TEST2: _ = 42u32;
-   |              ^
-   |              |
-   |              not allowed in type signatures
-   |              help: replace with the correct type: `u32`
+   |              ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | const TEST2: u32 = 42u32;
+   |              ~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for constants
   --> $DIR/typeck_type_placeholder_item_help.rs:10:14
    |
 LL | const TEST3: _ = Some(42);
-   |              ^
-   |              |
-   |              not allowed in type signatures
-   |              help: replace with the correct type: `Option<i32>`
+   |              ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL | const TEST3: Option<i32> = Some(42);
+   |              ~~~~~~~~~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
   --> $DIR/typeck_type_placeholder_item_help.rs:13:22
@@ -41,19 +45,23 @@ error[E0121]: the placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item_help.rs:25:18
    |
 LL |     const TEST6: _ = 13;
-   |                  ^
-   |                  |
-   |                  not allowed in type signatures
-   |                  help: replace with the correct type: `i32`
+   |                  ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     const TEST6: i32 = 13;
+   |                  ~~~
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for associated constants
   --> $DIR/typeck_type_placeholder_item_help.rs:18:18
    |
 LL |     const TEST5: _ = 42;
-   |                  ^
-   |                  |
-   |                  not allowed in type signatures
-   |                  help: replace with the correct type: `i32`
+   |                  ^ not allowed in type signatures
+   |
+help: replace this with a fully-specified type
+   |
+LL |     const TEST5: i32 = 42;
+   |                  ~~~
 
 error[E0308]: mismatched types
   --> $DIR/typeck_type_placeholder_item_help.rs:30:28


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/135010.

This PR does a few things to (imo) greatly improve the error message when users write something like `static FOO: [i32; _] = [1, 2, 3]`.

Firstly, it adapts the recovery code for when we encounter `_` in a const/static to work a bit more like `fn foo() -> _`, and removes the somewhat redundant query `diagnostic_only_typeck`.

Secondly, it changes the lowering for `[T; _]` to always lower under the `feature(generic_arg_infer)` logic to `ConstArgKind::Infer`. We still issue the feature error, so it's not doing anything *observable* on the good path, but it does mean that we no longer erroneously interpret `[T; _]`'s array length as a `_` **wildcard expression** (à la destructuring assignment, like `(_, y) = expr`).

Lastly it makes the suggestions verbose and fixes (well, suppresses) a bug with stashing and suggestions.

r? oli-obk