### PR TITLE
Add a deterministic constructor for `RandomState`

### DIFF
--- a/library/std/src/hash/random.rs
+++ b/library/std/src/hash/random.rs
@@ -75,6 +75,44 @@ impl RandomState {
             RandomState { k0, k1 }
         })
     }
+
+    /// Constructs a new `RandomState` that is initialized with fixed keys.
+    ///
+    /// There are no guarantees about the returned value other than it being
+    /// deterministic. The returned value may vary across releases.
+    ///
+    /// This constructor is meant for testing purposes, where it is important
+    /// that a program behaves deterministically in order to reproduce test
+    /// failures. Although it is possible to use other deterministic hashers,
+    /// there are libraries which have hash collections with `RandomState`
+    /// hardcoded in their public interface.
+    ///
+    /// # Examples
+    ///
+    /// Rerunning the following program always produces the same output, which
+    /// isn't the case if `s` is created with `RandomState::new`.
+    ///
+    /// ```
+    /// #![feature(deterministic_random_state)]
+    /// use std::collections::HashSet;
+    /// use std::hash::RandomState;
+    ///
+    /// let s = RandomState::deterministic();
+    /// let mut set = HashSet::with_hasher(s);
+    /// set.insert(0);
+    /// set.insert(1);
+    /// for v in set {
+    ///     println!("{v}");
+    /// }
+    /// ```
+    #[inline]
+    #[allow(deprecated)]
+    // rand
+    #[must_use]
+    #[unstable(feature = "deterministic_random_state", issue = "none")]
+    pub fn deterministic() -> RandomState {
+        RandomState { k0: 0, k1: 0 }
+    }
 }
 
 #[stable(feature = "hashmap_build_hasher", since = "1.7.0")]


### PR DESCRIPTION
`RandomState` is the default hasher for `std::collections::{HashMap, HashSet}`. Today, the only way to construct a `RandomState` is via `RandomState:new()`, which generates fresh random keys on every call. That's a good default for security, but it makes testing challenging, because test failures might not be reproducible due to nondeterministic behavior.

Although in principle it is possible to use other deterministic hashers, there are libraries which have hash collections with `RandomState` hardcoded in their public interface. For example, see [aws_sdk_dynamodb](https://docs.rs/aws-sdk-dynamodb/1.60.0/aws_sdk_dynamodb/operation/put_item/builders/struct.PutItemFluentBuilder.html#method.set_item) (and [this](https://github.com/smithy-lang/smithy-rs/issues/1795) discussion).

This change adds a new constructor for `RandomState` that returns a fixed value, which makes it possible for programs to behave deterministically even if they are locked in to `RandomState` for hashing.

ACP: https://github.com/rust-lang/libs-team/issues/523