### PR TITLE
Emit fewer `assume`s now that we have `range` metadata on parameters

### DIFF
--- a/tests/codegen/cast-optimized.rs
+++ b/tests/codegen/cast-optimized.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -O -Z merge-functions=disabled
+//@ min-llvm-version: 19 (these optimizations depend on range parameter metadata)
 #![crate_type = "lib"]
 
 // This tests that LLVM can optimize based on the niches in the source or

--- a/tests/codegen/intrinsics/transmute-niched.rs
+++ b/tests/codegen/intrinsics/transmute-niched.rs
@@ -20,9 +20,8 @@ pub enum SmallEnum {
 pub unsafe fn check_to_enum(x: i8) -> SmallEnum {
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
-    // OPT: %0 = icmp uge i8 %x, 10
-    // OPT: call void @llvm.assume(i1 %0)
-    // OPT: %1 = icmp ule i8 %x, 12
+    // OPT: %0 = sub i8 %x, 10
+    // OPT: %1 = icmp ule i8 %0, 2
     // OPT: call void @llvm.assume(i1 %1)
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
@@ -47,10 +46,9 @@ pub unsafe fn check_from_enum(x: SmallEnum) -> i8 {
 pub unsafe fn check_to_ordering(x: u8) -> std::cmp::Ordering {
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
-    // OPT: %0 = icmp uge i8 %x, -1
-    // OPT: %1 = icmp ule i8 %x, 1
-    // OPT: %2 = or i1 %0, %1
-    // OPT: call void @llvm.assume(i1 %2)
+    // OPT: %0 = sub i8 %x, -1
+    // OPT: %1 = icmp ule i8 %0, 2
+    // OPT: call void @llvm.assume(i1 %1)
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
     // CHECK: ret i8 %x
@@ -100,10 +98,9 @@ pub enum Minus100ToPlus100 {
 pub unsafe fn check_enum_from_char(x: char) -> Minus100ToPlus100 {
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
-    // OPT: %0 = icmp uge i32 %x, -100
-    // OPT: %1 = icmp ule i32 %x, 100
-    // OPT: %2 = or i1 %0, %1
-    // OPT: call void @llvm.assume(i1 %2)
+    // OPT: %0 = sub i32 %x, -100
+    // OPT: %1 = icmp ule i32 %0, 200
+    // OPT: call void @llvm.assume(i1 %1)
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
     // CHECK: ret i32 %x
@@ -133,10 +130,11 @@ pub unsafe fn check_enum_to_char(x: Minus100ToPlus100) -> char {
 pub unsafe fn check_swap_pair(x: (char, NonZero<u32>)) -> (NonZero<u32>, char) {
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
-    // OPT: %0 = icmp uge i32 %x.0, 1
-    // OPT: call void @llvm.assume(i1 %0)
-    // OPT: %1 = icmp ule i32 %x.1, 1114111
+    // OPT: %0 = sub i32 %x.0, 1
+    // OPT: %1 = icmp ule i32 %0, -2
     // OPT: call void @llvm.assume(i1 %1)
+    // OPT: %2 = icmp ule i32 %x.1, 1114111
+    // OPT: call void @llvm.assume(i1 %2)
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
     // CHECK: %[[P1:.+]] = insertvalue { i32, i32 } poison, i32 %x.0, 0
@@ -169,10 +167,9 @@ pub unsafe fn check_bool_to_ordering(x: bool) -> std::cmp::Ordering {
     // CHECK: %_0 = zext i1 %x to i8
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
-    // OPT: %0 = icmp uge i8 %_0, -1
-    // OPT: %1 = icmp ule i8 %_0, 1
-    // OPT: %2 = or i1 %0, %1
-    // OPT: call void @llvm.assume(i1 %2)
+    // OPT: %0 = sub i8 %_0, -1
+    // OPT: %1 = icmp ule i8 %0, 2
+    // OPT: call void @llvm.assume(i1 %1)
     // CHECK-NOT: icmp
     // CHECK-NOT: assume
     // CHECK: ret i8 %_0

--- a/tests/codegen/intrinsics/transmute-niched.rs
+++ b/tests/codegen/intrinsics/transmute-niched.rs
@@ -1,5 +1,6 @@
 //@ revisions: OPT DBG
 //@ [OPT] compile-flags: -C opt-level=3 -C no-prepopulate-passes
+//@ [OPT] min-llvm-version: 19 (for range parameter metadata)
 //@ [DBG] compile-flags: -C opt-level=0 -C no-prepopulate-passes
 //@ only-64bit (so I don't need to worry about usize)
 #![crate_type = "lib"]
@@ -17,26 +18,25 @@ pub enum SmallEnum {
 // CHECK-LABEL: @check_to_enum(
 #[no_mangle]
 pub unsafe fn check_to_enum(x: i8) -> SmallEnum {
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // OPT: %0 = icmp uge i8 %x, 10
     // OPT: call void @llvm.assume(i1 %0)
     // OPT: %1 = icmp ule i8 %x, 12
     // OPT: call void @llvm.assume(i1 %1)
-    // DBG-NOT: icmp
-    // DBG-NOT: assume
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // CHECK: ret i8 %x
 
     transmute(x)
 }
 
 // CHECK-LABEL: @check_from_enum(
+// OPT-SAME: range(i8 10, 13){{.+}}%x
 #[no_mangle]
 pub unsafe fn check_from_enum(x: SmallEnum) -> i8 {
-    // OPT: %0 = icmp uge i8 %x, 10
-    // OPT: call void @llvm.assume(i1 %0)
-    // OPT: %1 = icmp ule i8 %x, 12
-    // OPT: call void @llvm.assume(i1 %1)
-    // DBG-NOT: icmp
-    // DBG-NOT: assume
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // CHECK: ret i8 %x
 
     transmute(x)
@@ -45,26 +45,25 @@ pub unsafe fn check_from_enum(x: SmallEnum) -> i8 {
 // CHECK-LABEL: @check_to_ordering(
 #[no_mangle]
 pub unsafe fn check_to_ordering(x: u8) -> std::cmp::Ordering {
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // OPT: %0 = icmp uge i8 %x, -1
     // OPT: %1 = icmp ule i8 %x, 1
     // OPT: %2 = or i1 %0, %1
     // OPT: call void @llvm.assume(i1 %2)
-    // DBG-NOT: icmp
-    // DBG-NOT: assume
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // CHECK: ret i8 %x
 
     transmute(x)
 }
 
 // CHECK-LABEL: @check_from_ordering(
+// OPT-SAME: range(i8 -1, 2){{.+}}%x
 #[no_mangle]
 pub unsafe fn check_from_ordering(x: std::cmp::Ordering) -> u8 {
-    // OPT: %0 = icmp uge i8 %x, -1
-    // OPT: %1 = icmp ule i8 %x, 1
-    // OPT: %2 = or i1 %0, %1
-    // OPT: call void @llvm.assume(i1 %2)
-    // DBG-NOT: icmp
-    // DBG-NOT: assume
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // CHECK: ret i8 %x
 
     transmute(x)
@@ -96,50 +95,50 @@ pub enum Minus100ToPlus100 {
 }
 
 // CHECK-LABEL: @check_enum_from_char(
+// OPT-SAME: range(i32 0, 1114112){{.+}}%x
 #[no_mangle]
 pub unsafe fn check_enum_from_char(x: char) -> Minus100ToPlus100 {
-    // OPT: %0 = icmp ule i32 %x, 1114111
-    // OPT: call void @llvm.assume(i1 %0)
-    // OPT: %1 = icmp uge i32 %x, -100
-    // OPT: %2 = icmp ule i32 %x, 100
-    // OPT: %3 = or i1 %1, %2
-    // OPT: call void @llvm.assume(i1 %3)
-    // DBG-NOT: icmp
-    // DBG-NOT: assume
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
+    // OPT: %0 = icmp uge i32 %x, -100
+    // OPT: %1 = icmp ule i32 %x, 100
+    // OPT: %2 = or i1 %0, %1
+    // OPT: call void @llvm.assume(i1 %2)
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // CHECK: ret i32 %x
 
     transmute(x)
 }
 
 // CHECK-LABEL: @check_enum_to_char(
+// OPT-SAME: range(i32 -100, 101){{.+}}%x
 #[no_mangle]
 pub unsafe fn check_enum_to_char(x: Minus100ToPlus100) -> char {
-    // OPT: %0 = icmp uge i32 %x, -100
-    // OPT: %1 = icmp ule i32 %x, 100
-    // OPT: %2 = or i1 %0, %1
-    // OPT: call void @llvm.assume(i1 %2)
-    // OPT: %3 = icmp ule i32 %x, 1114111
-    // OPT: call void @llvm.assume(i1 %3)
-    // DBG-NOT: icmp
-    // DBG-NOT: assume
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
+    // OPT: %0 = icmp ule i32 %x, 1114111
+    // OPT: call void @llvm.assume(i1 %0)
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // CHECK: ret i32 %x
 
     transmute(x)
 }
 
 // CHECK-LABEL: @check_swap_pair(
+// OPT-SAME: range(i32 0, 1114112){{.+}}%x.0
+// OPT-SAME: range(i32 1, 0){{.+}}%x.1
 #[no_mangle]
 pub unsafe fn check_swap_pair(x: (char, NonZero<u32>)) -> (NonZero<u32>, char) {
-    // OPT: %0 = icmp ule i32 %x.0, 1114111
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
+    // OPT: %0 = icmp uge i32 %x.0, 1
     // OPT: call void @llvm.assume(i1 %0)
-    // OPT: %1 = icmp uge i32 %x.0, 1
+    // OPT: %1 = icmp ule i32 %x.1, 1114111
     // OPT: call void @llvm.assume(i1 %1)
-    // OPT: %2 = icmp uge i32 %x.1, 1
-    // OPT: call void @llvm.assume(i1 %2)
-    // OPT: %3 = icmp ule i32 %x.1, 1114111
-    // OPT: call void @llvm.assume(i1 %3)
-    // DBG-NOT: icmp
-    // DBG-NOT: assume
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // CHECK: %[[P1:.+]] = insertvalue { i32, i32 } poison, i32 %x.0, 0
     // CHECK: %[[P2:.+]] = insertvalue { i32, i32 } %[[P1]], i32 %x.1, 1
     // CHECK: ret { i32, i32 } %[[P2]]
@@ -148,16 +147,15 @@ pub unsafe fn check_swap_pair(x: (char, NonZero<u32>)) -> (NonZero<u32>, char) {
 }
 
 // CHECK-LABEL: @check_bool_from_ordering(
+// OPT-SAME: range(i8 -1, 2){{.+}}%x
 #[no_mangle]
 pub unsafe fn check_bool_from_ordering(x: std::cmp::Ordering) -> bool {
-    // OPT: %0 = icmp uge i8 %x, -1
-    // OPT: %1 = icmp ule i8 %x, 1
-    // OPT: %2 = or i1 %0, %1
-    // OPT: call void @llvm.assume(i1 %2)
-    // OPT: %3 = icmp ule i8 %x, 1
-    // OPT: call void @llvm.assume(i1 %3)
-    // DBG-NOT: icmp
-    // DBG-NOT: assume
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
+    // OPT: %0 = icmp ule i8 %x, 1
+    // OPT: call void @llvm.assume(i1 %0)
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // CHECK: %[[R:.+]] = trunc i8 %x to i1
     // CHECK: ret i1 %[[R]]
 
@@ -165,17 +163,18 @@ pub unsafe fn check_bool_from_ordering(x: std::cmp::Ordering) -> bool {
 }
 
 // CHECK-LABEL: @check_bool_to_ordering(
+// OPT-SAME: i1 {{.+}} %x
 #[no_mangle]
 pub unsafe fn check_bool_to_ordering(x: bool) -> std::cmp::Ordering {
     // CHECK: %_0 = zext i1 %x to i8
-    // OPT: %0 = icmp ule i8 %_0, 1
-    // OPT: call void @llvm.assume(i1 %0)
-    // OPT: %1 = icmp uge i8 %_0, -1
-    // OPT: %2 = icmp ule i8 %_0, 1
-    // OPT: %3 = or i1 %1, %2
-    // OPT: call void @llvm.assume(i1 %3)
-    // DBG-NOT: icmp
-    // DBG-NOT: assume
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
+    // OPT: %0 = icmp uge i8 %_0, -1
+    // OPT: %1 = icmp ule i8 %_0, 1
+    // OPT: %2 = or i1 %0, %1
+    // OPT: call void @llvm.assume(i1 %2)
+    // CHECK-NOT: icmp
+    // CHECK-NOT: assume
     // CHECK: ret i8 %_0
 
     transmute(x)

--- a/tests/codegen/issues/issue-119422.rs
+++ b/tests/codegen/issues/issue-119422.rs
@@ -2,6 +2,7 @@
 //! for `NonZero` integer types.
 //!
 //@ compile-flags: -O --edition=2021 -Zmerge-functions=disabled
+//@ min-llvm-version: 19 (for range parameter metadata)
 //@ only-64bit (because the LLVM type of i64 for usize shows up)
 #![crate_type = "lib"]
 

--- a/tests/codegen/transmute-optimized.rs
+++ b/tests/codegen/transmute-optimized.rs
@@ -94,15 +94,10 @@ pub enum OneTwoThree {
 // CHECK-SAME: range(i8 -1, 2){{.+}}%x
 #[no_mangle]
 pub unsafe fn ordering_transmute_onetwothree(x: std::cmp::Ordering) -> OneTwoThree {
-    // FIXME: this *should* just be `ret i8 1`, but that's not happening today.
-    // cc <https://github.com/llvm/llvm-project/issues/123278>
-
-    // CHECK: %[[TEMP1:.+]] = icmp ne i8 %x, 0
-    // CHECK: tail call void @llvm.assume(i1 %[[TEMP1]])
-    // CHECK: %[[TEMP2:.+]] = icmp ult i8 %x, 4
+    // CHECK: %[[TEMP1:.+]] = add nsw i8 %x, -1
+    // CHECK: %[[TEMP2:.+]] = icmp ult i8 %[[TEMP1]], 3
     // CHECK: tail call void @llvm.assume(i1 %[[TEMP2]])
-
-    // CHECK: ret i8 %x
+    // CHECK: ret i8 1
     std::mem::transmute(x)
 }
 

--- a/tests/codegen/vec-in-place.rs
+++ b/tests/codegen/vec-in-place.rs
@@ -41,18 +41,12 @@ pub fn vec_iterator_cast_primitive(vec: Vec<i8>) -> Vec<u8> {
     // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
     // CHECK-NOT: loop
     // CHECK-NOT: call
-    // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
-    // CHECK-NOT: loop
-    // CHECK-NOT: call
     vec.into_iter().map(|e| e as u8).collect()
 }
 
 // CHECK-LABEL: @vec_iterator_cast_wrapper
 #[no_mangle]
 pub fn vec_iterator_cast_wrapper(vec: Vec<u8>) -> Vec<Wrapper<u8>> {
-    // CHECK-NOT: loop
-    // CHECK-NOT: call
-    // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
     // CHECK-NOT: loop
     // CHECK-NOT: call
     // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
@@ -86,18 +80,12 @@ pub fn vec_iterator_cast_unwrap(vec: Vec<Wrapper<u8>>) -> Vec<u8> {
     // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
     // CHECK-NOT: loop
     // CHECK-NOT: call
-    // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
-    // CHECK-NOT: loop
-    // CHECK-NOT: call
     vec.into_iter().map(|e| e.0).collect()
 }
 
 // CHECK-LABEL: @vec_iterator_cast_aggregate
 #[no_mangle]
 pub fn vec_iterator_cast_aggregate(vec: Vec<[u64; 4]>) -> Vec<Foo> {
-    // CHECK-NOT: loop
-    // CHECK-NOT: call
-    // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
     // CHECK-NOT: loop
     // CHECK-NOT: call
     // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
@@ -114,9 +102,6 @@ pub fn vec_iterator_cast_deaggregate_tra(vec: Vec<Bar>) -> Vec<[u64; 4]> {
     // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
     // CHECK-NOT: loop
     // CHECK-NOT: call
-    // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
-    // CHECK-NOT: loop
-    // CHECK-NOT: call
 
     // Safety: For the purpose of this test we assume that Bar layout matches [u64; 4].
     // This currently is not guaranteed for repr(Rust) types, but it happens to work here and
@@ -128,9 +113,6 @@ pub fn vec_iterator_cast_deaggregate_tra(vec: Vec<Bar>) -> Vec<[u64; 4]> {
 // CHECK-LABEL: @vec_iterator_cast_deaggregate_fold
 #[no_mangle]
 pub fn vec_iterator_cast_deaggregate_fold(vec: Vec<Baz>) -> Vec<[u64; 4]> {
-    // CHECK-NOT: loop
-    // CHECK-NOT: call
-    // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
     // CHECK-NOT: loop
     // CHECK-NOT: call
     // CHECK: call{{.+}}void @llvm.assume(i1 %{{.+}})
@@ -156,12 +138,6 @@ pub fn vec_iterator_cast_unwrap_drop(vec: Vec<Wrapper<String>>) -> Vec<String> {
     // CHECK-NOT: call
     // CHECK-NOT: %{{.*}} = mul
     // CHECK-NOT: %{{.*}} = udiv
-    // CHECK: call
-    // CHECK-SAME: void @llvm.assume(i1 %{{.+}})
-    // CHECK-NOT: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}
-    // CHECK-NOT: call
-    // CHECK-NOT: %{{.*}} = mul
-    // CHECK-NOT: %{{.*}} = udiv
 
     vec.into_iter().map(|Wrapper(e)| e).collect()
 }
@@ -170,12 +146,6 @@ pub fn vec_iterator_cast_unwrap_drop(vec: Vec<Wrapper<String>>) -> Vec<String> {
 #[no_mangle]
 pub fn vec_iterator_cast_wrap_drop(vec: Vec<String>) -> Vec<Wrapper<String>> {
     // CHECK-NOT: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}
-    // CHECK-NOT: %{{.*}} = mul
-    // CHECK-NOT: %{{.*}} = udiv
-    // CHECK: call
-    // CHECK-SAME: void @llvm.assume(i1 %{{.+}})
-    // CHECK-NOT: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}
-    // CHECK-NOT: call
     // CHECK-NOT: %{{.*}} = mul
     // CHECK-NOT: %{{.*}} = udiv
     // CHECK: call


### PR DESCRIPTION
We still need the `assume` for the *target* type's range, but we no longer need it for the *source* type's range.

The first stab at this regressed a test, but thanks to good advice in https://github.com/llvm/llvm-project/issues/123278#issuecomment-2597440158 the second commit here changes how we emit these range assertions to the form that LLVM apparently likes better (and, conveniently, is easier to emit too) which got that test passing again 🎉 

Hopefully this means less crud for LLVM to churn through in `opt` builds...
