### PR TITLE
Remove unused `item-row` CSS class

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2473,7 +2473,7 @@ in src-script.js and main.js
 	}
 
 	/* Display an alternating layout on tablets and phones */
-	.item-row, .search-results > a, .search-results > a > div {
+	.search-results > a, .search-results > a > div {
 		display: block;
 	}
 

--- a/tests/rustdoc/multiple-mods-w-same-name-doc-inline-83375.rs
+++ b/tests/rustdoc/multiple-mods-w-same-name-doc-inline-83375.rs
@@ -10,7 +10,7 @@ pub mod sub {
 }
 
 //@ count foo/index.html '//a[@class="mod"][@title="mod foo::prelude"]' 1
-//@ count foo/prelude/index.html '//div[@class="item-row"]' 0
+//@ count foo/prelude/index.html '//ul[@class="item-table"]' 0
 pub mod prelude {}
 
 #[doc(inline)]

--- a/tests/rustdoc/multiple-mods-w-same-name-doc-inline-last-item-83375.rs
+++ b/tests/rustdoc/multiple-mods-w-same-name-doc-inline-last-item-83375.rs
@@ -13,5 +13,5 @@ pub mod sub {
 pub use sub::*;
 
 //@ count foo/index.html '//a[@class="mod"][@title="mod foo::prelude"]' 1
-//@ count foo/prelude/index.html '//div[@class="item-row"]' 0
+//@ count foo/prelude/index.html '//ul[@class="item-table"]' 0
 pub mod prelude {}


### PR DESCRIPTION
Seems like a CSS class we forgot to remove at some point.

r? @notriddle 