### PR TITLE
Make `bare-fn-no-impl-fn-ptr-99875` test less dependent on path width

### DIFF
--- a/tests/ui/traits/fn-pointer/bare-fn-no-impl-fn-ptr-99875.rs
+++ b/tests/ui/traits/fn-pointer/bare-fn-no-impl-fn-ptr-99875.rs
@@ -1,3 +1,5 @@
+// Sets some arbitrarily large width for more consistent output (see #135288).
+//@ compile-flags: --diagnostic-width=120
 struct Argument;
 struct Return;
 

--- a/tests/ui/traits/fn-pointer/bare-fn-no-impl-fn-ptr-99875.stderr
+++ b/tests/ui/traits/fn-pointer/bare-fn-no-impl-fn-ptr-99875.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `fn(Argument) -> Return {function}: Trait` is not satisfied
-  --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:12:11
+  --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:14:11
    |
 LL |     takes(function);
    |     ----- ^^^^^^^^ the trait `Trait` is not implemented for fn item `fn(Argument) -> Return {function}`
@@ -7,7 +7,7 @@ LL |     takes(function);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `takes`
-  --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:9:18
+  --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:11:18
    |
 LL | fn takes(_: impl Trait) {}
    |                  ^^^^^ required by this bound in `takes`
@@ -16,18 +16,18 @@ help: the trait `Trait` is implemented for fn pointer `fn(Argument) -> Return`, 
 LL |     takes(function as fn(Argument) -> Return);
    |                    +++++++++++++++++++++++++
 
-error[E0277]: the trait bound `{closure@$DIR/bare-fn-no-impl-fn-ptr-99875.rs:14:11: 14:34}: Trait` is not satisfied
-  --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:14:11
+error[E0277]: the trait bound `{closure@$DIR/bare-fn-no-impl-fn-ptr-99875.rs:16:11: 16:34}: Trait` is not satisfied
+  --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:16:11
    |
 LL |     takes(|_: Argument| -> Return { todo!() });
    |     ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Trait` is not implemented for closure `{closure@$DIR/bare-fn-no-impl-fn-ptr-99875.rs:14:11: 14:34}`
+   = help: the trait `Trait` is not implemented for closure `{closure@$DIR/bare-fn-no-impl-fn-ptr-99875.rs:16:11: 16:34}`
    = help: the trait `Trait` is implemented for fn pointer `fn(Argument) -> Return`
 note: required by a bound in `takes`
-  --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:9:18
+  --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:11:18
    |
 LL | fn takes(_: impl Trait) {}
    |                  ^^^^^ required by this bound in `takes`


### PR DESCRIPTION
This sets diagnostic-width to some arbitrary number. Seems to work on my machine.