### PR TITLE
rustfmt: drop nightly-gating of the `--style-edition` flag registration

### DIFF
--- a/src/tools/rustfmt/src/bin/main.rs
+++ b/src/tools/rustfmt/src/bin/main.rs
@@ -161,6 +161,12 @@ fn make_opts() -> Options {
         "Set options from command line. These settings take priority over .rustfmt.toml",
         "[key1=val1,key2=val2...]",
     );
+    opts.optopt(
+        "",
+        "style-edition",
+        "The edition of the Style Guide.",
+        "[2015|2018|2021|2024]",
+    );
 
     if is_nightly {
         opts.optflag(
@@ -185,12 +191,6 @@ fn make_opts() -> Options {
             "",
             "skip-children",
             "Don't reformat child modules (unstable).",
-        );
-        opts.optopt(
-            "",
-            "style-edition",
-            "The edition of the Style Guide (unstable).",
-            "[2015|2018|2021|2024]",
         );
     }
 


### PR DESCRIPTION
Follow-up to [Stabilize `style_edition = "2024"` in-tree #134929](https://github.com/rust-lang/rust/pull/134929).

#134929 un-nightly-gated the *read* of `--style-edition`, but didn't also un-nightly-gate the *registration*/*declaration* of the `--style-edition` flag itself. Reading `--style-edition` on a non-nightly channel (e.g. beta) will thus panic because `--style-edition` is never declared.

This PR also un-nightly-gates the registration. Not sure how to write a regression test for this, because this *requires* the non-nightly / beta channel. Though existing tests do fail (albeit indirectly).

Checking if this fixes the panic against beta in https://github.com/rust-lang/rust/pull/135197.

r? rustfmt
