### PR TITLE
fix error for when results in a rustdoc-js test are in the wrong order

### DIFF
--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -256,7 +256,7 @@ async function runSearch(query, expected, doSearch, loadedFile, queryName) {
                                 JSON.stringify(results[key][index]) + "'");
             } else if (ignore_order === false && entry_pos < prev_pos) {
                 error_text.push(queryName + "==> '" + JSON.stringify(elem) + "' was supposed " +
-                                "to be before '" + JSON.stringify(results[key][entry_pos]) + "'");
+                                "to be before '" + JSON.stringify(results[key][prev_pos]) + "'");
             } else {
                 prev_pos = entry_pos;
             }


### PR DESCRIPTION
see https://github.com/rust-lang/rust/pull/131806#issuecomment-2596305614

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
