### PR TITLE
Clarified the documentation on `core::iter::from_fn` and `core::iter::successors`

### DIFF
--- a/library/core/src/iter/sources/from_fn.rs
+++ b/library/core/src/iter/sources/from_fn.rs
@@ -3,6 +3,8 @@ use crate::fmt;
 /// Creates a new iterator where each iteration calls the provided closure
 /// `F: FnMut() -> Option<T>`.
 ///
+/// The iterator will yield the `T`s returned from the closure.
+///
 /// This allows creating a custom iterator with any behavior
 /// without using the more verbose syntax of creating a dedicated type
 /// and implementing the [`Iterator`] trait for it.

--- a/library/core/src/iter/sources/successors.rs
+++ b/library/core/src/iter/sources/successors.rs
@@ -5,6 +5,7 @@ use crate::iter::FusedIterator;
 ///
 /// The iterator starts with the given first item (if any)
 /// and calls the given `FnMut(&T) -> Option<T>` closure to compute each item’s successor.
+/// The iterator will yield the `T`s returned from the closure.
 ///
 /// ```
 /// use std::iter::successors;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This PR clarifies the closure requirements for `core::iter::from_fn` and `core::iter::successors`.

`std::iter::successors` in particular is a bit difficult to understand if you are not already familiar with the signature of [`checked_mul`](https://docs.rs/num/latest/num/trait.CheckedMul.html) used in the example.


See https://github.com/rust-lang/rust/issues/135087
