### PR TITLE
Do not ICE when encountering predicates from other items in method error reporting

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -1067,7 +1067,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     )
                 ) {
                     continue;
-                };
+                }
 
                 match self.tcx.hir().get_if_local(item_def_id) {
                     // Unmet obligation comes from a `derive` macro, point at it once to
@@ -1181,8 +1181,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         entry.1.insert((cause_span, "unsatisfied trait bound introduced here"));
                         entry.2.push(p);
                     }
-                    Some(node) => unreachable!("encountered `{node:?}` due to `{cause:#?}`"),
-                    None => (),
+                    _ => {
+                        // It's possible to use well-formedness clauses to get obligations
+                        // which point arbitrary items like ADTs, so there's no use in ICEing
+                        // here if we find that the obligation originates from some other
+                        // node that we don't handle.
+                    }
                 }
             }
             let mut spanned_predicates: Vec<_> = spanned_predicates.into_iter().collect();

--- a/tests/ui/methods/bad-wf-when-selecting-method.rs
+++ b/tests/ui/methods/bad-wf-when-selecting-method.rs
@@ -1,0 +1,18 @@
+trait Wf {
+    type Assoc;
+}
+
+struct Wrapper<T: Wf<Assoc = U>, U>(T);
+
+trait Trait {
+    fn needs_sized(self);
+}
+
+fn test<T>(t: T) {
+    Wrapper(t).needs_sized();
+    //~^ ERROR the trait bound `T: Wf` is not satisfied
+    //~| ERROR the trait bound `T: Wf` is not satisfied
+    //~| the method `needs_sized` exists for struct `Wrapper<T, _>`, but its trait bounds were not satisfied
+}
+
+fn main() {}

--- a/tests/ui/methods/bad-wf-when-selecting-method.stderr
+++ b/tests/ui/methods/bad-wf-when-selecting-method.stderr
@@ -1,0 +1,54 @@
+error[E0277]: the trait bound `T: Wf` is not satisfied
+  --> $DIR/bad-wf-when-selecting-method.rs:12:13
+   |
+LL |     Wrapper(t).needs_sized();
+   |     ------- ^ the trait `Wf` is not implemented for `T`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `Wrapper`
+  --> $DIR/bad-wf-when-selecting-method.rs:5:19
+   |
+LL | struct Wrapper<T: Wf<Assoc = U>, U>(T);
+   |                   ^^^^^^^^^^^^^ required by this bound in `Wrapper`
+help: consider restricting type parameter `T` with trait `Wf`
+   |
+LL | fn test<T: Wf>(t: T) {
+   |          ++++
+
+error[E0277]: the trait bound `T: Wf` is not satisfied
+  --> $DIR/bad-wf-when-selecting-method.rs:12:5
+   |
+LL |     Wrapper(t).needs_sized();
+   |     ^^^^^^^^^^ the trait `Wf` is not implemented for `T`
+   |
+note: required by a bound in `Wrapper`
+  --> $DIR/bad-wf-when-selecting-method.rs:5:19
+   |
+LL | struct Wrapper<T: Wf<Assoc = U>, U>(T);
+   |                   ^^^^^^^^^^^^^ required by this bound in `Wrapper`
+help: consider restricting type parameter `T` with trait `Wf`
+   |
+LL | fn test<T: Wf>(t: T) {
+   |          ++++
+
+error[E0599]: the method `needs_sized` exists for struct `Wrapper<T, _>`, but its trait bounds were not satisfied
+  --> $DIR/bad-wf-when-selecting-method.rs:12:16
+   |
+LL | struct Wrapper<T: Wf<Assoc = U>, U>(T);
+   | ----------------------------------- method `needs_sized` not found for this struct
+...
+LL |     Wrapper(t).needs_sized();
+   |                ^^^^^^^^^^^ method cannot be called on `Wrapper<T, _>` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `T: Wf`
+help: consider restricting the type parameter to satisfy the trait bound
+   |
+LL | fn test<T>(t: T) where T: Wf {
+   |                  +++++++++++
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
See the comments I left in the code and the test file.

Fixes https://github.com/rust-lang/rust/issues/124350