### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -360,10 +360,7 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
             // sensitive check here. But we can at least rule out functions that are not const at
             // all. That said, we have to allow calling functions inside a trait marked with
             // #[const_trait]. These *are* const-checked!
-            // FIXME(const_trait_impl): why does `is_const_fn` not classify them as const?
-            if (!ecx.tcx.is_const_fn(def) && !ecx.tcx.is_const_default_method(def))
-                || ecx.tcx.has_attr(def, sym::rustc_do_not_const_check)
-            {
+            if !ecx.tcx.is_const_fn(def) || ecx.tcx.has_attr(def, sym::rustc_do_not_const_check) {
                 // We certainly do *not* want to actually call the fn
                 // though, so be sure we return here.
                 throw_unsup_format!("calling non-const function `{}`", instance)

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -331,7 +331,7 @@
 //!
 //! Note that this invariant is enforced by simply making it impossible to call code that would
 //! perform a move on the pinned value. This is the case since the only way to access that pinned
-//! value is through the pinning <code>[Pin]<[&mut] T>></code>, which in turn restricts our access.
+//! value is through the pinning <code>[Pin]<[&mut] T></code>, which in turn restricts our access.
 //!
 //! ## [`Unpin`]
 //!
@@ -379,7 +379,7 @@
 //!
 //! Exposing access to the inner field which you want to remain pinned must then be carefully
 //! considered as well! Remember, exposing a method that gives access to a
-//! <code>[Pin]<[&mut] InnerT>></code> where <code>InnerT: [Unpin]</code> would allow safe code to
+//! <code>[Pin]<[&mut] InnerT></code> where <code>InnerT: [Unpin]</code> would allow safe code to
 //! trivially move the inner value out of that pinning pointer, which is precisely what you're
 //! seeking to prevent! Exposing a field of a pinned value through a pinning pointer is called
 //! "projecting" a pin, and the more general case of deciding in which cases a pin should be able

--- a/tests/incremental/overlapping-impls-in-new-solver-issue-135514.rs
+++ b/tests/incremental/overlapping-impls-in-new-solver-issue-135514.rs
@@ -1,0 +1,40 @@
+// Regression test for #135514 where the new solver didn't properly record deps for incremental
+// compilation, similarly to `track-deps-in-new-solver.rs`.
+//
+// In this specially crafted example, @steffahn was able to trigger unsoundness with an overlapping
+// impl that was accepted during the incremental rebuild.
+
+//@ revisions: cpass1 cfail2
+//@ compile-flags: -Znext-solver
+
+pub trait Trait {}
+
+pub struct S0<T>(T);
+
+pub struct S<T>(T);
+impl<T> Trait for S<T> where S0<T>: Trait {}
+
+pub struct W;
+
+pub trait Other {
+    type Choose<L, R>;
+}
+
+// first impl
+impl<T: Trait> Other for T {
+    type Choose<L, R> = L;
+}
+
+// second impl
+impl<T> Other for S<T> {
+    //[cfail2]~^ ERROR conflicting implementations of trait
+    type Choose<L, R> = R;
+}
+
+#[cfg(cpass1)]
+impl Trait for W {}
+
+#[cfg(cfail2)]
+impl Trait for S<W> {}
+
+fn main() {}

--- a/tests/rustdoc-gui/links-color.goml
+++ b/tests/rustdoc-gui/links-color.goml
@@ -5,6 +5,7 @@ go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 // This is needed so that the text color is computed.
 show-text: true
 
+// First we check the links of the different items.
 define-function: (
     "check-colors",
     [theme, mod, macro, struct, enum, trait, fn, type, union, keyword,
@@ -35,6 +36,11 @@ define-function: (
                 "font-weight": "500",
             },
             ALL,
+        )
+        move-cursor-to: ".desc a[href='long_code_block_link/index.html']"
+        assert-css: (
+            ".desc a[href='long_code_block_link/index.html']",
+            {"text-decoration": "underline solid " + |mod|},
         )
     },
 )

--- a/tests/ui/consts/const-block-const-bound.rs
+++ b/tests/ui/consts/const-block-const-bound.rs
@@ -1,5 +1,3 @@
-//@ known-bug: #103507
-
 #![allow(unused)]
 #![feature(const_trait_impl, negative_impls, const_destruct)]
 
@@ -16,6 +14,6 @@ impl Drop for UnconstDrop {
 fn main() {
     const {
         f(UnconstDrop);
-        //FIXME ~^ ERROR can't drop
+        //~^ ERROR trait bound `UnconstDrop: const Destruct` is not satisfied
     }
 }

--- a/tests/ui/consts/const-block-const-bound.stderr
+++ b/tests/ui/consts/const-block-const-bound.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `UnconstDrop: const Destruct` is not satisfied
-  --> $DIR/const-block-const-bound.rs:18:11
+  --> $DIR/const-block-const-bound.rs:16:11
    |
 LL |         f(UnconstDrop);
    |         - ^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |         f(UnconstDrop);
    |         required by a bound introduced by this call
    |
 note: required by a bound in `f`
-  --> $DIR/const-block-const-bound.rs:8:15
+  --> $DIR/const-block-const-bound.rs:6:15
    |
 LL | const fn f<T: ~const Destruct>(x: T) {}
    |               ^^^^^^ required by this bound in `f`

--- a/tests/ui/consts/issue-94675.rs
+++ b/tests/ui/consts/issue-94675.rs
@@ -1,5 +1,3 @@
-//@ known-bug: #103507
-
 #![feature(const_trait_impl, const_vec_string_slice)]
 
 struct Foo<'a> {
@@ -9,9 +7,7 @@ struct Foo<'a> {
 impl<'a> Foo<'a> {
     const fn spam(&mut self, baz: &mut Vec<u32>) {
         self.bar[0] = baz.len();
-        //FIXME ~^ ERROR: cannot call
-        //FIXME ~| ERROR: cannot call
-        //FIXME ~| ERROR: the trait bound
+        //~^ ERROR: cannot call
     }
 }
 

--- a/tests/ui/consts/issue-94675.stderr
+++ b/tests/ui/consts/issue-94675.stderr
@@ -1,5 +1,5 @@
 error[E0015]: cannot call non-const operator in constant functions
-  --> $DIR/issue-94675.rs:11:17
+  --> $DIR/issue-94675.rs:9:17
    |
 LL |         self.bar[0] = baz.len();
    |                 ^^^

--- a/tests/ui/impl-trait/normalize-tait-in-const.rs
+++ b/tests/ui/impl-trait/normalize-tait-in-const.rs
@@ -1,4 +1,5 @@
-//@ known-bug: #103507
+//! This is a regression test for <https://github.com/rust-lang/rust/issues/103507>.
+//@ known-bug: #110395
 
 #![feature(type_alias_impl_trait)]
 #![feature(const_trait_impl, const_destruct)]

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -1,5 +1,5 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/normalize-tait-in-const.rs:26:35
+  --> $DIR/normalize-tait-in-const.rs:27:35
    |
 LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
    |                                   ^^^^^^ can't be applied to `Fn`
@@ -8,7 +8,7 @@ note: `Fn` can't be used with `~const` because it isn't annotated with `#[const_
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/normalize-tait-in-const.rs:26:35
+  --> $DIR/normalize-tait-in-const.rs:27:35
    |
 LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
    |                                   ^^^^^^ can't be applied to `Fn`
@@ -18,7 +18,7 @@ note: `Fn` can't be used with `~const` because it isn't annotated with `#[const_
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0015]: cannot call non-const closure in constant functions
-  --> $DIR/normalize-tait-in-const.rs:27:5
+  --> $DIR/normalize-tait-in-const.rs:28:5
    |
 LL |     fun(filter_positive());
    |     ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Successful merges:

 - #135497 (fix typo in typenames of pin documentation)
 - #135522 (add incremental test for issue 135514)
 - #135523 (const traits: remove some known-bug that do not seem to make sense)
 - #135535 (Add GUI test for #135499)
 - #135541 (Methods of const traits are const)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135497,135522,135523,135535,135541)
<!-- homu-ignore:end -->