### PR TITLE
Add license-metadata.json to rustc-src tarball.

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1001,6 +1001,7 @@ impl Step for PlainSourceTarball {
             "README.md",
             "RELEASES.md",
             "REUSE.toml",
+            "license-metadata.json",
             "configure",
             "x.py",
             "config.example.toml",


### PR DESCRIPTION
Adds a license-metadata.json to the source tarball.

This file was reported as missing as a comment on #133461, and it prevents you building the compiler from the source tarball (unless you re-generate it yourself, which is non-obvious and requires `reuse` to be installed).

r? Kobzol