### PR TITLE
Bump cc in the compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,9 +419,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "shlex",
 ]

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -10,7 +10,7 @@ arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.4.1"
 # Pinned so `cargo update` bumps don't cause breakage. Please also update the
 # `cc` in `rustc_llvm` if you update the `cc` here.
-cc = "=1.2.6"
+cc = "=1.2.7"
 either = "1.5.0"
 itertools = "0.12"
 pathdiff = "0.2.0"

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -12,5 +12,5 @@ libc = "0.2.73"
 # tidy-alphabetical-start
 # Pinned so `cargo update` bumps don't cause breakage. Please also update the
 # pinned `cc` in `rustc_codegen_ssa` if you update `cc` here.
-cc = "=1.2.6"
+cc = "=1.2.7"
 # tidy-alphabetical-end


### PR DESCRIPTION
Changelog:

- Regenerate target info ([#1342](https://github.com/rust-lang/cc-rs/pull/1342))
- Allow using Visual Studio target names in `find_tool` ([#1335](https://github.com/rust-lang/cc-rs/pull/1335))
- Fix `is_flag_supported` on msvc ([#1336](https://github.com/rust-lang/cc-rs/pull/1336))

