### PR TITLE
Move the has_errors check in rustdoc back to after TyCtxt is created

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -865,11 +865,11 @@ fn main_args(
         }
 
         let krate = rustc_interface::passes::parse(sess);
-        if sess.dcx().has_errors().is_some() {
-            sess.dcx().fatal("Compilation failed, aborting rustdoc");
-        }
-
         rustc_interface::create_and_enter_global_ctxt(compiler, krate, |tcx| {
+            if sess.dcx().has_errors().is_some() {
+                sess.dcx().fatal("Compilation failed, aborting rustdoc");
+            }
+
             let (krate, render_opts, mut cache) = sess.time("run_global_ctxt", || {
                 core::run_global_ctxt(tcx, show_coverage, render_options, output_format)
             });


### PR DESCRIPTION
This was accidentally moved before TyCtxt creation by https://github.com/rust-lang/rust/pull/134302.
