### PR TITLE
proc-macro-srv: drop unnecessary usage of RTLD_DEEPBIND

### DIFF
--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/dylib.rs
@@ -12,15 +12,6 @@ use paths::{Utf8Path, Utf8PathBuf};
 use crate::{proc_macros::ProcMacros, server_impl::TopSubtree, ProcMacroKind, ProcMacroSrvSpan};
 
 /// Loads dynamic library in platform dependent manner.
-///
-/// For unix, you have to use RTLD_DEEPBIND flag to escape problems described
-/// [here](https://github.com/fedochet/rust-proc-macro-panic-inside-panic-expample)
-/// and [here](https://github.com/rust-lang/rust/issues/60593).
-///
-/// Usage of RTLD_DEEPBIND
-/// [here](https://github.com/fedochet/rust-proc-macro-panic-inside-panic-expample/issues/1)
-///
-/// It seems that on Windows that behaviour is default, so we do nothing in that case.
 #[cfg(windows)]
 fn load_library(file: &Utf8Path) -> Result<Library, libloading::Error> {
     unsafe { Library::new(file) }
@@ -29,12 +20,7 @@ fn load_library(file: &Utf8Path) -> Result<Library, libloading::Error> {
 #[cfg(unix)]
 fn load_library(file: &Utf8Path) -> Result<Library, libloading::Error> {
     use libloading::os::unix::Library as UnixLibrary;
-    use std::os::raw::c_int;
-
-    const RTLD_NOW: c_int = 0x00002;
-    const RTLD_DEEPBIND: c_int = 0x00008;
-
-    unsafe { UnixLibrary::open(Some(file), RTLD_NOW | RTLD_DEEPBIND).map(|lib| lib.into()) }
+    unsafe { UnixLibrary::open(Some(file), libloading::os::unix::RTLD_NOW).map(|lib| lib.into()) }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
the constant is wrong on some platforms (e.g., on mips64el it's 0x10, and 0x8 is RTLD_NOLOAD which makes all this functionality broken), and it is no longer needed because https://github.com/rust-lang/rust/issues/60593 got fixed by https://github.com/rust-lang/rust/pull/99944 in the meantime.