### PR TITLE
Enable `unreachable_pub` lint in `test` and `proc_macro` crates

### DIFF
--- a/library/proc_macro/src/bridge/closure.rs
+++ b/library/proc_macro/src/bridge/closure.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 #[repr(C)]
-pub struct Closure<'a, A, R> {
+pub(super) struct Closure<'a, A, R> {
     call: unsafe extern "C" fn(*mut Env, A) -> R,
     env: *mut Env,
     // Prevent Send and Sync impls. `!Send`/`!Sync` is the usual way of doing
@@ -26,7 +26,7 @@ impl<'a, A, R, F: FnMut(A) -> R> From<&'a mut F> for Closure<'a, A, R> {
 }
 
 impl<'a, A, R> Closure<'a, A, R> {
-    pub fn call(&mut self, arg: A) -> R {
+    pub(super) fn call(&mut self, arg: A) -> R {
         unsafe { (self.call)(self.env, arg) }
     }
 }

--- a/library/proc_macro/src/bridge/fxhash.rs
+++ b/library/proc_macro/src/bridge/fxhash.rs
@@ -9,7 +9,7 @@ use std::hash::{BuildHasherDefault, Hasher};
 use std::ops::BitXor;
 
 /// Type alias for a hashmap using the `fx` hash algorithm.
-pub type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+pub(super) type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
 
 /// A speedy hash algorithm for use within rustc. The hashmap in alloc by
 /// default uses SipHash which isn't quite as speedy as we want. In the compiler
@@ -23,7 +23,7 @@ pub type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
 /// similar or slightly worse than FNV, but the speed of the hash function
 /// itself is much higher because it works on up to 8 bytes at a time.
 #[derive(Default)]
-pub struct FxHasher {
+pub(super) struct FxHasher {
     hash: usize,
 }
 

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -67,7 +67,7 @@ macro_rules! rpc_encode_decode {
                 mod tag {
                     #[repr(u8)] enum Tag { $($variant),* }
 
-                    $(pub const $variant: u8 = Tag::$variant as u8;)*
+                    $(pub(crate) const $variant: u8 = Tag::$variant as u8;)*
                 }
 
                 match self {
@@ -89,7 +89,7 @@ macro_rules! rpc_encode_decode {
                 mod tag {
                     #[repr(u8)] enum Tag { $($variant),* }
 
-                    $(pub const $variant: u8 = Tag::$variant as u8;)*
+                    $(pub(crate) const $variant: u8 = Tag::$variant as u8;)*
                 }
 
                 match u8::decode(r, s) {

--- a/library/proc_macro/src/bridge/selfless_reify.rs
+++ b/library/proc_macro/src/bridge/selfless_reify.rs
@@ -44,7 +44,7 @@ macro_rules! define_reify_functions {
         fn $name:ident $(<$($param:ident),*>)?
             for $(extern $abi:tt)? fn($($arg:ident: $arg_ty:ty),*) -> $ret_ty:ty;
     )+) => {
-        $(pub const fn $name<
+        $(pub(super) const fn $name<
             $($($param,)*)?
             F: Fn($($arg_ty),*) -> $ret_ty + Copy
         >(f: F) -> $(extern $abi)? fn($($arg_ty),*) -> $ret_ty {

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -32,6 +32,7 @@
 #![allow(internal_features)]
 #![deny(ffi_unwind_calls)]
 #![warn(rustdoc::unescaped_backticks)]
+#![warn(unreachable_pub)]
 
 #[unstable(feature = "proc_macro_internals", issue = "27812")]
 #[doc(hidden)]

--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -44,7 +44,7 @@ impl TestOpts {
 }
 
 /// Result of parsing the options.
-pub type OptRes = Result<TestOpts, String>;
+pub(crate) type OptRes = Result<TestOpts, String>;
 /// Result of parsing the option part.
 type OptPartRes<T> = Result<T, String>;
 

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -20,7 +20,7 @@ use super::types::{NamePadding, TestDesc, TestDescAndFn};
 use super::{filter_tests, run_tests, term};
 
 /// Generic wrapper over stdout.
-pub enum OutputLocation<T> {
+pub(crate) enum OutputLocation<T> {
     Pretty(Box<term::StdoutTerminal>),
     Raw(T),
 }
@@ -41,7 +41,7 @@ impl<T: Write> Write for OutputLocation<T> {
     }
 }
 
-pub struct ConsoleTestDiscoveryState {
+pub(crate) struct ConsoleTestDiscoveryState {
     pub log_out: Option<File>,
     pub tests: usize,
     pub benchmarks: usize,
@@ -49,7 +49,7 @@ pub struct ConsoleTestDiscoveryState {
 }
 
 impl ConsoleTestDiscoveryState {
-    pub fn new(opts: &TestOpts) -> io::Result<ConsoleTestDiscoveryState> {
+    pub(crate) fn new(opts: &TestOpts) -> io::Result<ConsoleTestDiscoveryState> {
         let log_out = match opts.logfile {
             Some(ref path) => Some(File::create(path)?),
             None => None,
@@ -58,7 +58,7 @@ impl ConsoleTestDiscoveryState {
         Ok(ConsoleTestDiscoveryState { log_out, tests: 0, benchmarks: 0, ignored: 0 })
     }
 
-    pub fn write_log<F, S>(&mut self, msg: F) -> io::Result<()>
+    pub(crate) fn write_log<F, S>(&mut self, msg: F) -> io::Result<()>
     where
         S: AsRef<str>,
         F: FnOnce() -> S,
@@ -74,7 +74,7 @@ impl ConsoleTestDiscoveryState {
     }
 }
 
-pub struct ConsoleTestState {
+pub(crate) struct ConsoleTestState {
     pub log_out: Option<File>,
     pub total: usize,
     pub passed: usize,
@@ -92,7 +92,7 @@ pub struct ConsoleTestState {
 }
 
 impl ConsoleTestState {
-    pub fn new(opts: &TestOpts) -> io::Result<ConsoleTestState> {
+    pub(crate) fn new(opts: &TestOpts) -> io::Result<ConsoleTestState> {
         let log_out = match opts.logfile {
             Some(ref path) => Some(File::create(path)?),
             None => None,
@@ -116,7 +116,7 @@ impl ConsoleTestState {
         })
     }
 
-    pub fn write_log<F, S>(&mut self, msg: F) -> io::Result<()>
+    pub(crate) fn write_log<F, S>(&mut self, msg: F) -> io::Result<()>
     where
         S: AsRef<str>,
         F: FnOnce() -> S,
@@ -131,7 +131,7 @@ impl ConsoleTestState {
         }
     }
 
-    pub fn write_log_result(
+    pub(crate) fn write_log_result(
         &mut self,
         test: &TestDesc,
         result: &TestResult,
@@ -170,7 +170,7 @@ impl ConsoleTestState {
 }
 
 // List the tests to console, and optionally to logfile. Filters are honored.
-pub fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Result<()> {
+pub(crate) fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Result<()> {
     let output = match term::stdout() {
         None => OutputLocation::Raw(io::stdout().lock()),
         Some(t) => OutputLocation::Pretty(t),

--- a/library/test/src/formatters/json.rs
+++ b/library/test/src/formatters/json.rs
@@ -13,7 +13,7 @@ pub(crate) struct JsonFormatter<T> {
 }
 
 impl<T: Write> JsonFormatter<T> {
-    pub fn new(out: OutputLocation<T>) -> Self {
+    pub(crate) fn new(out: OutputLocation<T>) -> Self {
         Self { out }
     }
 

--- a/library/test/src/formatters/junit.rs
+++ b/library/test/src/formatters/junit.rs
@@ -8,13 +8,13 @@ use crate::test_result::TestResult;
 use crate::time;
 use crate::types::{TestDesc, TestType};
 
-pub struct JunitFormatter<T> {
+pub(crate) struct JunitFormatter<T> {
     out: OutputLocation<T>,
     results: Vec<(TestDesc, TestResult, Duration, Vec<u8>)>,
 }
 
 impl<T: Write> JunitFormatter<T> {
-    pub fn new(out: OutputLocation<T>) -> Self {
+    pub(crate) fn new(out: OutputLocation<T>) -> Self {
         Self { out, results: Vec::new() }
     }
 

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -20,7 +20,7 @@ pub(crate) struct PrettyFormatter<T> {
 }
 
 impl<T: Write> PrettyFormatter<T> {
-    pub fn new(
+    pub(crate) fn new(
         out: OutputLocation<T>,
         use_color: bool,
         max_name_len: usize,
@@ -31,19 +31,19 @@ impl<T: Write> PrettyFormatter<T> {
     }
 
     #[cfg(test)]
-    pub fn output_location(&self) -> &OutputLocation<T> {
+    pub(crate) fn output_location(&self) -> &OutputLocation<T> {
         &self.out
     }
 
-    pub fn write_ok(&mut self) -> io::Result<()> {
+    pub(crate) fn write_ok(&mut self) -> io::Result<()> {
         self.write_short_result("ok", term::color::GREEN)
     }
 
-    pub fn write_failed(&mut self) -> io::Result<()> {
+    pub(crate) fn write_failed(&mut self) -> io::Result<()> {
         self.write_short_result("FAILED", term::color::RED)
     }
 
-    pub fn write_ignored(&mut self, message: Option<&'static str>) -> io::Result<()> {
+    pub(crate) fn write_ignored(&mut self, message: Option<&'static str>) -> io::Result<()> {
         if let Some(message) = message {
             self.write_short_result(&format!("ignored, {message}"), term::color::YELLOW)
         } else {
@@ -51,15 +51,15 @@ impl<T: Write> PrettyFormatter<T> {
         }
     }
 
-    pub fn write_time_failed(&mut self) -> io::Result<()> {
+    pub(crate) fn write_time_failed(&mut self) -> io::Result<()> {
         self.write_short_result("FAILED (time limit exceeded)", term::color::RED)
     }
 
-    pub fn write_bench(&mut self) -> io::Result<()> {
+    pub(crate) fn write_bench(&mut self) -> io::Result<()> {
         self.write_pretty("bench", term::color::CYAN)
     }
 
-    pub fn write_short_result(
+    pub(crate) fn write_short_result(
         &mut self,
         result: &str,
         color: term::color::Color,
@@ -67,7 +67,7 @@ impl<T: Write> PrettyFormatter<T> {
         self.write_pretty(result, color)
     }
 
-    pub fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
+    pub(crate) fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
         match self.out {
             OutputLocation::Pretty(ref mut term) => {
                 if self.use_color {
@@ -86,7 +86,7 @@ impl<T: Write> PrettyFormatter<T> {
         }
     }
 
-    pub fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
+    pub(crate) fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
         let s = s.as_ref();
         self.out.write_all(s.as_bytes())?;
         self.out.flush()
@@ -154,15 +154,15 @@ impl<T: Write> PrettyFormatter<T> {
         Ok(())
     }
 
-    pub fn write_successes(&mut self, state: &ConsoleTestState) -> io::Result<()> {
+    pub(crate) fn write_successes(&mut self, state: &ConsoleTestState) -> io::Result<()> {
         self.write_results(&state.not_failures, "successes")
     }
 
-    pub fn write_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
+    pub(crate) fn write_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
         self.write_results(&state.failures, "failures")
     }
 
-    pub fn write_time_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
+    pub(crate) fn write_time_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
         self.write_results(&state.time_failures, "failures (time limit exceeded)")
     }
 

--- a/library/test/src/formatters/terse.rs
+++ b/library/test/src/formatters/terse.rs
@@ -25,7 +25,7 @@ pub(crate) struct TerseFormatter<T> {
 }
 
 impl<T: Write> TerseFormatter<T> {
-    pub fn new(
+    pub(crate) fn new(
         out: OutputLocation<T>,
         use_color: bool,
         max_name_len: usize,
@@ -42,11 +42,11 @@ impl<T: Write> TerseFormatter<T> {
         }
     }
 
-    pub fn write_ok(&mut self) -> io::Result<()> {
+    pub(crate) fn write_ok(&mut self) -> io::Result<()> {
         self.write_short_result(".", term::color::GREEN)
     }
 
-    pub fn write_failed(&mut self, name: &str) -> io::Result<()> {
+    pub(crate) fn write_failed(&mut self, name: &str) -> io::Result<()> {
         // Put failed tests on their own line and include the test name, so that it's faster
         // to see which test failed without having to wait for them all to run.
 
@@ -62,15 +62,15 @@ impl<T: Write> TerseFormatter<T> {
         self.write_plain("\n")
     }
 
-    pub fn write_ignored(&mut self) -> io::Result<()> {
+    pub(crate) fn write_ignored(&mut self) -> io::Result<()> {
         self.write_short_result("i", term::color::YELLOW)
     }
 
-    pub fn write_bench(&mut self) -> io::Result<()> {
+    pub(crate) fn write_bench(&mut self) -> io::Result<()> {
         self.write_pretty("bench", term::color::CYAN)
     }
 
-    pub fn write_short_result(
+    pub(crate) fn write_short_result(
         &mut self,
         result: &str,
         color: term::color::Color,
@@ -95,7 +95,7 @@ impl<T: Write> TerseFormatter<T> {
         Ok(())
     }
 
-    pub fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
+    pub(crate) fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
         match self.out {
             OutputLocation::Pretty(ref mut term) => {
                 if self.use_color {
@@ -114,13 +114,13 @@ impl<T: Write> TerseFormatter<T> {
         }
     }
 
-    pub fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
+    pub(crate) fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
         let s = s.as_ref();
         self.out.write_all(s.as_bytes())?;
         self.out.flush()
     }
 
-    pub fn write_outputs(&mut self, state: &ConsoleTestState) -> io::Result<()> {
+    pub(crate) fn write_outputs(&mut self, state: &ConsoleTestState) -> io::Result<()> {
         self.write_plain("\nsuccesses:\n")?;
         let mut successes = Vec::new();
         let mut stdouts = String::new();
@@ -146,7 +146,7 @@ impl<T: Write> TerseFormatter<T> {
         Ok(())
     }
 
-    pub fn write_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
+    pub(crate) fn write_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
         self.write_plain("\nfailures:\n")?;
         let mut failures = Vec::new();
         let mut fail_out = String::new();

--- a/library/test/src/helpers/concurrency.rs
+++ b/library/test/src/helpers/concurrency.rs
@@ -4,7 +4,7 @@
 use std::num::NonZero;
 use std::{env, thread};
 
-pub fn get_concurrency() -> usize {
+pub(crate) fn get_concurrency() -> usize {
     if let Ok(value) = env::var("RUST_TEST_THREADS") {
         match value.parse::<NonZero<usize>>().ok() {
             Some(n) => n.get(),

--- a/library/test/src/helpers/mod.rs
+++ b/library/test/src/helpers/mod.rs
@@ -1,6 +1,6 @@
 //! Module with common helpers not directly related to tests
 //! but used in `libtest`.
 
-pub mod concurrency;
-pub mod metrics;
-pub mod shuffle;
+pub(crate) mod concurrency;
+pub(crate) mod metrics;
+pub(crate) mod shuffle;

--- a/library/test/src/helpers/shuffle.rs
+++ b/library/test/src/helpers/shuffle.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::cli::TestOpts;
 use crate::types::{TestDescAndFn, TestId, TestName};
 
-pub fn get_shuffle_seed(opts: &TestOpts) -> Option<u64> {
+pub(crate) fn get_shuffle_seed(opts: &TestOpts) -> Option<u64> {
     opts.shuffle_seed.or_else(|| {
         if opts.shuffle {
             Some(
@@ -19,7 +19,7 @@ pub fn get_shuffle_seed(opts: &TestOpts) -> Option<u64> {
     })
 }
 
-pub fn shuffle_tests(shuffle_seed: u64, tests: &mut [(TestId, TestDescAndFn)]) {
+pub(crate) fn shuffle_tests(shuffle_seed: u64, tests: &mut [(TestId, TestDescAndFn)]) {
     let test_names: Vec<&TestName> = tests.iter().map(|test| &test.1.desc.name).collect();
     let test_names_hash = calculate_hash(&test_names);
     let mut rng = Rng::new(shuffle_seed, test_names_hash);

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -27,6 +27,7 @@
 #![feature(thread_spawn_hook)]
 #![allow(internal_features)]
 #![warn(rustdoc::unescaped_backticks)]
+#![warn(unreachable_pub)]
 
 pub use cli::TestOpts;
 

--- a/library/test/src/options.rs
+++ b/library/test/src/options.rs
@@ -2,7 +2,7 @@
 
 /// Number of times to run a benchmarked function
 #[derive(Clone, PartialEq, Eq)]
-pub enum BenchMode {
+pub(crate) enum BenchMode {
     Auto,
     Single,
 }

--- a/library/test/src/stats/tests.rs
+++ b/library/test/src/stats/tests.rs
@@ -573,13 +573,13 @@ fn test_sum_f64_between_ints_that_sum_to_0() {
 }
 
 #[bench]
-pub fn sum_three_items(b: &mut Bencher) {
+fn sum_three_items(b: &mut Bencher) {
     b.iter(|| {
         [1e20f64, 1.5f64, -1e20f64].sum();
     })
 }
 #[bench]
-pub fn sum_many_f64(b: &mut Bencher) {
+fn sum_many_f64(b: &mut Bencher) {
     let nums = [-1e30f64, 1e60, 1e30, 1.0, -1e60];
     let v = (0..500).map(|i| nums[i % 5]).collect::<Vec<_>>();
 
@@ -589,4 +589,4 @@ pub fn sum_many_f64(b: &mut Bencher) {
 }
 
 #[bench]
-pub fn no_iter(_: &mut Bencher) {}
+fn no_iter(_: &mut Bencher) {}

--- a/library/test/src/term.rs
+++ b/library/test/src/term.rs
@@ -62,7 +62,7 @@ pub(crate) mod color {
 
 /// A terminal with similar capabilities to an ANSI Terminal
 /// (foreground/background colors etc).
-pub trait Terminal: Write {
+pub(crate) trait Terminal: Write {
     /// Sets the foreground color to the given color.
     ///
     /// If the color is a bright color, but the terminal only supports 8 colors,

--- a/library/test/src/test_result.rs
+++ b/library/test/src/test_result.rs
@@ -12,7 +12,7 @@ use super::types::TestDesc;
 // Return code for secondary process.
 // Start somewhere other than 0 so we know the return code means what we think
 // it means.
-pub const TR_OK: i32 = 50;
+pub(crate) const TR_OK: i32 = 50;
 
 // On Windows we use __fastfail to abort, which is documented to use this
 // exception code.
@@ -39,7 +39,7 @@ pub enum TestResult {
 
 /// Creates a `TestResult` depending on the raw result of test execution
 /// and associated data.
-pub fn calc_result<'a>(
+pub(crate) fn calc_result<'a>(
     desc: &TestDesc,
     task_result: Result<(), &'a (dyn Any + 'static + Send)>,
     time_opts: Option<&time::TestTimeOptions>,
@@ -93,7 +93,7 @@ pub fn calc_result<'a>(
 }
 
 /// Creates a `TestResult` depending on the exit code of test subprocess.
-pub fn get_result_from_exit_code(
+pub(crate) fn get_result_from_exit_code(
     desc: &TestDesc,
     status: ExitStatus,
     time_opts: Option<&time::TestTimeOptions>,

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -78,7 +78,7 @@ fn one_ignored_one_unignored_test() -> Vec<TestDescAndFn> {
 }
 
 #[test]
-pub fn do_not_run_ignored_tests() {
+fn do_not_run_ignored_tests() {
     fn f() -> Result<(), String> {
         panic!();
     }
@@ -106,7 +106,7 @@ pub fn do_not_run_ignored_tests() {
 }
 
 #[test]
-pub fn ignored_tests_result_in_ignored() {
+fn ignored_tests_result_in_ignored() {
     fn f() -> Result<(), String> {
         Ok(())
     }
@@ -479,7 +479,7 @@ fn parse_include_ignored_flag() {
 }
 
 #[test]
-pub fn filter_for_ignored_option() {
+fn filter_for_ignored_option() {
     // When we run ignored tests the test filter should filter out all the
     // unignored tests and flip the ignore flag on the rest to false
 
@@ -496,7 +496,7 @@ pub fn filter_for_ignored_option() {
 }
 
 #[test]
-pub fn run_include_ignored_option() {
+fn run_include_ignored_option() {
     // When we "--include-ignored" tests, the ignore flag should be set to false on
     // all tests and no test filtered out
 
@@ -513,7 +513,7 @@ pub fn run_include_ignored_option() {
 }
 
 #[test]
-pub fn exclude_should_panic_option() {
+fn exclude_should_panic_option() {
     let mut opts = TestOpts::new();
     opts.run_tests = true;
     opts.exclude_should_panic = true;
@@ -544,7 +544,7 @@ pub fn exclude_should_panic_option() {
 }
 
 #[test]
-pub fn exact_filter_match() {
+fn exact_filter_match() {
     fn tests() -> Vec<TestDescAndFn> {
         ["base", "base::test", "base::test1", "base::test2"]
             .into_iter()
@@ -667,7 +667,7 @@ fn sample_tests() -> Vec<TestDescAndFn> {
 }
 
 #[test]
-pub fn shuffle_tests() {
+fn shuffle_tests() {
     let mut opts = TestOpts::new();
     opts.shuffle = true;
 
@@ -686,7 +686,7 @@ pub fn shuffle_tests() {
 }
 
 #[test]
-pub fn shuffle_tests_with_seed() {
+fn shuffle_tests_with_seed() {
     let mut opts = TestOpts::new();
     opts.shuffle = true;
 
@@ -704,7 +704,7 @@ pub fn shuffle_tests_with_seed() {
 }
 
 #[test]
-pub fn order_depends_on_more_than_seed() {
+fn order_depends_on_more_than_seed() {
     let mut opts = TestOpts::new();
     opts.shuffle = true;
 
@@ -732,7 +732,7 @@ pub fn order_depends_on_more_than_seed() {
 }
 
 #[test]
-pub fn test_metricmap_compare() {
+fn test_metricmap_compare() {
     let mut m1 = MetricMap::new();
     let mut m2 = MetricMap::new();
     m1.insert_metric("in-both-noise", 1000.0, 200.0);
@@ -755,7 +755,7 @@ pub fn test_metricmap_compare() {
 }
 
 #[test]
-pub fn test_bench_once_no_iter() {
+fn test_bench_once_no_iter() {
     fn f(_: &mut Bencher) -> Result<(), String> {
         Ok(())
     }
@@ -763,7 +763,7 @@ pub fn test_bench_once_no_iter() {
 }
 
 #[test]
-pub fn test_bench_once_iter() {
+fn test_bench_once_iter() {
     fn f(b: &mut Bencher) -> Result<(), String> {
         b.iter(|| {});
         Ok(())
@@ -772,7 +772,7 @@ pub fn test_bench_once_iter() {
 }
 
 #[test]
-pub fn test_bench_no_iter() {
+fn test_bench_no_iter() {
     fn f(_: &mut Bencher) -> Result<(), String> {
         Ok(())
     }
@@ -799,7 +799,7 @@ pub fn test_bench_no_iter() {
 }
 
 #[test]
-pub fn test_bench_iter() {
+fn test_bench_iter() {
     fn f(b: &mut Bencher) -> Result<(), String> {
         b.iter(|| {});
         Ok(())

--- a/library/test/src/time.rs
+++ b/library/test/src/time.rs
@@ -11,7 +11,7 @@ use std::{env, fmt};
 
 use super::types::{TestDesc, TestType};
 
-pub const TEST_WARN_TIMEOUT_S: u64 = 60;
+pub(crate) const TEST_WARN_TIMEOUT_S: u64 = 60;
 
 /// This small module contains constants used by `report-time` option.
 /// Those constants values will be used if corresponding environment variables are not set.
@@ -22,42 +22,42 @@ pub const TEST_WARN_TIMEOUT_S: u64 = 60;
 ///
 /// Example of the expected format is `RUST_TEST_TIME_xxx=100,200`, where 100 means
 /// warn time, and 200 means critical time.
-pub mod time_constants {
+pub(crate) mod time_constants {
     use std::time::Duration;
 
     use super::TEST_WARN_TIMEOUT_S;
 
     /// Environment variable for overriding default threshold for unit-tests.
-    pub const UNIT_ENV_NAME: &str = "RUST_TEST_TIME_UNIT";
+    pub(crate) const UNIT_ENV_NAME: &str = "RUST_TEST_TIME_UNIT";
 
     // Unit tests are supposed to be really quick.
-    pub const UNIT_WARN: Duration = Duration::from_millis(50);
-    pub const UNIT_CRITICAL: Duration = Duration::from_millis(100);
+    pub(crate) const UNIT_WARN: Duration = Duration::from_millis(50);
+    pub(crate) const UNIT_CRITICAL: Duration = Duration::from_millis(100);
 
     /// Environment variable for overriding default threshold for unit-tests.
-    pub const INTEGRATION_ENV_NAME: &str = "RUST_TEST_TIME_INTEGRATION";
+    pub(crate) const INTEGRATION_ENV_NAME: &str = "RUST_TEST_TIME_INTEGRATION";
 
     // Integration tests may have a lot of work, so they can take longer to execute.
-    pub const INTEGRATION_WARN: Duration = Duration::from_millis(500);
-    pub const INTEGRATION_CRITICAL: Duration = Duration::from_millis(1000);
+    pub(crate) const INTEGRATION_WARN: Duration = Duration::from_millis(500);
+    pub(crate) const INTEGRATION_CRITICAL: Duration = Duration::from_millis(1000);
 
     /// Environment variable for overriding default threshold for unit-tests.
-    pub const DOCTEST_ENV_NAME: &str = "RUST_TEST_TIME_DOCTEST";
+    pub(crate) const DOCTEST_ENV_NAME: &str = "RUST_TEST_TIME_DOCTEST";
 
     // Doctests are similar to integration tests, because they can include a lot of
     // initialization code.
-    pub const DOCTEST_WARN: Duration = INTEGRATION_WARN;
-    pub const DOCTEST_CRITICAL: Duration = INTEGRATION_CRITICAL;
+    pub(crate) const DOCTEST_WARN: Duration = INTEGRATION_WARN;
+    pub(crate) const DOCTEST_CRITICAL: Duration = INTEGRATION_CRITICAL;
 
     // Do not suppose anything about unknown tests, base limits on the
     // `TEST_WARN_TIMEOUT_S` constant.
-    pub const UNKNOWN_WARN: Duration = Duration::from_secs(TEST_WARN_TIMEOUT_S);
-    pub const UNKNOWN_CRITICAL: Duration = Duration::from_secs(TEST_WARN_TIMEOUT_S * 2);
+    pub(crate) const UNKNOWN_WARN: Duration = Duration::from_secs(TEST_WARN_TIMEOUT_S);
+    pub(crate) const UNKNOWN_CRITICAL: Duration = Duration::from_secs(TEST_WARN_TIMEOUT_S * 2);
 }
 
 /// Returns an `Instance` object denoting when the test should be considered
 /// timed out.
-pub fn get_default_test_timeout() -> Instant {
+pub(crate) fn get_default_test_timeout() -> Instant {
     Instant::now() + Duration::from_secs(TEST_WARN_TIMEOUT_S)
 }
 
@@ -73,7 +73,7 @@ impl fmt::Display for TestExecTime {
 
 /// The measured execution time of the whole test suite.
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct TestSuiteExecTime(pub Duration);
+pub(crate) struct TestSuiteExecTime(pub Duration);
 
 impl fmt::Display for TestSuiteExecTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This PR enables the [`unreachable_pub`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub) lint as warn in the `test` and `proc_macro` crates.

The diff was mostly generated with `./x.py fix --stage 1 library/proc_macro/ -- --broken-code`, as well as manual edits for code in macros and in tests.

Continuation of #134286

r? libs