### PR TITLE
Changed docs to be less misleading in path::file_name(&self)

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2453,7 +2453,7 @@ impl Path {
     /// If the path is a normal file, this is the file name. If it's the path of a directory, this
     /// is the directory name.
     ///
-    /// Returns [`None`] if the path terminates in `..`.
+    /// Returns [`None`] if the path cannot be named (without accessing the filesystem)
     ///
     /// # Examples
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
The documentation of Path::file_name(&self) says that it will return None iff it ends with `..`. This does not match the behavior in cases such as
- "."
- "/"