### PR TITLE
Add and improve debuginfo tests for Windows

### DIFF
--- a/tests/debuginfo/closures.rs
+++ b/tests/debuginfo/closures.rs
@@ -1,0 +1,155 @@
+//@ only-cdb
+//@ compile-flags:-g
+
+// === CDB TESTS ===================================================================================
+// Generic functions cause ambigious breakpoints.
+// cdb-command:dx @$debuggerRootNamespace.Debugger.Settings.EngineInitialization.ResolveAmbiguousBreakpoints = true;
+// cdb-command:bp `closures.rs:57`
+// cdb-command:g
+// cdb-command:dx add_closure
+// cdb-check:add_closure      [Type: closures::main::closure_env$0]
+// cdb-check:     [+0x[...]] _ref__base_value : 0x[...] : 42 [Type: int *]
+// cdb-command:dx increment
+// cdb-check:increment        [Type: closures::main::closure_env$1]
+// cdb-check:     [+0x[...]] _ref__count      : 0x[...] : 2 [Type: int *]
+// cdb-command:dx consume_closure
+// cdb-check:consume_closure  [Type: closures::main::closure_env$2]
+// cdb-check:     [+0x[...]] x                : [...] [Type: alloc::string::String]
+// cdb-check:     [+0x[...]] _ref__base_value : 0x[...] : 42 [Type: int *]
+// cdb-command:dx simple_closure
+// cdb-checksimple_closure   [Type: closures::main::closure_env$5]
+// cdb-check:     [+0x[...]] _ref__base_value : 0x[...] : 42 [Type: int *]
+// cdb-command:g
+// cdb-command:dx first_closure
+// cdb-check:first_closure    [Type: closures::main::closure_env$6]
+// cdb-check:     [+0x[...]] _ref__variable   : 0x[...] : 1 [Type: int *]
+// cdb-check:     [+0x[...]] _ref__constant   : 0x[...] : 2 [Type: int *]
+// cdb-check:     [+0x[...]] _ref__a_struct   : 0x[...] [Type: closures::Struct *]
+// cdb-check:     [+0x[...]] _ref__struct_ref : 0x[...] [Type: closures::Struct * *]
+// cdb-check:     [+0x[...]] _ref__owned_value : 0x[...] [Type: int * *]
+// cdb-command:g
+// cdb-command:dx many_param_closure
+// cdb-check:many_param_closure [Type: closures::main::closure_env$7]
+// cdb-check:     [+0x[...]] _ref__base_value : 0x[...] : 42 [Type: int *]
+// cdb-command:g
+// cdb-command:dv
+// cdb-command:dx generic_closure
+// cdb-check:generic_closure  [Type: closures::generic_func::closure_env$0<i32>]
+// cdb-check:     [+0x[...]] _ref__x          : 0x[...] : 42 [Type: int *]
+// cdb-command:g
+// cdb-command:dx generic_closure
+// cdb-check:generic_closure  [Type: closures::generic_func::closure_env$0<ref$<str$> >]
+// cdb-check:     [+0x000] _ref__x          : 0x[...] : "base_value" [Type: ref$<str$> *]
+// cdb-command:g
+// cdb-command:dx second_closure
+// cdb-check:second_closure   [Type: closures::main::closure_env$8]
+// cdb-check:     [+0x[...]] _ref__variable   : 0x[...] : 2 [Type: int *]
+// cdb-check:     [+0x[...]] _ref__constant   : 0x[...] : 2 [Type: int *]
+// cdb-check:     [+0x[...]] _ref__a_struct   : 0x[...] [Type: closures::Struct *]
+// cdb-check:     [+0x[...]] _ref__struct_ref : 0x[...] [Type: closures::Struct * *]
+// cdb-check:     [+0x[...]] _ref__owned_value : 0x[...] [Type: int * *]
+
+#[inline(never)]
+fn generic_func<Tfunc: std::fmt::Debug>(x: Tfunc) {
+    let generic_closure = |a: i32| {
+        println!("{:?} {}", x, a);
+    };
+
+    _zzz(); // #break
+
+    // rustc really wants to inline this closure, so we use black_box instead of calling it
+    std::hint::black_box(generic_closure);
+}
+
+struct Struct {
+    a: isize,
+    b: f64,
+    c: usize,
+}
+
+fn main() {
+    let base_value: i32 = 42;
+    let mut count: i32 = 0;
+
+    let add_closure = |a: i32, b: i32| a + b + base_value;
+
+    add_closure(40, 2);
+
+    let mut increment = || {
+        count += 1;
+    };
+
+    increment(); // count: 1
+    increment(); // count: 2
+
+    let x = String::from("hello");
+
+    // Define a closure that consumes the captured variable `x`
+    let consume_closure = move || {
+        drop(x);
+        base_value + 1
+    };
+
+    consume_closure();
+
+    let paramless_closure = || 42_i32;
+
+    let void_closure = |a: i32| {
+        println!("Closure with arg: {:?}", a);
+    };
+
+    let simple_closure = || {
+        let incremented_value = base_value + 1;
+        incremented_value
+    };
+
+    let result = /*42; */ add_closure(40, 2);
+    println!("Result: {:?}", result);
+    void_closure(result);
+    let result = simple_closure();
+    println!("Result: {:?}", result);
+
+    let mut variable: i32 = 1;
+    let constant: i32 = 2;
+
+    let a_struct = Struct { a: -3, b: 4.5, c: 5 };
+
+    _zzz(); // #break
+
+    let struct_ref = &a_struct;
+    let owned_value: Box<i32> = Box::new(6);
+
+    {
+        let mut first_closure = || {
+            variable = constant + a_struct.a as i32 + struct_ref.a as i32 + *owned_value;
+        };
+
+        _zzz(); // #break
+
+        first_closure();
+    }
+
+    let many_param_closure =
+        |a: i32, b: f64, c: usize, d: Struct| base_value + a + b as i32 + c as i32 + d.c as i32;
+
+    _zzz(); // #break
+
+    many_param_closure(1, 2.0, 3, Struct { a: 4, b: 5.0, c: 6 });
+
+    generic_func(42);
+    generic_func("base_value");
+
+    {
+        let mut second_closure = || {
+            variable = constant + a_struct.a as i32 + struct_ref.a as i32 + *owned_value;
+        };
+
+        _zzz(); // #break
+
+        second_closure();
+    }
+}
+
+fn _zzz() {
+    ()
+}

