### PR TITLE
Add `explicit_extern_abis` Feature and Enforce Explicit ABIs

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -79,6 +79,10 @@ ast_passes_extern_types_cannot = `type`s inside `extern` blocks cannot have {$de
     .suggestion = remove the {$remove_descr}
     .label = `extern` block begins here
 
+ast_passes_extern_without_abi = `extern` declarations without an explicit ABI are disallowed
+    .suggestion = specify an ABI
+    .help = prior to Rust 2024, a default ABI was inferred
+
 ast_passes_feature_on_non_nightly = `#![feature]` may not be used on the {$channel} release channel
     .suggestion = remove the attribute
     .stable_since = the feature `{$name}` has been stable since `{$since}` and no longer requires an attribute to enable

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -823,3 +823,12 @@ pub(crate) struct DuplicatePreciseCapturing {
     #[label]
     pub bound2: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(ast_passes_extern_without_abi)]
+#[help]
+pub(crate) struct MissingAbi {
+    #[primary_span]
+    #[suggestion(code = "extern \"<abi>\"", applicability = "has-placeholders")]
+    pub span: Span,
+}

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -477,6 +477,8 @@ declare_features! (
     (incomplete, ergonomic_clones, "1.87.0", Some(132290)),
     /// Allows exhaustive pattern matching on types that contain uninhabited types.
     (unstable, exhaustive_patterns, "1.13.0", Some(51085)),
+    /// Disallows `extern` without an explicit ABI.
+    (unstable, explicit_extern_abis, "CURRENT_RUSTC_VERSION", Some(134986)),
     /// Allows explicit tail calls via `become` expression.
     (incomplete, explicit_tail_calls, "1.72.0", Some(112788)),
     /// Allows using `aapcs`, `efiapi`, `sysv64` and `win64` as calling conventions

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -271,7 +271,7 @@ lint_expectation = this lint expectation is unfulfilled
 lint_extern_crate_not_idiomatic = `extern crate` is not idiomatic in the new edition
     .suggestion = convert it to a `use`
 
-lint_extern_without_abi = extern declarations without an explicit ABI are deprecated
+lint_extern_without_abi = `extern` declarations without an explicit ABI are deprecated
     .label = ABI should be specified here
     .suggestion = explicitly specify the {$default_abi} ABI
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -916,6 +916,7 @@ symbols! {
         expf16,
         expf32,
         expf64,
+        explicit_extern_abis,
         explicit_generic_args_with_impl_trait,
         explicit_tail_calls,
         export_name,

--- a/src/doc/unstable-book/src/language-features/explicit-extern-abis.md
+++ b/src/doc/unstable-book/src/language-features/explicit-extern-abis.md
@@ -1,0 +1,23 @@
+# `explicit_extern_abis`
+
+The tracking issue for this feature is: #134986
+
+------
+
+Disallow `extern` without an explicit ABI. We should write `extern "C"`
+(or another ABI) instead of just `extern`.
+
+By making the ABI explicit, it becomes much clearer that "C" is just one of the
+possible choices, rather than the "standard" way for external functions.
+Removing the default makes it easier to add a new ABI on equal footing as "C".
+
+```rust,editionfuture,compile_fail
+#![feature(explicit_extern_abis)]
+
+extern fn function1() {}  // ERROR `extern` declarations without an explicit ABI
+                          // are disallowed
+
+extern "C" fn function2() {} // compiles
+
+extern "aapcs" fn function3() {} // compiles
+```

--- a/tests/ui/feature-gates/feature-gate-explicit-extern-abis.current.fixed
+++ b/tests/ui/feature-gates/feature-gate-explicit-extern-abis.current.fixed
@@ -1,0 +1,45 @@
+// The purpose of this feature gate is to make something into a hard error in a
+// future edition.  Consequently, this test differs from most other feature gate
+// tests.  Instead of verifying that an error occurs when the feature gate is
+// missing, it ensures that the hard error is only produced with the feature
+// gate is present in the `future` edition -- and otherwise that only a warning
+// is emitted.
+
+//@ revisions: current current_feature future future_feature
+
+//@ [current] run-rustfix
+//@ [current] check-pass
+
+//@ [current_feature] run-rustfix
+//@ [current_feature] check-pass
+
+//@ [future] edition: future
+//@ [future] compile-flags: -Z unstable-options
+//@ [future] run-rustfix
+//@ [future] check-pass
+
+//@ [future_feature] edition: future
+//@ [future_feature] compile-flags: -Z unstable-options
+
+#![cfg_attr(future_feature, feature(explicit_extern_abis))]
+#![cfg_attr(current_feature, feature(explicit_extern_abis))]
+
+extern "C" fn _foo() {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+unsafe extern "C" fn _bar() {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+unsafe extern "C" {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-explicit-extern-abis.current.stderr
+++ b/tests/ui/feature-gates/feature-gate-explicit-extern-abis.current.stderr
@@ -1,0 +1,22 @@
+warning: `extern` declarations without an explicit ABI are deprecated
+  --> $DIR/feature-gate-explicit-extern-abis.rs:27:1
+   |
+LL | extern fn _foo() {}
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
+   |
+   = note: `#[warn(missing_abi)]` on by default
+
+warning: `extern` declarations without an explicit ABI are deprecated
+  --> $DIR/feature-gate-explicit-extern-abis.rs:33:8
+   |
+LL | unsafe extern fn _bar() {}
+   |        ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
+
+warning: `extern` declarations without an explicit ABI are deprecated
+  --> $DIR/feature-gate-explicit-extern-abis.rs:39:8
+   |
+LL | unsafe extern {}
+   |        ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
+
+warning: 3 warnings emitted
+

--- a/tests/ui/feature-gates/feature-gate-explicit-extern-abis.current_feature.fixed
+++ b/tests/ui/feature-gates/feature-gate-explicit-extern-abis.current_feature.fixed
@@ -1,0 +1,45 @@
+// The purpose of this feature gate is to make something into a hard error in a
+// future edition.  Consequently, this test differs from most other feature gate
+// tests.  Instead of verifying that an error occurs when the feature gate is
+// missing, it ensures that the hard error is only produced with the feature
+// gate is present in the `future` edition -- and otherwise that only a warning
+// is emitted.
+
+//@ revisions: current current_feature future future_feature
+
+//@ [current] run-rustfix
+//@ [current] check-pass
+
+//@ [current_feature] run-rustfix
+//@ [current_feature] check-pass
+
+//@ [future] edition: future
+//@ [future] compile-flags: -Z unstable-options
+//@ [future] run-rustfix
+//@ [future] check-pass
+
+//@ [future_feature] edition: future
+//@ [future_feature] compile-flags: -Z unstable-options
+
+#![cfg_attr(future_feature, feature(explicit_extern_abis))]
+#![cfg_attr(current_feature, feature(explicit_extern_abis))]
+
+extern "C" fn _foo() {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+unsafe extern "C" fn _bar() {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+unsafe extern "C" {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-explicit-extern-abis.current_feature.stderr
+++ b/tests/ui/feature-gates/feature-gate-explicit-extern-abis.current_feature.stderr
@@ -1,0 +1,22 @@
+warning: `extern` declarations without an explicit ABI are deprecated
+  --> $DIR/feature-gate-explicit-extern-abis.rs:27:1
+   |
+LL | extern fn _foo() {}
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
+   |
+   = note: `#[warn(missing_abi)]` on by default
+
+warning: `extern` declarations without an explicit ABI are deprecated
+  --> $DIR/feature-gate-explicit-extern-abis.rs:33:8
+   |
+LL | unsafe extern fn _bar() {}
+   |        ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
+
+warning: `extern` declarations without an explicit ABI are deprecated
+  --> $DIR/feature-gate-explicit-extern-abis.rs:39:8
+   |
+LL | unsafe extern {}
+   |        ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
+
+warning: 3 warnings emitted
+

--- a/tests/ui/feature-gates/feature-gate-explicit-extern-abis.future.fixed
+++ b/tests/ui/feature-gates/feature-gate-explicit-extern-abis.future.fixed
@@ -1,0 +1,45 @@
+// The purpose of this feature gate is to make something into a hard error in a
+// future edition.  Consequently, this test differs from most other feature gate
+// tests.  Instead of verifying that an error occurs when the feature gate is
+// missing, it ensures that the hard error is only produced with the feature
+// gate is present in the `future` edition -- and otherwise that only a warning
+// is emitted.
+
+//@ revisions: current current_feature future future_feature
+
+//@ [current] run-rustfix
+//@ [current] check-pass
+
+//@ [current_feature] run-rustfix
+//@ [current_feature] check-pass
+
+//@ [future] edition: future
+//@ [future] compile-flags: -Z unstable-options
+//@ [future] run-rustfix
+//@ [future] check-pass
+
+//@ [future_feature] edition: future
+//@ [future_feature] compile-flags: -Z unstable-options
+
+#![cfg_attr(future_feature, feature(explicit_extern_abis))]
+#![cfg_attr(current_feature, feature(explicit_extern_abis))]
+
+extern "C" fn _foo() {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+unsafe extern "C" fn _bar() {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+unsafe extern "C" {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-explicit-extern-abis.future.stderr
+++ b/tests/ui/feature-gates/feature-gate-explicit-extern-abis.future.stderr
@@ -1,0 +1,22 @@
+warning: `extern` declarations without an explicit ABI are deprecated
+  --> $DIR/feature-gate-explicit-extern-abis.rs:27:1
+   |
+LL | extern fn _foo() {}
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
+   |
+   = note: `#[warn(missing_abi)]` on by default
+
+warning: `extern` declarations without an explicit ABI are deprecated
+  --> $DIR/feature-gate-explicit-extern-abis.rs:33:8
+   |
+LL | unsafe extern fn _bar() {}
+   |        ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
+
+warning: `extern` declarations without an explicit ABI are deprecated
+  --> $DIR/feature-gate-explicit-extern-abis.rs:39:8
+   |
+LL | unsafe extern {}
+   |        ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
+
+warning: 3 warnings emitted
+

--- a/tests/ui/feature-gates/feature-gate-explicit-extern-abis.future_feature.stderr
+++ b/tests/ui/feature-gates/feature-gate-explicit-extern-abis.future_feature.stderr
@@ -1,0 +1,26 @@
+error: `extern` declarations without an explicit ABI are disallowed
+  --> $DIR/feature-gate-explicit-extern-abis.rs:27:1
+   |
+LL | extern fn _foo() {}
+   | ^^^^^^ help: specify an ABI: `extern "<abi>"`
+   |
+   = help: prior to Rust 2024, a default ABI was inferred
+
+error: `extern` declarations without an explicit ABI are disallowed
+  --> $DIR/feature-gate-explicit-extern-abis.rs:33:8
+   |
+LL | unsafe extern fn _bar() {}
+   |        ^^^^^^ help: specify an ABI: `extern "<abi>"`
+   |
+   = help: prior to Rust 2024, a default ABI was inferred
+
+error: `extern` declarations without an explicit ABI are disallowed
+  --> $DIR/feature-gate-explicit-extern-abis.rs:39:8
+   |
+LL | unsafe extern {}
+   |        ^^^^^^ help: specify an ABI: `extern "<abi>"`
+   |
+   = help: prior to Rust 2024, a default ABI was inferred
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/feature-gates/feature-gate-explicit-extern-abis.rs
+++ b/tests/ui/feature-gates/feature-gate-explicit-extern-abis.rs
@@ -1,0 +1,45 @@
+// The purpose of this feature gate is to make something into a hard error in a
+// future edition.  Consequently, this test differs from most other feature gate
+// tests.  Instead of verifying that an error occurs when the feature gate is
+// missing, it ensures that the hard error is only produced with the feature
+// gate is present in the `future` edition -- and otherwise that only a warning
+// is emitted.
+
+//@ revisions: current current_feature future future_feature
+
+//@ [current] run-rustfix
+//@ [current] check-pass
+
+//@ [current_feature] run-rustfix
+//@ [current_feature] check-pass
+
+//@ [future] edition: future
+//@ [future] compile-flags: -Z unstable-options
+//@ [future] run-rustfix
+//@ [future] check-pass
+
+//@ [future_feature] edition: future
+//@ [future_feature] compile-flags: -Z unstable-options
+
+#![cfg_attr(future_feature, feature(explicit_extern_abis))]
+#![cfg_attr(current_feature, feature(explicit_extern_abis))]
+
+extern fn _foo() {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+unsafe extern fn _bar() {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+unsafe extern {}
+//[current]~^ WARN `extern` declarations without an explicit ABI are deprecated
+//[current_feature]~^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
+//[future_feature]~^^^^ ERROR `extern` declarations without an explicit ABI are disallowed
+
+fn main() {}

--- a/tests/ui/link-native-libs/suggest-libname-only-1.rs
+++ b/tests/ui/link-native-libs/suggest-libname-only-1.rs
@@ -2,7 +2,7 @@
 //@ compile-flags: --crate-type rlib
 
 #[link(name = "libfoo.a", kind = "static")]
-extern { } //~ WARN extern declarations without an explicit ABI are deprecated
+extern { } //~ WARN `extern` declarations without an explicit ABI are deprecated
            //~| HELP explicitly specify the "C" ABI
 
 pub fn main() { }

--- a/tests/ui/link-native-libs/suggest-libname-only-1.stderr
+++ b/tests/ui/link-native-libs/suggest-libname-only-1.stderr
@@ -1,4 +1,4 @@
-warning: extern declarations without an explicit ABI are deprecated
+warning: `extern` declarations without an explicit ABI are deprecated
   --> $DIR/suggest-libname-only-1.rs:5:1
    |
 LL | extern { }

--- a/tests/ui/link-native-libs/suggest-libname-only-2.rs
+++ b/tests/ui/link-native-libs/suggest-libname-only-2.rs
@@ -2,7 +2,7 @@
 //@ compile-flags: --crate-type rlib
 
 #[link(name = "bar.lib", kind = "static")]
-extern { } //~ WARN extern declarations without an explicit ABI are deprecated
+extern { } //~ WARN `extern` declarations without an explicit ABI are deprecated
            //~| HELP explicitly specify the "C" ABI
 
 pub fn main() { }

--- a/tests/ui/link-native-libs/suggest-libname-only-2.stderr
+++ b/tests/ui/link-native-libs/suggest-libname-only-2.stderr
@@ -1,4 +1,4 @@
-warning: extern declarations without an explicit ABI are deprecated
+warning: `extern` declarations without an explicit ABI are deprecated
   --> $DIR/suggest-libname-only-2.rs:5:1
    |
 LL | extern { }

--- a/tests/ui/lint/cli-lint-override.forbid_warn.stderr
+++ b/tests/ui/lint/cli-lint-override.forbid_warn.stderr
@@ -1,4 +1,4 @@
-error: extern declarations without an explicit ABI are deprecated
+error: `extern` declarations without an explicit ABI are deprecated
   --> $DIR/cli-lint-override.rs:12:1
    |
 LL | extern fn foo() {}

--- a/tests/ui/lint/cli-lint-override.force_warn_deny.stderr
+++ b/tests/ui/lint/cli-lint-override.force_warn_deny.stderr
@@ -1,4 +1,4 @@
-warning: extern declarations without an explicit ABI are deprecated
+warning: `extern` declarations without an explicit ABI are deprecated
   --> $DIR/cli-lint-override.rs:12:1
    |
 LL | extern fn foo() {}

--- a/tests/ui/lint/cli-lint-override.rs
+++ b/tests/ui/lint/cli-lint-override.rs
@@ -10,8 +10,8 @@
 
 
 extern fn foo() {}
-//[warn_deny]~^ ERROR extern declarations without an explicit ABI are deprecated
-//[forbid_warn]~^^ ERROR extern declarations without an explicit ABI are deprecated
-//[force_warn_deny]~^^^ WARN extern declarations without an explicit ABI are deprecated
+//[warn_deny]~^ ERROR `extern` declarations without an explicit ABI are deprecated
+//[forbid_warn]~^^ ERROR `extern` declarations without an explicit ABI are deprecated
+//[force_warn_deny]~^^^ WARN `extern` declarations without an explicit ABI are deprecated
 
 fn main() {}

--- a/tests/ui/lint/cli-lint-override.warn_deny.stderr
+++ b/tests/ui/lint/cli-lint-override.warn_deny.stderr
@@ -1,4 +1,4 @@
-error: extern declarations without an explicit ABI are deprecated
+error: `extern` declarations without an explicit ABI are deprecated
   --> $DIR/cli-lint-override.rs:12:1
    |
 LL | extern fn foo() {}

--- a/tests/ui/parser/bad-lit-suffixes.stderr
+++ b/tests/ui/parser/bad-lit-suffixes.stderr
@@ -51,7 +51,7 @@ LL | #[rustc_layout_scalar_valid_range_start(0suffix)]
    |
    = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
 
-warning: extern declarations without an explicit ABI are deprecated
+warning: `extern` declarations without an explicit ABI are deprecated
   --> $DIR/bad-lit-suffixes.rs:3:1
    |
 LL | extern
@@ -59,7 +59,7 @@ LL | extern
    |
    = note: `#[warn(missing_abi)]` on by default
 
-warning: extern declarations without an explicit ABI are deprecated
+warning: `extern` declarations without an explicit ABI are deprecated
   --> $DIR/bad-lit-suffixes.rs:7:1
    |
 LL | extern

--- a/tests/ui/parser/lit-err-in-macro.stderr
+++ b/tests/ui/parser/lit-err-in-macro.stderr
@@ -4,7 +4,7 @@ error: suffixes on string literals are invalid
 LL | f!("Foo"__);
    |    ^^^^^^^ invalid suffix `__`
 
-warning: extern declarations without an explicit ABI are deprecated
+warning: `extern` declarations without an explicit ABI are deprecated
   --> $DIR/lit-err-in-macro.rs:3:9
    |
 LL |         extern $abi fn f() {}

--- a/tests/ui/proc-macro/inner-attrs.rs
+++ b/tests/ui/proc-macro/inner-attrs.rs
@@ -82,7 +82,7 @@ fn bar() {
 }
 
 
-extern { //~ WARN extern declarations without an explicit ABI are deprecated
+extern { //~ WARN `extern` declarations without an explicit ABI are deprecated
     fn weird_extern() {
         #![print_target_and_args_consume(tenth)]
     }

--- a/tests/ui/proc-macro/inner-attrs.stderr
+++ b/tests/ui/proc-macro/inner-attrs.stderr
@@ -22,7 +22,7 @@ error: expected non-macro inner attribute, found attribute macro `print_attr`
 LL |         #![print_attr]
    |            ^^^^^^^^^^ not a non-macro inner attribute
 
-warning: extern declarations without an explicit ABI are deprecated
+warning: `extern` declarations without an explicit ABI are deprecated
   --> $DIR/inner-attrs.rs:85:1
    |
 LL | extern {


### PR DESCRIPTION
The unstable `explicit_extern_abis` feature is introduced, requiring explicit ABIs in `extern` blocks. Hard errors will be enforced with this feature enabled in a future edition.

RFC rust-lang/rfcs#3722

Update #134986