### PR TITLE
add more `s390x` target features

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -611,7 +611,26 @@ static LOONGARCH_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
 const IBMZ_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start
     ("backchain", Unstable(sym::s390x_target_feature), &[]),
+    ("deflate-conversion", Unstable(sym::s390x_target_feature), &[]),
+    ("enhanced-sort", Unstable(sym::s390x_target_feature), &[]),
+    ("guarded-storage", Unstable(sym::s390x_target_feature), &[]),
+    ("high-word", Unstable(sym::s390x_target_feature), &[]),
+    ("nnp-assist", Unstable(sym::s390x_target_feature), &["vector"]),
+    ("transactional-execution", Unstable(sym::s390x_target_feature), &[]),
     ("vector", Unstable(sym::s390x_target_feature), &[]),
+    ("vector-enhancements-1", Unstable(sym::s390x_target_feature), &["vector"]),
+    ("vector-enhancements-2", Unstable(sym::s390x_target_feature), &["vector-enhancements-1"]),
+    ("vector-packed-decimal", Unstable(sym::s390x_target_feature), &["vector"]),
+    (
+        "vector-packed-decimal-enhancement",
+        Unstable(sym::s390x_target_feature),
+        &["vector-packed-decimal"],
+    ),
+    (
+        "vector-packed-decimal-enhancement-2",
+        Unstable(sym::s390x_target_feature),
+        &["vector-packed-decimal-enhancement"],
+    ),
     // tidy-alphabetical-end
 ];
 
@@ -768,7 +787,7 @@ impl Target {
     /// the first list contains target features that must be enabled for ABI reasons,
     /// and the second list contains target feature that must be disabled for ABI reasons.
     ///
-    /// These features are automatically appended to whatever the target spec sats as default
+    /// These features are automatically appended to whatever the target spec sets as default
     /// features for the target.
     ///
     /// All features enabled/disabled via `-Ctarget-features` and `#[target_features]` are checked

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -58,6 +58,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `cssc`
 `d`
 `d32`
+`deflate-conversion`
 `dit`
 `doloop`
 `dotprod`
@@ -72,6 +73,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `ecv`
 `edsp`
 `elrw`
+`enhanced-sort`
 `ermsb`
 `exception-handling`
 `extended-const`
@@ -109,11 +111,13 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `frintts`
 `fxsr`
 `gfni`
+`guarded-storage`
 `hard-float`
 `hard-float-abi`
 `hard-tp`
 `hbc`
 `high-registers`
+`high-word`
 `hvx`
 `hvx-length128b`
 `hwdiv`
@@ -151,6 +155,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `multivalue`
 `mutable-globals`
 `neon`
+`nnp-assist`
 `nontrapping-fptoint`
 `nvic`
 `paca`
@@ -229,6 +234,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `thumb-mode`
 `thumb2`
 `tme`
+`transactional-execution`
 `trust`
 `trustzone`
 `ual`
@@ -262,6 +268,11 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `vdspv1`
 `vdspv2`
 `vector`
+`vector-enhancements-1`
+`vector-enhancements-2`
+`vector-packed-decimal`
+`vector-packed-decimal-enhancement`
+`vector-packed-decimal-enhancement-2`
 `vfp2`
 `vfp3`
 `vfp4`


### PR DESCRIPTION
Closes #88937

tracking issue: https://github.com/rust-lang/rust/issues/130869

The target feature names are, right now, just the llvm target feature names. These mostly line up well with the names of [Facility Indications](https://publibfp.dhe.ibm.com/epubs/pdf/a227832d.pdf#page=301) names. The linux kernel (and `/proc/cpuinfo`) uses shorter, more cryptic names. (e.g. "vector" is `vx`). We can deviate from the llvm names, but the CPU vendor (IBM) does not appear to use e.g. `vx` for what they call `vector`.

There are a number of implied target features between the vector facilities (based on the [Facility Indications](https://publibfp.dhe.ibm.com/epubs/pdf/a227832d.pdf#page=301) table):

- 129 The vector facility for z/Architecture is installed in the z/Architecture architectural mode.
- 134 The vector packed decimal facility is installed in the z/Architecture architectural mode. When bit 134 is one, bit 129 is also one.
- 135 The vector enhancements facility 1 is installed in the z/Architecture architectural mode. When bit 135 is one, bit 129 is also one.
- 148 The vector-enhancements facility 2 is installed in the z/Architecture architectural mode. When bit 148 is one, bits 129 and 135 are also one.
- 152 The vector-packed-decimal-enhancement facility 1 is installed in the z/Architecture architectural mode. When bit 152 is one, bits 129 and 134 are also one.
- 165 The neural-network-processing-assist facility is installed in the z/Architecture architectural mode. When bit 165 is one, bit 129 is also one.
- 192 The vector-packed-decimal-enhancement facility 2 is installed in the z/Architecture architectural mode. When bit 192 is one, bits 129, 134, and 152 are also one.

The remaining facilities do not have any implied target features (that we provide):

- 45 The distinct-operands, fast-BCR-serialization, high-word, and population-count facilities, the interlocked-access facility 1, and the load/store-oncondition facility 1 are installed in the z/Architecture architectural mode.
- 73 The transactional-execution facility is installed in the z/Architecture architectural mode. Bit 49 is one when bit 73 is one.
- 133 The guarded-storage facility is installed in the z/Architecture architectural mode.
- 150 The enhanced-sort facility is installed in the z/Architecture architectural mode.
- 151 The DEFLATE-conversion facility is installed in the z/Architecture architectural mode.

The added target features are those that have ISA implications, can be queried at runtime, and have LLVM support. LLVM [defines more target features](https://github.com/llvm/llvm-project/blob/d49a2d2bc9c65c787bfa04ac8ece614da48a8cd5/llvm/lib/Target/SystemZ/SystemZFeatures.td), but I'm not sure those are useful. They can always be added later, and can already be set globally using `-Ctarget-feature`.

I'll also update the `is_s390x_feature_supported` macro (added in https://github.com/rust-lang/stdarch/pull/1699, not yet on nightly, that needs an stdarch sync) to include these target features.

@Amanieu you had some reservations about the `"vector"` target feature name. It does appear to be the most "official" name we have. On the one hand the name is very generic, and some of the other names are rather long. For the `neural-network-processing-assist` even LLVM thought that was a bit much and shortened it to `nnp-assist`. Also for `vector-packed-decimal-enhancement facility 1` the llvm naming is inconsistent. On the other hand, the cpuinfo names are very cryptic, and aren't found in the IBM documentation.

r? @Amanieu

cc @uweigand @taiki-e