--- a/tests/debuginfo/coroutine-closure.rs
+++ b/tests/debuginfo/coroutine-closure.rs
@@ -1,0 +1,29 @@
+#![feature(async_closure)]
+//@ only-cdb
+//@ compile-flags:-g --edition=2021
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+// cdb-command: dx closure
+// cdb-check:closure          [Type: coroutine_closure::main::closure_env$0]
+// cdb-check:     [+0x[...]] y                : "" [Type: alloc::string::String]
+// cdb-check:     [+0x[...]] x                : "" [Type: alloc::string::String]
+#![allow(unused)]
+fn main() {
+    let x = String::new();
+    let y = String::new();
+    let closure = async move || {
+        drop(y);
+        println!("{x}");
+    };
+
+    _zzz(); // #break
+
+    std::hint::black_box(closure);
+}
+
+#[inline(never)]
+fn _zzz() {
+    ()
+}

--- a/tests/debuginfo/fn_ptr.rs
+++ b/tests/debuginfo/fn_ptr.rs
@@ -1,0 +1,51 @@
+//@ only-cdb
+//@ compile-flags:-g
+
+// === CDB TESTS ==================================================================================
+
+// cdb-command: g
+// cdb-command: dx basic
+// cdb-check: basic            : [...] : a!core::ops::function::FnOnce::call_once<fn_ptr::main::closure_env$0,tuple$<i32,i32> >+0x0 [Type: int (__cdecl*)(int,int)]
+// cdb-check: a!core::ops::function::FnOnce::call_once<fn_ptr::main::closure_env$0,tuple$<i32,i32> >+0x0 [Type: int __cdecl(int,int)]
+
+// cdb-command: dx paramless
+// cdb-check: paramless        : [...] : a!core::ops::function::FnOnce::call_once<fn_ptr::main::closure_env$1,tuple$<> >+0x0 [Type: int (__cdecl*)()]
+// cdb-check: a!core::ops::function::FnOnce::call_once<fn_ptr::main::closure_env$1,tuple$<> >+0x0 [Type: int __cdecl()]
+
+// cdb-command: dx my_struct
+// cdb-check: my_struct        [Type: fn_ptr::MyStruct]
+// cdb-check:   [+0x000] my_field         : [...] : a!core::ops::function::FnOnce::call_once<fn_ptr::main::closure_env$2,tuple$<ref$<fn_ptr::MyStruct> > >+0x0 [Type: int (__cdecl*)(fn_ptr::MyStruct *)]
+
+// cdb-command: dx non_rec_struct
+// cdb-check: non_rec_struct   [Type: fn_ptr::NonRecStruct]
+// cdb-check:  [+0x000] my_field         : [...] : a!core::ops::function::FnOnce::call_once<fn_ptr::main::closure_env$3,tuple$<i32> >+0x0 [Type: int (__cdecl*)(int)]
+
+type BasicFnPtr = fn(i32, i32) -> i32;
+
+pub type ParamlessFnPtr = fn() -> i32;
+
+type MyFnPtr = fn(b: &MyStruct) -> i32;
+
+type NonRecFnPtr = fn(i: i32) -> i32;
+
+struct MyStruct {
+    my_field: MyFnPtr,
+}
+
+struct NonRecStruct {
+    my_field: NonRecFnPtr,
+}
+
+fn main() {
+    let basic: BasicFnPtr = |a, b| a + b;
+    let paramless: ParamlessFnPtr = || 1;
+    let my_struct = MyStruct { my_field: |_| 1 };
+    let non_rec_struct = NonRecStruct { my_field: |i| i };
+
+    _zzz(); // #break
+}
+
+#[inline(never)]
+fn _zzz() {
+    ()
+}

