### PR TITLE
Fix ICE in resolving associated items as non-bindings

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3960,7 +3960,7 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         match res {
             Res::SelfCtor(_) // See #70549.
             | Res::Def(
-                DefKind::Ctor(_, CtorKind::Const) | DefKind::Const | DefKind::ConstParam,
+                DefKind::Ctor(_, CtorKind::Const) | DefKind::Const | DefKind::AssocConst | DefKind::ConstParam,
                 _,
             ) if is_syntactic_ambiguity => {
                 // Disambiguate in favor of a unit struct/variant or constant pattern.
@@ -3969,7 +3969,7 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 }
                 Some(res)
             }
-            Res::Def(DefKind::Ctor(..) | DefKind::Const | DefKind::Static { .. }, _) => {
+            Res::Def(DefKind::Ctor(..) | DefKind::Const | DefKind::AssocConst | DefKind::Static { .. }, _) => {
                 // This is unambiguously a fresh binding, either syntactically
                 // (e.g., `IDENT @ PAT` or `ref IDENT`) or because `IDENT` resolves
                 // to something unusable as a pattern (e.g., constructor function),
@@ -4005,7 +4005,7 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 );
                 None
             }
-            Res::Def(DefKind::Fn, _) | Res::Local(..) | Res::Err => {
+            Res::Def(DefKind::Fn | DefKind::AssocFn, _) | Res::Local(..) | Res::Err => {
                 // These entities are explicitly allowed to be shadowed by fresh bindings.
                 None
             }

--- a/tests/ui/resolve/resolve-issue-135614-assoc-const.import_trait_associated_functions.stderr
+++ b/tests/ui/resolve/resolve-issue-135614-assoc-const.import_trait_associated_functions.stderr
@@ -1,0 +1,19 @@
+error[E0005]: refutable pattern in local binding
+  --> $DIR/resolve-issue-135614-assoc-const.rs:21:9
+   |
+LL |     let DEFAULT: u32 = 0;
+   |         ^^^^^^^ pattern `1_u32..=u32::MAX` not covered
+LL |     const DEFAULT: u32 = 0;
+   |     ------------------ missing patterns are not covered because `DEFAULT` is interpreted as a constant pattern, not a new variable
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
+   = note: the matched value is of type `u32`
+help: introduce a variable instead
+   |
+LL |     let DEFAULT_var: u32 = 0;
+   |         ~~~~~~~~~~~
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0005`.

--- a/tests/ui/resolve/resolve-issue-135614-assoc-const.normal.stderr
+++ b/tests/ui/resolve/resolve-issue-135614-assoc-const.normal.stderr
@@ -1,0 +1,30 @@
+error[E0658]: `use` associated items of traits is unstable
+  --> $DIR/resolve-issue-135614-assoc-const.rs:6:5
+   |
+LL | use MyDefault::DEFAULT;
+   |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #134691 <https://github.com/rust-lang/rust/issues/134691> for more information
+   = help: add `#![feature(import_trait_associated_functions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0005]: refutable pattern in local binding
+  --> $DIR/resolve-issue-135614-assoc-const.rs:21:9
+   |
+LL |     let DEFAULT: u32 = 0;
+   |         ^^^^^^^ pattern `1_u32..=u32::MAX` not covered
+LL |     const DEFAULT: u32 = 0;
+   |     ------------------ missing patterns are not covered because `DEFAULT` is interpreted as a constant pattern, not a new variable
+   |
+   = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
+   = note: the matched value is of type `u32`
+help: introduce a variable instead
+   |
+LL |     let DEFAULT_var: u32 = 0;
+   |         ~~~~~~~~~~~
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0005, E0658.
+For more information about an error, try `rustc --explain E0005`.

--- a/tests/ui/resolve/resolve-issue-135614-assoc-const.rs
+++ b/tests/ui/resolve/resolve-issue-135614-assoc-const.rs
@@ -1,0 +1,30 @@
+//@ revisions: normal import_trait_associated_functions
+#![cfg_attr(import_trait_associated_functions, feature(import_trait_associated_functions))]
+
+// Makes sure that imported constant can be used in pattern bindings.
+
+use MyDefault::DEFAULT; //[normal]~ ERROR `use` associated items of traits is unstable
+
+trait MyDefault {
+    const DEFAULT: Self;
+}
+
+impl MyDefault for u32 {
+    const DEFAULT: u32 = 0;
+}
+
+impl MyDefault for () {
+    const DEFAULT: () = ();
+}
+
+fn foo(x: u32) -> u32 {
+    let DEFAULT: u32 = 0; //~ ERROR refutable pattern in local binding
+    const DEFAULT: u32 = 0;
+    if let DEFAULT = x { DEFAULT } else { 1 }
+}
+
+fn bar() {
+    let DEFAULT = ();
+}
+
+fn main() {}

--- a/tests/ui/resolve/resolve-issue-135614.normal.stderr
+++ b/tests/ui/resolve/resolve-issue-135614.normal.stderr
@@ -1,0 +1,13 @@
+error[E0658]: `use` associated items of traits is unstable
+  --> $DIR/resolve-issue-135614.rs:7:5
+   |
+LL | use A::b;
+   |     ^^^^
+   |
+   = note: see issue #134691 <https://github.com/rust-lang/rust/issues/134691> for more information
+   = help: add `#![feature(import_trait_associated_functions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/resolve/resolve-issue-135614.rs
+++ b/tests/ui/resolve/resolve-issue-135614.rs
@@ -1,0 +1,15 @@
+//@ revisions: normal import_trait_associated_functions
+//@[import_trait_associated_functions] check-pass
+#![cfg_attr(import_trait_associated_functions, feature(import_trait_associated_functions))]
+
+// Makes sure that imported associated functions are shadowed by the local declarations.
+
+use A::b; //[normal]~ ERROR `use` associated items of traits is unstable
+
+trait A {
+    fn b() {}
+}
+
+fn main() {
+    let b: ();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes #135614 so that imported associated functions of traits can be shadowed by local bindings and associated constants of traits can be used in patterns.