### PR TITLE
Properly note when query stack is being cut off

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1530,9 +1530,9 @@ fn report_ice(
     // If backtraces are enabled, also print the query stack
     let backtrace = env::var_os("RUST_BACKTRACE").is_some_and(|x| &x != "0");
 
-    let num_frames = if backtrace { None } else { Some(2) };
+    let limit_frames = if backtrace { None } else { Some(2) };
 
-    interface::try_print_query_stack(dcx, num_frames, file);
+    interface::try_print_query_stack(dcx, limit_frames, file);
 
     // We don't trust this callback not to panic itself, so run it at the end after we're sure we've
     // printed all the relevant info.

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -567,7 +567,7 @@ pub fn print_query_stack<Qcx: QueryContext>(
     qcx: Qcx,
     mut current_query: Option<QueryJobId>,
     dcx: DiagCtxtHandle<'_>,
-    num_frames: Option<usize>,
+    limit_frames: Option<usize>,
     mut file: Option<std::fs::File>,
 ) -> usize {
     // Be careful relying on global state here: this code is called from
@@ -584,7 +584,7 @@ pub fn print_query_stack<Qcx: QueryContext>(
         let Some(query_info) = query_map.get(&query) else {
             break;
         };
-        if Some(count_printed) < num_frames || num_frames.is_none() {
+        if Some(count_printed) < limit_frames || limit_frames.is_none() {
             // Only print to stderr as many stack frames as `num_frames` when present.
             // FIXME: needs translation
             #[allow(rustc::diagnostic_outside_of_impl)]
@@ -615,5 +615,5 @@ pub fn print_query_stack<Qcx: QueryContext>(
     if let Some(ref mut file) = file {
         let _ = writeln!(file, "end of query stack");
     }
-    count_printed
+    count_total
 }

--- a/tests/ui/const-generics/generic_const_exprs/issue-80742.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-80742.stderr
@@ -6,6 +6,6 @@ Box<dyn Any>
 query stack during panic:
 #0 [eval_to_allocation_raw] const-evaluating + checking `<impl at $DIR/issue-80742.rs:26:1: 28:32>::{constant#0}`
 #1 [eval_to_valtree] evaluating type-level constant
-end of query stack
+... and 2 other queries... use `env RUST_BACKTRACE=1` to see the full query stack
 error: aborting due to 1 previous error
 

--- a/tests/ui/layout/valid_range_oob.stderr
+++ b/tests/ui/layout/valid_range_oob.stderr
@@ -5,4 +5,4 @@ error: the compiler unexpectedly panicked. this is a bug.
 query stack during panic:
 #0 [layout_of] computing layout of `Foo`
 #1 [eval_to_allocation_raw] const-evaluating + checking `FOO`
-end of query stack
+... and 2 other queries... use `env RUST_BACKTRACE=1` to see the full query stack

--- a/tests/ui/resolve/multiple_definitions_attribute_merging.stderr
+++ b/tests/ui/resolve/multiple_definitions_attribute_merging.stderr
@@ -21,7 +21,7 @@ Box<dyn Any>
 query stack during panic:
 #0 [mir_built] building MIR for `<impl at $DIR/multiple_definitions_attribute_merging.rs:15:10: 15:19>::eq`
 #1 [check_unsafety] unsafety-checking `<impl at $DIR/multiple_definitions_attribute_merging.rs:15:10: 15:19>::eq`
-end of query stack
+... and 1 other queries... use `env RUST_BACKTRACE=1` to see the full query stack
 error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0428`.

--- a/tests/ui/resolve/proc_macro_generated_packed.stderr
+++ b/tests/ui/resolve/proc_macro_generated_packed.stderr
@@ -12,6 +12,6 @@ Box<dyn Any>
 query stack during panic:
 #0 [mir_built] building MIR for `<impl at $DIR/proc_macro_generated_packed.rs:15:10: 15:19>::eq`
 #1 [check_unsafety] unsafety-checking `<impl at $DIR/proc_macro_generated_packed.rs:15:10: 15:19>::eq`
-end of query stack
+... and 1 other queries... use `env RUST_BACKTRACE=1` to see the full query stack
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
cc #70953

also, i'm not certain whether we should even limit this at all. i don't see the problem with printing the full query stack, apparently it was limited b/c we used to ICE? but we're already printing the full stack to disk since #108714.

r? oli-obk