### PR TITLE
proc-macro-srv: make usage of RTLD_DEEPBIND portable

### DIFF
--- a/src/tools/rust-analyzer/Cargo.lock
+++ b/src/tools/rust-analyzer/Cargo.lock
@@ -1371,6 +1371,7 @@ version = "0.0.0"
 dependencies = [
  "expect-test",
  "intern",
+ "libc",
  "libloading",
  "memmap2",
  "object 0.33.0",

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/Cargo.toml
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 
 [dependencies]
 object.workspace = true
+libc.workspace = true
 libloading.workspace = true
 memmap2.workspace = true
 


### PR DESCRIPTION
the constant is wrong on some platforms (e.g., on mips64el it's 0x10, and 0x8 is RTLD_NOLOAD which makes all this functionality broken), the libc crate takes care of those differences for us.

fallback to old hard-coded value for non-glibc environments (which might or might not have RTLD_DEEPBIND support).