### PR TITLE
Update the explanation for why we use box_new in vec!

### DIFF
--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -48,8 +48,8 @@ macro_rules! vec {
     );
     ($($x:expr),+ $(,)?) => (
         <[_]>::into_vec(
-            // Using the intrinsic produces a dramatic improvement in compile
-            // time when constructing arrays with many elements.
+            // Using the intrinsic produces a dramatic improvement in stack usage for
+            // unoptimized programs using this code path to construct large Vecs.
             $crate::boxed::box_new([$($x),+])
         )
     );


### PR DESCRIPTION
The perf run in this PR demonstrates that there is no longer a dramatic change in compile time with the intrinsic `box_new` vs calling `Box::new`, but I've locally confirmed that there is still a dramatic change in stack use.