### PR TITLE
ci: mirror ubuntu:22.04 to ghcr.io

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,57 @@
+# Mirror DockerHub images used by the Rust project to ghcr.io.
+# Images are available at https://github.com/orgs/rust-lang/packages.
+#
+# In some CI jobs, we pull images from ghcr.io instead of Docker Hub because
+# Docker Hub has a rate limit, while ghcr.io doesn't.
+# Those images are pushed to ghcr.io by this job.
+#
+# Note that authenticating to DockerHub or other registries isn't possible
+# for PR jobs, because forks can't access secrets.
+# That's why we use ghcr.io: it has no rate limit and it doesn't require authentication.
+
+name: GHCR
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run daily at midnight UTC
+    - cron: '0 0 * * *'
+
+jobs:
+  mirror:
+    name: DockerHub mirror
+    runs-on: ubuntu-24.04
+    if: github.repository == 'rust-lang/rust'
+    permissions:
+      # Needed to write to the ghcr.io registry
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+
+      # Download crane in the current directory.
+      # We use crane because it copies the docker image for all the architectures available in
+      # DockerHub for the image.
+      # Learn more about crane at
+      # https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md
+      - name: Download crane
+        run: |
+          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" | tar -xzf -
+        env:
+          VERSION: v0.20.2
+          OS: Linux
+          ARCH: x86_64
+
+      - name: Mirror DockerHub
+        run: |
+          # DockerHub image we want to mirror
+          image="ubuntu:22.04"
+
+          # Mirror image from DockerHub to ghcr.io
+          ./crane copy \
+            docker.io/${image} \
+            ghcr.io/${{ github.repository_owner }}/${image}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
This PR mirrors the `ubuntu:22.04` image from DockerHub to ghcr.io.
Tested [here](https://github.com/marcoieni/dockerhub-mirror/blob/9d6a2dc6639a0c82f339792e557ea44cf5e406dc/.github/workflows/ghcr.yml#L1). In my repository, I tried pushing the ubuntu 18.10 image, which you can see it was pushed [here](https://github.com/marcoieni/dockerhub-mirror/pkgs/container/ubuntu).

## Why is this needed
The PR job [mingw-check-tidy](https://github.com/rust-lang/rust/blob/2776bdfe423c9fdfcd6313d678f0852ea26f1309/src/ci/github-actions/jobs.yml#L96) always downloads the base layer from DockerHub, while the other jobs rely on the cache to download the base layer.

To avoid the risk of being rate limited by DockerHub, we want to download the base layer from ghcr.io, which doesn't have rate limits on pulls.

Agreed in [zulip](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Mirroring.20of.20Docker.20base.20images.20in.20ghcr.2Eio/near/493633733).

## Next steps

Once this workflow runs, we can edit the `mingw-check-tidy` [Dockerfile](https://github.com/rust-lang/rust/blob/master/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile) to use it.

Related to https://github.com/rust-lang/infra-team/issues/176



r? @Kobzol 
<!-- homu-ignore:end -->
