### PR TITLE
Fix GDB `OsString` provider on Windows 

### DIFF
--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -71,7 +71,7 @@ class StdOsStringProvider(printer_base):
         self._valobj = valobj
         buf = self._valobj["inner"]["inner"]
         is_windows = "Wtf8Buf" in buf.type.name
-        vec = buf[ZERO_FIELD] if is_windows else buf
+        vec = buf["bytes"] if is_windows else buf
 
         self._length = int(vec["len"])
         self._data_ptr = unwrap_unique_or_non_null(vec["buf"]["inner"]["ptr"])


### PR DESCRIPTION
It would throw an exception due to trying to look up `Wtf8Buf.__0`. The field it actually wants is called [`bytes`](https://github.com/rust-lang/rust/blob/b605c65b6eb5fa71783f8e26df69975f9f1680ee/library/std/src/sys_common/wtf8.rs#L134).