### PR TITLE
Remove workaround from pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,6 @@ tracking issue or there are none, feel free to ignore this.
 This PR will get automatically assigned to a reviewer. In case you would like
 a specific user to review your work, you can assign it to them by using
 
-    r\? <reviewer name> (with the `\` removed)
+    r? <reviewer name>
 -->
 <!-- homu-ignore:end -->


### PR DESCRIPTION
This PR removes the workaround (`\`) from our pull request template as triagebot/rustbot now ignores HTML blocks.

cf. https://github.com/rust-lang/triagebot/pull/1869
cc @jieyouxu
r? @ehuss

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
