### PR TITLE
Remove the need to update `build-gccjit.sh` script every time GCC backend do a sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ no_llvm_build
 /src/tools/x/target
 # Created by default with `src/ci/docker/run.sh`
 /obj/
+/src/ci/docker/scripts/libgccjit.version
 # Created by nix dev shell / .envrc
 src/tools/nix-dev-shell/flake.lock
 

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-18/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-18/Dockerfile
@@ -55,6 +55,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set rust.thin-lto-import-instr-limit=10
 
 COPY scripts/shared.sh /scripts/
+COPY scripts/libgccjit.version /scripts/
 COPY scripts/build-gccjit.sh /scripts/
 
 RUN /scripts/build-gccjit.sh /scripts

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-19/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-19/Dockerfile
@@ -55,6 +55,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set rust.thin-lto-import-instr-limit=10
 
 COPY scripts/shared.sh /scripts/
+COPY scripts/libgccjit.version /scripts/
 COPY scripts/build-gccjit.sh /scripts/
 
 RUN /scripts/build-gccjit.sh /scripts

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -90,6 +90,7 @@ ENV HOST_TARGET x86_64-unknown-linux-gnu
 #ENV FORCE_CI_RUSTC 1
 
 COPY scripts/shared.sh /scripts/
+COPY scripts/libgccjit.version /scripts/
 COPY scripts/build-gccjit.sh /scripts/
 
 RUN /scripts/build-gccjit.sh /scripts

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -324,6 +324,7 @@ SUMMARY_FILE=github-summary.md
 touch $objdir/${SUMMARY_FILE}
 
 extra_env=""
+cp /checkout/compiler/rustc_codegen_gcc/libgccjit.version /checkout/src/ci/docker/scripts/libgccjit.version
 if [ "$ENABLE_GCC_CODEGEN" = "1" ]; then
   extra_env="$extra_env --env ENABLE_GCC_CODEGEN=1"
   # Fix rustc_codegen_gcc lto issues.

--- a/src/ci/docker/scripts/build-gccjit.sh
+++ b/src/ci/docker/scripts/build-gccjit.sh
@@ -2,12 +2,12 @@
 
 GIT_REPO="https://github.com/rust-lang/gcc"
 
-# This commit hash needs to be updated to use a more recent gcc fork version.
-GIT_COMMIT="45648c2edd4ecd862d9f08196d3d6c6ccba79f07"
-
 set -ex
 
 cd $1
+
+# This is the forked git commit hash used by the GCC backend.
+GIT_COMMIT="$(head -n 1 libgccjit.version)"
 
 source shared.sh
 


### PR DESCRIPTION
Last sync we lost some time remembering we needed to update `build-gccjit.sh`. I don't think there is any reason to not copy the file inside the Dockerfile so here it is.

cc @antoyo 
r? @Kobzol 