### PR TITLE
Implement `&pin const self` and `&pin mut self` sugars

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1783,6 +1783,13 @@ impl<'a> State<'a> {
                 self.print_mutability(*m, false);
                 self.word("self")
             }
+            SelfKind::Pinned(lt, m) => {
+                self.word("&");
+                self.print_opt_lifetime(lt);
+                self.word("pin ");
+                self.print_mutability(*m, true);
+                self.word("self")
+            }
             SelfKind::Explicit(typ, m) => {
                 self.print_mutability(*m, false);
                 self.word("self");

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -2359,6 +2359,21 @@ impl Rewrite for ast::Param {
     }
 }
 
+fn rewrite_opt_lifetime(
+    context: &RewriteContext<'_>,
+    lifetime: Option<ast::Lifetime>,
+) -> RewriteResult {
+    let Some(l) = lifetime else {
+        return Ok(String::new());
+    };
+    let mut result = l.rewrite_result(
+        context,
+        Shape::legacy(context.config.max_width(), Indent::empty()),
+    )?;
+    result.push(' ');
+    Ok(result)
+}
+
 fn rewrite_explicit_self(
     context: &RewriteContext<'_>,
     explicit_self: &ast::ExplicitSelf,
@@ -2367,85 +2382,34 @@ fn rewrite_explicit_self(
     shape: Shape,
     has_multiple_attr_lines: bool,
 ) -> RewriteResult {
-    match explicit_self.node {
+    let self_str = match explicit_self.node {
         ast::SelfKind::Region(lt, m) => {
             let mut_str = format_mutability(m);
-            match lt {
-                Some(ref l) => {
-                    let lifetime_str = l.rewrite_result(
-                        context,
-                        Shape::legacy(context.config.max_width(), Indent::empty()),
-                    )?;
-                    Ok(combine_strs_with_missing_comments(
-                        context,
-                        param_attrs,
-                        &format!("&{lifetime_str} {mut_str}self"),
-                        span,
-                        shape,
-                        !has_multiple_attr_lines,
-                    )?)
-                }
-                None => Ok(combine_strs_with_missing_comments(
-                    context,
-                    param_attrs,
-                    &format!("&{mut_str}self"),
-                    span,
-                    shape,
-                    !has_multiple_attr_lines,
-                )?),
-            }
+            let lifetime_str = rewrite_opt_lifetime(context, lt)?;
+            format!("&{lifetime_str}{mut_str}self")
         }
         ast::SelfKind::Pinned(lt, m) => {
             let mut_str = m.ptr_str();
-            match lt {
-                Some(ref l) => {
-                    let lifetime_str = l.rewrite_result(
-                        context,
-                        Shape::legacy(context.config.max_width(), Indent::empty()),
-                    )?;
-                    Ok(combine_strs_with_missing_comments(
-                        context,
-                        param_attrs,
-                        &format!("&{lifetime_str} pin {mut_str} self"),
-                        span,
-                        shape,
-                        !has_multiple_attr_lines,
-                    )?)
-                }
-                None => Ok(combine_strs_with_missing_comments(
-                    context,
-                    param_attrs,
-                    &format!("&pin {mut_str} self"),
-                    span,
-                    shape,
-                    !has_multiple_attr_lines,
-                )?),
-            }
+            let lifetime_str = rewrite_opt_lifetime(context, lt)?;
+            format!("&{lifetime_str}pin {mut_str} self")
         }
         ast::SelfKind::Explicit(ref ty, mutability) => {
             let type_str = ty.rewrite_result(
                 context,
                 Shape::legacy(context.config.max_width(), Indent::empty()),
             )?;
-
-            Ok(combine_strs_with_missing_comments(
-                context,
-                param_attrs,
-                &format!("{}self: {}", format_mutability(mutability), type_str),
-                span,
-                shape,
-                !has_multiple_attr_lines,
-            )?)
+            format!("{}self: {}", format_mutability(mutability), type_str)
         }
-        ast::SelfKind::Value(mutability) => Ok(combine_strs_with_missing_comments(
-            context,
-            param_attrs,
-            &format!("{}self", format_mutability(mutability)),
-            span,
-            shape,
-            !has_multiple_attr_lines,
-        )?),
-    }
+        ast::SelfKind::Value(mutability) => format!("{}self", format_mutability(mutability)),
+    };
+    Ok(combine_strs_with_missing_comments(
+        context,
+        param_attrs,
+        &self_str,
+        span,
+        shape,
+        !has_multiple_attr_lines,
+    )?)
 }
 
 pub(crate) fn span_lo_for_param(param: &ast::Param) -> BytePos {

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -2395,6 +2395,33 @@ fn rewrite_explicit_self(
                 )?),
             }
         }
