### PR TITLE
don't bless `proc_macro_deps.rs` unless it's necessary

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -622,12 +622,17 @@ fn check_proc_macro_dep_list(root: &Path, cargo: &Path, bless: bool, bad: &mut b
     }
     // Remove the proc-macro crates themselves
     proc_macro_deps.retain(|pkg| !is_proc_macro_pkg(&metadata[pkg]));
-    let proc_macro_deps_iter = proc_macro_deps.into_iter().map(|dep| metadata[dep].name.clone());
 
-    if bless {
-        let mut proc_macro_deps: Vec<_> = proc_macro_deps_iter.collect();
+    let proc_macro_deps: HashSet<_> =
+        proc_macro_deps.into_iter().map(|dep| metadata[dep].name.clone()).collect();
+    let expected = proc_macro_deps::CRATES.iter().map(|s| s.to_string()).collect::<HashSet<_>>();
+
+    let needs_blessing = proc_macro_deps.difference(&expected).next().is_some()
+        || expected.difference(&proc_macro_deps).next().is_some();
+
+    if needs_blessing && bless {
+        let mut proc_macro_deps: Vec<_> = proc_macro_deps.into_iter().collect();
         proc_macro_deps.sort();
-        proc_macro_deps.dedup();
         let mut file = File::create(root.join("src/bootstrap/src/utils/proc_macro_deps.rs"))
             .expect("`proc_macro_deps` should exist");
         writeln!(
@@ -649,10 +654,8 @@ pub static CRATES: &[&str] = &[
         )
         .unwrap();
     } else {
-        let proc_macro_deps: HashSet<_> = proc_macro_deps_iter.collect();
-        let expected =
-            proc_macro_deps::CRATES.iter().map(|s| s.to_string()).collect::<HashSet<_>>();
         let old_bad = *bad;
+
         for missing in proc_macro_deps.difference(&expected) {
             tidy_error!(
                 bad,


### PR DESCRIPTION
Running tidy with `--bless` flag is breaking the build cache as tidy updates mtime of `proc_macro_deps.rs` (https://github.com/rust-lang/rust/pull/134865) unconditionally and that leads cargo to recompile tidy.

This patch fixes that.