--- a/tests/debuginfo/lexical-scope-in-if-let.rs
+++ b/tests/debuginfo/lexical-scope-in-if-let.rs
@@ -47,30 +47,33 @@
 
 // === CDB TESTS ==================================================================================
 
+// Note: `/n` causes the the output to be sorted to avoid depending on the order in PDB which may
+// be arbitrary.
+
 // cdb-command: g
-// cdb-command: dv
+// cdb-command: dv /n
 // cdb-check:[...]a = 0n123
 
 // cdb-command: g
-// cdb-command: dv
+// cdb-command: dv /n
 // cdb-check:[...]a = 0n123
 // cdb-check:[...]x = 0n42
 
 // cdb-command: g
-// cdb-command: dv
+// cdb-command: dv /n
 // cdb-check:[...]a = 0n123
-// cdb-check:[...]x = 0n42
 // cdb-check:[...]b = 0n456
+// cdb-check:[...]x = 0n42
 // cdb-check:[...]y = true
 
 // cdb-command: g
-// cdb-command: dv
-// cdb-check:[...]z = 0n10
+// cdb-command: dv /n
+// cdb-check:[...]a = 0n123
+// cdb-check:[...]b = 0n456
 // cdb-check:[...]c = 0n789
-// cdb-check:[...]a = 0n123
 // cdb-check:[...]x = 0n42
-// cdb-check:[...]b = 0n456
 // cdb-check:[...]y = true
+// cdb-check:[...]z = 0n10
 
 fn main() {
     let a = id(123);
@@ -95,6 +98,8 @@ fn main() {
 }
 
 #[inline(never)]
-fn id<T>(value: T) -> T { value }
+fn id<T>(value: T) -> T {
+    value
+}
 
-fn zzz() { }
+fn zzz() {}

--- a/tests/debuginfo/step-into-match.rs
+++ b/tests/debuginfo/step-into-match.rs
@@ -117,7 +117,7 @@
 // gdb-check:[...]match (a, b) {
 
 // gdb-command: s
-// gdb-check:[...](_, _) => 5
+// gdb-check:[...](_, _) => 5,
 
 // gdb-command: s
 // gdb-check:[...]}
@@ -300,7 +300,7 @@
 // cdb-check:   [...]:     match (a, b) {
 
 // cdb-command: t
-// cdb-check:   [...]:         (_, _) => 5
+// cdb-check:   [...]:         (_, _) => 5,
 
 // cdb-command: t
 // cdb-check:   [...]: }
@@ -378,6 +378,6 @@ fn match_tuple(a: u8, b: i8) -> u32 {
         (29, _) => 2,
         (5, 12) => 3,
         (_, 9) => 4,
-        (_, _) => 5
+        (_, _) => 5,
     }
 }

--- a/tests/debuginfo/type-names.rs
+++ b/tests/debuginfo/type-names.rs
@@ -5,7 +5,7 @@
 
 //@ compile-flags:-g
 
-// === GDB TESTS ===================================================================================
+// === GDB TESTS ==================================================================================
 
 // gdb-command:run
 
