### PR TITLE
Avoid replacing the definition of `CURRENT_RUSTC_VERSION`

### DIFF
--- a/compiler/rustc_attr_data_structures/src/stability.rs
+++ b/compiler/rustc_attr_data_structures/src/stability.rs
@@ -9,7 +9,12 @@ use crate::RustcVersion;
 /// `since` field of the `#[stable]` attribute.
 ///
 /// For more, see [this pull request](https://github.com/rust-lang/rust/pull/100591).
-pub const VERSION_PLACEHOLDER: &str = "CURRENT_RUSTC_VERSION";
+pub const VERSION_PLACEHOLDER: &str = concat!("CURRENT_RUSTC_VERSIO", "N");
+// Note that the `concat!` macro above prevents `src/tools/replace-version-placeholder` from
+// replacing the constant with the current version. Hardcoding the tool to skip this file doesn't
+// work as the file can (and at some point will) be moved around.
+//
+// Turning the `concat!` macro into a string literal will make Pietro cry. That'd be sad :(
 
 /// Represents the following attributes:
 ///

--- a/src/tools/replace-version-placeholder/src/main.rs
+++ b/src/tools/replace-version-placeholder/src/main.rs
@@ -11,12 +11,7 @@ fn main() {
     let version_str = version_str.trim();
     walk::walk_many(
         &[&root_path.join("compiler"), &root_path.join("library")],
-        |path, _is_dir| {
-            walk::filter_dirs(path)
-                // We exempt these as they require the placeholder
-                // for their operation
-                || path.ends_with("compiler/rustc_attr/src/builtin.rs")
-        },
+        |path, _is_dir| walk::filter_dirs(path),
         &mut |entry, contents| {
             if !contents.contains(VERSION_PLACEHOLDER) {
                 return;


### PR DESCRIPTION
Before this PR, replace-version-placeholder hardcoded the path defining CURRENT_RUSTC_VERSION (to avoid replacing it). After a refactor moved the file defining it without changing the hardcoded path, the tool started replacing the constant itself with the version number.

To avoid this from happening in the future, this changes the definition of the constant to avoid the tool from ever matching it.

r? @workingjubilee  

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
