### PR TITLE
Emit single error for `+ use<'_>` and don't suggest `use<'static>`

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -657,10 +657,15 @@ impl<'a, 'tcx> Visitor<'tcx> for BoundVarContext<'a, 'tcx> {
                 LifetimeName::Param(def_id) => {
                     self.resolve_lifetime_ref(def_id, lt);
                 }
-                LifetimeName::Error => {}
-                LifetimeName::ImplicitObjectLifetimeDefault
-                | LifetimeName::Infer
-                | LifetimeName::Static => {
+                LifetimeName::Infer | LifetimeName::Error => {
+                    // We don't check for explicit `'_` lifetimes because we'll already have an
+                    // explicit error from late resolution explaining `use<'_>` is invalid.
+                    self.tcx.dcx().span_delayed_bug(
+                        lt.ident.span,
+                        "found infer or error lifetime but no prior error",
+                    );
+                }
+                LifetimeName::ImplicitObjectLifetimeDefault | LifetimeName::Static => {
                     self.tcx.dcx().emit_err(errors::BadPreciseCapture {
                         span: lt.ident.span,
                         kind: "lifetime",

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1132,6 +1132,18 @@ impl<'ra: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'r
 
     fn visit_precise_capturing_arg(&mut self, arg: &'ast PreciseCapturingArg) {
         match arg {
+            PreciseCapturingArg::Lifetime(lt) if lt.ident.name == kw::UnderscoreLifetime => {
+                // We account for `+ use<'_>` explicitly to avoid providing an invalid suggestion
+                // for `+ use<'static>`.
+                let outer_failures = take(&mut self.diag_metadata.current_elision_failures);
+                visit::walk_precise_capturing_arg(self, arg);
+                let elision_failures =
+                    replace(&mut self.diag_metadata.current_elision_failures, outer_failures);
+                if !elision_failures.is_empty() {
+                    self.report_missing_lifetime_specifiers(elision_failures, None, true);
+                }
+                return;
+            }
             // Lower the lifetime regularly; we'll resolve the lifetime and check
             // it's a parameter later on in HIR lowering.
             PreciseCapturingArg::Lifetime(_) => {}
@@ -1884,7 +1896,7 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             }
         }
         self.record_lifetime_res(lifetime.id, LifetimeRes::Error, elision_candidate);
-        self.report_missing_lifetime_specifiers(vec![missing_lifetime], None);
+        self.report_missing_lifetime_specifiers(vec![missing_lifetime], None, false);
     }
 
     #[instrument(level = "debug", skip(self))]
@@ -2104,7 +2116,11 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                                 LifetimeElisionCandidate::Ignore,
                             );
                         }
-                        self.report_missing_lifetime_specifiers(vec![missing_lifetime], None);
+                        self.report_missing_lifetime_specifiers(
+                            vec![missing_lifetime],
+                            None,
+                            false,
+                        );
                         break;
                     }
                     LifetimeRibKind::Generics { .. } | LifetimeRibKind::ConstParamTy => {}
@@ -2227,7 +2243,7 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             replace(&mut self.diag_metadata.current_elision_failures, outer_failures);
         if !elision_failures.is_empty() {
             let Err(failure_info) = elision_lifetime else { bug!() };
-            self.report_missing_lifetime_specifiers(elision_failures, Some(failure_info));
+            self.report_missing_lifetime_specifiers(elision_failures, Some(failure_info), false);
         }
     }
 

--- a/tests/ui/impl-trait/precise-capturing/bad-lifetimes.rs
+++ b/tests/ui/impl-trait/precise-capturing/bad-lifetimes.rs
@@ -1,6 +1,5 @@
 fn no_elided_lt() -> impl Sized + use<'_> {}
 //~^ ERROR missing lifetime specifier
-//~| ERROR expected lifetime parameter in `use<...>` precise captures list, found `'_`
 
 fn static_lt() -> impl Sized + use<'static> {}
 //~^ ERROR expected lifetime parameter in `use<...>` precise captures list, found `'static`

--- a/tests/ui/impl-trait/precise-capturing/bad-lifetimes.stderr
+++ b/tests/ui/impl-trait/precise-capturing/bad-lifetimes.stderr
@@ -2,36 +2,25 @@ error[E0106]: missing lifetime specifier
   --> $DIR/bad-lifetimes.rs:1:39
    |
 LL | fn no_elided_lt() -> impl Sized + use<'_> {}
-   |                                       ^^ expected named lifetime parameter
+   |                                       ^^
    |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime, but this is uncommon unless you're returning a borrowed value from a `const` or a `static`, or if you will only have owned values
-   |
-LL - fn no_elided_lt() -> impl Sized + use<'_> {}
-LL + fn no_elided_lt() -> impl Sized + use<'static> {}
-   |
+   = note: cannot capture elided lifetime with `use<'_>` when there is no lifetime in scope to capture
 
 error[E0261]: use of undeclared lifetime name `'missing`
-  --> $DIR/bad-lifetimes.rs:8:37
+  --> $DIR/bad-lifetimes.rs:7:37
    |
 LL | fn missing_lt() -> impl Sized + use<'missing> {}
    |              -                      ^^^^^^^^ undeclared lifetime
    |              |
    |              help: consider introducing lifetime `'missing` here: `<'missing>`
 
-error: expected lifetime parameter in `use<...>` precise captures list, found `'_`
-  --> $DIR/bad-lifetimes.rs:1:39
-   |
-LL | fn no_elided_lt() -> impl Sized + use<'_> {}
-   |                                       ^^
-
 error: expected lifetime parameter in `use<...>` precise captures list, found `'static`
-  --> $DIR/bad-lifetimes.rs:5:36
+  --> $DIR/bad-lifetimes.rs:4:36
    |
 LL | fn static_lt() -> impl Sized + use<'static> {}
    |                                    ^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0106, E0261.
 For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
```
error[E0106]: missing lifetime specifier
  --> $DIR/bad-lifetimes.rs:1:39
   |
LL | fn no_elided_lt() -> impl Sized + use<'_> {}
   |                                       ^^ expected named lifetime parameter
   |
help: consider introducing a named lifetime parameter
   |
LL | fn no_elided_lt<'a>() -> impl Sized + use<'a> {}
   |                ++++                       ~~
```

Fix #134194.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
r? @compiler-errors