### PR TITLE
Prune unreachable variants of coroutines

### DIFF
--- a/tests/mir-opt/coroutine_dead_variants.outer-{closure#0}.SimplifyCfg-final.panic-abort.diff
+++ b/tests/mir-opt/coroutine_dead_variants.outer-{closure#0}.SimplifyCfg-final.panic-abort.diff
@@ -1,0 +1,158 @@
+- // MIR for `outer::{closure#0}` before SimplifyCfg-final
++ // MIR for `outer::{closure#0}` after SimplifyCfg-final
+  /* coroutine_layout = CoroutineLayout {
+      field_tys: {
+          _0: CoroutineSavedTy {
+              ty: Coroutine(
+                  DefId(0:5 ~ coroutine_dead_variants[61c4]::inner::{closure#0}),
+                  [
+                      (),
+                      std::future::ResumeTy,
+                      (),
+                      (),
+                      CoroutineWitness(
+                          DefId(0:5 ~ coroutine_dead_variants[61c4]::inner::{closure#0}),
+                          [],
+                      ),
+                      (),
+                  ],
+              ),
+              source_info: SourceInfo {
+                  span: $DIR/coroutine_dead_variants.rs:13:9: 13:22 (#16),
+                  scope: scope[0],
+              },
+              ignore_for_traits: false,
+          },
+      },
+      variant_fields: {
+          Unresumed(0): [],
+          Returned (1): [],
+          Panicked (2): [],
+          Suspend0 (3): [_0],
+      },
+      storage_conflicts: BitMatrix(1x1) {
+          (_0, _0),
+      },
+  } */
+  
+  fn outer::{closure#0}(_1: Pin<&mut {async fn body of outer()}>, _2: &mut Context<'_>) -> Poll<()> {
+      debug _task_context => _2;
+      let mut _0: std::task::Poll<()>;
+      let mut _3: {async fn body of inner()};
+      let mut _4: {async fn body of inner()};
+      let mut _5: std::task::Poll<()>;
+      let mut _6: std::pin::Pin<&mut {async fn body of inner()}>;
+      let mut _7: &mut {async fn body of inner()};
+      let mut _8: &mut std::task::Context<'_>;
+      let mut _9: isize;
+      let mut _11: ();
+      let mut _12: &mut std::task::Context<'_>;
+      let mut _13: u32;
+      let mut _14: &mut {async fn body of outer()};
+      scope 1 {
+          debug __awaitee => (((*(_1.0: &mut {async fn body of outer()})) as variant#3).0: {async fn body of inner()});
+          let _10: ();
+          scope 2 {
+              debug result => const ();
+          }
+      }
+  
+      bb0: {
+          _14 = copy (_1.0: &mut {async fn body of outer()});
+          _13 = discriminant((*_14));
+-         switchInt(move _13) -> [0: bb1, 1: bb15, 3: bb14, otherwise: bb8];
++         switchInt(move _13) -> [0: bb2, 1: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
+-         nop;
+-         goto -> bb12;
+-     }
+- 
+-     bb2: {
+-         StorageLive(_3);
+-         StorageLive(_4);
+-         _4 = inner() -> [return: bb3, unwind unreachable];
+-     }
+- 
+-     bb3: {
+-         _3 = <{async fn body of inner()} as IntoFuture>::into_future(move _4) -> [return: bb4, unwind unreachable];
+-     }
+- 
+-     bb4: {
+-         StorageDead(_4);
+-         (((*_14) as variant#3).0: {async fn body of inner()}) = move _3;
+-         goto -> bb5;
+-     }
+- 
+-     bb5: {
+-         StorageLive(_5);
+-         StorageLive(_6);
+-         _7 = &mut (((*_14) as variant#3).0: {async fn body of inner()});
+-         _6 = Pin::<&mut {async fn body of inner()}>::new_unchecked(copy _7) -> [return: bb6, unwind unreachable];
+-     }
+- 
+-     bb6: {
+-         nop;
+-         _5 = <{async fn body of inner()} as Future>::poll(move _6, copy _2) -> [return: bb7, unwind unreachable];
+-     }
+- 
+-     bb7: {
+-         StorageDead(_6);
+-         _9 = discriminant(_5);
+-         switchInt(move _9) -> [0: bb10, 1: bb9, otherwise: bb8];
+-     }
+- 
+-     bb8: {
+          unreachable;
+      }
+  
+-     bb9: {
+-         StorageDead(_5);
+-         _0 = const Poll::<()>::Pending;
+-         StorageDead(_3);
+-         discriminant((*_14)) = 3;
+-         return;
+-     }
+- 
+-     bb10: {
+-         StorageLive(_10);
+-         nop;
+-         StorageDead(_10);
+-         StorageDead(_5);
+-         drop((((*_14) as variant#3).0: {async fn body of inner()})) -> [return: bb11, unwind unreachable];
+-     }
+- 
+-     bb11: {
+-         StorageDead(_3);
++     bb2: {
+          _11 = const ();
+-         goto -> bb13;
++         goto -> bb3;
+      }
+  
+-     bb12: {
+-         _11 = const ();
+-         goto -> bb13;
+-     }
+- 
+-     bb13: {
++     bb3: {
+          _0 = Poll::<()>::Ready(const ());
+          discriminant((*_14)) = 1;
+          return;
+      }
+  
+-     bb14: {
+-         StorageLive(_3);
+-         nop;
+-         goto -> bb5;
+-     }
+- 
+-     bb15: {
+-         assert(const false, "`async fn` resumed after completion") -> [success: bb15, unwind unreachable];
++     bb4: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb4, unwind unreachable];
+      }
+  }
+  

--- a/tests/mir-opt/coroutine_dead_variants.outer-{closure#0}.SimplifyCfg-final.panic-unwind.diff
+++ b/tests/mir-opt/coroutine_dead_variants.outer-{closure#0}.SimplifyCfg-final.panic-unwind.diff
@@ -1,0 +1,194 @@
+- // MIR for `outer::{closure#0}` before SimplifyCfg-final
++ // MIR for `outer::{closure#0}` after SimplifyCfg-final
+  /* coroutine_layout = CoroutineLayout {
+      field_tys: {
+          _0: CoroutineSavedTy {
+              ty: Coroutine(
+                  DefId(0:5 ~ coroutine_dead_variants[61c4]::inner::{closure#0}),
+                  [
+                      (),
+                      std::future::ResumeTy,
+                      (),
+                      (),
+                      CoroutineWitness(
+                          DefId(0:5 ~ coroutine_dead_variants[61c4]::inner::{closure#0}),
+                          [],
+                      ),
+                      (),
+                  ],
+              ),
+              source_info: SourceInfo {
+                  span: $DIR/coroutine_dead_variants.rs:13:9: 13:22 (#16),
+                  scope: scope[0],
+              },
+              ignore_for_traits: false,
+          },
+      },
+      variant_fields: {
+          Unresumed(0): [],
+          Returned (1): [],
+          Panicked (2): [],
+          Suspend0 (3): [_0],
+      },
+      storage_conflicts: BitMatrix(1x1) {
+          (_0, _0),
+      },
+  } */
+  
+  fn outer::{closure#0}(_1: Pin<&mut {async fn body of outer()}>, _2: &mut Context<'_>) -> Poll<()> {
+      debug _task_context => _2;
+      let mut _0: std::task::Poll<()>;
+      let mut _3: {async fn body of inner()};
+      let mut _4: {async fn body of inner()};
+      let mut _5: std::task::Poll<()>;
+      let mut _6: std::pin::Pin<&mut {async fn body of inner()}>;
+      let mut _7: &mut {async fn body of inner()};
+      let mut _8: &mut std::task::Context<'_>;
+      let mut _9: isize;
+      let mut _11: ();
+      let mut _12: &mut std::task::Context<'_>;
+      let mut _13: u32;
+      let mut _14: &mut {async fn body of outer()};
+      scope 1 {
+          debug __awaitee => (((*(_1.0: &mut {async fn body of outer()})) as variant#3).0: {async fn body of inner()});
+          let _10: ();
+          scope 2 {
+              debug result => const ();
+          }
+      }
+  
+      bb0: {
+          _14 = copy (_1.0: &mut {async fn body of outer()});
+          _13 = discriminant((*_14));
+-         switchInt(move _13) -> [0: bb1, 1: bb21, 2: bb20, 3: bb19, otherwise: bb8];
++         switchInt(move _13) -> [0: bb2, 1: bb5, 2: bb4, otherwise: bb1];
+      }
+  
+      bb1: {
+-         nop;
+-         goto -> bb12;
+-     }
+- 
+-     bb2: {
+-         StorageLive(_3);
+-         StorageLive(_4);
+-         _4 = inner() -> [return: bb3, unwind: bb17];
+-     }
+- 
+-     bb3: {
+-         _3 = <{async fn body of inner()} as IntoFuture>::into_future(move _4) -> [return: bb4, unwind: bb17];
+-     }
+- 
+-     bb4: {
+-         StorageDead(_4);
+-         (((*_14) as variant#3).0: {async fn body of inner()}) = move _3;
+-         goto -> bb5;
+-     }
+- 
+-     bb5: {
+-         StorageLive(_5);
+-         StorageLive(_6);
+-         _7 = &mut (((*_14) as variant#3).0: {async fn body of inner()});
+-         _6 = Pin::<&mut {async fn body of inner()}>::new_unchecked(copy _7) -> [return: bb6, unwind: bb15];
+-     }
+- 
+-     bb6: {
+-         nop;
+-         _5 = <{async fn body of inner()} as Future>::poll(move _6, copy _2) -> [return: bb7, unwind: bb14];
+-     }
+- 
+-     bb7: {
+-         StorageDead(_6);
+-         _9 = discriminant(_5);
+-         switchInt(move _9) -> [0: bb10, 1: bb9, otherwise: bb8];
+-     }
+- 
+-     bb8: {
+          unreachable;
+      }
+  
+-     bb9: {
+-         StorageDead(_5);
+-         _0 = const Poll::<()>::Pending;
+-         StorageDead(_3);
+-         discriminant((*_14)) = 3;
+-         return;
+-     }
+- 
+-     bb10: {
+-         StorageLive(_10);
+-         nop;
+-         StorageDead(_10);
+-         StorageDead(_5);
+-         drop((((*_14) as variant#3).0: {async fn body of inner()})) -> [return: bb11, unwind: bb18];
+-     }
+- 
+-     bb11: {
+-         StorageDead(_3);
++     bb2: {
+          _11 = const ();
+-         goto -> bb13;
++         goto -> bb3;
+      }
+  
+-     bb12: {
+-         _11 = const ();
+-         goto -> bb13;
+-     }
+- 
+-     bb13: {
++     bb3: {
+          _0 = Poll::<()>::Ready(const ());
+          discriminant((*_14)) = 1;
+          return;
+      }
+  
+-     bb14 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb16;
++     bb4: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb4, unwind continue];
+      }
+  
+-     bb15 (cleanup): {
+-         StorageDead(_6);
+-         goto -> bb16;
+-     }
+- 
+-     bb16 (cleanup): {
+-         StorageDead(_5);
+-         drop((((*_14) as variant#3).0: {async fn body of inner()})) -> [return: bb18, unwind terminate(cleanup)];
+-     }
+- 
+-     bb17 (cleanup): {
+-         StorageDead(_4);
+-         goto -> bb18;
+-     }
+- 
+-     bb18 (cleanup): {
+-         StorageDead(_3);
+-         discriminant((*_14)) = 2;
+-         resume;
+-     }
+- 
+-     bb19: {
+-         StorageLive(_3);
+-         nop;
+-         goto -> bb5;
+-     }
+- 
+-     bb20: {
+-         assert(const false, "`async fn` resumed after panicking") -> [success: bb20, unwind continue];
+-     }
+- 
+-     bb21: {
+-         assert(const false, "`async fn` resumed after completion") -> [success: bb21, unwind continue];
+-     }
+- 
+-     bb22 (cleanup): {
+-         resume;
++     bb5: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb5, unwind continue];
+      }
+  }
+  

--- a/tests/mir-opt/coroutine_dead_variants.rs
+++ b/tests/mir-opt/coroutine_dead_variants.rs
@@ -1,0 +1,15 @@
+// skip-filecheck
+// EMIT_MIR_FOR_EACH_PANIC_STRATEGY
+//@ compile-flags: -Zmir-enable-passes=+GVN,+SimplifyLocals-after-value-numbering
+//@ edition: 2021
+
+async fn inner() {
+    panic!("disco");
+}
+
+// EMIT_MIR coroutine_dead_variants.outer-{closure#0}.SimplifyCfg-final.diff
+async fn outer() {
+    if false {
+        inner().await;
+    }
+}


### PR DESCRIPTION
Fixes #135468

`SimplifyCfg` doesn't detect cases where coroutine variants are effectively unreachable since they'll never reach a specific variant if we repeatedly poll the coroutine from the "uninitialized" variant 0. This PR attempts to implement that, since otherwise futures suffer from dead code problems across await points.

I gotta explain a bunch about why this is so weird, sitll. But, anyone have a vibe-check about the approach?

r? mir-opt