### PR TITLE
Revert #131365

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1592,15 +1592,9 @@ impl Step for Extended {
             prepare("cargo");
             prepare("rust-std");
             prepare("rust-analysis");
-
-            for tool in &[
-                "clippy",
-                "rustfmt",
-                "rust-analyzer",
-                "rust-docs",
-                "miri",
-                "rustc-codegen-cranelift",
-            ] {
+            prepare("clippy");
+            prepare("rust-analyzer");
+            for tool in &["rust-docs", "miri", "rustc-codegen-cranelift"] {
                 if built_tools.contains(tool) {
                     prepare(tool);
                 }

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1634,8 +1634,6 @@ impl Step for Extended {
                     "rust-analyzer-preview".to_string()
                 } else if name == "clippy" {
                     "clippy-preview".to_string()
-                } else if name == "rustfmt" {
-                    "rustfmt-preview".to_string()
                 } else if name == "miri" {
                     "miri-preview".to_string()
                 } else if name == "rustc-codegen-cranelift" {
@@ -1655,7 +1653,7 @@ impl Step for Extended {
             prepare("cargo");
             prepare("rust-analysis");
             prepare("rust-std");
-            for tool in &["clippy", "rustfmt", "rust-analyzer", "rust-docs", "miri"] {
+            for tool in &["clippy", "rust-analyzer", "rust-docs", "miri"] {
                 if built_tools.contains(tool) {
                     prepare(tool);
                 }
@@ -1773,24 +1771,6 @@ impl Step for Extended {
                     .arg(etc.join("msi/remove-duplicates.xsl"))
                     .run(builder);
             }
-            if built_tools.contains("rustfmt") {
-                command(&heat)
-                    .current_dir(&exe)
-                    .arg("dir")
-                    .arg("rustfmt")
-                    .args(heat_flags)
-                    .arg("-cg")
-                    .arg("RustFmtGroup")
-                    .arg("-dr")
-                    .arg("RustFmt")
-                    .arg("-var")
-                    .arg("var.RustFmtDir")
-                    .arg("-out")
-                    .arg(exe.join("RustFmtGroup.wxs"))
-                    .arg("-t")
-                    .arg(etc.join("msi/remove-duplicates.xsl"))
-                    .run(builder);
-            }
             if built_tools.contains("miri") {
                 command(&heat)
                     .current_dir(&exe)
@@ -1862,9 +1842,6 @@ impl Step for Extended {
                 if built_tools.contains("clippy") {
                     cmd.arg("-dClippyDir=clippy");
                 }
-                if built_tools.contains("rustfmt") {
-                    cmd.arg("-dRustFmtDir=rustfmt");
-                }
                 if built_tools.contains("rust-docs") {
                     cmd.arg("-dDocsDir=rust-docs");
                 }
@@ -1890,9 +1867,6 @@ impl Step for Extended {
             candle("StdGroup.wxs".as_ref());
             if built_tools.contains("clippy") {
                 candle("ClippyGroup.wxs".as_ref());
-            }
-            if built_tools.contains("rustfmt") {
-                candle("RustFmtGroup.wxs".as_ref());
             }
             if built_tools.contains("miri") {
                 candle("MiriGroup.wxs".as_ref());
@@ -1931,9 +1905,6 @@ impl Step for Extended {
 
             if built_tools.contains("clippy") {
                 cmd.arg("ClippyGroup.wixobj");
-            }
-            if built_tools.contains("rustfmt") {
-                cmd.arg("RustFmtGroup.wixobj");
             }
             if built_tools.contains("miri") {
                 cmd.arg("MiriGroup.wixobj");

--- a/src/etc/installer/msi/rust.wxs
+++ b/src/etc/installer/msi/rust.wxs
@@ -172,11 +172,6 @@
                     <!-- tool-rust-docs-end -->
                     <Directory Id="Cargo" Name="." />
                     <Directory Id="Std" Name="." />
-                    <Directory Id="RustFmt" Name="." />
-                    <Directory Id="RustAnalyzer" Name="." />
-                    <Directory Id="Miri" Name="." />
-                    <Directory Id="Analysis" Name="." />
-                    <Directory Id="Clippy" Name="." />
                 </Directory>
             </Directory>
 
@@ -284,41 +279,7 @@
                  <ComponentRef Id="PathEnvPerMachine" />
                  <ComponentRef Id="PathEnvPerUser" />
         </Feature>
-        <Feature Id="RustFmt"
-                 Title="Formatter for rust"
-                 Display="7"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="RustFmtGroup" />
-        </Feature>
-        <Feature Id="Clippy"
-                 Title="Formatter and checker for rust"
-                 Display="8"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="ClippyGroup" />
-        </Feature>
-        <Feature Id="Miri"
-                 Title="Soundness checker for rust"
-                 Display="9"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="MiriGroup" />
-        </Feature>
-        <Feature Id="RustAnalyzer"
-                 Title="Analyzer for rust"
-                 Display="10"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="RustAnalyzerGroup" />
-        </Feature>
-        <Feature Id="Analysis"
-                 Title="Analysis for rust"
-                 Display="11"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="AnalysisGroup" />
-        </Feature>
+
         <UIRef Id="RustUI" />
     </Product>
 </Wix>


### PR DESCRIPTION
This PR reverts #131365, following the revert we did on the beta branches for both 1.84 and 1.85.

While the PR passes CI successfully on master, as soon as we branch off beta it starts failing in the newly created beta branch. This caused the release team to revert it for both 1.84 and 1.85, and if nothing is done it would continue being reverted every cycle.

@heiseish (PR author) feel free to submit the PR again in the future: this revert doesn't represent the release team rejecting your change, but just a (hopefully temporary!) revert to ensure future beta branches can be created without reverting it each time.

When submitting the PR again, I recommend you test your changes by configuring `rust.channel` to both `nightly` and `beta` in your `config.toml`. You can see the latest failure [here](https://github.com/rust-lang/rust/pull/135163#issuecomment-2576373995).