### PR TITLE
bootstrap: Build jemalloc with support for 64K pages

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1207,6 +1207,15 @@ pub fn rustc_cargo_env(
             rustc_llvm_env(builder, cargo, target)
         }
     }
+
+    // Build jemalloc on AArch64 with support for page sizes up to 64K
+    // See: https://github.com/rust-lang/rust/pull/135081
+    if builder.config.jemalloc
+        && target.starts_with("aarch64")
+        && env::var_os("JEMALLOC_SYS_WITH_LG_PAGE").is_none()
+    {
+        cargo.env("JEMALLOC_SYS_WITH_LG_PAGE", "16");
+    }
 }
 
 /// Pass down configuration from the LLVM build into the build of


### PR DESCRIPTION
By default, jemalloc is built to only support the same page size as the host machine. Set an env variable so that jemalloc is built with support for page sizes up to 64K regardless of the host machine.

r? @Kobzol 

Resolves #134563 
Potentially resolves #133748 (needs verification)

----

Results from local rustc-perf testing below, within 0.5% on every metric except max-rss.
AArch64:
![Screenshot 2025-01-03 at 5 53 13 pm](https://github.com/user-attachments/assets/71705c59-7d7b-4753-a184-8c784233e603)
x86_64:
![Screenshot 2025-01-03 at 5 54 16 pm](https://github.com/user-attachments/assets/ea28aded-3b90-43f4-a965-b081b07b95ab)

