### PR TITLE
library: fix adler{ -> 2}.debug

### DIFF
--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -32,7 +32,7 @@ codegen-units = 10000
 [profile.release.package]
 addr2line.debug = 0
 addr2line.opt-level = "s"
-adler.debug = 0
+adler2.debug = 0
 gimli.debug = 0
 gimli.opt-level = "s"
 miniz_oxide.debug = 0


### PR DESCRIPTION
Fixes
```
Checking stage0 library artifacts {alloc, core, panic_abort, panic_unwind, proc_macro, std, sysroot, test, unwind} (x86_64-unknown-linux-gnu)
warning: profile package spec `adler` in profile `release` did not match any packages

	Did you mean `adler2`?
```
r? @bjorn3 