### PR TITLE
Parse `pin`ned local variable declarations

### DIFF
--- a/compiler/rustc_ast_ir/src/lib.rs
+++ b/compiler/rustc_ast_ir/src/lib.rs
@@ -93,3 +93,12 @@ pub enum Pinnedness {
     Not,
     Pinned,
 }
+
+impl Pinnedness {
+    pub fn is_pin(self) -> bool {
+        matches!(self, Self::Pinned)
+    }
+    pub fn is_not(self) -> bool {
+        matches!(self, Self::Not)
+    }
+}

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1283,7 +1283,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
             // Check if this is a binding pattern, if so, we can optimize and avoid adding a
             // `let <pat> = __argN;` statement. In this case, we do not rename the parameter.
             let (ident, is_simple_parameter) = match parameter.pat.kind {
-                hir::PatKind::Binding(hir::BindingMode(ByRef::No, _), _, ident, _) => (ident, true),
+                hir::PatKind::Binding(hir::BindingMode(ByRef::No, _, _), _, ident, _) => {
+                    (ident, true)
+                }
                 // For `ref mut` or wildcard arguments, we can't reuse the binding, but
                 // we can keep the same name for the parameter.
                 // This lets rustdoc render it correctly in documentation.

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1628,7 +1628,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             implicit_self: decl.inputs.get(0).map_or(hir::ImplicitSelfKind::None, |arg| {
                 let is_mutable_pat = matches!(
                     arg.pat.kind,
-                    PatKind::Ident(hir::BindingMode(_, Mutability::Mut), ..)
+                    PatKind::Ident(hir::BindingMode(_, _, Mutability::Mut), ..)
                 );
 
                 match &arg.ty.kind {

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1620,7 +1620,10 @@ impl<'a> State<'a> {
         match &pat.kind {
             PatKind::Wild => self.word("_"),
             PatKind::Never => self.word("!"),
-            PatKind::Ident(BindingMode(by_ref, mutbl), ident, sub) => {
+            PatKind::Ident(BindingMode(by_ref, pin, mutbl), ident, sub) => {
+                if pin.is_pin() {
+                    self.word_nbsp("pin");
+                }
                 if mutbl.is_mut() {
                     self.word_nbsp("mut");
                 }

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -305,7 +305,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 {
                     match *decl.local_info() {
                         LocalInfo::User(BindingForm::Var(mir::VarBindingForm {
-                            binding_mode: BindingMode(ByRef::No, Mutability::Not),
+                            binding_mode: BindingMode(ByRef::No, _, Mutability::Not),
                             opt_ty_info: Some(sp),
                             opt_match_place: _,
                             pat_span: _,
@@ -732,7 +732,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         debug!("local_decl: {:?}", local_decl);
         let pat_span = match *local_decl.local_info() {
             LocalInfo::User(BindingForm::Var(mir::VarBindingForm {
-                binding_mode: BindingMode(ByRef::No, Mutability::Not),
+                binding_mode: BindingMode(ByRef::No, _, Mutability::Not),
                 opt_ty_info: _,
                 opt_match_place: _,
                 pat_span,
@@ -1144,7 +1144,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             }
 
             LocalInfo::User(mir::BindingForm::Var(mir::VarBindingForm {
-                binding_mode: BindingMode(ByRef::No, _),
+                binding_mode: BindingMode(ByRef::No, _, _),
                 opt_ty_info,
                 ..
             })) => {
@@ -1223,7 +1223,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             }
 
             LocalInfo::User(mir::BindingForm::Var(mir::VarBindingForm {
-                binding_mode: BindingMode(ByRef::Yes(_), _),
+                binding_mode: BindingMode(ByRef::Yes(_), _, _),
                 ..
             })) => {
                 let pattern_span: Span = local_decl.source_info.span;
@@ -1438,7 +1438,7 @@ fn mut_borrow_of_mutable_ref(local_decl: &LocalDecl<'_>, local_name: Option<Symb
     match *local_decl.local_info() {
         // Check if mutably borrowing a mutable reference.
         LocalInfo::User(mir::BindingForm::Var(mir::VarBindingForm {
-            binding_mode: BindingMode(ByRef::No, Mutability::Not),
+            binding_mode: BindingMode(ByRef::No, _, Mutability::Not),
             ..
         })) => matches!(local_decl.ty.kind(), ty::Ref(_, _, hir::Mutability::Mut)),
         LocalInfo::User(mir::BindingForm::ImplicitSelf(kind)) => {

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -183,7 +183,7 @@ pub(crate) use SubstructureFields::*;
 use rustc_ast::ptr::P;
 use rustc_ast::{
     self as ast, AnonConst, BindingMode, ByRef, EnumDef, Expr, GenericArg, GenericParamKind,
-    Generics, Mutability, PatKind, VariantData,
+    Generics, Mutability, PatKind, Pinnedness, VariantData,
 };
 use rustc_attr_parsing as attr;
 use rustc_expand::base::{Annotatable, ExtCtxt};
@@ -1470,7 +1470,11 @@ impl<'a> TraitDef<'a> {
                             struct_field.ident,
                             cx.pat(
                                 path.span,
-                                PatKind::Ident(BindingMode(by_ref, Mutability::Not), path, None),
+                                PatKind::Ident(
+                                    BindingMode(by_ref, Pinnedness::Not, Mutability::Not),
+                                    path,
+                                    None,
+                                ),
                             ),
                         )
                     });

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -11,7 +11,7 @@ use rustc_ast::{
 };
 pub use rustc_ast::{
     BinOp, BinOpKind, BindingMode, BorrowKind, BoundConstness, BoundPolarity, ByRef, CaptureBy,
-    ImplPolarity, IsAuto, Movability, Mutability, UnOp, UnsafeBinderCastKind,
+    ImplPolarity, IsAuto, Movability, Mutability, Pinnedness, UnOp, UnsafeBinderCastKind,
 };
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::sorted_map::SortedMap;

--- a/compiler/rustc_hir/src/pat_util.rs
+++ b/compiler/rustc_hir/src/pat_util.rs
@@ -95,7 +95,7 @@ impl hir::Pat<'_> {
 
     pub fn simple_ident(&self) -> Option<Ident> {
         match self.kind {
-            PatKind::Binding(BindingMode(ByRef::No, _), _, ident, None) => Some(ident),
+            PatKind::Binding(BindingMode(ByRef::No, _, _), _, ident, None) => Some(ident),
             _ => None,
         }
     }

--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -681,7 +681,7 @@ fn resolve_local<'tcx>(
         // & expression, and its lifetime would be extended to the end of the block (due
         // to a different rule, not the below code).
         match pat.kind {
-            PatKind::Binding(hir::BindingMode(hir::ByRef::Yes(_), _), ..) => true,
+            PatKind::Binding(hir::BindingMode(hir::ByRef::Yes(_), _, _), ..) => true,
 
             PatKind::Struct(_, field_pats, _) => field_pats.iter().any(|fp| is_binding_pat(fp.pat)),
 
@@ -700,7 +700,7 @@ fn resolve_local<'tcx>(
             }
 
             PatKind::Ref(_, _)
-            | PatKind::Binding(hir::BindingMode(hir::ByRef::No, _), ..)
+            | PatKind::Binding(hir::BindingMode(hir::ByRef::No, _, _), ..)
             | PatKind::Wild
             | PatKind::Never
             | PatKind::Expr(_)

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1914,7 +1914,10 @@ impl<'a> State<'a> {
         match pat.kind {
             PatKind::Wild => self.word("_"),
             PatKind::Never => self.word("!"),
-            PatKind::Binding(BindingMode(by_ref, mutbl), _, ident, sub) => {
+            PatKind::Binding(BindingMode(by_ref, pin, mutbl), _, ident, sub) => {
+                if pin.is_pin() {
+                    self.word_nbsp("pin");
+                }
                 if mutbl.is_mut() {
                     self.word_nbsp("mut");
                 }

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -276,7 +276,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 else {
                     bug!();
                 };
-                let hir::PatKind::Binding(hir::BindingMode(hir::ByRef::No, _), _, _, _) = pat.kind
+                let hir::PatKind::Binding(hir::BindingMode(hir::ByRef::No, _, _), _, _, _) =
+                    pat.kind
                 else {
                     // Complex pattern, skip the non-upvar local.
                     continue;
@@ -1802,7 +1803,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let bm = *typeck_results.pat_binding_modes().get(var_hir_id).expect("missing binding mode");
 
-        let mut is_mutbl = bm.1;
+        let mut is_mutbl = bm.2;
 
         for pointer_ty in place.deref_tys() {
             match self.structurally_resolve_type(self.tcx.hir().span(var_hir_id), pointer_ty).kind()

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -19,6 +19,7 @@ use rustc_hir::def::{CtorKind, Namespace};
 use rustc_hir::def_id::{CRATE_DEF_ID, DefId};
 use rustc_hir::{
     self as hir, BindingMode, ByRef, CoroutineDesugaring, CoroutineKind, HirId, ImplicitSelfKind,
+    Pinnedness,
 };
 use rustc_index::bit_set::DenseBitSet;
 use rustc_index::{Idx, IndexSlice, IndexVec};
@@ -1094,7 +1095,8 @@ impl<'tcx> LocalDecl<'tcx> {
             self.local_info(),
             LocalInfo::User(
                 BindingForm::Var(VarBindingForm {
-                    binding_mode: BindingMode(ByRef::No, _, _),
+                    // FIXME(pin_ergonomics): `pin const` can also be made mutable, but needs special handling.
+                    binding_mode: BindingMode(ByRef::No, Pinnedness::Not, _),
                     opt_ty_info: _,
                     opt_match_place: _,
                     pat_span: _,

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1094,7 +1094,7 @@ impl<'tcx> LocalDecl<'tcx> {
             self.local_info(),
             LocalInfo::User(
                 BindingForm::Var(VarBindingForm {
-                    binding_mode: BindingMode(ByRef::No, _),
+                    binding_mode: BindingMode(ByRef::No, _, _),
                     opt_ty_info: _,
                     opt_match_place: _,
                     pat_span: _,
@@ -1111,7 +1111,7 @@ impl<'tcx> LocalDecl<'tcx> {
             self.local_info(),
             LocalInfo::User(
                 BindingForm::Var(VarBindingForm {
-                    binding_mode: BindingMode(ByRef::No, _),
+                    binding_mode: BindingMode(ByRef::No, _, _),
                     opt_ty_info: _,
                     opt_match_place: _,
                     pat_span: _,

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -633,7 +633,7 @@ impl<'tcx> Pat<'tcx> {
     pub fn simple_ident(&self) -> Option<Symbol> {
         match self.kind {
             PatKind::Binding {
-                name, mode: BindingMode(ByRef::No, _), subpattern: None, ..
+                name, mode: BindingMode(ByRef::No, _, _), subpattern: None, ..
             } => Some(name),
             _ => None,
         }

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -454,7 +454,7 @@ impl<'tcx> TypeckResults<'tcx> {
         let mut has_ref_mut = false;
         pat.walk(|pat| {
             if let hir::PatKind::Binding(_, id, _, _) = pat.kind
-                && let Some(BindingMode(ByRef::Yes(Mutability::Mut), _)) =
+                && let Some(BindingMode(ByRef::Yes(Mutability::Mut), _, _)) =
                     self.pat_binding_modes().get(id)
             {
                 has_ref_mut = true;

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -594,7 +594,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) -> BlockAnd<()> {
         match irrefutable_pat.kind {
             // Optimize the case of `let x = ...` to write directly into `x`
-            PatKind::Binding { mode: BindingMode(ByRef::No, _), var, subpattern: None, .. } => {
+            PatKind::Binding {
+                mode: BindingMode(ByRef::No, _, _), var, subpattern: None, ..
+            } => {
                 let place = self.storage_live_binding(
                     block,
                     var,
@@ -618,7 +620,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 ref subpattern,
                 ascription: thir::Ascription { ref annotation, variance: _ },
             } if let PatKind::Binding {
-                mode: BindingMode(ByRef::No, _),
+                mode: BindingMode(ByRef::No, _, _),
                 var,
                 subpattern: None,
                 ..
@@ -2772,7 +2774,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let tcx = self.tcx;
         let debug_source_info = SourceInfo { span: source_info.span, scope: visibility_scope };
         let local = LocalDecl {
-            mutability: mode.1,
+            mutability: mode.2,
             ty: var_ty,
             user_ty: if user_ty.is_empty() { None } else { Some(Box::new(user_ty)) },
             source_info,

--- a/compiler/rustc_mir_build/src/builder/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/mod.rs
@@ -953,7 +953,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // Don't introduce extra copies for simple bindings
                 PatKind::Binding {
                     var,
-                    mode: BindingMode(ByRef::No, mutability),
+                    mode: BindingMode(ByRef::No, pin, mutability),
                     subpattern: None,
                     ..
                 } => {
@@ -963,7 +963,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         if let Some(kind) = param.self_kind {
                             LocalInfo::User(BindingForm::ImplicitSelf(kind))
                         } else {
-                            let binding_mode = BindingMode(ByRef::No, mutability);
+                            let binding_mode = BindingMode(ByRef::No, pin, mutability);
                             LocalInfo::User(BindingForm::Var(VarBindingForm {
                                 binding_mode,
                                 opt_ty_info: param.ty_span,

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -374,7 +374,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 }
                 visit::walk_pat(self, pat);
             }
-            PatKind::Binding { mode: BindingMode(ByRef::Yes(rm), _), ty, .. } => {
+            PatKind::Binding { mode: BindingMode(ByRef::Yes(rm), _, _), ty, .. } => {
                 if self.inside_adt {
                     let ty::Ref(_, ty, _) = ty.kind() else {
                         span_bug!(

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -871,7 +871,7 @@ fn check_for_bindings_named_same_as_variants(
 ) {
     if let PatKind::Binding {
         name,
-        mode: BindingMode(ByRef::No, Mutability::Not),
+        mode: BindingMode(ByRef::No, _, Mutability::Not),
         subpattern: None,
         ty,
         ..

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -663,6 +663,8 @@ parse_note_mut_pattern_usage = `mut` may be followed by `variable` and `variable
 
 parse_note_pattern_alternatives_use_single_vert = alternatives in or-patterns are separated with `|`, not `||`
 
+parse_note_pin_pattern_usage = `pin mut` or `pin const` may be followed by `variable` and `variable @ pattern`
+
 parse_nul_in_c_str = null characters in C string literals are not supported
 
 parse_or_pattern_not_allowed_in_fn_parameters = top-level or-patterns are not allowed in function parameters
@@ -697,6 +699,11 @@ parse_pattern_on_wrong_side_of_at = pattern on wrong side of `@`
     .label_pattern = pattern on the left, should be on the right
     .label_binding = binding on the right, should be on the left
     .suggestion = switch the order
+
+parse_pin_on_nested_ident_pattern = `pin {$mutbl}` must be attached to each individual binding
+    .suggestion = add `pin {$mutbl}` to each binding
+parse_pin_on_non_ident_pattern = `pin {$mutbl}` must be followed by a named binding
+    .suggestion = remove the `pin {$mutbl}` prefix
 
 parse_question_mark_in_type = invalid `?` in type
     .label = `?` is only allowed on expressions, not types

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2629,6 +2629,27 @@ pub(crate) enum InvalidMutInPattern {
 }
 
 #[derive(Diagnostic)]
+pub(crate) enum InvalidPinInPattern {
+    #[diag(parse_pin_on_nested_ident_pattern)]
+    #[note(parse_note_pin_pattern_usage)]
+    NestedIdent {
+        #[primary_span]
+        #[suggestion(code = "{pat}", applicability = "machine-applicable", style = "verbose")]
+        span: Span,
+        mutbl: &'static str,
+        pat: String,
+    },
+    #[diag(parse_pin_on_non_ident_pattern)]
+    #[note(parse_note_pin_pattern_usage)]
+    NonIdent {
+        #[primary_span]
+        #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
+        span: Span,
+        mutbl: &'static str,
+    },
+}
+
+#[derive(Diagnostic)]
 #[diag(parse_repeated_mut_in_pattern)]
 pub(crate) struct RepeatedMutInPattern {
     #[primary_span]

--- a/src/tools/clippy/clippy_lints/src/index_refutable_slice.rs
+++ b/src/tools/clippy/clippy_lints/src/index_refutable_slice.rs
@@ -94,7 +94,7 @@ fn find_slice_values(cx: &LateContext<'_>, pat: &hir::Pat<'_>) -> FxIndexMap<Hir
     let mut slices: FxIndexMap<HirId, SliceLintInformation> = FxIndexMap::default();
     pat.walk_always(|pat| {
         // We'll just ignore mut and ref mut for simplicity sake right now
-        if let hir::PatKind::Binding(hir::BindingMode(by_ref, hir::Mutability::Not), value_hir_id, ident, sub_pat) =
+        if let hir::PatKind::Binding(hir::BindingMode(by_ref, _, hir::Mutability::Not), value_hir_id, ident, sub_pat) =
             pat.kind
             && by_ref != hir::ByRef::Yes(hir::Mutability::Mut)
         {

--- a/src/tools/clippy/clippy_lints/src/let_if_seq.rs
+++ b/src/tools/clippy/clippy_lints/src/let_if_seq.rs
@@ -104,7 +104,7 @@ impl<'tcx> LateLintPass<'tcx> for LetIfSeq {
                 };
 
                 let mutability = match mode {
-                    BindingMode(_, Mutability::Mut) => "<mut> ",
+                    BindingMode(_, _, Mutability::Mut) => "<mut> ",
                     _ => "",
                 };
 

--- a/src/tools/clippy/clippy_lints/src/loops/same_item_push.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/same_item_push.rs
@@ -73,7 +73,7 @@ pub(super) fn check<'tcx>(
                         let node = cx.tcx.hir_node(hir_id);
                         if let Node::Pat(pat) = node
                             && let PatKind::Binding(bind_ann, ..) = pat.kind
-                            && !matches!(bind_ann, BindingMode(_, Mutability::Mut))
+                            && !matches!(bind_ann, BindingMode(_, _, Mutability::Mut))
                             && let Node::LetStmt(parent_let_expr) = cx.tcx.parent_hir_node(hir_id)
                             && let Some(init) = parent_let_expr.init
                         {

--- a/src/tools/clippy/clippy_lints/src/matches/match_as_ref.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/match_as_ref.rs
@@ -59,7 +59,7 @@ pub(crate) fn check(cx: &LateContext<'_>, ex: &Expr<'_>, arms: &[Arm<'_>], expr:
 fn is_ref_some_arm(cx: &LateContext<'_>, arm: &Arm<'_>) -> Option<Mutability> {
     if let PatKind::TupleStruct(ref qpath, [first_pat, ..], _) = arm.pat.kind
         && is_res_lang_ctor(cx, cx.qpath_res(qpath, arm.pat.hir_id), LangItem::OptionSome)
-        && let PatKind::Binding(BindingMode(ByRef::Yes(mutabl), _), .., ident, _) = first_pat.kind
+        && let PatKind::Binding(BindingMode(ByRef::Yes(mutabl), _, _), .., ident, _) = first_pat.kind
         && let ExprKind::Call(e, [arg]) = peel_blocks(arm.body).kind
         && is_res_lang_ctor(cx, path_res(cx, e), LangItem::OptionSome)
         && let ExprKind::Path(QPath::Resolved(_, path2)) = arg.kind

--- a/src/tools/clippy/clippy_lints/src/matches/needless_match.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/needless_match.rs
@@ -182,7 +182,7 @@ fn pat_same_as_expr(pat: &Pat<'_>, expr: &Expr<'_>) -> bool {
                 },
             )),
         ) => {
-            return !matches!(annot, BindingMode(ByRef::Yes(_), _)) && pat_ident.name == first_seg.ident.name;
+            return !matches!(annot, BindingMode(ByRef::Yes(_), _, _)) && pat_ident.name == first_seg.ident.name;
         },
         // Example: `Custom::TypeA => Custom::TypeB`, or `None => None`
         (

--- a/src/tools/clippy/clippy_lints/src/methods/clone_on_copy.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/clone_on_copy.rs
@@ -69,7 +69,7 @@ pub(super) fn check(
                 _ => false,
             },
             // local binding capturing a reference
-            Node::LetStmt(l) if matches!(l.pat.kind, PatKind::Binding(BindingMode(ByRef::Yes(_), _), ..)) => {
+            Node::LetStmt(l) if matches!(l.pat.kind, PatKind::Binding(BindingMode(ByRef::Yes(_), _, _), ..)) => {
                 return;
             },
             _ => false,

--- a/src/tools/clippy/clippy_lints/src/methods/filter_next.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/filter_next.rs
@@ -46,7 +46,7 @@ pub(super) fn check<'tcx>(
             span_lint_and_then(cx, FILTER_NEXT, expr.span, msg, |diag| {
                 let (applicability, pat) = if let Some(id) = path_to_local(recv)
                     && let hir::Node::Pat(pat) = cx.tcx.hir_node(id)
-                    && let hir::PatKind::Binding(BindingMode(_, Mutability::Not), _, ident, _) = pat.kind
+                    && let hir::PatKind::Binding(BindingMode(_, _, Mutability::Not), _, ident, _) = pat.kind
                 {
                     (Applicability::Unspecified, Some((pat.span, ident)))
                 } else {

--- a/src/tools/clippy/clippy_lints/src/methods/iter_overeager_cloned.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/iter_overeager_cloned.rs
@@ -82,7 +82,7 @@ pub(super) fn check<'tcx>(
                 }
 
                 match it.kind {
-                    PatKind::Binding(BindingMode(_, Mutability::Mut), _, _, _) | PatKind::Ref(_, Mutability::Mut) => {
+                    PatKind::Binding(BindingMode(_, _, Mutability::Mut), _, _, _) | PatKind::Ref(_, Mutability::Mut) => {
                         to_be_discarded = true;
                         false
                     },

--- a/src/tools/clippy/clippy_lints/src/methods/manual_inspect.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/manual_inspect.rs
@@ -24,7 +24,7 @@ pub(crate) fn check(cx: &LateContext<'_>, expr: &Expr<'_>, arg: &Expr<'_>, name:
                 && (is_diag_item_method(cx, fn_id, sym::Option) || is_diag_item_method(cx, fn_id, sym::Result))))
         && let body = cx.tcx.hir_body(c.body)
         && let [param] = body.params
-        && let PatKind::Binding(BindingMode(ByRef::No, Mutability::Not), arg_id, _, None) = param.pat.kind
+        && let PatKind::Binding(BindingMode(ByRef::No, _, Mutability::Not), arg_id, _, None) = param.pat.kind
         && let arg_ty = typeck.node_type(arg_id)
         && let ExprKind::Block(block, _) = body.value.kind
         && let Some(final_expr) = block.expr

--- a/src/tools/clippy/clippy_lints/src/misc.rs
+++ b/src/tools/clippy/clippy_lints/src/misc.rs
@@ -159,7 +159,7 @@ impl<'tcx> LateLintPass<'tcx> for LintPass {
     ) {
         if !matches!(k, FnKind::Closure) {
             for arg in iter_input_pats(decl, body) {
-                if let PatKind::Binding(BindingMode(ByRef::Yes(_), _), ..) = arg.pat.kind
+                if let PatKind::Binding(BindingMode(ByRef::Yes(_), _, _), ..) = arg.pat.kind
                     && is_lint_allowed(cx, REF_PATTERNS, arg.pat.hir_id)
                     && !arg.span.in_external_macro(cx.tcx.sess.source_map())
                 {
@@ -178,7 +178,7 @@ impl<'tcx> LateLintPass<'tcx> for LintPass {
 
     fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx Stmt<'_>) {
         if let StmtKind::Let(local) = stmt.kind
-            && let PatKind::Binding(BindingMode(ByRef::Yes(mutabl), _), .., name, None) = local.pat.kind
+            && let PatKind::Binding(BindingMode(ByRef::Yes(mutabl), _, _), .., name, None) = local.pat.kind
             && let Some(init) = local.init
             // Do not emit if clippy::ref_patterns is not allowed to avoid having two lints for the same issue.
             && is_lint_allowed(cx, REF_PATTERNS, local.pat.hir_id)

--- a/src/tools/clippy/clippy_lints/src/needless_arbitrary_self_type.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_arbitrary_self_type.rs
@@ -120,7 +120,7 @@ impl EarlyLintPass for NeedlessArbitrarySelfType {
 
         match &p.ty.kind {
             TyKind::Path(None, path) => {
-                if let PatKind::Ident(BindingMode(ByRef::No, mutbl), _, _) = p.pat.kind {
+                if let PatKind::Ident(BindingMode(ByRef::No, _, mutbl), _, _) = p.pat.kind {
                     check_param_inner(cx, path, p.span.to(p.ty.span), &Mode::Value, mutbl);
                 }
             },

--- a/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_pass_by_value.rs
@@ -192,7 +192,7 @@ impl<'tcx> LateLintPass<'tcx> for NeedlessPassByValue {
                 })
                 && !implements_borrow_trait
                 && !all_borrowable_trait
-                && let PatKind::Binding(BindingMode(_, Mutability::Not), canonical_id, ..) = arg.pat.kind
+                && let PatKind::Binding(BindingMode(_, _, Mutability::Not), canonical_id, ..) = arg.pat.kind
                 && !moved_vars.contains(&canonical_id)
             {
                 // Dereference suggestion

--- a/src/tools/clippy/clippy_lints/src/question_mark.rs
+++ b/src/tools/clippy/clippy_lints/src/question_mark.rs
@@ -415,7 +415,7 @@ fn check_if_let_some_or_err_and_early_return<'tcx>(cx: &LateContext<'tcx>, expr:
         && !is_else_clause(cx.tcx, expr)
         && let PatKind::TupleStruct(ref path1, [field], ddpos) = let_pat.kind
         && ddpos.as_opt_usize().is_none()
-        && let PatKind::Binding(BindingMode(by_ref, _), bind_id, ident, None) = field.kind
+        && let PatKind::Binding(BindingMode(by_ref, _, _), bind_id, ident, None) = field.kind
         && let caller_ty = cx.typeck_results().expr_ty(let_expr)
         && let if_block = IfBlockType::IfLet(
             cx.qpath_res(path1, let_pat.hir_id),

--- a/src/tools/clippy/clippy_lints/src/redundant_locals.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_locals.rs
@@ -49,7 +49,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantLocals {
     fn check_local(&mut self, cx: &LateContext<'tcx>, local: &'tcx LetStmt<'tcx>) {
         if !local.span.is_desugaring(DesugaringKind::Async)
             // the pattern is a single by-value binding
-            && let PatKind::Binding(BindingMode(ByRef::No, mutability), _, ident, None) = local.pat.kind
+            && let PatKind::Binding(BindingMode(ByRef::No, _, mutability), _, ident, None) = local.pat.kind
             // the binding is not type-ascribed
             && local.ty.is_none()
             // the expression is a resolved path
@@ -62,7 +62,7 @@ impl<'tcx> LateLintPass<'tcx> for RedundantLocals {
             && let Res::Local(binding_id) = cx.qpath_res(&qpath, expr.hir_id)
             && let Node::Pat(binding_pat) = cx.tcx.hir_node(binding_id)
             // the previous binding has the same mutability
-            && find_binding(binding_pat, ident).is_some_and(|bind| bind.1 == mutability)
+            && find_binding(binding_pat, ident).is_some_and(|bind| bind.2 == mutability)
             // the local does not change the effect of assignments to the binding. see #11290
             && !affects_assignments(cx, mutability, binding_id, local.hir_id)
             // the local does not affect the code's drop behavior

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -1,6 +1,6 @@
 use clippy_utils::{get_attr, higher};
 use rustc_ast::LitIntType;
-use rustc_ast::ast::{LitFloatType, LitKind};
+use rustc_ast::ast::{LitFloatType, LitKind, Pinnedness};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::{
     self as hir, BindingMode, CaptureBy, Closure, ClosureKind, ConstArg, ConstArgKind, CoroutineKind, ExprKind,
@@ -682,6 +682,9 @@ impl<'a, 'tcx> PrintVisitor<'a, 'tcx> {
                     BindingMode::REF_MUT => "REF_MUT",
                     BindingMode::MUT_REF => "MUT_REF",
                     BindingMode::MUT_REF_MUT => "MUT_REF_MUT",
+                    BindingMode::PIN_CONST => "PIN_CONST ",
+                    BindingMode::PIN_MUT => "PIN_MUT",
+                    BindingMode(_, Pinnedness::Pinned, _) => panic!("unsupported pinned binding mode"),
                 };
                 kind!("Binding(BindingMode::{ann}, _, {name}, {sub})");
                 self.ident(name);

--- a/src/tools/clippy/clippy_utils/src/hir_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/hir_utils.rs
@@ -1124,8 +1124,9 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
     pub fn hash_pat(&mut self, pat: &Pat<'_>) {
         std::mem::discriminant(&pat.kind).hash(&mut self.s);
         match pat.kind {
-            PatKind::Binding(BindingMode(by_ref, mutability), _, _, pat) => {
+            PatKind::Binding(BindingMode(by_ref, pinnedness, mutability), _, _, pat) => {
                 std::mem::discriminant(&by_ref).hash(&mut self.s);
+                std::mem::discriminant(&pinnedness).hash(&mut self.s);
                 std::mem::discriminant(&mutability).hash(&mut self.s);
                 if let Some(pat) = pat {
                     self.hash_pat(pat);

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -133,6 +133,19 @@ pub(crate) fn format_mutability(mutability: ast::Mutability) -> &'static str {
 }
 
 #[inline]
+pub(crate) fn format_pin_and_mut(
+    pinnedness: ast::Pinnedness,
+    mutability: ast::Mutability,
+) -> (&'static str, &'static str) {
+    match (pinnedness, mutability) {
+        (ast::Pinnedness::Not, ast::Mutability::Mut) => ("", "mut "),
+        (ast::Pinnedness::Not, ast::Mutability::Not) => ("", ""),
+        (ast::Pinnedness::Pinned, ast::Mutability::Mut) => ("pin ", "mut "),
+        (ast::Pinnedness::Pinned, ast::Mutability::Not) => ("pin ", "const "),
+    }
+}
+
+#[inline]
 pub(crate) fn format_extern(ext: ast::Extern, explicit_abi: bool) -> Cow<'static, str> {
     match ext {
         ast::Extern::None => Cow::from(""),

--- a/src/tools/rustfmt/tests/source/pin_sugar.rs
+++ b/src/tools/rustfmt/tests/source/pin_sugar.rs
@@ -8,3 +8,36 @@ fn g<'a>(x: &  'a pin const  i32) {}
 fn h<'a>(x: &  'a pin  
 mut i32) {}
 fn i(x: &pin      mut  i32) {}
+
+fn pinned_locals() {
+    let    pin                 mut
+x = 0_i32;
+    let    pin    /* comment */             mut
+x = 0_i32;
+    let    pin                 mut /* comment */
+x = 0_i32;
+    let          pin
+const 
+y = 0_i32;
+    let          pin
+/* comment */ const 
+y = 0_i32;
+    let          pin
+const /* comment */
+y = 0_i32;
+let (
+    pin               
+    const      x,
+    pin           mut   y
+) = (0_i32, 0_i32);
+let (
+    pin               /* comment */
+    const      x,
+    pin   /* comment */        mut   y
+) = (0_i32, 0_i32);
+let (
+    pin               
+    const  /* comment */    x,
+    pin           mut  /* comment */ y
+) = (0_i32, 0_i32);
+}

--- a/src/tools/rustfmt/tests/target/pin_sugar.rs
+++ b/src/tools/rustfmt/tests/target/pin_sugar.rs
@@ -7,3 +7,17 @@ fn f(x: &pin const i32) {}
 fn g<'a>(x: &'a pin const i32) {}
 fn h<'a>(x: &'a pin mut i32) {}
 fn i(x: &pin mut i32) {}
+
+fn pinned_locals() {
+    let pin mut x = 0_i32;
+    let pin /* comment */ mut x = 0_i32;
+    let pin mut /* comment */ x = 0_i32;
+    let pin const y = 0_i32;
+    let pin
+    /* comment */
+    const y = 0_i32;
+    let pin const /* comment */ y = 0_i32;
+    let (pin const x, pin mut y) = (0_i32, 0_i32);
+    let (pin /* comment */ const x, pin /* comment */ mut y) = (0_i32, 0_i32);
+    let (pin const /* comment */ x, pin mut /* comment */ y) = (0_i32, 0_i32);
+}

--- a/tests/ui/async-await/pin-ergonomics/pinned-local-no-const.rs
+++ b/tests/ui/async-await/pin-ergonomics/pinned-local-no-const.rs
@@ -1,0 +1,13 @@
+#![feature(pin_ergonomics)]
+#![allow(dead_code, incomplete_features)]
+
+// Makes sure we reject `pin pat`.
+
+struct Foo;
+
+fn foo() {
+    let pin x = Foo; //~ ERROR expected one of `:`, `;`, `=`, `@`, or `|`, found `x`
+    x = Foo;
+}
+
+fn main() {}

--- a/tests/ui/async-await/pin-ergonomics/pinned-local-no-const.stderr
+++ b/tests/ui/async-await/pin-ergonomics/pinned-local-no-const.stderr
@@ -1,0 +1,14 @@
+error: expected one of `:`, `;`, `=`, `@`, or `|`, found `x`
+  --> $DIR/pinned-local-no-const.rs:9:13
+   |
+LL |     let pin x = Foo;
+   |             ^ expected one of `:`, `;`, `=`, `@`, or `|`
+   |
+help: there is a keyword `in` with a similar name
+   |
+LL -     let pin x = Foo;
+LL +     let in x = Foo;
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/async-await/pin-ergonomics/pinned-local.rs
+++ b/tests/ui/async-await/pin-ergonomics/pinned-local.rs
@@ -1,0 +1,19 @@
+#![feature(pin_ergonomics)]
+#![allow(dead_code, incomplete_features)]
+
+// Makes sure we can handle `pin mut pat` and `pin const pat`.
+
+struct Foo;
+
+fn foo() {
+    let pin mut x = Foo;
+    let pin const y = Foo;
+    x = Foo; // FIXME: this should be an error
+    y = Foo; //~ ERROR cannot assign twice to immutable variable `y`
+
+    let (pin mut x, pin const y) = (Foo, Foo);
+    x = Foo; // FIXME: this should be an error
+    y = Foo; //~ ERROR cannot assign twice to immutable variable `y`
+}
+
+fn main() {}

--- a/tests/ui/async-await/pin-ergonomics/pinned-local.stderr
+++ b/tests/ui/async-await/pin-ergonomics/pinned-local.stderr
@@ -1,0 +1,35 @@
+error[E0384]: cannot assign twice to immutable variable `y`
+  --> $DIR/pinned-local.rs:12:5
+   |
+LL |     let pin const y = Foo;
+   |         ----------- first assignment to `y`
+LL |     x = Foo; // FIXME: this should be an error
+LL |     y = Foo;
+   |     ^^^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut pin const y = Foo;
+   |         +++
+
+error[E0384]: cannot assign twice to immutable variable `y`
+  --> $DIR/pinned-local.rs:16:5
+   |
+LL |     let (pin mut x, pin const y) = (Foo, Foo);
+   |                     ----------- first assignment to `y`
+LL |     x = Foo; // FIXME: this should be an error
+LL |     y = Foo;
+   |     ^^^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let (pin mut x, mut pin const y) = (Foo, Foo);
+   |                     +++
+help: to modify the original value, take a borrow instead
+   |
+LL |     let (pin mut x, ref mut pin const y) = (Foo, Foo);
+   |                     +++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/async-await/pin-ergonomics/pinned-local.stderr
+++ b/tests/ui/async-await/pin-ergonomics/pinned-local.stderr
@@ -6,11 +6,6 @@ LL |     let pin const y = Foo;
 LL |     x = Foo; // FIXME: this should be an error
 LL |     y = Foo;
    |     ^^^^^^^ cannot assign twice to immutable variable
-   |
-help: consider making this binding mutable
-   |
-LL |     let mut pin const y = Foo;
-   |         +++
 
 error[E0384]: cannot assign twice to immutable variable `y`
   --> $DIR/pinned-local.rs:16:5
@@ -20,15 +15,6 @@ LL |     let (pin mut x, pin const y) = (Foo, Foo);
 LL |     x = Foo; // FIXME: this should be an error
 LL |     y = Foo;
    |     ^^^^^^^ cannot assign twice to immutable variable
-   |
-help: consider making this binding mutable
-   |
-LL |     let (pin mut x, mut pin const y) = (Foo, Foo);
-   |                     +++
-help: to modify the original value, take a borrow instead
-   |
-LL |     let (pin mut x, ref mut pin const y) = (Foo, Foo);
-   |                     +++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -27,4 +27,11 @@ fn baz(mut x: Pin<&mut Foo>) {
 
 fn baz_sugar(_: &pin const Foo) {} //~ ERROR pinned reference syntax is experimental
 
+fn pinned_locals() {
+    let pin mut x = Foo; //~ ERROR pinned reference syntax is experimental
+    let pin const y = Foo; //~ ERROR pinned reference syntax is experimental
+    x = Foo; // FIXME: this should be an error
+    y = Foo; //~ ERROR cannot assign twice to immutable variable `y`
+}
+
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -28,6 +28,26 @@ LL | fn baz_sugar(_: &pin const Foo) {}
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:31:9
+   |
+LL |     let pin mut x = Foo;
+   |         ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:32:9
+   |
+LL |     let pin const y = Foo;
+   |         ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0382]: use of moved value: `x`
   --> $DIR/feature-gate-pin_ergonomics.rs:20:9
    |
@@ -66,7 +86,21 @@ help: consider reborrowing the `Pin` instead of moving it
 LL |     x.as_mut().foo();
    |      +++++++++
 
-error: aborting due to 5 previous errors
+error[E0384]: cannot assign twice to immutable variable `y`
+  --> $DIR/feature-gate-pin_ergonomics.rs:34:5
+   |
+LL |     let pin const y = Foo;
+   |         ----------- first assignment to `y`
+LL |     x = Foo; // FIXME: this should be an error
+LL |     y = Foo;
+   |     ^^^^^^^ cannot assign twice to immutable variable
+   |
+help: consider making this binding mutable
+   |
+LL |     let mut pin const y = Foo;
+   |         +++
 
-Some errors have detailed explanations: E0382, E0658.
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0382, E0384, E0658.
 For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -94,11 +94,6 @@ LL |     let pin const y = Foo;
 LL |     x = Foo; // FIXME: this should be an error
 LL |     y = Foo;
    |     ^^^^^^^ cannot assign twice to immutable variable
-   |
-help: consider making this binding mutable
-   |
-LL |     let mut pin const y = Foo;
-   |         +++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/thir-print/thir-tree-match.stdout
+++ b/tests/ui/thir-print/thir-tree-match.stdout
@@ -12,7 +12,7 @@ params: [
                 kind: PatKind {
                     Binding {
                         name: "foo"
-                        mode: BindingMode(No, Not)
+                        mode: BindingMode(No, Not, Not)
                         var: LocalVarId(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).2))
                         ty: Foo
                         is_primary: true


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/135631)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR implements part of rust-lang/rust#130494, parsing `let pin mut x` or `let pin const x` in local variables that cannot be moved.