### PR TITLE
CI: fix name of jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: python3 src/ci/github-actions/ci.py calculate-job-matrix >> $GITHUB_OUTPUT
         id: jobs
   job:
-    name: ${{ matrix.name }}
+    name: ${{ matrix.full_name }}
     needs: [ calculate_matrix ]
     runs-on: "${{ matrix.os }}"
     defaults:
@@ -67,7 +67,7 @@ jobs:
         shell: ${{ contains(matrix.os, 'windows') && 'msys2 {0}' || 'bash' }}
     timeout-minutes: 360
     env:
-      CI_JOB_NAME: ${{ matrix.image }}
+      CI_JOB_NAME: ${{ matrix.name }}
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
       # commit of PR sha or commit sha. `GITHUB_SHA` is not accurate for PRs.
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -233,7 +233,7 @@ jobs:
         env:
           DATADOG_SITE: datadoghq.com
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-          DD_GITHUB_JOB_NAME: ${{ matrix.name }}
+          DD_GITHUB_JOB_NAME: ${{ matrix.full_name }}
         run: |
           cd src/ci
           npm ci

--- a/src/ci/github-actions/ci.py
+++ b/src/ci/github-actions/ci.py
@@ -37,7 +37,7 @@ def add_job_properties(jobs: List[Dict], prefix: str) -> List[Job]:
         # Create a copy of the `job` dictionary to avoid modifying `jobs`
         new_job = dict(job)
         new_job["image"] = get_job_image(new_job)
-        new_job["name"] = f"{prefix} - {new_job['name']}"
+        new_job["full_name"] = f"{prefix} - {new_job['name']}"
         modified_jobs.append(new_job)
     return modified_jobs
 


### PR DESCRIPTION
There is a difference between the `image` (the Dockerfile), the `name` of the job (which determines also its properties) and the `full_name`, which includes the `auto/try/pr` prefix.

Missed this in https://github.com/rust-lang/rust/pull/134898.