### PR TITLE
mgca: Lower all const paths as `ConstArgKind::Path`

### DIFF
--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -190,7 +190,8 @@ fn make_format_args(
                                 && let [stmt] = block.stmts.as_slice()
                                 && let StmtKind::Expr(expr) = &stmt.kind
                                 && let ExprKind::Path(None, path) = &expr.kind
-                                && path.is_potential_trivial_const_arg()
+                                && path.segments.len() == 1
+                                && path.segments[0].args.is_none()
                             {
                                 err.multipart_suggestion(
                                     "quote your inlined format argument to use as string literal",

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -576,6 +576,13 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         EncodeCrossCrate::Yes, experimental!(patchable_function_entry)
     ),
 
+    // Probably temporary component of min_generic_const_args.
+    // `#[type_const] const ASSOC: usize;`
+    gated!(
+        type_const, Normal, template!(Word), ErrorFollowing,
+        EncodeCrossCrate::Yes, min_generic_const_args, experimental!(type_const),
+    ),
+
     // ==========================================================================
     // Internal attributes: Stability, deprecation, and unsafe:
     // ==========================================================================

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -468,11 +468,13 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
                 // Good error for `where Trait::method(..): Send`.
                 let Some(self_ty) = opt_self_ty else {
-                    return self.error_missing_qpath_self_ty(
+                    let guar = self.error_missing_qpath_self_ty(
                         trait_def_id,
                         hir_ty.span,
                         item_segment,
+                        ty::AssocKind::Type,
                     );
+                    return Ty::new_error(tcx, guar);
                 };
                 let self_ty = self.lower_ty(self_ty);
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -115,7 +115,7 @@ fn generic_arg_mismatch_err(
                     body.value.kind
                 && let Res::Def(DefKind::Fn { .. }, id) = path.res
             {
-                // FIXME(min_generic_const_args): this branch is dead once new const path lowering
+                // FIXME(mgca): this branch is dead once new const path lowering
                 // (for single-segment paths) is no longer gated
                 err.help(format!("`{}` is a function item, not a type", tcx.item_name(id)));
                 err.help("function item types cannot be named directly");

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -2174,7 +2174,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                 let result = self
                     .lowerer()
-                    .lower_assoc_path(hir_id, path_span, ty.raw, qself, segment, true);
+                    .lower_assoc_path_ty(hir_id, path_span, ty.raw, qself, segment, true);
                 let ty = result
                     .map(|(ty, _, _)| ty)
                     .unwrap_or_else(|guar| Ty::new_error(self.tcx(), guar));

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2083,6 +2083,7 @@ symbols! {
         type_ascribe,
         type_ascription,
         type_changing_struct_update,
+        type_const,
         type_id,
         type_ir_inherent,
         type_length_limit,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -3250,7 +3250,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         obligation: &PredicateObligation<'tcx>,
         span: Span,
     ) -> Result<Diag<'a>, ErrorGuaranteed> {
-        if !self.tcx.features().generic_const_exprs() {
+        if !self.tcx.features().generic_const_exprs()
+            && !self.tcx.features().min_generic_const_args()
+        {
             let guar = self
                 .dcx()
                 .struct_span_err(span, "constant expression depends on a generic parameter")

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -85,6 +85,12 @@ pub fn is_const_evaluatable<'tcx>(
             }
             _ => bug!("unexpected constkind in `is_const_evalautable: {unexpanded_ct:?}`"),
         }
+    } else if tcx.features().min_generic_const_args() {
+        // This is a sanity check to make sure that non-generics consts are checked to
+        // be evaluatable in case they aren't cchecked elsewhere. This will NOT error
+        // if the const uses generics, as desired.
+        crate::traits::evaluate_const(infcx, unexpanded_ct, param_env);
+        Ok(())
     } else {
         let uv = match unexpanded_ct.kind() {
             ty::ConstKind::Unevaluated(uv) => uv,

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -410,7 +410,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let predicate = obligation.predicate.skip_binder();
 
         let mut assume = predicate.trait_ref.args.const_at(2);
-        // FIXME(min_generic_const_exprs): We should shallowly normalize this.
+        // FIXME(mgca): We should shallowly normalize this.
         if self.tcx().features().generic_const_exprs() {
             assume = crate::traits::evaluate_const(self.infcx, assume, obligation.param_env)
         }

--- a/tests/ui/associated-inherent-types/issue-109299-1.stderr
+++ b/tests/ui/associated-inherent-types/issue-109299-1.stderr
@@ -2,7 +2,7 @@ error[E0220]: associated type `Cursor` not found for `Lexer<T>` in the current s
   --> $DIR/issue-109299-1.rs:10:40
    |
 LL | struct Lexer<T>(T);
-   | --------------- associated item `Cursor` not found for this struct
+   | --------------- associated type `Cursor` not found for this struct
 ...
 LL | type X = impl for<T> Fn() -> Lexer<T>::Cursor;
    |                                        ^^^^^^ associated item not found in `Lexer<T>`
@@ -14,7 +14,7 @@ error[E0220]: associated type `Cursor` not found for `Lexer<T>` in the current s
   --> $DIR/issue-109299-1.rs:10:40
    |
 LL | struct Lexer<T>(T);
-   | --------------- associated item `Cursor` not found for this struct
+   | --------------- associated type `Cursor` not found for this struct
 ...
 LL | type X = impl for<T> Fn() -> Lexer<T>::Cursor;
    |                                        ^^^^^^ associated item not found in `Lexer<T>`

--- a/tests/ui/associated-inherent-types/not-found-self-type-differs-shadowing-trait-item.shadowed.stderr
+++ b/tests/ui/associated-inherent-types/not-found-self-type-differs-shadowing-trait-item.shadowed.stderr
@@ -2,7 +2,7 @@ error[E0220]: associated type `Pr` not found for `S<bool>` in the current scope
   --> $DIR/not-found-self-type-differs-shadowing-trait-item.rs:28:23
    |
 LL | struct S<T>(T);
-   | ----------- associated item `Pr` not found for this struct
+   | ----------- associated type `Pr` not found for this struct
 ...
 LL |     let _: S::<bool>::Pr = ();
    |                       ^^ associated item not found in `S<bool>`

--- a/tests/ui/associated-inherent-types/not-found-self-type-differs.stderr
+++ b/tests/ui/associated-inherent-types/not-found-self-type-differs.stderr
@@ -2,7 +2,7 @@ error[E0220]: associated type `Proj` not found for `Family<Option<()>>` in the c
   --> $DIR/not-found-self-type-differs.rs:15:32
    |
 LL | struct Family<T>(T);
-   | ---------------- associated item `Proj` not found for this struct
+   | ---------------- associated type `Proj` not found for this struct
 ...
 LL |     let _: Family<Option<()>>::Proj;
    |                                ^^^^ associated item not found in `Family<Option<()>>`
@@ -15,7 +15,7 @@ error[E0220]: associated type `Proj` not found for `Family<PathBuf>` in the curr
   --> $DIR/not-found-self-type-differs.rs:16:40
    |
 LL | struct Family<T>(T);
-   | ---------------- associated item `Proj` not found for this struct
+   | ---------------- associated type `Proj` not found for this struct
 ...
 LL |     let _: Family<std::path::PathBuf>::Proj = ();
    |                                        ^^^^ associated item not found in `Family<PathBuf>`

--- a/tests/ui/associated-inherent-types/not-found-unsatisfied-bounds-0.stderr
+++ b/tests/ui/associated-inherent-types/not-found-unsatisfied-bounds-0.stderr
@@ -2,7 +2,7 @@ error: the associated type `Yield` exists for `Container<[u8]>`, but its trait b
   --> $DIR/not-found-unsatisfied-bounds-0.rs:19:29
    |
 LL | struct Container<T: ?Sized>(T);
-   | --------------------------- associated item `Yield` not found for this struct
+   | --------------------------- associated type `Yield` not found for this struct
 ...
 LL |     let _: Container<[u8]>::Yield = 1;
    |                             ^^^^^ associated type cannot be referenced on `Container<[u8]>` due to unsatisfied trait bounds
@@ -14,7 +14,7 @@ error: the associated type `Combination` exists for `Duple<String, Rc<str>>`, bu
   --> $DIR/not-found-unsatisfied-bounds-0.rs:20:45
    |
 LL | struct Duple<T, U>(T, U);
-   | ------------------ associated item `Combination` not found for this struct
+   | ------------------ associated type `Combination` not found for this struct
 ...
 LL |     let _: Duple<String, std::rc::Rc<str>>::Combination;
    |                                             ^^^^^^^^^^^ associated type cannot be referenced on `Duple<String, Rc<str>>` due to unsatisfied trait bounds

--- a/tests/ui/associated-inherent-types/not-found-unsatisfied-bounds-1.stderr
+++ b/tests/ui/associated-inherent-types/not-found-unsatisfied-bounds-1.stderr
@@ -5,7 +5,7 @@ LL |     let _: Container<T>::Proj = String::new();
    |                          ^^^^ associated type cannot be referenced on `Container<T>` due to unsatisfied trait bounds
 ...
 LL | struct Container<T>(T);
-   | ------------------- associated item `Proj` not found for this struct
+   | ------------------- associated type `Proj` not found for this struct
    |
    = note: the following trait bounds were not satisfied:
            `T: Clone`

--- a/tests/ui/associated-inherent-types/not-found-unsatisfied-bounds-in-multiple-impls.stderr
+++ b/tests/ui/associated-inherent-types/not-found-unsatisfied-bounds-in-multiple-impls.stderr
@@ -2,7 +2,7 @@ error: the associated type `X` exists for `S<Featureless, Featureless>`, but its
   --> $DIR/not-found-unsatisfied-bounds-in-multiple-impls.rs:19:43
    |
 LL | struct S<A, B>(A, B);
-   | -------------- associated item `X` not found for this struct
+   | -------------- associated type `X` not found for this struct
 LL | struct Featureless;
    | ------------------ doesn't satisfy `Featureless: One` or `Featureless: Two`
 ...

--- a/tests/ui/const-generics/mgca/ambiguous-assoc-const.rs
+++ b/tests/ui/const-generics/mgca/ambiguous-assoc-const.rs
@@ -1,0 +1,15 @@
+#![feature(min_generic_const_args)]
+#![expect(incomplete_features)]
+
+trait Tr {
+    const N: usize;
+}
+
+struct Blah<const N: usize>;
+
+fn foo() -> Blah<{ Tr::N }> {
+    //~^ ERROR ambiguous associated constant
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/ambiguous-assoc-const.stderr
+++ b/tests/ui/const-generics/mgca/ambiguous-assoc-const.stderr
@@ -1,0 +1,15 @@
+error[E0223]: ambiguous associated constant
+  --> $DIR/ambiguous-assoc-const.rs:10:20
+   |
+LL | fn foo() -> Blah<{ Tr::N }> {
+   |                    ^^^^^
+   |
+help: if there were a type named `Example` that implemented `Tr`, you could use the fully-qualified path
+   |
+LL - fn foo() -> Blah<{ Tr::N }> {
+LL + fn foo() -> Blah<{ <Example as Tr>::N }> {
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0223`.

--- a/tests/ui/const-generics/mgca/assoc-const-without-type_const.rs
+++ b/tests/ui/const-generics/mgca/assoc-const-without-type_const.rs
@@ -1,0 +1,14 @@
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features)]
+
+pub trait Tr {
+    const SIZE: usize;
+}
+
+fn mk_array<T: Tr>(_x: T) -> [(); T::SIZE] {
+    //~^ ERROR type_const
+    [(); T::SIZE]
+    //~^ ERROR type_const
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/assoc-const-without-type_const.stderr
+++ b/tests/ui/const-generics/mgca/assoc-const-without-type_const.stderr
@@ -1,0 +1,18 @@
+error: use of trait associated const without `#[type_const]`
+  --> $DIR/assoc-const-without-type_const.rs:8:35
+   |
+LL | fn mk_array<T: Tr>(_x: T) -> [(); T::SIZE] {
+   |                                   ^^^^^^^
+   |
+   = note: the declaration in the trait must be marked with `#[type_const]`
+
+error: use of trait associated const without `#[type_const]`
+  --> $DIR/assoc-const-without-type_const.rs:10:10
+   |
+LL |     [(); T::SIZE]
+   |          ^^^^^^^
+   |
+   = note: the declaration in the trait must be marked with `#[type_const]`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/const-generics/mgca/assoc-const.rs
+++ b/tests/ui/const-generics/mgca/assoc-const.rs
@@ -1,0 +1,15 @@
+//@ check-pass
+
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features)]
+
+pub trait Tr<X> {
+    #[type_const]
+    const SIZE: usize;
+}
+
+fn mk_array<T: Tr<bool>>(_x: T) -> [(); <T as Tr<bool>>::SIZE] {
+    [(); T::SIZE]
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/bad-type_const-syntax.rs
+++ b/tests/ui/const-generics/mgca/bad-type_const-syntax.rs
@@ -1,0 +1,17 @@
+trait Tr {
+    #[type_const()]
+    //~^ ERROR malformed
+    //~| ERROR experimental
+    const N: usize;
+}
+
+struct S;
+
+impl Tr for S {
+    #[type_const]
+    //~^ ERROR must only be applied to trait associated constants
+    //~| ERROR experimental
+    const N: usize = 0;
+}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/bad-type_const-syntax.stderr
+++ b/tests/ui/const-generics/mgca/bad-type_const-syntax.stderr
@@ -1,0 +1,35 @@
+error: malformed `type_const` attribute input
+  --> $DIR/bad-type_const-syntax.rs:2:5
+   |
+LL |     #[type_const()]
+   |     ^^^^^^^^^^^^^^^ help: must be of the form: `#[type_const]`
+
+error[E0658]: the `#[type_const]` attribute is an experimental feature
+  --> $DIR/bad-type_const-syntax.rs:2:5
+   |
+LL |     #[type_const()]
+   |     ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: the `#[type_const]` attribute is an experimental feature
+  --> $DIR/bad-type_const-syntax.rs:11:5
+   |
+LL |     #[type_const]
+   |     ^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: `#[type_const]` must only be applied to trait associated constants
+  --> $DIR/bad-type_const-syntax.rs:11:5
+   |
+LL |     #[type_const]
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/const-generics/mgca/inherent-const-gating.rs
+++ b/tests/ui/const-generics/mgca/inherent-const-gating.rs
@@ -1,0 +1,13 @@
+#![feature(min_generic_const_args)]
+#![allow(incomplete_features)]
+
+struct S;
+
+impl S {
+    const N: usize = 42;
+}
+
+fn main() {
+    let _x: [(); S::N] = todo!();
+    //~^ ERROR inherent associated types are unstable
+}

--- a/tests/ui/const-generics/mgca/inherent-const-gating.stderr
+++ b/tests/ui/const-generics/mgca/inherent-const-gating.stderr
@@ -1,0 +1,13 @@
+error[E0658]: inherent associated types are unstable
+  --> $DIR/inherent-const-gating.rs:11:18
+   |
+LL |     let _x: [(); S::N] = todo!();
+   |                  ^^^^
+   |
+   = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
+   = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-min-generic-const-args.rs
+++ b/tests/ui/feature-gates/feature-gate-min-generic-const-args.rs
@@ -1,8 +1,10 @@
 trait Trait {
+    #[type_const]
+    //~^ ERROR experimental
     const ASSOC: usize;
 }
 
-// FIXME(min_generic_const_args): implement support for this, behind the feature gate
+// FIXME(mgca): add suggestion for mgca to this error
 fn foo<T: Trait>() -> [u8; <T as Trait>::ASSOC] {
     //~^ ERROR generic parameters may not be used in const operations
     loop {}

--- a/tests/ui/feature-gates/feature-gate-min-generic-const-args.stderr
+++ b/tests/ui/feature-gates/feature-gate-min-generic-const-args.stderr
@@ -1,5 +1,5 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/feature-gate-min-generic-const-args.rs:6:29
+  --> $DIR/feature-gate-min-generic-const-args.rs:8:29
    |
 LL | fn foo<T: Trait>() -> [u8; <T as Trait>::ASSOC] {
    |                             ^ cannot perform const operation using `T`
@@ -7,5 +7,16 @@ LL | fn foo<T: Trait>() -> [u8; <T as Trait>::ASSOC] {
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error: aborting due to 1 previous error
+error[E0658]: the `#[type_const]` attribute is an experimental feature
+  --> $DIR/feature-gate-min-generic-const-args.rs:2:5
+   |
+LL |     #[type_const]
+   |     ^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = help: add `#![feature(min_generic_const_args)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
When `#![feature(min_generic_const_args)]` is enabled, we now lower all
const paths in generic arg position to `hir::ConstArgKind::Path`. We
then lower assoc const paths to `ty::ConstKind::Unevaluated` since we
can no longer use the anon const expression lowering machinery. In the
process of implementing this, I factored out `hir_ty_lowering` code that
is now shared between lowering assoc types and assoc consts.

This PR also introduces a `#[type_const]` attribute for trait assoc
consts that are allowed as const args. However, we still need to
implement code to check that assoc const definitions satisfy
`#[type_const]` if present (basically is it a const path or a
monomorphic anon const).

r? @BoxyUwU
