### PR TITLE
const traits: remove some known-bug that do not seem to make sense

### DIFF
--- a/tests/ui/consts/const-block-const-bound.rs
+++ b/tests/ui/consts/const-block-const-bound.rs
@@ -1,5 +1,3 @@
-//@ known-bug: #103507
-
 #![allow(unused)]
 #![feature(const_trait_impl, negative_impls, const_destruct)]
 
@@ -16,6 +14,6 @@ impl Drop for UnconstDrop {
 fn main() {
     const {
         f(UnconstDrop);
-        //FIXME ~^ ERROR can't drop
+        //~^ ERROR trait bound `UnconstDrop: const Destruct` is not satisfied
     }
 }

--- a/tests/ui/consts/const-block-const-bound.stderr
+++ b/tests/ui/consts/const-block-const-bound.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `UnconstDrop: const Destruct` is not satisfied
-  --> $DIR/const-block-const-bound.rs:18:11
+  --> $DIR/const-block-const-bound.rs:16:11
    |
 LL |         f(UnconstDrop);
    |         - ^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |         f(UnconstDrop);
    |         required by a bound introduced by this call
    |
 note: required by a bound in `f`
-  --> $DIR/const-block-const-bound.rs:8:15
+  --> $DIR/const-block-const-bound.rs:6:15
    |
 LL | const fn f<T: ~const Destruct>(x: T) {}
    |               ^^^^^^ required by this bound in `f`

--- a/tests/ui/consts/issue-94675.rs
+++ b/tests/ui/consts/issue-94675.rs
@@ -1,5 +1,3 @@
-//@ known-bug: #103507
-
 #![feature(const_trait_impl, const_vec_string_slice)]
 
 struct Foo<'a> {
@@ -9,9 +7,7 @@ struct Foo<'a> {
 impl<'a> Foo<'a> {
     const fn spam(&mut self, baz: &mut Vec<u32>) {
         self.bar[0] = baz.len();
-        //FIXME ~^ ERROR: cannot call
-        //FIXME ~| ERROR: cannot call
-        //FIXME ~| ERROR: the trait bound
+        //~^ ERROR: cannot call
     }
 }
 

--- a/tests/ui/consts/issue-94675.stderr
+++ b/tests/ui/consts/issue-94675.stderr
@@ -1,5 +1,5 @@
 error[E0015]: cannot call non-const operator in constant functions
-  --> $DIR/issue-94675.rs:11:17
+  --> $DIR/issue-94675.rs:9:17
    |
 LL |         self.bar[0] = baz.len();
    |                 ^^^

--- a/tests/ui/impl-trait/normalize-tait-in-const.rs
+++ b/tests/ui/impl-trait/normalize-tait-in-const.rs
@@ -1,4 +1,5 @@
-//@ known-bug: #103507
+//! This is a regression test for <https://github.com/rust-lang/rust/issues/103507>.
+//@ known-bug: #110395
 
 #![feature(type_alias_impl_trait)]
 #![feature(const_trait_impl, const_destruct)]

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -1,5 +1,5 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/normalize-tait-in-const.rs:26:35
+  --> $DIR/normalize-tait-in-const.rs:27:35
    |
 LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
    |                                   ^^^^^^ can't be applied to `Fn`
@@ -8,7 +8,7 @@ note: `Fn` can't be used with `~const` because it isn't annotated with `#[const_
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/normalize-tait-in-const.rs:26:35
+  --> $DIR/normalize-tait-in-const.rs:27:35
    |
 LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
    |                                   ^^^^^^ can't be applied to `Fn`
@@ -18,7 +18,7 @@ note: `Fn` can't be used with `~const` because it isn't annotated with `#[const_
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0015]: cannot call non-const closure in constant functions
-  --> $DIR/normalize-tait-in-const.rs:27:5
+  --> $DIR/normalize-tait-in-const.rs:28:5
    |
 LL |     fun(filter_positive());
    |     ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
These tests were made to point to #103507 in https://github.com/rust-lang/rust/pull/114134; I think that was a mistake: that issue is about a rather specific problem, and most tests marked as known-bug in that PR are pointing at https://github.com/rust-lang/rust/issues/110395 which makes more sense.

Of the 4 tests that still point to #103507:
- One is [the original test](https://github.com/rust-lang/rust/blob/20882608529a969bd878ad787cf0038716c021df/tests/ui/impl-trait/normalize-tait-in-const.rs). It still fails to compile, though currently for unrelated reasons (`~const Fn` is not valid as that is not a const trait). I made it point at #110395 like all the other tests that were disabled when the previous const trait impl was removed.
- One is being fixed in https://github.com/rust-lang/rust/pull/135423
- The other two are fixed in this PR

The errors we are getting here are not great but they do look correct?

FWIW there are still a whole lot of tests mentioning #110395 despite that issue being closed... I hope someone is tracking that.^^

r? @compiler-errors 