### PR TITLE
further improve panic_immediate_abort by removing rtprintpanic! messages

### DIFF
--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -32,8 +32,13 @@ use crate::{mem, panic, sys};
 // - nothing (so this macro is a no-op)
 macro_rules! rtprintpanic {
     ($($t:tt)*) => {
+        #[cfg(not(feature = "panic_immediate_abort"))]
         if let Some(mut out) = crate::sys::stdio::panic_output() {
             let _ = crate::io::Write::write_fmt(&mut out, format_args!($($t)*));
+        }
+        #[cfg(feature = "panic_immediate_abort")]
+        {
+            let _ = format_args!($($t)*);
         }
     }
 }


### PR DESCRIPTION
Reduces binary size using `panic_immediate_abort` by removing strings used by `rtprintpanic!`.

for `main.rs`
```rust
fn main() {
    println!("Hello, world!");
}
```
with `Cargo.toml`
```toml
[package]
name = "tst"
version = "0.1.0"
edition = "2024"

[dependencies]

[profile.release]
lto = true
codegen-units = 1
panic = "abort"

```

and build with `RUSTFLAGS="-Zlocation-detail=none -Zfmt-debug=none" cargo +stage-1 b -r -Z build-std=std,panic_abort -Z build-std-features=optimize_for_size,panic_immediate_abort` for `x86_64-unknown-linux-gnu`

This reduces size:
| before |  after | type |
| - | - | - |
| 25256 | 21880 | unstripped |
| 18072 | 15288 | stripped |