### PR TITLE
ci: added test log format for ci

### DIFF
--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -10,6 +10,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{ChildStdout, Stdio};
 use std::time::Duration;
 
+use build_helper::ci::CiEnv;
 use termcolor::{Color, ColorSpec, WriteColor};
 
 use crate::core::builder::Builder;
@@ -91,7 +92,9 @@ struct Renderer<'a> {
     /// Number of tests that were skipped due to already being up-to-date
     /// (i.e. no relevant changes occurred since they last ran).
     up_to_date_tests: usize,
+    ignored_tests: usize,
     terse_tests_in_line: usize,
+    ci_latest_logged_percentage: f64,
 }
 
 impl<'a> Renderer<'a> {
@@ -104,7 +107,9 @@ impl<'a> Renderer<'a> {
             tests_count: None,
             executed_tests: 0,
             up_to_date_tests: 0,
+            ignored_tests: 0,
             terse_tests_in_line: 0,
+            ci_latest_logged_percentage: 0.0,
         }
     }
 
@@ -159,9 +164,12 @@ impl<'a> Renderer<'a> {
     fn render_test_outcome(&mut self, outcome: Outcome<'_>, test: &TestOutcome) {
         self.executed_tests += 1;
 
-        // Keep this in sync with the "up-to-date" ignore message inserted by compiletest.
-        if let Outcome::Ignored { reason: Some("up-to-date") } = outcome {
-            self.up_to_date_tests += 1;
+        if let Outcome::Ignored { reason } = outcome {
+            self.ignored_tests += 1;
+            // Keep this in sync with the "up-to-date" ignore message inserted by compiletest.
+            if reason == Some("up-to-date") {
+                self.up_to_date_tests += 1;
+            }
         }
 
         #[cfg(feature = "build-metrics")]
@@ -179,6 +187,8 @@ impl<'a> Renderer<'a> {
 
         if self.builder.config.verbose_tests {
             self.render_test_outcome_verbose(outcome, test);
+        } else if CiEnv::is_ci() {
+            self.render_test_outcome_ci(outcome, test);
         } else {
             self.render_test_outcome_terse(outcome, test);
         }
@@ -206,6 +216,31 @@ impl<'a> Renderer<'a> {
 
         self.terse_tests_in_line += 1;
         self.builder.colored_stdout(|stdout| outcome.write_short(stdout, &test.name)).unwrap();
+        let _ = std::io::stdout().flush();
+    }
+
+    fn render_test_outcome_ci(&mut self, outcome: Outcome<'_>, test: &TestOutcome) {
+        if let Some(total) = self.tests_count {
+            let percent = self.executed_tests as f64 / total as f64;
+
+            if self.ci_latest_logged_percentage + 0.10 < percent {
+                let total = total.to_string();
+                let executed = format!("{:>width$}", self.executed_tests, width = total.len());
+                let pretty_percent = format!("{:.0}%", percent * 100.0);
+                let passed_tests = self.executed_tests - (self.failures.len() + self.ignored_tests);
+                println!(
+                    "{:<4} -- {executed}/{total}, {:>total_indent$} passed, {} failed, {} ignored",
+                    pretty_percent,
+                    passed_tests,
+                    self.failures.len(),
+                    self.ignored_tests,
+                    total_indent = total.len()
+                );
+                self.ci_latest_logged_percentage += 0.10;
+            }
+        }
+
+        self.builder.colored_stdout(|stdout| outcome.write_ci(stdout, &test.name)).unwrap();
         let _ = std::io::stdout().flush();
     }
 
@@ -374,6 +409,17 @@ impl Outcome<'_> {
                 if let Some(reason) = reason {
                     write!(writer, ", {reason}")?;
                 }
+            }
+        }
+        writer.reset()
+    }
+
+    fn write_ci(&self, writer: &mut dyn WriteColor, name: &str) -> Result<(), std::io::Error> {
+        match self {
+            Outcome::Ok | Outcome::BenchOk | Outcome::Ignored { .. } => {}
+            Outcome::Failed => {
+                writer.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
+                writeln!(writer, "   {name} ... FAILED")?;
             }
         }
         writer.reset()


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR adds a new test render format specifically for ci. 
The goal as stated in #134910 is to make reviewing test failures in CI easier.

See the new test output format in the CI for this PR ([here](https://github.com/rust-lang/rust/actions/runs/12723914643/job/35469515397?pr=135355))


closes #134910 cc: @jyn514 