### PR TITLE
Cleanup `suggest_binding_for_closure_capture_self` diag in borrowck

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2695,7 +2695,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             }
 
             err.multipart_suggestion_verbose(
-                "try explicitly pass `&Self` into the Closure as an argument",
+                "try explicitly passing `&Self` into the closure as an argument",
                 sugg,
                 Applicability::MachineApplicable,
             );

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2680,19 +2680,16 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 return;
             }
 
-            let mut sugg = vec![];
             let sm = self.infcx.tcx.sess.source_map();
-
-            if let Some(span) = finder.closure_arg_span {
-                sugg.push((sm.next_point(span.shrink_to_lo()).shrink_to_hi(), finder.suggest_arg));
-            }
-            for span in finder.closure_change_spans {
-                sugg.push((span, "this".to_string()));
-            }
-
-            for (span, suggest) in finder.closure_call_changes {
-                sugg.push((span, suggest));
-            }
+            let sugg = finder
+                .closure_arg_span
+                .map(|span| (sm.next_point(span.shrink_to_lo()).shrink_to_hi(), finder.suggest_arg))
+                .into_iter()
+                .chain(
+                    finder.closure_change_spans.into_iter().map(|span| (span, "this".to_string())),
+                )
+                .chain(finder.closure_call_changes)
+                .collect();
 
             err.multipart_suggestion_verbose(
                 "try explicitly passing `&Self` into the closure as an argument",

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -880,7 +880,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         )
     } }
 
-    /// Show a suggestion that has multiple parts to it, always as it's own subdiagnostic.
+    /// Show a suggestion that has multiple parts to it, always as its own subdiagnostic.
     /// In other words, multiple changes need to be applied as part of this suggestion.
     #[rustc_lint_diagnostics]
     pub fn multipart_suggestion_verbose(

--- a/tests/ui/suggestions/issue-105761-suggest-self-for-closure.stderr
+++ b/tests/ui/suggestions/issue-105761-suggest-self-for-closure.stderr
@@ -11,7 +11,7 @@ LL |         self.qux();
 LL |         x(1);
    |         - immutable borrow later used here
    |
-help: try explicitly pass `&Self` into the Closure as an argument
+help: try explicitly passing `&Self` into the closure as an argument
    |
 LL ~         let x = |this: &Self, v: i32| {
 LL ~             this.bar();
@@ -35,7 +35,7 @@ LL |         self.qux();
 LL |         y();
    |         - immutable borrow later used here
    |
-help: try explicitly pass `&Self` into the Closure as an argument
+help: try explicitly passing `&Self` into the closure as an argument
    |
 LL ~         let y = |this: &Self| {
 LL ~             this.bar();


### PR DESCRIPTION
Mostly grammar fix/improvement, but also a small cleanup to use iterators instead of for loops for collecting into a vector.