### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/library/core/src/prelude/common.rs
+++ b/library/core/src/prelude/common.rs
@@ -12,6 +12,9 @@ pub use crate::marker::{Copy, Send, Sized, Sync, Unpin};
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
+#[stable(feature = "async_closure", since = "1.85.0")]
+#[doc(no_inline)]
+pub use crate::ops::{AsyncFn, AsyncFnMut, AsyncFnOnce};
 
 // Re-exported functions
 #[stable(feature = "core_prelude", since = "1.4.0")]

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -2387,13 +2387,12 @@ mod async_keyword {}
 /// [`async`]: ../std/keyword.async.html
 mod await_keyword {}
 
-// FIXME(dyn_compat_renaming): Update URL and link text.
 #[doc(keyword = "dyn")]
 //
 /// `dyn` is a prefix of a [trait object]'s type.
 ///
 /// The `dyn` keyword is used to highlight that calls to methods on the associated `Trait`
-/// are [dynamically dispatched]. To use the trait this way, it must be 'dyn-compatible'[^1].
+/// are [dynamically dispatched]. To use the trait this way, it must be *dyn compatible*[^1].
 ///
 /// Unlike generic parameters or `impl Trait`, the compiler does not know the concrete type that
 /// is being passed. That is, the type has been [erased].
@@ -2406,7 +2405,7 @@ mod await_keyword {}
 /// the function pointer and then that function pointer is called.
 ///
 /// See the Reference for more information on [trait objects][ref-trait-obj]
-/// and [object safety][ref-obj-safety].
+/// and [dyn compatibility][ref-dyn-compat].
 ///
 /// ## Trade-offs
 ///
@@ -2419,9 +2418,9 @@ mod await_keyword {}
 /// [trait object]: ../book/ch17-02-trait-objects.html
 /// [dynamically dispatched]: https://en.wikipedia.org/wiki/Dynamic_dispatch
 /// [ref-trait-obj]: ../reference/types/trait-object.html
-/// [ref-obj-safety]: ../reference/items/traits.html#object-safety
+/// [ref-dyn-compat]: ../reference/items/traits.html#dyn-compatibility
 /// [erased]: https://en.wikipedia.org/wiki/Type_erasure