@@ -17,7 +17,7 @@
 // gdb-check:type = type_names::GenericStruct<type_names::mod1::Struct2, type_names::mod1::mod2::Struct3>
 
 // gdb-command:whatis generic_struct2
-// gdb-check:type = type_names::GenericStruct<type_names::Struct1, extern "system" fn(isize) -> usize>
+// gdb-check:type = type_names::GenericStruct<type_names::Struct1, extern "fastcall" fn(isize) -> usize>
 
 // gdb-command:whatis mod_struct
 // gdb-check:type = type_names::mod1::Struct2
@@ -169,81 +169,85 @@
 
 // === CDB TESTS ==================================================================================
 
+// Note: `/n` causes the wildcard matches to be sorted to avoid depending on order in PDB which
+// can be arbitrary.
+
 // cdb-command: g
 
 // STRUCTS
 // 0-sized structs appear to be optimized away in some cases, so only check the structs that do
 // actually appear.
-// cdb-command:dv /t *_struct
+// cdb-command:dv /t /n *_struct
 
 // ENUMS
-// cdb-command:dv /t *_enum_*
+// cdb-command:dv /t /n *_enum_*
+// cdb-check:union enum2$<type_names::mod1::mod2::Enum3<type_names::mod1::Struct2> > generic_enum_1 = [...]
+// cdb-check:union enum2$<type_names::mod1::mod2::Enum3<type_names::Struct1> > generic_enum_2 = [...]
 // cdb-check:union enum2$<type_names::Enum1> simple_enum_1 = [...]
 // cdb-check:union enum2$<type_names::Enum1> simple_enum_2 = [...]
 // cdb-check:union enum2$<type_names::mod1::Enum2> simple_enum_3 = [...]
-// cdb-check:union enum2$<type_names::mod1::mod2::Enum3<type_names::mod1::Struct2> > generic_enum_1 = [...]
-// cdb-check:union enum2$<type_names::mod1::mod2::Enum3<type_names::Struct1> > generic_enum_2 = [...]
 
 // TUPLES
-// cdb-command:dv /t tuple*
+// cdb-command:dv /t /n tuple*
 // cdb-check:struct tuple$<u32,type_names::Struct1,enum2$<type_names::mod1::mod2::Enum3<type_names::mod1::Struct2> > > tuple1 = [...]
 // cdb-check:struct tuple$<tuple$<type_names::Struct1,type_names::mod1::mod2::Struct3>,enum2$<type_names::mod1::Enum2>,char> tuple2 = [...]
 
 // BOX
-// cdb-command:dv /t box*
+// cdb-command:dv /t /n box*
 // cdb-check:struct tuple$<alloc::boxed::Box<f32,alloc::alloc::Global>,i32> box1 = [...]
 // cdb-check:struct tuple$<alloc::boxed::Box<enum2$<type_names::mod1::mod2::Enum3<f32> >,alloc::alloc::Global>,i32> box2 = [...]
 
 // REFERENCES
-// cdb-command:dv /t *ref*
-// cdb-check:struct tuple$<ref$<type_names::Struct1>,i32> ref1 = [...]
-// cdb-check:struct tuple$<ref$<type_names::GenericStruct<char,type_names::Struct1> >,i32> ref2 = [...]
+// cdb-command:dv /t /n *ref*
 // cdb-check:struct tuple$<ref_mut$<type_names::Struct1>,i32> mut_ref1 = [...]
 // cdb-check:struct tuple$<ref_mut$<type_names::GenericStruct<enum2$<type_names::mod1::Enum2>,f64> >,i32> mut_ref2 = [...]
+// cdb-check:struct tuple$<ref$<type_names::Struct1>,i32> ref1 = [...]
+// cdb-check:struct tuple$<ref$<type_names::GenericStruct<char,type_names::Struct1> >,i32> ref2 = [...]
 
 // RAW POINTERS
-// cdb-command:dv /t *_ptr*
-// cdb-check:struct tuple$<ptr_mut$<type_names::Struct1>,isize> mut_ptr1 = [...]
-// cdb-check:struct tuple$<ptr_mut$<isize>,isize> mut_ptr2 = [...]
-// cdb-check:struct tuple$<ptr_mut$<enum2$<type_names::mod1::mod2::Enum3<type_names::Struct1> > >,isize> mut_ptr3 = [...]
+// cdb-command:dv /t /n *_ptr*
 // cdb-check:struct tuple$<ptr_const$<type_names::Struct1>,isize> const_ptr1 = [...]
 // cdb-check:struct tuple$<ptr_const$<isize>,isize> const_ptr2 = [...]
 // cdb-check:struct tuple$<ptr_const$<enum2$<type_names::mod1::mod2::Enum3<type_names::Struct1> > >,isize> const_ptr3 = [...]
