### PR TITLE
[generic_assert] "Constify" the `Debug` trait

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -845,6 +845,8 @@ impl Display for Arguments<'_> {
 /// assert_eq!(format!("The origin is: {origin:#?}"), expected);
 /// ```
 
+#[const_trait]
+#[rustc_const_unstable(feature = "const_debug", issue = "none")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_on_unimplemented(
     on(

--- a/tests/ui/traits/const-traits/debug.rs
+++ b/tests/ui/traits/const-traits/debug.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+
+#![feature(const_debug, const_trait_impl)]
+
+use std::fmt::Debug;
+use std::fmt::Formatter;
+
+pub struct Foo;
+
+impl const Debug for Foo {
+    fn fmt(&self, _: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        Ok(())
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
cc #44838

With the merging of #135423, it now appears possible to start "constifying" arbitrary traits. Therefore, I am starting the "constification" of all the traits involved in the execution of the formatting system to unblock `generic_assert`.

```rust
const _: () = { panic!("{}", "foo"); };
```

r? @rust-lang/project-const-traits