### PR TITLE
Less unsafe in `dangling`/`without_provenance`

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -596,12 +596,7 @@ pub const fn null_mut<T: ?Sized + Thin>() -> *mut T {
 #[stable(feature = "strict_provenance", since = "1.84.0")]
 #[rustc_const_stable(feature = "strict_provenance", since = "1.84.0")]
 pub const fn without_provenance<T>(addr: usize) -> *const T {
-    // An int-to-pointer transmute currently has exactly the intended semantics: it creates a
-    // pointer without provenance. Note that this is *not* a stable guarantee about transmute
-    // semantics, it relies on sysroot crates having special status.
-    // SAFETY: every valid integer is also a valid pointer (as long as you don't dereference that
-    // pointer).
-    unsafe { mem::transmute(addr) }
+    without_provenance_mut(addr)
 }
 
 /// Creates a new pointer that is dangling, but non-null and well-aligned.
@@ -618,7 +613,7 @@ pub const fn without_provenance<T>(addr: usize) -> *const T {
 #[stable(feature = "strict_provenance", since = "1.84.0")]
 #[rustc_const_stable(feature = "strict_provenance", since = "1.84.0")]
 pub const fn dangling<T>() -> *const T {
-    without_provenance(mem::align_of::<T>())
+    dangling_mut()
 }
 
 /// Creates a pointer with the given address and no [provenance][crate::ptr#provenance].
@@ -661,7 +656,7 @@ pub const fn without_provenance_mut<T>(addr: usize) -> *mut T {
 #[stable(feature = "strict_provenance", since = "1.84.0")]
 #[rustc_const_stable(feature = "strict_provenance", since = "1.84.0")]
 pub const fn dangling_mut<T>() -> *mut T {
-    without_provenance_mut(mem::align_of::<T>())
+    NonNull::dangling().as_ptr()
 }
 
 /// Converts an address back to a pointer, picking up some previously 'exposed'

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -91,12 +91,12 @@ impl<T: Sized> NonNull<T> {
     ///
     /// This is a [Strict Provenance][crate::ptr#strict-provenance] API.
     #[unstable(feature = "nonnull_provenance", issue = "135243")]
+    #[must_use]
+    #[inline]
     pub const fn without_provenance(addr: NonZero<usize>) -> Self {
+        let pointer = crate::ptr::without_provenance(addr.get());
         // SAFETY: we know `addr` is non-zero.
-        unsafe {
-            let ptr = crate::ptr::without_provenance_mut(addr.get());
-            NonNull::new_unchecked(ptr)
-        }
+        unsafe { NonNull { pointer } }
     }
 
     /// Creates a new `NonNull` that is dangling, but well-aligned.
@@ -123,11 +123,8 @@ impl<T: Sized> NonNull<T> {
     #[must_use]
     #[inline]
     pub const fn dangling() -> Self {
-        // SAFETY: ptr::dangling_mut() returns a non-null well-aligned pointer.
-        unsafe {
-            let ptr = crate::ptr::dangling_mut::<T>();
-            NonNull::new_unchecked(ptr)
-        }
+        let align = crate::ptr::Alignment::of::<T>();
+        NonNull::without_provenance(align.as_nonzero())
     }
 
     /// Converts an address back to a mutable pointer, picking up some previously 'exposed'
@@ -137,6 +134,7 @@ impl<T: Sized> NonNull<T> {
     ///
     /// This is an [Exposed Provenance][crate::ptr#exposed-provenance] API.
     #[unstable(feature = "nonnull_provenance", issue = "135243")]
+    #[inline]
     pub fn with_exposed_provenance(addr: NonZero<usize>) -> Self {
         // SAFETY: we know `addr` is non-zero.
         unsafe {

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-abort.diff
@@ -16,25 +16,23 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let _6: *mut [bool; 0];
+                  let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 10 (inlined NonNull::<[bool; 0]>::new_unchecked) {
-                          let mut _8: bool;
-                          let _9: ();
-                          let mut _10: *mut ();
-                          let mut _11: *const [bool; 0];
-                          scope 11 (inlined core::ub_checks::check_language_ub) {
-                              scope 12 (inlined core::ub_checks::check_language_ub::runtime) {
+                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      }
+                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                          let _7: *const [bool; 0];
+                          scope 10 {
+                          }
+                          scope 11 (inlined NonZero::<usize>::get) {
+                          }
+                          scope 12 (inlined without_provenance::<[bool; 0]>) {
+                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
                               }
                           }
                       }
                   }
-                  scope 7 (inlined dangling_mut::<[bool; 0]>) {
-                      let mut _7: usize;
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined without_provenance_mut::<[bool; 0]>) {
-                      }
+                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
                   }
               }
           }
@@ -44,40 +42,13 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
+          _6 = const NonZero::<usize>(core::num::niche_types::NonZeroUsizeInner(1_usize));
           StorageLive(_7);
-          _7 = const 1_usize;
-          _6 = const {0x1 as *mut [bool; 0]};
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbChecks();
-          switchInt(move _8) -> [0: bb4, otherwise: bb2];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2: {
-          StorageLive(_10);
-          _10 = const {0x1 as *mut ()};
-          _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb3, unwind unreachable];
-      }
-  
-      bb3: {
-          StorageDead(_10);
-          goto -> bb4;
-      }
-  
-      bb4: {
-          StorageDead(_8);
-          _11 = const {0x1 as *const [bool; 0]};
+          _7 = const {0x1 as *const [bool; 0]};
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
           StorageDead(_7);
           StorageDead(_6);
           _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
@@ -85,12 +56,16 @@
           _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
           _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
           _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
       }
   }
   

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.32bit.panic-unwind.diff
@@ -16,25 +16,23 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let _6: *mut [bool; 0];
+                  let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 10 (inlined NonNull::<[bool; 0]>::new_unchecked) {
-                          let mut _8: bool;
-                          let _9: ();
-                          let mut _10: *mut ();
-                          let mut _11: *const [bool; 0];
-                          scope 11 (inlined core::ub_checks::check_language_ub) {
-                              scope 12 (inlined core::ub_checks::check_language_ub::runtime) {
+                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      }
+                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                          let _7: *const [bool; 0];
+                          scope 10 {
+                          }
+                          scope 11 (inlined NonZero::<usize>::get) {
+                          }
+                          scope 12 (inlined without_provenance::<[bool; 0]>) {
+                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
                               }
                           }
                       }
                   }
-                  scope 7 (inlined dangling_mut::<[bool; 0]>) {
-                      let mut _7: usize;
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined without_provenance_mut::<[bool; 0]>) {
-                      }
+                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
                   }
               }
           }
