### PR TITLE
Don't enable anyhow's `backtrace` feature in opt-dist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,6 @@ name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "ar_archive_writer"

--- a/src/tools/opt-dist/Cargo.toml
+++ b/src/tools/opt-dist/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 build_helper = { path = "../../build_helper" }
 env_logger = "0.11"
 log = "0.4"
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = "1"
 humantime = "2"
 humansize = "2"
 sysinfo = { version = "0.31.2", default-features = false, features = ["disk"] }


### PR DESCRIPTION
As of the stabilization of `std::backtrace` in Rust 1.65, this package flag has no effect other than to enable an unused dependency on the `backtrace` crate.

(See <https://github.com/dtolnay/anyhow/blob/af0937ef72fbaf9784a6c991e029738728d025e2/Cargo.toml#L18-L23>.)

While the presence of this feature in opt-dist doesn't cause other tools (which use anyhow) to actually *build* backtrace, it does affect the global crate graph used for dependency version resolution. After removing this feature, we can use `cargo tree --invert --package backtrace` to see that the only remaining reverse-dependency of backtrace is `color-eyre`, which is used by `ui_test`.