### PR TITLE
ci: mirror buildkit image to ghcr

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -48,10 +48,21 @@ jobs:
 
       - name: Mirror DockerHub
         run: |
-          # DockerHub image we want to mirror
-          image="ubuntu:22.04"
+          # List of DockerHub images to mirror to ghcr.io
+          images=(
+            # Mirrored because used by the mingw-check-tidy, which doesn't cache Docker images
+            "ubuntu:22.04"
+            # Mirrored because used by all linux CI jobs, including mingw-check-tidy
+            "moby/buildkit:buildx-stable-1"
+          )
 
-          # Mirror image from DockerHub to ghcr.io
-          ./crane copy \
-            docker.io/${image} \
-            ghcr.io/${{ github.repository_owner }}/${image}
+          # Mirror each image from DockerHub to ghcr.io
+          for img in "${images[@]}"; do
+            echo "Mirroring ${img}..."
+            # Remove namespace from the image if any.
+            # E.g. "moby/buildkit:buildx-stable-1" becomes "buildkit:buildx-stable-1"
+            dest_image=$(echo "${img}" | cut -d'/' -f2-)
+            ./crane copy \
+              "docker.io/${img}" \
+              "ghcr.io/${{ github.repository_owner }}/${dest_image}"
+          done


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Thanks to https://github.com/rust-lang/rust/pull/135574 we successfully mirrored the `ubuntu:22.04` image in ghcr to allow `mingw-check-tidy` working without Docker caching.
However, I found out that all CI jobs pull an additional image from the dockerhub, i.e. `moby/buildkit:buildx-stable-1`.

You can see this from the logs of the `mingw-check-tidy` job:

```
25-01-17T10:47:34.9901947Z Attempting with retry: docker buildx build --rm -t rust-ci -f /home/runner/work/rust/rust/src/ci/docker/host-x86_64/mingw-check-tidy/Dockerfile /home/runner/work/rust/rust/src/ci/docker --cache-from type=registry,ref=ghcr.io/rust-lang-ci/rust-ci-cache:818dbd7e9bcfe13d21021d72c9ea5568237eba7e220c64f0f20a1459383140536afa115373590ba6fa2de3836339f2f0e1e169134fe8d9246583741aefa19c77 --output=type=docker
2025-01-17T10:47:35.0373736Z #0 building with "quirky_keldysh" instance using docker-container driver
2025-01-17T10:47:35.0374273Z 
2025-01-17T10:47:35.0374662Z #1 [internal] booting buildkit
2025-01-17T10:47:35.1881201Z #1 pulling image moby/buildkit:buildx-stable-1
2025-01-17T10:47:37.1338973Z #1 pulling image moby/buildkit:buildx-stable-1 2.1s done
2025-01-17T10:47:37.2842181Z #1 creating container buildx_buildkit_quirky_keldysh0
2025-01-17T10:47:37.4417076Z #1 creating container buildx_buildkit_quirky_keldysh0 0.3s done
```

I saw jobs failing in https://github.com/rust-lang/rust/pull/133912 because they failed to pull this image for the dockerhub rate limit.

So this PR mirrors this additional image in ghcr 👍

To use it, we need to add the flag `--driver-opt image=ghcr.io/marcoieni/buildkit:buildx-stable-1` to `docker buildx create --use --driver docker-container` (I tested this in https://github.com/rust-lang/rust/pull/133912).

If you think this bash script is becoming too complex, I can rewrite the script in python as I did in https://github.com/rust-lang/rust/pull/135530

r? @Kobzol 
<!-- homu-ignore:end -->
