### PR TITLE
Make sure to walk into nested const blocks in `RegionResolutionVisitor`

### DIFF
--- a/tests/ui/inline-const/collect-scopes-in-pat.rs
+++ b/tests/ui/inline-const/collect-scopes-in-pat.rs
@@ -1,0 +1,16 @@
+// @compile-flags: -Zlint-mir
+//@ check-pass
+
+#![feature(inline_const_pat)]
+
+fn main() {
+    match 1 {
+        const {
+            || match 0 {
+                x => 0,
+            };
+            0
+        } => (),
+        _ => (),
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/135306

I tried auditing the rest of the visitors that called `.visit_body`, and it seems like this is the only one that was missing it. I wonder if we should modify intravisit (specifcially, that `NestedBodyFilter` stuff) to make this less likely to happen, tho...

r? oli-obk