### PR TITLE
Ignore `mermaid.min.js`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ __pycache__/
 node_modules
 package-lock.json
 package.json
+/src/doc/rustc-dev-guide/mermaid.min.js
 
 ## Rustdoc GUI tests
 tests/rustdoc-gui/src/**.lock


### PR DESCRIPTION
It is very long and tends to match a lot of search queries. It's not useful to show with ripgrep.

Note that this does not actually untrack the file; changes can still be committed (although I suspect it may not have been intentional to commit originally?). This just changes how it interacts with tools that use `.gitignore` as a default filter.

r? rustc-dev-guide

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
