### PR TITLE
Detect if-else chains with a missing final else in type errors

### DIFF
--- a/tests/ui/expr/if/if-else-chain-missing-else.rs
+++ b/tests/ui/expr/if/if-else-chain-missing-else.rs
@@ -1,0 +1,20 @@
+enum Cause { Cause1, Cause2 }
+struct MyErr { x: Cause }
+
+fn main() {
+    _ = f();
+}
+
+fn f() -> Result<i32, MyErr> {
+    let res = could_fail();
+    let x = if let Ok(x) = res {
+        x
+    } else if let Err(e) = res { //~ ERROR `if` and `else`
+        return Err(e);
+    };
+    Ok(x)
+}
+
+fn could_fail() -> Result<i32, MyErr> {
+    Ok(0)
+}

--- a/tests/ui/expr/if/if-else-chain-missing-else.stderr
+++ b/tests/ui/expr/if/if-else-chain-missing-else.stderr
@@ -1,0 +1,22 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/if-else-chain-missing-else.rs:12:12
+   |
+LL |        let x = if let Ok(x) = res {
+   |  ______________-
+LL | |          x
+   | |          - expected because of this
+LL | |      } else if let Err(e) = res {
+   | | ____________^
+LL | ||         return Err(e);
+LL | ||     };
+   | ||     ^
+   | ||_____|
+   |  |_____`if` and `else` have incompatible types
+   |        expected `i32`, found `()`
+   |
+   = note: `if` expressions without `else` evaluate to `()`
+   = note: consider adding an `else` block that evaluates to the expected type
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
```
error[E0308]: `if` and `else` have incompatible types
  --> $DIR/if-else-chain-missing-else.rs:12:12
   |
LL |        let x = if let Ok(x) = res {
   |  ______________-
LL | |          x
   | |          - expected because of this
LL | |      } else if let Err(e) = res {
   | | ____________^
LL | ||         return Err(e);
LL | ||     };
   | ||     ^
   | ||_____|
   |  |_____`if` and `else` have incompatible types
   |        expected `i32`, found `()`
   |
   = note: `if` expressions without `else` evaluate to `()`
   = note: consider adding an `else` block that evaluates to the expected type
```

We probably want a longer explanation and fewer spans on this case.

Partially address #133316.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