@@ -44,17 +42,25 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
+          _6 = const NonZero::<usize>(core::num::niche_types::NonZeroUsizeInner(1_usize));
           StorageLive(_7);
-          _7 = const 1_usize;
-          _6 = const {0x1 as *mut [bool; 0]};
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbChecks();
-          switchInt(move _8) -> [0: bb5, otherwise: bb3];
+          _7 = const {0x1 as *const [bool; 0]};
+          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_7);
+          StorageDead(_6);
+          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind: bb2];
       }
   
       bb1: {
@@ -64,37 +70,6 @@
   
       bb2 (cleanup): {
           resume;
-      }
-  
-      bb3: {
-          StorageLive(_10);
-          _10 = const {0x1 as *mut ()};
-          _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb4, unwind unreachable];
-      }
-  
-      bb4: {
-          StorageDead(_10);
-          goto -> bb5;
-      }
-  
-      bb5: {
-          StorageDead(_8);
-          _11 = const {0x1 as *const [bool; 0]};
-          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
-          StorageDead(_7);
-          StorageDead(_6);
-          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
-          StorageDead(_5);
-          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
-          StorageDead(_4);
-          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
-          StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
-          StorageDead(_2);
-          _0 = const ();
-          drop(_1) -> [return: bb1, unwind: bb2];
       }
   }
   

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-abort.diff
@@ -16,25 +16,23 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let _6: *mut [bool; 0];
+                  let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 10 (inlined NonNull::<[bool; 0]>::new_unchecked) {
-                          let mut _8: bool;
-                          let _9: ();
-                          let mut _10: *mut ();
-                          let mut _11: *const [bool; 0];
-                          scope 11 (inlined core::ub_checks::check_language_ub) {
-                              scope 12 (inlined core::ub_checks::check_language_ub::runtime) {
+                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      }
+                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                          let _7: *const [bool; 0];
+                          scope 10 {
+                          }
+                          scope 11 (inlined NonZero::<usize>::get) {
+                          }
+                          scope 12 (inlined without_provenance::<[bool; 0]>) {
+                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
                               }
                           }
                       }
                   }
-                  scope 7 (inlined dangling_mut::<[bool; 0]>) {
-                      let mut _7: usize;
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined without_provenance_mut::<[bool; 0]>) {
-                      }
+                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
                   }
               }
           }
