### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,6 @@ name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
-dependencies = [
- "backtrace",
-]
 
 [[package]]
 name = "ar_archive_writer"

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1845,13 +1845,18 @@ pub(super) fn check_coroutine_obligations(
 
     debug!(?typeck_results.coroutine_stalled_predicates);
 
+    let mode = if tcx.next_trait_solver_globally() {
+        TypingMode::post_borrowck_analysis(tcx, def_id)
+    } else {
+        TypingMode::analysis_in_body(tcx, def_id)
+    };
+
     let infcx = tcx
         .infer_ctxt()
         // typeck writeback gives us predicates with their regions erased.
         // As borrowck already has checked lifetimes, we do not need to do it again.
         .ignoring_regions()
-        // FIXME(#132279): This should eventually use the already defined hidden types.
-        .build(TypingMode::analysis_in_body(tcx, def_id));
+        .build(mode);
 
     let ocx = ObligationCtxt::new_with_diagnostics(&infcx);
     for (predicate, cause) in &typeck_results.coroutine_stalled_predicates {
@@ -1864,12 +1869,14 @@ pub(super) fn check_coroutine_obligations(
         return Err(infcx.err_ctxt().report_fulfillment_errors(errors));
     }
 
-    // Check that any hidden types found when checking these stalled coroutine obligations
-    // are valid.
-    for (key, ty) in infcx.take_opaque_types() {
-        let hidden_type = infcx.resolve_vars_if_possible(ty.hidden_type);
-        let key = infcx.resolve_vars_if_possible(key);
-        sanity_check_found_hidden_type(tcx, key, hidden_type)?;
+    if !tcx.next_trait_solver_globally() {
+        // Check that any hidden types found when checking these stalled coroutine obligations
+        // are valid.
+        for (key, ty) in infcx.take_opaque_types() {
+            let hidden_type = infcx.resolve_vars_if_possible(ty.hidden_type);
+            let key = infcx.resolve_vars_if_possible(key);
+            sanity_check_found_hidden_type(tcx, key, hidden_type)?;
+        }
     }
 
     Ok(())

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -114,7 +114,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         //
                         // We rely on a few heuristics to identify cases where this root
                         // obligation is more important than the leaf obligation:
-                        let (main_trait_predicate, o) = if let ty::PredicateKind::Clause(
+                        let (main_trait_predicate, main_obligation) = if let ty::PredicateKind::Clause(
                             ty::ClauseKind::Trait(root_pred)
                         ) = root_obligation.predicate.kind().skip_binder()
                             && !leaf_trait_predicate.self_ty().skip_binder().has_escaping_bound_vars()
@@ -199,7 +199,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             notes,
                             parent_label,
                             append_const_msg,
-                        } = self.on_unimplemented_note(main_trait_predicate, o, &mut long_ty_file);
+                        } = self.on_unimplemented_note(main_trait_predicate, main_obligation, &mut long_ty_file);
 
                         let have_alt_message = message.is_some() || label.is_some();
                         let is_try_conversion = self.is_try_conversion(span, main_trait_ref.def_id());

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -550,7 +550,7 @@ impl OsString {
         OsStr::from_inner_mut(self.inner.leak())
     }
 
-    /// Truncate the the `OsString` to the specified length.
+    /// Truncate the `OsString` to the specified length.
     ///
     /// # Panics
     /// Panics if `len` does not lie on a valid `OsStr` boundary

--- a/library/std/src/pipe.rs
+++ b/library/std/src/pipe.rs
@@ -97,7 +97,7 @@ impl PipeReader {
     /// let mut jobs = vec![];
     /// let (reader, mut writer) = std::pipe::pipe()?;
     ///
-    /// // Write NUM_SLOT characters the the pipe.
+    /// // Write NUM_SLOT characters the pipe.
     /// writer.write_all(&[b'|'; NUM_SLOT as usize])?;
     ///
     /// // Spawn several processes that read a character from the pipe, do some work, then

--- a/library/std/src/sync/poison/mutex.rs
+++ b/library/std/src/sync/poison/mutex.rs
@@ -534,7 +534,7 @@ impl<T: ?Sized> Mutex<T> {
     /// # Errors
     ///
     /// If another user of this mutex panicked while holding the mutex, then
-    /// this call will return an error containing the the underlying data
+    /// this call will return an error containing the underlying data
     /// instead.
     ///
     /// # Examples

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -943,8 +943,6 @@ impl<'a> Builder<'a> {
                 test::Ui,
                 test::Crashes,
                 test::Coverage,
-                test::CoverageMap,
-                test::CoverageRun,
                 test::MirOpt,
                 test::Codegen,
                 test::CodegenUnits,

--- a/src/ci/docker/host-x86_64/dist-riscv64-linux/patches/gcc/8.5.0/0002-hidden-jump-target.patch
+++ b/src/ci/docker/host-x86_64/dist-riscv64-linux/patches/gcc/8.5.0/0002-hidden-jump-target.patch
@@ -10,7 +10,7 @@ https://sourceware.org/bugzilla/show_bug.cgi?id=28509
 And this is the first version of the proposed binutils patch,
 https://sourceware.org/pipermail/binutils/2021-November/118398.html
 
-After applying the binutils patch, I get the the unexpected error when
+After applying the binutils patch, I get the unexpected error when
 building libgcc,
 
 /scratch/nelsonc/riscv-gnu-toolchain/riscv-gcc/libgcc/config/riscv/div.S:42:

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -865,11 +865,11 @@ fn main_args(
         }
 
         let krate = rustc_interface::passes::parse(sess);
-        if sess.dcx().has_errors().is_some() {
-            sess.dcx().fatal("Compilation failed, aborting rustdoc");
-        }
-
         rustc_interface::create_and_enter_global_ctxt(compiler, krate, |tcx| {
+            if sess.dcx().has_errors().is_some() {
+                sess.dcx().fatal("Compilation failed, aborting rustdoc");
+            }
+
             let (krate, render_opts, mut cache) = sess.time("run_global_ctxt", || {
                 core::run_global_ctxt(tcx, show_coverage, render_options, output_format)
             });

--- a/src/tools/opt-dist/Cargo.toml
+++ b/src/tools/opt-dist/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 build_helper = { path = "../../build_helper" }
 env_logger = "0.11"
 log = "0.4"
-anyhow = { version = "1", features = ["backtrace"] }
+anyhow = "1"
 humantime = "2"
 humansize = "2"
 sysinfo = { version = "0.31.2", default-features = false, features = ["disk"] }

--- a/tests/ui/coroutine/issue-52304.rs
+++ b/tests/ui/coroutine/issue-52304.rs
@@ -1,4 +1,6 @@
 //@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
 
 #![feature(coroutines, coroutine_trait)]
 

--- a/tests/ui/duplicate/multiple-types-with-same-name-and-derive.rs
+++ b/tests/ui/duplicate/multiple-types-with-same-name-and-derive.rs
@@ -1,5 +1,5 @@
 // Here, there are two types with the same name. One of these has a `derive` annotation, but in the
-// expansion these `impl`s are associated to the the *other* type. There is a suggestion to remove
+// expansion these `impl`s are associated to the *other* type. There is a suggestion to remove
 // unneeded type parameters, but because we're now point at a type with no type parameters, the
 // suggestion would suggest removing code from an empty span, which would ICE in nightly.
 //

--- a/tests/ui/traits/const-traits/double-error-for-unimplemented-trait.rs
+++ b/tests/ui/traits/const-traits/double-error-for-unimplemented-trait.rs
@@ -1,0 +1,22 @@
+// Make sure we don't issue *two* error messages for the trait predicate *and* host predicate.
+
+#![feature(const_trait_impl)]
+
+#[const_trait]
+trait Trait {
+  type Out;
+}
+
+const fn needs_const<T: ~const Trait>(_: &T) {}
+
+const IN_CONST: () = {
+  needs_const(&());
+  //~^ ERROR the trait bound `(): Trait` is not satisfied
+};
+
+const fn conditionally_const() {
+  needs_const(&());
+  //~^ ERROR the trait bound `(): Trait` is not satisfied
+}
+
+fn main() {}

--- a/tests/ui/traits/const-traits/double-error-for-unimplemented-trait.stderr
+++ b/tests/ui/traits/const-traits/double-error-for-unimplemented-trait.stderr
@@ -1,0 +1,41 @@
+error[E0277]: the trait bound `(): Trait` is not satisfied
+  --> $DIR/double-error-for-unimplemented-trait.rs:13:15
+   |
+LL |   needs_const(&());
+   |   ----------- ^^^ the trait `Trait` is not implemented for `()`
+   |   |
+   |   required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/double-error-for-unimplemented-trait.rs:6:1
+   |
+LL | trait Trait {
+   | ^^^^^^^^^^^
+note: required by a bound in `needs_const`
+  --> $DIR/double-error-for-unimplemented-trait.rs:10:25
+   |
+LL | const fn needs_const<T: ~const Trait>(_: &T) {}
+   |                         ^^^^^^^^^^^^ required by this bound in `needs_const`
+
+error[E0277]: the trait bound `(): Trait` is not satisfied
+  --> $DIR/double-error-for-unimplemented-trait.rs:18:15
+   |
+LL |   needs_const(&());
+   |   ----------- ^^^ the trait `Trait` is not implemented for `()`
+   |   |
+   |   required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/double-error-for-unimplemented-trait.rs:6:1
+   |
+LL | trait Trait {
+   | ^^^^^^^^^^^
+note: required by a bound in `needs_const`
+  --> $DIR/double-error-for-unimplemented-trait.rs:10:25
+   |
+LL | const fn needs_const<T: ~const Trait>(_: &T) {}
+   |                         ^^^^^^^^^^^^ required by this bound in `needs_const`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.current.stderr
+++ b/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.current.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> $DIR/const-in-impl-fn-return-type.rs:15:39
+  --> $DIR/const-in-impl-fn-return-type.rs:20:39
    |
 LL |     fn func<const N: u32>() -> [(); { () }] {
    |                                       ^^ expected `usize`, found `()`
 
 error: the constant `N` is not of type `usize`
-  --> $DIR/const-in-impl-fn-return-type.rs:7:32
+  --> $DIR/const-in-impl-fn-return-type.rs:12:32
    |
 LL |     fn func<const N: u32>() -> [(); N];
    |                                ^^^^^^^ expected `usize`, found `u32`

--- a/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.next.stderr
+++ b/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.next.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/const-in-impl-fn-return-type.rs:20:39
+   |
+LL |     fn func<const N: u32>() -> [(); { () }] {
+   |                                       ^^ expected `usize`, found `()`
+
+error: the constant `N` is not of type `usize`
+  --> $DIR/const-in-impl-fn-return-type.rs:12:32
+   |
+LL |     fn func<const N: u32>() -> [(); N];
+   |                                ^^^^^^^ expected `usize`, found `u32`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.rs
+++ b/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.rs
@@ -1,4 +1,9 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@ ignore-compare-mode-next-solver (explicit revisions)
+
 // Regression test for #114918
+
 // Test that a const generic enclosed in a block within the return type
 // of an impl fn produces a type mismatch error instead of triggering
 // a const eval cycle


### PR DESCRIPTION
Successful merges:

 - #134742 (Use `PostBorrowckAnalysis` in `check_coroutine_obligations`)
 - #134771 (Report correct `SelectionError` for `ConstArgHasType` in new solver fulfill)
 - #134951 (Suppress host effect predicates if underlying trait doesn't hold)
 - #135097 (bootstrap: Consolidate coverage test suite steps into a single step)
 - #135146 (Don't enable anyhow's `backtrace` feature in opt-dist)
 - #135153 (chore: remove redundant words in comment)
 - #135157 (Move the has_errors check in rustdoc back to after TyCtxt is created)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134742,134771,134951,135097,135146,135153,135157)
<!-- homu-ignore:end -->