+// cdb-check:struct tuple$<ptr_mut$<type_names::Struct1>,isize> mut_ptr1 = [...]
+// cdb-check:struct tuple$<ptr_mut$<isize>,isize> mut_ptr2 = [...]
+// cdb-check:struct tuple$<ptr_mut$<enum2$<type_names::mod1::mod2::Enum3<type_names::Struct1> > >,isize> mut_ptr3 = [...]
 
 // VECTORS
-// cdb-command:dv /t *vec*
+// cdb-command:dv /t /n *vec*
 // cdb-check:struct tuple$<array$<type_names::Struct1,3>,i16> fixed_size_vec1 = [...]
 // cdb-check:struct tuple$<array$<usize,3>,i16> fixed_size_vec2 = [...]
 // cdb-check:struct alloc::vec::Vec<usize,alloc::alloc::Global> vec1 = [...]
 // cdb-check:struct alloc::vec::Vec<enum2$<type_names::mod1::Enum2>,alloc::alloc::Global> vec2 = [...]
-// cdb-command:dv /t slice*
+// cdb-command:dv /t /n slice*
 // cdb-check:struct ref$<slice2$<usize> > slice1 = [...]
 // cdb-check:struct ref_mut$<slice2$<enum2$<type_names::mod1::Enum2> > > slice2 = [...]
 
 // TRAITS
-// cdb-command:dv /t *_trait
+// cdb-command:dv /t /n *_trait
+
+// cdb-check:struct alloc::boxed::Box<dyn$<type_names::Trait1>,alloc::alloc::Global> box_trait = [...]
+// cdb-check:struct alloc::boxed::Box<dyn$<type_names::Trait2<i32,type_names::mod1::Struct2> >,alloc::alloc::Global> generic_box_trait = [...]
 // cdb-check:struct ref_mut$<dyn$<type_names::Trait2<type_names::mod1::mod2::Struct3,type_names::GenericStruct<usize,isize> > > > generic_mut_ref_trait = [...]
 // cdb-check:struct ref$<dyn$<type_names::Trait2<type_names::Struct1,type_names::Struct1> > > generic_ref_trait = [...]
-// cdb-check:struct alloc::boxed::Box<dyn$<type_names::Trait2<i32,type_names::mod1::Struct2> >,alloc::alloc::Global> generic_box_trait = [...]
-// cdb-check:struct alloc::boxed::Box<dyn$<type_names::Trait1>,alloc::alloc::Global> box_trait = [...]
-// cdb-check:struct ref$<dyn$<type_names::Trait1> > ref_trait = [...]
+// cdb-check:struct ref$<dyn$<type_names::TraitNoGenericsButWithAssocType<assoc$<Output,isize> > > > has_associated_type_but_no_generics_trait = struct ref$<dyn$<type_names::TraitNoGenericsButWithAssocType<assoc$<Output,isize> > > >
+// cdb-check:struct ref$<dyn$<type_names::Trait3<u32,assoc$<AssocType,isize> >,core::marker::Send> > has_associated_type_trait = struct ref$<dyn$<type_names::Trait3<u32,assoc$<AssocType,isize> >,core::marker::Send> >
 // cdb-check:struct ref_mut$<dyn$<type_names::Trait1> > mut_ref_trait = [...]
 // cdb-check:struct alloc::boxed::Box<dyn$<core::marker::Send,core::marker::Sync>,alloc::alloc::Global> no_principal_trait = [...]
-// cdb-check:struct ref$<dyn$<type_names::Trait3<u32,assoc$<AssocType,isize> >,core::marker::Send> > has_associated_type_trait = struct ref$<dyn$<type_names::Trait3<u32,assoc$<AssocType,isize> >,core::marker::Send> >
-// cdb-check:struct ref$<dyn$<type_names::TraitNoGenericsButWithAssocType<assoc$<Output,isize> > > > has_associated_type_but_no_generics_trait = struct ref$<dyn$<type_names::TraitNoGenericsButWithAssocType<assoc$<Output,isize> > > >
+// cdb-check:struct ref$<dyn$<type_names::Trait1> > ref_trait = [...]
 
 // BARE FUNCTIONS
