### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -661,9 +661,6 @@ impl UseSpans<'_> {
             UseSpans::ClosureUse { args_span: span, .. }
             | UseSpans::PatUse(span)
             | UseSpans::OtherUse(span) => span,
-            UseSpans::FnSelfUse { fn_call_span, kind: CallKind::DerefCoercion { .. }, .. } => {
-                fn_call_span
-            }
             UseSpans::FnSelfUse { var_span, .. } => var_span,
         }
     }
@@ -674,9 +671,6 @@ impl UseSpans<'_> {
             UseSpans::ClosureUse { path_span: span, .. }
             | UseSpans::PatUse(span)
             | UseSpans::OtherUse(span) => span,
-            UseSpans::FnSelfUse { fn_call_span, kind: CallKind::DerefCoercion { .. }, .. } => {
-                fn_call_span
-            }
             UseSpans::FnSelfUse { var_span, .. } => var_span,
         }
     }
@@ -687,9 +681,6 @@ impl UseSpans<'_> {
             UseSpans::ClosureUse { capture_kind_span: span, .. }
             | UseSpans::PatUse(span)
             | UseSpans::OtherUse(span) => span,
-            UseSpans::FnSelfUse { fn_call_span, kind: CallKind::DerefCoercion { .. }, .. } => {
-                fn_call_span
-            }
             UseSpans::FnSelfUse { var_span, .. } => var_span,
         }
     }

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1244,8 +1244,8 @@ impl<'tcx> LateLintPass<'tcx> for UngatedAsyncFnTrackCaller {
 
 declare_lint! {
     /// The `unreachable_pub` lint triggers for `pub` items not reachable from other crates - that
-    /// means neither directly accessible, nor reexported, nor leaked through things like return
-    /// types.
+    /// means neither directly accessible, nor reexported (with `pub use`), nor leaked through
+    /// things like return types (which the [`unnameable_types`] lint can detect if desired).
     ///
     /// ### Example
     ///
@@ -1272,8 +1272,10 @@ declare_lint! {
     /// intent that the item is only visible within its own crate.
     ///
     /// This lint is "allow" by default because it will trigger for a large
-    /// amount existing Rust code, and has some false-positives. Eventually it
+    /// amount of existing Rust code, and has some false-positives. Eventually it
     /// is desired for this to become warn-by-default.
+    ///
+    /// [`unnameable_types`]: #unnameable-types
     pub UNREACHABLE_PUB,
     Allow,
     "`pub` items not reachable from crate root"

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4362,7 +4362,7 @@ declare_lint! {
     /// ### Explanation
     ///
     /// It is often expected that if you can obtain an object of type `T`, then
-    /// you can name the type `T` as well, this lint attempts to enforce this rule.
+    /// you can name the type `T` as well; this lint attempts to enforce this rule.
     /// The recommended action is to either reexport the type properly to make it nameable,
     /// or document that users are not supposed to be able to name it for one reason or another.
     ///

--- a/library/std/src/f128.rs
+++ b/library/std/src/f128.rs
@@ -227,6 +227,7 @@ impl f128 {
     /// ```
     #[inline]
     #[rustc_allow_incoherent_impl]
+    #[doc(alias = "fmaf128", alias = "fusedMultiplyAdd")]
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn mul_add(self, a: f128, b: f128) -> f128 {
@@ -384,6 +385,7 @@ impl f128 {
     /// # }
     /// ```
     #[inline]
+    #[doc(alias = "squareRoot")]
     #[rustc_allow_incoherent_impl]
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]

--- a/library/std/src/f16.rs
+++ b/library/std/src/f16.rs
@@ -228,6 +228,7 @@ impl f16 {
     #[inline]
     #[rustc_allow_incoherent_impl]
     #[unstable(feature = "f16", issue = "116909")]
+    #[doc(alias = "fmaf16", alias = "fusedMultiplyAdd")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn mul_add(self, a: f16, b: f16) -> f16 {
         unsafe { intrinsics::fmaf16(self, a, b) }
@@ -384,6 +385,7 @@ impl f16 {
     /// # }
     /// ```
     #[inline]
+    #[doc(alias = "squareRoot")]
     #[rustc_allow_incoherent_impl]
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -210,6 +210,7 @@ impl f32 {
     /// assert_eq!(one_plus_eps * one_minus_eps + minus_one, 0.0);
     /// ```
     #[rustc_allow_incoherent_impl]
+    #[doc(alias = "fmaf", alias = "fusedMultiplyAdd")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -360,6 +361,7 @@ impl f32 {
     /// assert!(negative.sqrt().is_nan());
     /// assert!(negative_zero.sqrt() == negative_zero);
     /// ```
+    #[doc(alias = "squareRoot")]
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -210,6 +210,7 @@ impl f64 {
     /// assert_eq!(one_plus_eps * one_minus_eps + minus_one, 0.0);
     /// ```
     #[rustc_allow_incoherent_impl]
+    #[doc(alias = "fma", alias = "fusedMultiplyAdd")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -360,6 +361,7 @@ impl f64 {
     /// assert!(negative.sqrt().is_nan());
     /// assert!(negative_zero.sqrt() == negative_zero);
     /// ```
+    #[doc(alias = "squareRoot")]
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
+++ b/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
@@ -2,11 +2,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/tail-expr-in-nested-expr.rs:4:15
    |
 LL |     let _ = { String::new().as_str() }.len();
-   |               ^^^^^^^^^^^^^---------
+   |               ^^^^^^^^^^^^^        -   --- borrow later used by call
    |               |                    |
    |               |                    temporary value is freed at the end of this statement
    |               creates a temporary value which is freed while still in use
-   |               borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
 

--- a/tests/ui/lint/lint-const-item-mutation.stderr
+++ b/tests/ui/lint/lint-const-item-mutation.stderr
@@ -75,10 +75,15 @@ warning: taking a mutable reference to a `const` item
   --> $DIR/lint-const-item-mutation.rs:42:5
    |
 LL |     (&mut MY_STRUCT).use_mut();
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: each usage of a `const` item creates a new temporary
    = note: the mutable reference will refer to this temporary, not the original `const` item
+note: mutable reference created due to call to this method
+  --> $DIR/lint-const-item-mutation.rs:9:5
+   |
+LL |     fn use_mut(&mut self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^
 note: `const` item defined here
   --> $DIR/lint-const-item-mutation.rs:27:1
    |

--- a/tests/ui/moves/move-deref-coercion.stderr
+++ b/tests/ui/moves/move-deref-coercion.stderr
@@ -4,7 +4,7 @@ error[E0382]: borrow of partially moved value: `val`
 LL |     let _val = val.first;
    |                --------- value partially moved here
 LL |     val.inner;
-   |     ^^^^^^^^^ value borrowed here after partial move
+   |     ^^^ value borrowed here after partial move
    |
    = note: partial move occurs because `val.first` has type `NotCopy`, which does not implement the `Copy` trait
    = note: borrow occurs due to deref coercion to `NotCopy`
@@ -20,7 +20,7 @@ error[E0382]: borrow of partially moved value: `val`
 LL |     let _val = val.first;
    |                --------- value partially moved here
 LL |     val.inner_method();
-   |     ^^^^^^^^^^^^^^^^^^ value borrowed here after partial move
+   |     ^^^ value borrowed here after partial move
    |
    = note: partial move occurs because `val.first` has type `NotCopy`, which does not implement the `Copy` trait
    = note: borrow occurs due to deref coercion to `NotCopy`

--- a/tests/ui/no-capture-arc.stderr
+++ b/tests/ui/no-capture-arc.stderr
@@ -1,5 +1,5 @@
 error[E0382]: borrow of moved value: `arc_v`
-  --> $DIR/no-capture-arc.rs:14:16
+  --> $DIR/no-capture-arc.rs:14:18
    |
 LL |     let arc_v = Arc::new(v);
    |         ----- move occurs because `arc_v` has type `Arc<Vec<i32>>`, which does not implement the `Copy` trait
@@ -10,7 +10,7 @@ LL |         assert_eq!((*arc_v)[3], 4);
    |                      ----- variable moved due to use in closure
 ...
 LL |     assert_eq!((*arc_v)[2], 3);
-   |                ^^^^^^^^ value borrowed here after move
+   |                  ^^^^^ value borrowed here after move
    |
    = note: borrow occurs due to deref coercion to `Vec<i32>`
 

--- a/tests/ui/no-reuse-move-arc.stderr
+++ b/tests/ui/no-reuse-move-arc.stderr
@@ -1,5 +1,5 @@
 error[E0382]: borrow of moved value: `arc_v`
-  --> $DIR/no-reuse-move-arc.rs:12:16
+  --> $DIR/no-reuse-move-arc.rs:12:18
    |
 LL |     let arc_v = Arc::new(v);
    |         ----- move occurs because `arc_v` has type `Arc<Vec<i32>>`, which does not implement the `Copy` trait
@@ -10,7 +10,7 @@ LL |         assert_eq!((*arc_v)[3], 4);
    |                      ----- variable moved due to use in closure
 ...
 LL |     assert_eq!((*arc_v)[2], 3);
-   |                ^^^^^^^^ value borrowed here after move
+   |                  ^^^^^ value borrowed here after move
    |
    = note: borrow occurs due to deref coercion to `Vec<i32>`
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -990,6 +990,10 @@ https://github.com/rust-lang/reference/blob/HEAD/src/identifiers.md.
 """
 cc = ["@ehuss"]
 
+[mentions."src/doc/rustc-dev-guide"]
+message = "The rustc-dev-guide subtree was changed. If this PR *only* touches the dev guide consider submitting a PR directly to [rust-lang/rustc-dev-guide](https://github.com/rust-lang/rustc-dev-guide/pulls) otherwise thank you for updating the dev guide with your changes."
+cc = ["@BoxyUwU", "@jieyouxu", "@kobzol"]
+
 [assign]
 warn_non_default_branch.enable = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
@@ -1208,7 +1212,7 @@ project-exploit-mitigations = [
 "/src/doc/nomicon" =                                     ["@ehuss"]
 "/src/doc/reference" =                                   ["@ehuss"]
 "/src/doc/rust-by-example" =                             ["@ehuss"]
-"/src/doc/rustc-dev-guide" =                             ["@kobzol", "@jieyouxu"]
+"/src/doc/rustc-dev-guide" =                             ["compiler"]
 "/src/doc/rustdoc" =                                     ["rustdoc"]
 "/src/doc/style-guide" =                                 ["style-team"]
 "/src/etc" =                                             ["@Mark-Simulacrum"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -498,6 +498,11 @@ trigger_files = [
     "src/tools/compiletest"
 ]
 
+[autolabel."A-rustc-dev-guide"]
+trigger_files = [
+    "src/doc/rustc-dev-guide",
+]
+
 [notify-zulip."I-prioritize"]
 zulip_stream = 245100 # #t-compiler/wg-prioritization/alerts
 topic = "#{number} {title}"


### PR DESCRIPTION
Successful merges:

 - #135111 (Add doc aliases for `libm` and IEEE names)
 - #135129 (triagebot: label `src/doc/rustc-dev-guide` changes with `A-rustc-dev-guide`)
 - #135132 (dev guide ping group and set adhoc reviewers to compiler)
 - #135145 (Mention `unnameable_types` in `unreachable_pub` documentation.)
 - #135147 (A few borrowck tweaks to improve 2024 edition migration lints)
 - #135150 (move footnote to ordinary comment)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135111,135129,135132,135145,135147,135150)
<!-- homu-ignore:end -->