### PR TITLE
CI: split i686-msvc job to two free runners

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -97,6 +97,11 @@ tidy:
 prepare:
 	$(Q)$(BOOTSTRAP) build --stage 2 --dry-run
 
+# Set of tests that represent around half of the time of the test suite.
+# Used to split tests across multiple CI runners.
+STAGE_2_TEST_SET1 := test --stage 2 --skip=compiler --skip=src
+STAGE_2_TEST_SET2 := test --stage 2 --skip=tests --skip=coverage-map --skip=coverage-run --skip=library --skip=tidyselftest
+
 ## MSVC native builders
 
 # this intentionally doesn't use `$(BOOTSTRAP)` so we can test the shebang on Windows
@@ -105,6 +110,10 @@ ci-msvc-py:
 ci-msvc-ps1:
 	$(Q)$(CFG_SRC_DIR)/x.ps1 test --stage 2 --skip tidy
 ci-msvc: ci-msvc-py ci-msvc-ps1
+ci-msvc-py-set1:
+	$(Q)$(CFG_SRC_DIR)/x.py $(STAGE_2_TEST_SET1)
+ci-msvc-ps1-set2:
+	$(Q)$(CFG_SRC_DIR)/x.ps1 $(STAGE_2_TEST_SET2)
 
 ## MingW native builders
 
@@ -112,9 +121,9 @@ ci-msvc: ci-msvc-py ci-msvc-ps1
 # Used to split tests across multiple CI runners.
 # Test both x and bootstrap entrypoints.
 ci-mingw-x:
-	$(Q)$(CFG_SRC_DIR)/x test --stage 2 --skip=compiler --skip=src
+	$(Q)$(CFG_SRC_DIR)/x $(STAGE_2_TEST_SET1)
 ci-mingw-bootstrap:
-	$(Q)$(BOOTSTRAP) test --stage 2 --skip=tests --skip=coverage-map --skip=coverage-run --skip=library --skip=tidyselftest
+	$(Q)$(BOOTSTRAP) $(STAGE_2_TEST_SET2)
 ci-mingw: ci-mingw-x ci-mingw-bootstrap
 
 .PHONY: dist

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -448,11 +448,18 @@ auto:
       SCRIPT: make ci-msvc
     <<: *job-windows-8c
 
-  - name: i686-msvc
+  # i686-msvc is split into two jobs to run tests in parallel.
+  - name: i686-msvc-1
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
-      SCRIPT: make ci-msvc
-    <<: *job-windows-8c
+      SCRIPT: make ci-msvc-py-set1
+    <<: *job-windows
+
+  - name: i686-msvc-2
+    env:
+      RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
+      SCRIPT: make ci-msvc-ps1-set2
+    <<: *job-windows
 
   # x86_64-msvc-ext is split into multiple jobs to run tests in parallel.
   - name: x86_64-msvc-ext1


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Split the i686-msvc job in two to move it to free runners and reduce the use of large runners in CI. Related to https://github.com/rust-lang/infra-team/issues/189

This PR is similar to https://github.com/rust-lang/rust/pull/133632 however the job `i686-msvc` fails less often than `x86_64-msvc` in CI, so it can be split more safely.

In the last month, this job failed only 3 times:

![image](https://github.com/user-attachments/assets/bfdcad17-32c5-4ece-aafd-a4461b3f85a7)

Datadog [link](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40git.branch%3Aauto%20%40ci.job.name%3A%22auto%20-%20i686-msvc%22%20%40ci.status%3Aerror&agg_m=%40duration&agg_m_source=base&agg_t=avg&colorBy=meta%5B%27ci.job.name%27%5D&colorByAttr=meta%5B%27ci.job.name%27%5D&currentTab=trace&fromUser=false&graphType=flamegraph&index=cipipeline&spanID=16171819458268483629&spanViewType=logs&viz=stream&start=1734279334301&end=1736871334301&paused=false) for the infra team.

r? @Kobzol 

I opened this PR after https://github.com/rust-lang/rust/pull/135483 was closed by mistake.
<!-- homu-ignore:end -->
try-job: i686-msvc-1
try-job: i686-msvc-2
