### PR TITLE
Detect struct construction with private field in field with default

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -395,6 +395,7 @@ provide! { tcx, def_id, other, cdata,
 
     crate_extern_paths => { cdata.source().paths().cloned().collect() }
     expn_that_defined => { cdata.get_expn_that_defined(def_id.index, tcx.sess) }
+    default_field => { cdata.get_default_field(def_id.index) }
     is_doc_hidden => { cdata.get_attr_flags(def_id.index).contains(AttrFlags::IS_DOC_HIDDEN) }
     doc_link_resolutions => { tcx.arena.alloc(cdata.get_doc_link_resolutions(def_id.index)) }
     doc_link_traits_in_scope => {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1864,6 +1864,13 @@ rustc_queries! {
         feedable
     }
 
+    /// Returns whether the impl or associated function has the `default` keyword.
+    query default_field(def_id: DefId) -> Option<DefId> {
+        desc { |tcx| "looking up the `const` corresponding to the default for `{}`", tcx.def_path_str(def_id) }
+        separate_provide_extern
+        feedable
+    }
+
     query check_well_formed(key: LocalDefId) -> Result<(), ErrorGuaranteed> {
         desc { |tcx| "checking that `{}` is well-formed", tcx.def_path_str(key) }
         return_result_from_ensure_ok

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1864,11 +1864,10 @@ rustc_queries! {
         feedable
     }
 
-    /// Returns whether the impl or associated function has the `default` keyword.
+    /// Returns whether the field corresponding to the `DefId` has a default field value.
     query default_field(def_id: DefId) -> Option<DefId> {
         desc { |tcx| "looking up the `const` corresponding to the default for `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
-        feedable
     }
 
     query check_well_formed(key: LocalDefId) -> Result<(), ErrorGuaranteed> {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1967,54 +1967,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         let mut err =
             self.dcx().create_err(errors::IsPrivate { span: ident.span, ident_descr, ident });
 
-        if let Some(expr) = source
-            && let ast::ExprKind::Struct(struct_expr) = &expr.kind
-            && let Some(Res::Def(_, def_id)) = self.partial_res_map
-                [&struct_expr.path.segments.iter().last().unwrap().id]
-                .full_res()
-            && let Some(default_fields) = self.field_defaults(def_id)
-            && !struct_expr.fields.is_empty()
-        {
-            let last_span = struct_expr.fields.iter().last().unwrap().span;
-            let mut iter = struct_expr.fields.iter().peekable();
-            let mut prev: Option<Span> = None;
-            while let Some(field) = iter.next() {
-                if field.expr.span.overlaps(ident.span) {
-                    err.span_label(field.ident.span, "while setting this field");
-                    if default_fields.contains(&field.ident.name) {
-                        let sugg = if last_span == field.span {
-                            vec![(field.span, "..".to_string())]
-                        } else {
-                            vec![
-                                (
-                                    // Account for trailing commas and ensure we remove them.
-                                    match (prev, iter.peek()) {
-                                        (_, Some(next)) => field.span.with_hi(next.span.lo()),
-                                        (Some(prev), _) => field.span.with_lo(prev.hi()),
-                                        (None, None) => field.span,
-                                    },
-                                    String::new(),
-                                ),
-                                (last_span.shrink_to_hi(), ", ..".to_string()),
-                            ]
-                        };
-                        err.multipart_suggestion_verbose(
-                            format!(
-                                "the type `{ident}` of field `{}` is private, but you can \
-                                 construct the default value defined for it in `{}` using `..` in \
-                                 the struct initializer expression",
-                                field.ident,
-                                self.tcx.item_name(def_id),
-                            ),
-                            sugg,
-                            Applicability::MachineApplicable,
-                        );
-                        break;
-                    }
-                }
-                prev = Some(field.span);
-            }
-        }
+        self.mention_default_field_values(source, ident, &mut err);
 
         let mut not_publicly_reexported = false;
         if let Some((this_res, outer_ident)) = outermost_res {
@@ -2195,6 +2148,85 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         }
 
         err.emit();
+    }
+
+    /// When a private field is being set that has a default field value, we suggest using `..` and
+    /// setting the value of that field implicitly with its default.
+    ///
+    /// If we encounter code like
+    /// ```text
+    /// struct Priv;
+    /// pub struct S {
+    ///     pub field: Priv = Priv,
+    /// }
+    /// ```
+    /// which is used from a place where `Priv` isn't accessible
+    /// ```text
+    /// let _ = S { field: m::Priv1 {} };
+    /// //                    ^^^^^ private struct
+    /// ```
+    /// we will suggest instead using the `default_field_values` syntax instead:
+    /// ```text
+    /// let _ = S { .. };
+    /// ```
+    fn mention_default_field_values(
+        &self,
+        source: &Option<ast::Expr>,
+        ident: Ident,
+        err: &mut Diag<'_>,
+    ) {
+        let Some(expr) = source else { return };
+        let ast::ExprKind::Struct(struct_expr) = &expr.kind else { return };
+        // We don't have to handle type-relative paths because they're forbidden in ADT
+        // expressions, but that would change with `#[feature(more_qualified_paths)]`.
+        let Some(Res::Def(_, def_id)) =
+            self.partial_res_map[&struct_expr.path.segments.iter().last().unwrap().id].full_res()
+        else {
+            return;
+        };
+        let Some(default_fields) = self.field_defaults(def_id) else { return };
+        if struct_expr.fields.is_empty() {
+            return;
+        }
+        let last_span = struct_expr.fields.iter().last().unwrap().span;
+        let mut iter = struct_expr.fields.iter().peekable();
+        let mut prev: Option<Span> = None;
+        while let Some(field) = iter.next() {
+            if field.expr.span.overlaps(ident.span) {
+                err.span_label(field.ident.span, "while setting this field");
+                if default_fields.contains(&field.ident.name) {
+                    let sugg = if last_span == field.span {
+                        vec![(field.span, "..".to_string())]
+                    } else {
+                        vec![
+                            (
+                                // Account for trailing commas and ensure we remove them.
+                                match (prev, iter.peek()) {
+                                    (_, Some(next)) => field.span.with_hi(next.span.lo()),
+                                    (Some(prev), _) => field.span.with_lo(prev.hi()),
+                                    (None, None) => field.span,
+                                },
+                                String::new(),
+                            ),
+                            (last_span.shrink_to_hi(), ", ..".to_string()),
+                        ]
+                    };
+                    err.multipart_suggestion_verbose(
+                        format!(
+                            "the type `{ident}` of field `{}` is private, but you can construct \
+                             the default value defined for it in `{}` using `..` in the struct \
+                             initializer expression",
+                            field.ident,
+                            self.tcx.item_name(def_id),
+                        ),
+                        sugg,
+                        Applicability::MachineApplicable,
+                    );
+                    break;
+                }
+            }
+            prev = Some(field.span);
+        }
     }
 
     pub(crate) fn find_similarly_named_module_or_crate(

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -174,7 +174,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         &mut self,
         path: &[Segment],
         span: Span,
-        source: PathSource<'_, '_, '_>,
+        source: PathSource<'_, 'ast, 'ra>,
         res: Option<Res>,
     ) -> BaseError {
         // Make the base error.
@@ -318,7 +318,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 (String::new(), "the crate root".to_string(), Some(CRATE_DEF_ID.to_def_id()), None)
             } else {
                 let mod_path = &path[..path.len() - 1];
-                let mod_res = self.resolve_path(mod_path, Some(TypeNS), None);
+                let mod_res = self.resolve_path(mod_path, Some(TypeNS), None, source);
                 let mod_prefix = match mod_res {
                     PathResult::Module(ModuleOrUniformRoot::Module(module)) => module.res(),
                     _ => None,
@@ -419,7 +419,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
-        source: PathSource<'_, '_, '_>,
+        source: PathSource<'_, 'ast, 'ra>,
         res: Option<Res>,
         qself: Option<&QSelf>,
     ) -> (Diag<'tcx>, Vec<ImportSuggestion>) {
@@ -1014,7 +1014,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_typo(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_, '_>,
+        source: PathSource<'_, 'ast, 'ra>,
         path: &[Segment],
         following_seg: Option<&Segment>,
         span: Span,
@@ -1333,7 +1333,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn suggest_swapping_misplaced_self_ty_and_trait(
         &mut self,
         err: &mut Diag<'_>,
-        source: PathSource<'_, '_, '_>,
+        source: PathSource<'_, 'ast, 'ra>,
         res: Option<Res>,
         span: Span,
     ) {
@@ -1341,7 +1341,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             self.diag_metadata.currently_processing_impl_trait.clone()
             && let TyKind::Path(_, self_ty_path) = &self_ty.kind
             && let PathResult::Module(ModuleOrUniformRoot::Module(module)) =
-                self.resolve_path(&Segment::from_path(self_ty_path), Some(TypeNS), None)
+                self.resolve_path(&Segment::from_path(self_ty_path), Some(TypeNS), None, source)
             && let ModuleKind::Def(DefKind::Trait, ..) = module.kind
             && trait_ref.path.span == span
             && let PathSource::Trait(_) = source
@@ -1449,13 +1449,13 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
     fn get_single_associated_item(
         &mut self,
         path: &[Segment],
-        source: &PathSource<'_, '_, '_>,
+        source: &PathSource<'_, 'ast, 'ra>,
         filter_fn: &impl Fn(Res) -> bool,
     ) -> Option<TypoSuggestion> {
         if let crate::PathSource::TraitItem(_, _) = source {
             let mod_path = &path[..path.len() - 1];
             if let PathResult::Module(ModuleOrUniformRoot::Module(module)) =
-                self.resolve_path(mod_path, None, None)
+                self.resolve_path(mod_path, None, None, *source)
             {
                 let targets: Vec<_> = self
                     .r
@@ -1854,7 +1854,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 PathSource::Expr(Some(Expr {
                     kind: ExprKind::Index(..) | ExprKind::Call(..), ..
                 }))
-                | PathSource::Struct,
+                | PathSource::Struct(_),
             ) => {
                 // Don't suggest macro if it's unstable.
                 let suggestable = def_id.is_local()
@@ -2502,7 +2502,7 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             // Search in module.
             let mod_path = &path[..path.len() - 1];
             if let PathResult::Module(ModuleOrUniformRoot::Module(module)) =
-                self.resolve_path(mod_path, Some(TypeNS), None)
+                self.resolve_path(mod_path, Some(TypeNS), None, PathSource::Type)
             {
                 self.r.add_module_candidates(module, &mut names, &filter_fn, None);
             }
@@ -3673,7 +3673,12 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                                 if let TyKind::Path(None, path) = &ty.kind {
                                     // Check if the path being borrowed is likely to be owned.
                                     let path: Vec<_> = Segment::from_path(path);
-                                    match self.resolve_path(&path, Some(TypeNS), None) {
+                                    match self.resolve_path(
+                                        &path,
+                                        Some(TypeNS),
+                                        None,
+                                        PathSource::Type,
+                                    ) {
                                         PathResult::Module(ModuleOrUniformRoot::Module(module)) => {
                                             match module.res() {
                                                 Some(Res::PrimTy(PrimTy::Str)) => {

--- a/tests/ui/structs/default-field-values/auxiliary/struct_field_default.rs
+++ b/tests/ui/structs/default-field-values/auxiliary/struct_field_default.rs
@@ -3,3 +3,13 @@
 pub struct A {
     pub a: isize = 42,
 }
+
+struct Priv;
+
+pub struct B {
+    pub a: Priv = Priv,
+}
+
+pub struct C {
+    pub a: Priv,
+}

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor-2.rs
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor-2.rs
@@ -1,0 +1,29 @@
+//@ aux-build:struct_field_default.rs
+#![feature(default_field_values)]
+
+extern crate struct_field_default as xc;
+
+use m::S;
+
+mod m {
+   pub struct S {
+       pub field: () = (),
+       pub field1: Priv1 = Priv1 {},
+       pub field2: Priv2 = Priv2,
+   }
+   struct Priv1 {}
+   struct Priv2;
+}
+
+fn main() {
+    let _ = S { field: (), field1: m::Priv1 {} };
+    //~^ ERROR missing field `field2`
+    //~| ERROR struct `Priv1` is private
+    let _ = S { field: (), field1: m::Priv1 {}, field2: m::Priv2 };
+    //~^ ERROR struct `Priv1` is private
+    //~| ERROR unit struct `Priv2` is private
+    let _ = xc::B { a: xc::Priv };
+    //~^ ERROR unit struct `Priv` is private
+    let _ = xc::C { a: xc::Priv };
+    //~^ ERROR unit struct `Priv` is private
+}

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor-2.stderr
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor-2.stderr
@@ -1,0 +1,105 @@
+error[E0603]: struct `Priv1` is private
+  --> $DIR/non-exhaustive-ctor-2.rs:19:39
+   |
+LL |     let _ = S { field: (), field1: m::Priv1 {} };
+   |                            ------     ^^^^^ private struct
+   |                            |
+   |                            while setting this field
+   |
+note: the struct `Priv1` is defined here
+  --> $DIR/non-exhaustive-ctor-2.rs:14:4
+   |
+LL |    struct Priv1 {}
+   |    ^^^^^^^^^^^^
+help: the type `Priv1` of field `field1` is private, but you can construct the default value defined for it in `S` using `..` in the struct initializer expression
+   |
+LL -     let _ = S { field: (), field1: m::Priv1 {} };
+LL +     let _ = S { field: (), .. };
+   |
+
+error[E0603]: struct `Priv1` is private
+  --> $DIR/non-exhaustive-ctor-2.rs:22:39
+   |
+LL |     let _ = S { field: (), field1: m::Priv1 {}, field2: m::Priv2 };
+   |                            ------     ^^^^^ private struct
+   |                            |
+   |                            while setting this field
+   |
+note: the struct `Priv1` is defined here
+  --> $DIR/non-exhaustive-ctor-2.rs:14:4
+   |
+LL |    struct Priv1 {}
+   |    ^^^^^^^^^^^^
+help: the type `Priv1` of field `field1` is private, but you can construct the default value defined for it in `S` using `..` in the struct initializer expression
+   |
+LL -     let _ = S { field: (), field1: m::Priv1 {}, field2: m::Priv2 };
+LL +     let _ = S { field: (), field2: m::Priv2, .. };
+   |
+
+error[E0603]: unit struct `Priv2` is private
+  --> $DIR/non-exhaustive-ctor-2.rs:22:60
+   |
+LL |     let _ = S { field: (), field1: m::Priv1 {}, field2: m::Priv2 };
+   |                                                 ------     ^^^^^ private unit struct
+   |                                                 |
+   |                                                 while setting this field
+   |
+note: the unit struct `Priv2` is defined here
+  --> $DIR/non-exhaustive-ctor-2.rs:15:4
+   |
+LL |    struct Priv2;
+   |    ^^^^^^^^^^^^^
+help: the type `Priv2` of field `field2` is private, but you can construct the default value defined for it in `S` using `..` in the struct initializer expression
+   |
+LL -     let _ = S { field: (), field1: m::Priv1 {}, field2: m::Priv2 };
+LL +     let _ = S { field: (), field1: m::Priv1 {}, .. };
+   |
+
+error[E0603]: unit struct `Priv` is private
+  --> $DIR/non-exhaustive-ctor-2.rs:25:28
+   |
+LL |     let _ = xc::B { a: xc::Priv };
+   |                     -      ^^^^ private unit struct
+   |                     |
+   |                     while setting this field
+   |
+note: the unit struct `Priv` is defined here
+  --> $DIR/auxiliary/struct_field_default.rs:7:1
+   |
+LL | struct Priv;
+   | ^^^^^^^^^^^
+help: the type `Priv` of field `a` is private, but you can construct the default value defined for it in `B` using `..` in the struct initializer expression
+   |
+LL -     let _ = xc::B { a: xc::Priv };
+LL +     let _ = xc::B { .. };
+   |
+
+error[E0603]: unit struct `Priv` is private
+  --> $DIR/non-exhaustive-ctor-2.rs:27:28
+   |
+LL |     let _ = xc::C { a: xc::Priv };
+   |                     -      ^^^^ private unit struct
+   |                     |
+   |                     while setting this field
+   |
+note: the unit struct `Priv` is defined here
+  --> $DIR/auxiliary/struct_field_default.rs:7:1
+   |
+LL | struct Priv;
+   | ^^^^^^^^^^^
+
+error[E0063]: missing field `field2` in initializer of `S`
+  --> $DIR/non-exhaustive-ctor-2.rs:19:13
+   |
+LL |     let _ = S { field: (), field1: m::Priv1 {} };
+   |             ^ missing `field2`
+   |
+help: all remaining fields have default values, you can use those values with `..`
+   |
+LL |     let _ = S { field: (), field1: m::Priv1 {}, .. };
+   |                                               ++++
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0063, E0603.
+For more information about an error, try `rustc --explain E0063`.


### PR DESCRIPTION
When trying to construct a struct that has a public field of a private type, suggest using `..` if that field has a default value.

```
error[E0603]: struct `Priv1` is private
  --> $DIR/non-exhaustive-ctor-2.rs:19:39
   |
LL |     let _ = S { field: (), field1: m::Priv1 {} };
   |                            ------     ^^^^^ private struct
   |                            |
   |                            while setting this field
   |
note: the struct `Priv1` is defined here
  --> $DIR/non-exhaustive-ctor-2.rs:14:4
   |
LL |    struct Priv1 {}
   |    ^^^^^^^^^^^^
help: the type `Priv1` of field `field1` is private, but you can construct the default value defined for it in `S` using `..` in the struct initializer expression
   |
LL |     let _ = S { field: (), .. };
   |                            ~~
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
