### PR TITLE
triagebot: label `src/doc/rustc-dev-guide` changes with `A-rustc-dev-guide`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -498,6 +498,11 @@ trigger_files = [
     "src/tools/compiletest"
 ]
 
+[autolabel."A-rustc-dev-guide"]
+trigger_files = [
+    "src/doc/rustc-dev-guide",
+]
+
 [notify-zulip."I-prioritize"]
 zulip_stream = 245100 # #t-compiler/wg-prioritization/alerts
 topic = "#{number} {title}"


### PR DESCRIPTION
Probably should also create a dev-guide reviewer pool for this repo 🤔 

r? @Kobzol 