### PR TITLE
std: net: Add function to return the system hostname

### DIFF
--- a/library/std/src/net/hostname.rs
+++ b/library/std/src/net/hostname.rs
@@ -5,7 +5,18 @@ use crate::ffi::OsString;
 /// This can error out in platform-specific error cases;
 /// for example, uefi and wasm, where hostnames aren't
 /// supported.
+///
+/// # Underlying system calls
+///
+/// | Platform | System call                                                                                             |
+/// |----------|---------------------------------------------------------------------------------------------------------|
+/// | UNIX     | [`gethostname`](https://www.man7.org/linux/man-pages/man2/gethostname.2.html)                           |
+/// | Windows  | [`GetHostNameW`](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-gethostnamew) |
+///
+/// Note that platform-specific behavior [may change in the future][changes].
+///
+/// [changes]: crate::io#platform-specific-behavior
 #[unstable(feature = "gethostname", issue = "135142")]
 pub fn hostname() -> crate::io::Result<OsString> {
-    crate::sys_common::net::gethostname()
+    crate::sys::net::gethostname()
 }

--- a/library/std/src/net/hostname.rs
+++ b/library/std/src/net/hostname.rs
@@ -1,0 +1,11 @@
+use crate::ffi::OsString;
+
+/// Returns the system hostname.
+///
+/// This can error out in platform-specific error cases;
+/// for example, uefi and wasm, where hostnames aren't
+/// supported.
+#[unstable(feature = "gethostname", issue = "135142")]
+pub fn hostname() -> crate::io::Result<OsString> {
+    crate::sys_common::net::gethostname()
+}

--- a/library/std/src/net/mod.rs
+++ b/library/std/src/net/mod.rs
@@ -1,7 +1,8 @@
 //! Networking primitives for TCP/UDP communication.
 //!
 //! This module provides networking functionality for the Transmission Control and User
-//! Datagram Protocols, as well as types for IP and socket addresses.
+//! Datagram Protocols, as well as types for IP and socket addresses, and functions related
+//! to network properties.
 //!
 //! # Organization
 //!
@@ -24,6 +25,8 @@
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::net::AddrParseError;
 
+#[unstable(feature = "gethostname", issue = "135142")]
+pub use self::hostname::hostname;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::ip_addr::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -36,6 +39,7 @@ pub use self::tcp::{Incoming, TcpListener, TcpStream};
 pub use self::udp::UdpSocket;
 use crate::io::{self, ErrorKind};
 
+mod hostname;
 mod ip_addr;
 mod socket_addr;
 mod tcp;

--- a/library/std/src/sys/pal/unsupported/net.rs
+++ b/library/std/src/sys/pal/unsupported/net.rs
@@ -1,8 +1,13 @@
+use crate::ffi::OsString;
 use crate::fmt;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut};
 use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
 use crate::sys::unsupported;
 use crate::time::Duration;
+
+pub fn gethostname() -> crate::io::Result<OsString> {
+    unsupported()
+}
 
 pub struct TcpStream(!);
 

--- a/library/std/src/sys/pal/windows/c/bindings.txt
+++ b/library/std/src/sys/pal/windows/c/bindings.txt
@@ -1978,7 +1978,7 @@ Windows.Win32.Networking.WinSock.FD_SET
 Windows.Win32.Networking.WinSock.FIONBIO
 Windows.Win32.Networking.WinSock.freeaddrinfo
 Windows.Win32.Networking.WinSock.getaddrinfo
-Windows.Win32.Networking.WinSock.gethostname
+Windows.Win32.Networking.WinSock.GetHostNameW
 Windows.Win32.Networking.WinSock.getpeername
 Windows.Win32.Networking.WinSock.getsockname
 Windows.Win32.Networking.WinSock.getsockopt

--- a/library/std/src/sys/pal/windows/c/bindings.txt
+++ b/library/std/src/sys/pal/windows/c/bindings.txt
@@ -1978,6 +1978,7 @@ Windows.Win32.Networking.WinSock.FD_SET
 Windows.Win32.Networking.WinSock.FIONBIO
 Windows.Win32.Networking.WinSock.freeaddrinfo
 Windows.Win32.Networking.WinSock.getaddrinfo
+Windows.Win32.Networking.WinSock.gethostname
 Windows.Win32.Networking.WinSock.getpeername
 Windows.Win32.Networking.WinSock.getsockname
 Windows.Win32.Networking.WinSock.getsockopt

