### PR TITLE
A couple simple borrowck cleanups

### DIFF
--- a/compiler/rustc_borrowck/src/consumers.rs
+++ b/compiler/rustc_borrowck/src/consumers.rs
@@ -11,7 +11,7 @@ pub use super::dataflow::{BorrowIndex, Borrows, calculate_borrows_out_of_scope_a
 pub use super::place_ext::PlaceExt;
 pub use super::places_conflict::{PlaceConflictBias, places_conflict};
 pub use super::polonius::legacy::{
-    AllFacts as PoloniusInput, PoloniusLocationTable, PoloniusOutput, PoloniusRegionVid,
+    PoloniusFacts as PoloniusInput, PoloniusLocationTable, PoloniusOutput, PoloniusRegionVid,
     RichLocation, RustcFacts,
 };
 pub use super::region_infer::RegionInferenceContext;

--- a/compiler/rustc_borrowck/src/consumers.rs
+++ b/compiler/rustc_borrowck/src/consumers.rs
@@ -11,8 +11,8 @@ pub use super::dataflow::{BorrowIndex, Borrows, calculate_borrows_out_of_scope_a
 pub use super::place_ext::PlaceExt;
 pub use super::places_conflict::{PlaceConflictBias, places_conflict};
 pub use super::polonius::legacy::{
-    AllFacts as PoloniusInput, LocationTable, PoloniusOutput, PoloniusRegionVid, RichLocation,
-    RustcFacts,
+    AllFacts as PoloniusInput, PoloniusLocationTable, PoloniusOutput, PoloniusRegionVid,
+    RichLocation, RustcFacts,
 };
 pub use super::region_infer::RegionInferenceContext;
 
@@ -33,7 +33,7 @@ pub enum ConsumerOptions {
     /// without significant slowdowns.
     ///
     /// Implies [`RegionInferenceContext`](ConsumerOptions::RegionInferenceContext),
-    /// and additionally retrieve the [`LocationTable`] and [`PoloniusInput`] that
+    /// and additionally retrieve the [`PoloniusLocationTable`] and [`PoloniusInput`] that
     /// would be given to Polonius. Critically, this does not run Polonius, which
     /// one may want to avoid due to performance issues on large bodies.
     PoloniusInputFacts,
@@ -71,7 +71,7 @@ pub struct BodyWithBorrowckFacts<'tcx> {
     /// The table that maps Polonius points to locations in the table.
     /// Populated when using [`ConsumerOptions::PoloniusInputFacts`]
     /// or [`ConsumerOptions::PoloniusOutputFacts`].
-    pub location_table: Option<LocationTable>,
+    pub location_table: Option<PoloniusLocationTable>,
     /// Polonius input facts.
     /// Populated when using [`ConsumerOptions::PoloniusInputFacts`]
     /// or [`ConsumerOptions::PoloniusOutputFacts`].

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -56,7 +56,7 @@ use crate::diagnostics::{
 use crate::path_utils::*;
 use crate::place_ext::PlaceExt;
 use crate::places_conflict::{PlaceConflictBias, places_conflict};
-use crate::polonius::legacy::{LocationTable, PoloniusOutput};
+use crate::polonius::legacy::{PoloniusLocationTable, PoloniusOutput};
 use crate::prefixes::PrefixSet;
 use crate::region_infer::RegionInferenceContext;
 use crate::renumber::RegionCtxt;
@@ -175,7 +175,7 @@ fn do_mir_borrowck<'tcx>(
         infcx.register_predefined_opaques_for_next_solver(def);
     }
 
-    let location_table = LocationTable::new(body);
+    let location_table = PoloniusLocationTable::new(body);
 
     let move_data = MoveData::gather_moves(body, tcx, |_| true);
     let promoted_move_data = promoted
@@ -246,7 +246,8 @@ fn do_mir_borrowck<'tcx>(
             infcx: &infcx,
             body: promoted_body,
             move_data: &move_data,
-            location_table: &location_table, // no need to create a real one for the promoted, it is not used
+            // no need to create a real location table for the promoted, it is not used
+            location_table: &location_table,
             movable_coroutine,
             fn_self_span_reported: Default::default(),
             locals_are_invalidated_at_exit,
@@ -512,7 +513,7 @@ struct MirBorrowckCtxt<'a, 'infcx, 'tcx> {
 
     /// Map from MIR `Location` to `LocationIndex`; created
     /// when MIR borrowck begins.
-    location_table: &'a LocationTable,
+    location_table: &'a PoloniusLocationTable,
 
     movable_coroutine: bool,
     /// This keeps track of whether local variables are free-ed when the function

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -28,7 +28,7 @@ use crate::borrow_set::BorrowSet;
 use crate::consumers::ConsumerOptions;
 use crate::diagnostics::{BorrowckDiagnosticsBuffer, RegionErrors};
 use crate::polonius::LocalizedOutlivesConstraintSet;
-use crate::polonius::legacy::{AllFacts, AllFactsExt, LocationTable, PoloniusOutput};
+use crate::polonius::legacy::{AllFacts, AllFactsExt, PoloniusLocationTable, PoloniusOutput};
 use crate::region_infer::RegionInferenceContext;
 use crate::type_check::{self, MirTypeckResults};
 use crate::universal_regions::UniversalRegions;
@@ -80,7 +80,7 @@ pub(crate) fn compute_regions<'a, 'tcx>(
     universal_regions: UniversalRegions<'tcx>,
     body: &Body<'tcx>,
     promoted: &IndexSlice<Promoted, Body<'tcx>>,
-    location_table: &LocationTable,
+    location_table: &PoloniusLocationTable,
     flow_inits: ResultsCursor<'a, 'tcx, MaybeInitializedPlaces<'a, 'tcx>>,
     move_data: &MoveData<'tcx>,
     borrow_set: &BorrowSet<'tcx>,

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -94,7 +94,7 @@ pub(crate) fn compute_regions<'a, 'tcx>(
     let mut all_facts =
         (polonius_input || AllFacts::enabled(infcx.tcx)).then_some(AllFacts::default());
 
-    let elements = Rc::new(DenseLocationMap::new(body));
+    let location_map = Rc::new(DenseLocationMap::new(body));
 
     // Run the MIR type-checker.
     let MirTypeckResults {
@@ -112,7 +112,7 @@ pub(crate) fn compute_regions<'a, 'tcx>(
         &mut all_facts,
         flow_inits,
         move_data,
-        Rc::clone(&elements),
+        Rc::clone(&location_map),
     );
 
     // Create the region inference context, taking ownership of the
@@ -137,7 +137,7 @@ pub(crate) fn compute_regions<'a, 'tcx>(
         var_infos,
         constraints,
         universal_region_relations,
-        elements,
+        location_map,
     );
 
     // If requested for `-Zpolonius=next`, convert NLL constraints to localized outlives

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -28,7 +28,9 @@ use crate::borrow_set::BorrowSet;
 use crate::consumers::ConsumerOptions;
 use crate::diagnostics::{BorrowckDiagnosticsBuffer, RegionErrors};
 use crate::polonius::LocalizedOutlivesConstraintSet;
-use crate::polonius::legacy::{AllFacts, AllFactsExt, PoloniusLocationTable, PoloniusOutput};
+use crate::polonius::legacy::{
+    PoloniusFacts, PoloniusFactsExt, PoloniusLocationTable, PoloniusOutput,
+};
 use crate::region_infer::RegionInferenceContext;
 use crate::type_check::{self, MirTypeckResults};
 use crate::universal_regions::UniversalRegions;
@@ -39,7 +41,7 @@ use crate::{BorrowckInferCtxt, polonius, renumber};
 pub(crate) struct NllOutput<'tcx> {
     pub regioncx: RegionInferenceContext<'tcx>,
     pub opaque_type_values: FxIndexMap<LocalDefId, OpaqueHiddenType<'tcx>>,
-    pub polonius_input: Option<Box<AllFacts>>,
+    pub polonius_input: Option<Box<PoloniusFacts>>,
     pub polonius_output: Option<Box<PoloniusOutput>>,
     pub opt_closure_req: Option<ClosureRegionRequirements<'tcx>>,
     pub nll_errors: RegionErrors<'tcx>,
@@ -91,8 +93,8 @@ pub(crate) fn compute_regions<'a, 'tcx>(
         || is_polonius_legacy_enabled;
     let polonius_output = consumer_options.map(|c| c.polonius_output()).unwrap_or_default()
         || is_polonius_legacy_enabled;
-    let mut all_facts =
-        (polonius_input || AllFacts::enabled(infcx.tcx)).then_some(AllFacts::default());
+    let mut polonius_facts =
+        (polonius_input || PoloniusFacts::enabled(infcx.tcx)).then_some(PoloniusFacts::default());
 
     let location_map = Rc::new(DenseLocationMap::new(body));
 
@@ -109,7 +111,7 @@ pub(crate) fn compute_regions<'a, 'tcx>(
         universal_regions,
         location_table,
         borrow_set,
-        &mut all_facts,
+        &mut polonius_facts,
         flow_inits,
         move_data,
         Rc::clone(&location_map),
@@ -122,7 +124,7 @@ pub(crate) fn compute_regions<'a, 'tcx>(
 
     // If requested, emit legacy polonius facts.
     polonius::legacy::emit_facts(
-        &mut all_facts,
+        &mut polonius_facts,
         infcx.tcx,
         location_table,
         body,
@@ -147,13 +149,13 @@ pub(crate) fn compute_regions<'a, 'tcx>(
     });
 
     // If requested: dump NLL facts, and run legacy polonius analysis.
-    let polonius_output = all_facts.as_ref().and_then(|all_facts| {
+    let polonius_output = polonius_facts.as_ref().and_then(|polonius_facts| {
         if infcx.tcx.sess.opts.unstable_opts.nll_facts {
             let def_id = body.source.def_id();
             let def_path = infcx.tcx.def_path(def_id);
             let dir_path = PathBuf::from(&infcx.tcx.sess.opts.unstable_opts.nll_facts_dir)
                 .join(def_path.to_filename_friendly_no_crate());
-            all_facts.write_to_dir(dir_path, location_table).unwrap();
+            polonius_facts.write_to_dir(dir_path, location_table).unwrap();
         }
 
         if polonius_output {
@@ -162,7 +164,7 @@ pub(crate) fn compute_regions<'a, 'tcx>(
             let algorithm = Algorithm::from_str(&algorithm).unwrap();
             debug!("compute_regions: using polonius algorithm {:?}", algorithm);
             let _prof_timer = infcx.tcx.prof.generic_activity("polonius_analysis");
-            Some(Box::new(Output::compute(all_facts, algorithm, false)))
+            Some(Box::new(Output::compute(polonius_facts, algorithm, false)))
         } else {
             None
         }
@@ -182,7 +184,7 @@ pub(crate) fn compute_regions<'a, 'tcx>(
     NllOutput {
         regioncx,
         opaque_type_values: remapped_opaque_tys,
-        polonius_input: all_facts.map(Box::new),
+        polonius_input: polonius_facts.map(Box::new),
         polonius_output,
         opt_closure_req: closure_region_requirements,
         nll_errors,

--- a/compiler/rustc_borrowck/src/polonius/legacy/accesses.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/accesses.rs
@@ -4,7 +4,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_mir_dataflow::move_paths::{LookupResult, MoveData};
 use tracing::debug;
 
-use super::{AllFacts, LocationIndex, LocationTable};
+use super::{AllFacts, LocationIndex, PoloniusLocationTable};
 use crate::def_use::{self, DefUse};
 use crate::universal_regions::UniversalRegions;
 
@@ -13,7 +13,7 @@ pub(crate) fn emit_access_facts<'tcx>(
     tcx: TyCtxt<'tcx>,
     facts: &mut AllFacts,
     body: &Body<'tcx>,
-    location_table: &LocationTable,
+    location_table: &PoloniusLocationTable,
     move_data: &MoveData<'tcx>,
     universal_regions: &UniversalRegions<'tcx>,
 ) {
@@ -33,7 +33,7 @@ pub(crate) fn emit_access_facts<'tcx>(
 struct AccessFactsExtractor<'a, 'tcx> {
     facts: &'a mut AllFacts,
     move_data: &'a MoveData<'tcx>,
-    location_table: &'a LocationTable,
+    location_table: &'a PoloniusLocationTable,
 }
 
 impl<'tcx> AccessFactsExtractor<'_, 'tcx> {

--- a/compiler/rustc_borrowck/src/polonius/legacy/accesses.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/accesses.rs
@@ -4,14 +4,14 @@ use rustc_middle::ty::TyCtxt;
 use rustc_mir_dataflow::move_paths::{LookupResult, MoveData};
 use tracing::debug;
 
-use super::{AllFacts, LocationIndex, PoloniusLocationTable};
+use super::{LocationIndex, PoloniusFacts, PoloniusLocationTable};
 use crate::def_use::{self, DefUse};
 use crate::universal_regions::UniversalRegions;
 
 /// Emit polonius facts for variable defs, uses, drops, and path accesses.
 pub(crate) fn emit_access_facts<'tcx>(
     tcx: TyCtxt<'tcx>,
-    facts: &mut AllFacts,
+    facts: &mut PoloniusFacts,
     body: &Body<'tcx>,
     location_table: &PoloniusLocationTable,
     move_data: &MoveData<'tcx>,
@@ -31,7 +31,7 @@ pub(crate) fn emit_access_facts<'tcx>(
 
 /// MIR visitor extracting point-wise facts about accesses.
 struct AccessFactsExtractor<'a, 'tcx> {
-    facts: &'a mut AllFacts,
+    facts: &'a mut PoloniusFacts,
     move_data: &'a MoveData<'tcx>,
     location_table: &'a PoloniusLocationTable,
 }

--- a/compiler/rustc_borrowck/src/polonius/legacy/facts.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/facts.rs
@@ -10,7 +10,7 @@ use rustc_middle::mir::Local;
 use rustc_middle::ty::{RegionVid, TyCtxt};
 use rustc_mir_dataflow::move_paths::MovePathIndex;
 
-use super::{LocationIndex, LocationTable};
+use super::{LocationIndex, PoloniusLocationTable};
 use crate::BorrowIndex;
 
 #[derive(Copy, Clone, Debug)]
@@ -63,7 +63,7 @@ impl AllFacts {
     fn write_to_dir(
         &self,
         dir: impl AsRef<Path>,
-        location_table: &LocationTable,
+        location_table: &PoloniusLocationTable,
     ) -> Result<(), Box<dyn Error>> {
         let dir: &Path = dir.as_ref();
         fs::create_dir_all(dir)?;
@@ -119,7 +119,7 @@ impl Atom for LocationIndex {
 }
 
 struct FactWriter<'w> {
-    location_table: &'w LocationTable,
+    location_table: &'w PoloniusLocationTable,
     dir: &'w Path,
 }
 
@@ -141,7 +141,7 @@ trait FactRow {
     fn write(
         &self,
         out: &mut dyn Write,
-        location_table: &LocationTable,
+        location_table: &PoloniusLocationTable,
     ) -> Result<(), Box<dyn Error>>;
 }
 
@@ -149,7 +149,7 @@ impl FactRow for PoloniusRegionVid {
     fn write(
         &self,
         out: &mut dyn Write,
-        location_table: &LocationTable,
+        location_table: &PoloniusLocationTable,
     ) -> Result<(), Box<dyn Error>> {
         write_row(out, location_table, &[self])
     }
@@ -163,7 +163,7 @@ where
     fn write(
         &self,
         out: &mut dyn Write,
-        location_table: &LocationTable,
+        location_table: &PoloniusLocationTable,
     ) -> Result<(), Box<dyn Error>> {
         write_row(out, location_table, &[&self.0, &self.1])
     }
@@ -178,7 +178,7 @@ where
     fn write(
         &self,
         out: &mut dyn Write,
-        location_table: &LocationTable,
+        location_table: &PoloniusLocationTable,
     ) -> Result<(), Box<dyn Error>> {
         write_row(out, location_table, &[&self.0, &self.1, &self.2])
     }
@@ -194,7 +194,7 @@ where
     fn write(
         &self,
         out: &mut dyn Write,
-        location_table: &LocationTable,
+        location_table: &PoloniusLocationTable,
     ) -> Result<(), Box<dyn Error>> {
         write_row(out, location_table, &[&self.0, &self.1, &self.2, &self.3])
     }
@@ -202,7 +202,7 @@ where
 
 fn write_row(
     out: &mut dyn Write,
-    location_table: &LocationTable,
+    location_table: &PoloniusLocationTable,
     columns: &[&dyn FactCell],
 ) -> Result<(), Box<dyn Error>> {
     for (index, c) in columns.iter().enumerate() {
@@ -213,41 +213,41 @@ fn write_row(
 }
 
 trait FactCell {
-    fn to_string(&self, location_table: &LocationTable) -> String;
+    fn to_string(&self, location_table: &PoloniusLocationTable) -> String;
 }
 
 impl FactCell for BorrowIndex {
-    fn to_string(&self, _location_table: &LocationTable) -> String {
+    fn to_string(&self, _location_table: &PoloniusLocationTable) -> String {
         format!("{self:?}")
     }
 }
 
 impl FactCell for Local {
-    fn to_string(&self, _location_table: &LocationTable) -> String {
+    fn to_string(&self, _location_table: &PoloniusLocationTable) -> String {
         format!("{self:?}")
     }
 }
 
 impl FactCell for MovePathIndex {
-    fn to_string(&self, _location_table: &LocationTable) -> String {
+    fn to_string(&self, _location_table: &PoloniusLocationTable) -> String {
         format!("{self:?}")
     }
 }
 
 impl FactCell for PoloniusRegionVid {
-    fn to_string(&self, _location_table: &LocationTable) -> String {
+    fn to_string(&self, _location_table: &PoloniusLocationTable) -> String {
         format!("{self:?}")
     }
 }
 
 impl FactCell for RegionVid {
-    fn to_string(&self, _location_table: &LocationTable) -> String {
+    fn to_string(&self, _location_table: &PoloniusLocationTable) -> String {
         format!("{self:?}")
     }
 }
 
 impl FactCell for LocationIndex {
-    fn to_string(&self, location_table: &LocationTable) -> String {
+    fn to_string(&self, location_table: &PoloniusLocationTable) -> String {
         format!("{:?}", location_table.to_rich_location(*self))
     }
 }

--- a/compiler/rustc_borrowck/src/polonius/legacy/facts.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/facts.rs
@@ -4,7 +4,7 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 
-use polonius_engine::{AllFacts as PoloniusFacts, Atom, Output};
+use polonius_engine::{AllFacts, Atom, Output};
 use rustc_macros::extension;
 use rustc_middle::mir::Local;
 use rustc_middle::ty::{RegionVid, TyCtxt};
@@ -49,11 +49,11 @@ impl polonius_engine::FactTypes for RustcFacts {
     type Path = MovePathIndex;
 }
 
-pub type AllFacts = PoloniusFacts<RustcFacts>;
+pub type PoloniusFacts = AllFacts<RustcFacts>;
 
-#[extension(pub(crate) trait AllFactsExt)]
-impl AllFacts {
-    /// Returns `true` if there is a need to gather `AllFacts` given the
+#[extension(pub(crate) trait PoloniusFactsExt)]
+impl PoloniusFacts {
+    /// Returns `true` if there is a need to gather `PoloniusFacts` given the
     /// current `-Z` flags.
     fn enabled(tcx: TyCtxt<'_>) -> bool {
         tcx.sess.opts.unstable_opts.nll_facts

--- a/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
@@ -11,7 +11,7 @@ use rustc_middle::mir::{
 use rustc_middle::ty::TyCtxt;
 use tracing::debug;
 
-use super::{AllFacts, LocationTable};
+use super::{AllFacts, PoloniusLocationTable};
 use crate::borrow_set::BorrowSet;
 use crate::path_utils::*;
 use crate::{
@@ -24,7 +24,7 @@ pub(super) fn emit_loan_invalidations<'tcx>(
     tcx: TyCtxt<'tcx>,
     facts: &mut AllFacts,
     body: &Body<'tcx>,
-    location_table: &LocationTable,
+    location_table: &PoloniusLocationTable,
     borrow_set: &BorrowSet<'tcx>,
 ) {
     let dominators = body.basic_blocks.dominators();
@@ -37,7 +37,7 @@ struct LoanInvalidationsGenerator<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     facts: &'a mut AllFacts,
     body: &'a Body<'tcx>,
-    location_table: &'a LocationTable,
+    location_table: &'a PoloniusLocationTable,
     dominators: &'a Dominators<BasicBlock>,
     borrow_set: &'a BorrowSet<'tcx>,
 }

--- a/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/loan_invalidations.rs
@@ -11,7 +11,7 @@ use rustc_middle::mir::{
 use rustc_middle::ty::TyCtxt;
 use tracing::debug;
 
-use super::{AllFacts, PoloniusLocationTable};
+use super::{PoloniusFacts, PoloniusLocationTable};
 use crate::borrow_set::BorrowSet;
 use crate::path_utils::*;
 use crate::{
@@ -22,7 +22,7 @@ use crate::{
 /// Emit `loan_invalidated_at` facts.
 pub(super) fn emit_loan_invalidations<'tcx>(
     tcx: TyCtxt<'tcx>,
-    facts: &mut AllFacts,
+    facts: &mut PoloniusFacts,
     body: &Body<'tcx>,
     location_table: &PoloniusLocationTable,
     borrow_set: &BorrowSet<'tcx>,
@@ -35,7 +35,7 @@ pub(super) fn emit_loan_invalidations<'tcx>(
 
 struct LoanInvalidationsGenerator<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
-    facts: &'a mut AllFacts,
+    facts: &'a mut PoloniusFacts,
     body: &'a Body<'tcx>,
     location_table: &'a PoloniusLocationTable,
     dominators: &'a Dominators<BasicBlock>,

--- a/compiler/rustc_borrowck/src/polonius/legacy/loan_kills.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/loan_kills.rs
@@ -6,7 +6,7 @@ use rustc_middle::mir::{
 use rustc_middle::ty::TyCtxt;
 use tracing::debug;
 
-use super::{AllFacts, LocationTable};
+use super::{AllFacts, PoloniusLocationTable};
 use crate::borrow_set::BorrowSet;
 use crate::places_conflict;
 
@@ -15,7 +15,7 @@ pub(super) fn emit_loan_kills<'tcx>(
     tcx: TyCtxt<'tcx>,
     facts: &mut AllFacts,
     body: &Body<'tcx>,
-    location_table: &LocationTable,
+    location_table: &PoloniusLocationTable,
     borrow_set: &BorrowSet<'tcx>,
 ) {
     let mut visitor = LoanKillsGenerator { borrow_set, tcx, location_table, facts, body };
@@ -27,7 +27,7 @@ pub(super) fn emit_loan_kills<'tcx>(
 struct LoanKillsGenerator<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     facts: &'a mut AllFacts,
-    location_table: &'a LocationTable,
+    location_table: &'a PoloniusLocationTable,
     borrow_set: &'a BorrowSet<'tcx>,
     body: &'a Body<'tcx>,
 }

--- a/compiler/rustc_borrowck/src/polonius/legacy/loan_kills.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/loan_kills.rs
@@ -6,14 +6,14 @@ use rustc_middle::mir::{
 use rustc_middle::ty::TyCtxt;
 use tracing::debug;
 
-use super::{AllFacts, PoloniusLocationTable};
+use super::{PoloniusFacts, PoloniusLocationTable};
 use crate::borrow_set::BorrowSet;
 use crate::places_conflict;
 
 /// Emit `loan_killed_at` and `cfg_edge` facts at the same time.
 pub(super) fn emit_loan_kills<'tcx>(
     tcx: TyCtxt<'tcx>,
-    facts: &mut AllFacts,
+    facts: &mut PoloniusFacts,
     body: &Body<'tcx>,
     location_table: &PoloniusLocationTable,
     borrow_set: &BorrowSet<'tcx>,
@@ -26,7 +26,7 @@ pub(super) fn emit_loan_kills<'tcx>(
 
 struct LoanKillsGenerator<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
-    facts: &'a mut AllFacts,
+    facts: &'a mut PoloniusFacts,
     location_table: &'a PoloniusLocationTable,
     borrow_set: &'a BorrowSet<'tcx>,
     body: &'a Body<'tcx>,

--- a/compiler/rustc_borrowck/src/polonius/legacy/location.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/location.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 /// granularity through outlives relations; however, the rich location
 /// table serves another purpose: it compresses locations from
 /// multiple words into a single u32.
-pub struct LocationTable {
+pub struct PoloniusLocationTable {
     num_points: usize,
     statements_before_block: IndexVec<BasicBlock, usize>,
 }
@@ -30,7 +30,7 @@ pub enum RichLocation {
     Mid(Location),
 }
 
-impl LocationTable {
+impl PoloniusLocationTable {
     pub(crate) fn new(body: &Body<'_>) -> Self {
         let mut num_points = 0;
         let statements_before_block = body
@@ -43,8 +43,8 @@ impl LocationTable {
             })
             .collect();
 
-        debug!("LocationTable(statements_before_block={:#?})", statements_before_block);
-        debug!("LocationTable: num_points={:#?}", num_points);
+        debug!("PoloniusLocationTable(statements_before_block={:#?})", statements_before_block);
+        debug!("PoloniusLocationTable: num_points={:#?}", num_points);
 
         Self { num_points, statements_before_block }
     }

--- a/compiler/rustc_borrowck/src/polonius/legacy/mod.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/mod.rs
@@ -36,7 +36,7 @@ pub use self::facts::*;
 ///
 /// The rest of the facts are emitted during typeck and liveness.
 pub(crate) fn emit_facts<'tcx>(
-    all_facts: &mut Option<AllFacts>,
+    facts: &mut Option<PoloniusFacts>,
     tcx: TyCtxt<'tcx>,
     location_table: &PoloniusLocationTable,
     body: &Body<'tcx>,
@@ -45,7 +45,7 @@ pub(crate) fn emit_facts<'tcx>(
     universal_region_relations: &UniversalRegionRelations<'tcx>,
     constraints: &MirTypeckRegionConstraints<'tcx>,
 ) {
-    let Some(facts) = all_facts else {
+    let Some(facts) = facts else {
         // We don't do anything if there are no facts to fill.
         return;
     };
@@ -67,7 +67,7 @@ pub(crate) fn emit_facts<'tcx>(
 
 /// Emit facts needed for move/init analysis: moves and assignments.
 fn emit_move_facts(
-    facts: &mut AllFacts,
+    facts: &mut PoloniusFacts,
     body: &Body<'_>,
     location_table: &PoloniusLocationTable,
     move_data: &MoveData<'_>,
@@ -139,7 +139,7 @@ fn emit_move_facts(
 
 /// Emit universal regions facts, and their relations.
 fn emit_universal_region_facts(
-    facts: &mut AllFacts,
+    facts: &mut PoloniusFacts,
     borrow_set: &BorrowSet<'_>,
     universal_region_relations: &UniversalRegionRelations<'_>,
 ) {
@@ -187,10 +187,10 @@ pub(crate) fn emit_drop_facts<'tcx>(
     local: Local,
     kind: &GenericArg<'tcx>,
     universal_regions: &UniversalRegions<'tcx>,
-    all_facts: &mut Option<AllFacts>,
+    facts: &mut Option<PoloniusFacts>,
 ) {
     debug!("emit_drop_facts(local={:?}, kind={:?}", local, kind);
-    let Some(facts) = all_facts.as_mut() else { return };
+    let Some(facts) = facts.as_mut() else { return };
     let _prof_timer = tcx.prof.generic_activity("polonius_fact_generation");
     tcx.for_each_free_region(kind, |drop_live_region| {
         let region_vid = universal_regions.to_region_vid(drop_live_region);
@@ -201,7 +201,7 @@ pub(crate) fn emit_drop_facts<'tcx>(
 /// Emit facts about the outlives constraints: the `subset` base relation, i.e. not a transitive
 /// closure.
 fn emit_outlives_facts<'tcx>(
-    facts: &mut AllFacts,
+    facts: &mut PoloniusFacts,
     location_table: &PoloniusLocationTable,
     constraints: &MirTypeckRegionConstraints<'tcx>,
 ) {

--- a/compiler/rustc_borrowck/src/polonius/legacy/mod.rs
+++ b/compiler/rustc_borrowck/src/polonius/legacy/mod.rs
@@ -38,7 +38,7 @@ pub use self::facts::*;
 pub(crate) fn emit_facts<'tcx>(
     all_facts: &mut Option<AllFacts>,
     tcx: TyCtxt<'tcx>,
-    location_table: &LocationTable,
+    location_table: &PoloniusLocationTable,
     body: &Body<'tcx>,
     borrow_set: &BorrowSet<'tcx>,
     move_data: &MoveData<'tcx>,
@@ -69,7 +69,7 @@ pub(crate) fn emit_facts<'tcx>(
 fn emit_move_facts(
     facts: &mut AllFacts,
     body: &Body<'_>,
-    location_table: &LocationTable,
+    location_table: &PoloniusLocationTable,
     move_data: &MoveData<'_>,
 ) {
     facts.path_is_var.extend(move_data.rev_lookup.iter_locals_enumerated().map(|(l, r)| (r, l)));
@@ -202,7 +202,7 @@ pub(crate) fn emit_drop_facts<'tcx>(
 /// closure.
 fn emit_outlives_facts<'tcx>(
     facts: &mut AllFacts,
-    location_table: &LocationTable,
+    location_table: &PoloniusLocationTable,
     constraints: &MirTypeckRegionConstraints<'tcx>,
 ) {
     facts.subset_base.extend(constraints.outlives_constraints.outlives().iter().flat_map(

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -396,7 +396,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         var_infos: VarInfos,
         constraints: MirTypeckRegionConstraints<'tcx>,
         universal_region_relations: Frozen<UniversalRegionRelations<'tcx>>,
-        elements: Rc<DenseLocationMap>,
+        location_map: Rc<DenseLocationMap>,
     ) -> Self {
         let universal_regions = &universal_region_relations.universal_regions;
         let MirTypeckRegionConstraints {
@@ -440,7 +440,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         }
 
         let mut scc_values =
-            RegionValues::new(elements, universal_regions.len(), placeholder_indices);
+            RegionValues::new(location_map, universal_regions.len(), placeholder_indices);
 
         for region in liveness_constraints.regions() {
             let scc = constraint_sccs.scc(region);

--- a/compiler/rustc_borrowck/src/type_check/liveness/local_use_map.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/local_use_map.rs
@@ -82,7 +82,7 @@ impl<'a> Iterator for AppearancesIter<'a> {
 impl LocalUseMap {
     pub(crate) fn build(
         live_locals: &[Local],
-        elements: &DenseLocationMap,
+        location_map: &DenseLocationMap,
         body: &Body<'_>,
     ) -> Self {
         let nones = IndexVec::from_elem(None, &body.local_decls);
@@ -101,7 +101,7 @@ impl LocalUseMap {
             IndexVec::from_elem(false, &body.local_decls);
         live_locals.iter().for_each(|&local| locals_with_use_data[local] = true);
 
-        LocalUseMapBuild { local_use_map: &mut local_use_map, elements, locals_with_use_data }
+        LocalUseMapBuild { local_use_map: &mut local_use_map, location_map, locals_with_use_data }
             .visit_body(body);
 
         local_use_map
@@ -125,7 +125,7 @@ impl LocalUseMap {
 
 struct LocalUseMapBuild<'me> {
     local_use_map: &'me mut LocalUseMap,
-    elements: &'me DenseLocationMap,
+    location_map: &'me DenseLocationMap,
 
     // Vector used in `visit_local` to signal which `Local`s do we need
     // def/use/drop information on, constructed from `live_locals` (that
@@ -147,7 +147,7 @@ impl Visitor<'_> for LocalUseMapBuild<'_> {
                 DefUse::Use => &mut self.local_use_map.first_use_at[local],
                 DefUse::Drop => &mut self.local_use_map.first_drop_at[local],
             };
-            let point_index = self.elements.point_from_location(location);
+            let point_index = self.location_map.point_from_location(location);
             let appearance_index = self
                 .local_use_map
                 .appearances

--- a/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
@@ -32,7 +32,7 @@ mod trace;
 pub(super) fn generate<'a, 'tcx>(
     typeck: &mut TypeChecker<'_, 'tcx>,
     body: &Body<'tcx>,
-    elements: &DenseLocationMap,
+    location_map: &DenseLocationMap,
     flow_inits: ResultsCursor<'a, 'tcx, MaybeInitializedPlaces<'a, 'tcx>>,
     move_data: &MoveData<'tcx>,
 ) {
@@ -49,7 +49,7 @@ pub(super) fn generate<'a, 'tcx>(
     trace::trace(
         typeck,
         body,
-        elements,
+        location_map,
         flow_inits,
         move_data,
         relevant_live_locals,

--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -37,13 +37,13 @@ use crate::type_check::{NormalizeLocation, TypeChecker};
 pub(super) fn trace<'a, 'tcx>(
     typeck: &mut TypeChecker<'_, 'tcx>,
     body: &Body<'tcx>,
-    elements: &DenseLocationMap,
+    location_map: &DenseLocationMap,
     flow_inits: ResultsCursor<'a, 'tcx, MaybeInitializedPlaces<'a, 'tcx>>,
     move_data: &MoveData<'tcx>,
     relevant_live_locals: Vec<Local>,
     boring_locals: Vec<Local>,
 ) {
-    let local_use_map = &LocalUseMap::build(&relevant_live_locals, elements, body);
+    let local_use_map = &LocalUseMap::build(&relevant_live_locals, location_map, body);
 
     // When using `-Zpolonius=next`, compute the set of loans that can reach a given region.
     if typeck.tcx().sess.opts.unstable_opts.polonius.is_next_enabled() {
@@ -79,7 +79,7 @@ pub(super) fn trace<'a, 'tcx>(
         typeck,
         body,
         flow_inits,
-        elements,
+        location_map,
         local_use_map,
         move_data,
         drop_data: FxIndexMap::default(),
@@ -100,7 +100,7 @@ struct LivenessContext<'a, 'typeck, 'b, 'tcx> {
     typeck: &'a mut TypeChecker<'typeck, 'tcx>,
 
     /// Defines the `PointIndex` mapping
-    elements: &'a DenseLocationMap,
+    location_map: &'a DenseLocationMap,
 
     /// MIR we are analyzing.
     body: &'a Body<'tcx>,
@@ -149,7 +149,7 @@ struct LivenessResults<'a, 'typeck, 'b, 'tcx> {
 
 impl<'a, 'typeck, 'b, 'tcx> LivenessResults<'a, 'typeck, 'b, 'tcx> {
     fn new(cx: LivenessContext<'a, 'typeck, 'b, 'tcx>) -> Self {
-        let num_points = cx.elements.num_points();
+        let num_points = cx.location_map.num_points();
         LivenessResults {
             cx,
             defs: BitSet::new_empty(num_points),
@@ -240,7 +240,7 @@ impl<'a, 'typeck, 'b, 'tcx> LivenessResults<'a, 'typeck, 'b, 'tcx> {
                 .collect()
         };
 
-        let live_at = IntervalSet::new(self.cx.elements.num_points());
+        let live_at = IntervalSet::new(self.cx.location_map.num_points());
         for (local, local_ty, location) in facts_to_add {
             self.cx.add_drop_live_facts_for(local, local_ty, &[location], &live_at);
         }
@@ -279,7 +279,7 @@ impl<'a, 'typeck, 'b, 'tcx> LivenessResults<'a, 'typeck, 'b, 'tcx> {
             //  * Inclusively, the block start
             //  * Exclusively, the previous definition (if it's in this block)
             //  * Exclusively, the previous live_at setting (an optimization)
-            let block_start = self.cx.elements.to_block_start(p);
+            let block_start = self.cx.location_map.to_block_start(p);
             let previous_defs = self.defs.last_set_in(block_start..=p);
             let previous_live_at = self.use_live_at.last_set_in(block_start..=p);
 
@@ -303,12 +303,12 @@ impl<'a, 'typeck, 'b, 'tcx> LivenessResults<'a, 'typeck, 'b, 'tcx> {
                 // terminators of predecessor basic blocks. Push those onto the
                 // stack so that the next iteration(s) will process them.
 
-                let block = self.cx.elements.to_location(block_start).block;
+                let block = self.cx.location_map.to_location(block_start).block;
                 self.stack.extend(
                     self.cx.body.basic_blocks.predecessors()[block]
                         .iter()
                         .map(|&pred_bb| self.cx.body.terminator_loc(pred_bb))
-                        .map(|pred_loc| self.cx.elements.point_from_location(pred_loc)),
+                        .map(|pred_loc| self.cx.location_map.point_from_location(pred_loc)),
                 );
             }
         }
@@ -331,7 +331,7 @@ impl<'a, 'typeck, 'b, 'tcx> LivenessResults<'a, 'typeck, 'b, 'tcx> {
 
         // Find the drops where `local` is initialized.
         for drop_point in self.cx.local_use_map.drops(local) {
-            let location = self.cx.elements.to_location(drop_point);
+            let location = self.cx.location_map.to_location(drop_point);
             debug_assert_eq!(self.cx.body.terminator_loc(location.block), location,);
 
             if self.cx.initialized_at_terminator(location.block, mpi)
@@ -367,7 +367,7 @@ impl<'a, 'typeck, 'b, 'tcx> LivenessResults<'a, 'typeck, 'b, 'tcx> {
         debug!(
             "compute_drop_live_points_for_block(mpi={:?}, term_point={:?})",
             self.cx.move_data.move_paths[mpi].place,
-            self.cx.elements.to_location(term_point),
+            self.cx.location_map.to_location(term_point),
         );
 
         // We are only invoked with terminators where `mpi` is
@@ -377,12 +377,15 @@ impl<'a, 'typeck, 'b, 'tcx> LivenessResults<'a, 'typeck, 'b, 'tcx> {
         // Otherwise, scan backwards through the statements in the
         // block. One of them may be either a definition or use
         // live point.
-        let term_location = self.cx.elements.to_location(term_point);
+        let term_location = self.cx.location_map.to_location(term_point);
         debug_assert_eq!(self.cx.body.terminator_loc(term_location.block), term_location,);
         let block = term_location.block;
-        let entry_point = self.cx.elements.entry_point(term_location.block);
+        let entry_point = self.cx.location_map.entry_point(term_location.block);
         for p in (entry_point..term_point).rev() {
-            debug!("compute_drop_live_points_for_block: p = {:?}", self.cx.elements.to_location(p));
+            debug!(
+                "compute_drop_live_points_for_block: p = {:?}",
+                self.cx.location_map.to_location(p)
+            );
 
             if self.defs.contains(p) {
                 debug!("compute_drop_live_points_for_block: def site");
@@ -428,7 +431,7 @@ impl<'a, 'typeck, 'b, 'tcx> LivenessResults<'a, 'typeck, 'b, 'tcx> {
             }
 
             let pred_term_loc = self.cx.body.terminator_loc(pred_block);
-            let pred_term_point = self.cx.elements.point_from_location(pred_term_loc);
+            let pred_term_point = self.cx.location_map.point_from_location(pred_term_loc);
 
             // If the terminator of this predecessor either *assigns*
             // our value or is a "normal use", then stop.
@@ -523,7 +526,7 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
     /// points `live_at`.
     fn add_use_live_facts_for(&mut self, value: Ty<'tcx>, live_at: &IntervalSet<PointIndex>) {
         debug!("add_use_live_facts_for(value={:?})", value);
-        Self::make_all_regions_live(self.elements, self.typeck, value, live_at);
+        Self::make_all_regions_live(self.location_map, self.typeck, value, live_at);
     }
 
     /// Some variable with type `live_ty` is "drop live" at `location`
@@ -547,7 +550,7 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
             dropped_local,
             dropped_ty,
             drop_locations,
-            values::pretty_print_points(self.elements, live_at.iter()),
+            values::pretty_print_points(self.location_map, live_at.iter()),
         );
 
         let drop_data = self.drop_data.entry(dropped_ty).or_insert_with({
@@ -574,7 +577,7 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
         // All things in the `outlives` array may be touched by
         // the destructor and must be live at this point.
         for &kind in &drop_data.dropck_result.kinds {
-            Self::make_all_regions_live(self.elements, self.typeck, kind, live_at);
+            Self::make_all_regions_live(self.location_map, self.typeck, kind, live_at);
             polonius::legacy::emit_drop_facts(
                 self.typeck.tcx(),
                 dropped_local,
@@ -586,7 +589,7 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
     }
 
     fn make_all_regions_live(
-        elements: &DenseLocationMap,
+        location_map: &DenseLocationMap,
         typeck: &mut TypeChecker<'_, 'tcx>,
         value: impl TypeVisitable<TyCtxt<'tcx>> + Relate<TyCtxt<'tcx>>,
         live_at: &IntervalSet<PointIndex>,
@@ -594,7 +597,7 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
         debug!("make_all_regions_live(value={:?})", value);
         debug!(
             "make_all_regions_live: live_at={}",
-            values::pretty_print_points(elements, live_at.iter()),
+            values::pretty_print_points(location_map, live_at.iter()),
         );
 
         value.visit_with(&mut for_liveness::FreeRegionsVisitor {

--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -213,14 +213,14 @@ impl<'a, 'typeck, 'b, 'tcx> LivenessResults<'a, 'typeck, 'b, 'tcx> {
     fn add_extra_drop_facts(&mut self, relevant_live_locals: &[Local]) {
         // This collect is more necessary than immediately apparent
         // because these facts go into `add_drop_live_facts_for()`,
-        // which also writes to `all_facts`, and so this is genuinely
+        // which also writes to `polonius_facts`, and so this is genuinely
         // a simultaneous overlapping mutable borrow.
         // FIXME for future hackers: investigate whether this is
         // actually necessary; these facts come from Polonius
         // and probably maybe plausibly does not need to go back in.
         // It may be necessary to just pick out the parts of
         // `add_drop_live_facts_for()` that make sense.
-        let Some(facts) = self.cx.typeck.all_facts.as_ref() else { return };
+        let Some(facts) = self.cx.typeck.polonius_facts.as_ref() else { return };
         let facts_to_add: Vec<_> = {
             let relevant_live_locals: FxIndexSet<_> =
                 relevant_live_locals.iter().copied().collect();
@@ -583,7 +583,7 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
                 dropped_local,
                 &kind,
                 self.typeck.universal_regions,
-                self.typeck.all_facts,
+                self.typeck.polonius_facts,
             );
         }
     }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -49,7 +49,7 @@ use crate::constraints::{OutlivesConstraint, OutlivesConstraintSet};
 use crate::diagnostics::UniverseInfo;
 use crate::member_constraints::MemberConstraintSet;
 use crate::polonius::PoloniusContext;
-use crate::polonius::legacy::{AllFacts, LocationTable};
+use crate::polonius::legacy::{AllFacts, PoloniusLocationTable};
 use crate::region_infer::TypeTest;
 use crate::region_infer::values::{LivenessValues, PlaceholderIndex, PlaceholderIndices};
 use crate::renumber::RegionCtxt;
@@ -98,7 +98,7 @@ mod relate_tys;
 /// - `body` -- MIR body to type-check
 /// - `promoted` -- map of promoted constants within `body`
 /// - `universal_regions` -- the universal regions from `body`s function signature
-/// - `location_table` -- MIR location map of `body`
+/// - `location_table` -- for datalog polonius, the map between `Location`s and `RichLocation`s
 /// - `borrow_set` -- information about borrows occurring in `body`
 /// - `all_facts` -- when using Polonius, this is the generated set of Polonius facts
 /// - `flow_inits` -- results of a maybe-init dataflow analysis
@@ -109,7 +109,7 @@ pub(crate) fn type_check<'a, 'tcx>(
     body: &Body<'tcx>,
     promoted: &IndexSlice<Promoted, Body<'tcx>>,
     universal_regions: UniversalRegions<'tcx>,
-    location_table: &LocationTable,
+    location_table: &PoloniusLocationTable,
     borrow_set: &BorrowSet<'tcx>,
     all_facts: &mut Option<AllFacts>,
     flow_inits: ResultsCursor<'a, 'tcx, MaybeInitializedPlaces<'a, 'tcx>>,
@@ -560,7 +560,7 @@ struct TypeChecker<'a, 'tcx> {
     implicit_region_bound: ty::Region<'tcx>,
     reported_errors: FxIndexSet<(Ty<'tcx>, Span)>,
     universal_regions: &'a UniversalRegions<'tcx>,
-    location_table: &'a LocationTable,
+    location_table: &'a PoloniusLocationTable,
     all_facts: &'a mut Option<AllFacts>,
     borrow_set: &'a BorrowSet<'tcx>,
     constraints: &'a mut MirTypeckRegionConstraints<'tcx>,


### PR DESCRIPTION
This PR has a couple simple renamings:
- it's been a long time since the mapping from `Location`s to `PointIndex`es was extracted from `RegionElements` into the `DenseLocationMap`, but only the types were renamed at the time. borrowck still refers to this map as `elements`. That's confusing, especially since sometimes we also use the mapping via `LivenessValues`, and makes more sense as `location_map` instead.
- to clarify `LocationTable` is not as general as it sounds, and is only for datalog polonius. In this branch I didn't rename the handful of `location_table` fields and params to `polonius_table`, but can do that to differentiate it even more from `location_map`. I did try it locally and it looks worthwhile, so if you'd prefer I can also push it here. (Or we could even switch these datalog types and fields to even more explicit names)
- to clarify the incomprehensible `AllFacts`, it is renamed to `PoloniusFacts`. These can be referred to as `facts` within the legacy polonius module, but as `polonius_facts` outside of it to make it clear that they're not about NLLs (nor are they about in-tree polonius but that'll be magically fixed when they're removed in the future)

r? @matthewjasper 