### PR TITLE
ci: use ghcr ubuntu image for mingw-check-tidy

### DIFF
--- a/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:22.04
+# We use the ghcr base image because ghcr doesn't have a rate limit
+# and the mingw-check-tidy job doesn't cache docker images in CI.
+FROM ghcr.io/rust-lang/ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
https://github.com/rust-lang/rust/pull/135574 mirrored ubuntu into ghcr.io.
This edits the mingw-check-tidy job to use it.
We only edit this job because it is the only one without caching.

r? @Kobzol 
<!-- homu-ignore:end -->
