### PR TITLE
Suggest adding `mut` or `const` after `&raw`  

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -764,6 +764,8 @@ parse_suffixed_literal_in_attribute = suffixed literals are not allowed in attri
 
 parse_sugg_add_let_for_stmt = you might have meant to introduce a new binding
 
+parse_sugg_add_mut_or_const_in_raw_ref = you might have meant to use a raw reference
+
 parse_sugg_add_semi = add `;` here
 parse_sugg_change_inner_attr_to_outer = to annotate the {$item}, change the attribute from inner to outer style
 

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1581,7 +1581,10 @@ impl<'a> Parser<'a> {
                 ExprKind::Array(exprs)
             } else {
                 // Vector with one element
-                self.expect(close)?;
+                self.expect(close).map_err(|mut e| {
+                    self.suggest_add_mut_or_const_in_raw_ref(&mut e, &first_expr);
+                    e
+                })?;
                 ExprKind::Array(thin_vec![first_expr])
             }
         };

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -897,6 +897,7 @@ impl<'a> Parser<'a> {
                                 res?
                             } else {
                                 res.unwrap_or_else(|mut e| {
+                                    self.suggest_add_mut_or_const_in_raw_ref(&mut e, expr);
                                     self.recover_missing_dot(&mut e);
                                     let guar = e.emit();
                                     self.recover_stmt();
@@ -920,6 +921,7 @@ impl<'a> Parser<'a> {
                     LocalKind::Init(expr) | LocalKind::InitElse(expr, _) => {
                         self.check_mistyped_turbofish_with_multiple_type_params(e, expr).map_err(
                             |mut e| {
+                                self.suggest_add_mut_or_const_in_raw_ref(&mut e, expr);
                                 self.recover_missing_dot(&mut e);
                                 e
                             },

--- a/tests/ui/raw-ref-op/missing-modifier/let-stmt.rs
+++ b/tests/ui/raw-ref-op/missing-modifier/let-stmt.rs
@@ -1,0 +1,12 @@
+//! Check that `&raw` that isn't followed by `const` or `mut` produces a
+//! helpful error message.
+//!
+//! Related issue: <https://github.com/rust-lang/rust/issues/133231>.
+
+fn main() {
+    let foo = 2;
+    let _ = &raw foo;
+    //~^ ERROR expected one of
+    //~| HELP you might have meant to use a raw reference
+    //~| HELP you might have meant to write a field access
+}

--- a/tests/ui/raw-ref-op/missing-modifier/let-stmt.stderr
+++ b/tests/ui/raw-ref-op/missing-modifier/let-stmt.stderr
@@ -4,6 +4,12 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, fo
 LL |     let _ = &raw foo;
    |                  ^^^ expected one of 8 possible tokens
    |
+help: you might have meant to use a raw reference
+   |
+LL |     let _ = &raw mut foo;
+   |                  +++
+LL |     let _ = &raw const foo;
+   |                  +++++
 help: you might have meant to write a field access
    |
 LL |     let _ = &raw.foo;

--- a/tests/ui/raw-ref-op/missing-modifier/let-stmt.stderr
+++ b/tests/ui/raw-ref-op/missing-modifier/let-stmt.stderr
@@ -1,0 +1,13 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, found `foo`
+  --> $DIR/let-stmt.rs:8:18
+   |
+LL |     let _ = &raw foo;
+   |                  ^^^ expected one of 8 possible tokens
+   |
+help: you might have meant to write a field access
+   |
+LL |     let _ = &raw.foo;
+   |                 +
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/raw-ref-op/missing-modifier/nested-array-expr.rs
+++ b/tests/ui/raw-ref-op/missing-modifier/nested-array-expr.rs
@@ -1,0 +1,14 @@
+//! Check that `&raw` that isn't followed by `const` or `mut` produces a
+//! helpful error message.
+//!
+//! Related issue: <https://github.com/rust-lang/rust/issues/133231>.
+
+mod foo {
+    pub static A: i32 = 0;
+}
+
+fn main() {
+    [&raw foo::A; 3];
+    //~^ ERROR expected one of
+    //~| HELP you might have meant to use a raw reference
+}

--- a/tests/ui/raw-ref-op/missing-modifier/nested-array-expr.stderr
+++ b/tests/ui/raw-ref-op/missing-modifier/nested-array-expr.stderr
@@ -3,6 +3,13 @@ error: expected one of `!`, `,`, `.`, `::`, `;`, `?`, `]`, `{`, or an operator, 
    |
 LL |     [&raw foo::A; 3];
    |           ^^^ expected one of 9 possible tokens
+   |
+help: you might have meant to use a raw reference
+   |
+LL |     [&raw mut foo::A; 3];
+   |           +++
+LL |     [&raw const foo::A; 3];
+   |           +++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/raw-ref-op/missing-modifier/nested-array-expr.stderr
+++ b/tests/ui/raw-ref-op/missing-modifier/nested-array-expr.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `,`, `.`, `::`, `;`, `?`, `]`, `{`, or an operator, found `foo`
+  --> $DIR/nested-array-expr.rs:11:11
+   |
+LL |     [&raw foo::A; 3];
+   |           ^^^ expected one of 9 possible tokens
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/raw-ref-op/missing-modifier/return-expr.rs
+++ b/tests/ui/raw-ref-op/missing-modifier/return-expr.rs
@@ -1,0 +1,16 @@
+//! Check that `&raw` that isn't followed by `const` or `mut` produces a
+//! helpful error message.
+//!
+//! Related issue: <https://github.com/rust-lang/rust/issues/133231>.
+
+mod foo {
+    pub static A: i32 = 0;
+}
+
+fn get_ref() -> *const i32 {
+    &raw foo::A
+    //~^ ERROR expected one of
+    //~| HELP you might have meant to use a raw reference
+}
+
+fn main() {}

--- a/tests/ui/raw-ref-op/missing-modifier/return-expr.stderr
+++ b/tests/ui/raw-ref-op/missing-modifier/return-expr.stderr
@@ -3,6 +3,13 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
    |
 LL |     &raw foo::A
    |          ^^^ expected one of 8 possible tokens
+   |
+help: you might have meant to use a raw reference
+   |
+LL |     &raw mut foo::A
+   |          +++
+LL |     &raw const foo::A
+   |          +++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/raw-ref-op/missing-modifier/return-expr.stderr
+++ b/tests/ui/raw-ref-op/missing-modifier/return-expr.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `foo`
+  --> $DIR/return-expr.rs:11:10
+   |
+LL |     &raw foo::A
+   |          ^^^ expected one of 8 possible tokens
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
On parse errors where we just parsed `&raw` we can suggest using a raw reference adding `mut` or `const` after, though raw is contextual so it might not always be accurate.

Example:

```rust
mod foo {
    pub static A: i32 = 0;
}

fn get_ref() -> *const i32 {
    &raw foo::A
}
```

```
error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `foo`
  --> $DIR/return-expr.rs:11:10
   |
LL |     &raw foo::A
   |          ^^^ expected one of 8 possible tokens
   |
help: you might have meant to use a raw reference
   |
LL |     &raw mut foo::A
   |          +++
LL |     &raw const foo::A
   |          +++++

error: aborting due to 1 previous error
```

Closes #133231