### PR TITLE
Update triagebot.toml: celinval vacation is over

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -824,7 +824,7 @@ cc = ["@rust-lang/rustfmt"]
 
 [mentions."compiler/rustc_middle/src/mir/syntax.rs"]
 message = "This PR changes MIR"
-cc = ["@oli-obk", "@RalfJung", "@JakobDegen", "@davidtwco", "@celinval", "@vakaras"]
+cc = ["@oli-obk", "@RalfJung", "@JakobDegen", "@davidtwco", "@vakaras"]
 
 [mentions."compiler/rustc_error_messages"]
 message = "`rustc_error_messages` was changed"
@@ -1004,7 +1004,6 @@ warn_non_default_branch.enable = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
 users_on_vacation = [
     "jyn514",
-    "celinval",
     "nnethercote",
     "spastorino",
     "workingjubilee",


### PR DESCRIPTION
I'm also removing myself from the MIR syntax changes notifications.
