### PR TITLE
Exclude dependencies of `std` for diagnostics

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -179,7 +179,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         // all visible traits. If there's one clear winner, just suggest that.
 
         let visible_traits: Vec<_> = tcx
-            .all_traits()
+            .visible_traits()
             .filter(|trait_def_id| {
                 let viz = tcx.visibility(*trait_def_id);
                 let def_id = self.item_def_id();

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -262,7 +262,7 @@ pub(crate) struct CrateLocator<'a> {
 
 #[derive(Clone)]
 pub(crate) struct CratePaths {
-    name: Symbol,
+    pub(crate) name: Symbol,
     source: CrateSource,
 }
 
@@ -765,10 +765,10 @@ impl<'a> CrateLocator<'a> {
         self.extract_lib(rlibs, rmetas, dylibs).map(|opt| opt.map(|(_, lib)| lib))
     }
 
-    pub(crate) fn into_error(self, root: Option<CratePaths>) -> CrateError {
+    pub(crate) fn into_error(self, dep_root: Option<CratePaths>) -> CrateError {
         CrateError::LocatorCombined(Box::new(CombinedLocatorError {
             crate_name: self.crate_name,
-            root,
+            dep_root,
             triple: self.tuple,
             dll_prefix: self.target.dll_prefix.to_string(),
             dll_suffix: self.target.dll_suffix.to_string(),
@@ -914,7 +914,7 @@ struct CrateRejections {
 /// otherwise they are ignored.
 pub(crate) struct CombinedLocatorError {
     crate_name: Symbol,
-    root: Option<CratePaths>,
+    dep_root: Option<CratePaths>,
     triple: TargetTuple,
     dll_prefix: String,
     dll_suffix: String,
@@ -987,7 +987,7 @@ impl CrateError {
             }
             CrateError::LocatorCombined(locator) => {
                 let crate_name = locator.crate_name;
-                let add_info = match &locator.root {
+                let add_info = match &locator.dep_root {
                     None => String::new(),
                     Some(r) => format!(" which `{}` depends on", r.name),
                 };
@@ -1012,7 +1012,7 @@ impl CrateError {
                             path.display()
                         ));
                     }
-                    if let Some(r) = locator.root {
+                    if let Some(r) = locator.dep_root {
                         for path in r.source.paths() {
                             found_crates.push_str(&format!(
                                 "\ncrate `{}`: {}",

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2128,6 +2128,8 @@ rustc_queries! {
         eval_always
         desc { "calculating the stability index for the local crate" }
     }
+    /// All available crates in the graph, including those that should not be user-facing
+    /// (such as private crates).
     query crates(_: ()) -> &'tcx [CrateNum] {
         eval_always
         desc { "fetching all foreign CrateNum instances" }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2078,9 +2078,20 @@ impl<'tcx> TyCtxt<'tcx> {
         self.limits(()).move_size_limit
     }
 
+    /// All traits in the crate graph, including those not visible to the user.
     pub fn all_traits(self) -> impl Iterator<Item = DefId> + 'tcx {
         iter::once(LOCAL_CRATE)
             .chain(self.crates(()).iter().copied())
+            .flat_map(move |cnum| self.traits(cnum).iter().copied())
+    }
+
+    /// All traits that are visible within the crate graph (i.e. excluding private dependencies).
+    pub fn visible_traits(self) -> impl Iterator<Item = DefId> + 'tcx {
+        let visible_crates =
+            self.crates(()).iter().copied().filter(move |cnum| self.is_user_visible_dep(*cnum));
+
+        iter::once(LOCAL_CRATE)
+            .chain(visible_crates)
             .flat_map(move |cnum| self.traits(cnum).iter().copied())
     }
 

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -876,6 +876,11 @@ impl<'tcx> TyCtxt<'tcx> {
     /// [public]: TyCtxt::is_private_dep
     /// [direct]: rustc_session::cstore::ExternCrate::is_direct
     pub fn is_user_visible_dep(self, key: CrateNum) -> bool {
+        // `#![rustc_private]` overrides defaults to make private dependencies usable.
+        if self.features().enabled(sym::rustc_private) {
+            return true;
+        }
+
         // | Private | Direct | Visible |                    |
         // |---------|--------|---------|--------------------|
         // | Yes     | Yes    | Yes     | !true || true   |

--- a/compiler/rustc_passes/src/diagnostic_items.rs
+++ b/compiler/rustc_passes/src/diagnostic_items.rs
@@ -79,8 +79,14 @@ fn all_diagnostic_items(tcx: TyCtxt<'_>, (): ()) -> DiagnosticItems {
     // Initialize the collector.
     let mut items = DiagnosticItems::default();
 
-    // Collect diagnostic items in other crates.
-    for &cnum in tcx.crates(()).iter().chain(std::iter::once(&LOCAL_CRATE)) {
+    // Collect diagnostic items in visible crates.
+    for cnum in tcx
+        .crates(())
+        .iter()
+        .copied()
+        .filter(|cnum| tcx.is_user_visible_dep(*cnum))
+        .chain(std::iter::once(LOCAL_CRATE))
+    {
         for (&name, &def_id) in &tcx.diagnostic_items(cnum).name_to_id {
             collect_item(tcx, &mut items, name, def_id);
         }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2189,7 +2189,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let required_trait_path = self.tcx.def_path_str(trait_ref.def_id());
         let traits_with_same_path: UnordSet<_> = self
             .tcx
-            .all_traits()
+            .visible_traits()
             .filter(|trait_def_id| *trait_def_id != trait_ref.def_id())
             .map(|trait_def_id| (self.tcx.def_path_str(trait_def_id), trait_def_id))
             .filter(|(p, _)| *p == required_trait_path)

--- a/tests/ui/privacy/sysroot-private.default.stderr
+++ b/tests/ui/privacy/sysroot-private.default.stderr
@@ -1,0 +1,39 @@
+error[E0405]: cannot find trait `Equivalent` in this scope
+  --> $DIR/sysroot-private.rs:26:18
+   |
+LL | trait Trait2<K>: Equivalent<K> {}
+   |                  ^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `K` in this scope
+  --> $DIR/sysroot-private.rs:31:35
+   |
+LL | fn trait_member<T>(val: &T, key: &K) -> bool {
+   |                 -                 ^
+   |                 |
+   |                 similarly named type parameter `T` defined here
+   |
+help: a type parameter with a similar name exists
+   |
+LL | fn trait_member<T>(val: &T, key: &T) -> bool {
+   |                                   ~
+help: you might be missing a type parameter
+   |
+LL | fn trait_member<T, K>(val: &T, key: &K) -> bool {
+   |                  +++
+
+error[E0220]: associated type `ExpressionStack` not found for `Trait`
+  --> $DIR/sysroot-private.rs:21:31
+   |
+LL | type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
+   |                               ^^^^^^^^^^^^^^^ there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
+
+error[E0425]: cannot find function `memchr2` in this scope
+  --> $DIR/sysroot-private.rs:39:5
+   |
+LL |     memchr2(b'a', b'b', buf)
+   |     ^^^^^^^ not found in this scope
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0220, E0405, E0412, E0425.
+For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/privacy/sysroot-private.default.stderr
+++ b/tests/ui/privacy/sysroot-private.default.stderr
@@ -25,7 +25,7 @@ error[E0220]: associated type `ExpressionStack` not found for `Trait`
   --> $DIR/sysroot-private.rs:21:31
    |
 LL | type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
-   |                               ^^^^^^^^^^^^^^^ there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
+   |                               ^^^^^^^^^^^^^^^ help: `Trait` has the following associated type: `Bar`
 
 error[E0425]: cannot find function `memchr2` in this scope
   --> $DIR/sysroot-private.rs:39:5

--- a/tests/ui/privacy/sysroot-private.rs
+++ b/tests/ui/privacy/sysroot-private.rs
@@ -1,0 +1,42 @@
+//! Test that private dependencies of `std` that live in the sysroot do not reach through to
+//! diagnostics.
+//!
+//! This test would be more robust if we could patch the sysroot with an "evil" crate that
+//! provided known types that we control; however, this would effectively require rebuilding
+//! `std` (or patching crate metadata). So, this test relies on what is currently public API
+//! of `std`'s dependencies, but may not be robust against dependency upgrades/changes.
+
+//@ only-unix Windows sysroots seem to not expose this dependency
+//@ revisions: default rustc_private_enabled
+
+// Enabling `rustc_private` should `std`'s dependencies accessible, so they should show up
+// in diagnostics. NB: not all diagnostics are affected by this.
+#![cfg_attr(rustc_private_enabled, feature(rustc_private))]
+#![crate_type = "lib"]
+
+trait Trait { type Bar; }
+
+// Attempt to get a suggestion for `gimli::read::op::EvaluationStoreage`, which should not be
+// present in diagnostics (it is a dependency of the compiler).
+type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
+//~^ ERROR associated type `ExpressionStack` not found
+//~| NOTE there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
+
+// Attempt to get a suggestion for `hashbrown::Equivalent`
+trait Trait2<K>: Equivalent<K> {}
+//~^ ERROR cannot find trait
+//~| NOTE not found
+
+// Attempt to get a suggestion for `hashbrown::Equivalent::equivalent`
+fn trait_member<T>(val: &T, key: &K) -> bool {
+    //~^ ERROR cannot find type `K`
+    //~| NOTE similarly named
+    val.equivalent(key)
+}
+
+// Attempt to get a suggestion for `memchr::memchr2`
+fn free_function(buf: &[u8]) -> Option<usize> {
+    memchr2(b'a', b'b', buf)
+    //~^ ERROR cannot find function
+    //~| NOTE not found
+}

--- a/tests/ui/privacy/sysroot-private.rs
+++ b/tests/ui/privacy/sysroot-private.rs
@@ -20,7 +20,7 @@ trait Trait { type Bar; }
 // present in diagnostics (it is a dependency of the compiler).
 type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
 //~^ ERROR associated type `ExpressionStack` not found
-//~| NOTE there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
+//[rustc_private_enabled]~| NOTE there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
 
 // Attempt to get a suggestion for `hashbrown::Equivalent`
 trait Trait2<K>: Equivalent<K> {}

--- a/tests/ui/privacy/sysroot-private.rustc_private_enabled.stderr
+++ b/tests/ui/privacy/sysroot-private.rustc_private_enabled.stderr
@@ -1,0 +1,39 @@
+error[E0405]: cannot find trait `Equivalent` in this scope
+  --> $DIR/sysroot-private.rs:26:18
+   |
+LL | trait Trait2<K>: Equivalent<K> {}
+   |                  ^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `K` in this scope
+  --> $DIR/sysroot-private.rs:31:35
+   |
+LL | fn trait_member<T>(val: &T, key: &K) -> bool {
+   |                 -                 ^
+   |                 |
+   |                 similarly named type parameter `T` defined here
+   |
+help: a type parameter with a similar name exists
+   |
+LL | fn trait_member<T>(val: &T, key: &T) -> bool {
+   |                                   ~
+help: you might be missing a type parameter
+   |
+LL | fn trait_member<T, K>(val: &T, key: &K) -> bool {
+   |                  +++
+
+error[E0220]: associated type `ExpressionStack` not found for `Trait`
+  --> $DIR/sysroot-private.rs:21:31
+   |
+LL | type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
+   |                               ^^^^^^^^^^^^^^^ there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
+
+error[E0425]: cannot find function `memchr2` in this scope
+  --> $DIR/sysroot-private.rs:39:5
+   |
+LL |     memchr2(b'a', b'b', buf)
+   |     ^^^^^^^ not found in this scope
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0220, E0405, E0412, E0425.
+For more information about an error, try `rustc --explain E0220`.


### PR DESCRIPTION
Currently crates in the sysroot can show up in diagnostic suggestions, such as in https://github.com/rust-lang/rust/issues/135232. To prevent this, duplicate `all_traits` into `visible_traits` which only shows traits in non-private crates.

Setting `#![feature(rustc_private)]` overrides this and makes items in private crates visible as well, since `rustc_private` enables use of `std`'s private dependencies.

This may be reviewed per-commit.

Fixes: https://github.com/rust-lang/rust/issues/135232