### PR TITLE
compiletest: include stage0-sysroot libstd dylib in recipe dylib search path

### DIFF
--- a/src/tools/run-make-support/src/external_deps/rustdoc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustdoc.rs
@@ -45,8 +45,7 @@ impl Rustdoc {
     #[track_caller]
     pub fn new() -> Self {
         let mut cmd = setup_common();
-        let target_rpath_dir = env_var_os("TARGET_RPATH_DIR");
-        cmd.arg(format!("-L{}", target_rpath_dir.to_string_lossy()));
+        cmd.arg("-L").arg(env_var_os("TARGET_RPATH_DIR"));
         Self { cmd }
     }
 


### PR DESCRIPTION
To fix some of the failures in `COMPILETEST_FORCE_STAGE0=1 ./x test run-make --stage 0`. Specifically,

```
COMPILETEST_FORCE_STAGE0=1 ./x test tests/run-make/rustdoc-default-output/ --stage 0
```

should now pass.

Fixes #135373. (As in, make *some* of the `run-make` tests pass, other `run-make` tests fail for various reasons against stage0, and generally `run-make` tests are not guaranteed to pass at stage 0.)

cc @lolbinarycat 

r? bootstrap