### PR TITLE
Add and modify safety descriptions in some of intrinsics APIs

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2014,6 +2014,10 @@ pub fn ptr_mask<T>(_ptr: *const T, _mask: usize) -> *const T {
 /// The volatile parameter is set to `true`, so it will not be optimized out
 /// unless size is equal to zero.
 ///
+/// # Safety
+///
+/// The safety concerns are the same with [`copy_nonoverlapping`].
+///
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_intrinsic_must_be_overridden]
@@ -2041,6 +2045,16 @@ pub unsafe fn volatile_copy_memory<T>(_dst: *mut T, _src: *const T, _count: usiz
 ///
 /// The volatile parameter is set to `true`, so it will not be optimized out
 /// unless size is equal to zero.
+///
+/// # Safety
+///
+/// Behavior is undefined if any of the following conditions are violated:
+///
+/// * `_dst` must be [valid] for writes of `_count * size_of::<T>()` bytes.
+///
+/// * `_dst` must be properly aligned.
+///
+/// Note that even if `T` has size `0`, the pointer must be properly aligned.
 ///
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
@@ -3965,8 +3979,15 @@ pub const fn is_val_statically_known<T: Copy>(_arg: T) -> bool {
 /// The stabilized form of this intrinsic is [`crate::mem::swap`].
 ///
 /// # Safety
+/// Behavior is undefined if any of the following conditions are violated:
 ///
-/// `x` and `y` are readable and writable as `T`, and non-overlapping.
+/// * Both `x` and `y` must be [valid] for both reads and writes.
+///
+/// * Both `x` and `y` must be properly aligned.
+///
+/// * The region of memory beginning at `x` must *not* overlap with the region of memory
+///   beginning at `y`.
+///
 #[rustc_nounwind]
 #[inline]
 #[rustc_intrinsic]

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2056,6 +2056,8 @@ pub unsafe fn volatile_copy_memory<T>(_dst: *mut T, _src: *const T, _count: usiz
 ///
 /// Note that even if `T` has size `0`, the pointer must be properly aligned.
 ///
+/// [valid]: crate::ptr#safety
+///
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_intrinsic_must_be_overridden]
@@ -3988,6 +3990,7 @@ pub const fn is_val_statically_known<T: Copy>(_arg: T) -> bool {
 /// * The region of memory beginning at `x` must *not* overlap with the region of memory
 ///   beginning at `y`.
 ///
+/// [valid]: crate::ptr#safety
 #[rustc_nounwind]
 #[inline]
 #[rustc_intrinsic]


### PR DESCRIPTION
### PR Description
Many public `intrinsics` unsafe APIs lack clear or sufficiently detailed `# Safety` descriptions. These updates aim to provide clearer and more accurate safety documentation for parts of these unsafe APIs.

This PR includes the following changes:

- [volatile_copy_nonoverlapping_memory](https://doc.rust-lang.org/nightly/core/intrinsics/fn.volatile_copy_nonoverlapping_memory.html): Added a safety description aligning with that of `copy_nonoverlapping`.

- [volatile_set_memory](https://doc.rust-lang.org/nightly/core/intrinsics/fn.volatile_set_memory.html): Added a detailed safety description specifying the validity and alignment requirements for the `_dst` pointer.

- [typed_swap_nonoverlapping](https://doc.rust-lang.org/nightly/core/intrinsics/fn.typed_swap_nonoverlapping.html): Removed the vague safety description and replaced it with the precise one, referencing `swap_nonoverlapping`.
