### PR TITLE
stop specializing on `Copy`

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/bounds.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/bounds.rs
@@ -25,6 +25,7 @@ pub(crate) fn expand_deriving_copy(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
 
     trait_def.expand(cx, mitem, item, push);
@@ -50,6 +51,7 @@ pub(crate) fn expand_deriving_const_param_ty(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
 
     trait_def.expand(cx, mitem, item, push);

--- a/compiler/rustc_builtin_macros/src/deriving/bounds.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/bounds.rs
@@ -1,4 +1,4 @@
-use rustc_ast::MetaItem;
+use rustc_ast::{MetaItem, Safety};
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_span::Span;
 
@@ -24,6 +24,7 @@ pub(crate) fn expand_deriving_copy(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
 
     trait_def.expand(cx, mitem, item, push);
@@ -48,6 +49,7 @@ pub(crate) fn expand_deriving_const_param_ty(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
 
     trait_def.expand(cx, mitem, item, push);

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -1,7 +1,7 @@
-use rustc_ast::{self as ast, Generics, ItemKind, MetaItem, VariantData};
+use rustc_ast::{self as ast, Generics, ItemKind, MetaItem, Safety, VariantData};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_expand::base::{Annotatable, ExtCtxt};
-use rustc_span::{Ident, Span, kw, sym};
+use rustc_span::{DUMMY_SP, Ident, Span, kw, sym};
 use thin_vec::{ThinVec, thin_vec};
 
 use crate::deriving::generic::ty::*;
@@ -68,6 +68,26 @@ pub(crate) fn expand_deriving_clone(
         _ => cx.dcx().span_bug(span, "`#[derive(Clone)]` on trait item or impl item"),
     }
 
+    // If the clone method is just copying the value, also mark the type as
+    // `TrivialClone` to allow some library optimizations.
+    if is_simple {
+        let trivial_def = TraitDef {
+            span,
+            path: path_std!(clone::TrivialClone),
+            skip_path_as_bound: false,
+            needs_copy_as_bound_if_packed: true,
+            additional_bounds: bounds.clone(),
+            supports_unions: true,
+            methods: Vec::new(),
+            associated_types: Vec::new(),
+            is_const,
+            is_staged_api_crate: cx.ecfg.features.staged_api(),
+            safety: Safety::Unsafe(DUMMY_SP),
+        };
+
+        trivial_def.expand_ext(cx, mitem, item, push, true);
+    }
+
     let trait_def = TraitDef {
         span,
         path: path_std!(clone::Clone),
@@ -88,6 +108,7 @@ pub(crate) fn expand_deriving_clone(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
 
     trait_def.expand_ext(cx, mitem, item, push, is_simple)

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -83,6 +83,9 @@ pub(crate) fn expand_deriving_clone(
             is_const,
             is_staged_api_crate: cx.ecfg.features.staged_api(),
             safety: Safety::Unsafe(DUMMY_SP),
+            // `TrivialClone` is not part of an API guarantee, so it shouldn't
+            // appear in rustdoc output.
+            document: false,
         };
 
         trivial_def.expand_ext(cx, mitem, item, push, true);
@@ -109,6 +112,7 @@ pub(crate) fn expand_deriving_clone(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
 
     trait_def.expand_ext(cx, mitem, item, push, is_simple)

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
@@ -1,4 +1,4 @@
-use rustc_ast::{self as ast, MetaItem};
+use rustc_ast::{self as ast, MetaItem, Safety};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_span::{Span, sym};
@@ -44,6 +44,7 @@ pub(crate) fn expand_deriving_eq(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
     trait_def.expand_ext(cx, mitem, item, push, true)
 }

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
@@ -45,6 +45,7 @@ pub(crate) fn expand_deriving_eq(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
     trait_def.expand_ext(cx, mitem, item, push, true)
 }

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
@@ -1,4 +1,4 @@
-use rustc_ast::MetaItem;
+use rustc_ast::{MetaItem, Safety};
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_span::{Ident, Span, sym};
 use thin_vec::thin_vec;
@@ -35,6 +35,7 @@ pub(crate) fn expand_deriving_ord(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
 
     trait_def.expand(cx, mitem, item, push)

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
@@ -36,6 +36,7 @@ pub(crate) fn expand_deriving_ord(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
 
     trait_def.expand(cx, mitem, item, push)

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
@@ -31,6 +31,7 @@ pub(crate) fn expand_deriving_partial_eq(
         is_const: false,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
     structural_trait_def.expand(cx, mitem, item, push);
 
@@ -61,6 +62,7 @@ pub(crate) fn expand_deriving_partial_eq(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
@@ -1,4 +1,4 @@
-use rustc_ast::{BinOpKind, BorrowKind, Expr, ExprKind, MetaItem, Mutability};
+use rustc_ast::{BinOpKind, BorrowKind, Expr, ExprKind, MetaItem, Mutability, Safety};
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_span::{Span, sym};
 use thin_vec::thin_vec;
@@ -30,6 +30,7 @@ pub(crate) fn expand_deriving_partial_eq(
         associated_types: Vec::new(),
         is_const: false,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
     structural_trait_def.expand(cx, mitem, item, push);
 
@@ -59,6 +60,7 @@ pub(crate) fn expand_deriving_partial_eq(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
@@ -66,6 +66,7 @@ pub(crate) fn expand_deriving_partial_ord(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
@@ -1,4 +1,4 @@
-use rustc_ast::{ExprKind, ItemKind, MetaItem, PatKind};
+use rustc_ast::{ExprKind, ItemKind, MetaItem, PatKind, Safety};
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_span::{Ident, Span, sym};
 use thin_vec::thin_vec;
@@ -65,6 +65,7 @@ pub(crate) fn expand_deriving_partial_ord(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/compiler/rustc_builtin_macros/src/deriving/debug.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/debug.rs
@@ -43,6 +43,7 @@ pub(crate) fn expand_deriving_debug(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/compiler/rustc_builtin_macros/src/deriving/debug.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/debug.rs
@@ -1,4 +1,4 @@
-use rustc_ast::{self as ast, EnumDef, MetaItem};
+use rustc_ast::{self as ast, EnumDef, MetaItem, Safety};
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_session::config::FmtDebug;
 use rustc_span::{Ident, Span, Symbol, sym};
@@ -42,6 +42,7 @@ pub(crate) fn expand_deriving_debug(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/compiler/rustc_builtin_macros/src/deriving/default.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/default.rs
@@ -1,8 +1,7 @@
 use core::ops::ControlFlow;
 
-use rustc_ast as ast;
 use rustc_ast::visit::visit_opt;
-use rustc_ast::{EnumDef, VariantData, attr};
+use rustc_ast::{self as ast, EnumDef, Safety, VariantData, attr};
 use rustc_expand::base::{Annotatable, DummyResult, ExtCtxt};
 use rustc_span::{ErrorGuaranteed, Ident, Span, kw, sym};
 use smallvec::SmallVec;
@@ -52,6 +51,7 @@ pub(crate) fn expand_deriving_default(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/compiler/rustc_builtin_macros/src/deriving/default.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/default.rs
@@ -52,6 +52,7 @@ pub(crate) fn expand_deriving_default(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
     trait_def.expand(cx, mitem, item, push)
 }

--- a/compiler/rustc_builtin_macros/src/deriving/from.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/from.rs
@@ -1,5 +1,5 @@
 use rustc_ast as ast;
-use rustc_ast::{ItemKind, VariantData};
+use rustc_ast::{ItemKind, Safety, VariantData};
 use rustc_errors::MultiSpan;
 use rustc_expand::base::{Annotatable, DummyResult, ExtCtxt};
 use rustc_span::{Ident, Span, kw, sym};
@@ -127,6 +127,7 @@ pub(crate) fn expand_deriving_from(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
 
     from_trait_def.expand(cx, mitem, annotatable, push);

--- a/compiler/rustc_builtin_macros/src/deriving/from.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/from.rs
@@ -128,6 +128,7 @@ pub(crate) fn expand_deriving_from(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
 
     from_trait_def.expand(cx, mitem, annotatable, push);

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -225,6 +225,9 @@ pub(crate) struct TraitDef<'a> {
     pub is_const: bool,
 
     pub is_staged_api_crate: bool,
+
+    /// The safety of the `impl`.
+    pub safety: Safety,
 }
 
 pub(crate) struct MethodDef<'a> {
@@ -832,7 +835,7 @@ impl<'a> TraitDef<'a> {
             ast::ItemKind::Impl(ast::Impl {
                 generics: trait_generics,
                 of_trait: Some(Box::new(ast::TraitImplHeader {
-                    safety: ast::Safety::Default,
+                    safety: self.safety,
                     polarity: ast::ImplPolarity::Positive,
                     defaultness: ast::Defaultness::Final,
                     constness: if self.is_const {

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -228,6 +228,9 @@ pub(crate) struct TraitDef<'a> {
 
     /// The safety of the `impl`.
     pub safety: Safety,
+
+    /// Whether the added `impl` should appear in rustdoc output.
+    pub document: bool,
 }
 
 pub(crate) struct MethodDef<'a> {
@@ -827,6 +830,10 @@ impl<'a> TraitDef<'a> {
                     self.span,
                 ),
             )
+        }
+
+        if !self.document {
+            attrs.push(cx.attr_nested_word(sym::doc, sym::hidden, self.span));
         }
 
         cx.item(

--- a/compiler/rustc_builtin_macros/src/deriving/hash.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/hash.rs
@@ -43,6 +43,7 @@ pub(crate) fn expand_deriving_hash(
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
         safety: Safety::Default,
+        document: true,
     };
 
     hash_trait_def.expand(cx, mitem, item, push);

--- a/compiler/rustc_builtin_macros/src/deriving/hash.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/hash.rs
@@ -1,4 +1,4 @@
-use rustc_ast::{MetaItem, Mutability};
+use rustc_ast::{MetaItem, Mutability, Safety};
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_span::{Span, sym};
 use thin_vec::thin_vec;
@@ -42,6 +42,7 @@ pub(crate) fn expand_deriving_hash(
         associated_types: Vec::new(),
         is_const,
         is_staged_api_crate: cx.ecfg.features.staged_api(),
+        safety: Safety::Default,
     };
 
     hash_trait_def.expand(cx, mitem, item, push);

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -176,6 +176,7 @@ language_item_table! {
     Clone,                   sym::clone,               clone_trait,                Target::Trait,          GenericRequirement::None;
     CloneFn,                 sym::clone_fn,            clone_fn,                   Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
     UseCloned,               sym::use_cloned,          use_cloned_trait,           Target::Trait,          GenericRequirement::None;
+    TrivialClone,            sym::trivial_clone,       trivial_clone_trait,        Target::Trait,          GenericRequirement::None;
     Sync,                    sym::sync,                sync_trait,                 Target::Trait,          GenericRequirement::Exact(0);
     DiscriminantKind,        sym::discriminant_kind,   discriminant_kind_trait,    Target::Trait,          GenericRequirement::None;
     /// The associated item of the `DiscriminantKind` trait.

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -856,6 +856,7 @@ bidirectional_lang_item_map! {
     PointeeTrait,
     Sized,
     TransmuteTrait,
+    TrivialClone,
     Tuple,
     Unpin,
     Unsize,

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -547,9 +547,11 @@ where
                 Some(SolverTraitLangItem::PointeeSized) => {
                     unreachable!("`PointeeSized` is removed during lowering");
                 }
-                Some(SolverTraitLangItem::Copy | SolverTraitLangItem::Clone) => {
-                    G::consider_builtin_copy_clone_candidate(self, goal)
-                }
+                Some(
+                    SolverTraitLangItem::Copy
+                    | SolverTraitLangItem::Clone
+                    | SolverTraitLangItem::TrivialClone,
+                ) => G::consider_builtin_copy_clone_candidate(self, goal),
                 Some(SolverTraitLangItem::Fn) => {
                     G::consider_builtin_fn_trait_candidates(self, goal, ty::ClosureKind::Fn)
                 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2271,6 +2271,7 @@ symbols! {
         transparent_enums,
         transparent_unions,
         trivial_bounds,
+        trivial_clone,
         truncf16,
         truncf32,
         truncf64,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -372,6 +372,7 @@ symbols! {
         ToString,
         TokenStream,
         Trait,
+        TrivialClone,
         Try,
         TryCaptureGeneric,
         TryCapturePrintable,

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -67,7 +67,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
             let lang_item = tcx.as_lang_item(def_id);
             match lang_item {
-                Some(LangItem::Copy | LangItem::Clone) => {
+                Some(LangItem::Copy | LangItem::Clone | LangItem::TrivialClone) => {
                     debug!(obligation_self_ty = ?obligation.predicate.skip_binder().self_ty());
 
                     // User-defined copy impls are permitted, but only for

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -249,7 +249,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             Some(LangItem::PointeeSized) => {
                 bug!("`PointeeSized` is removing during lowering");
             }
-            Some(LangItem::Copy | LangItem::Clone) => self.copy_clone_conditions(self_ty),
+            Some(LangItem::Copy | LangItem::Clone | LangItem::TrivialClone) => {
+                self.copy_clone_conditions(self_ty)
+            }
             Some(LangItem::FusedIterator) => {
                 if self.coroutine_is_gen(self_ty) {
                     ty::Binder::dummy(vec![])

--- a/compiler/rustc_type_ir/src/lang_items.rs
+++ b/compiler/rustc_type_ir/src/lang_items.rs
@@ -48,6 +48,7 @@ pub enum SolverTraitLangItem {
     PointeeTrait,
     Sized,
     TransmuteTrait,
+    TrivialClone,
     Tuple,
     Unpin,
     Unsize,

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -7,6 +7,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+#[cfg(not(no_global_oom_handling))]
+use core::clone::TrivialClone;
 use core::cmp::{self, Ordering};
 use core::hash::{Hash, Hasher};
 use core::iter::{ByRefSized, repeat_n, repeat_with};
@@ -3419,7 +3421,7 @@ impl<T: Clone, A: Allocator> SpecExtendFromWithin for VecDeque<T, A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<T: Copy, A: Allocator> SpecExtendFromWithin for VecDeque<T, A> {
+impl<T: TrivialClone, A: Allocator> SpecExtendFromWithin for VecDeque<T, A> {
     unsafe fn spec_extend_from_within(&mut self, src: Range<usize>) {
         let dst = self.len();
         let count = src.end - src.start;

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -146,6 +146,7 @@
 #![feature(std_internals)]
 #![feature(str_internals)]
 #![feature(temporary_niche_types)]
+#![feature(trivial_clone)]
 #![feature(trusted_fused)]
 #![feature(trusted_len)]
 #![feature(trusted_random_access)]

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -11,6 +11,8 @@
 
 use core::borrow::{Borrow, BorrowMut};
 #[cfg(not(no_global_oom_handling))]
+use core::clone::TrivialClone;
+#[cfg(not(no_global_oom_handling))]
 use core::cmp::Ordering::{self, Less};
 #[cfg(not(no_global_oom_handling))]
 use core::mem::MaybeUninit;
@@ -439,7 +441,7 @@ impl<T> [T] {
             }
         }
 
-        impl<T: Copy> ConvertVec for T {
+        impl<T: TrivialClone> ConvertVec for T {
             #[inline]
             fn to_vec<A: Allocator>(s: &[Self], alloc: A) -> Vec<Self, A> {
                 let mut v = Vec::with_capacity_in(s.len(), alloc);
@@ -822,7 +824,7 @@ impl<T: Clone, A: Allocator> SpecCloneIntoVec<T, A> for [T] {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<T: Copy, A: Allocator> SpecCloneIntoVec<T, A> for [T] {
+impl<T: TrivialClone, A: Allocator> SpecCloneIntoVec<T, A> for [T] {
     fn clone_into(&self, target: &mut Vec<T, A>) {
         target.clear();
         target.extend_from_slice(self);

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -74,6 +74,8 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 #[cfg(not(no_global_oom_handling))]
+use core::clone::TrivialClone;
+#[cfg(not(no_global_oom_handling))]
 use core::cmp;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
@@ -3494,7 +3496,7 @@ impl<T: Clone, A: Allocator> ExtendFromWithinSpec for Vec<T, A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-impl<T: Copy, A: Allocator> ExtendFromWithinSpec for Vec<T, A> {
+impl<T: TrivialClone, A: Allocator> ExtendFromWithinSpec for Vec<T, A> {
     unsafe fn spec_extend_from_within(&mut self, src: Range<usize>) {
         let count = src.len();
         {
@@ -3507,8 +3509,8 @@ impl<T: Copy, A: Allocator> ExtendFromWithinSpec for Vec<T, A> {
             // SAFETY:
             // - Both pointers are created from unique slice references (`&mut [_]`)
             //   so they are valid and do not overlap.
-            // - Elements are :Copy so it's OK to copy them, without doing
-            //   anything with the original values
+            // - Elements implement `TrivialClone` so this is equivalent to calling
+            //   `clone` on every one of them.
             // - `count` is equal to the len of `source`, so source is valid for
             //   `count` reads
             // - `.reserve(count)` guarantees that `spare.len() >= count` so spare

--- a/library/alloc/src/vec/spec_extend.rs
+++ b/library/alloc/src/vec/spec_extend.rs
@@ -1,3 +1,4 @@
+use core::clone::TrivialClone;
 use core::iter::TrustedLen;
 use core::slice::{self};
 
@@ -48,7 +49,7 @@ where
 
 impl<'a, T: 'a, A: Allocator> SpecExtend<&'a T, slice::Iter<'a, T>> for Vec<T, A>
 where
-    T: Copy,
+    T: TrivialClone,
 {
     fn spec_extend(&mut self, iterator: slice::Iter<'a, T>) {
         let slice = iterator.as_slice();

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -40,6 +40,7 @@
 #![feature(slice_range)]
 #![feature(std_internals)]
 #![feature(temporary_niche_types)]
+#![feature(trivial_clone)]
 #![feature(trusted_fused)]
 #![feature(trusted_len)]
 #![feature(trusted_random_access)]

--- a/library/alloctests/tests/vec.rs
+++ b/library/alloctests/tests/vec.rs
@@ -2300,20 +2300,6 @@ fn test_vec_swap() {
 }
 
 #[test]
-fn test_extend_from_within_spec() {
-    #[derive(Copy)]
-    struct CopyOnly;
-
-    impl Clone for CopyOnly {
-        fn clone(&self) -> Self {
-            panic!("extend_from_within must use specialization on copy");
-        }
-    }
-
-    vec![CopyOnly, CopyOnly].extend_from_within(..);
-}
-
-#[test]
 fn test_extend_from_within_clone() {
     let mut v = vec![String::from("sssss"), String::from("12334567890"), String::from("c")];
     v.extend_from_within(1..);

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -5,10 +5,10 @@
 #![stable(feature = "core_array", since = "1.35.0")]
 
 use crate::borrow::{Borrow, BorrowMut};
+use crate::clone::TrivialClone;
 use crate::cmp::Ordering;
 use crate::convert::Infallible;
 use crate::error::Error;
-use crate::fmt;
 use crate::hash::{self, Hash};
 use crate::intrinsics::transmute_unchecked;
 use crate::iter::{UncheckedIterator, repeat_n};
@@ -18,6 +18,7 @@ use crate::ops::{
 };
 use crate::ptr::{null, null_mut};
 use crate::slice::{Iter, IterMut};
+use crate::{fmt, ptr};
 
 mod ascii;
 mod drain;
@@ -451,6 +452,9 @@ impl<T: Clone, const N: usize> Clone for [T; N] {
     }
 }
 
+#[unstable(feature = "trivial_clone", issue = "none")]
+unsafe impl<T: TrivialClone, const N: usize> TrivialClone for [T; N] {}
+
 trait SpecArrayClone: Clone {
     fn clone<const N: usize>(array: &[Self; N]) -> [Self; N];
 }
@@ -462,10 +466,12 @@ impl<T: Clone> SpecArrayClone for T {
     }
 }
 
-impl<T: Copy> SpecArrayClone for T {
+impl<T: TrivialClone> SpecArrayClone for T {
     #[inline]
     fn clone<const N: usize>(array: &[T; N]) -> [T; N] {
-        *array
+        // SAFETY: `TrivialClone` implies that this is equivalent to calling
+        // `Clone` on every element.
+        unsafe { ptr::read(array) }
     }
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -452,6 +452,7 @@ impl<T: Clone, const N: usize> Clone for [T; N] {
     }
 }
 
+#[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
 unsafe impl<T: TrivialClone, const N: usize> TrivialClone for [T; N] {}
 

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -616,6 +616,7 @@ mod impls {
                     }
                 }
 
+                #[doc(hidden)]
                 #[unstable(feature = "trivial_clone", issue = "none")]
                 #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
                 unsafe impl const TrivialClone for $t {}
@@ -639,6 +640,7 @@ mod impls {
         }
     }
 
+    #[doc(hidden)]
     #[unstable(feature = "trivial_clone", issue = "none")]
     #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
     unsafe impl const TrivialClone for ! {}
@@ -652,6 +654,7 @@ mod impls {
         }
     }
 
+    #[doc(hidden)]
     #[unstable(feature = "trivial_clone", issue = "none")]
     #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
     unsafe impl<T: PointeeSized> const TrivialClone for *const T {}
@@ -665,6 +668,7 @@ mod impls {
         }
     }
 
+    #[doc(hidden)]
     #[unstable(feature = "trivial_clone", issue = "none")]
     #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
     unsafe impl<T: PointeeSized> const TrivialClone for *mut T {}
@@ -680,6 +684,7 @@ mod impls {
         }
     }
 
+    #[doc(hidden)]
     #[unstable(feature = "trivial_clone", issue = "none")]
     #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
     unsafe impl<T: PointeeSized> const TrivialClone for &T {}

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -280,7 +280,7 @@ pub const unsafe trait TrivialClone: [const] Clone {}
 /// Derive macro generating an impl of the trait `Clone`.
 #[rustc_builtin_macro]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
+#[allow_internal_unstable(core_intrinsics, derive_clone_copy, trivial_clone)]
 pub macro Clone($item:item) {
     /* compiler built-in */
 }

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -250,6 +250,33 @@ pub const trait Clone: Sized {
     }
 }
 
+/// Indicates that the `Clone` implementation is identical to copying the value.
+///
+/// This is used for some optimizations in the standard library, which specializes
+/// on this trait to select faster implementations of functions such as
+/// [`clone_from_slice`](slice::clone_from_slice). It is automatically implemented
+/// when using `#[derive(Clone, Copy)]`.
+///
+/// Note that this trait does not imply that the type is `Copy`, because e.g.
+/// `core::ops::Range<i32>` could soundly implement this trait.
+///
+/// # Safety
+/// `Clone::clone` must be equivalent to copying the value, otherwise calling functions
+/// such as `slice::clone_from_slice` can have undefined behaviour.
+#[unstable(
+    feature = "trivial_clone",
+    reason = "this isn't part of any API guarantee",
+    issue = "none"
+)]
+#[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+// SAFETY:
+// It is sound to specialize on this because the `clone` implementation cannot be
+// lifetime-dependent. Therefore, if `TrivialClone` is implemented for any lifetime,
+// its invariant holds whenever `Clone` is implemented, even if the actual
+// `TrivialClone` bound would not be satisfied because of lifetime bounds.
+#[rustc_unsafe_specialization_marker]
+pub const unsafe trait TrivialClone: [const] Clone {}
+
 /// Derive macro generating an impl of the trait `Clone`.
 #[rustc_builtin_macro]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
@@ -569,6 +596,7 @@ unsafe impl CloneToUninit for crate::bstr::ByteStr {
 /// are implemented in `traits::SelectionContext::copy_clone_conditions()`
 /// in `rustc_trait_selection`.
 mod impls {
+    use super::TrivialClone;
     use crate::marker::PointeeSized;
 
     macro_rules! impl_clone {
@@ -582,6 +610,10 @@ mod impls {
                         *self
                     }
                 }
+
+                #[unstable(feature = "trivial_clone", issue = "none")]
+                #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+                unsafe impl const TrivialClone for $t {}
             )*
         }
     }
@@ -602,6 +634,10 @@ mod impls {
         }
     }
 
+    #[unstable(feature = "trivial_clone", issue = "none")]
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    unsafe impl const TrivialClone for ! {}
+
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
     impl<T: PointeeSized> const Clone for *const T {
@@ -611,6 +647,10 @@ mod impls {
         }
     }
 
+    #[unstable(feature = "trivial_clone", issue = "none")]
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    unsafe impl<T: PointeeSized> const TrivialClone for *const T {}
+
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
     impl<T: PointeeSized> const Clone for *mut T {
@@ -619,6 +659,10 @@ mod impls {
             *self
         }
     }
+
+    #[unstable(feature = "trivial_clone", issue = "none")]
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    unsafe impl<T: PointeeSized> const TrivialClone for *mut T {}
 
     /// Shared references can be cloned, but mutable references *cannot*!
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -630,6 +674,10 @@ mod impls {
             self
         }
     }
+
+    #[unstable(feature = "trivial_clone", issue = "none")]
+    #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+    unsafe impl<T: PointeeSized> const TrivialClone for &T {}
 
     /// Shared references can be cloned, but mutable references *cannot*!
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -275,6 +275,10 @@ pub const trait Clone: Sized {
 // its invariant holds whenever `Clone` is implemented, even if the actual
 // `TrivialClone` bound would not be satisfied because of lifetime bounds.
 #[rustc_unsafe_specialization_marker]
+// If `#[derive(Clone, Clone, Copy)]` is written, there will be multiple
+// implementations of `TrivialClone`. To keep it from appearing in error
+// messages, make it a `#[marker]` trait.
+#[marker]
 pub const unsafe trait TrivialClone: [const] Clone {}
 
 /// Derive macro generating an impl of the trait `Clone`.

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -269,6 +269,7 @@ pub const trait Clone: Sized {
     issue = "none"
 )]
 #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+#[lang = "trivial_clone"]
 // SAFETY:
 // It is sound to specialize on this because the `clone` implementation cannot be
 // lifetime-dependent. Therefore, if `TrivialClone` is implemented for any lifetime,

--- a/library/core/src/clone/uninit.rs
+++ b/library/core/src/clone/uninit.rs
@@ -1,3 +1,4 @@
+use super::TrivialClone;
 use crate::mem::{self, MaybeUninit};
 use crate::ptr;
 
@@ -49,9 +50,9 @@ unsafe impl<T: Clone> CopySpec for T {
     }
 }
 
-// Specialized implementation for types that are [`Copy`], not just [`Clone`],
+// Specialized implementation for types that are [`TrivialClone`], not just [`Clone`],
 // and can therefore be copied bitwise.
-unsafe impl<T: Copy> CopySpec for T {
+unsafe impl<T: TrivialClone> CopySpec for T {
     #[inline]
     unsafe fn clone_one(src: &Self, dst: *mut Self) {
         // SAFETY: The safety conditions of clone_to_uninit() are a superset of those of

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -858,6 +858,7 @@ impl<T: PointeeSized> Clone for PhantomData<T> {
     }
 }
 
+#[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
 unsafe impl<T: ?Sized> TrivialClone for PhantomData<T> {}
 

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -14,6 +14,7 @@ pub use self::variance::{
     PhantomInvariant, PhantomInvariantLifetime, Variance, variance,
 };
 use crate::cell::UnsafeCell;
+use crate::clone::TrivialClone;
 use crate::cmp;
 use crate::fmt::Debug;
 use crate::hash::{Hash, Hasher};
@@ -454,12 +455,8 @@ marker_impls! {
 /// [impls]: #implementors
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "copy"]
-// FIXME(matthewjasper) This allows copying a type that doesn't implement
-// `Copy` because of unsatisfied lifetime bounds (copying `A<'_>` when only
-// `A<'static>: Copy` and `A<'_>: Clone`).
-// We have this attribute here for now only because there are quite a few
-// existing specializations on `Copy` that already exist in the standard
-// library, and there's no way to safely have this behavior right now.
+// This is unsound, but required by `hashbrown`
+// FIXME(joboet): change `hashbrown` to use `TrivialClone`
 #[rustc_unsafe_specialization_marker]
 #[rustc_diagnostic_item = "Copy"]
 pub trait Copy: Clone {
@@ -860,6 +857,9 @@ impl<T: PointeeSized> Clone for PhantomData<T> {
         Self
     }
 }
+
+#[unstable(feature = "trivial_clone", issue = "none")]
+unsafe impl<T: ?Sized> TrivialClone for PhantomData<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_default", issue = "143894")]

--- a/library/core/src/marker/variance.rs
+++ b/library/core/src/marker/variance.rs
@@ -2,6 +2,7 @@
 
 use super::PhantomData;
 use crate::any::type_name;
+use crate::clone::TrivialClone;
 use crate::cmp::Ordering;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
@@ -59,6 +60,8 @@ macro_rules! phantom_type {
         }
 
         impl<T> Copy for $name<T> where T: ?Sized {}
+
+        unsafe impl<T> TrivialClone for $name<T> where T: ?Sized {}
 
         impl<T> PartialEq for $name<T>
             where T: ?Sized

--- a/library/core/src/marker/variance.rs
+++ b/library/core/src/marker/variance.rs
@@ -61,6 +61,7 @@ macro_rules! phantom_type {
 
         impl<T> Copy for $name<T> where T: ?Sized {}
 
+        #[doc(hidden)]
         unsafe impl<T> TrivialClone for $name<T> where T: ?Sized {}
 
         impl<T> PartialEq for $name<T>

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -358,6 +358,7 @@ impl<T: Copy> Clone for MaybeUninit<T> {
 }
 
 // SAFETY: the clone implementation is a copy, see above.
+#[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
 unsafe impl<T> TrivialClone for MaybeUninit<T> where MaybeUninit<T>: Clone {}
 

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1,4 +1,5 @@
 use crate::any::type_name;
+use crate::clone::TrivialClone;
 use crate::marker::Destruct;
 use crate::mem::ManuallyDrop;
 use crate::{fmt, intrinsics, ptr, slice};
@@ -355,6 +356,10 @@ impl<T: Copy> Clone for MaybeUninit<T> {
         *self
     }
 }
+
+// SAFETY: the clone implementation is a copy, see above.
+#[unstable(feature = "trivial_clone", issue = "none")]
+unsafe impl<T> TrivialClone for MaybeUninit<T> where MaybeUninit<T>: Clone {}
 
 #[stable(feature = "maybe_uninit_debug", since = "1.41.0")]
 impl<T> fmt::Debug for MaybeUninit<T> {
@@ -1599,8 +1604,12 @@ impl<T: Clone> SpecFill<T> for [MaybeUninit<T>] {
     }
 }
 
-impl<T: Copy> SpecFill<T> for [MaybeUninit<T>] {
+impl<T: TrivialClone> SpecFill<T> for [MaybeUninit<T>] {
     fn spec_fill(&mut self, value: T) {
-        self.fill(MaybeUninit::new(value));
+        // SAFETY: because `T` is `TrivialClone`, this is equivalent to calling
+        // `T::clone` for every element. Notably, `TrivialClone` also implies
+        // that the `clone` implementation will not panic, so we can avoid
+        // initialization guards and such.
+        self.fill_with(|| MaybeUninit::new(unsafe { ptr::read(&value) }));
     }
 }

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -6,6 +6,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::alloc::Layout;
+use crate::clone::TrivialClone;
 use crate::marker::{Destruct, DiscriminantKind};
 use crate::panic::const_assert;
 use crate::{clone, cmp, fmt, hash, intrinsics, ptr};
@@ -1069,6 +1070,9 @@ impl<T> clone::Clone for Discriminant<T> {
         *self
     }
 }
+
+#[unstable(feature = "trivial_clone", issue = "none")]
+unsafe impl<T> TrivialClone for Discriminant<T> {}
 
 #[stable(feature = "discriminant_value", since = "1.21.0")]
 impl<T> cmp::PartialEq for Discriminant<T> {

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -1071,6 +1071,7 @@ impl<T> clone::Clone for Discriminant<T> {
     }
 }
 
+#[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
 unsafe impl<T> TrivialClone for Discriminant<T> {}
 

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1,7 +1,7 @@
 //! Definitions of integer that is known not to equal zero.
 
 use super::{IntErrorKind, ParseIntError};
-use crate::clone::UseCloned;
+use crate::clone::{TrivialClone, UseCloned};
 use crate::cmp::Ordering;
 use crate::hash::{Hash, Hasher};
 use crate::marker::{Destruct, Freeze, StructuralPartialEq};
@@ -198,6 +198,9 @@ impl<T> UseCloned for NonZero<T> where T: ZeroablePrimitive {}
 
 #[stable(feature = "nonzero", since = "1.28.0")]
 impl<T> Copy for NonZero<T> where T: ZeroablePrimitive {}
+
+#[unstable(feature = "trivial_clone", issue = "none")]
+unsafe impl<T> TrivialClone for NonZero<T> where T: ZeroablePrimitive {}
 
 #[stable(feature = "nonzero", since = "1.28.0")]
 #[rustc_const_unstable(feature = "const_cmp", issue = "143800")]

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -199,6 +199,7 @@ impl<T> UseCloned for NonZero<T> where T: ZeroablePrimitive {}
 #[stable(feature = "nonzero", since = "1.28.0")]
 impl<T> Copy for NonZero<T> where T: ZeroablePrimitive {}
 
+#[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
 unsafe impl<T> TrivialClone for NonZero<T> where T: ZeroablePrimitive {}
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2216,6 +2216,7 @@ where
 #[unstable(feature = "ergonomic_clones", issue = "132290")]
 impl<T> crate::clone::UseCloned for Option<T> where T: crate::clone::UseCloned {}
 
+#[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
 #[rustc_const_unstable(feature = "const_clone", issue = "142757")]
 unsafe impl<T> const TrivialClone for Option<T> where T: [const] TrivialClone + [const] Destruct {}

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -581,6 +581,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::clone::TrivialClone;
 use crate::iter::{self, FusedIterator, TrustedLen};
 use crate::marker::Destruct;
 use crate::ops::{self, ControlFlow, Deref, DerefMut};
@@ -2214,6 +2215,10 @@ where
 
 #[unstable(feature = "ergonomic_clones", issue = "132290")]
 impl<T> crate::clone::UseCloned for Option<T> where T: crate::clone::UseCloned {}
+
+#[unstable(feature = "trivial_clone", issue = "none")]
+#[rustc_const_unstable(feature = "const_clone", issue = "142757")]
+unsafe impl<T> const TrivialClone for Option<T> where T: [const] TrivialClone + [const] Destruct {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_default", issue = "143894")]

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -1,5 +1,6 @@
 #![unstable(feature = "ptr_metadata", issue = "81513")]
 
+use crate::clone::TrivialClone;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
 use crate::intrinsics::{aggregate_raw_ptr, ptr_metadata};
@@ -230,6 +231,8 @@ impl<Dyn: PointeeSized> Clone for DynMetadata<Dyn> {
         *self
     }
 }
+
+unsafe impl<Dyn: ?Sized> TrivialClone for DynMetadata<Dyn> {}
 
 impl<Dyn: PointeeSized> Eq for DynMetadata<Dyn> {}
 

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -232,6 +232,7 @@ impl<Dyn: PointeeSized> Clone for DynMetadata<Dyn> {
     }
 }
 
+#[doc(hidden)]
 unsafe impl<Dyn: ?Sized> TrivialClone for DynMetadata<Dyn> {}
 
 impl<Dyn: PointeeSized> Eq for DynMetadata<Dyn> {}

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1654,6 +1654,7 @@ impl<T: PointeeSized> Clone for NonNull<T> {
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: PointeeSized> Copy for NonNull<T> {}
 
+#[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
 unsafe impl<T: ?Sized> TrivialClone for NonNull<T> {}
 

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1,3 +1,4 @@
+use crate::clone::TrivialClone;
 use crate::cmp::Ordering;
 use crate::marker::{Destruct, PointeeSized, Unsize};
 use crate::mem::{MaybeUninit, SizedTypeProperties};
@@ -1652,6 +1653,9 @@ impl<T: PointeeSized> Clone for NonNull<T> {
 
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: PointeeSized> Copy for NonNull<T> {}
+
+#[unstable(feature = "trivial_clone", issue = "none")]
+unsafe impl<T: ?Sized> TrivialClone for NonNull<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "18598")]
 impl<T: PointeeSized, U: PointeeSized> CoerceUnsized<NonNull<U>> for NonNull<T> where T: Unsize<U> {}

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -166,6 +166,7 @@ impl<T: PointeeSized> Clone for Unique<T> {
 #[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: PointeeSized> Copy for Unique<T> {}
 
+#[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
 unsafe impl<T: ?Sized> TrivialClone for Unique<T> {}
 

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -1,3 +1,4 @@
+use crate::clone::TrivialClone;
 use crate::fmt;
 use crate::marker::{PhantomData, PointeeSized, Unsize};
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
@@ -164,6 +165,9 @@ impl<T: PointeeSized> Clone for Unique<T> {
 
 #[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: PointeeSized> Copy for Unique<T> {}
+
+#[unstable(feature = "trivial_clone", issue = "none")]
+unsafe impl<T: ?Sized> TrivialClone for Unique<T> {}
 
 #[unstable(feature = "ptr_internals", issue = "none")]
 impl<T: PointeeSized, U: PointeeSized> CoerceUnsized<Unique<U>> for Unique<T> where T: Unsize<U> {}

--- a/library/core/src/slice/specialize.rs
+++ b/library/core/src/slice/specialize.rs
@@ -1,3 +1,6 @@
+use crate::clone::TrivialClone;
+use crate::ptr;
+
 pub(super) trait SpecFill<T> {
     fn spec_fill(&mut self, value: T);
 }
@@ -14,10 +17,12 @@ impl<T: Clone> SpecFill<T> for [T] {
     }
 }
 
-impl<T: Copy> SpecFill<T> for [T] {
+impl<T: TrivialClone> SpecFill<T> for [T] {
     default fn spec_fill(&mut self, value: T) {
         for item in self.iter_mut() {
-            *item = value;
+            // SAFETY: `TrivialClone` indicates that this is equivalent to
+            // calling `Clone::clone`
+            *item = unsafe { ptr::read(&value) };
         }
     }
 }

--- a/library/core/src/sync/exclusive.rs
+++ b/library/core/src/sync/exclusive.rs
@@ -1,5 +1,6 @@
 //! Defines [`Exclusive`].
 
+use core::clone::TrivialClone;
 use core::cmp::Ordering;
 use core::fmt;
 use core::future::Future;
@@ -260,6 +261,9 @@ where
         Self { inner: self.inner.clone() }
     }
 }
+
+#[unstable(feature = "trivial_clone", issue = "none")]
+unsafe impl<T> TrivialClone for Exclusive<T> where T: Sync + TrivialClone {}
 
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 impl<T> Copy for Exclusive<T> where T: Sync + Copy {}

--- a/library/core/src/sync/exclusive.rs
+++ b/library/core/src/sync/exclusive.rs
@@ -262,6 +262,7 @@ where
     }
 }
 
+#[doc(hidden)]
 #[unstable(feature = "trivial_clone", issue = "none")]
 unsafe impl<T> TrivialClone for Exclusive<T> where T: Sync + TrivialClone {}
 

--- a/tests/ui/derives/duplicate-derive-copy-clone-diagnostics.rs
+++ b/tests/ui/derives/duplicate-derive-copy-clone-diagnostics.rs
@@ -6,7 +6,6 @@
 #[derive(Copy, Clone)]
 //~^ ERROR conflicting implementations of trait `Clone` for type `E`
 //~| ERROR conflicting implementations of trait `Copy` for type `E`
-//~| ERROR conflicting implementations of trait `TrivialClone` for type `E`
 enum E {}
 
 fn main() {}

--- a/tests/ui/derives/duplicate-derive-copy-clone-diagnostics.rs
+++ b/tests/ui/derives/duplicate-derive-copy-clone-diagnostics.rs
@@ -6,6 +6,7 @@
 #[derive(Copy, Clone)]
 //~^ ERROR conflicting implementations of trait `Clone` for type `E`
 //~| ERROR conflicting implementations of trait `Copy` for type `E`
+//~| ERROR conflicting implementations of trait `TrivialClone` for type `E`
 enum E {}
 
 fn main() {}

--- a/tests/ui/derives/duplicate-derive-copy-clone-diagnostics.stderr
+++ b/tests/ui/derives/duplicate-derive-copy-clone-diagnostics.stderr
@@ -6,6 +6,16 @@ LL | #[derive(Copy, Clone)]
 LL | #[derive(Copy, Clone)]
    |          ^^^^ conflicting implementation for `E`
 
+error[E0119]: conflicting implementations of trait `TrivialClone` for type `E`
+  --> $DIR/duplicate-derive-copy-clone-diagnostics.rs:6:16
+   |
+LL | #[derive(Copy, Clone)]
+   |                ----- first implementation here
+LL | #[derive(Copy, Clone)]
+   |                ^^^^^ conflicting implementation for `E`
+   |
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0119]: conflicting implementations of trait `Clone` for type `E`
   --> $DIR/duplicate-derive-copy-clone-diagnostics.rs:6:16
    |
@@ -14,6 +24,6 @@ LL | #[derive(Copy, Clone)]
 LL | #[derive(Copy, Clone)]
    |                ^^^^^ conflicting implementation for `E`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/derives/duplicate-derive-copy-clone-diagnostics.stderr
+++ b/tests/ui/derives/duplicate-derive-copy-clone-diagnostics.stderr
@@ -6,16 +6,6 @@ LL | #[derive(Copy, Clone)]
 LL | #[derive(Copy, Clone)]
    |          ^^^^ conflicting implementation for `E`
 
-error[E0119]: conflicting implementations of trait `TrivialClone` for type `E`
-  --> $DIR/duplicate-derive-copy-clone-diagnostics.rs:6:16
-   |
-LL | #[derive(Copy, Clone)]
-   |                ----- first implementation here
-LL | #[derive(Copy, Clone)]
-   |                ^^^^^ conflicting implementation for `E`
-   |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0119]: conflicting implementations of trait `Clone` for type `E`
   --> $DIR/duplicate-derive-copy-clone-diagnostics.rs:6:16
    |
@@ -24,6 +14,6 @@ LL | #[derive(Copy, Clone)]
 LL | #[derive(Copy, Clone)]
    |                ^^^^^ conflicting implementation for `E`
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -28,6 +28,7 @@ use std::from::From;
 // Empty struct.
 struct Empty;
 #[automatically_derived]
+#[doc(hidden)]
 unsafe impl ::core::clone::TrivialClone for Empty { }
 #[automatically_derived]
 impl ::core::clone::Clone for Empty {
@@ -90,6 +91,7 @@ struct Point {
     y: u32,
 }
 #[automatically_derived]
+#[doc(hidden)]
 unsafe impl ::core::clone::TrivialClone for Point { }
 #[automatically_derived]
 impl ::core::clone::Clone for Point {
@@ -177,6 +179,7 @@ struct PackedPoint {
     y: u32,
 }
 #[automatically_derived]
+#[doc(hidden)]
 unsafe impl ::core::clone::TrivialClone for PackedPoint { }
 #[automatically_derived]
 impl ::core::clone::Clone for PackedPoint {
@@ -260,6 +263,7 @@ impl ::core::cmp::Ord for PackedPoint {
 
 struct TupleSingleField(u32);
 #[automatically_derived]
+#[doc(hidden)]
 unsafe impl ::core::clone::TrivialClone for TupleSingleField { }
 #[automatically_derived]
 impl ::core::clone::Clone for TupleSingleField {
@@ -334,6 +338,7 @@ struct SingleField {
     foo: bool,
 }
 #[automatically_derived]
+#[doc(hidden)]
 unsafe impl ::core::clone::TrivialClone for SingleField { }
 #[automatically_derived]
 impl ::core::clone::Clone for SingleField {
@@ -417,6 +422,7 @@ struct Big {
     b8: u32,
 }
 #[automatically_derived]
+#[doc(hidden)]
 unsafe impl ::core::clone::TrivialClone for Big { }
 #[automatically_derived]
 impl ::core::clone::Clone for Big {
@@ -1019,6 +1025,7 @@ impl<T: ::core::cmp::Ord + ::core::marker::Copy + Trait, U: ::core::cmp::Ord +
 // An empty enum.
 enum Enum0 {}
 #[automatically_derived]
+#[doc(hidden)]
 unsafe impl ::core::clone::TrivialClone for Enum0 { }
 #[automatically_derived]
 impl ::core::clone::Clone for Enum0 {
@@ -1216,6 +1223,7 @@ enum Fieldless {
     C,
 }
 #[automatically_derived]
+#[doc(hidden)]
 unsafe impl ::core::clone::TrivialClone for Fieldless { }
 #[automatically_derived]
 impl ::core::clone::Clone for Fieldless {
@@ -1300,6 +1308,7 @@ enum Mixed {
     },
 }
 #[automatically_derived]
+#[doc(hidden)]
 unsafe impl ::core::clone::TrivialClone for Mixed { }
 #[automatically_derived]
 impl ::core::clone::Clone for Mixed {
@@ -1770,6 +1779,7 @@ pub union Union {
     pub i: i32,
 }
 #[automatically_derived]
+#[doc(hidden)]
 unsafe impl ::core::clone::TrivialClone for Union { }
 #[automatically_derived]
 impl ::core::clone::Clone for Union {

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -28,6 +28,8 @@ use std::from::From;
 // Empty struct.
 struct Empty;
 #[automatically_derived]
+unsafe impl ::core::clone::TrivialClone for Empty { }
+#[automatically_derived]
 impl ::core::clone::Clone for Empty {
     #[inline]
     fn clone(&self) -> Empty { *self }
@@ -87,6 +89,8 @@ struct Point {
     x: u32,
     y: u32,
 }
+#[automatically_derived]
+unsafe impl ::core::clone::TrivialClone for Point { }
 #[automatically_derived]
 impl ::core::clone::Clone for Point {
     #[inline]
@@ -173,6 +177,8 @@ struct PackedPoint {
     y: u32,
 }
 #[automatically_derived]
+unsafe impl ::core::clone::TrivialClone for PackedPoint { }
+#[automatically_derived]
 impl ::core::clone::Clone for PackedPoint {
     #[inline]
     fn clone(&self) -> PackedPoint {
@@ -254,6 +260,8 @@ impl ::core::cmp::Ord for PackedPoint {
 
 struct TupleSingleField(u32);
 #[automatically_derived]
+unsafe impl ::core::clone::TrivialClone for TupleSingleField { }
+#[automatically_derived]
 impl ::core::clone::Clone for TupleSingleField {
     #[inline]
     fn clone(&self) -> TupleSingleField {
@@ -325,6 +333,8 @@ impl ::core::cmp::Ord for TupleSingleField {
 struct SingleField {
     foo: bool,
 }
+#[automatically_derived]
+unsafe impl ::core::clone::TrivialClone for SingleField { }
 #[automatically_derived]
 impl ::core::clone::Clone for SingleField {
     #[inline]
@@ -406,6 +416,8 @@ struct Big {
     b7: u32,
     b8: u32,
 }
+#[automatically_derived]
+unsafe impl ::core::clone::TrivialClone for Big { }
 #[automatically_derived]
 impl ::core::clone::Clone for Big {
     #[inline]
@@ -1007,6 +1019,8 @@ impl<T: ::core::cmp::Ord + ::core::marker::Copy + Trait, U: ::core::cmp::Ord +
 // An empty enum.
 enum Enum0 {}
 #[automatically_derived]
+unsafe impl ::core::clone::TrivialClone for Enum0 { }
+#[automatically_derived]
 impl ::core::clone::Clone for Enum0 {
     #[inline]
     fn clone(&self) -> Enum0 { *self }
@@ -1202,6 +1216,8 @@ enum Fieldless {
     C,
 }
 #[automatically_derived]
+unsafe impl ::core::clone::TrivialClone for Fieldless { }
+#[automatically_derived]
 impl ::core::clone::Clone for Fieldless {
     #[inline]
     fn clone(&self) -> Fieldless { *self }
@@ -1283,6 +1299,8 @@ enum Mixed {
         d2: Option<i32>,
     },
 }
+#[automatically_derived]
+unsafe impl ::core::clone::TrivialClone for Mixed { }
 #[automatically_derived]
 impl ::core::clone::Clone for Mixed {
     #[inline]
@@ -1751,6 +1769,8 @@ pub union Union {
     pub u: u32,
     pub i: i32,
 }
+#[automatically_derived]
+unsafe impl ::core::clone::TrivialClone for Union { }
 #[automatically_derived]
 impl ::core::clone::Clone for Union {
     #[inline]

--- a/tests/ui/functions-closures/trivial-clone-closure.rs
+++ b/tests/ui/functions-closures/trivial-clone-closure.rs
@@ -1,0 +1,13 @@
+//@ run-pass
+// Check that closures implement `TrivialClone`.
+
+#![feature(trivial_clone)]
+
+use std::clone::TrivialClone;
+
+fn require_trivial_clone<T: TrivialClone>(_t: T) {}
+
+fn main() {
+    let some_trivial_clone_value = 42i32;
+    require_trivial_clone(move || some_trivial_clone_value);
+}

--- a/tests/ui/stats/macro-stats.stderr
+++ b/tests/ui/stats/macro-stats.stderr
@@ -2,7 +2,7 @@ macro-stats ====================================================================
 macro-stats MACRO EXPANSION STATS: macro_stats
 macro-stats Macro Name                         Uses      Lines  Avg Lines      Bytes  Avg Bytes
 macro-stats -----------------------------------------------------------------------------------
-macro-stats #[derive(Clone)]                      8         66        8.2      1_864      233.0
+macro-stats #[derive(Clone)]                      8         67        8.4      1_879      234.9
 macro-stats #[derive(PartialOrd)]                 1         17       17.0        675      675.0
 macro-stats #[derive(Hash)]                       2         17        8.5        577      288.5
 macro-stats q!                                    1         26       26.0        519      519.0

--- a/tests/ui/stats/macro-stats.stderr
+++ b/tests/ui/stats/macro-stats.stderr
@@ -2,7 +2,7 @@ macro-stats ====================================================================
 macro-stats MACRO EXPANSION STATS: macro_stats
 macro-stats Macro Name                         Uses      Lines  Avg Lines      Bytes  Avg Bytes
 macro-stats -----------------------------------------------------------------------------------
-macro-stats #[derive(Clone)]                      8         64        8.0      1_788      223.5
+macro-stats #[derive(Clone)]                      8         66        8.2      1_864      233.0
 macro-stats #[derive(PartialOrd)]                 1         17       17.0        675      675.0
 macro-stats #[derive(Hash)]                       2         17        8.5        577      288.5
 macro-stats q!                                    1         26       26.0        519      519.0


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/132442

`std` specializes on `Copy` to optimize certain library functions such as `clone_from_slice`. This is unsound, however, as the `Copy` implementation may not be always applicable because of lifetime bounds, which specialization does not take into account; the result being that values are copied even though they are not `Copy`. For instance, this code:
```rust
struct SometimesCopy<'a>(&'a Cell<bool>);

impl<'a> Clone for SometimesCopy<'a> {
    fn clone(&self) -> Self {
        self.0.set(true);
        Self(self.0)
    }
}

impl Copy for SometimesCopy<'static> {}

let clone_called = Cell::new(false);
// As SometimesCopy<'clone_called> is not 'static, this must run `clone`,
// setting the value to `true`.
let _ = [SometimesCopy(&clone_called)].clone();
assert!(clone_called.get());
```
should not panic, but does ([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=6be7a48cad849d8bd064491616fdb43c)).

To solve this, this PR introduces a new `unsafe` trait: `TrivialClone`. This trait may be implemented whenever the `Clone` implementation is equivalent to copying the value (so e.g. `fn clone(&self) -> Self { *self }`). Because of lifetime erasure, there is no way for the `Clone` implementation to observe lifetime bounds, meaning that even if the `TrivialClone` has stricter bounds than the `Clone` implementation, its invariant still holds. Therefore, it is sound to specialize on `TrivialClone`.

I've changed all `Copy` specializations in the standard library to specialize on `TrivialClone` instead. Unfortunately, the unsound `#[rustc_unsafe_specialization_marker]` attribute on `Copy` cannot be removed in this PR as `hashbrown` still depends on it. I'll make a PR updating `hashbrown` once this lands.

With `Copy` no longer being considered for specialization, this change alone would result in the standard library optimizations not being applied for user types unaware of `TrivialClone`. To avoid this and restore the optimizations in most cases, I have changed the expansion of `#[derive(Clone)]`: Currently, whenever both `Clone` and `Copy` are derived, the `clone` method performs a copy of the value. With this PR, the derive macro also adds a `TrivialClone` implementation to make this case observable using specialization. I anticipate that most users will use `#[derive(Clone, Copy)]` whenever both are applicable, so most users will still profit from the library optimizations.

Unfortunately, Hyrum's law applies to this PR: there are some popular crates which rely on the precise specialization behaviour of `core` to implement "specialization at home", e.g. [`libAFL`](https://github.com/AFLplusplus/LibAFL/blob/89cff637025c1652c24e8d97a30a2e3d01f187a4/libafl_bolts/src/tuples.rs#L27-L49). I have no remorse for breaking such horrible code, but perhaps we should open other, better ways to satisfy their needs – for example by dropping the `'static` bound on `TypeId::of`...