--- a/library/std/src/sys/pal/windows/c/windows_sys.rs
+++ b/library/std/src/sys/pal/windows/c/windows_sys.rs
@@ -113,6 +113,7 @@ windows_targets::link!("ntdll.dll" "system" fn NtReadFile(filehandle : HANDLE, e
 windows_targets::link!("ntdll.dll" "system" fn NtWriteFile(filehandle : HANDLE, event : HANDLE, apcroutine : PIO_APC_ROUTINE, apccontext : *const core::ffi::c_void, iostatusblock : *mut IO_STATUS_BLOCK, buffer : *const core::ffi::c_void, length : u32, byteoffset : *const i64, key : *const u32) -> NTSTATUS);
 windows_targets::link!("ntdll.dll" "system" fn RtlNtStatusToDosError(status : NTSTATUS) -> u32);
 windows_targets::link!("userenv.dll" "system" fn GetUserProfileDirectoryW(htoken : HANDLE, lpprofiledir : PWSTR, lpcchsize : *mut u32) -> BOOL);
+windows_targets::link!("ws2_32.dll" "system" fn GetHostNameW(name : PWSTR, namelen : i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn WSACleanup() -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn WSADuplicateSocketW(s : SOCKET, dwprocessid : u32, lpprotocolinfo : *mut WSAPROTOCOL_INFOW) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn WSAGetLastError() -> WSA_ERROR);
@@ -126,7 +127,6 @@ windows_targets::link!("ws2_32.dll" "system" fn closesocket(s : SOCKET) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn connect(s : SOCKET, name : *const SOCKADDR, namelen : i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn freeaddrinfo(paddrinfo : *const ADDRINFOA));
 windows_targets::link!("ws2_32.dll" "system" fn getaddrinfo(pnodename : PCSTR, pservicename : PCSTR, phints : *const ADDRINFOA, ppresult : *mut *mut ADDRINFOA) -> i32);
-windows_targets::link!("ws2_32.dll" "system" fn gethostname(name : PSTR, namelen : i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn getpeername(s : SOCKET, name : *mut SOCKADDR, namelen : *mut i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn getsockname(s : SOCKET, name : *mut SOCKADDR, namelen : *mut i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn getsockopt(s : SOCKET, level : i32, optname : i32, optval : PSTR, optlen : *mut i32) -> i32);

--- a/library/std/src/sys/pal/windows/c/windows_sys.rs
+++ b/library/std/src/sys/pal/windows/c/windows_sys.rs
@@ -126,6 +126,7 @@ windows_targets::link!("ws2_32.dll" "system" fn closesocket(s : SOCKET) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn connect(s : SOCKET, name : *const SOCKADDR, namelen : i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn freeaddrinfo(paddrinfo : *const ADDRINFOA));
 windows_targets::link!("ws2_32.dll" "system" fn getaddrinfo(pnodename : PCSTR, pservicename : PCSTR, phints : *const ADDRINFOA, ppresult : *mut *mut ADDRINFOA) -> i32);
+windows_targets::link!("ws2_32.dll" "system" fn gethostname(name : PSTR, namelen : i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn getpeername(s : SOCKET, name : *mut SOCKADDR, namelen : *mut i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn getsockname(s : SOCKET, name : *mut SOCKADDR, namelen : *mut i32) -> i32);
 windows_targets::link!("ws2_32.dll" "system" fn getsockopt(s : SOCKET, level : i32, optname : i32, optval : PSTR, optlen : *mut i32) -> i32);

--- a/library/std/src/sys/pal/windows/net.rs
+++ b/library/std/src/sys/pal/windows/net.rs
@@ -31,8 +31,8 @@ pub mod netc {
         IP_DROP_MEMBERSHIP, IP_MULTICAST_LOOP, IP_MULTICAST_TTL, IP_TTL, IPPROTO_IP, IPPROTO_IPV6,
         IPV6_ADD_MEMBERSHIP, IPV6_DROP_MEMBERSHIP, IPV6_MULTICAST_LOOP, IPV6_V6ONLY, SO_BROADCAST,
         SO_RCVTIMEO, SO_SNDTIMEO, SOCK_DGRAM, SOCK_STREAM, SOCKADDR as sockaddr,
-        SOCKADDR_STORAGE as sockaddr_storage, SOL_SOCKET, bind, connect, freeaddrinfo, getpeername,
-        getsockname, getsockopt, listen, setsockopt,
+        SOCKADDR_STORAGE as sockaddr_storage, SOL_SOCKET, bind, connect, freeaddrinfo, gethostname,
+        getpeername, getsockname, getsockopt, listen, setsockopt,
     };
 
     #[allow(non_camel_case_types)]

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::ffi::{c_int, c_void};
+use crate::ffi::{CStr, OsString, c_char, c_int, c_void};
 use crate::io::{self, BorrowedCursor, ErrorKind, IoSlice, IoSliceMut};
 use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
 use crate::sys::common::small_c_string::run_with_cstr;
@@ -213,6 +213,31 @@ impl<'a> TryFrom<(&'a str, u16)> for LookupHost {
             }
         })
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// gethostname
+////////////////////////////////////////////////////////////////////////////////
+
+pub fn gethostname() -> crate::io::Result<OsString> {
+    init();
+    // 255 bytes is the maximum allowable length for a hostname (as per the DNS spec),
+    // so we shouldn't ever have problems with this. I (@orowith2os) considered using a constant
+    // and letting the platform set the length, but it was determined after some discussion that
+    // this could break things if the platform changes their length. Possible alternative is to
+    // read the sysconf setting for the max hostname length, but that might be a bit too much work.
+    // The 256 byte length is to allow for the NUL terminator.
+    let mut temp_buffer: [c_char; 256] = [0; 256];
+
+    // SAFETY: should never be unsafe, as we're passing in a valid (0-initialized) buffer, and the
+    // length of said buffer.
+    unsafe {
+        cvt(c::gethostname(temp_buffer.as_mut_ptr() as _, temp_buffer.len() as _))?;
+    }
+
+    // SAFETY: we already know the pointer here is valid, we made it from safe Rust earlier.
+    let cstring = unsafe { CStr::from_ptr(temp_buffer.as_mut_ptr()) };
+    Ok(OsString::from(cstring.to_string_lossy().as_ref()))
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Resolves https://github.com/rust-lang/libs-team/issues/330
Tracking issue: https://github.com/rust-lang/rust/issues/135142

Now you can retrieve the system hostname, without relying on anything other than `std`! 

This is my first pull request to the Rust standard library (or anything inside rust-lang/rust, period, quite possible rust-lang itself), so there are bound to be issues. I'll try my best to resolve them.
