### PR TITLE
Update windows-gnu targets to set `DebuginfoKind::DWARF`

### DIFF
--- a/compiler/rustc_target/src/spec/base/windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnu.rs
@@ -97,9 +97,9 @@ pub(crate) fn opts() -> TargetOptions {
         emit_debug_gdb_scripts: false,
         requires_uwtable: true,
         eh_frame_header: false,
+        debuginfo_kind: DebuginfoKind::Dwarf,
         // FIXME(davidtwco): Support Split DWARF on Windows GNU - may require LLVM changes to
         // output DWO, despite using DWARF, doesn't use ELF..
-        debuginfo_kind: DebuginfoKind::Pdb,
         supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
         ..Default::default()
     }

--- a/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
+++ b/compiler/rustc_target/src/spec/base/windows_gnullvm.rs
@@ -44,9 +44,9 @@ pub(crate) fn opts() -> TargetOptions {
         has_thread_local: true,
         crt_static_allows_dylibs: true,
         crt_static_respected: true,
+        debuginfo_kind: DebuginfoKind::Dwarf,
         // FIXME(davidtwco): Support Split DWARF on Windows GNU - may require LLVM changes to
         // output DWO, despite using DWARF, doesn't use ELF..
-        debuginfo_kind: DebuginfoKind::Pdb,
         supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
         ..Default::default()
     }

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_off.rs
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_off.rs
@@ -1,0 +1,29 @@
+//@ revisions: aarch64_gl i686_g i686_gl i686_uwp_g x86_64_g x86_64_gl x86_64_uwp_g
+//@ compile-flags: --crate-type cdylib -Csplit-debuginfo=off
+//@ check-pass
+
+//@[aarch64_gl] compile-flags: --target aarch64-pc-windows-gnullvm
+//@[aarch64_gl] needs-llvm-components: aarch64
+
+//@[i686_g] compile-flags: --target i686-pc-windows-gnu
+//@[i686_g] needs-llvm-components: x86
+
+//@[i686_gl] compile-flags: --target i686-pc-windows-gnullvm
+//@[i686_gl] needs-llvm-components: x86
+
+//@[i686_uwp_g] compile-flags: --target i686-uwp-windows-gnu
+//@[i686_uwp_g] needs-llvm-components: x86
+
+//@[x86_64_g] compile-flags: --target x86_64-pc-windows-gnu
+//@[x86_64_g] needs-llvm-components: x86
+
+//@[x86_64_gl] compile-flags: --target x86_64-pc-windows-gnullvm
+//@[x86_64_gl] needs-llvm-components: x86
+
+//@[x86_64_uwp_g] compile-flags: --target x86_64-uwp-windows-gnu
+//@[x86_64_uwp_g] needs-llvm-components: x86
+
+#![feature(no_core)]
+
+#![no_core]
+#![no_std]

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.aarch64_gl.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.aarch64_gl.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=packed` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.i686_g.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.i686_g.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=packed` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.i686_gl.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.i686_gl.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=packed` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.i686_uwp_g.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.i686_uwp_g.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=packed` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.rs
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.rs
@@ -1,0 +1,29 @@
+//@ revisions: aarch64_gl i686_g i686_gl i686_uwp_g x86_64_g x86_64_gl x86_64_uwp_g
+//@ compile-flags: --crate-type cdylib -Csplit-debuginfo=packed
+//@ error-pattern: error: `-Csplit-debuginfo=packed` is unstable on this platform
+
+//@[aarch64_gl] compile-flags: --target aarch64-pc-windows-gnullvm
+//@[aarch64_gl] needs-llvm-components: aarch64
+
+//@[i686_g] compile-flags: --target i686-pc-windows-gnu
+//@[i686_g] needs-llvm-components: x86
+
+//@[i686_gl] compile-flags: --target i686-pc-windows-gnullvm
+//@[i686_gl] needs-llvm-components: x86
+
+//@[i686_uwp_g] compile-flags: --target i686-uwp-windows-gnu
+//@[i686_uwp_g] needs-llvm-components: x86
+
+//@[x86_64_g] compile-flags: --target x86_64-pc-windows-gnu
+//@[x86_64_g] needs-llvm-components: x86
+
+//@[x86_64_gl] compile-flags: --target x86_64-pc-windows-gnullvm
+//@[x86_64_gl] needs-llvm-components: x86
+
+//@[x86_64_uwp_g] compile-flags: --target x86_64-uwp-windows-gnu
+//@[x86_64_uwp_g] needs-llvm-components: x86
+
+#![feature(no_core)]
+
+#![no_core]
+#![no_std]

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.x86_64_g.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.x86_64_g.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=packed` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.x86_64_gl.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.x86_64_gl.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=packed` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.x86_64_uwp_g.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_packed.x86_64_uwp_g.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=packed` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.aarch64_gl.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.aarch64_gl.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=unpacked` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.i686_g.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.i686_g.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=unpacked` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.i686_gl.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.i686_gl.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=unpacked` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.i686_uwp_g.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.i686_uwp_g.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=unpacked` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.rs
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.rs
@@ -1,0 +1,29 @@
+//@ revisions: aarch64_gl i686_g i686_gl i686_uwp_g x86_64_g x86_64_gl x86_64_uwp_g
+//@ compile-flags: --crate-type cdylib -Csplit-debuginfo=unpacked
+//@ error-pattern: error: `-Csplit-debuginfo=unpacked` is unstable on this platform
+
+//@[aarch64_gl] compile-flags: --target aarch64-pc-windows-gnullvm
+//@[aarch64_gl] needs-llvm-components: aarch64
+
+//@[i686_g] compile-flags: --target i686-pc-windows-gnu
+//@[i686_g] needs-llvm-components: x86
+
+//@[i686_gl] compile-flags: --target i686-pc-windows-gnullvm
+//@[i686_gl] needs-llvm-components: x86
+
+//@[i686_uwp_g] compile-flags: --target i686-uwp-windows-gnu
+//@[i686_uwp_g] needs-llvm-components: x86
+
+//@[x86_64_g] compile-flags: --target x86_64-pc-windows-gnu
+//@[x86_64_g] needs-llvm-components: x86
+
+//@[x86_64_gl] compile-flags: --target x86_64-pc-windows-gnullvm
+//@[x86_64_gl] needs-llvm-components: x86
+
+//@[x86_64_uwp_g] compile-flags: --target x86_64-uwp-windows-gnu
+//@[x86_64_uwp_g] needs-llvm-components: x86
+
+#![feature(no_core)]
+
+#![no_core]
+#![no_std]

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.x86_64_g.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.x86_64_g.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=unpacked` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.x86_64_gl.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.x86_64_gl.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=unpacked` is unstable on this platform
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.x86_64_uwp_g.stderr
+++ b/tests/ui/debuginfo/windows_gnu_split_debuginfo_unpacked.x86_64_uwp_g.stderr
@@ -1,0 +1,4 @@
+error: `-Csplit-debuginfo=unpacked` is unstable on this platform
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
These targets have always used DWARF debuginfo and not CodeView/PDB debuginfo like the MSVC Windows targets. However, their target definitions claim to use `DebuginfoKind::PDB` probably to ensure that we do not try to allow the use of split-DWARF debuginfo. 

This does not appear to be necessary since the targets set their supported split debug info to `Off`. I've looked at all of the uses of these properties and this patch does not appear to cause any functional changes in compiler behavior. I also added UI tests to attempt to validate there is no change in the behavior of these options on stable compilers.

cc @mati865 since you mentioned this in #135739
cc @davidtwco for split-dwarf