-/// [^1]: Formerly known as 'object safe'.
+/// [^1]: Formerly known as *object safe*.
 mod dyn_keyword {}
 
 #[doc(keyword = "union")]

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -328,9 +328,6 @@ impl File {
                         mem::size_of::<c::FILE_ALLOCATION_INFO>() as u32,
                     );
                     if result == 0 {
-                        if api::get_last_error().code != 0 {
-                            panic!("FILE_ALLOCATION_INFO failed!!!");
-                        }
                         let eof = c::FILE_END_OF_FILE_INFO { EndOfFile: 0 };
                         let result = c::SetFileInformationByHandle(
                             handle.as_raw_handle(),

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -123,6 +123,7 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
       build_args+=("--build-arg" "SCRIPT_ARG=${DOCKER_SCRIPT}")
     fi
 
+    GHCR_BUILDKIT_IMAGE="ghcr.io/rust-lang/buildkit:buildx-stable-1"
     # On non-CI jobs, we try to download a pre-built image from the rust-lang-ci
     # ghcr.io registry. If it is not possible, we fall back to building the image
     # locally.
@@ -140,7 +141,9 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
     elif [[ "$PR_CI_JOB" == "1" ]];
     then
         # Enable a new Docker driver so that --cache-from works with a registry backend
-        docker buildx create --use --driver docker-container
+        # Use a custom image to avoid DockerHub rate limits
+        docker buildx create --use --driver docker-container \
+          --driver-opt image=${GHCR_BUILDKIT_IMAGE}
 
         # Build the image using registry caching backend
         retry docker \
@@ -156,7 +159,9 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
             --password-stdin
 
         # Enable a new Docker driver so that --cache-from/to works with a registry backend
-        docker buildx create --use --driver docker-container
+        # Use a custom image to avoid DockerHub rate limits
+        docker buildx create --use --driver docker-container \
+          --driver-opt image=${GHCR_BUILDKIT_IMAGE}
 
         # Build the image using registry caching backend
         retry docker \

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -44,6 +44,8 @@ runners:
     <<: *base-job
 
   - &job-aarch64-linux
+    # Free some disk space to avoid running out of space during the build.
+    free_disk: true
     os: ubuntu-22.04-arm
 
 envs:

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/assert-with-custom-errors-does-not-create-unnecessary-code.rs
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/assert-with-custom-errors-does-not-create-unnecessary-code.rs
@@ -1,4 +1,6 @@
-//@ compile-flags: --test
+// -Zpanic_abort_tests makes this test work on panic=abort targets and
+// it's a no-op on panic=unwind targets
+//@ compile-flags: --test -Zpanic_abort_tests
 //@ run-pass
 
 #![feature(core_intrinsics, generic_assert)]

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/feature-gate-generic_assert.rs
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/feature-gate-generic_assert.rs
@@ -1,4 +1,6 @@
-//@ compile-flags: --test
+// -Zpanic_abort_tests makes this test work on panic=abort targets and
+// it's a no-op on panic=unwind targets
+//@ compile-flags: --test -Zpanic_abort_tests
 // ignore-tidy-linelength
 //@ run-pass
 

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor.disabled.stderr
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor.disabled.stderr
@@ -1,0 +1,86 @@
+error[E0658]: default values on fields are experimental
+  --> $DIR/non-exhaustive-ctor.rs:9:22
+   |
+LL |         pub field: () = (),
+   |                      ^^^^^
+   |
+   = note: see issue #132162 <https://github.com/rust-lang/rust/issues/132162> for more information
+   = help: add `#![feature(default_field_values)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: default values on fields are experimental
+  --> $DIR/non-exhaustive-ctor.rs:11:25
+   |
+LL |         pub field1: Priv = Priv,
+   |                         ^^^^^^^
+   |
+   = note: see issue #132162 <https://github.com/rust-lang/rust/issues/132162> for more information
+   = help: add `#![feature(default_field_values)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: default values on fields are experimental
+  --> $DIR/non-exhaustive-ctor.rs:13:25
+   |
+LL |         pub field2: Priv = Priv,
+   |                         ^^^^^^^
+   |
+   = note: see issue #132162 <https://github.com/rust-lang/rust/issues/132162> for more information
+   = help: add `#![feature(default_field_values)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0797]: base expression required after `..`
+  --> $DIR/non-exhaustive-ctor.rs:20:19
+   |
+LL |     let _ = S { .. }; // ok
+   |                   ^
+   |
+help: add `#![feature(default_field_values)]` to the crate attributes to enable default values on `struct` fields
+   |
+LL + #![feature(default_field_values)]
+   |
+help: add a base expression here
+   |
+LL |     let _ = S { ../* expr */ }; // ok
+   |                   ++++++++++
+
+error[E0797]: base expression required after `..`
+  --> $DIR/non-exhaustive-ctor.rs:22:30
+   |
+LL |     let _ = S { field: (), .. }; // ok
+   |                              ^
+   |
+help: add `#![feature(default_field_values)]` to the crate attributes to enable default values on `struct` fields
+   |
+LL + #![feature(default_field_values)]
+   |
+help: add a base expression here
+   |
+LL |     let _ = S { field: (), ../* expr */ }; // ok
+   |                              ++++++++++
+
+error[E0063]: missing fields `field`, `field1` and `field2` in initializer of `S`
+  --> $DIR/non-exhaustive-ctor.rs:24:13
+   |
+LL |     let _ = S { };
+   |             ^ missing `field`, `field1` and `field2`
+   |
+help: all remaining fields have default values, if you added `#![feature(default_field_values)]` to your crate you could use those values with `..`
+   |
+LL |     let _ = S { .. };
+   |               ~~~~~~
+
+error[E0063]: missing fields `field1` and `field2` in initializer of `S`
+  --> $DIR/non-exhaustive-ctor.rs:26:13
+   |
+LL |     let _ = S { field: () };
+   |             ^ missing `field1` and `field2`
+   |
+help: all remaining fields have default values, if you added `#![feature(default_field_values)]` to your crate you could use those values with `..`
+   |
+LL |     let _ = S { field: (), .. };
+   |                          ++++
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0063, E0658, E0797.
+For more information about an error, try `rustc --explain E0063`.

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor.enabled.fixed
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor.enabled.fixed
@@ -1,0 +1,28 @@
+//@ revisions: enabled disabled
+//@[enabled] run-rustfix
+#![allow(private_interfaces, dead_code)]
+#![cfg_attr(enabled, feature(default_field_values))]
+use m::S;
+
+mod m {
+    pub struct S {
+        pub field: () = (),
+        //[disabled]~^ ERROR default values on fields are experimental
+        pub field1: Priv = Priv,
+        //[disabled]~^ ERROR default values on fields are experimental
+        pub field2: Priv = Priv,
+        //[disabled]~^ ERROR default values on fields are experimental
+    }
+    struct Priv;
+}
+
+fn main() {
+    let _ = S { .. }; // ok
+    //[disabled]~^ ERROR base expression required after `..`
+    let _ = S { field: (), .. }; // ok
+    //[disabled]~^ ERROR base expression required after `..`
+    let _ = S { .. };
+    //~^ ERROR missing fields `field`, `field1` and `field2`
+    let _ = S { field: (), .. };
+    //~^ ERROR missing fields `field1` and `field2`
+}

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor.enabled.stderr
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor.enabled.stderr
@@ -1,0 +1,25 @@
+error[E0063]: missing fields `field`, `field1` and `field2` in initializer of `S`
+  --> $DIR/non-exhaustive-ctor.rs:24:13
+   |
+LL |     let _ = S { };
+   |             ^ missing `field`, `field1` and `field2`
+   |
+help: all remaining fields have default values, you can use those values with `..`
+   |
+LL |     let _ = S { .. };
+   |               ~~~~~~
+
+error[E0063]: missing fields `field1` and `field2` in initializer of `S`
+  --> $DIR/non-exhaustive-ctor.rs:26:13
+   |
+LL |     let _ = S { field: () };
+   |             ^ missing `field1` and `field2`
+   |
+help: all remaining fields have default values, you can use those values with `..`
+   |
+LL |     let _ = S { field: (), .. };
+   |                          ++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0063`.

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor.rs
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor.rs
@@ -1,0 +1,28 @@
+//@ revisions: enabled disabled
+//@[enabled] run-rustfix
+#![allow(private_interfaces, dead_code)]
+#![cfg_attr(enabled, feature(default_field_values))]
+use m::S;
+
+mod m {
+    pub struct S {
+        pub field: () = (),
+        //[disabled]~^ ERROR default values on fields are experimental
+        pub field1: Priv = Priv,
+        //[disabled]~^ ERROR default values on fields are experimental
+        pub field2: Priv = Priv,
+        //[disabled]~^ ERROR default values on fields are experimental
+    }
+    struct Priv;
+}
+
+fn main() {
+    let _ = S { .. }; // ok
+    //[disabled]~^ ERROR base expression required after `..`
+    let _ = S { field: (), .. }; // ok
+    //[disabled]~^ ERROR base expression required after `..`
+    let _ = S { };
+    //~^ ERROR missing fields `field`, `field1` and `field2`
+    let _ = S { field: () };
+    //~^ ERROR missing fields `field1` and `field2`
+}


### PR DESCRIPTION
Successful merges:

 - #135779 (CI: free disk on linux arm runner)
 - #135794 (Detect missing fields with default values and suggest `..`)
 - #135814 (ci: use ghcr buildkit image)
 - #135823 (make UI tests that use `--test` work on panic=abort targets)
 - #135837 (Remove test panic from File::open)
 - #135852 (Add `AsyncFn*` to `core` prelude)
 - #135856 (Library: Finalize dyn compatibility renaming)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135779,135794,135814,135823,135837,135852,135856)
<!-- homu-ignore:end -->