### PR TITLE
wix: allow to skip more components

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1863,7 +1863,7 @@ impl Step for Extended {
                     .arg("-out")
                     .arg(&output)
                     .arg(input);
-                add_env(builder, &mut cmd, target);
+                add_env(builder, &mut cmd, target, &built_tools);
 
                 if built_tools.contains("clippy") {
                     cmd.arg("-dClippyDir=clippy");
@@ -1967,7 +1967,14 @@ impl Step for Extended {
     }
 }
 
-fn add_env(builder: &Builder<'_>, cmd: &mut BootstrapCommand, target: TargetSelection) {
+fn add_env(
+    builder: &Builder<'_>,
+    cmd: &mut BootstrapCommand,
+    target: TargetSelection,
+    built_tools: &HashSet<&'static str>,
+) {
+    // envs for wix should be always defined, even if not used
+    // FIXME: is they affect ccache?
     let mut parts = builder.version.split('.');
     cmd.env("CFG_RELEASE_INFO", builder.rust_version())
         .env("CFG_RELEASE_NUM", &builder.version)
@@ -1987,6 +1994,27 @@ fn add_env(builder: &Builder<'_>, cmd: &mut BootstrapCommand, target: TargetSele
         cmd.env("CFG_MINGW", "1").env("CFG_ABI", "GNU");
     } else {
         cmd.env("CFG_MINGW", "0").env("CFG_ABI", "MSVC");
+    }
+
+    if built_tools.contains("rustfmt") {
+        cmd.env("CFG_RUSTFMT", "1");
+    } else {
+        cmd.env("CFG_RUSTFMT", "0");
+    }
+    if built_tools.contains("clippy") {
+        cmd.env("CFG_CLIPPY", "1");
+    } else {
+        cmd.env("CFG_CLIPPY", "0");
+    }
+    if built_tools.contains("miri") {
+        cmd.env("CFG_MIRI", "1");
+    } else {
+        cmd.env("CFG_MIRI", "0");
+    }
+    if built_tools.contains("rust-analyzer") {
+        cmd.env("CFG_RA", "1");
+    } else {
+        cmd.env("CFG_RA", "0");
     }
 }
 

--- a/src/etc/installer/msi/rust.wxs
+++ b/src/etc/installer/msi/rust.wxs
@@ -172,11 +172,19 @@
                     <!-- tool-rust-docs-end -->
                     <Directory Id="Cargo" Name="." />
                     <Directory Id="Std" Name="." />
-                    <Directory Id="RustFmt" Name="." />
-                    <Directory Id="RustAnalyzer" Name="." />
-                    <Directory Id="Miri" Name="." />
+                    <?if $(env.CFG_RUSTFMT)="1" ?>
+                        <Directory Id="RustFmt" Name="." />
+                    <?endif?>
+                    <?if $(env.CFG_RA)="1" ?>
+                        <Directory Id="RustAnalyzer" Name="." />
+                    <?endif?>
+                    <?if $(env.CFG_MIRI)="1" ?>
+                        <Directory Id="Miri" Name="." />
+                    <?endif?>
                     <Directory Id="Analysis" Name="." />
-                    <Directory Id="Clippy" Name="." />
+                    <?if $(env.CFG_CLIPPY)="1" ?>
+                        <Directory Id="Clippy" Name="." />
+                    <?endif?>
                 </Directory>
             </Directory>
 
@@ -284,34 +292,42 @@
                  <ComponentRef Id="PathEnvPerMachine" />
                  <ComponentRef Id="PathEnvPerUser" />
         </Feature>
-        <Feature Id="RustFmt"
-                 Title="Formatter for rust"
-                 Display="7"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="RustFmtGroup" />
-        </Feature>
-        <Feature Id="Clippy"
-                 Title="Formatter and checker for rust"
-                 Display="8"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="ClippyGroup" />
-        </Feature>
-        <Feature Id="Miri"
-                 Title="Soundness checker for rust"
-                 Display="9"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="MiriGroup" />
-        </Feature>
-        <Feature Id="RustAnalyzer"
-                 Title="Analyzer for rust"
-                 Display="10"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="RustAnalyzerGroup" />
-        </Feature>
+        <?if $(env.CFG_RUSTFMT)="1" ?>
+            <Feature Id="RustFmt"
+                     Title="Formatter for rust"
+                     Display="7"
+                     Level="1"
+                     AllowAdvertise="no">
+                     <ComponentGroupRef Id="RustFmtGroup" />
+            </Feature>
+        <?endif?>
+        <?if $(env.CFG_CLIPPY)="1" ?>
+            <Feature Id="Clippy"
+                     Title="Formatter and checker for rust"
+                     Display="8"
+                     Level="1"
+                     AllowAdvertise="no">
+                     <ComponentGroupRef Id="ClippyGroup" />
+            </Feature>
+        <?endif?>
+        <?if $(env.CFG_MIRI)="1" ?>
+            <Feature Id="Miri"
+                     Title="Soundness checker for rust"
+                     Display="9"
+                     Level="1"
+                     AllowAdvertise="no">
+                     <ComponentGroupRef Id="MiriGroup" />
+            </Feature>
+        <?endif?>
+        <?if $(env.CFG_RA)="1" ?>
+            <Feature Id="RustAnalyzer"
+                     Title="Analyzer for rust"
+                     Display="10"
+                     Level="1"
+                     AllowAdvertise="no">
+                     <ComponentGroupRef Id="RustAnalyzerGroup" />
+            </Feature>
+        <?endif?>
         <Feature Id="Analysis"
                  Title="Analysis for rust"
                  Display="11"


### PR DESCRIPTION
Initially this fixed try builds for `dist-x86_64-msvc` when i played with it https://github.com/rust-lang/rust/pull/133033#issuecomment-2480471366

Looking at errors, it should probably fix issues with beta\stable bumps too: https://github.com/rust-lang/rust/pull/133447#issuecomment-2500141554 https://github.com/rust-lang/rust/pull/135163#issuecomment-2576373995

This makes tools like clippy/rustfmt/(and miri, which is nightly only component)/etc optional for msi, so they can be turned on/off by dist.