### PR TITLE
re-add a warning for old master branch, but with much simpler logic

### DIFF
--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -114,7 +114,7 @@ fn print_paths(verb: &str, adjective: Option<&str>, paths: &[String]) {
     } else {
         println!("fmt: {verb} {len} {adjective}files");
     }
-    if len > 1000 {
+    if len > 1000 && !CiEnv::is_ci() {
         println!("hint: if this number seems too high, try running `git fetch origin master");
     }
 }

--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -114,6 +114,9 @@ fn print_paths(verb: &str, adjective: Option<&str>, paths: &[String]) {
     } else {
         println!("fmt: {verb} {len} {adjective}files");
     }
+    if len > 1000 {
+        println!("hint: if this number seems too high, try running `git fetch origin master");
+    }
 }
 
 pub fn format(build: &Builder<'_>, check: bool, all: bool, paths: &[PathBuf]) {


### PR DESCRIPTION
instead of calling into git or checking the modification time of files, simply print the warning if there is a very large number of "modified" files.

also make the wording much softer, so false positives are less alarming.

(warning was removed in https://github.com/rust-lang/rust/issues/134935)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
