### PR TITLE
core: Make `Debug` impl of raw pointers print metadata if present

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -79,6 +79,7 @@ version = "0.0.0"
 dependencies = [
  "rand",
  "rand_xorshift",
+ "regex",
 ]
 
 [[package]]
@@ -296,6 +297,31 @@ checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2776,7 +2776,14 @@ impl Display for char {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> Pointer for *const T {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        pointer_fmt_inner(self.expose_provenance(), f)
+        if <<T as core::ptr::Pointee>::Metadata as core::unit::IsUnit>::is_unit() {
+            pointer_fmt_inner(self.expose_provenance(), f)
+        } else {
+            f.debug_struct("Pointer")
+                .field_with("addr", |f| pointer_fmt_inner(self.expose_provenance(), f))
+                .field("metadata", &core::ptr::metadata(*self))
+                .finish()
+        }
     }
 }
 

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -61,6 +61,8 @@ pub trait Pointee {
     // NOTE: Keep trait bounds in `static_assert_expected_bounds_for_metadata`
     // in `library/core/src/ptr/metadata.rs`
     // in sync with those here:
+    // NOTE: The metadata of `dyn Trait + 'a` is `DynMetadata<dyn Trait + 'a>`
+    // so a `'static` bound must not be added.
     type Metadata: fmt::Debug + Copy + Send + Sync + Ord + Hash + Unpin + Freeze;
 }
 

--- a/library/core/src/unit.rs
+++ b/library/core/src/unit.rs
@@ -17,3 +17,19 @@ impl FromIterator<()> for () {
         iter.into_iter().for_each(|()| {})
     }
 }
+
+pub(crate) trait IsUnit {
+    fn is_unit() -> bool;
+}
+
+impl<T: ?Sized> IsUnit for T {
+    default fn is_unit() -> bool {
+        false
+    }
+}
+
+impl IsUnit for () {
+    fn is_unit() -> bool {
+        true
+    }
+}

--- a/library/coretests/Cargo.toml
+++ b/library/coretests/Cargo.toml
@@ -25,3 +25,4 @@ test = true
 [dev-dependencies]
 rand = { version = "0.9.0", default-features = false }
 rand_xorshift = { version = "0.4.0", default-features = false }
+regex = { version = "1.11.1", default-features = false }

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -42,12 +42,12 @@ fn test_fmt_debug_of_raw_pointers() {
     check_fmt(plain as *const i32, "$HEX");
 
     let slice = &mut [200, 300, 400][..];
-    check_fmt(slice as *mut [i32], "$HEX");
-    check_fmt(slice as *const [i32], "$HEX");
+    check_fmt(slice as *mut [i32], "Pointer { addr: $HEX, metadata: 3 }");
+    check_fmt(slice as *const [i32], "Pointer { addr: $HEX, metadata: 3 }");
 
     let vtable = &mut 500 as &mut dyn Debug;
-    check_fmt(vtable as *mut dyn Debug, "$HEX");
-    check_fmt(vtable as *const dyn Debug, "$HEX");
+    check_fmt(vtable as *mut dyn Debug, "Pointer { addr: $HEX, metadata: DynMetadata($HEX) }");
+    check_fmt(vtable as *const dyn Debug, "Pointer { addr: $HEX, metadata: DynMetadata($HEX) }");
 }
 
 #[test]

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -15,8 +15,8 @@ fn test_format_flags() {
 fn test_pointer_formats_data_pointer() {
     let b: &[u8] = b"";
     let s: &str = "";
-    assert_eq!(format!("{s:p}"), format!("{:p}", s.as_ptr()));
-    assert_eq!(format!("{b:p}"), format!("{:p}", b.as_ptr()));
+    assert_eq!(format!("{s:p}"), format!("{:p}", s as *const _));
+    assert_eq!(format!("{b:p}"), format!("{:p}", b as *const _));
 }
 
 #[test]


### PR DESCRIPTION
Make Rust pointers appear less magic by including metadata information in their `Debug` output.

This does not break Rust stability guarantees because `Debug` impl are explicitly exempted from stability:
https://doc.rust-lang.org/std/fmt/trait.Debug.html#stability

> ## Stability
>
> Derived `Debug` formats are not stable, and so may change with future Rust versions. Additionally, `Debug` implementations of types provided by the standard library (`std`, `core`, `alloc`, etc.) are not stable, and may also change with future Rust versions.

Note that a regression test is added as a separate commit to make it clear what impact the last commit has on the output.

Closes #128684 because the output of that code now becomes:

```
thread 'main' panicked at src/main.rs:5:5:
assertion `left == right` failed
  left: Pointer { addr: 0x7ffd45c6fc6b, metadata: 5 }
 right: Pointer { addr: 0x7ffd45c6fc6b, metadata: 3 }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```