### PR TITLE
Add missing allocator safety in alloc crate

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1115,6 +1115,8 @@ impl<T: ?Sized> Box<T> {
     /// memory problems. For example, a double-free may occur if the
     /// function is called twice on the same `NonNull` pointer.
     ///
+    /// The non-null pointer must point to a block of memory allocated by the global allocator.
+    ///
     /// The safety conditions are described in the [memory layout] section.
     ///
     /// # Examples
@@ -1170,7 +1172,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// memory problems. For example, a double-free may occur if the
     /// function is called twice on the same raw pointer.
     ///
-    /// The raw pointer must point to a block of memory allocated by `alloc`
+    /// The raw pointer must point to a block of memory allocated by `alloc`.
     ///
     /// # Examples
     ///
@@ -1225,6 +1227,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// memory problems. For example, a double-free may occur if the
     /// function is called twice on the same raw pointer.
     ///
+    /// The non-null pointer must point to a block of memory allocated by `alloc`.
     ///
     /// # Examples
     ///

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2740,7 +2740,7 @@ impl<T: ?Sized> Weak<T> {
     /// # Safety
     ///
     /// The pointer must have originated from the [`into_raw`] and must still own its potential
-    /// weak reference.
+    /// weak reference, and must point to a block of memory allocated by global allocator.
     ///
     /// It is allowed for the strong count to be 0 at the time of calling this. Nevertheless, this
     /// takes ownership of one weak reference currently represented as a raw pointer (the weak


### PR DESCRIPTION
### PR Description
In the previous PR [#135009](https://github.com/rust-lang/rust/pull/135009), PR [#134496](https://github.com/rust-lang/rust/pull/134496), some incomplete API documentation issues have been fixed. 

Based on these changes,  other inconsistencies related to the allocator have also been identified, including:

- `Box::from_non_null`
- `Box::from_non_null_in`
- `Weak::from_raw`