### PR TITLE
[beta] TRPL: incorporate all backward-compatible Edition changes

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -334,7 +334,11 @@ macro_rules! bootstrap_tool {
 }
 
 bootstrap_tool!(
-    Rustbook, "src/tools/rustbook", "rustbook", submodules = SUBMODULES_FOR_RUSTBOOK;
+    // This is marked as an external tool because it includes dependencies
+    // from submodules. Trying to keep the lints in sync between all the repos
+    // is a bit of a pain. Unfortunately it means the rustbook source itself
+    // doesn't deny warnings, but it is a relatively small piece of code.
+    Rustbook, "src/tools/rustbook", "rustbook", is_external_tool = true, submodules = SUBMODULES_FOR_RUSTBOOK;
     UnstableBookGen, "src/tools/unstable-book-gen", "unstable-book-gen";
     Tidy, "src/tools/tidy", "tidy";
     Linkchecker, "src/tools/linkchecker", "linkchecker";


### PR DESCRIPTION
This incorporates all the backwards-compatible changes for the 2024 Edition. There will also be a follow-on PR to land revisions to the new chapter on async so it can be as ready as possible when officially released with 1.85 and the 2024 Edition.

Additionally, there are a few other, non-backward-compatible, changes (largely around `use<..>`) we can only land using the stable edition, which we may or may not be able to land in 1.85 by using the beta toolchain in the example code. Those may or may not be ported over, depending on how that does or does not play with the infrastructure.

This is identical to #135507 except that this targets `beta` instead of `master`, with the intent that these changes land in 1.85 and go out with the Edition release.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
