### PR TITLE
bootstrap: still require `COMPILETEST_FORCE_STAGE0` for `./x test rustdoc-js --stage 0`

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1638,10 +1638,7 @@ impl Step for Compiletest {
             return;
         }
 
-        if builder.top_stage == 0
-            && env::var("COMPILETEST_FORCE_STAGE0").is_err()
-            && self.mode != "js-doc-test"
-        {
+        if builder.top_stage == 0 && env::var("COMPILETEST_FORCE_STAGE0").is_err() {
             eprintln!("\
 ERROR: `--stage 0` runs compiletest on the beta compiler, not your local changes, and will almost always cause tests to fail
 HELP: to test the compiler, use `--stage 1` instead


### PR DESCRIPTION
This PR reverts #135375, because through some more testing I found out `./x test rustdoc-js --stage 0` does not in fact build rustdoc, and all the tests fail. This can't be intended behavior, so at least require `COMPILETEST_FORCE_STAGE0` to make it less likely to run `rustdoc-js --stage 0` by accident.

The problem that `--stage 0` is not working at all for this rustdoc-js test suite is tracked over at #135603.

cc @lolbinarycat 

r? bootstrap