### PR TITLE
CI: split x86_64-msvc job using windows 2025

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -106,14 +106,10 @@ STAGE_2_TEST_SET2 := test --stage 2 --skip=tests --skip=coverage-map --skip=cove
 
 # this intentionally doesn't use `$(BOOTSTRAP)` so we can test the shebang on Windows
 ci-msvc-py:
-	$(Q)$(CFG_SRC_DIR)/x.py test --stage 2 tidy
-ci-msvc-ps1:
-	$(Q)$(CFG_SRC_DIR)/x.ps1 test --stage 2 --skip tidy
-ci-msvc: ci-msvc-py ci-msvc-ps1
-ci-msvc-py-set1:
 	$(Q)$(CFG_SRC_DIR)/x.py $(STAGE_2_TEST_SET1)
-ci-msvc-ps1-set2:
+ci-msvc-ps1:
 	$(Q)$(CFG_SRC_DIR)/x.ps1 $(STAGE_2_TEST_SET2)
+ci-msvc: ci-msvc-py ci-msvc-ps1
 
 ## MingW native builders
 

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -35,6 +35,10 @@ runners:
     os: windows-2022
     <<: *base-job
 
+  - &job-windows-25
+    os: windows-2025
+    <<: *base-job
+
   - &job-windows-8c
     os: windows-2022-8core-32gb
     <<: *base-job
@@ -442,23 +446,29 @@ auto:
   #  Windows Builders  #
   ######################
 
-  - name: x86_64-msvc
+  - name: x86_64-msvc-1
     env:
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
-      SCRIPT: make ci-msvc
-    <<: *job-windows-8c
+      SCRIPT: make ci-msvc-py
+    <<: *job-windows-25
+
+  - name: x86_64-msvc-2
+    env:
+      RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
+      SCRIPT: make ci-msvc-ps1
+    <<: *job-windows-25
 
   # i686-msvc is split into two jobs to run tests in parallel.
   - name: i686-msvc-1
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
-      SCRIPT: make ci-msvc-py-set1
+      SCRIPT: make ci-msvc-py
     <<: *job-windows
 
   - name: i686-msvc-2
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
-      SCRIPT: make ci-msvc-ps1-set2
+      SCRIPT: make ci-msvc-ps1
     <<: *job-windows
 
   # x86_64-msvc-ext is split into multiple jobs to run tests in parallel.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
windows-2025 _seems_ to fix the flakiness discribed in https://github.com/rust-lang/rust/issues/127883 — This PR never failed a `bors try`.
This PR also removes the large runner by splitting it into two free runners, addressing https://github.com/rust-lang/infra-team/issues/189 🥳

Too good to be true? Let's see! My suggestion is to merge this PR and observe how it behaves in the `auto` branch in the [public dashboard](https://app.datadoghq.com/dashboard/rev-2bu-vu2/ci-visibility-public) over the following weeks.

## Additional context

I discussed this change in [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/High.20failure.20rate.20on.20.60i686-mingw.60.20recently/near/494499910) as well.

If you want to see a similar PR to this one where `x86_64-msvc` on windows 2022 fails in CI consistently, see https://github.com/rust-lang/rust/pull/135483#issuecomment-2594646980

r? @Kobzol 
<!-- homu-ignore:end -->
try-job: x86_64-msvc-1
try-job: x86_64-msvc-2
try-job: dist-x86_64-msvc