### PR TITLE
rustdoc: use stable paths as preferred canonical paths

### DIFF
--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -1,5 +1,6 @@
 use std::mem;
 
+use rustc_attr_parsing::StabilityLevel;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, DefIdSet};
 use rustc_middle::ty::{self, TyCtxt};
@@ -306,7 +307,12 @@ impl DocFolder for CacheBuilder<'_, '_> {
             | clean::ProcMacroItem(..)
             | clean::VariantItem(..) => {
                 use rustc_data_structures::fx::IndexEntry as Entry;
-                if !self.cache.stripped_mod {
+                if !self.cache.stripped_mod
+                    && !matches!(
+                        item.stability.map(|stab| stab.level),
+                        Some(StabilityLevel::Stable { allowed_through_unstable_modules: true, .. })
+                    )
+                {
                     // Re-exported items mean that the same id can show up twice
                     // in the rustdoc ast that we're looking at. We know,
                     // however, that a re-exported item doesn't show up in the

--- a/tests/rustdoc/inline_local/fully-stable-path-is-better.rs
+++ b/tests/rustdoc/inline_local/fully-stable-path-is-better.rs
@@ -1,0 +1,40 @@
+//! Test case for [134702]
+//!
+//! [134702]: https://github.com/rust-lang/rust/issues/134702
+#![crate_name = "foo"]
+#![stable(since = "1.0", feature = "v1")]
+
+#![feature(staged_api, rustc_attrs)]
+
+#[stable(since = "1.0", feature = "stb1")]
+pub mod stb1 {
+    #[doc(inline)]
+    #[stable(since = "1.0", feature = "stb1")]
+    pub use crate::uns::Inside1;
+}
+
+#[unstable(feature = "uns", issue = "135003")]
+pub mod uns {
+    #[stable(since = "1.0", feature = "stb1")]
+    #[rustc_allowed_through_unstable_modules]
+    pub struct Inside1;
+    #[stable(since = "1.0", feature = "stb2")]
+    #[rustc_allowed_through_unstable_modules]
+    pub struct Inside2;
+}
+
+#[stable(since = "1.0", feature = "stb2")]
+pub mod stb2 {
+    #[doc(inline)]
+    #[stable(since = "1.0", feature = "stb2")]
+    pub use crate::uns::Inside2;
+}
+
+#[stable(since = "1.0", feature = "nested")]
+pub mod nested {
+    //! [Inside1] [Inside2]
+    //@ has foo/nested/index.html '//a[@href="../stb1/struct.Inside1.html"]' 'Inside1'
+    //@ has foo/nested/index.html '//a[@href="../stb2/struct.Inside2.html"]' 'Inside2'
+    use crate::stb1::Inside1;
+    use crate::stb2::Inside2;
+}


### PR DESCRIPTION
This accomplishes something like 16a4ad7d7b0d163f7be6803c786c3b83d42913bb, but with the `rustc_allowed_through_unstable_modules` attribute instead of the path length.

Fixes #131676