### PR TITLE
diagnostic attribute name

### DIFF
--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -31,7 +31,7 @@ const STR_SENTINEL: u8 = 0xC1;
 /// a `finish` method that finishes up encoding. If the encoder is fallible,
 /// `finish` should return a `Result` that indicates success or failure.
 ///
-/// This current does not support `f32` nor `f64`, as they're not needed in any
+/// This currently does not support `f32` nor `f64`, as they're not needed in any
 /// serialized data structures. That could be changed, but consider whether it
 /// really makes sense to store floating-point values at all.
 /// (If you need it, revert <https://github.com/rust-lang/rust/pull/109984>.)
@@ -81,7 +81,7 @@ pub trait Encoder {
 // infallibility made things faster and lots of code a little simpler and more
 // concise.
 ///
-/// This current does not support `f32` nor `f64`, as they're not needed in any
+/// This currently does not support `f32` nor `f64`, as they're not needed in any
 /// serialized data structures. That could be changed, but consider whether it
 /// really makes sense to store floating-point values at all.
 /// (If you need it, revert <https://github.com/rust-lang/rust/pull/109984>.)

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -234,7 +234,7 @@ pub(crate) struct CrateNameEmpty {
 }
 
 #[derive(Diagnostic)]
-#[diag(session_invalid_character_in_create_name)]
+#[diag(session_invalid_character_in_crate_name)]
 pub(crate) struct InvalidCharacterInCrateName {
     #[primary_span]
     pub(crate) span: Option<Span>,
@@ -246,7 +246,7 @@ pub(crate) struct InvalidCharacterInCrateName {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum InvalidCrateNameHelp {
-    #[help(session_invalid_character_in_create_name_help)]
+    #[help(session_invalid_character_in_crate_name_help)]
     AddCrateName,
 }
 


### PR DESCRIPTION


Changes in compiler/rustc_session/src/errors.rs:
- #[diag(session_invalid_character_in_create_name)]
+ #[diag(session_invalid_character_in_crate_name)]

Old word: "create" (verb meaning "to make")
New word: "crate" (Rust term for a compilation unit)

Reason:
The diagnostic attribute contained a typo using "create" instead of "crate". This is incorrect because the diagnostic is specifically about checking invalid characters in crate names, and "crate" is the proper Rust terminology for a compilation unit.

Testing:
- Compile the compiler
- Verify diagnostic triggers correctly
- Check error message displays properly
