### PR TITLE
Remove outdated comment about std::hash::DefaultHasher being inaccessible

### DIFF
--- a/library/std/src/hash/random.rs
+++ b/library/std/src/hash/random.rs
@@ -2,9 +2,6 @@
 //! [`collections`] module without actually publicly exporting them, so that parts of that
 //! implementation can more easily be moved to the [`alloc`] crate.
 //!
-//! Although its items are public and contain stability attributes, they can't actually be accessed
-//! outside this crate.
-//!
 //! [`collections`]: crate::collections
 
 #[allow(deprecated)]


### PR DESCRIPTION
Fixes #134717 (confirmed by @hkBst)