@@ -44,40 +42,13 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
+          _6 = const NonZero::<usize>(core::num::niche_types::NonZeroUsizeInner(1_usize));
           StorageLive(_7);
-          _7 = const 1_usize;
-          _6 = const {0x1 as *mut [bool; 0]};
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbChecks();
-          switchInt(move _8) -> [0: bb4, otherwise: bb2];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2: {
-          StorageLive(_10);
-          _10 = const {0x1 as *mut ()};
-          _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb3, unwind unreachable];
-      }
-  
-      bb3: {
-          StorageDead(_10);
-          goto -> bb4;
-      }
-  
-      bb4: {
-          StorageDead(_8);
-          _11 = const {0x1 as *const [bool; 0]};
+          _7 = const {0x1 as *const [bool; 0]};
           _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
           StorageDead(_7);
           StorageDead(_6);
           _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
@@ -85,12 +56,16 @@
           _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
           StorageDead(_4);
           _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
           _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
       }
   }
   

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.DataflowConstProp.64bit.panic-unwind.diff
@@ -16,25 +16,23 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let _6: *mut [bool; 0];
+                  let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 10 (inlined NonNull::<[bool; 0]>::new_unchecked) {
-                          let mut _8: bool;
-                          let _9: ();
-                          let mut _10: *mut ();
-                          let mut _11: *const [bool; 0];
-                          scope 11 (inlined core::ub_checks::check_language_ub) {
-                              scope 12 (inlined core::ub_checks::check_language_ub::runtime) {
+                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      }
+                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                          let _7: *const [bool; 0];
+                          scope 10 {
+                          }
+                          scope 11 (inlined NonZero::<usize>::get) {
+                          }
+                          scope 12 (inlined without_provenance::<[bool; 0]>) {
+                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
                               }
                           }
                       }
                   }
-                  scope 7 (inlined dangling_mut::<[bool; 0]>) {
-                      let mut _7: usize;
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined without_provenance_mut::<[bool; 0]>) {
-                      }
+                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
                   }
               }
           }
@@ -44,17 +42,25 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
+          _6 = const NonZero::<usize>(core::num::niche_types::NonZeroUsizeInner(1_usize));
           StorageLive(_7);
-          _7 = const 1_usize;
-          _6 = const {0x1 as *mut [bool; 0]};
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbChecks();
-          switchInt(move _8) -> [0: bb5, otherwise: bb3];
+          _7 = const {0x1 as *const [bool; 0]};
+          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
+          StorageDead(_7);
+          StorageDead(_6);
+          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
+          StorageDead(_5);
+          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
+          StorageDead(_4);
+          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
+          StorageDead(_3);
+          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
+          StorageDead(_2);
+          _0 = const ();
+          drop(_1) -> [return: bb1, unwind: bb2];
       }
   
       bb1: {
@@ -64,37 +70,6 @@
   
       bb2 (cleanup): {
           resume;
-      }
-  
-      bb3: {
-          StorageLive(_10);
-          _10 = const {0x1 as *mut ()};
-          _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb4, unwind unreachable];
-      }
-  
-      bb4: {
-          StorageDead(_10);
-          goto -> bb5;
-      }
-  
-      bb5: {
-          StorageDead(_8);
-          _11 = const {0x1 as *const [bool; 0]};
-          _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
-          StorageDead(_7);
-          StorageDead(_6);
-          _4 = const Unique::<[bool; 0]> {{ pointer: NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }}, _marker: PhantomData::<[bool; 0]> }};
-          StorageDead(_5);
-          _3 = const Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC0, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }};
-          StorageDead(_4);
-          _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
-          StorageDead(_3);
-          _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
-          StorageDead(_2);
-          _0 = const ();
-          drop(_1) -> [return: bb1, unwind: bb2];
       }
   }
   

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-abort.diff
@@ -16,25 +16,23 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let _6: *mut [bool; 0];
+                  let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 10 (inlined NonNull::<[bool; 0]>::new_unchecked) {
-                          let mut _8: bool;
-                          let _9: ();
-                          let mut _10: *mut ();
-                          let mut _11: *const [bool; 0];
-                          scope 11 (inlined core::ub_checks::check_language_ub) {
-                              scope 12 (inlined core::ub_checks::check_language_ub::runtime) {
+                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      }
+                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                          let _7: *const [bool; 0];
+                          scope 10 {
+                          }
+                          scope 11 (inlined NonZero::<usize>::get) {
+                          }
+                          scope 12 (inlined without_provenance::<[bool; 0]>) {
+                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
                               }
                           }
                       }
                   }