+        ast::SelfKind::Pinned(lt, m) => {
+            let mut_str = m.ptr_str();
+            match lt {
+                Some(ref l) => {
+                    let lifetime_str = l.rewrite_result(
+                        context,
+                        Shape::legacy(context.config.max_width(), Indent::empty()),
+                    )?;
+                    Ok(combine_strs_with_missing_comments(
+                        context,
+                        param_attrs,
+                        &format!("&{lifetime_str} pin {mut_str} self"),
+                        span,
+                        shape,
+                        !has_multiple_attr_lines,
+                    )?)
+                }
+                None => Ok(combine_strs_with_missing_comments(
+                    context,
+                    param_attrs,
+                    &format!("&pin {mut_str} self"),
+                    span,
+                    shape,
+                    !has_multiple_attr_lines,
+                )?),
+            }
+        }
         ast::SelfKind::Explicit(ref ty, mutability) => {
             let type_str = ty.rewrite_result(
                 context,

--- a/src/tools/rustfmt/tests/source/pin_sugar.rs
+++ b/src/tools/rustfmt/tests/source/pin_sugar.rs
@@ -8,3 +8,13 @@ fn g<'a>(x: &  'a pin const  i32) {}
 fn h<'a>(x: &  'a pin  
 mut i32) {}
 fn i(x: &pin      mut  i32) {}
+
+struct Foo;
+
+impl Foo {
+    fn f(&pin   const self) {}
+    fn g<'a>(&   'a pin const    self) {}
+    fn h<'a>(&    'a pin
+mut self) {}
+    fn i(&pin      mut   self) {}
+}

--- a/src/tools/rustfmt/tests/target/pin_sugar.rs
+++ b/src/tools/rustfmt/tests/target/pin_sugar.rs
@@ -7,3 +7,12 @@ fn f(x: &pin const i32) {}
 fn g<'a>(x: &'a pin const i32) {}
 fn h<'a>(x: &'a pin mut i32) {}
 fn i(x: &pin mut i32) {}
+
+struct Foo;
+
+impl Foo {
+    fn f(&pin const self) {}
+    fn g<'a>(&'a pin const self) {}
+    fn h<'a>(&'a pin mut self) {}
+    fn i(&pin mut self) {}
+}

