### PR TITLE
Make sure to use `Receiver` trait when extracting object method candidate

### DIFF
--- a/tests/ui/self/arbitrary_self_types_dispatch_to_vtable.rs
+++ b/tests/ui/self/arbitrary_self_types_dispatch_to_vtable.rs
@@ -1,0 +1,33 @@
+//@ check-pass
+
+#![feature(derive_coerce_pointee)]
+#![feature(arbitrary_self_types)]
+
+use std::marker::CoercePointee;
+use std::ops::Receiver;
+
+// `CoercePointee` isn't needed here, it's just a simpler
+// (and more conceptual) way of deriving `DispatchFromDyn`.
+// You could think of `MyDispatcher` as a smart pointer
+// that just doesn't deref to its target type.
+#[derive(CoercePointee)]
+#[repr(transparent)]
+struct MyDispatcher<T: ?Sized>(*const T);
+
+impl<T: ?Sized> Receiver for MyDispatcher<T> {
+    type Target = T;
+}
+struct Test;
+
+trait Trait {
+    fn test(self: MyDispatcher<Self>);
+}
+
+impl Trait for Test {
+    fn test(self: MyDispatcher<Self>) {
+        todo!()
+    }
+}
+fn main() {
+    MyDispatcher::<dyn Trait>(core::ptr::null_mut::<Test>()).test();
+}


### PR DESCRIPTION
In method confirmation, the `extract_existential_trait_ref` function re-extracts the object type by derefing until it reaches an object. If we're assembling methods via the `Receiver` trait, make sure we re-do our work also using the receiver trait.

Fixes #135155

cc @adetaylor