### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -110,7 +110,6 @@ Compatibility Notes
 - Support for the target named `wasm32-wasi` has been removed as the target is now named `wasm32-wasip1`. This completes the [transition](https://github.com/rust-lang/compiler-team/issues/607) [plan](https://github.com/rust-lang/compiler-team/issues/695) for this target following [the introduction of `wasm32-wasip1`](https://github.com/rust-lang/rust/pull/120468) in Rust 1.78. Compiler warnings on [use of `wasm32-wasi`](https://github.com/rust-lang/rust/pull/126662) introduced in Rust 1.81 are now gone as well as the target is removed.
 - [The syntax `&pin (mut|const) T` is now parsed as a type which in theory could affect macro expansion results in some edge cases](https://github.com/rust-lang/rust/pull/130635#issuecomment-2375462821)
 - [Legacy syntax for calling `std::arch` functions is no longer permitted to declare items or bodies (such as closures, inline consts, or async blocks).](https://github.com/rust-lang/rust/pull/130443#issuecomment-2445678945)
-- The `wasm32-unknown-emscripten` target's binary release of the standard library is now [built with the latest emsdk 3.1.68](https://github.com/rust-lang/rust/pull/131533), which fixes an ABI-incompatibility with Emscripten >= 3.1.42. If you are locally using a version of emsdk with an incompatible ABI (e.g. before 3.1.42 or a future one), you should build your code with `-Zbuild-std` to ensure that `std` uses the correct ABI.
 - [Declaring functions with a calling convention not supported on the current target now triggers a hard error](https://github.com/rust-lang/rust/pull/129935)
 - [The next-generation trait solver is now enabled for coherence, fixing multiple soundness issues](https://github.com/rust-lang/rust/pull/130654)
 
@@ -2183,7 +2182,7 @@ Language
 --------
 
 - [Stabilize default_alloc_error_handler](https://github.com/rust-lang/rust/pull/102318/)
-  This allows usage of `alloc` on stable without requiring the 
+  This allows usage of `alloc` on stable without requiring the
   definition of a handler for allocation failure. Defining custom handlers is still unstable.
 - [Stabilize `efiapi` calling convention.](https://github.com/rust-lang/rust/pull/105795/)
 - [Remove implicit promotion for types with drop glue](https://github.com/rust-lang/rust/pull/105085/)

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2695,7 +2695,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             }
 
             err.multipart_suggestion_verbose(
-                "try explicitly pass `&Self` into the Closure as an argument",
+                "try explicitly passing `&Self` into the closure as an argument",
                 sugg,
                 Applicability::MachineApplicable,
             );

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2680,19 +2680,16 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 return;
             }
 
-            let mut sugg = vec![];
             let sm = self.infcx.tcx.sess.source_map();
-
-            if let Some(span) = finder.closure_arg_span {
-                sugg.push((sm.next_point(span.shrink_to_lo()).shrink_to_hi(), finder.suggest_arg));
-            }
-            for span in finder.closure_change_spans {
-                sugg.push((span, "this".to_string()));
-            }
-
-            for (span, suggest) in finder.closure_call_changes {
-                sugg.push((span, suggest));
-            }
+            let sugg = finder
+                .closure_arg_span
+                .map(|span| (sm.next_point(span.shrink_to_lo()).shrink_to_hi(), finder.suggest_arg))
+                .into_iter()
+                .chain(
+                    finder.closure_change_spans.into_iter().map(|span| (span, "this".to_string())),
+                )
+                .chain(finder.closure_call_changes)
+                .collect();
 
             err.multipart_suggestion_verbose(
                 "try explicitly passing `&Self` into the closure as an argument",

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -880,7 +880,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
         )
     } }
 
-    /// Show a suggestion that has multiple parts to it, always as it's own subdiagnostic.
+    /// Show a suggestion that has multiple parts to it, always as its own subdiagnostic.
     /// In other words, multiple changes need to be applied as part of this suggestion.
     #[rustc_lint_diagnostics]
     pub fn multipart_suggestion_verbose(

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -3708,7 +3708,11 @@ pub struct UniqueRc<
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
 > {
     ptr: NonNull<RcInner<T>>,
-    phantom: PhantomData<RcInner<T>>,
+    // Define the ownership of `RcInner<T>` for drop-check
+    _marker: PhantomData<RcInner<T>>,
+    // Invariance is necessary for soundness: once other `Weak`
+    // references exist, we already have a form of shared mutability!
+    _marker2: PhantomData<*mut T>,
     alloc: A,
 }
 
@@ -3994,7 +3998,7 @@ impl<T, A: Allocator> UniqueRc<T, A> {
             },
             alloc,
         ));
-        Self { ptr: ptr.into(), phantom: PhantomData, alloc }
+        Self { ptr: ptr.into(), _marker: PhantomData, _marker2: PhantomData, alloc }
     }
 }
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1637,7 +1637,10 @@ impl Step for Compiletest {
             return;
         }
 
-        if builder.top_stage == 0 && env::var("COMPILETEST_FORCE_STAGE0").is_err() {
+        if builder.top_stage == 0
+            && env::var("COMPILETEST_FORCE_STAGE0").is_err()
+            && self.mode != "js-doc-test"
+        {
             eprintln!("\
 ERROR: `--stage 0` runs compiletest on the beta compiler, not your local changes, and will almost always cause tests to fail
 HELP: to test the compiler, use `--stage 1` instead

--- a/src/tools/run-make-support/src/external_deps/rustdoc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustdoc.rs
@@ -45,8 +45,7 @@ impl Rustdoc {
     #[track_caller]
     pub fn new() -> Self {
         let mut cmd = setup_common();
-        let target_rpath_dir = env_var_os("TARGET_RPATH_DIR");
-        cmd.arg(format!("-L{}", target_rpath_dir.to_string_lossy()));
+        cmd.arg("-L").arg(env_var_os("TARGET_RPATH_DIR"));
         Self { cmd }
     }
 

--- a/tests/ui/suggestions/issue-105761-suggest-self-for-closure.stderr
+++ b/tests/ui/suggestions/issue-105761-suggest-self-for-closure.stderr
@@ -11,7 +11,7 @@ LL |         self.qux();
 LL |         x(1);
    |         - immutable borrow later used here
    |
-help: try explicitly pass `&Self` into the Closure as an argument
+help: try explicitly passing `&Self` into the closure as an argument
    |
 LL ~         let x = |this: &Self, v: i32| {
 LL ~             this.bar();
@@ -35,7 +35,7 @@ LL |         self.qux();
 LL |         y();
    |         - immutable borrow later used here
    |
-help: try explicitly pass `&Self` into the Closure as an argument
+help: try explicitly passing `&Self` into the closure as an argument
    |
 LL ~         let y = |this: &Self| {
 LL ~             this.bar();

--- a/tests/ui/variance/variance-uniquerc.rs
+++ b/tests/ui/variance/variance-uniquerc.rs
@@ -1,0 +1,27 @@
+// regression test of https://github.com/rust-lang/rust/pull/133572#issuecomment-2543007164
+// we should also test UniqueArc once implemented
+//
+// inline comments explain how this code *would* compile if UniqueRc was still covariant
+
+#![feature(unique_rc_arc)]
+
+use std::rc::UniqueRc;
+
+fn extend_lifetime<'a, 'b>(x: &'a str) -> &'b str {
+    let r = UniqueRc::new(""); // UniqueRc<&'static str>
+    let w = UniqueRc::downgrade(&r); // Weak<&'static str>
+    let mut r = r; // [IF COVARIANT]: ==>> UniqueRc<&'a str>
+    *r = x; // assign the &'a str
+    let _r = UniqueRc::into_rc(r); // Rc<&'a str>, but we only care to activate the weak
+    let r = w.upgrade().unwrap(); // Rc<&'static str>
+    *r // &'static str, coerces to &'b str
+    //~^ ERROR lifetime may not live long enough
+}
+
+fn main() {
+    let s = String::from("Hello World!");
+    let r = extend_lifetime(&s);
+    println!("{r}");
+    drop(s);
+    println!("{r}");
+}

--- a/tests/ui/variance/variance-uniquerc.stderr
+++ b/tests/ui/variance/variance-uniquerc.stderr
@@ -1,0 +1,15 @@
+error: lifetime may not live long enough
+  --> $DIR/variance-uniquerc.rs:17:5
+   |
+LL | fn extend_lifetime<'a, 'b>(x: &'a str) -> &'b str {
+   |                    --  -- lifetime `'b` defined here
+   |                    |
+   |                    lifetime `'a` defined here
+...
+LL |     *r // &'static str, coerces to &'b str
+   |     ^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
+   |
+   = help: consider adding the following bound: `'a: 'b`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - #135266 (Remove emsdk version update from 1.84.0 relnotes)
 - #135364 (Cleanup `suggest_binding_for_closure_capture_self` diag in borrowck)
 - #135375 (allow rustdoc-js tests to be run at stage0)
 - #135379 (Make (unstable API) `UniqueRc` invariant for soundness)
 - #135389 (compiletest: include stage0-sysroot libstd dylib in recipe dylib search path)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135266,135364,135375,135379,135389)
<!-- homu-ignore:end -->