### PR TITLE
Remove special-casing for argument patterns in MIR typeck (attempt to fix perf regression of  #133858)

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -892,19 +892,6 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     Some(l) if !body.local_decls[l].is_user_variable() => {
                         ConstraintCategory::Boring
                     }
-                    Some(_)
-                        if let Some(body_id) = tcx
-                            .hir_node_by_def_id(body.source.def_id().expect_local())
-                            .body_id()
-                            && let params = tcx.hir().body(body_id).params
-                            && params
-                                .iter()
-                                .any(|param| param.span.contains(stmt.source_info.span)) =>
-                    {
-                        // Assignments generated from lowering argument patterns shouldn't be called
-                        // "assignments" in diagnostics and aren't interesting to blame for errors.
-                        ConstraintCategory::Boring
-                    }
                     _ => ConstraintCategory::Assignment,
                 };
                 debug!(

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-2.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-2.rs
@@ -1,6 +1,6 @@
 fn foo(&mut (ref mut v, w): &mut (&u8, &u8), x: &u8) {
-    *v = x;
     //~^ ERROR lifetime may not live long enough
+    *v = x;
 }
 
 fn main() { }

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-2.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-2.stderr
@@ -1,13 +1,15 @@
 error: lifetime may not live long enough
-  --> $DIR/ex3-both-anon-regions-2.rs:2:5
+  --> $DIR/ex3-both-anon-regions-2.rs:1:14
    |
 LL | fn foo(&mut (ref mut v, w): &mut (&u8, &u8), x: &u8) {
-   |                                   -             - let's call the lifetime of this reference `'1`
-   |                                   |
-   |                                   let's call the lifetime of this reference `'2`
-LL |     *v = x;
-   |     ^^^^^^ assignment requires that `'1` must outlive `'2`
+   |              ^^^^^^^^^            -             - let's call the lifetime of this reference `'1`
+   |              |                    |
+   |              |                    let's call the lifetime of this reference `'2`
+   |              assignment requires that `'1` must outlive `'2`
    |
+   = note: requirement occurs because of a mutable reference to `&u8`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 help: consider introducing a named lifetime parameter
    |
 LL | fn foo<'a>(&mut (ref mut v, w): &mut (&'a u8, &u8), x: &'a u8) {


### PR DESCRIPTION
See [my comment](https://github.com/rust-lang/rust/pull/133858#issuecomment-2579029618) on #133858 for more information. This is just a guess as to what went wrong, and I haven't been able to get the profiler running locally, so I'll need a perf run to make sure this actually helps.

There's one test's stderr that suffers a bit, but this was just papering over the issue anyway. Making region errors point to the correct constraints in the presence of invariance/contravariance is a broader problem; the current way it's handled is mostly based on guesswork, luck, and hoping it works out. Properly handling that (somehow) would improve the test's stderr without the hack that this PR reverts.