### PR TITLE
Add `File already exists` error doc to `hard_link` function

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2529,6 +2529,7 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
 /// limited to just these cases:
 ///
 /// * The `original` path is not a file or doesn't exist.
+/// * The 'link' path already exists.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Description
If the link path already exists, the error `AlreadyExists` is returned. This commit adds this error to the docs.

I tested it with the current rust master version, this error was returned when there is already a link for the file is present.
This was the error returned:
```
[harshit:../Desktop/rust_compiler_testing/hard_link (master|…5)] cargo +stage1 run
   Compiling hard_link v0.1.0 (/home/harshit/Desktop/rust_compiler_testing/hard_link)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/hard_link`
Err(Os { code: 17, kind: AlreadyExists, message: "File exists" })
```
This is my first PR on rust, any suggestions on which issue I can take next are most welcome :smile: 

Fixes #130117

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
