### PR TITLE
mir_build: Use let-chains in `prefix_slice_suffix`, and note an edge case

### DIFF
--- a/src/tools/tidy/src/issues.txt
+++ b/src/tools/tidy/src/issues.txt
@@ -410,7 +410,6 @@ ui/closure_context/issue-26046-fn-once.rs
 ui/closure_context/issue-42065.rs
 ui/closures/2229_closure_analysis/issue-118144.rs
 ui/closures/2229_closure_analysis/issue-87378.rs
-ui/closures/2229_closure_analysis/issue-87987.rs
 ui/closures/2229_closure_analysis/issue-88118-2.rs
 ui/closures/2229_closure_analysis/issue-88476.rs
 ui/closures/2229_closure_analysis/issue-89606.rs

--- a/tests/mir-opt/building/match/array_non_capture.prefix_only-{closure#0}.built.after.mir
+++ b/tests/mir-opt/building/match/array_non_capture.prefix_only-{closure#0}.built.after.mir
@@ -1,0 +1,18 @@
+// MIR for `prefix_only::{closure#0}` after built
+
+fn prefix_only::{closure#0}(_1: &{closure@$DIR/array_non_capture.rs:21:19: 21:21}) -> u32 {
+    let mut _0: u32;
+
+    bb0: {
+        _0 = const 101_u32;
+        goto -> bb2;
+    }
+
+    bb1: {
+        unreachable;
+    }
+
+    bb2: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/match/array_non_capture.prefix_slice_only-{closure#0}.built.after.mir
+++ b/tests/mir-opt/building/match/array_non_capture.prefix_slice_only-{closure#0}.built.after.mir
@@ -1,0 +1,18 @@
+// MIR for `prefix_slice_only::{closure#0}` after built
+
+fn prefix_slice_only::{closure#0}(_1: &{closure@$DIR/array_non_capture.rs:30:19: 30:21}) -> u32 {
+    let mut _0: u32;
+
+    bb0: {
+        _0 = const 102_u32;
+        goto -> bb2;
+    }
+
+    bb1: {
+        unreachable;
+    }
+
+    bb2: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/match/array_non_capture.prefix_slice_suffix-{closure#0}.built.after.mir
+++ b/tests/mir-opt/building/match/array_non_capture.prefix_slice_suffix-{closure#0}.built.after.mir
@@ -1,0 +1,18 @@
+// MIR for `prefix_slice_suffix::{closure#0}` after built
+
+fn prefix_slice_suffix::{closure#0}(_1: &{closure@$DIR/array_non_capture.rs:39:19: 39:21}) -> u32 {
+    let mut _0: u32;
+
+    bb0: {
+        _0 = const 103_u32;
+        goto -> bb2;
+    }
+
+    bb1: {
+        unreachable;
+    }
+
+    bb2: {
+        return;
+    }
+}

--- a/tests/mir-opt/building/match/array_non_capture.rs
+++ b/tests/mir-opt/building/match/array_non_capture.rs
@@ -1,0 +1,43 @@
+//@ edition: 2021
+// skip-filecheck
+
+// Under the Rust 2021 disjoint capture rules, a "captured" place sometimes
+// doesn't actually need to be captured, if it is only matched against
+// irrefutable patterns that don't bind anything.
+//
+// When that happens, there is currently some MIR-building code
+// (`Builder::prefix_slice_suffix`) that can no longer distinguish between
+// array patterns and slice patterns, so it falls back to the code for dealing
+// with slice patterns.
+//
+// That appears to be benign, but it's worth having a test that explicitly
+// triggers the edge-case scenario. If someone makes a change that assumes the
+// edge case can't happen, then hopefully this test will demand attention by
+// either triggering an ICE, or needing its MIR to be re-blessed.
+
+// EMIT_MIR array_non_capture.prefix_only-{closure#0}.built.after.mir
+fn prefix_only() -> u32 {
+    let arr = [1, 2, 3];
+    let closure = || match arr {
+        [_, _, _] => 101u32,
+    };
+    closure()
+}
+
+// EMIT_MIR array_non_capture.prefix_slice_only-{closure#0}.built.after.mir
+fn prefix_slice_only() -> u32 {
+    let arr = [1, 2, 3];
+    let closure = || match arr {
+        [_, ..] => 102u32,
+    };
+    closure()
+}
+
+// EMIT_MIR array_non_capture.prefix_slice_suffix-{closure#0}.built.after.mir
+fn prefix_slice_suffix() -> u32 {
+    let arr = [1, 2, 3];
+    let closure = || match arr {
+        [_, .., _] => 103u32,
+    };
+    closure()
+}

--- a/tests/ui/closures/2229_closure_analysis/unresolvable-upvar-issue-87987.rs
+++ b/tests/ui/closures/2229_closure_analysis/unresolvable-upvar-issue-87987.rs
@@ -25,8 +25,16 @@ fn main() {
 
     let mref = &mut arr;
 
+    // These array patterns don't need to inspect the array, so the array
+    // isn't captured.
     let _c = || match arr {
-        [_, _, _, _] => println!("A"),
+        [_, _, _, _] => println!("C"),
+    };
+    let _d = || match arr {
+        [_, .., _] => println!("D"),
+    };
+    let _e = || match arr {
+        [_, ..] => println!("E"),
     };
 
     println!("{:#?}", mref);

--- a/tests/ui/closures/2229_closure_analysis/unresolvable-upvar-issue-87987.rs
+++ b/tests/ui/closures/2229_closure_analysis/unresolvable-upvar-issue-87987.rs
@@ -1,6 +1,12 @@
 //@ run-pass
 //@ edition:2021
 
+// When a closure syntactically captures a place, but doesn't actually capture
+// it, make sure MIR building doesn't ICE when handling that place.
+//
+// Under the Rust 2021 disjoint capture rules, this sort of non-capture can
+// occur when a place is only inspected by infallible non-binding patterns.
+
 struct Props {
     field_1: u32, //~ WARNING: fields `field_1` and `field_2` are never read
     field_2: u32,

--- a/tests/ui/closures/2229_closure_analysis/unresolvable-upvar-issue-87987.stderr
+++ b/tests/ui/closures/2229_closure_analysis/unresolvable-upvar-issue-87987.stderr
@@ -1,5 +1,5 @@
 warning: fields `field_1` and `field_2` are never read
-  --> $DIR/issue-87987.rs:5:5
+  --> $DIR/unresolvable-upvar-issue-87987.rs:11:5
    |
 LL | struct Props {
    |        ----- fields in this struct


### PR DESCRIPTION
I noticed that the original code has two identical fallback paths that can be combined into one by using a let-chain for the success case.

---

While investigating this code, I tried to check my understanding by adding an assertion that `exact_size` is true iff we are dealing with an array pattern (and not a slice pattern). That uncovered a non-obvious edge case that is not well represented in our test suite, so I added a mir-opt test that explicitly triggers that edge case, to catch any future changes that assume it can't happen.