### PR TITLE
fix doc for std::sync::mpmc

### DIFF
--- a/library/std/src/sync/mpmc/mod.rs
+++ b/library/std/src/sync/mpmc/mod.rs
@@ -18,7 +18,7 @@
 //!    infinite buffer.
 //!
 //! 2. A synchronous, bounded channel. The [`sync_channel`] function will
-//!    return a `(SyncSender, Receiver)` tuple where the storage for pending
+//!    return a `(Sender, Receiver)` tuple where the storage for pending
 //!    messages is a pre-allocated buffer of a fixed size. All sends will be
 //!    **synchronous** by blocking until there is buffer space available. Note
 //!    that a bound of 0 is allowed, causing the channel to become a "rendezvous"
@@ -360,9 +360,17 @@ impl<T> Sender<T> {
     /// that a return value of [`Err`] means that the data will never be
     /// received, but a return value of [`Ok`] does *not* mean that the data
     /// will be received. It is possible for the corresponding receiver to
-    /// hang up immediately after this function returns [`Ok`].
+    /// hang up immediately after this function returns [`Ok`]. However, if
+    /// the channel is zero-capacity, it acts as a rendezvous channel and a
+    /// return value of [`Ok`] means that the data has been received.
     ///
-    /// This method will never block the current thread.
+    /// If the channel is full and not disconnected, this call will block until
+    /// the send operation can proceed. If the channel becomes disconnected,
+    /// this call will wake up and return an error. The returned error contains
+    /// the original message.
+    ///
+    /// If called on a zero-capacity channel, this method will wait for a receive
+    /// operation to appear on the other side of the channel.
     ///
     /// # Examples
     ///
@@ -650,7 +658,7 @@ impl<T> fmt::Debug for Sender<T> {
 }
 
 /// The receiving half of Rust's [`channel`] (or [`sync_channel`]) type.
-/// Different threads can share this [`Sender`] by cloning it.
+/// Different threads can share this [`Receiver`] by cloning it.
 ///
 /// Messages sent to the channel can be retrieved using [`recv`].
 ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

fix document of `std::sync::mpmc` (tracked in https://github.com/rust-lang/rust/issues/126840)