### PR TITLE
bootstrap: fix outdated feature name in comment

### DIFF
--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -65,7 +65,7 @@ xz2 = "0.1"
 # Dependencies needed by the build-metrics feature
 sysinfo = { version = "0.33.0", default-features = false, optional = true, features = ["system"] }
 
-# Dependencies needed by the `logging` feature
+# Dependencies needed by the `tracing` feature
 tracing = { version = "0.1", optional = true, features = ["attributes"] }
 tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter", "fmt", "registry", "std"] }
 tracing-tree = { version = "0.4.0", optional = true }


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/135391#discussion_r1912826594.

I guess I updated everything else **except** the comment right next to the actual dependencies 💀

r? bootstrap