### PR TITLE
Add Location::file_with_nul

### DIFF
--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -1,3 +1,4 @@
+use crate::ffi::CStr;
 use crate::fmt;
 
 /// A struct containing information about the location of a panic.
@@ -32,7 +33,12 @@ use crate::fmt;
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 pub struct Location<'a> {
-    file: &'a str,
+    // Note: this filename will have exactly one nul byte at its end, but otherwise
+    // it must never contain interior nul bytes. This is relied on for the conversion
+    // to `CStr` below.
+    //
+    // The prefix of the string without the trailing nul byte will be a regular UTF8 `str`.
+    file_bytes_with_nul: &'a [u8],
     line: u32,
     col: u32,
 }
@@ -125,9 +131,24 @@ impl<'a> Location<'a> {
     #[must_use]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     #[rustc_const_stable(feature = "const_location_fields", since = "1.79.0")]
-    #[inline]
     pub const fn file(&self) -> &str {
-        self.file
+        let str_len = self.file_bytes_with_nul.len() - 1;
+        // SAFETY: `file_bytes_with_nul` without the trailing nul byte is guaranteed to be
+        // valid UTF8.
+        unsafe { crate::str::from_raw_parts(self.file_bytes_with_nul.as_ptr(), str_len) }
+    }
+
+    /// Returns the name of the source file as a nul-terminated `CStr`.
+    ///
+    /// This is useful for interop with APIs that expect C/C++ `__FILE__` or
+    /// `std::source_location::file_name`, both of which return a nul-terminated `const char*`.
+    #[must_use]
+    #[unstable(feature = "file_with_nul", issue = "141727")]
+    #[inline]
+    pub const fn file_with_nul(&self) -> &CStr {
+        // SAFETY: `file_bytes_with_nul` is guaranteed to have a trailing nul byte and no
+        // interior nul bytes.
+        unsafe { CStr::from_bytes_with_nul_unchecked(self.file_bytes_with_nul) }
     }
 
     /// Returns the line number from which the panic originated.
@@ -181,22 +202,10 @@ impl<'a> Location<'a> {
     }
 }
 
-#[unstable(
-    feature = "panic_internals",
-    reason = "internal details of the implementation of the `panic!` and related macros",
-    issue = "none"
-)]
-impl<'a> Location<'a> {
-    #[doc(hidden)]
-    pub const fn internal_constructor(file: &'a str, line: u32, col: u32) -> Self {
-        Location { file, line, col }
-    }
-}
-
 #[stable(feature = "panic_hook_display", since = "1.26.0")]
 impl fmt::Display for Location<'_> {
     #[inline]
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "{}:{}:{}", self.file, self.line, self.col)
+        write!(formatter, "{}:{}:{}", self.file(), self.line, self.col)
     }
 }

--- a/tests/ui/rfcs/rfc-2091-track-caller/file-is-nul-terminated.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/file-is-nul-terminated.rs
@@ -1,0 +1,25 @@
+//@ run-pass
+#![feature(file_with_nul)]
+
+#[track_caller]
+const fn assert_file_has_trailing_zero() {
+    let caller = core::panic::Location::caller();
+    let file_str = caller.file();
+    let file_with_nul = caller.file_with_nul();
+    if file_str.len() != file_with_nul.count_bytes() {
+        panic!("mismatched lengths");
+    }
+    let trailing_byte: core::ffi::c_char = unsafe {
+        *file_with_nul.as_ptr().offset(file_with_nul.count_bytes() as _)
+    };
+    if trailing_byte != 0 {
+        panic!("trailing byte was nonzero")
+    }
+}
+
+#[allow(dead_code)]
+const _: () = assert_file_has_trailing_zero();
+
+fn main() {
+    assert_file_has_trailing_zero();
+}


### PR DESCRIPTION
This is useful for C/C++ APIs which expect the const char* returned from __FILE__ or std::source_location::file_name.

ACP: https://github.com/rust-lang/libs-team/issues/466
Tracking issue: https://github.com/rust-lang/rust/issues/141727