### PR TITLE
CI: split i686-mingw job to three free runners

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -99,16 +99,18 @@ prepare:
 
 # Set of tests that represent around half of the time of the test suite.
 # Used to split tests across multiple CI runners.
-STAGE_2_TEST_SET1 := test --stage 2 --skip=compiler --skip=src
-STAGE_2_TEST_SET2 := test --stage 2 --skip=tests --skip=coverage-map --skip=coverage-run --skip=library --skip=tidyselftest
+SKIP_COMPILER := --skip=compiler
+SKIP_SRC := --skip=src
+TEST_SET1 := $(SKIP_COMPILER) $(SKIP_SRC)
+TEST_SET2 := --skip=tests --skip=coverage-map --skip=coverage-run --skip=library --skip=tidyselftest
 
 ## MSVC native builders
 
 # this intentionally doesn't use `$(BOOTSTRAP)` so we can test the shebang on Windows
 ci-msvc-py:
-	$(Q)$(CFG_SRC_DIR)/x.py $(STAGE_2_TEST_SET1)
+	$(Q)$(CFG_SRC_DIR)/x.py test --stage 2 $(TEST_SET1)
 ci-msvc-ps1:
-	$(Q)$(CFG_SRC_DIR)/x.ps1 $(STAGE_2_TEST_SET2)
+	$(Q)$(CFG_SRC_DIR)/x.ps1 test --stage 2 $(TEST_SET2)
 ci-msvc: ci-msvc-py ci-msvc-ps1
 
 ## MingW native builders
@@ -116,10 +118,14 @@ ci-msvc: ci-msvc-py ci-msvc-ps1
 # Set of tests that should represent half of the time of the test suite.
 # Used to split tests across multiple CI runners.
 # Test both x and bootstrap entrypoints.
+ci-mingw-x-1:
+	$(Q)$(CFG_SRC_DIR)/x test --stage 2 $(SKIP_COMPILER) $(TEST_SET2)
+ci-mingw-x-2:
+	$(Q)$(CFG_SRC_DIR)/x test --stage 2 $(SKIP_SRC) $(TEST_SET2)
 ci-mingw-x:
-	$(Q)$(CFG_SRC_DIR)/x $(STAGE_2_TEST_SET1)
+	$(Q)$(CFG_SRC_DIR)/x test --stage 2 $(TEST_SET1)
 ci-mingw-bootstrap:
-	$(Q)$(BOOTSTRAP) $(STAGE_2_TEST_SET2)
+	$(Q)$(BOOTSTRAP) test --stage 2 $(TEST_SET2)
 ci-mingw: ci-mingw-x ci-mingw-bootstrap
 
 .PHONY: dist

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -456,6 +456,7 @@ auto:
   #  Windows Builders  #
   ######################
 
+  # x86_64-msvc is split into two jobs to run tests in parallel.
   - name: x86_64-msvc-1
     env:
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-sanitizers --enable-profiler
@@ -527,13 +528,30 @@ auto:
   # came from the mingw-w64 SourceForge download site. Unfortunately
   # SourceForge is notoriously flaky, so we mirror it on our own infrastructure.
 
-  - name: i686-mingw
+  # i686-mingw is split into three jobs to run tests in parallel.
+  - name: i686-mingw-1
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
-      SCRIPT: make ci-mingw
+      SCRIPT: make ci-mingw-x-1
       # There is no dist-i686-mingw-alt, so there is no prebuilt LLVM with assertions
       NO_DOWNLOAD_CI_LLVM: 1
-    <<: *job-windows-25-8c
+    <<: *job-windows-25
+
+  - name: i686-mingw-2
+    env:
+      RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
+      SCRIPT: make ci-mingw-x-2
+      # There is no dist-i686-mingw-alt, so there is no prebuilt LLVM with assertions
+      NO_DOWNLOAD_CI_LLVM: 1
+    <<: *job-windows-25
+
+  - name: i686-mingw-3
+    env:
+      RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
+      SCRIPT: make ci-mingw-bootstrap
+      # There is no dist-i686-mingw-alt, so there is no prebuilt LLVM with assertions
+      NO_DOWNLOAD_CI_LLVM: 1
+    <<: *job-windows-25
 
   # x86_64-mingw is split into two jobs to run tests in parallel.
   - name: x86_64-mingw-1


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Split the i686-mingw job in three to move it to free runners and reduce the use of large runners in CI. Related to https://github.com/rust-lang/infra-team/issues/189

- [x] try this for some time so that we verify it's not flaky.

r? @ghost
<!-- homu-ignore:end -->

try-job: i686-mingw-1
try-job: i686-mingw-2
try-job: i686-mingw-3
try-job: x86_64-mingw-1