### PR TITLE
Bump Fuchsia integration commit

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-fuchsia/build-fuchsia.sh
+++ b/src/ci/docker/host-x86_64/x86_64-fuchsia/build-fuchsia.sh
@@ -35,7 +35,7 @@ PICK_REFS=()
 # commit hash of fuchsia.git and some other repos in the "monorepo" checkout, in
 # addition to versions of prebuilts. It should be bumped regularly by the
 # Fuchsia team – we aim for every 1-2 months.
-INTEGRATION_SHA=bb38af4e3d45e490531b71fc52a460003141d032
+INTEGRATION_SHA=f6f83d3e3852209f7752be55694006afbe979e50
 
 checkout=fuchsia
 jiri=.jiri_root/bin/jiri


### PR DESCRIPTION
This advances Fuchsia to a checkout from 2025-01-13, which corresponds to a recent Rust roll, and hopefully avoids #135667, where a repository used by the older version of Rust was accidentally archived and broke checking out the prior version.

try-job: x86_64-fuchsia

cc @ehuss 