-// cdb-command:dv /t *_fn*
-// cdb-check:struct tuple$<type_names::mod1::Struct2 (*)(type_names::GenericStruct<u16,u8>),usize> unsafe_fn_with_return_value = [...]
+// cdb-command:dv /t /n *_fn*
+// cdb-check:struct tuple$<void (*)(isize),usize> extern_c_fn = [...]
 // cdb-check:struct tuple$<type_names::Struct1 (*)(),usize> extern_c_fn_with_return_value = [...]
+// cdb-check:struct tuple$<void (*)(enum2$<core::option::Option<isize> >,enum2$<core::option::Option<ref$<type_names::mod1::Struct2> > >),usize> rust_fn = [...]
 // cdb-check:struct tuple$<usize (*)(f64),usize> rust_fn_with_return_value = [...]
 // cdb-check:struct tuple$<void (*)(enum2$<core::result::Result<char,f64> >),usize> unsafe_fn = [...]
-// cdb-check:struct tuple$<void (*)(isize),usize> extern_c_fn = [...]
-// cdb-check:struct tuple$<void (*)(enum2$<core::option::Option<isize> >,enum2$<core::option::Option<ref$<type_names::mod1::Struct2> > >),usize> rust_fn = [...]
-// cdb-command:dv /t *_function*
-// cdb-check:struct tuple$<isize (*)(ptr_const$<u8>, ...),usize> variadic_function = [...]
-// cdb-check:struct tuple$<type_names::mod1::mod2::Struct3 (*)(type_names::mod1::mod2::Struct3),usize> generic_function_struct3 = [...]
+// cdb-check:struct tuple$<type_names::mod1::Struct2 (*)(type_names::GenericStruct<u16,u8>),usize> unsafe_fn_with_return_value = [...]
+// cdb-command:dv /t /n *_function*
 // cdb-check:struct tuple$<isize (*)(isize),usize> generic_function_int = [...]
+// cdb-check:struct tuple$<type_names::mod1::mod2::Struct3 (*)(type_names::mod1::mod2::Struct3),usize> generic_function_struct3 = [...]
+// cdb-check:struct tuple$<isize (*)(ptr_const$<u8>, ...),usize> variadic_function = [...]
 // cdb-command:dx Debugger.State.Scripts.@"type-names.cdb".Contents.getFunctionDetails("rust_fn")
 // cdb-check:Return Type: void
 // cdb-check:Parameter Types: enum2$<core::option::Option<isize> >,enum2$<core::option::Option<ref$<type_names::mod1::Struct2> > >
@@ -255,23 +259,24 @@
 // cdb-check:Parameter Types:
 
 // CLOSURES
-// cdb-command:dv /t closure*
-// cdb-check:struct tuple$<type_names::main::closure_env$1,usize> closure2 = [...]
+// cdb-command:dv /t /n closure*
 // cdb-check:struct tuple$<type_names::main::closure_env$0,usize> closure1 = [...]
+// cdb-check:struct tuple$<type_names::main::closure_env$1,usize> closure2 = [...]
 
 // FOREIGN TYPES
-// cdb-command:dv /t foreign*
-// cdb-check:struct type_names::mod1::extern$0::ForeignType2 * foreign2 = [...]
+// cdb-command:dv /t /n foreign*
 // cdb-check:struct type_names::extern$0::ForeignType1 * foreign1 = [...]
+// cdb-check:struct type_names::mod1::extern$0::ForeignType2 * foreign2 = [...]
 
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 #![feature(extern_types)]
 
-use self::Enum1::{Variant1, Variant2};
 use std::marker::PhantomData;
 use std::ptr;
+
+use self::Enum1::{Variant1, Variant2};
 
 pub struct Struct1;
 struct GenericStruct<T1, T2>(PhantomData<(T1, T2)>);
@@ -372,7 +377,7 @@ fn main() {
     let simple_struct = Struct1;
     let generic_struct1: GenericStruct<mod1::Struct2, mod1::mod2::Struct3> =
         GenericStruct(PhantomData);
-    let generic_struct2: GenericStruct<Struct1, extern "system" fn(isize) -> usize> =
+    let generic_struct2: GenericStruct<Struct1, extern "fastcall" fn(isize) -> usize> =
         GenericStruct(PhantomData);
     let mod_struct = mod1::Struct2;
 


### PR DESCRIPTION
Adds new test for closures and function pointers.
Improves robustness of existing tests by sorting wildcard matched outputs.

try-job: i686-msvc