### PR TITLE
Add missing check for async body when suggesting await on futures.

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
@@ -167,6 +167,18 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
             exp_span, exp_found.expected, exp_found.found,
         );
 
+        match self.tcx.coroutine_kind(cause.body_id) {
+            Some(hir::CoroutineKind::Desugared(
+                hir::CoroutineDesugaring::Async | hir::CoroutineDesugaring::AsyncGen,
+                _,
+            )) => (),
+            None
+            | Some(
+                hir::CoroutineKind::Coroutine(_)
+                | hir::CoroutineKind::Desugared(hir::CoroutineDesugaring::Gen, _),
+            ) => return,
+        }
+
         if let ObligationCauseCode::CompareImplItem { .. } = cause.code() {
             return;
         }

--- a/tests/ui/async-await/coroutine-desc.stderr
+++ b/tests/ui/async-await/coroutine-desc.stderr
@@ -30,7 +30,6 @@ LL |     fun(one(), two());
    |     |   expected all arguments to be this future type because they need to match the type of this parameter
    |     arguments to this function are incorrect
    |
-   = help: consider `await`ing on both `Future`s
    = note: distinct uses of `impl Trait` result in different opaque types
 note: function defined here
   --> $DIR/coroutine-desc.rs:7:4

--- a/tests/ui/async-await/dont-suggest-missing-await.stderr
+++ b/tests/ui/async-await/dont-suggest-missing-await.stderr
@@ -6,20 +6,11 @@ LL |         take_u32(x)
    |         |
    |         arguments to this function are incorrect
    |
-note: calling an async function returns a future
-  --> $DIR/dont-suggest-missing-await.rs:14:18
-   |
-LL |         take_u32(x)
-   |                  ^
 note: function defined here
   --> $DIR/dont-suggest-missing-await.rs:5:4
    |
 LL | fn take_u32(x: u32) {}
    |    ^^^^^^^^ ------
-help: consider `await`ing on the `Future`
-   |
-LL |         take_u32(x.await)
-   |                   ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/issue-102605.stderr
+++ b/tests/ui/impl-trait/issue-102605.stderr
@@ -14,20 +14,11 @@ LL |     convert_result(foo())
    |     |
    |     arguments to this function are incorrect
    |
-note: calling an async function returns a future
-  --> $DIR/issue-102605.rs:13:20
-   |
-LL |     convert_result(foo())
-   |                    ^^^^^
 note: function defined here
   --> $DIR/issue-102605.rs:7:4
    |
 LL | fn convert_result<T, E>(r: Result<T, E>) -> Option<T> {
    |    ^^^^^^^^^^^^^^       ---------------
-help: consider `await`ing on the `Future`
-   |
-LL |     convert_result(foo().await)
-   |                         ++++++
 help: try wrapping the expression in `Err`
    |
 LL |     convert_result(Err(foo()))


### PR DESCRIPTION
Currently the compiler suggests adding `.await` to resolve some type conflicts without checking if the conflict happens in an async context. This can lead to the compiler suggesting `.await` in function signatures where it is invalid. Example:

```rs
trait A {
    fn a() -> impl Future<Output = ()>;
}
struct B;
impl A for B {
    fn a() -> impl Future<Output = impl Future<Output = ()>> {
        async { async { () } }
    }
}
```
```
error[E0271]: expected `impl Future<Output = impl Future<Output = ()>>` to be a future that resolves to `()`, but it resolves to `impl Future<Output = ()>`
 --> bug.rs:6:15
  |
6 |     fn a() -> impl Future<Output = impl Future<Output = ()>> {
  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found future
  |
note: calling an async function returns a future
 --> bug.rs:6:15
  |
6 |     fn a() -> impl Future<Output = impl Future<Output = ()>> {
  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: required by a bound in `A::{synthetic#0}`
 --> bug.rs:2:27
  |
2 |     fn a() -> impl Future<Output = ()>;
  |                           ^^^^^^^^^^^ required by this bound in `A::{synthetic#0}`
help: consider `await`ing on the `Future`
  |
6 |     fn a() -> impl Future<Output = impl Future<Output = ()>>.await {
  |                                                             ++++++
```

The documentation of suggest_await_on_expect_found (`compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs:156`) even mentions such a check but does not actually implement it.

This PR adds that check to ensure `.await` is only suggested within async blocks.

There were 3 unit tests whose expected output needed to be changed because they had the suggestion outside of async. One of them (`tests/ui/async-await/dont-suggest-missing-await.rs`) actually tests that exact problem but expects it to be present.

Thanks to @llenck for initially noticing the bug and helping with fixing it