-                  scope 7 (inlined dangling_mut::<[bool; 0]>) {
-                      let mut _7: usize;
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined without_provenance_mut::<[bool; 0]>) {
-                      }
+                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
                   }
               }
           }
@@ -44,46 +42,16 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
+-         _6 = const std::ptr::Alignment::of::<[bool; 0]>::{constant#0} as std::num::NonZero<usize> (Transmute);
++         _6 = const NonZero::<usize>(core::num::niche_types::NonZeroUsizeInner(1_usize));
           StorageLive(_7);
--         _7 = AlignOf([bool; 0]);
--         _6 = copy _7 as *mut [bool; 0] (Transmute);
-+         _7 = const 1_usize;
-+         _6 = const {0x1 as *mut [bool; 0]};
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbChecks();
-          switchInt(move _8) -> [0: bb4, otherwise: bb2];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2: {
-          StorageLive(_10);
--         _10 = copy _7 as *mut () (Transmute);
--         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb3, unwind unreachable];
-+         _10 = const {0x1 as *mut ()};
-+         _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb3, unwind unreachable];
-      }
-  
-      bb3: {
-          StorageDead(_10);
-          goto -> bb4;
-      }
-  
-      bb4: {
-          StorageDead(_8);
--         _11 = copy _7 as *const [bool; 0] (Transmute);
--         _5 = NonNull::<[bool; 0]> { pointer: copy _11 };
-+         _11 = const {0x1 as *const [bool; 0]};
+-         _7 = copy _6 as *const [bool; 0] (Transmute);
+-         _5 = NonNull::<[bool; 0]> { pointer: copy _7 };
++         _7 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
           StorageDead(_7);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
@@ -94,13 +62,17 @@
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
 +         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
 +         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
       }
   }
 + 

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.32bit.panic-unwind.diff
@@ -16,25 +16,23 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let _6: *mut [bool; 0];
+                  let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 10 (inlined NonNull::<[bool; 0]>::new_unchecked) {
-                          let mut _8: bool;
-                          let _9: ();
-                          let mut _10: *mut ();
-                          let mut _11: *const [bool; 0];
-                          scope 11 (inlined core::ub_checks::check_language_ub) {
-                              scope 12 (inlined core::ub_checks::check_language_ub::runtime) {
+                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      }
+                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                          let _7: *const [bool; 0];
+                          scope 10 {
+                          }
+                          scope 11 (inlined NonZero::<usize>::get) {
+                          }
+                          scope 12 (inlined without_provenance::<[bool; 0]>) {
+                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
                               }
                           }
                       }
                   }
-                  scope 7 (inlined dangling_mut::<[bool; 0]>) {
-                      let mut _7: usize;
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined without_provenance_mut::<[bool; 0]>) {
-                      }
+                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
                   }
               }
           }
@@ -44,50 +42,16 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
+-         _6 = const std::ptr::Alignment::of::<[bool; 0]>::{constant#0} as std::num::NonZero<usize> (Transmute);
++         _6 = const NonZero::<usize>(core::num::niche_types::NonZeroUsizeInner(1_usize));
           StorageLive(_7);
--         _7 = AlignOf([bool; 0]);
--         _6 = copy _7 as *mut [bool; 0] (Transmute);
-+         _7 = const 1_usize;
-+         _6 = const {0x1 as *mut [bool; 0]};
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbChecks();
-          switchInt(move _8) -> [0: bb5, otherwise: bb3];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2 (cleanup): {
-          resume;
-      }
-  
-      bb3: {
-          StorageLive(_10);
--         _10 = copy _7 as *mut () (Transmute);
--         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb4, unwind unreachable];
-+         _10 = const {0x1 as *mut ()};
-+         _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb4, unwind unreachable];
-      }
-  
-      bb4: {
-          StorageDead(_10);
-          goto -> bb5;
-      }
-  
-      bb5: {
-          StorageDead(_8);
--         _11 = copy _7 as *const [bool; 0] (Transmute);
--         _5 = NonNull::<[bool; 0]> { pointer: copy _11 };
-+         _11 = const {0x1 as *const [bool; 0]};
+-         _7 = copy _6 as *const [bool; 0] (Transmute);
+-         _5 = NonNull::<[bool; 0]> { pointer: copy _7 };
++         _7 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
           StorageDead(_7);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
@@ -98,13 +62,21 @@
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
 +         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
 +         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
+  
+      bb2 (cleanup): {
+          resume;
       }
   }
 + 

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-abort.diff
@@ -16,25 +16,23 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let _6: *mut [bool; 0];
+                  let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 10 (inlined NonNull::<[bool; 0]>::new_unchecked) {
-                          let mut _8: bool;
-                          let _9: ();
-                          let mut _10: *mut ();
-                          let mut _11: *const [bool; 0];
-                          scope 11 (inlined core::ub_checks::check_language_ub) {
-                              scope 12 (inlined core::ub_checks::check_language_ub::runtime) {
+                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      }
+                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                          let _7: *const [bool; 0];
+                          scope 10 {
+                          }
+                          scope 11 (inlined NonZero::<usize>::get) {
+                          }
+                          scope 12 (inlined without_provenance::<[bool; 0]>) {
+                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
                               }
                           }
                       }
                   }
