### PR TITLE
mark deprecated option as deprecated in rustc_session to remove copypasta and small refactor

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -582,6 +582,7 @@ fn test_codegen_options_tracking_hash() {
     untracked!(dlltool, Some(PathBuf::from("custom_dlltool.exe")));
     untracked!(extra_filename, String::from("extra-filename"));
     untracked!(incremental, Some(String::from("abc")));
+    untracked!(inline_threshold, Some(0xf007ba11));
     // `link_arg` is omitted because it just forwards to `link_args`.
     untracked!(link_args, vec![String::from("abc"), String::from("def")]);
     untracked!(link_self_contained, LinkSelfContained::on());
@@ -613,7 +614,6 @@ fn test_codegen_options_tracking_hash() {
     tracked!(embed_bitcode, false);
     tracked!(force_frame_pointers, FramePointer::Always);
     tracked!(force_unwind_tables, Some(true));
-    tracked!(inline_threshold, Some(0xf007ba11));
     tracked!(instrument_coverage, InstrumentCoverage::Yes);
     tracked!(link_dead_code, Some(true));
     tracked!(linker_plugin_lto, LinkerPluginLto::LinkerPluginAuto);

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -239,7 +239,8 @@ macro_rules! options {
         $init:expr,
         $parse:ident,
         [$dep_tracking_marker:ident],
-        $desc:expr)
+        $desc:expr
+        $(, deprecated_do_nothing: $dnn:literal )?)
      ),* ,) =>
 (
     #[derive(Clone)]
@@ -280,7 +281,8 @@ macro_rules! options {
     }
 
     pub const $stat: OptionDescrs<$struct_name> =
-        &[ $( (stringify!($opt), $optmod::$opt, desc::$parse, $desc) ),* ];
+        &[ $( OptionDesc{ name: stringify!($opt), setter: $optmod::$opt,
+            type_desc: desc::$parse, desc: $desc, is_deprecated_and_do_nothing: false $( || $dnn )? } ),* ];
 
     mod $optmod {
     $(
@@ -315,7 +317,27 @@ macro_rules! redirect_field {
 }
 
 type OptionSetter<O> = fn(&mut O, v: Option<&str>) -> bool;
-type OptionDescrs<O> = &'static [(&'static str, OptionSetter<O>, &'static str, &'static str)];
+type OptionDescrs<O> = &'static [OptionDesc<O>];
+
+pub struct OptionDesc<O> {
+    name: &'static str,
+    setter: OptionSetter<O>,
+    // description for return value/type from mod desc
+    type_desc: &'static str,
+    // description for option from options table
+    desc: &'static str,
+    is_deprecated_and_do_nothing: bool,
+}
+
+impl<O> OptionDesc<O> {
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub fn desc(&self) -> &'static str {
+        self.desc
+    }
+}
 
 #[allow(rustc::untranslatable_diagnostic)] // FIXME: make this translatable
 fn build_options<O: Default>(
@@ -333,8 +355,13 @@ fn build_options<O: Default>(
         };
 
         let option_to_lookup = key.replace('-', "_");
-        match descrs.iter().find(|(name, ..)| *name == option_to_lookup) {
-            Some((_, setter, type_desc, _)) => {
+        match descrs.iter().find(|opt_desc| opt_desc.name == option_to_lookup) {
+            Some(OptionDesc { name: _, setter, type_desc, desc, is_deprecated_and_do_nothing }) => {
+                if *is_deprecated_and_do_nothing {
+                    // deprecation works for prefixed options only
+                    assert!(!prefix.is_empty());
+                    early_dcx.early_warn(format!("`-{prefix} {key}`: {desc}"));
+                }
                 if !setter(&mut op, value) {
                     match value {
                         None => early_dcx.early_fatal(
@@ -1546,7 +1573,8 @@ options! {
     // tidy-alphabetical-start
     #[rustc_lint_opt_deny_field_access("documented to do nothing")]
     ar: String = (String::new(), parse_string, [UNTRACKED],
-        "this option is deprecated and does nothing"),
+        "this option is deprecated and does nothing",
+        deprecated_do_nothing: true),
     #[rustc_lint_opt_deny_field_access("use `Session::code_model` instead of this field")]
     code_model: Option<CodeModel> = (None, parse_code_model, [TRACKED],
         "choose the code model to use (`rustc --print code-models` for details)"),
@@ -1578,9 +1606,10 @@ options! {
     incremental: Option<String> = (None, parse_opt_string, [UNTRACKED],
         "enable incremental compilation"),
     #[rustc_lint_opt_deny_field_access("documented to do nothing")]
-    inline_threshold: Option<u32> = (None, parse_opt_number, [TRACKED],
+    inline_threshold: Option<u32> = (None, parse_opt_number, [UNTRACKED],
         "this option is deprecated and does nothing \
-        (consider using `-Cllvm-args=--inline-threshold=...`)"),
+        (consider using `-Cllvm-args=--inline-threshold=...`)",
+        deprecated_do_nothing: true),
     #[rustc_lint_opt_deny_field_access("use `Session::instrument_coverage` instead of this field")]
     instrument_coverage: InstrumentCoverage = (InstrumentCoverage::No, parse_instrument_coverage, [TRACKED],
         "instrument the generated code to support LLVM source-based code coverage reports \
@@ -1616,7 +1645,8 @@ options! {
         "disable the use of the redzone"),
     #[rustc_lint_opt_deny_field_access("documented to do nothing")]
     no_stack_check: bool = (false, parse_no_value, [UNTRACKED],
-        "this option is deprecated and does nothing"),
+        "this option is deprecated and does nothing",
+        deprecated_do_nothing: true),
     no_vectorize_loops: bool = (false, parse_no_value, [TRACKED],
         "disable loop vectorization optimization passes"),
     no_vectorize_slp: bool = (false, parse_no_value, [TRACKED],

--- a/tests/ui/deprecation/deprecated_ar.rs
+++ b/tests/ui/deprecation/deprecated_ar.rs
@@ -1,0 +1,4 @@
+//@ check-pass
+//@ compile-flags: -Car=foo
+
+fn main() {}

--- a/tests/ui/deprecation/deprecated_ar.stderr
+++ b/tests/ui/deprecation/deprecated_ar.stderr
@@ -1,0 +1,2 @@
+warning: `-C ar`: this option is deprecated and does nothing
+

--- a/tests/ui/deprecation/deprecated_inline_threshold.bad_val.stderr
+++ b/tests/ui/deprecation/deprecated_inline_threshold.bad_val.stderr
@@ -1,0 +1,4 @@
+warning: `-C inline-threshold`: this option is deprecated and does nothing (consider using `-Cllvm-args=--inline-threshold=...`)
+
+error: incorrect value `asd` for codegen option `inline-threshold` - a number was expected
+

--- a/tests/ui/deprecation/deprecated_inline_threshold.good_val.stderr
+++ b/tests/ui/deprecation/deprecated_inline_threshold.good_val.stderr
@@ -1,0 +1,2 @@
+warning: `-C inline-threshold`: this option is deprecated and does nothing (consider using `-Cllvm-args=--inline-threshold=...`)
+

--- a/tests/ui/deprecation/deprecated_inline_threshold.no_val.stderr
+++ b/tests/ui/deprecation/deprecated_inline_threshold.no_val.stderr
@@ -1,0 +1,4 @@
+warning: `-C inline-threshold`: this option is deprecated and does nothing (consider using `-Cllvm-args=--inline-threshold=...`)
+
+error: codegen option `inline-threshold` requires a number (C inline-threshold=<value>)
+

--- a/tests/ui/deprecation/deprecated_inline_threshold.rs
+++ b/tests/ui/deprecation/deprecated_inline_threshold.rs
@@ -1,4 +1,8 @@
-//@ check-pass
-//@ compile-flags: -Cinline-threshold=666
+//@ revisions: good_val bad_val no_val
+//
+//@[good_val] compile-flags: -Cinline-threshold=666
+//@[good_val] check-pass
+//@[bad_val] compile-flags: -Cinline-threshold=asd
+//@[no_val] compile-flags: -Cinline-threshold
 
 fn main() {}

--- a/tests/ui/deprecation/deprecated_inline_threshold.stderr
+++ b/tests/ui/deprecation/deprecated_inline_threshold.stderr
@@ -1,2 +1,0 @@
-warning: the `-Cinline-threshold` flag is deprecated and does nothing (consider using `-Cllvm-args=--inline-threshold=...`)
-

--- a/tests/ui/deprecation/deprecated_no_stack_check_opt.rs
+++ b/tests/ui/deprecation/deprecated_no_stack_check_opt.rs
@@ -1,0 +1,4 @@
+//@ check-pass
+//@ compile-flags: -Cno-stack-check
+
+fn main() {}

--- a/tests/ui/deprecation/deprecated_no_stack_check_opt.stderr
+++ b/tests/ui/deprecation/deprecated_no_stack_check_opt.stderr
@@ -1,0 +1,2 @@
+warning: `-C no-stack-check`: this option is deprecated and does nothing
+


### PR DESCRIPTION
This marks deprecated options as deprecated via flag in options table in rustc_session, which removes copypasted deprecation text from rustc_driver_impl.

This also adds warning for deprecated `-C ar` option, which didn't emitted any warnings before.
Makes `inline_threshold` `[UNTRACKED]`, as it do nothing.
Adds few tests.

See individual commits.
