### PR TITLE
Add Profile Override for Non-Git Sources

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1268,6 +1268,11 @@ def bootstrap(args):
         config_toml = ""
 
     profile = RustBuild.get_toml_static(config_toml, "profile")
+    is_non_git_source = not os.path.exists(os.path.join(rust_root, ".git"))
+
+    if profile is None and is_non_git_source:
+        profile = "dist"
+
     if profile is not None:
         # Allows creating alias for profile names, allowing
         # profiles to be renamed while maintaining back compatibility

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2926,10 +2926,8 @@ impl Config {
         let if_unchanged = || {
             if self.rust_info.is_from_tarball() {
                 // Git is needed for running "if-unchanged" logic.
-                println!(
-                    "WARNING: 'if-unchanged' has no effect on tarball sources; ignoring `download-ci-llvm`."
-                );
-                return false;
+                println!("ERROR: 'if-unchanged' is only compatible with Git managed sources.");
+                crate::exit!(1);
             }
 
             // Fetching the LLVM submodule is unnecessary for self-tests.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

## PR description

- Fixes #135358 

This PR introduces the following updates to

1. `bootstrap.py`:
    - If the `profile` is `None` and the source is non-git, the `profile` is automatically overridden to `"dist"`.
    - Ensures that options like `download-ci-llvm` and `download-rustc` are not used with non-git sources. An exception is raised if these options are present in the configuration when the source is non-git.

2. `bootstrap_test.py`
   - Added unit tests to verify both the profile override mechanism and the assertion for restricted options.  
These tests ensure the correct behavior for non-git sources and the handling of `if-unchanged` options.

r? @onur-ozkan  
@rustbot T-bootstrap