### PR TITLE
rustdoc-json: Include items in stripped modules in `Crate::paths`.

### DIFF
--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -303,6 +303,12 @@ impl<'a> Validator<'a> {
             PathKind::Trait => self.add_trait_or_alias_id(&x.id),
             PathKind::Type => self.add_type_id(&x.id),
         }
+
+        // FIXME: More robust support for checking things in $.index also exist in $.paths
+        if !self.krate.paths.contains_key(&x.id) {
+            self.fail(&x.id, ErrorKind::Custom(format!("No entry in '$.paths' for {x:?}")));
+        }
+
         if let Some(args) = &x.args {
             self.check_generic_args(&**args);
         }

--- a/tests/rustdoc-json/reexport/simple_private.rs
+++ b/tests/rustdoc-json/reexport/simple_private.rs
@@ -12,3 +12,9 @@ mod inner {
 pub use inner::Public;
 
 //@ ismany "$.index[*][?(@.name=='simple_private')].inner.module.items[*]" $use_id
+
+// Test for https://github.com/rust-lang/rust/issues/135309
+//@ has  "$.paths[*][?(@.kind=='module')].path" '["simple_private"]'
+//@ !has "$.paths[*].path"                      '["simple_private", "inner"]'
+//@ has  "$.paths[*][?(@.kind=='struct')].path" '["simple_private", "inner", "Public"]'
+//@ !has "$.paths[*].path"                      '["simple_private", "Public"]'

--- a/tests/rustdoc-json/reexport/simple_public.rs
+++ b/tests/rustdoc-json/reexport/simple_public.rs
@@ -14,3 +14,8 @@ pub mod inner {
 pub use inner::Public;
 
 //@ ismany "$.index[*][?(@.name=='simple_public')].inner.module.items[*]" $import_id $inner_id
+
+//@ has  "$.paths[*][?(@.kind=='module')].path" '["simple_public"]'
+//@ has  "$.paths[*][?(@.kind=='module')].path" '["simple_public", "inner"]'
+//@ has  "$.paths[*][?(@.kind=='struct')].path" '["simple_public", "inner", "Public"]'
+//@ !has "$.paths[*].path"                      '["simple_public", "Public"]'


### PR DESCRIPTION
Closes #135309

When we're running rustdoc-json, we should err on the side of adding more items to `Cache::paths`, as that directly becomes `Crate::paths` in the output.

r? @GuillaumeGomez. Best reviewed commit-by-commit.