-                  scope 7 (inlined dangling_mut::<[bool; 0]>) {
-                      let mut _7: usize;
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined without_provenance_mut::<[bool; 0]>) {
-                      }
+                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
                   }
               }
           }
@@ -44,46 +42,16 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
+-         _6 = const std::ptr::Alignment::of::<[bool; 0]>::{constant#0} as std::num::NonZero<usize> (Transmute);
++         _6 = const NonZero::<usize>(core::num::niche_types::NonZeroUsizeInner(1_usize));
           StorageLive(_7);
--         _7 = AlignOf([bool; 0]);
--         _6 = copy _7 as *mut [bool; 0] (Transmute);
-+         _7 = const 1_usize;
-+         _6 = const {0x1 as *mut [bool; 0]};
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbChecks();
-          switchInt(move _8) -> [0: bb4, otherwise: bb2];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2: {
-          StorageLive(_10);
--         _10 = copy _7 as *mut () (Transmute);
--         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb3, unwind unreachable];
-+         _10 = const {0x1 as *mut ()};
-+         _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb3, unwind unreachable];
-      }
-  
-      bb3: {
-          StorageDead(_10);
-          goto -> bb4;
-      }
-  
-      bb4: {
-          StorageDead(_8);
--         _11 = copy _7 as *const [bool; 0] (Transmute);
--         _5 = NonNull::<[bool; 0]> { pointer: copy _11 };
-+         _11 = const {0x1 as *const [bool; 0]};
+-         _7 = copy _6 as *const [bool; 0] (Transmute);
+-         _5 = NonNull::<[bool; 0]> { pointer: copy _7 };
++         _7 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
           StorageDead(_7);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
@@ -94,13 +62,17 @@
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
 +         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
 +         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind unreachable];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
       }
   }
 + 

