### PR TITLE
re-export `FromCoroutine` from `core::iter`

### DIFF
--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -420,14 +420,14 @@ pub use self::adapters::{Intersperse, IntersperseWith};
     issue = "42168"
 )]
 pub use self::range::Step;
+#[stable(feature = "iter_empty", since = "1.2.0")]
+pub use self::sources::{Empty, empty};
 #[unstable(
     feature = "iter_from_coroutine",
     issue = "43122",
     reason = "coroutines are unstable"
 )]
-pub use self::sources::from_coroutine;
-#[stable(feature = "iter_empty", since = "1.2.0")]
-pub use self::sources::{Empty, empty};
+pub use self::sources::{FromCoroutine, from_coroutine};
 #[stable(feature = "iter_from_fn", since = "1.34.0")]
 pub use self::sources::{FromFn, from_fn};
 #[stable(feature = "iter_once", since = "1.2.0")]

--- a/library/core/src/iter/sources.rs
+++ b/library/core/src/iter/sources.rs
@@ -15,7 +15,7 @@ pub use self::empty::{Empty, empty};
     issue = "43122",
     reason = "coroutines are unstable"
 )]
-pub use self::from_coroutine::from_coroutine;
+pub use self::from_coroutine::{FromCoroutine, from_coroutine};
 #[stable(feature = "iter_from_fn", since = "1.34.0")]
 pub use self::from_fn::{FromFn, from_fn};
 #[stable(feature = "iter_once", since = "1.2.0")]


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/43122
fixes: #135686