--- a/tests/pretty/pin-ergonomics.rs
+++ b/tests/pretty/pin-ergonomics.rs
@@ -1,0 +1,24 @@
+//@ pp-exact
+
+#![feature(pin_ergonomics)]
+#![allow(dead_code, incomplete_features)]
+
+struct Foo;
+
+impl Foo {
+    fn baz(&pin mut self) {}
+
+    fn baz_const(&pin const self) {}
+
+    fn baz_lt<'a>(&'a pin mut self) {}
+
+    fn baz_const_lt(&'_ pin const self) {}
+}
+
+fn foo(_: &pin mut Foo) {}
+fn foo_lt<'a>(_: &'a pin mut Foo) {}
+
+fn foo_const(_: &pin const Foo) {}
+fn foo_const_lt(_: &'_ pin const Foo) {}
+
+fn main() {}

--- a/tests/ui/async-await/pin-ergonomics/sugar-self.rs
+++ b/tests/ui/async-await/pin-ergonomics/sugar-self.rs
@@ -1,0 +1,46 @@
+//@ check-pass
+
+#![feature(pin_ergonomics)]
+#![allow(dead_code, incomplete_features)]
+
+// Makes sure we can handle `&pin mut self` and `&pin const self` as sugar for
+// `self: Pin<&mut Self>` and `self: Pin<&Self>`.
+
+use std::pin::Pin;
+
+struct Foo;
+
+impl Foo {
+    fn baz(&pin mut self) {}
+
+    fn baz_const(&pin const self) {}
+
+    fn baz_lt<'a>(&'a pin mut self) {}
+
+    fn baz_const_lt(&'_ pin const self) {}
+}
+
+fn foo(_: &pin mut Foo) {}
+
+fn foo_const(_: &pin const Foo) {}
+
+fn bar(x: &pin mut Foo) {
+    // For the calls below to work we need to automatically reborrow,
+    // as if the user had written `foo(x.as_mut())`.
+    foo(x);
+    foo(x);
+
+    Foo::baz(x);
+    Foo::baz(x);
+
+    // make sure we can reborrow &mut as &.
+    foo_const(x);
+    Foo::baz_const(x);
+
+    let x: &pin const _ = Pin::new(&Foo);
+
+    foo_const(x); // make sure reborrowing from & to & works.
+    foo_const(x);
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -7,9 +7,13 @@ struct Foo;
 impl Foo {
     fn foo(self: Pin<&mut Self>) {
     }
+    fn foo_sugar(&pin mut self) {} //~ ERROR pinned reference syntax is experimental
+    fn foo_sugar_const(&pin const self) {} //~ ERROR pinned reference syntax is experimental
 }
 
-fn foo(x: Pin<&mut Foo>) {
+fn foo(mut x: Pin<&mut Foo>) {
+    Foo::foo_sugar(x.as_mut());
+    Foo::foo_sugar_const(x.as_ref());
     let _y: &pin mut Foo = x; //~ ERROR pinned reference syntax is experimental
 }
 
@@ -26,5 +30,39 @@ fn baz(mut x: Pin<&mut Foo>) {
 }
 
 fn baz_sugar(_: &pin const Foo) {} //~ ERROR pinned reference syntax is experimental
+
+#[cfg(any())]
+mod not_compiled {
+    use std::pin::Pin;
+
+    struct Foo;
+
+    impl Foo {
+        fn foo(self: Pin<&mut Self>) {
+        }
+        fn foo_sugar(&pin mut self) {} //~ ERROR pinned reference syntax is experimental
+        fn foo_sugar_const(&pin const self) {} //~ ERROR pinned reference syntax is experimental
+    }
+
+    fn foo(mut x: Pin<&mut Foo>) {
+        Foo::foo_sugar(x.as_mut());
+        Foo::foo_sugar_const(x.as_ref());
+        let _y: &pin mut Foo = x; //~ ERROR pinned reference syntax is experimental
+    }
+
+    fn foo_sugar(_: &pin mut Foo) {} //~ ERROR pinned reference syntax is experimental
+
+    fn bar(x: Pin<&mut Foo>) {
+        foo(x);
+        foo(x);
+    }
+
+    fn baz(mut x: Pin<&mut Foo>) {
+        x.foo();
+        x.foo();
+    }
+
+    fn baz_sugar(_: &pin const Foo) {} //~ ERROR pinned reference syntax is experimental
+}
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -1,5 +1,25 @@
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:13:14
+  --> $DIR/feature-gate-pin_ergonomics.rs:10:19
+   |
+LL |     fn foo_sugar(&pin mut self) {}
+   |                   ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:11:25
+   |
+LL |     fn foo_sugar_const(&pin const self) {}
+   |                         ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:17:14
    |
 LL |     let _y: &pin mut Foo = x;
    |              ^^^
@@ -9,7 +29,7 @@ LL |     let _y: &pin mut Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:16:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:20:18
    |
 LL | fn foo_sugar(_: &pin mut Foo) {}
    |                  ^^^
@@ -19,7 +39,7 @@ LL | fn foo_sugar(_: &pin mut Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:28:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:32:18
    |
 LL | fn baz_sugar(_: &pin const Foo) {}
    |                  ^^^
@@ -28,8 +48,58 @@ LL | fn baz_sugar(_: &pin const Foo) {}
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:43:23
+   |
+LL |         fn foo_sugar(&pin mut self) {}
+   |                       ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:44:29
+   |
+LL |         fn foo_sugar_const(&pin const self) {}
+   |                             ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:50:18
+   |
+LL |         let _y: &pin mut Foo = x;
+   |                  ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:53:22
+   |
+LL |     fn foo_sugar(_: &pin mut Foo) {}
+   |                      ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:65:22
+   |
+LL |     fn baz_sugar(_: &pin const Foo) {}
+   |                      ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:20:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:24:9
    |
 LL | fn bar(x: Pin<&mut Foo>) {
    |        - move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -39,15 +109,15 @@ LL |     foo(x);
    |         ^ value used here after move
    |
 note: consider changing this parameter type in function `foo` to borrow instead if owning the value isn't necessary
-  --> $DIR/feature-gate-pin_ergonomics.rs:12:11
+  --> $DIR/feature-gate-pin_ergonomics.rs:14:15
    |
-LL | fn foo(x: Pin<&mut Foo>) {
-   |    ---    ^^^^^^^^^^^^^ this parameter takes ownership of the value
+LL | fn foo(mut x: Pin<&mut Foo>) {
+   |    ---        ^^^^^^^^^^^^^ this parameter takes ownership of the value
    |    |
    |    in this function
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:25:5
+  --> $DIR/feature-gate-pin_ergonomics.rs:29:5
    |
 LL | fn baz(mut x: Pin<&mut Foo>) {
    |        ----- move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -66,7 +136,7 @@ help: consider reborrowing the `Pin` instead of moving it
 LL |     x.as_mut().foo();
    |      +++++++++
 
-error: aborting due to 5 previous errors
+error: aborting due to 12 previous errors
 
 Some errors have detailed explanations: E0382, E0658.
 For more information about an error, try `rustc --explain E0382`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR implements part of #130494.

It introduces the sugars `&pin const self` and `&pin mut self` for `self: Pin<&Self>` and `self: Pin<&mut Self>`.