### PR TITLE
add incremental test for issue 135514

### DIFF
--- a/tests/incremental/overlapping-impls-in-new-solver-issue-135514.rs
+++ b/tests/incremental/overlapping-impls-in-new-solver-issue-135514.rs
@@ -1,0 +1,40 @@
+// Regression test for #135514 where the new solver didn't properly record deps for incremental
+// compilation, similarly to `track-deps-in-new-solver.rs`.
+//
+// In this specially crafted example, @steffahn was able to trigger unsoundness with an overlapping
+// impl that was accepted during the incremental rebuild.
+
+//@ revisions: cpass1 cfail2
+//@ compile-flags: -Znext-solver
+
+pub trait Trait {}
+
+pub struct S0<T>(T);
+
+pub struct S<T>(T);
+impl<T> Trait for S<T> where S0<T>: Trait {}
+
+pub struct W;
+
+pub trait Other {
+    type Choose<L, R>;
+}
+
+// first impl
+impl<T: Trait> Other for T {
+    type Choose<L, R> = L;
+}
+
+// second impl
+impl<T> Other for S<T> {
+    //[cfail2]~^ ERROR conflicting implementations of trait
+    type Choose<L, R> = R;
+}
+
+#[cfg(cpass1)]
+impl Trait for W {}
+
+#[cfg(cfail2)]
+impl Trait for S<W> {}
+
+fn main() {}


### PR DESCRIPTION
r? @compiler-errors as requested in https://github.com/rust-lang/rust/issues/135514#issuecomment-2591614811

This adds parts of @steffahn's repro as an incremental test for #135514. I had initially added the actual exploitation of the issue into the safe transmute, but removed it because it's not exactly needed for such a test. I can add it back if you'd like.

I've verified that the test fails with https://github.com/rust-lang/rust/pull/133828 reverted.
