### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1656,6 +1656,7 @@ supported_targets! {
     ("loongarch64-unknown-linux-gnu", loongarch64_unknown_linux_gnu),
     ("loongarch64-unknown-linux-musl", loongarch64_unknown_linux_musl),
     ("m68k-unknown-linux-gnu", m68k_unknown_linux_gnu),
+    ("m68k-unknown-none-elf", m68k_unknown_none_elf),
     ("csky-unknown-linux-gnuabiv2", csky_unknown_linux_gnuabiv2),
     ("csky-unknown-linux-gnuabiv2hf", csky_unknown_linux_gnuabiv2hf),
     ("mips-unknown-linux-gnu", mips_unknown_linux_gnu),

--- a/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs
@@ -1,0 +1,30 @@
+use crate::abi::Endian;
+use crate::spec::{CodeModel, PanicStrategy, Target, TargetOptions};
+
+pub(crate) fn target() -> Target {
+    let options = TargetOptions {
+        cpu: "M68010".into(),
+        max_atomic_width: None,
+        endian: Endian::Big,
+        // LLD currently does not have support for M68k
+        linker: Some("m68k-linux-gnu-ld".into()),
+        panic_strategy: PanicStrategy::Abort,
+        code_model: Some(CodeModel::Medium),
+        has_rpath: false,
+        ..Default::default()
+    };
+
+    Target {
+        llvm_target: "m68k".into(),
+        metadata: crate::spec::TargetMetadata {
+            description: Some("Motorola 680x0".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(false),
+        },
+        pointer_width: 32,
+        data_layout: "E-m:e-p:32:16:32-i8:8:8-i16:16:16-i32:16:32-n8:16:32-a:0:16-S16".into(),
+        arch: "m68k".into(),
+        options,
+    }
+}

--- a/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs
@@ -1,5 +1,5 @@
 use crate::abi::Endian;
-use crate::spec::{CodeModel, PanicStrategy, Target, TargetOptions};
+use crate::spec::{CodeModel, PanicStrategy, RelocModel, Target, TargetOptions};
 
 pub(crate) fn target() -> Target {
     let options = TargetOptions {
@@ -13,6 +13,7 @@ pub(crate) fn target() -> Target {
         has_rpath: false,
         // should be soft-float
         llvm_floatabi: None,
+        relocation_model: RelocModel::Static,
         ..Default::default()
     };
 

--- a/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs
@@ -11,6 +11,8 @@ pub(crate) fn target() -> Target {
         panic_strategy: PanicStrategy::Abort,
         code_model: Some(CodeModel::Medium),
         has_rpath: false,
+        // should be soft-float
+        llvm_floatabi: None,
         ..Default::default()
     };
 

--- a/library/std/src/f128.rs
+++ b/library/std/src/f128.rs
@@ -227,6 +227,7 @@ impl f128 {
     /// ```
     #[inline]
     #[rustc_allow_incoherent_impl]
+    #[doc(alias = "fmaf128", alias = "fusedMultiplyAdd")]
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn mul_add(self, a: f128, b: f128) -> f128 {
@@ -384,6 +385,7 @@ impl f128 {
     /// # }
     /// ```
     #[inline]
+    #[doc(alias = "squareRoot")]
     #[rustc_allow_incoherent_impl]
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]

--- a/library/std/src/f16.rs
+++ b/library/std/src/f16.rs
@@ -228,6 +228,7 @@ impl f16 {
     #[inline]
     #[rustc_allow_incoherent_impl]
     #[unstable(feature = "f16", issue = "116909")]
+    #[doc(alias = "fmaf16", alias = "fusedMultiplyAdd")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn mul_add(self, a: f16, b: f16) -> f16 {
         unsafe { intrinsics::fmaf16(self, a, b) }
@@ -384,6 +385,7 @@ impl f16 {
     /// # }
     /// ```
     #[inline]
+    #[doc(alias = "squareRoot")]
     #[rustc_allow_incoherent_impl]
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -210,6 +210,7 @@ impl f32 {
     /// assert_eq!(one_plus_eps * one_minus_eps + minus_one, 0.0);
     /// ```
     #[rustc_allow_incoherent_impl]
+    #[doc(alias = "fmaf", alias = "fusedMultiplyAdd")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -360,6 +361,7 @@ impl f32 {
     /// assert!(negative.sqrt().is_nan());
     /// assert!(negative_zero.sqrt() == negative_zero);
     /// ```
+    #[doc(alias = "squareRoot")]
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -210,6 +210,7 @@ impl f64 {
     /// assert_eq!(one_plus_eps * one_minus_eps + minus_one, 0.0);
     /// ```
     #[rustc_allow_incoherent_impl]
+    #[doc(alias = "fma", alias = "fusedMultiplyAdd")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -360,6 +361,7 @@ impl f64 {
     /// assert!(negative.sqrt().is_nan());
     /// assert!(negative_zero.sqrt() == negative_zero);
     /// ```
+    #[doc(alias = "squareRoot")]
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -60,6 +60,7 @@
     - [loongarch\*-unknown-linux-\*](platform-support/loongarch-linux.md)
     - [loongarch\*-unknown-none\*](platform-support/loongarch-none.md)
     - [m68k-unknown-linux-gnu](platform-support/m68k-unknown-linux-gnu.md)
+    - [m68k-unknown-none-elf](platform-support/m68k-unknown-none-elf.md)
     - [mips64-openwrt-linux-musl](platform-support/mips64-openwrt-linux-musl.md)
     - [mipsel-sony-psx](platform-support/mipsel-sony-psx.md)
     - [mipsisa\*r6\*-unknown-linux-gnu\*](platform-support/mips-release-6.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -317,6 +317,7 @@ target | std | host | notes
 [`i686-wrs-vxworks`](platform-support/vxworks.md) | ✓ |  | [^x86_32-floats-return-ABI]
 [`loongarch64-unknown-linux-ohos`](platform-support/openharmony.md) | ✓ |   | LoongArch64 OpenHarmony
 [`m68k-unknown-linux-gnu`](platform-support/m68k-unknown-linux-gnu.md) | ? |  | Motorola 680x0 Linux
+[`m68k-unknown-none-elf`](platform-support/m68k-unknown-none-elf.md) |  |  | Motorola 680x0
 `mips-unknown-linux-gnu` | ✓ | ✓ | MIPS Linux (kernel 4.4, glibc 2.23)
 `mips-unknown-linux-musl` | ✓ |  | MIPS Linux with musl 1.2.3
 `mips-unknown-linux-uclibc` | ✓ |  | MIPS Linux with uClibc

--- a/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
@@ -1,0 +1,110 @@
+# m68k-unknown-none-elf
+
+**Tier: 3**
+
+Motorola 680x0 Linux
+
+## Designated Developers
+
+* [@knickish](https://github.com/knickish)
+* [@glaubitz](https://github.com/glaubitz)
+* [@ricky26](https://github.com/ricky26)
+
+## Requirements
+
+This target requires am m68k build environment for cross-compilation which
+is available on Debian and Debian-based systems, openSUSE and other distributions.
+
+On Debian, it should be sufficient to install a g++ cross-compiler for the m68k
+architecture which will automatically pull in additional dependencies such as
+the glibc cross development package:
+
+```text
+# apt install g++-m68k-linux-gnu
+```
+
+Binaries can be run using QEMU user emulation. On Debian-based systems, it should be
+sufficient to install the package `qemu-user-static` to be able to run simple static
+binaries:
+
+```text
+# apt install qemu-user-static
+```
+
+To run more complex programs, it will be necessary to set up a Debian/m68k chroot with
+the help of the command `debootstrap`:
+
+```text
+# apt install debootstrap debian-ports-archive-keyring
+# debootstrap --keyring=/usr/share/keyrings/debian-ports-archive-keyring.gpg --arch=m68k unstable debian-68k http://ftp.ports.debian.org/debian-ports
+```
+
+This chroot can then seamlessly entered using the normal `chroot` command thanks to
+QEMU user emulation:
+
+```text
+# chroot /path/to/debian-68k
+```
+
+To get started with native builds, which are currently untested, a native Debian/m68k
+system can be installed either on real hardware such as 68k-based Commodore Amiga or
+Atari systems or emulated environments such as QEMU version 4.2 or newer or ARAnyM.
+
+ISO images for installation are provided by the Debian Ports team and can be obtained
+from the Debian CD image server available at:
+
+[https://cdimage.debian.org/cdimage/ports/current](https://cdimage.debian.org/cdimage/ports/current/)
+
+Documentation for Debian/m68k is available on the Debian Wiki at:
+
+[https://wiki.debian.org/M68k](https://wiki.debian.org/M68k)
+
+Support is available either through the `debian-68k` mailing list:
+
+[https://lists.debian.org/debian-68k/](https://lists.debian.org/debian-68k/)
+
+or the `#debian-68k` IRC channel on OFTC network.
+
+## Building
+
+At least llvm version `19.1.5` is required to build `core` and `alloc` for this target, and currently the gnu linker is required, as `lld` has no support for the `m68k` architecture
+
+## Cross-compilation
+
+This target can be cross-compiled from a standard Debian or Debian-based, openSUSE or any
+other distribution which has a basic m68k cross-toolchain available.
+
+## Testing
+
+Currently there is no support to run the rustc test suite for this target.
+
+## Building Rust programs
+
+Recommended `.cargo/config.toml`:
+```toml
+[unstable]
+build-std = ["panic_abort","core", "alloc"]
+
+[target.m68k-unknown-none-elf]
+# there is no easily available non-linux m68k linker, so just use the linux one
+linker = "m68k-linux-gnu-ld"
+
+# the mold linker also supports m68k, remove the above line and uncomment the
+# following ones to use that instead
+# linker = "clang"
+# rustflags = ["-C", "link-arg=-fuse-ld=/path/to/mold/binary"]
+```
+
+Rust programs can be built for this target using:
+
+```text
+cargo build --target m68k-unknown-none-elf
+```
+
+Very simple programs can be run using the `qemu-m68k-static` program:
+
+```text
+$ qemu-m68k-static your-code
+```
+
+For more complex applications, a chroot or native m68k system is required for testing.

--- a/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
@@ -2,7 +2,7 @@
 
 **Tier: 3**
 
-Motorola 680x0 Linux
+Bare metal Motorola 680x0
 
 ## Designated Developers
 
@@ -12,15 +12,15 @@ Motorola 680x0 Linux
 
 ## Requirements
 
-This target requires am m68k build environment for cross-compilation which
-is available on Debian and Debian-based systems, openSUSE and other distributions.
+This target requires an m68k build environment for cross-compilation which
+is available on Debian, Debian-based systems, openSUSE, and other distributions.
 
-On Debian, it should be sufficient to install a g++ cross-compiler for the m68k
+On Debian-based systems, it should be sufficient to install a g++ cross-compiler for the m68k
 architecture which will automatically pull in additional dependencies such as
 the glibc cross development package:
 
-```text
-# apt install g++-m68k-linux-gnu
+```sh
+apt install g++-m68k-linux-gnu
 ```
 
 Binaries can be run using QEMU user emulation. On Debian-based systems, it should be
@@ -83,10 +83,10 @@ Currently there is no support to run the rustc test suite for this target.
 Recommended `.cargo/config.toml`:
 ```toml
 [unstable]
-build-std = ["panic_abort","core", "alloc"]
+build-std = ["panic_abort", "core", "alloc"]
 
 [target.m68k-unknown-none-elf]
-# there is no easily available non-linux m68k linker, so just use the linux one
+# as we're building for ELF, the m68k-linux linker should be adequate
 linker = "m68k-linux-gnu-ld"
 
 # the mold linker also supports m68k, remove the above line and uncomment the
@@ -97,14 +97,14 @@ linker = "m68k-linux-gnu-ld"
 
 Rust programs can be built for this target using:
 
-```text
+```sh
 cargo build --target m68k-unknown-none-elf
 ```
 
 Very simple programs can be run using the `qemu-m68k-static` program:
 
-```text
-$ qemu-m68k-static your-code
+```sh
+qemu-m68k-static your-code
 ```
 
 For more complex applications, a chroot or native m68k system is required for testing.

--- a/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
@@ -7,8 +7,6 @@ Bare metal Motorola 680x0
 ## Designated Developers
 
 * [@knickish](https://github.com/knickish)
-* [@glaubitz](https://github.com/glaubitz)
-* [@ricky26](https://github.com/ricky26)
 
 ## Requirements
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -114,6 +114,7 @@ static TARGETS: &[&str] = &[
     "loongarch64-unknown-none",
     "loongarch64-unknown-none-softfloat",
     "m68k-unknown-linux-gnu",
+    "m68k-unknown-none-elf",
     "csky-unknown-linux-gnuabiv2",
     "csky-unknown-linux-gnuabiv2hf",
     "mips-unknown-linux-gnu",

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -617,6 +617,7 @@ fn is_big_endian() {
         ("x86_64-unknown-linux-gnu", false),
         ("bpfeb-unknown-none", true),
         ("m68k-unknown-linux-gnu", true),
+        ("m68k-unknown-none-elf", true),
         ("aarch64_be-unknown-linux-gnu", true),
         ("powerpc64-unknown-linux-gnu", true),
     ];

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -617,7 +617,6 @@ fn is_big_endian() {
         ("x86_64-unknown-linux-gnu", false),
         ("bpfeb-unknown-none", true),
         ("m68k-unknown-linux-gnu", true),
-        ("m68k-unknown-none-elf", true),
         ("aarch64_be-unknown-linux-gnu", true),
         ("powerpc64-unknown-linux-gnu", true),
     ];

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -261,6 +261,9 @@
 //@ revisions: m68k_unknown_linux_gnu
 //@ [m68k_unknown_linux_gnu] compile-flags: --target m68k-unknown-linux-gnu
 //@ [m68k_unknown_linux_gnu] needs-llvm-components: m68k
+//@ revisions: m68k_unknown_none_elf
+//@ [m68k_unknown_none_elf] compile-flags: --target m68k-unknown-none-elf
+//@ [m68k_unknown_none_elf] needs-llvm-components: m68k
 //@ revisions: mips64_openwrt_linux_musl
 //@ [mips64_openwrt_linux_musl] compile-flags: --target mips64-openwrt-linux-musl
 //@ [mips64_openwrt_linux_musl] needs-llvm-components: mips

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -990,6 +990,10 @@ https://github.com/rust-lang/reference/blob/HEAD/src/identifiers.md.
 """
 cc = ["@ehuss"]
 
+[mentions."src/doc/rustc-dev-guide"]
+message = "The rustc-dev-guide subtree was changed. If this PR *only* touches the dev guide consider submitting a PR directly to [rust-lang/rustc-dev-guide](https://github.com/rust-lang/rustc-dev-guide/pulls) otherwise thank you for updating the dev guide with your changes."
+cc = ["@BoxyUwU", "@jieyouxu", "@kobzol"]
+
 [assign]
 warn_non_default_branch.enable = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
@@ -1208,7 +1212,7 @@ project-exploit-mitigations = [
 "/src/doc/nomicon" =                                     ["@ehuss"]
 "/src/doc/reference" =                                   ["@ehuss"]
 "/src/doc/rust-by-example" =                             ["@ehuss"]
-"/src/doc/rustc-dev-guide" =                             ["@kobzol", "@jieyouxu"]
+"/src/doc/rustc-dev-guide" =                             ["compiler"]
 "/src/doc/rustdoc" =                                     ["rustdoc"]
 "/src/doc/style-guide" =                                 ["style-team"]
 "/src/etc" =                                             ["@Mark-Simulacrum"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -498,6 +498,11 @@ trigger_files = [
     "src/tools/compiletest"
 ]
 
+[autolabel."A-rustc-dev-guide"]
+trigger_files = [
+    "src/doc/rustc-dev-guide",
+]
+
 [notify-zulip."I-prioritize"]
 zulip_stream = 245100 # #t-compiler/wg-prioritization/alerts
 topic = "#{number} {title}"


### PR DESCRIPTION
Successful merges:

 - #135085 (add m68k-unknown-none-elf target)
 - #135111 (Add doc aliases for `libm` and IEEE names)
 - #135129 (triagebot: label `src/doc/rustc-dev-guide` changes with `A-rustc-dev-guide`)
 - #135132 (dev guide ping group and set adhoc reviewers to compiler)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135085,135111,135129,135132)
<!-- homu-ignore:end -->

try-job: dist-aarch64-apple