### PR TITLE
bootstrap: correctly handle doc paths within submodules

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -18,7 +18,7 @@ use crate::core::builder::{
     self, Alias, Builder, Compiler, Kind, RunConfig, ShouldRun, Step, crate_description,
 };
 use crate::core::config::{Config, TargetSelection};
-use crate::helpers::{is_path_in_submodule, symlink_dir, t, up_to_date};
+use crate::helpers::{submodule_path_of, symlink_dir, t, up_to_date};
 
 macro_rules! book {
     ($($name:ident, $path:expr, $book_name:expr, $lang:expr ;)+) => {
@@ -44,8 +44,8 @@ macro_rules! book {
             }
 
             fn run(self, builder: &Builder<'_>) {
-                if is_path_in_submodule(&builder, $path) {
-                    builder.require_submodule($path, None);
+                if let Some(submodule_path) = submodule_path_of(&builder, $path) {
+                    builder.require_submodule(&submodule_path, None)
                 }
 
                 builder.ensure(RustbookSrc {
@@ -933,9 +933,9 @@ macro_rules! tool_doc {
             fn run(self, builder: &Builder<'_>) {
                 let mut source_type = SourceType::InTree;
 
-                if is_path_in_submodule(&builder, $path) {
+                if let Some(submodule_path) = submodule_path_of(&builder, $path) {
                     source_type = SourceType::Submodule;
-                    builder.require_submodule($path, None);
+                    builder.require_submodule(&submodule_path, None);
                 }
 
                 let stage = builder.top_stage;

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -60,10 +60,12 @@ pub fn is_dylib(path: &Path) -> bool {
     })
 }
 
-/// Returns `true` if the given path is part of a submodule.
-pub fn is_path_in_submodule(builder: &Builder<'_>, path: &str) -> bool {
+/// Return the path to the containing submodule if available.
+pub fn submodule_path_of(builder: &Builder<'_>, path: &str) -> Option<String> {
     let submodule_paths = build_helper::util::parse_gitmodules(&builder.src);
-    submodule_paths.iter().any(|submodule_path| path.starts_with(submodule_path))
+    submodule_paths.iter().find_map(|submodule_path| {
+        if path.starts_with(submodule_path) { Some(submodule_path.to_string()) } else { None }
+    })
 }
 
 fn is_aix_shared_archive(path: &Path) -> bool {


### PR DESCRIPTION
Fixes #135041 by passing the correct submodule path when requiring submodules. This PR changes `is_path_in_submodule` to `submodule_path_of`. `submodule_path_of` returns the path of the containing submodule when given a path nested inside a submodule we handle, and `None` otherwise.

I tested this manually locally by unregistering the `src/tools/cargo` submodule, then running `./x doc src/tools/cargo/src/doc`. This command fails on master with

```
thread 'main' panicked at src/bootstrap/src/utils/helpers.rs:441:5:
std::fs::read_dir(dir) failed with No such file or directory (os error 2)
```

since the require submodule fails as `src/tools/cargo/src/doc` is not a known submodule. Now we use the submodule path if such a nested-in-submodule-path is passed, and thus running this command with cargo submodule unregistered still succeeds:

```
Rustbook (x86_64-unknown-linux-gnu) - cargo
Doc path: /home/joe/repos/rust/build/x86_64-unknown-linux-gnu/doc/cargo/index.html
Build completed successfully in 0:00:11
```

r? @onur-ozkan