### PR TITLE
Add examples to Option::map_or documentation

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1149,7 +1149,7 @@ impl<T> Option<T> {
         self
     }
 
-    /// Returns the provided default result (if none),
+        /// Returns the provided default result (if none),
     /// or applies a function to the contained value (if any).
     ///
     /// Arguments passed to `map_or` are eagerly evaluated; if you are passing
@@ -1166,6 +1166,23 @@ impl<T> Option<T> {
     ///
     /// let x: Option<&str> = None;
     /// assert_eq!(x.map_or(42, |v| v.len()), 42);
+    ///
+    /// // Using a default value for an empty option.
+    /// let empty: Option<i32> = None;
+    /// assert_eq!(empty.map_or(0, |v| v * 2), 0); // Default value is used.
+    ///
+    /// // Applying a function to a `Some` value.
+    /// let value = Some(21);
+    /// assert_eq!(value.map_or(0, |v| v * 2), 42); // Function is applied to `21`.
+    ///
+    /// // Practical example with `Option<&str>`:
+    /// let username: Option<&str> = Some("Alice");
+    /// let greeting = username.map_or("Hello, guest!".to_string(), |name| format!("Hello, {}!", name));
+    /// assert_eq!(greeting, "Hello, Alice!");
+    ///
+    /// let no_username: Option<&str> = None;
+    /// let fallback_greeting = no_username.map_or("Hello, guest!".to_string(), |name| format!("Hello, {}!", name));
+    /// assert_eq!(fallback_greeting, "Hello, guest!");
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!-- 
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related 
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like 
a specific user to review your work, you can assign it to them by using:

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR enhances the documentation of the `Option::map_or` method by adding more comprehensive and practical examples. These updates aim to help developers better understand the method's behavior and usage in various scenarios, especially when dealing with `Some` and `None` cases.

### Changes Made:
1. **Added Examples for Clarity**:
   - Demonstrated how `map_or` applies a function to a value when `Some` is present.
   - Showed how the default value is returned when `None` is encountered.

2. **Introduced a Real-World Use Case**:
   - Added an example illustrating how `map_or` can be used to handle fallback logic, such as generating personalized greeting messages.

3. **Improved Readability**:
   - Included comments to explain each example, ensuring developers understand the rationale behind each test case.

### Updated Examples:
```rust
// Using a default value for an empty option.
let empty: Option<i32> = None;
assert_eq!(empty.map_or(0, |v| v * 2), 0); // Default value is used.

// Applying a function to a `Some` value.
let value = Some(21);
assert_eq!(value.map_or(0, |v| v * 2), 42); // Function is applied to `21`.

// Practical example with `Option<&str>`:
let username: Option<&str> = Some("Alice");
let greeting = username.map_or("Hello, guest!".to_string(), |name| format!("Hello, {}!", name));
assert_eq!(greeting, "Hello, Alice!");

let no_username: Option<&str> = None;
let fallback_greeting = no_username.map_or("Hello, guest!".to_string(), |name| format!("Hello, {}!", name));
assert_eq!(fallback_greeting, "Hello, guest!");
```

### Benefits:
- **Improved Usability**: The examples provide clear, actionable guidance on how to use `map_or` effectively.
- **Increased Accessibility**: Developers at all levels can quickly grasp the method's functionality with the added real-world context.
- **Aligned with Rust's Philosophy**: Enhances documentation to prioritize clarity and developer experience.

If there are additional scenarios or edge cases worth including, I'm happy to expand this PR!