### PR TITLE
Do not include GCC source code in source tarballs

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1011,7 +1011,18 @@ impl Step for PlainSourceTarball {
         ];
         let src_dirs = ["src", "compiler", "library", "tests", "LICENSES"];
 
-        copy_src_dirs(builder, &builder.src, &src_dirs, &[], plain_dst_src);
+        copy_src_dirs(
+            builder,
+            &builder.src,
+            &src_dirs,
+            &[
+                // We don't currently use the GCC source code for building any official components,
+                // it is very big, and has unclear licensing implications due to being GPL licensed.
+                // We thus exclude it from the source tarball from now.
+                "src/gcc",
+            ],
+            plain_dst_src,
+        );
 
         // Copy the files normally
         for item in &src_files {


### PR DESCRIPTION
The licensing story is unclear, it makes the archive much larger, and we should not need it for building anything in the tarballs (yet).

```
Before:
121s building the archive
1.3 GiB gzipped size
5.7 GiB extracted size
402519 extracted files

After:
64s building the archive
961 MiB gzipped size
4.5 GiB extracted size
257719 extracfed files
```

Fixes: https://github.com/rust-lang/rust/issues/135606

r? @ehuss