### PR TITLE
Add Pin::as_deref_mut to 1.84 relnotes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -60,6 +60,7 @@ Stabilized APIs
 - [`core::ptr::without_provenance_mut`](https://doc.rust-lang.org/stable/core/ptr/fn.without_provenance_mut.html)
 - [`core::ptr::dangling`](https://doc.rust-lang.org/stable/core/ptr/fn.dangling.html)
 - [`core::ptr::dangling_mut`](https://doc.rust-lang.org/stable/core/ptr/fn.dangling_mut.html)
+- [`Pin::as_deref_mut`](https://doc.rust-lang.org/stable/core/pin/struct.Pin.html#method.as_deref_mut)
 
 These APIs are now stable in const contexts
 


### PR DESCRIPTION
Resolves #131243 - I think this got missed in the relnotes sweep or something.

@rustbot label relnotes