### PR TITLE
make UI tests that use `--test` work on panic=abort targets

### DIFF
--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/assert-with-custom-errors-does-not-create-unnecessary-code.rs
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/assert-with-custom-errors-does-not-create-unnecessary-code.rs
@@ -1,4 +1,6 @@
-//@ compile-flags: --test
+// -Zpanic_abort_tests makes this test work on panic=abort targets and
+// it's a no-op on panic=unwind targets
+//@ compile-flags: --test -Zpanic_abort_tests
 //@ run-pass
 
 #![feature(core_intrinsics, generic_assert)]

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/feature-gate-generic_assert.rs
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/feature-gate-generic_assert.rs
@@ -1,4 +1,6 @@
-//@ compile-flags: --test
+// -Zpanic_abort_tests makes this test work on panic=abort targets and
+// it's a no-op on panic=unwind targets
+//@ compile-flags: --test -Zpanic_abort_tests
 // ignore-tidy-linelength
 //@ run-pass
 


### PR DESCRIPTION
By passing `-Zpanic_abort_test`.

fixes #135819

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
