### PR TITLE
Make MIR cleanup for functions with impossible predicates into a real MIR pass

### DIFF
--- a/compiler/rustc_mir_transform/src/impossible_predicates.rs
+++ b/compiler/rustc_mir_transform/src/impossible_predicates.rs
@@ -1,0 +1,56 @@
+//! Check if it's even possible to satisfy the 'where' clauses
+//! for this item.
+//!
+//! It's possible to `#!feature(trivial_bounds)]` to write
+//! a function with impossible to satisfy clauses, e.g.:
+//! `fn foo() where String: Copy {}`.
+//!
+//! We don't usually need to worry about this kind of case,
+//! since we would get a compilation error if the user tried
+//! to call it. However, since we optimize even without any
+//! calls to the function, we need to make sure that it even
+//! makes sense to try to evaluate the body.
+//!
+//! If there are unsatisfiable where clauses, then all bets are
+//! off, and we just give up.
+//!
+//! We manually filter the predicates, skipping anything that's not
+//! "global". We are in a potentially generic context
+//! (e.g. we are evaluating a function without instantiating generic
+//! parameters, so this filtering serves two purposes:
+//!
+//! 1. We skip evaluating any predicates that we would
+//! never be able prove are unsatisfiable (e.g. `<T as Foo>`
+//! 2. We avoid trying to normalize predicates involving generic
+//! parameters (e.g. `<T as Foo>::MyItem`). This can confuse
+//! the normalization code (leading to cycle errors), since
+//! it's usually never invoked in this way.
+
+use rustc_middle::mir::{Body, START_BLOCK, TerminatorKind};
+use rustc_middle::ty::{TyCtxt, TypeVisitableExt};
+use rustc_trait_selection::traits;
+use tracing::trace;
+
+use crate::pass_manager::MirPass;
+
+pub(crate) struct ImpossiblePredicates;
+
+impl<'tcx> MirPass<'tcx> for ImpossiblePredicates {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let predicates = tcx
+            .predicates_of(body.source.def_id())
+            .predicates
+            .iter()
+            .filter_map(|(p, _)| if p.is_global() { Some(*p) } else { None });
+        if traits::impossible_predicates(tcx, traits::elaborate(tcx, predicates).collect()) {
+            trace!("found unsatisfiable predicates for {:?}", body.source);
+            // Clear the body to only contain a single `unreachable` statement.
+            let bbs = body.basic_blocks.as_mut();
+            bbs.raw.truncate(1);
+            bbs[START_BLOCK].statements.clear();
+            bbs[START_BLOCK].terminator_mut().kind = TerminatorKind::Unreachable;
+            body.var_debug_info.clear();
+            body.local_decls.raw.truncate(body.arg_count + 1);
+        }
+    }
+}

--- a/tests/mir-opt/impossible_predicates.impossible_predicate.ImpossiblePredicates.diff
+++ b/tests/mir-opt/impossible_predicates.impossible_predicate.ImpossiblePredicates.diff
@@ -1,0 +1,30 @@
+- // MIR for `impossible_predicate` before ImpossiblePredicates
++ // MIR for `impossible_predicate` after ImpossiblePredicates
+  
+  fn impossible_predicate(_1: &mut i32) -> (&mut i32, &mut i32) {
+-     debug x => _1;
+      let mut _0: (&mut i32, &mut i32);
+-     let _2: &mut i32;
+-     let mut _3: &mut i32;
+-     let mut _4: &mut i32;
+      scope 1 {
+-         debug y => _2;
+      }
+  
+      bb0: {
+-         StorageLive(_2);
+-         _2 = copy _1;
+-         FakeRead(ForLet(None), _2);
+-         StorageLive(_3);
+-         _3 = &mut (*_2);
+-         StorageLive(_4);
+-         _4 = &mut (*_1);
+-         _0 = (move _3, move _4);
+-         StorageDead(_4);
+-         StorageDead(_3);
+-         StorageDead(_2);
+-         return;
++         unreachable;
+      }
+  }
+  

--- a/tests/mir-opt/impossible_predicates.rs
+++ b/tests/mir-opt/impossible_predicates.rs
@@ -1,0 +1,10 @@
+// skip-filecheck
+// EMIT_MIR impossible_predicates.impossible_predicate.ImpossiblePredicates.diff
+
+pub fn impossible_predicate(x: &mut i32) -> (&mut i32, &mut i32)
+where
+    for<'a> &'a mut i32: Copy,
+{
+    let y = x;
+    (y, x)
+}


### PR DESCRIPTION
It's a bit jarring to see the body of a function with an impossible-to-satisfy where clause suddenly go to a single `unreachable` terminator when looking at the MIR dump output in order, and I discovered it's because we manually replace the body outside of a MIR pass.

Let's make it into a fully flegded MIR pass so it's more clear what it's doing and when it's being applied.