### PR TITLE
Detect missing fields with default values and suggest `..`

### DIFF
--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor.disabled.stderr
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor.disabled.stderr
@@ -1,0 +1,86 @@
+error[E0658]: default values on fields are experimental
+  --> $DIR/non-exhaustive-ctor.rs:9:22
+   |
+LL |         pub field: () = (),
+   |                      ^^^^^
+   |
+   = note: see issue #132162 <https://github.com/rust-lang/rust/issues/132162> for more information
+   = help: add `#![feature(default_field_values)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: default values on fields are experimental
+  --> $DIR/non-exhaustive-ctor.rs:11:25
+   |
+LL |         pub field1: Priv = Priv,
+   |                         ^^^^^^^
+   |
+   = note: see issue #132162 <https://github.com/rust-lang/rust/issues/132162> for more information
+   = help: add `#![feature(default_field_values)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: default values on fields are experimental
+  --> $DIR/non-exhaustive-ctor.rs:13:25
+   |
+LL |         pub field2: Priv = Priv,
+   |                         ^^^^^^^
+   |
+   = note: see issue #132162 <https://github.com/rust-lang/rust/issues/132162> for more information
+   = help: add `#![feature(default_field_values)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0797]: base expression required after `..`
+  --> $DIR/non-exhaustive-ctor.rs:20:19
+   |
+LL |     let _ = S { .. }; // ok
+   |                   ^
+   |
+help: add `#![feature(default_field_values)]` to the crate attributes to enable default values on `struct` fields
+   |
+LL + #![feature(default_field_values)]
+   |
+help: add a base expression here
+   |
+LL |     let _ = S { ../* expr */ }; // ok
+   |                   ++++++++++
+
+error[E0797]: base expression required after `..`
+  --> $DIR/non-exhaustive-ctor.rs:22:30
+   |
+LL |     let _ = S { field: (), .. }; // ok
+   |                              ^
+   |
+help: add `#![feature(default_field_values)]` to the crate attributes to enable default values on `struct` fields
+   |
+LL + #![feature(default_field_values)]
+   |
+help: add a base expression here
+   |
+LL |     let _ = S { field: (), ../* expr */ }; // ok
+   |                              ++++++++++
+
+error[E0063]: missing fields `field`, `field1` and `field2` in initializer of `S`
+  --> $DIR/non-exhaustive-ctor.rs:24:13
+   |
+LL |     let _ = S { };
+   |             ^ missing `field`, `field1` and `field2`
+   |
+help: all remaining fields have default values, if you added `#![feature(default_field_values)]` to your crate you could use those values with `..`
+   |
+LL |     let _ = S { .. };
+   |               ~~~~~~
+
+error[E0063]: missing fields `field1` and `field2` in initializer of `S`
+  --> $DIR/non-exhaustive-ctor.rs:26:13
+   |
+LL |     let _ = S { field: () };
+   |             ^ missing `field1` and `field2`
+   |
+help: all remaining fields have default values, if you added `#![feature(default_field_values)]` to your crate you could use those values with `..`
+   |
+LL |     let _ = S { field: (), .. };
+   |                          ++++
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0063, E0658, E0797.
+For more information about an error, try `rustc --explain E0063`.

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor.enabled.fixed
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor.enabled.fixed
@@ -1,0 +1,28 @@
+//@ revisions: enabled disabled
+//@[enabled] run-rustfix
+#![allow(private_interfaces, dead_code)]
+#![cfg_attr(enabled, feature(default_field_values))]
+use m::S;
+
+mod m {
+    pub struct S {
+        pub field: () = (),
+        //[disabled]~^ ERROR default values on fields are experimental
+        pub field1: Priv = Priv,
+        //[disabled]~^ ERROR default values on fields are experimental
+        pub field2: Priv = Priv,
+        //[disabled]~^ ERROR default values on fields are experimental
+    }
+    struct Priv;
+}
+
+fn main() {
+    let _ = S { .. }; // ok
+    //[disabled]~^ ERROR base expression required after `..`
+    let _ = S { field: (), .. }; // ok
+    //[disabled]~^ ERROR base expression required after `..`
+    let _ = S { .. };
+    //~^ ERROR missing fields `field`, `field1` and `field2`
+    let _ = S { field: (), .. };
+    //~^ ERROR missing fields `field1` and `field2`
+}

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor.enabled.stderr
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor.enabled.stderr
@@ -1,0 +1,25 @@
+error[E0063]: missing fields `field`, `field1` and `field2` in initializer of `S`
+  --> $DIR/non-exhaustive-ctor.rs:24:13
+   |
+LL |     let _ = S { };
+   |             ^ missing `field`, `field1` and `field2`
+   |
+help: all remaining fields have default values, you can use those values with `..`
+   |
+LL |     let _ = S { .. };
+   |               ~~~~~~
+
+error[E0063]: missing fields `field1` and `field2` in initializer of `S`
+  --> $DIR/non-exhaustive-ctor.rs:26:13
+   |
+LL |     let _ = S { field: () };
+   |             ^ missing `field1` and `field2`
+   |
+help: all remaining fields have default values, you can use those values with `..`
+   |
+LL |     let _ = S { field: (), .. };
+   |                          ++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0063`.

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor.rs
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor.rs
@@ -1,0 +1,28 @@
+//@ revisions: enabled disabled
+//@[enabled] run-rustfix
+#![allow(private_interfaces, dead_code)]
+#![cfg_attr(enabled, feature(default_field_values))]
+use m::S;
+
+mod m {
+    pub struct S {
+        pub field: () = (),
+        //[disabled]~^ ERROR default values on fields are experimental
+        pub field1: Priv = Priv,
+        //[disabled]~^ ERROR default values on fields are experimental
+        pub field2: Priv = Priv,
+        //[disabled]~^ ERROR default values on fields are experimental
+    }
+    struct Priv;
+}
+
+fn main() {
+    let _ = S { .. }; // ok
+    //[disabled]~^ ERROR base expression required after `..`
+    let _ = S { field: (), .. }; // ok
+    //[disabled]~^ ERROR base expression required after `..`
+    let _ = S { };
+    //~^ ERROR missing fields `field`, `field1` and `field2`
+    let _ = S { field: () };
+    //~^ ERROR missing fields `field1` and `field2`
+}


### PR DESCRIPTION
When a struct ctor use has missing fields, if all those missing fields have defaults, suggest `..`:

```
error[E0063]: missing fields `field1` and `field2` in initializer of `S`
  --> $DIR/non-exhaustive-ctor.rs:16:13
   |
LL |     let _ = S { field: () };
   |             ^ missing `field1` and `field2`
   |
help: all remaining fields have default values, you can use those values with `..`
   |
LL |     let _ = S { field: (), .. };
   |                          ++++
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
