### PR TITLE
warn about broken simd not only on structs but also enums and unions when we didn't opt in to it

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -242,7 +242,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
             }
 
-            ast::ItemKind::Struct(..) => {
+            ast::ItemKind::Struct(..) | ast::ItemKind::Enum(..) | ast::ItemKind::Union(..) => {
                 for attr in attr::filter_by_name(&i.attrs, sym::repr) {
                     for item in attr.meta_item_list().unwrap_or_else(ThinVec::new) {
                         if item.has_name(sym::simd) {

--- a/tests/ui/feature-gates/feature-gate-repr-simd.rs
+++ b/tests/ui/feature-gates/feature-gate-repr-simd.rs
@@ -1,9 +1,17 @@
-#[repr(simd)] //~ error: SIMD types are experimental
+#[repr(simd)] //~ ERROR: SIMD types are experimental
 struct Foo([u64; 2]);
 
 #[repr(C)] //~ ERROR conflicting representation hints
 //~^ WARN this was previously accepted
-#[repr(simd)] //~ error: SIMD types are experimental
+#[repr(simd)] //~ ERROR: SIMD types are experimental
 struct Bar([u64; 2]);
+
+#[repr(simd)] //~ ERROR: SIMD types are experimental
+//~^ ERROR: attribute should be applied to a struct
+union U {f: u32}
+
+#[repr(simd)] //~ ERROR: SIMD types are experimental
+//~^ error: attribute should be applied to a struct
+enum E { X }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/tests/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -18,6 +18,26 @@ LL | #[repr(simd)]
    = help: add `#![feature(repr_simd)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: SIMD types are experimental and possibly buggy
+  --> $DIR/feature-gate-repr-simd.rs:9:1
+   |
+LL | #[repr(simd)]
+   | ^^^^^^^^^^^^^
+   |
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
+   = help: add `#![feature(repr_simd)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: SIMD types are experimental and possibly buggy
+  --> $DIR/feature-gate-repr-simd.rs:13:1
+   |
+LL | #[repr(simd)]
+   | ^^^^^^^^^^^^^
+   |
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
+   = help: add `#![feature(repr_simd)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0566]: conflicting representation hints
   --> $DIR/feature-gate-repr-simd.rs:4:8
    |
@@ -31,10 +51,28 @@ LL | #[repr(simd)]
    = note: for more information, see issue #68585 <https://github.com/rust-lang/rust/issues/68585>
    = note: `#[deny(conflicting_repr_hints)]` on by default
 
-error: aborting due to 3 previous errors
+error[E0517]: attribute should be applied to a struct
+  --> $DIR/feature-gate-repr-simd.rs:9:8
+   |
+LL | #[repr(simd)]
+   |        ^^^^
+LL |
+LL | union U {f: u32}
+   | ---------------- not a struct
 
-Some errors have detailed explanations: E0566, E0658.
-For more information about an error, try `rustc --explain E0566`.
+error[E0517]: attribute should be applied to a struct
+  --> $DIR/feature-gate-repr-simd.rs:13:8
+   |
+LL | #[repr(simd)]
+   |        ^^^^
+LL |
+LL | enum E { X }
+   | ------------ not a struct
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0517, E0566, E0658.
+For more information about an error, try `rustc --explain E0517`.
 Future incompatibility report: Future breakage diagnostic:
 error[E0566]: conflicting representation hints
   --> $DIR/feature-gate-repr-simd.rs:4:8

--- a/tests/ui/repr/issue-83505-repr-simd.rs
+++ b/tests/ui/repr/issue-83505-repr-simd.rs
@@ -5,6 +5,8 @@
 #[repr(simd)]
 //~^ ERROR: attribute should be applied to a struct [E0517]
 //~| ERROR: unsupported representation for zero-variant enum [E0084]
+//~| ERROR: SIMD types are experimental and possibly buggy [E0658]
+
 enum Es {}
 static CLs: Es;
 //~^ ERROR: free static item without body

--- a/tests/ui/repr/issue-83505-repr-simd.stderr
+++ b/tests/ui/repr/issue-83505-repr-simd.stderr
@@ -1,10 +1,20 @@
 error: free static item without body
-  --> $DIR/issue-83505-repr-simd.rs:9:1
+  --> $DIR/issue-83505-repr-simd.rs:11:1
    |
 LL | static CLs: Es;
    | ^^^^^^^^^^^^^^-
    |               |
    |               help: provide a definition for the static: `= <expr>;`
+
+error[E0658]: SIMD types are experimental and possibly buggy
+  --> $DIR/issue-83505-repr-simd.rs:5:1
+   |
+LL | #[repr(simd)]
+   | ^^^^^^^^^^^^^
+   |
+   = note: see issue #27731 <https://github.com/rust-lang/rust/issues/27731> for more information
+   = help: add `#![feature(repr_simd)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0517]: attribute should be applied to a struct
   --> $DIR/issue-83505-repr-simd.rs:5:8
@@ -24,7 +34,7 @@ LL | #[repr(simd)]
 LL | enum Es {}
    | ------- zero-variant enum
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0084, E0517.
+Some errors have detailed explanations: E0084, E0517, E0658.
 For more information about an error, try `rustc --explain E0084`.


### PR DESCRIPTION
addresses https://github.com/rust-lang/rust/issues/135208#issuecomment-2576015186

r? @Noratrieb 