### PR TITLE
Implement partial capturing of types in `use<...>`

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -417,9 +417,9 @@ hir_analysis_param_in_ty_of_assoc_const_binding =
         *[normal] the {$param_def_kind} `{$param_name}` is defined here
     }
 
-hir_analysis_param_not_captured = `impl Trait` must mention all {$kind} parameters in scope in `use<...>`
+hir_analysis_param_not_captured = `impl Trait` must mention all used {$kind} parameters in scope in `use<...>`
     .label = {$kind} parameter is implicitly captured by this `impl Trait`
-    .note = currently, all {$kind} parameters are required to be mentioned in the precise captures list
+    .suggestion = add `{$name}` in the capture list
 
 hir_analysis_paren_sugar_attribute = the `#[rustc_paren_sugar]` attribute is a temporary means of controlling which traits can use parenthetical notation
     .help = add `#![feature(unboxed_closures)]` to the crate attributes to use it
@@ -481,7 +481,6 @@ hir_analysis_self_in_impl_self =
 
 hir_analysis_self_ty_not_captured = `impl Trait` must mention the `Self` type of the trait in `use<...>`
     .label = `Self` type parameter is implicitly captured by this `impl Trait`
-    .note = currently, all type parameters are required to be mentioned in the precise captures list
 
 hir_analysis_simd_ffi_highly_experimental = use of SIMD type{$snip} in FFI is highly experimental and may result in invalid code
     .help = add `#![feature(simd_ffi)]` to the crate attributes to enable

--- a/compiler/rustc_hir_analysis/src/errors/precise_captures.rs
+++ b/compiler/rustc_hir_analysis/src/errors/precise_captures.rs
@@ -4,7 +4,6 @@ use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_param_not_captured)]
-#[note]
 pub(crate) struct ParamNotCaptured {
     #[primary_span]
     pub opaque_span: Span,
@@ -15,7 +14,6 @@ pub(crate) struct ParamNotCaptured {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_self_ty_not_captured)]
-#[note]
 pub(crate) struct SelfTyNotCaptured {
     #[primary_span]
     pub opaque_span: Span,

--- a/tests/ui/impl-trait/precise-capturing/partial-capture.rs
+++ b/tests/ui/impl-trait/precise-capturing/partial-capture.rs
@@ -1,0 +1,56 @@
+// See #130043 and #130031
+
+fn main() {
+    let mut data = [1, 2, 3];
+    let mut i = indices(&data);
+    data = [4, 5, 6];
+    i.next();
+
+    let mut i = enumerated_opaque(&data);
+    i.next();
+
+    let mut i = enumerated(&data);
+    i.next();
+
+    let mut i = enumerated_lt(&data);
+    i.next();
+
+    let mut i = enumerated_arr(data);
+    i.next();
+}
+
+// No lifetime or type params captured
+fn indices<T>(slice: &[T]) -> impl Iterator<Item = usize> + use<> {
+    0..slice.len()
+}
+
+// `'_` and `T` are captured
+fn enumerated_opaque<T>(slice: &[T]) -> impl Iterator + use<> {
+    slice.iter().enumerate()
+    //~^ ERROR hidden type for `impl Iterator` captures lifetime that does not appear in bounds
+}
+
+// `'_` and `T` are captured
+fn enumerated_opaque_lt<T>(slice: &[T]) -> impl Iterator + use<'_> {
+    //~^ ERROR `impl Trait` must mention all used type parameters in scope in `use<...>`
+    slice.iter().enumerate()
+}
+
+// `'_` and `T` are captured
+fn enumerated<T>(slice: &[T]) -> impl Iterator<Item = (usize, &T)> + use<> {
+    //~^ ERROR `impl Trait` must mention all used type parameters in scope in `use<...>`
+    slice.iter().enumerate()
+}
+
+// `'_` and `T` are captured
+fn enumerated_lt<T>(slice: &[T]) -> impl Iterator<Item = (usize, &T)> + use<'_> {
+    //~^ ERROR `impl Trait` must mention all used type parameters in scope in `use<...>`
+    slice.iter().enumerate()
+}
+
+// `T` and `N` are captured
+fn enumerated_arr<T, const N: usize>(arr: [T; N]) -> impl Iterator<Item = (usize, T)> + use<> {
+    //~^ ERROR `impl Trait` must mention all used type parameters in scope in `use<...>`
+    //~| ERROR `impl Trait` must mention all used const parameters in scope in `use<...>`
+    <[T; N]>::into_iter(arr).enumerate()
+}

--- a/tests/ui/impl-trait/precise-capturing/partial-capture.stderr
+++ b/tests/ui/impl-trait/precise-capturing/partial-capture.stderr
@@ -1,0 +1,58 @@
+error[E0700]: hidden type for `impl Iterator` captures lifetime that does not appear in bounds
+  --> $DIR/partial-capture.rs:29:5
+   |
+LL | fn enumerated_opaque<T>(slice: &[T]) -> impl Iterator + use<> {
+   |                                ----     --------------------- opaque type defined here
+   |                                |
+   |                                hidden type `Enumerate<std::slice::Iter<'_, T>>` captures the anonymous lifetime defined here
+LL |     slice.iter().enumerate()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: add `'_` to the `use<...>` bound to explicitly capture it
+   |
+LL | fn enumerated_opaque<T>(slice: &[T]) -> impl Iterator + use<'_> {
+   |                                                             ++
+
+error: `impl Trait` must mention all used type parameters in scope in `use<...>`
+  --> $DIR/partial-capture.rs:34:44
+   |
+LL | fn enumerated_opaque_lt<T>(slice: &[T]) -> impl Iterator + use<'_> {
+   |                         -                  ^^^^^^^^^^^^^^^^^^^^^^^
+   |                         |
+   |                         type parameter is implicitly captured by this `impl Trait`
+
+error: `impl Trait` must mention all used type parameters in scope in `use<...>`
+  --> $DIR/partial-capture.rs:40:34
+   |
+LL | fn enumerated<T>(slice: &[T]) -> impl Iterator<Item = (usize, &T)> + use<> {
+   |               -                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               |
+   |               type parameter is implicitly captured by this `impl Trait`
+
+error: `impl Trait` must mention all used type parameters in scope in `use<...>`
+  --> $DIR/partial-capture.rs:46:37
+   |
+LL | fn enumerated_lt<T>(slice: &[T]) -> impl Iterator<Item = (usize, &T)> + use<'_> {
+   |                  -                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  type parameter is implicitly captured by this `impl Trait`
+
+error: `impl Trait` must mention all used type parameters in scope in `use<...>`
+  --> $DIR/partial-capture.rs:52:54
+   |
+LL | fn enumerated_arr<T, const N: usize>(arr: [T; N]) -> impl Iterator<Item = (usize, T)> + use<> {
+   |                   -                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                   |
+   |                   type parameter is implicitly captured by this `impl Trait`
+
+error: `impl Trait` must mention all used const parameters in scope in `use<...>`
+  --> $DIR/partial-capture.rs:52:54
+   |
+LL | fn enumerated_arr<T, const N: usize>(arr: [T; N]) -> impl Iterator<Item = (usize, T)> + use<> {
+   |                      --------------                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                      |
+   |                      const parameter is implicitly captured by this `impl Trait`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0700`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR implements #130043. It loses the requirement that all type and const params be mentioned in the `use<...>` list. Now only **used** type and const params should be mentioned.