### PR TITLE
re-add --disable-minification to rustdoc

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -303,6 +303,8 @@ pub(crate) struct RenderOptions {
     pub(crate) include_parts_dir: Vec<PathToParts>,
     /// Where to write crate-info
     pub(crate) parts_out_dir: Option<PathToParts>,
+    /// disable minification of CSS/JS
+    pub(crate) disable_minification: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -781,6 +783,9 @@ impl Options {
 
         let unstable_features =
             rustc_feature::UnstableFeatures::from_environment(crate_name.as_deref());
+
+        let disable_minification = matches.opt_present("disable-minification");
+
         let options = Options {
             bin_crate,
             proc_macro_crate,
@@ -857,6 +862,7 @@ impl Options {
             should_merge,
             include_parts_dir,
             parts_out_dir,
+            disable_minification,
         };
         Some((input, options, render_options))
     }

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -207,7 +207,15 @@ fn write_static_files(
     if opt.emit.is_empty() || opt.emit.contains(&EmitType::Toolchain) {
         static_files::for_each(|f: &static_files::StaticFile| {
             let filename = static_dir.join(f.output_filename());
-            fs::write(&filename, f.minified()).map_err(|e| PathError::new(e, &filename))
+            let contents: &[u8];
+            let contents_vec: Vec<u8>;
+            if opt.disable_minification {
+                contents = f.bytes;
+            } else {
+                contents_vec = f.minified();
+                contents = &contents_vec;
+            };
+            fs::write(&filename, contents).map_err(|e| PathError::new(e, &filename))
         })?;
     }
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -656,7 +656,7 @@ fn opts() -> Vec<RustcOptGroup> {
             FlagMulti,
             "",
             "disable-minification",
-            "diable the minification of CSS/JS files (perma-unstable, do not use with cached files)",
+            "disable the minification of CSS/JS files (perma-unstable, do not use with cached files)",
             "",
         ),
         // deprecated / removed options

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -651,8 +651,15 @@ fn opts() -> Vec<RustcOptGroup> {
             "",
             "add arguments to be used when compiling doctests",
         ),
+        opt(
+            Unstable,
+            FlagMulti,
+            "",
+            "disable-minification",
+            "diable the minification of CSS/JS files",
+            "",
+        ),
         // deprecated / removed options
-        opt(Unstable, FlagMulti, "", "disable-minification", "removed", ""),
         opt(
             Stable,
             Multi,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -656,7 +656,7 @@ fn opts() -> Vec<RustcOptGroup> {
             FlagMulti,
             "",
             "disable-minification",
-            "diable the minification of CSS/JS files",
+            "diable the minification of CSS/JS files (perma-unstable, do not use with cached files)",
             "",
         ),
         // deprecated / removed options

--- a/tests/run-make/rustdoc-default-output/output-default.stdout
+++ b/tests/run-make/rustdoc-default-output/output-default.stdout
@@ -194,7 +194,8 @@ Options:
         --doctest-compilation-args add arguments to be used when compiling doctests
                         
         --disable-minification 
-                        diable the minification of CSS/JS files
+                        disable the minification of CSS/JS files
+                        (perma-unstable, do not use with cached files)
         --plugin-path DIR
                         removed, see issue #44136
                         <https://github.com/rust-lang/rust/issues/44136> for

--- a/tests/run-make/rustdoc-default-output/output-default.stdout
+++ b/tests/run-make/rustdoc-default-output/output-default.stdout
@@ -194,7 +194,7 @@ Options:
         --doctest-compilation-args add arguments to be used when compiling doctests
                         
         --disable-minification 
-                        removed
+                        diable the minification of CSS/JS files
         --plugin-path DIR
                         removed, see issue #44136
                         <https://github.com/rust-lang/rust/issues/44136> for


### PR DESCRIPTION
this also makes the rust.docs-minification option work as advertised in config.toml

nothing fancy this time, this is intended to be perma-unstable. it's only really here for the benefit of rustdoc devs.

mitegates https://github.com/rust-lang/rust/issues/135345

It was removed in https://github.com/rust-lang/rust/commit/f9e1f6ffdf03ec33cb29e20c88fc7bcc938c7f42.
