### PR TITLE
Eagerly mono drop for structs with lifetimes

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1394,7 +1394,7 @@ impl<'v> RootCollector<'_, 'v> {
         match self.tcx.def_kind(id.owner_id) {
             DefKind::Enum | DefKind::Struct | DefKind::Union => {
                 if self.strategy == MonoItemCollectionStrategy::Eager
-                    && self.tcx.generics_of(id.owner_id).is_empty()
+                    && !self.tcx.generics_of(id.owner_id).requires_monomorphization(self.tcx)
                 {
                     debug!("RootCollector: ADT drop-glue for `{id:?}`",);
 
@@ -1407,7 +1407,10 @@ impl<'v> RootCollector<'_, 'v> {
                         return;
                     }
 
-                    let ty = self.tcx.type_of(id.owner_id.to_def_id()).no_bound_vars().unwrap();
+                    let ty = self.tcx.erase_regions(
+                        self.tcx.type_of(id.owner_id.to_def_id()).instantiate_identity(),
+                    );
+                    assert!(!ty.has_non_region_param());
                     visit_drop_use(self.tcx, ty, true, DUMMY_SP, self.output);
                 }
             }

--- a/tests/codegen-units/item-collection/drop-glue-eager.rs
+++ b/tests/codegen-units/item-collection/drop-glue-eager.rs
@@ -1,0 +1,43 @@
+// Ensure that we *eagerly* monomorphize drop instances for structs with lifetimes.
+
+//@ compile-flags:-Zprint-mono-items=eager
+//@ compile-flags:--crate-type=lib
+
+//~ MONO_ITEM fn std::ptr::drop_in_place::<StructWithDrop> - shim(Some(StructWithDrop))
+struct StructWithDrop {
+    x: i32,
+}
+
+impl Drop for StructWithDrop {
+    //~ MONO_ITEM fn <StructWithDrop as std::ops::Drop>::drop
+    fn drop(&mut self) {}
+}
+
+struct StructNoDrop {
+    x: i32,
+}
+
+//~ MONO_ITEM fn std::ptr::drop_in_place::<EnumWithDrop> - shim(Some(EnumWithDrop))
+enum EnumWithDrop {
+    A(i32),
+}
+
+impl Drop for EnumWithDrop {
+    //~ MONO_ITEM fn <EnumWithDrop as std::ops::Drop>::drop
+    fn drop(&mut self) {}
+}
+
+enum EnumNoDrop {
+    A(i32),
+}
+
+// We should be able to monomorphize drops for struct with lifetimes.
+impl<'a> Drop for StructWithDropAndLt<'a> {
+    //~ MONO_ITEM fn <StructWithDropAndLt<'_> as std::ops::Drop>::drop
+    fn drop(&mut self) {}
+}
+
+//~ MONO_ITEM fn std::ptr::drop_in_place::<StructWithDropAndLt<'_>> - shim(Some(StructWithDropAndLt<'_>))
+struct StructWithDropAndLt<'a> {
+    x: &'a i32,
+}


### PR DESCRIPTION
That is, use `!generics.requires_monomorphization()` rather than `generics.is_empty()` like the rest of the mono collector code.