### PR TITLE
Expand docs for `E0207` with additional example

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0207.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0207.md
@@ -195,6 +195,30 @@ impl<'a> Contains for Foo {
 Please note that unconstrained lifetime parameters are not supported if they are
 being used by an associated type.
 
+In cases where the associated type's lifetime is meant to be tied to the the
+self type, and none of the methods on the trait need ownership or different
+mutability, then an option is to implement the trait on a borrowed type:
+
+```rust
+struct Foo(i32);
+
+trait Contents {
+    type Item;
+
+    fn get(&self) -> Self::Item;
+}
+
+// Note the lifetime `'a` is used both for the self type...
+impl<'a> Contents for &'a Foo {
+    // ...and the associated type.
+    type Item = &'a i32;
+
+    fn get(&self) -> Self::Item {
+        &self.0
+    }
+}
+```
+
 ### Additional information
 
 For more information, please see [RFC 447].


### PR DESCRIPTION
Add an example to E0207 docs showing how to tie the lifetime of the self type to an associated type in an impl when the trait *doesn't* have a lifetime to begin with.

CC #135589.