### PR TITLE
rustdoc: Fix mismatched capitalization in sidebar

### DIFF
--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -357,7 +357,7 @@ fn sidebar_type_alias<'a>(
     deref_id_map: &'a DefIdMap<String>,
 ) {
     if let Some(inner_type) = &t.inner_type {
-        items.push(LinkBlock::forced(Link::new("aliased-type", "Aliased type"), "type"));
+        items.push(LinkBlock::forced(Link::new("aliased-type", "Aliased Type"), "type"));
         match inner_type {
             clean::TypeAliasInnerType::Enum { variants, is_non_exhaustive: _ } => {
                 let mut variants = variants

--- a/tests/rustdoc/type-alias/deref-32077.rs
+++ b/tests/rustdoc/type-alias/deref-32077.rs
@@ -19,8 +19,8 @@ impl<T> Foo for GenericStruct<T> {}
 impl Bar for GenericStruct<u32> {}
 
 //@ has 'foo/type.TypedefStruct.html'
-// We check that "Aliased type" is also present as a title in the sidebar.
-//@ has - '//*[@class="sidebar-elems"]//h3/a[@href="#aliased-type"]' 'Aliased type'
+// We check that "Aliased Type" is also present as a title in the sidebar.
+//@ has - '//*[@class="sidebar-elems"]//h3/a[@href="#aliased-type"]' 'Aliased Type'
 // We check that we have the implementation of the type alias itself.
 //@ has - '//*[@id="impl-GenericStruct%3Cu8%3E"]/h3' 'impl TypedefStruct'
 //@ has - '//*[@id="method.on_alias"]/h4' 'pub fn on_alias()'


### PR DESCRIPTION
Previously, the main content used "Aliased Type", while the sidebar said "Aliased type". Now, they both say "Aliased Type", which is the more common capitalization in Rustdoc.

See the following link for an example.
https://doc.rust-lang.org/1.83.0/std/io/type.Result.html

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
