### PR TITLE
Make sure to mark `IMPL_TRAIT_REDUNDANT_CAPTURES` as `Allow` in edition 2024

### DIFF
--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -99,7 +99,7 @@ declare_lint! {
     /// To fix this, remove the `use<'a>`, since the lifetime is already captured
     /// since it is in scope.
     pub IMPL_TRAIT_REDUNDANT_CAPTURES,
-    Warn,
+    Allow,
     "redundant precise-capturing `use<...>` syntax on an `impl Trait`",
 }
 

--- a/tests/ui/impl-trait/precise-capturing/redundant.rs
+++ b/tests/ui/impl-trait/precise-capturing/redundant.rs
@@ -1,24 +1,24 @@
 //@ edition: 2024
-//@ check-pass
 
 #![feature(precise_capturing_in_traits)]
+#![deny(impl_trait_redundant_captures)]
 
 fn hello<'a>() -> impl Sized + use<'a> {}
-//~^ WARN all possible in-scope parameters are already captured
+//~^ ERROR all possible in-scope parameters are already captured
 
 struct Inherent;
 impl Inherent {
     fn inherent(&self) -> impl Sized + use<'_> {}
-    //~^ WARN all possible in-scope parameters are already captured
+    //~^ ERROR all possible in-scope parameters are already captured
 }
 
 trait Test<'a> {
     fn in_trait() -> impl Sized + use<'a, Self>;
-    //~^ WARN all possible in-scope parameters are already captured
+    //~^ ERROR all possible in-scope parameters are already captured
 }
 impl<'a> Test<'a> for () {
     fn in_trait() -> impl Sized + use<'a> {}
-    //~^ WARN all possible in-scope parameters are already captured
+    //~^ ERROR all possible in-scope parameters are already captured
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/redundant.stderr
+++ b/tests/ui/impl-trait/precise-capturing/redundant.stderr
@@ -1,4 +1,4 @@
-warning: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
+error: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
   --> $DIR/redundant.rs:6:19
    |
 LL | fn hello<'a>() -> impl Sized + use<'a> {}
@@ -6,9 +6,13 @@ LL | fn hello<'a>() -> impl Sized + use<'a> {}
    |                                |
    |                                help: remove the `use<...>` syntax
    |
-   = note: `#[warn(impl_trait_redundant_captures)]` on by default
+note: the lint level is defined here
+  --> $DIR/redundant.rs:4:9
+   |
+LL | #![deny(impl_trait_redundant_captures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
+error: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
   --> $DIR/redundant.rs:11:27
    |
 LL |     fn inherent(&self) -> impl Sized + use<'_> {}
@@ -16,7 +20,7 @@ LL |     fn inherent(&self) -> impl Sized + use<'_> {}
    |                                        |
    |                                        help: remove the `use<...>` syntax
 
-warning: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
+error: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
   --> $DIR/redundant.rs:16:22
    |
 LL |     fn in_trait() -> impl Sized + use<'a, Self>;
@@ -24,7 +28,7 @@ LL |     fn in_trait() -> impl Sized + use<'a, Self>;
    |                                   |
    |                                   help: remove the `use<...>` syntax
 
-warning: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
+error: all possible in-scope parameters are already captured, so `use<...>` syntax is redundant
   --> $DIR/redundant.rs:20:22
    |
 LL |     fn in_trait() -> impl Sized + use<'a> {}
@@ -32,5 +36,5 @@ LL |     fn in_trait() -> impl Sized + use<'a> {}
    |                                   |
    |                                   help: remove the `use<...>` syntax
 
-warning: 4 warnings emitted
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
I never got sign-off on #127672 for this lint being warn by default in edition 2024, so let's turn downgrade this lint to allow for now.

Should be backported so it ships with the edition.

@rustbot label: +beta-nominated