### PR TITLE
Do not ICE on default_field_value const with lifetimes

### DIFF
--- a/tests/ui/structs/default-field-values/do-not-ice-on-invalid-lifetime.rs
+++ b/tests/ui/structs/default-field-values/do-not-ice-on-invalid-lifetime.rs
@@ -1,0 +1,6 @@
+#![feature(default_field_values)]
+struct A<'a> { //~ ERROR lifetime parameter `'a` is never used
+    x: Vec<A> = Vec::new(), //~ ERROR missing lifetime specifier
+}
+
+fn main() {}

--- a/tests/ui/structs/default-field-values/do-not-ice-on-invalid-lifetime.stderr
+++ b/tests/ui/structs/default-field-values/do-not-ice-on-invalid-lifetime.stderr
@@ -1,0 +1,23 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/do-not-ice-on-invalid-lifetime.rs:3:12
+   |
+LL |     x: Vec<A> = Vec::new(),
+   |            ^ expected named lifetime parameter
+   |
+help: consider using the `'a` lifetime
+   |
+LL |     x: Vec<A<'a>> = Vec::new(),
+   |             ++++
+
+error[E0392]: lifetime parameter `'a` is never used
+  --> $DIR/do-not-ice-on-invalid-lifetime.rs:2:10
+   |
+LL | struct A<'a> {
+   |          ^^ unused lifetime parameter
+   |
+   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0106, E0392.
+For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
`#![feature(default_field_values)]` uses a `const` body that should be treated as inline `const`s, but is actually being detected otherwise. This is similar to the situation in #78174, so we take the same solution: we check if the const actually comes from a field, and if it does, we use that logic to get the appropriate lifetimes and not ICE during borrowck.

Fix #135649.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
