### PR TITLE
ci: switch to linux free arm runners

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -44,7 +44,7 @@ runners:
     <<: *base-job
 
   - &job-aarch64-linux
-    os: ubuntu-22.04-arm64-8core-32gb
+    os: ubuntu-22.04-arm
 
 envs:
   env-x86_64-apple-tests: &env-x86_64-apple-tests


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Linux free arm runners are now available. We can use them instead of the large runners.

r? @ghost
<!-- homu-ignore:end -->

try-job: aarch64-gnu
try-job: aarch64-gnu-debug
try-job: dist-aarch64-linux