--- a/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/dataflow-const-prop/default_boxed_slice.main.GVN.64bit.panic-unwind.diff
@@ -16,25 +16,23 @@
           scope 4 (inlined Unique::<[bool; 0]>::dangling) {
               let mut _5: std::ptr::NonNull<[bool; 0]>;
               scope 5 (inlined NonNull::<[bool; 0]>::dangling) {
-                  let _6: *mut [bool; 0];
+                  let mut _6: std::num::NonZero<usize>;
                   scope 6 {
-                      scope 10 (inlined NonNull::<[bool; 0]>::new_unchecked) {
-                          let mut _8: bool;
-                          let _9: ();
-                          let mut _10: *mut ();
-                          let mut _11: *const [bool; 0];
-                          scope 11 (inlined core::ub_checks::check_language_ub) {
-                              scope 12 (inlined core::ub_checks::check_language_ub::runtime) {
+                      scope 8 (inlined std::ptr::Alignment::as_nonzero) {
+                      }
+                      scope 9 (inlined NonNull::<[bool; 0]>::without_provenance) {
+                          let _7: *const [bool; 0];
+                          scope 10 {
+                          }
+                          scope 11 (inlined NonZero::<usize>::get) {
+                          }
+                          scope 12 (inlined without_provenance::<[bool; 0]>) {
+                              scope 13 (inlined without_provenance_mut::<[bool; 0]>) {
                               }
                           }
                       }
                   }
-                  scope 7 (inlined dangling_mut::<[bool; 0]>) {
-                      let mut _7: usize;
-                      scope 8 (inlined align_of::<[bool; 0]>) {
-                      }
-                      scope 9 (inlined without_provenance_mut::<[bool; 0]>) {
-                      }
+                  scope 7 (inlined std::ptr::Alignment::of::<[bool; 0]>) {
                   }
               }
           }
@@ -44,50 +42,16 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
-          StorageLive(_9);
           StorageLive(_4);
           StorageLive(_5);
           StorageLive(_6);
+-         _6 = const std::ptr::Alignment::of::<[bool; 0]>::{constant#0} as std::num::NonZero<usize> (Transmute);
++         _6 = const NonZero::<usize>(core::num::niche_types::NonZeroUsizeInner(1_usize));
           StorageLive(_7);
--         _7 = AlignOf([bool; 0]);
--         _6 = copy _7 as *mut [bool; 0] (Transmute);
-+         _7 = const 1_usize;
-+         _6 = const {0x1 as *mut [bool; 0]};
-          StorageLive(_11);
-          StorageLive(_8);
-          _8 = UbChecks();
-          switchInt(move _8) -> [0: bb5, otherwise: bb3];
-      }
-  
-      bb1: {
-          StorageDead(_1);
-          return;
-      }
-  
-      bb2 (cleanup): {
-          resume;
-      }
-  
-      bb3: {
-          StorageLive(_10);
--         _10 = copy _7 as *mut () (Transmute);
--         _9 = NonNull::<T>::new_unchecked::precondition_check(move _10) -> [return: bb4, unwind unreachable];
-+         _10 = const {0x1 as *mut ()};
-+         _9 = NonNull::<T>::new_unchecked::precondition_check(const {0x1 as *mut ()}) -> [return: bb4, unwind unreachable];
-      }
-  
-      bb4: {
-          StorageDead(_10);
-          goto -> bb5;
-      }
-  
-      bb5: {
-          StorageDead(_8);
--         _11 = copy _7 as *const [bool; 0] (Transmute);
--         _5 = NonNull::<[bool; 0]> { pointer: copy _11 };
-+         _11 = const {0x1 as *const [bool; 0]};
+-         _7 = copy _6 as *const [bool; 0] (Transmute);
+-         _5 = NonNull::<[bool; 0]> { pointer: copy _7 };
++         _7 = const {0x1 as *const [bool; 0]};
 +         _5 = const NonNull::<[bool; 0]> {{ pointer: {0x1 as *const [bool; 0]} }};
-          StorageDead(_11);
           StorageDead(_7);
           StorageDead(_6);
 -         _4 = Unique::<[bool; 0]> { pointer: move _5, _marker: const PhantomData::<[bool; 0]> };
@@ -98,13 +62,21 @@
           StorageDead(_4);
 -         _2 = Box::<[bool]>(copy _3, const std::alloc::Global);
 +         _2 = const Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC1, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global);
-          StorageDead(_9);
           StorageDead(_3);
 -         _1 = A { foo: move _2 };
 +         _1 = const A {{ foo: Box::<[bool]>(Unique::<[bool]> {{ pointer: NonNull::<[bool]> {{ pointer: Indirect { alloc_id: ALLOC2, offset: Size(0 bytes) }: *const [bool] }}, _marker: PhantomData::<[bool]> }}, std::alloc::Global) }};
           StorageDead(_2);
           _0 = const ();
           drop(_1) -> [return: bb1, unwind: bb2];
+      }
+  
+      bb1: {
+          StorageDead(_1);
+          return;
+      }
+  
+      bb2 (cleanup): {
+          resume;
       }
   }
 + 

--- a/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
+++ b/tests/mir-opt/gvn_ptr_eq_with_constant.main.GVN.diff
@@ -6,17 +6,33 @@
       let _1: bool;
       let mut _2: *mut u8;
       scope 1 (inlined dangling_mut::<u8>) {
-          let mut _3: usize;
-          scope 2 (inlined align_of::<u8>) {
+          scope 2 (inlined NonNull::<u8>::dangling) {
+              let mut _3: std::num::NonZero<usize>;
+              scope 3 {
+                  scope 5 (inlined std::ptr::Alignment::as_nonzero) {
+                  }
+                  scope 6 (inlined NonNull::<u8>::without_provenance) {
+                      scope 7 {
+                      }
+                      scope 8 (inlined NonZero::<usize>::get) {
+                      }
+                      scope 9 (inlined without_provenance::<u8>) {
+                          scope 10 (inlined without_provenance_mut::<u8>) {
+                          }
+                      }
+                  }
+              }
+              scope 4 (inlined std::ptr::Alignment::of::<u8>) {
+              }
           }
-          scope 3 (inlined without_provenance_mut::<u8>) {
+          scope 11 (inlined NonNull::<u8>::as_ptr) {
           }
       }
-      scope 4 (inlined Foo::<u8>::cmp_ptr) {
+      scope 12 (inlined Foo::<u8>::cmp_ptr) {
           let mut _4: *const u8;
           let mut _5: *mut u8;
           let mut _6: *const u8;
-          scope 5 (inlined std::ptr::eq::<u8>) {
+          scope 13 (inlined std::ptr::eq::<u8>) {
           }
       }
   
@@ -24,9 +40,9 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
--         _3 = AlignOf(u8);
+-         _3 = const std::ptr::Alignment::of::<u8>::{constant#0} as std::num::NonZero<usize> (Transmute);
 -         _2 = copy _3 as *mut u8 (Transmute);
-+         _3 = const 1_usize;
++         _3 = const NonZero::<usize>(core::num::niche_types::NonZeroUsizeInner(1_usize));
 +         _2 = const {0x1 as *mut u8};
           StorageDead(_3);
           StorageLive(_4);

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
@@ -19,30 +19,30 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
             debug i => _22;
             debug x => _23;
         }
-        scope 18 (inlined <Enumerate<std::slice::Iter<'_, T>> as Iterator>::next) {
+        scope 19 (inlined <Enumerate<std::slice::Iter<'_, T>> as Iterator>::next) {
             let mut _14: &mut std::slice::Iter<'_, T>;
             let mut _15: std::option::Option<&T>;
             let mut _19: (usize, bool);
             let mut _20: (usize, &T);
-            scope 19 {
+            scope 20 {
                 let _18: usize;
-                scope 24 {
+                scope 25 {
                 }
             }
-            scope 20 {
-                scope 21 {
-                    scope 27 (inlined <Option<(usize, &T)> as FromResidual<Option<Infallible>>>::from_residual) {
+            scope 21 {
+                scope 22 {
+                    scope 28 (inlined <Option<(usize, &T)> as FromResidual<Option<Infallible>>>::from_residual) {
                     }
                 }
             }
-            scope 22 {
-                scope 23 {
+            scope 23 {
+                scope 24 {
                 }
             }
-            scope 25 (inlined <Option<&T> as Try>::branch) {
+            scope 26 (inlined <Option<&T> as Try>::branch) {
                 let mut _16: isize;
                 let _17: &T;
-                scope 26 {
+                scope 27 {
                 }
             }
         }
@@ -60,10 +60,12 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                     scope 7 {
                     }
                     scope 12 (inlined without_provenance::<T>) {
+                        scope 13 (inlined without_provenance_mut::<T>) {
+                        }
                     }
-                    scope 13 (inlined NonNull::<T>::as_ptr) {
+                    scope 14 (inlined NonNull::<T>::as_ptr) {
                     }
-                    scope 14 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
+                    scope 15 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
                 }
                 scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
@@ -79,11 +81,11 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
             }
         }
     }
-    scope 15 (inlined <std::slice::Iter<'_, T> as Iterator>::enumerate) {
-        scope 16 (inlined Enumerate::<std::slice::Iter<'_, T>>::new) {
+    scope 16 (inlined <std::slice::Iter<'_, T> as Iterator>::enumerate) {
+        scope 17 (inlined Enumerate::<std::slice::Iter<'_, T>>::new) {
         }
     }
-    scope 17 (inlined <Enumerate<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
+    scope 18 (inlined <Enumerate<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -35,10 +35,12 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                     scope 7 {
                     }
                     scope 12 (inlined without_provenance::<T>) {
+                        scope 13 (inlined without_provenance_mut::<T>) {
+                        }
                     }
-                    scope 13 (inlined NonNull::<T>::as_ptr) {
+                    scope 14 (inlined NonNull::<T>::as_ptr) {
                     }
-                    scope 14 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
+                    scope 15 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
                 }
                 scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
@@ -54,11 +56,11 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
             }
         }
     }
-    scope 15 (inlined <std::slice::Iter<'_, T> as Iterator>::enumerate) {
-        scope 16 (inlined Enumerate::<std::slice::Iter<'_, T>>::new) {
+    scope 16 (inlined <std::slice::Iter<'_, T> as Iterator>::enumerate) {
+        scope 17 (inlined Enumerate::<std::slice::Iter<'_, T>>::new) {
         }
     }
-    scope 17 (inlined <Enumerate<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
+    scope 18 (inlined <Enumerate<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -32,10 +32,12 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                     scope 7 {
                     }
                     scope 12 (inlined without_provenance::<T>) {
+                        scope 13 (inlined without_provenance_mut::<T>) {
+                        }
                     }
-                    scope 13 (inlined NonNull::<T>::as_ptr) {
+                    scope 14 (inlined NonNull::<T>::as_ptr) {
                     }
-                    scope 14 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
+                    scope 15 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
                 }
                 scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
@@ -51,7 +53,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
             }
         }
     }
-    scope 15 (inlined <std::slice::Iter<'_, T> as IntoIterator>::into_iter) {
+    scope 16 (inlined <std::slice::Iter<'_, T> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -32,10 +32,12 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                     scope 7 {
                     }
                     scope 12 (inlined without_provenance::<T>) {
+                        scope 13 (inlined without_provenance_mut::<T>) {
+                        }
                     }
-                    scope 13 (inlined NonNull::<T>::as_ptr) {
+                    scope 14 (inlined NonNull::<T>::as_ptr) {
                     }
-                    scope 14 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
+                    scope 15 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
                 }
                 scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
@@ -51,7 +53,7 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
             }
         }
     }
-    scope 15 (inlined <std::slice::Iter<'_, T> as IntoIterator>::into_iter) {
+    scope 16 (inlined <std::slice::Iter<'_, T> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -18,7 +18,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         scope 2 {
             debug x => _17;
         }
-        scope 18 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
+        scope 19 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
             let mut _14: &mut std::slice::Iter<'_, T>;
         }
     }
@@ -35,10 +35,12 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                     scope 7 {
                     }
                     scope 12 (inlined without_provenance::<T>) {
+                        scope 13 (inlined without_provenance_mut::<T>) {
+                        }
                     }
-                    scope 13 (inlined NonNull::<T>::as_ptr) {
+                    scope 14 (inlined NonNull::<T>::as_ptr) {
                     }
-                    scope 14 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
+                    scope 15 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
                 }
                 scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
@@ -54,11 +56,11 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
             }
         }
     }
-    scope 15 (inlined <std::slice::Iter<'_, T> as Iterator>::rev) {
-        scope 16 (inlined Rev::<std::slice::Iter<'_, T>>::new) {
+    scope 16 (inlined <std::slice::Iter<'_, T> as Iterator>::rev) {
+        scope 17 (inlined Rev::<std::slice::Iter<'_, T>>::new) {
         }
     }
-    scope 17 (inlined <Rev<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
+    scope 18 (inlined <Rev<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -18,7 +18,7 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         scope 2 {
             debug x => _17;
         }
-        scope 18 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
+        scope 19 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
             let mut _14: &mut std::slice::Iter<'_, T>;
         }
     }
@@ -35,10 +35,12 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
                     scope 7 {
                     }
                     scope 12 (inlined without_provenance::<T>) {
+                        scope 13 (inlined without_provenance_mut::<T>) {
+                        }
                     }
-                    scope 13 (inlined NonNull::<T>::as_ptr) {
+                    scope 14 (inlined NonNull::<T>::as_ptr) {
                     }
-                    scope 14 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
+                    scope 15 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
                 }
                 scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
@@ -54,11 +56,11 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
             }
         }
     }
-    scope 15 (inlined <std::slice::Iter<'_, T> as Iterator>::rev) {
-        scope 16 (inlined Rev::<std::slice::Iter<'_, T>>::new) {
+    scope 16 (inlined <std::slice::Iter<'_, T> as Iterator>::rev) {
+        scope 17 (inlined Rev::<std::slice::Iter<'_, T>>::new) {
         }
     }
-    scope 17 (inlined <Rev<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
+    scope 18 (inlined <Rev<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
     }
 
     bb0: {


### PR DESCRIPTION
This PR was inspired by the new `NonNull::without_provenance` (cc https://github.com/rust-lang/rust/issues/135243#issuecomment-2583913562) since it made me realize that we could write `NonNull::dangling` in completely-safe code using other existing things.

Then doing that led me to a few more places that could be simplified, like now that GVN will optimize Transmute-then-PtrToPtr, we can just implement `ptr::without_provenance` by calling `ptr::without_provenance_mut` since the shipped rlib of `core` ends up with the same single statement as the implementation (thanks to GVN merging the steps) and thus there's no need to duplicate the `transmute` -- and more importantly, no need to repeat a long safety comment.

There did end up being a couple of other changes needed to avoid exploding certain bits of MIR, though -- like `<Box<[i32]>>::default()`'s MIR originally got way worse as certain things didn't inline, or had a bunch of extraneous UbChecks -- so there's a couple of other changes to solve that.