### PR TITLE
run_make_support: add `#![warn(unreachable_pub)]`

### DIFF
--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -6,6 +6,7 @@
 // We want to control use declaration ordering and spacing (and preserve use group comments), so
 // skip rustfmt on this file.
 #![cfg_attr(rustfmt, rustfmt::skip)]
+#![warn(unreachable_pub)]
 
 mod command;
 mod macros;


### PR DESCRIPTION
This PR enables the [`unreachable_pub`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub) lint as warn in the `run_make_support` crate.

Related to https://github.com/rust-lang/compiler-team/issues/773

r? @jieyouxu