### PR TITLE
A few borrowck tweaks to improve 2024 edition migration lints

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -661,9 +661,6 @@ impl UseSpans<'_> {
             UseSpans::ClosureUse { args_span: span, .. }
             | UseSpans::PatUse(span)
             | UseSpans::OtherUse(span) => span,
-            UseSpans::FnSelfUse { fn_call_span, kind: CallKind::DerefCoercion { .. }, .. } => {
-                fn_call_span
-            }
             UseSpans::FnSelfUse { var_span, .. } => var_span,
         }
     }
@@ -674,9 +671,6 @@ impl UseSpans<'_> {
             UseSpans::ClosureUse { path_span: span, .. }
             | UseSpans::PatUse(span)
             | UseSpans::OtherUse(span) => span,
-            UseSpans::FnSelfUse { fn_call_span, kind: CallKind::DerefCoercion { .. }, .. } => {
-                fn_call_span
-            }
             UseSpans::FnSelfUse { var_span, .. } => var_span,
         }
     }
@@ -687,9 +681,6 @@ impl UseSpans<'_> {
             UseSpans::ClosureUse { capture_kind_span: span, .. }
             | UseSpans::PatUse(span)
             | UseSpans::OtherUse(span) => span,
-            UseSpans::FnSelfUse { fn_call_span, kind: CallKind::DerefCoercion { .. }, .. } => {
-                fn_call_span
-            }
             UseSpans::FnSelfUse { var_span, .. } => var_span,
         }
     }

--- a/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
+++ b/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
@@ -2,11 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/tail-expr-in-nested-expr.rs:4:15
    |
 LL |     let _ = { String::new().as_str() }.len();
-   |               ^^^^^^^^^^^^^---------
+   |               ^^^^^^^^^^^^^        -   --- borrow later used by call
    |               |                    |
    |               |                    temporary value is freed at the end of this statement
    |               creates a temporary value which is freed while still in use
-   |               borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
 

--- a/tests/ui/lint/lint-const-item-mutation.stderr
+++ b/tests/ui/lint/lint-const-item-mutation.stderr
@@ -75,10 +75,15 @@ warning: taking a mutable reference to a `const` item
   --> $DIR/lint-const-item-mutation.rs:42:5
    |
 LL |     (&mut MY_STRUCT).use_mut();
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: each usage of a `const` item creates a new temporary
    = note: the mutable reference will refer to this temporary, not the original `const` item
+note: mutable reference created due to call to this method
+  --> $DIR/lint-const-item-mutation.rs:9:5
+   |
+LL |     fn use_mut(&mut self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^
 note: `const` item defined here
   --> $DIR/lint-const-item-mutation.rs:27:1
    |

--- a/tests/ui/moves/move-deref-coercion.stderr
+++ b/tests/ui/moves/move-deref-coercion.stderr
@@ -4,7 +4,7 @@ error[E0382]: borrow of partially moved value: `val`
 LL |     let _val = val.first;
    |                --------- value partially moved here
 LL |     val.inner;
-   |     ^^^^^^^^^ value borrowed here after partial move
+   |     ^^^ value borrowed here after partial move
    |
    = note: partial move occurs because `val.first` has type `NotCopy`, which does not implement the `Copy` trait
    = note: borrow occurs due to deref coercion to `NotCopy`
@@ -20,7 +20,7 @@ error[E0382]: borrow of partially moved value: `val`
 LL |     let _val = val.first;
    |                --------- value partially moved here
 LL |     val.inner_method();
-   |     ^^^^^^^^^^^^^^^^^^ value borrowed here after partial move
+   |     ^^^ value borrowed here after partial move
    |
    = note: partial move occurs because `val.first` has type `NotCopy`, which does not implement the `Copy` trait
    = note: borrow occurs due to deref coercion to `NotCopy`

--- a/tests/ui/no-capture-arc.stderr
+++ b/tests/ui/no-capture-arc.stderr
@@ -1,5 +1,5 @@
 error[E0382]: borrow of moved value: `arc_v`
-  --> $DIR/no-capture-arc.rs:14:16
+  --> $DIR/no-capture-arc.rs:14:18
    |
 LL |     let arc_v = Arc::new(v);
    |         ----- move occurs because `arc_v` has type `Arc<Vec<i32>>`, which does not implement the `Copy` trait
@@ -10,7 +10,7 @@ LL |         assert_eq!((*arc_v)[3], 4);
    |                      ----- variable moved due to use in closure
 ...
 LL |     assert_eq!((*arc_v)[2], 3);
-   |                ^^^^^^^^ value borrowed here after move
+   |                  ^^^^^ value borrowed here after move
    |
    = note: borrow occurs due to deref coercion to `Vec<i32>`
 

--- a/tests/ui/no-reuse-move-arc.stderr
+++ b/tests/ui/no-reuse-move-arc.stderr
@@ -1,5 +1,5 @@
 error[E0382]: borrow of moved value: `arc_v`
-  --> $DIR/no-reuse-move-arc.rs:12:16
+  --> $DIR/no-reuse-move-arc.rs:12:18
    |
 LL |     let arc_v = Arc::new(v);
    |         ----- move occurs because `arc_v` has type `Arc<Vec<i32>>`, which does not implement the `Copy` trait
@@ -10,7 +10,7 @@ LL |         assert_eq!((*arc_v)[3], 4);
    |                      ----- variable moved due to use in closure
 ...
 LL |     assert_eq!((*arc_v)[2], 3);
-   |                ^^^^^^^^ value borrowed here after move
+   |                  ^^^^^ value borrowed here after move
    |
    = note: borrow occurs due to deref coercion to `Vec<i32>`
 


### PR DESCRIPTION
See first two commits' changes to test outputs. Test coverage in this area is kinda weak, but I think it affects more cases than this (like the craters that will begin to trigger the `tail_expr_drop_order` tests in #134523).

Third commit is a drive-by change that removes a deref hack from `UseSpans` which doesn't really improve diagnostics much.