### PR TITLE
Include rustc and rustdoc book in replace-version-placeholder

### DIFF
--- a/src/tools/replace-version-placeholder/src/main.rs
+++ b/src/tools/replace-version-placeholder/src/main.rs
@@ -10,7 +10,12 @@ fn main() {
     let version_str = t!(std::fs::read_to_string(&version_path), version_path);
     let version_str = version_str.trim();
     walk::walk_many(
-        &[&root_path.join("compiler"), &root_path.join("library")],
+        &[
+            &root_path.join("compiler"),
+            &root_path.join("library"),
+            &root_path.join("src/doc/rustc"),
+            &root_path.join("src/doc/rustdoc"),
+        ],
         |path, _is_dir| walk::filter_dirs(path),
         &mut |entry, contents| {
             if !contents.contains(VERSION_PLACEHOLDER) {


### PR DESCRIPTION
This PR includes the *(stable)* rustc and rustdoc books which might contain `CURRENT_RUSTC_VERSION` that should be replaced when branching beta. Include them so they are not forgotten.

I didn't include any other folder or books as they don't strike me as relevant for it and might be problematic in the future if some of the submodules are turned into subtree, because we have places where we wouldn't want to replace them.

cf. https://github.com/rust-lang/rust/pull/135163#issuecomment-2574694931
cc @pietroalbini
