### PR TITLE
Suggest to replace tuple constructor through projection

### DIFF
--- a/tests/ui/associated-types/invalid-ctor.fixed
+++ b/tests/ui/associated-types/invalid-ctor.fixed
@@ -1,0 +1,22 @@
+//@ run-rustfix
+
+#![allow(unused)]
+
+struct Constructor(i32);
+
+trait Trait {
+    type Out;
+
+    fn mk() -> Self::Out;
+}
+
+impl Trait for () {
+    type Out = Constructor;
+
+    fn mk() -> Self::Out {
+        Constructor(1)
+        //~^ ERROR no associated item named `Out` found for unit type `()`
+    }
+}
+
+fn main() {}

--- a/tests/ui/associated-types/invalid-ctor.rs
+++ b/tests/ui/associated-types/invalid-ctor.rs
@@ -1,0 +1,22 @@
+//@ run-rustfix
+
+#![allow(unused)]
+
+struct Constructor(i32);
+
+trait Trait {
+    type Out;
+
+    fn mk() -> Self::Out;
+}
+
+impl Trait for () {
+    type Out = Constructor;
+
+    fn mk() -> Self::Out {
+        Self::Out(1)
+        //~^ ERROR no associated item named `Out` found for unit type `()`
+    }
+}
+
+fn main() {}

--- a/tests/ui/associated-types/invalid-ctor.stderr
+++ b/tests/ui/associated-types/invalid-ctor.stderr
@@ -1,0 +1,14 @@
+error[E0599]: no associated item named `Out` found for unit type `()` in the current scope
+  --> $DIR/invalid-ctor.rs:17:15
+   |
+LL |         Self::Out(1)
+   |               ^^^ associated item not found in `()`
+   |
+help: to construct a value of type `Constructor`, use the explicit path
+   |
+LL |         Constructor(1)
+   |         ~~~~~~~~~~~
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
See the code example. when `Self::Assoc` normalizes to a struct that has a tuple constructor, you cannot construct the type via `Self::Assoc(field, field)`. Instead, suggest to replace it with the correct named struct.

Fixes #120871