### PR TITLE
rustc_feature: Avoid unsafe `std::env::set_var()` in `UnstableFeatures` tests

### DIFF
--- a/compiler/rustc_feature/src/tests.rs
+++ b/compiler/rustc_feature/src/tests.rs
@@ -2,9 +2,11 @@ use super::UnstableFeatures;
 
 #[test]
 fn rustc_bootstrap_parsing() {
-    let is_bootstrap = |env, krate| {
-        std::env::set_var("RUSTC_BOOTSTRAP", env);
-        matches!(UnstableFeatures::from_environment(krate), UnstableFeatures::Cheat)
+    let is_bootstrap = |env: &str, krate: Option<&str>| {
+        matches!(
+            UnstableFeatures::from_environment_value(krate, Ok(env.to_string())),
+            UnstableFeatures::Cheat
+        )
     };
     assert!(is_bootstrap("1", None));
     assert!(is_bootstrap("1", Some("x")));
@@ -22,9 +24,11 @@ fn rustc_bootstrap_parsing() {
     assert!(!is_bootstrap("0", None));
 
     // `RUSTC_BOOTSTRAP=-1` is force-stable, no unstable features allowed.
-    let is_force_stable = |krate| {
-        std::env::set_var("RUSTC_BOOTSTRAP", "-1");
-        matches!(UnstableFeatures::from_environment(krate), UnstableFeatures::Disallow)
+    let is_force_stable = |krate: Option<&str>| {
+        matches!(
+            UnstableFeatures::from_environment_value(krate, Ok("-1".to_string())),
+            UnstableFeatures::Disallow
+        )
     };
     assert!(is_force_stable(None));
     // Does not support specifying any crate.


### PR DESCRIPTION
Avoid unsafe `std::env::set_var()` by allowing tests to inject `std::env::var("RUSTC_BOOTSTRAP")` with a `env_var_rustc_bootstrap` parameter.

Part of https://github.com/rust-lang/rust/issues/130672

Discussed at https://github.com/rust-lang/rust/pull/129636#discussion_r1766381501 (CC @compiler-errors @bjorn3)
