### PR TITLE
Suggest typo fix when trait path expression is typo'ed

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
@@ -2,10 +2,12 @@ use rustc_ast::TraitObjectSyntax;
 use rustc_errors::codes::*;
 use rustc_errors::{Diag, EmissionGuarantee, ErrorGuaranteed, StashKey, Suggestions};
 use rustc_hir as hir;
-use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def::{DefKind, Namespace, Res};
+use rustc_hir::def_id::DefId;
 use rustc_lint_defs::Applicability;
 use rustc_lint_defs::builtin::BARE_TRAIT_OBJECTS;
 use rustc_span::Span;
+use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_trait_selection::error_reporting::traits::suggestions::NextTypeParamName;
 
 use super::HirTyLowerer;
@@ -86,7 +88,12 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             // Check if the impl trait that we are considering is an impl of a local trait.
             self.maybe_suggest_blanket_trait_impl(self_ty, &mut diag);
             self.maybe_suggest_assoc_ty_bound(self_ty, &mut diag);
-            // In case there is an associate type with the same name
+            self.maybe_suggest_typoed_method(
+                self_ty,
+                poly_trait_ref.trait_ref.trait_def_id(),
+                &mut diag,
+            );
+            // In case there is an associated type with the same name
             // Add the suggestion to this error
             if let Some(mut sugg) =
                 tcx.dcx().steal_non_err(self_ty.span, StashKey::AssociatedTypeSuggestion)
@@ -339,6 +346,46 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 lo.between(hi),
                 "you might have meant to write a bound here",
                 ": ",
+                Applicability::MaybeIncorrect,
+            );
+        }
+    }
+
+    fn maybe_suggest_typoed_method(
+        &self,
+        self_ty: &hir::Ty<'_>,
+        trait_def_id: Option<DefId>,
+        diag: &mut Diag<'_>,
+    ) {
+        let tcx = self.tcx();
+        let Some(trait_def_id) = trait_def_id else {
+            return;
+        };
+        let hir::Node::Expr(hir::Expr {
+            kind: hir::ExprKind::Path(hir::QPath::TypeRelative(path_ty, segment)),
+            ..
+        }) = tcx.parent_hir_node(self_ty.hir_id)
+        else {
+            return;
+        };
+        if path_ty.hir_id != self_ty.hir_id {
+            return;
+        }
+        let names: Vec<_> = tcx
+            .associated_items(trait_def_id)
+            .in_definition_order()
+            .filter(|assoc| assoc.kind.namespace() == Namespace::ValueNS)
+            .map(|cand| cand.name)
+            .collect();
+        if let Some(typo) = find_best_match_for_name(&names, segment.ident.name, None) {
+            diag.span_suggestion_verbose(
+                segment.ident.span,
+                format!(
+                    "you may have misspelled this associated item, causing `{}` \
+                    to be interpreted as a type rather than a trait",
+                    tcx.item_name(trait_def_id),
+                ),
+                typo,
                 Applicability::MaybeIncorrect,
             );
         }

--- a/tests/ui/dyn-keyword/misspelled-associated-item.rs
+++ b/tests/ui/dyn-keyword/misspelled-associated-item.rs
@@ -1,0 +1,12 @@
+//@ edition: 2021
+
+trait Trait {
+    fn typo() -> Self;
+}
+
+fn main() {
+    let () = Trait::typoe();
+    //~^ ERROR expected a type, found a trait
+    //~| HELP you can add the `dyn` keyword if you want a trait object
+    //~| HELP you may have misspelled this associated item
+}

--- a/tests/ui/dyn-keyword/misspelled-associated-item.stderr
+++ b/tests/ui/dyn-keyword/misspelled-associated-item.stderr
@@ -1,0 +1,18 @@
+error[E0782]: expected a type, found a trait
+  --> $DIR/misspelled-associated-item.rs:8:14
+   |
+LL |     let () = Trait::typoe();
+   |              ^^^^^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL |     let () = <dyn Trait>::typoe();
+   |              ++++      +
+help: you may have misspelled this associated item, causing `Trait` to be interpreted as a type rather than a trait
+   |
+LL |     let () = Trait::typo();
+   |                     ~~~~
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0782`.


### PR DESCRIPTION
When users write something like `Default::defualt()` (notice the typo), failure to resolve the erroneous `defualt` item will cause resolution + lowering to interpret this as a type-dependent path whose self type is `Default` which is a trait object without `dyn`, rather than a trait function like `<_ as Default>::default()`. 

Try to provide a bit of guidance in this situation when we can detect the typo.

Fixes https://github.com/rust-lang/rust/issues/135349