### PR TITLE
Remove a bunch of diagnostic stashing that doesn't do anything

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -152,7 +152,6 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                         let (Ok(e) | Err(e)) = prev
                             .build_mismatch_error(
                                 &OpaqueHiddenType { ty, span: concrete_type.span },
-                                opaque_type_key.def_id,
                                 infcx.tcx,
                             )
                             .map(|d| d.emit());

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -566,9 +566,7 @@ pub enum StashKey {
     /// FRU syntax
     MaybeFruTypo,
     CallAssocMethod,
-    TraitMissingMethod,
     AssociatedTypeSuggestion,
-    OpaqueHiddenTypeMismatch,
     MaybeForgetReturn,
     /// Query cycle detected, stashing in favor of a better error.
     Cycle,

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -575,7 +575,7 @@ fn sanity_check_found_hidden_type<'tcx>(
     } else {
         let span = tcx.def_span(key.def_id);
         let other = ty::OpaqueHiddenType { ty: hidden_ty, span };
-        Err(ty.build_mismatch_error(&other, key.def_id, tcx)?.emit())
+        Err(ty.build_mismatch_error(&other, tcx)?.emit())
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
@@ -96,7 +96,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 s1.append(s2);
                 sugg.cancel();
             }
-            diag.stash(self_ty.span, StashKey::TraitMissingMethod)
+            Some(diag.emit())
         } else {
             tcx.node_span_lint(BARE_TRAIT_OBJECTS, self_ty.hir_id, self_ty.span, |lint| {
                 lint.primary_message("trait objects without an explicit `dyn` are deprecated");

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -5,7 +5,7 @@
 use std::mem;
 
 use rustc_data_structures::unord::ExtendUnord;
-use rustc_errors::{ErrorGuaranteed, StashKey};
+use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
 use rustc_hir::HirId;
 use rustc_hir::intravisit::{self, Visitor};
@@ -582,15 +582,8 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
                 && last_opaque_ty.ty != hidden_type.ty
             {
                 assert!(!self.fcx.next_trait_solver());
-                if let Ok(d) = hidden_type.build_mismatch_error(
-                    &last_opaque_ty,
-                    opaque_type_key.def_id,
-                    self.tcx(),
-                ) {
-                    d.stash(
-                        self.tcx().def_span(opaque_type_key.def_id),
-                        StashKey::OpaqueHiddenTypeMismatch,
-                    );
+                if let Ok(d) = hidden_type.build_mismatch_error(&last_opaque_ty, self.tcx()) {
+                    d.emit();
                 }
             }
         }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -32,7 +32,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_data_structures::intern::Interned;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::steal::Steal;
-use rustc_errors::{Diag, ErrorGuaranteed, StashKey};
+use rustc_errors::{Diag, ErrorGuaranteed};
 use rustc_hir::LangItem;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, DocLinkResMap, LifetimeRes, Res};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LocalDefId, LocalDefIdMap};
@@ -782,18 +782,8 @@ impl<'tcx> OpaqueHiddenType<'tcx> {
     pub fn build_mismatch_error(
         &self,
         other: &Self,
-        opaque_def_id: LocalDefId,
         tcx: TyCtxt<'tcx>,
     ) -> Result<Diag<'tcx>, ErrorGuaranteed> {
-        // We used to cancel here for slightly better error messages, but
-        // cancelling stashed diagnostics is no longer allowed because it
-        // causes problems when tracking whether errors have actually
-        // occurred.
-        tcx.sess.dcx().try_steal_modify_and_emit_err(
-            tcx.def_span(opaque_def_id),
-            StashKey::OpaqueHiddenTypeMismatch,
-            |_err| {},
-        );
         (self.ty, other.ty).error_reported()?;
         // Found different concrete types for the opaque type.
         let sub_diag = if self.span == other.span {

--- a/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs
+++ b/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs
@@ -15,6 +15,7 @@ fn f<T>(
      }],
 ) -> impl Iterator<Item = SubAssign> {
 //~^ ERROR expected a type, found a trait
+//~| ERROR expected a type, found a trait
 //~| ERROR `()` is not an iterator
 }
 

--- a/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
@@ -16,14 +16,6 @@ help: you might be missing a type parameter
 LL | fn f<T, F>(
    |       +++
 
-error[E0277]: `()` is not an iterator
-  --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:6
-   |
-LL | ) -> impl Iterator<Item = SubAssign> {
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
-   |
-   = help: the trait `Iterator` is not implemented for `()`
-
 error[E0782]: expected a type, found a trait
   --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:27
    |
@@ -39,7 +31,31 @@ help: you might have meant to write a bound here
 LL | ) -> impl Iterator<Item: SubAssign> {
    |                        ~
 
-error: aborting due to 3 previous errors
+error[E0782]: expected a type, found a trait
+  --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:27
+   |
+LL | ) -> impl Iterator<Item = SubAssign> {
+   |                           ^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL | ) -> impl Iterator<Item = dyn SubAssign> {
+   |                           +++
+help: you might have meant to write a bound here
+   |
+LL | ) -> impl Iterator<Item: SubAssign> {
+   |                        ~
+
+error[E0277]: `()` is not an iterator
+  --> $DIR/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.rs:16:6
+   |
+LL | ) -> impl Iterator<Item = SubAssign> {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `()`
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0277, E0412, E0782.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.edition2021.stderr
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.edition2021.stderr
@@ -9,6 +9,18 @@ help: you can add the `dyn` keyword if you want a trait object
 LL | fn ice() -> impl AsRef<dyn Fn(&())> {
    |                        +++
 
-error: aborting due to 1 previous error
+error[E0782]: expected a type, found a trait
+  --> $DIR/generic-with-implicit-hrtb-without-dyn.rs:6:24
+   |
+LL | fn ice() -> impl AsRef<Fn(&())> {
+   |                        ^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL | fn ice() -> impl AsRef<dyn Fn(&())> {
+   |                        +++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0782`.

--- a/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
+++ b/tests/ui/impl-trait/generic-with-implicit-hrtb-without-dyn.rs
@@ -6,6 +6,7 @@
 fn ice() -> impl AsRef<Fn(&())> {
     //[edition2015]~^ ERROR: the trait bound `(): AsRef<(dyn for<'a> Fn(&'a ()) + 'static)>` is not satisfied [E0277]
     //[edition2021]~^^ ERROR: expected a type, found a trait [E0782]
+    //[edition2021]~| ERROR: expected a type, found a trait [E0782]
     todo!()
 }
 

--- a/tests/ui/impl-trait/issue-99073-2.stderr
+++ b/tests/ui/impl-trait/issue-99073-2.stderr
@@ -1,12 +1,3 @@
-error[E0792]: expected generic type parameter, found `i32`
-  --> $DIR/issue-99073-2.rs:9:22
-   |
-LL | fn test<T: Display>(t: T, recurse: bool) -> impl Display {
-   |         - this generic parameter must be used with a generic type parameter
-LL |     let f = || {
-LL |         let i: u32 = test::<i32>(-1, false);
-   |                      ^^^^^^^^^^^^^^^^^^^^^^
-
 error: concrete type differs from previous defining opaque type use
   --> $DIR/issue-99073-2.rs:9:22
    |
@@ -18,6 +9,15 @@ note: previous use here
    |
 LL | fn test<T: Display>(t: T, recurse: bool) -> impl Display {
    |                                             ^^^^^^^^^^^^
+
+error[E0792]: expected generic type parameter, found `i32`
+  --> $DIR/issue-99073-2.rs:9:22
+   |
+LL | fn test<T: Display>(t: T, recurse: bool) -> impl Display {
+   |         - this generic parameter must be used with a generic type parameter
+LL |     let f = || {
+LL |         let i: u32 = test::<i32>(-1, false);
+   |                      ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/issue-99073.stderr
+++ b/tests/ui/impl-trait/issue-99073.stderr
@@ -1,11 +1,3 @@
-error[E0792]: expected generic type parameter, found `&F`
-  --> $DIR/issue-99073.rs:6:11
-   |
-LL | fn fix<F: Fn(G), G: Fn()>(f: F) -> impl Fn() {
-   |        - this generic parameter must be used with a generic type parameter
-LL |   move || f(fix(&f))
-   |           ^^^^^^^^^^
-
 error: concrete type differs from previous defining opaque type use
   --> $DIR/issue-99073.rs:6:13
    |
@@ -17,6 +9,14 @@ note: previous use here
    |
 LL | fn fix<F: Fn(G), G: Fn()>(f: F) -> impl Fn() {
    |                                    ^^^^^^^^^
+
+error[E0792]: expected generic type parameter, found `&F`
+  --> $DIR/issue-99073.rs:6:11
+   |
+LL | fn fix<F: Fn(G), G: Fn()>(f: F) -> impl Fn() {
+   |        - this generic parameter must be used with a generic type parameter
+LL |   move || f(fix(&f))
+   |           ^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/multiple-defining-usages-in-body.stderr
+++ b/tests/ui/impl-trait/multiple-defining-usages-in-body.stderr
@@ -1,15 +1,3 @@
-warning: function cannot return without recursing
-  --> $DIR/multiple-defining-usages-in-body.rs:4:1
-   |
-LL | fn foo<T: Trait, U: Trait>() -> impl Trait {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
-LL |
-LL |     let a: T = foo::<T, U>();
-   |                ------------- recursive call site
-   |
-   = help: a `loop` may express intention better if this is on purpose
-   = note: `#[warn(unconditional_recursion)]` on by default
-
 error: concrete type differs from previous defining opaque type use
   --> $DIR/multiple-defining-usages-in-body.rs:8:16
    |
@@ -21,6 +9,18 @@ note: previous use here
    |
 LL |     let a: T = foo::<T, U>();
    |                ^^^^^^^^^^^^^
+
+warning: function cannot return without recursing
+  --> $DIR/multiple-defining-usages-in-body.rs:4:1
+   |
+LL | fn foo<T: Trait, U: Trait>() -> impl Trait {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
+LL |
+LL |     let a: T = foo::<T, U>();
+   |                ------------- recursive call site
+   |
+   = help: a `loop` may express intention better if this is on purpose
+   = note: `#[warn(unconditional_recursion)]` on by default
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/impl-trait/rpit/early_bound.stderr
+++ b/tests/ui/impl-trait/rpit/early_bound.stderr
@@ -1,12 +1,3 @@
-error[E0792]: expected generic lifetime parameter, found `'_`
-  --> $DIR/early_bound.rs:7:17
-   |
-LL | fn test<'a: 'a>(n: bool) -> impl Sized + 'a {
-   |                                          -- this generic parameter must be used with a generic lifetime parameter
-...
-LL |         let _ = identity::<&'a ()>(test(false));
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: concrete type differs from previous defining opaque type use
   --> $DIR/early_bound.rs:3:29
    |
@@ -18,6 +9,15 @@ note: previous use here
    |
 LL |         let _ = identity::<&'a ()>(test(false));
    |                                    ^^^^^^^^^^^
+
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/early_bound.rs:7:17
+   |
+LL | fn test<'a: 'a>(n: bool) -> impl Sized + 'a {
+   |                                          -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |         let _ = identity::<&'a ()>(test(false));
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/rpit/non-defining-use.stderr
+++ b/tests/ui/impl-trait/rpit/non-defining-use.stderr
@@ -6,14 +6,6 @@ LL | fn foo<T>() -> impl Sized {
 LL |     let _: () = foo::<u8>();
    |            ^^
 
-error[E0792]: expected generic type parameter, found `u8`
-  --> $DIR/non-defining-use.rs:8:12
-   |
-LL | fn bar<T>(val: T) -> impl Sized {
-   |        - this generic parameter must be used with a generic type parameter
-LL |     let _: u8 = bar(0u8);
-   |            ^^
-
 error: concrete type differs from previous defining opaque type use
   --> $DIR/non-defining-use.rs:8:17
    |
@@ -25,6 +17,14 @@ note: previous use here
    |
 LL | fn bar<T>(val: T) -> impl Sized {
    |                      ^^^^^^^^^^
+
+error[E0792]: expected generic type parameter, found `u8`
+  --> $DIR/non-defining-use.rs:8:12
+   |
+LL | fn bar<T>(val: T) -> impl Sized {
+   |        - this generic parameter must be used with a generic type parameter
+LL |     let _: u8 = bar(0u8);
+   |            ^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-self-2021-without-dyn.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-self-2021-without-dyn.stderr
@@ -1,42 +1,3 @@
-error: associated item referring to unboxed trait object for its own trait
-  --> $DIR/dyn-incompatible-trait-should-use-self-2021-without-dyn.rs:4:13
-   |
-LL | trait A: Sized {
-   |       - in this trait
-LL |     fn f(a: A) -> A;
-   |             ^     ^
-   |
-help: you might have meant to use `Self` to refer to the implementing type
-   |
-LL |     fn f(a: Self) -> Self;
-   |             ~~~~     ~~~~
-
-error: associated item referring to unboxed trait object for its own trait
-  --> $DIR/dyn-incompatible-trait-should-use-self-2021-without-dyn.rs:10:13
-   |
-LL | trait B {
-   |       - in this trait
-LL |     fn f(b: B) -> B;
-   |             ^     ^
-   |
-help: you might have meant to use `Self` to refer to the implementing type
-   |
-LL |     fn f(b: Self) -> Self;
-   |             ~~~~     ~~~~
-
-error: associated item referring to unboxed trait object for its own trait
-  --> $DIR/dyn-incompatible-trait-should-use-self-2021-without-dyn.rs:16:20
-   |
-LL | trait C {
-   |       - in this trait
-LL |     fn f(&self, c: C) -> C;
-   |                    ^     ^
-   |
-help: you might have meant to use `Self` to refer to the implementing type
-   |
-LL |     fn f(&self, c: Self) -> Self;
-   |                    ~~~~     ~~~~
-
 error[E0782]: expected a type, found a trait
   --> $DIR/dyn-incompatible-trait-should-use-self-2021-without-dyn.rs:4:13
    |
@@ -117,6 +78,45 @@ help: `C` is dyn-incompatible, use `impl C` to return an opaque type, as long as
    |
 LL |     fn f(&self, c: C) -> impl C;
    |                          ++++
+
+error: associated item referring to unboxed trait object for its own trait
+  --> $DIR/dyn-incompatible-trait-should-use-self-2021-without-dyn.rs:4:13
+   |
+LL | trait A: Sized {
+   |       - in this trait
+LL |     fn f(a: A) -> A;
+   |             ^     ^
+   |
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL |     fn f(a: Self) -> Self;
+   |             ~~~~     ~~~~
+
+error: associated item referring to unboxed trait object for its own trait
+  --> $DIR/dyn-incompatible-trait-should-use-self-2021-without-dyn.rs:10:13
+   |
+LL | trait B {
+   |       - in this trait
+LL |     fn f(b: B) -> B;
+   |             ^     ^
+   |
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL |     fn f(b: Self) -> Self;
+   |             ~~~~     ~~~~
+
+error: associated item referring to unboxed trait object for its own trait
+  --> $DIR/dyn-incompatible-trait-should-use-self-2021-without-dyn.rs:16:20
+   |
+LL | trait C {
+   |       - in this trait
+LL |     fn f(&self, c: C) -> C;
+   |                    ^     ^
+   |
+help: you might have meant to use `Self` to refer to the implementing type
+   |
+LL |     fn f(&self, c: Self) -> Self;
+   |                    ~~~~     ~~~~
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/traits/issue-106072.rs
+++ b/tests/ui/traits/issue-106072.rs
@@ -1,4 +1,6 @@
-#[derive(Clone)] //~  expected a type, found a trait
+#[derive(Clone)]
+//~^ expected a type, found a trait
+//~| expected a type, found a trait
 struct Foo;
 trait Foo {} //~ the name `Foo` is defined multiple times
 fn main() {}

--- a/tests/ui/traits/issue-106072.stderr
+++ b/tests/ui/traits/issue-106072.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `Foo` is defined multiple times
-  --> $DIR/issue-106072.rs:3:1
+  --> $DIR/issue-106072.rs:5:1
    |
 LL | struct Foo;
    | ----------- previous definition of the type `Foo` here
@@ -16,7 +16,16 @@ LL | #[derive(Clone)]
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error[E0782]: expected a type, found a trait
+  --> $DIR/issue-106072.rs:1:10
+   |
+LL | #[derive(Clone)]
+   |          ^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0428, E0782.
 For more information about an error, try `rustc --explain E0428`.

--- a/tests/ui/traits/missing-for-type-in-impl.e2021.stderr
+++ b/tests/ui/traits/missing-for-type-in-impl.e2021.stderr
@@ -1,15 +1,3 @@
-error[E0277]: the trait bound `i64: Foo<i64>` is not satisfied
-  --> $DIR/missing-for-type-in-impl.rs:19:19
-   |
-LL |     let x: i64 = <i64 as Foo<i64>>::id(10);
-   |                   ^^^ the trait `Foo<i64>` is not implemented for `i64`
-   |
-help: this trait has no implementations, consider adding one
-  --> $DIR/missing-for-type-in-impl.rs:3:1
-   |
-LL | trait Foo<T> {
-   | ^^^^^^^^^^^^
-
 error[E0782]: expected a type, found a trait
   --> $DIR/missing-for-type-in-impl.rs:8:6
    |
@@ -24,6 +12,18 @@ help: you might have intended to implement this trait for a given type
    |
 LL | impl Foo<i64> for /* Type */ {
    |               ++++++++++++++
+
+error[E0277]: the trait bound `i64: Foo<i64>` is not satisfied
+  --> $DIR/missing-for-type-in-impl.rs:19:19
+   |
+LL |     let x: i64 = <i64 as Foo<i64>>::id(10);
+   |                   ^^^ the trait `Foo<i64>` is not implemented for `i64`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/missing-for-type-in-impl.rs:3:1
+   |
+LL | trait Foo<T> {
+   | ^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden4.stderr
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden4.stderr
@@ -1,3 +1,15 @@
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/hkl_forbidden4.rs:12:1
+   |
+LL | async fn operation(_: &mut ()) -> () {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `FutNothing<'_>`, got `{async fn body of operation()}`
+   |
+note: previous use here
+  --> $DIR/hkl_forbidden4.rs:14:5
+   |
+LL |     call(operation).await
+   |     ^^^^^^^^^^^^^^^
+
 error: item does not constrain `FutNothing::{opaque#0}`, but has it in its signature
   --> $DIR/hkl_forbidden4.rs:18:10
    |
@@ -32,18 +44,6 @@ error[E0792]: expected generic lifetime parameter, found `'any`
 LL | async fn operation(_: &mut ()) -> () {
    |                       - this generic parameter must be used with a generic lifetime parameter
 LL |
-LL |     call(operation).await
-   |     ^^^^^^^^^^^^^^^
-
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/hkl_forbidden4.rs:12:1
-   |
-LL | async fn operation(_: &mut ()) -> () {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `FutNothing<'_>`, got `{async fn body of operation()}`
-   |
-note: previous use here
-  --> $DIR/hkl_forbidden4.rs:14:5
-   |
 LL |     call(operation).await
    |     ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
#121669 removed a bunch of conditional diagnostic stashing/canceling, but left around the `steal` calls which just emitted the error eagerly instead of canceling the diagnostic. I think that these no-op `steal` calls don't do much and are confusing to encounter, so let's remove them.

The net effect is:
1. We emit more duplicated errors, since stashing has the side effect of duplicating diagnostics. This is not a big deal, since outside of `-Zdeduplicate-diagnostics=no`, the errors are already being deduplicated by the compiler.
2. It changes the order of diagnostics, since we're no longer stashing and then later stealing the errors. I don't think this matters much for the changes that the UI test suite manifests, and it makes these errors less order dependent.