### PR TITLE
Disallow `A { .. }` if `A` has no fields

### DIFF
--- a/tests/ui/structs/default-field-values/empty-struct.rs
+++ b/tests/ui/structs/default-field-values/empty-struct.rs
@@ -1,0 +1,21 @@
+#![feature(default_field_values)]
+
+// If an API wants users to always use `..` even if they specify all the fields, they should use a
+// sentinel field. As of now, that field can't be made private so it is only constructable with this
+// syntax, but this might change in the future.
+
+struct A {}
+struct B();
+struct C;
+struct D {
+    x: i32,
+}
+struct E(i32);
+
+fn main() {
+    let _ = A { .. }; //~ ERROR has no fields
+    let _ = B { .. }; //~ ERROR has no fields
+    let _ = C { .. }; //~ ERROR has no fields
+    let _ = D { x: 0, .. };
+    let _ = E { 0: 0, .. };
+}

--- a/tests/ui/structs/default-field-values/empty-struct.stderr
+++ b/tests/ui/structs/default-field-values/empty-struct.stderr
@@ -1,0 +1,26 @@
+error: `A` has no fields, `..` needs at least one default field in the struct definition
+  --> $DIR/empty-struct.rs:16:17
+   |
+LL |     let _ = A { .. };
+   |             -   ^^
+   |             |
+   |             this type has no fields
+
+error: `B` has no fields, `..` needs at least one default field in the struct definition
+  --> $DIR/empty-struct.rs:17:17
+   |
+LL |     let _ = B { .. };
+   |             -   ^^
+   |             |
+   |             this type has no fields
+
+error: `C` has no fields, `..` needs at least one default field in the struct definition
+  --> $DIR/empty-struct.rs:18:17
+   |
+LL |     let _ = C { .. };
+   |             -   ^^
+   |             |
+   |             this type has no fields
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
```
error: `A` has no fields, `..` needs at least one default field in the struct definition
  --> $DIR/empty-struct.rs:16:17
   |
LL |     let _ = A { .. };
   |             -   ^^
   |             |
   |             this type has no fields
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
