### PR TITLE
Improve display of const unstable display feature info

### DIFF
--- a/src/librustdoc/html/templates/short_item_info.html
+++ b/src/librustdoc/html/templates/short_item_info.html
@@ -18,6 +18,18 @@
                 ) {# #}
             </span> {# #}
         </div>
+    {% when Self::ConstUnstable with { feature, tracking } %}
+        <div class="stab unstable"> {# #}
+            <span class="emoji">🔬</span> {# #}
+            <span> {# #}
+                The const version is a nightly-only experimental API. ({# #}
+                <code>{{feature}}</code>
+                {% if let Some(num) = tracking %}
+                    &nbsp;<a href="https://github.com/rust-lang/rust/issues/{{num}}">#{{num}}</a>
+                {% endif %}
+                ) {# #}
+            </span> {# #}
+        </div>
     {% when Self::Portability with { message } %}
         <div class="stab portability">{{message|safe}}</div>
 {% endmatch %}

--- a/tests/rustdoc/const-display.rs
+++ b/tests/rustdoc/const-display.rs
@@ -7,12 +7,18 @@
 
 //@ has 'foo/fn.foo.html' '//pre' 'pub fn foo() -> u32'
 //@ has - '//span[@class="since"]' '1.0.0 (const: unstable)'
+//@ has - '//span[@class="item-info"]//span' 'The const version is a \
+//        nightly-only experimental API. (foo)'
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature="foo", issue = "none")]
 pub const fn foo() -> u32 { 42 }
 
 //@ has 'foo/fn.foo_unsafe.html' '//pre' 'pub unsafe fn foo_unsafe() -> u32'
 //@ has - '//span[@class="since"]' '1.0.0 (const: unstable)'
+//@ has - '//span[@class="item-info"]//span' 'The const version is a \
+//        nightly-only experimental API. (foo #111)'
+//@ has - '//span[@class="item-info"]//a[@href="https://github.com/rust-lang/rust/issues/111"]' \
+//       '#111'
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature="foo", issue = "111")]
 pub const unsafe fn foo_unsafe() -> u32 { 42 }
@@ -63,12 +69,18 @@ pub struct Foo;
 impl Foo {
     //@ has 'foo/struct.Foo.html' '//*[@id="method.gated"]/h4[@class="code-header"]' 'pub fn gated() -> u32'
     //@ has - '//span[@class="since"]' '1.0.0 (const: unstable)'
+    //@ has - '//span[@class="item-info"]//span' 'The const version is a \
+    //        nightly-only experimental API. (foo #112)'
+    //@ has - '//span[@class="item-info"]//a[@href="https://github.com/rust-lang/rust/issues/112"]' \
+    //       '#112'
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature="foo", issue = "none")]
+    #[rustc_const_unstable(feature="foo", issue = "112")]
     pub const fn gated() -> u32 { 42 }
 
     //@ has 'foo/struct.Foo.html' '//*[@id="method.gated_unsafe"]/h4[@class="code-header"]' 'pub unsafe fn gated_unsafe() -> u32'
     //@ has - '//span[@class="since"]' '1.0.0 (const: unstable)'
+    //@ has - '//span[@class="item-info"]//span' 'The const version is a \
+    //        nightly-only experimental API. (foo)'
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature="foo", issue = "none")]
     pub const unsafe fn gated_unsafe() -> u32 { 42 }

--- a/tests/rustdoc/const-display.rs
+++ b/tests/rustdoc/const-display.rs
@@ -14,7 +14,7 @@ pub const fn foo() -> u32 { 42 }
 //@ has 'foo/fn.foo_unsafe.html' '//pre' 'pub unsafe fn foo_unsafe() -> u32'
 //@ has - '//span[@class="since"]' '1.0.0 (const: unstable)'
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature="foo", issue = "none")]
+#[rustc_const_unstable(feature="foo", issue = "111")]
 pub const unsafe fn foo_unsafe() -> u32 { 42 }
 
 //@ has 'foo/fn.foo2.html' '//pre' 'pub const fn foo2() -> u32'


### PR DESCRIPTION
Fixes #131618.

It looks like this:

![image](https://github.com/user-attachments/assets/8e9a58c2-a072-45ec-ad26-be6f17b04178)

And like this for methods:

![image](https://github.com/user-attachments/assets/71336df1-7208-417e-9e59-8351edf3d4c9)

You can check it online [here](https://rustdoc.crud.net/imperio/const-unstable-item-info/const-display/foo/fn.foo_unsafe.html).

r? @notriddle 