### PR TITLE
Correct counting to four in cell module docs

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -22,8 +22,8 @@
 //! (mutable via `&T`), in contrast with typical Rust types that exhibit 'inherited mutability'
 //! (mutable only via `&mut T`).
 //!
-//! Cell types come in three flavors: `Cell<T>`, `RefCell<T>`, and `OnceCell<T>`. Each provides
-//! a different way of providing safe interior mutability.
+//! Cell types come in four flavors: `Cell<T>`, `RefCell<T>`, `OnceCell<T>`, and `LazyCell<T>`.
+//! Each provides a different way of providing safe interior mutability.
 //!
 //! ## `Cell<T>`
 //!


### PR DESCRIPTION
It could also be argued that `OnceCell<T>` and `LazyCell<T>` don't really provide safe interior mutability in different ways. But it's a vague enough claim that I'm not sure it's worth being pedantic about.