### PR TITLE
Update unstable lint docs to include required feature attributes

### DIFF
--- a/compiler/rustc_lint/src/unqualified_local_imports.rs
+++ b/compiler/rustc_lint/src/unqualified_local_imports.rs
@@ -12,6 +12,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust,edition2018
+    /// #![feature(unqualified_local_imports)]
     /// #![warn(unqualified_local_imports)]
     ///
     /// mod localmod {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4035,7 +4035,8 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust
-    /// #![feature(test_unstable_lint)]
+    /// // This lint is intentionally used to test the compiler's behavior
+    /// // when an unstable lint is enabled without the corresponding feature gate.
     /// #![allow(test_unstable_lint)]
     /// ```
     ///

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2671,6 +2671,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust
+    /// #![feature(strict_provenance_lints)]
     /// #![warn(fuzzy_provenance_casts)]
     ///
     /// fn main() {
@@ -2714,6 +2715,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust
+    /// #![feature(strict_provenance_lints)]
     /// #![warn(lossy_provenance_casts)]
     ///
     /// fn main() {
@@ -4033,6 +4035,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust
+    /// #![feature(test_unstable_lint)]
     /// #![allow(test_unstable_lint)]
     /// ```
     ///


### PR DESCRIPTION
closes #135298 

## Summary
This PR updates the documentation examples for the following unstable lints to ensure they include the necessary feature attributes for proper usage:

- fuzzy_provenance_casts
- lossy_provenance_casts
- unqualified_local_imports
- test_unstable_lint

## Changes Made:

- Added the appropriate #![feature(...)] attributes to the example code for each lint.
- Updated the examples to produce correct and meaningful warnings, ensuring they align with current lint behavior.

Reference:
- Used the `must_not_suspend` lint documentation as a template for these updates.