### PR TITLE
-Znext-solver: "normalize" signature before checking it mentions self in `deduce_closure_signature`

### DIFF
--- a/tests/ui/borrowck/issue-103095.rs
+++ b/tests/ui/borrowck/issue-103095.rs
@@ -1,4 +1,7 @@
 //@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
 
 trait FnOnceForGenericRef<T>: FnOnce(&T) -> Self::FnOutput {
     type FnOutput;
@@ -16,10 +19,7 @@ struct Data<T, D: FnOnceForGenericRef<T>> {
 impl<T, D: FnOnceForGenericRef<T>> Data<T, D> {
     fn new(value: T, f: D) -> Self {
         let output = f(&value);
-        Self {
-            value: Some(value),
-            output: Some(output),
-        }
+        Self { value: Some(value), output: Some(output) }
     }
 }
 

--- a/tests/ui/closures/supertrait-hint-references-assoc-ty.rs
+++ b/tests/ui/closures/supertrait-hint-references-assoc-ty.rs
@@ -1,4 +1,7 @@
 //@ check-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
 
 pub trait Fn0: Fn(i32) -> Self::Out {
     type Out;

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.current.fixed
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.current.fixed
@@ -9,4 +9,5 @@ fn main() {
     let _ = (-10..=10).find(|x: &i32| x.signum() == 0);
     //[current]~^ ERROR type mismatch in closure arguments
     //[next]~^^ ERROR expected `RangeInclusive<{integer}>` to be an iterator that yields `&&i32`, but it yields `{integer}`
+    //[next]~| ERROR expected a `FnMut(&<RangeInclusive<{integer}> as Iterator>::Item)` closure, found
 }

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.next.stderr
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.next.stderr
@@ -13,12 +13,26 @@ note: required by a bound in `find`
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 
 error[E0271]: expected `RangeInclusive<{integer}>` to be an iterator that yields `&&i32`, but it yields `{integer}`
-  --> $DIR/closure-arg-type-mismatch-issue-45727.rs:9:33
+  --> $DIR/closure-arg-type-mismatch-issue-45727.rs:9:24
    |
 LL |     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
-   |                                 ^^^^^^ expected `&&i32`, found integer
+   |                        ^^^^ expected `&&i32`, found integer
 
-error: aborting due to 2 previous errors
+error[E0277]: expected a `FnMut(&<RangeInclusive<{integer}> as Iterator>::Item)` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:9:29: 9:40}`
+  --> $DIR/closure-arg-type-mismatch-issue-45727.rs:9:29
+   |
+LL |     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
+   |                        ---- ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnMut(&<RangeInclusive<{integer}> as Iterator>::Item)` closure, found `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:9:29: 9:40}`
+   |                        |
+   |                        required by a bound introduced by this call
+   |
+   = help: the trait `for<'a> FnMut(&'a <RangeInclusive<{integer}> as Iterator>::Item)` is not implemented for closure `{closure@$DIR/closure-arg-type-mismatch-issue-45727.rs:9:29: 9:40}`
+   = note: expected a closure with arguments `(&&&i32,)`
+              found a closure with arguments `(&<RangeInclusive<{integer}> as Iterator>::Item,)`
+note: required by a bound in `find`
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0271, E0277.
 For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.rs
+++ b/tests/ui/mismatched_types/closure-arg-type-mismatch-issue-45727.rs
@@ -9,4 +9,5 @@ fn main() {
     let _ = (-10..=10).find(|x: &&&i32| x.signum() == 0);
     //[current]~^ ERROR type mismatch in closure arguments
     //[next]~^^ ERROR expected `RangeInclusive<{integer}>` to be an iterator that yields `&&i32`, but it yields `{integer}`
+    //[next]~| ERROR expected a `FnMut(&<RangeInclusive<{integer}> as Iterator>::Item)` closure, found
 }

--- a/tests/ui/traits/next-solver/closure-signature-inference-hr-ambig-alias-naming-self.rs
+++ b/tests/ui/traits/next-solver/closure-signature-inference-hr-ambig-alias-naming-self.rs
@@ -1,0 +1,52 @@
+//@ check-pass
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+
+// When type checking a closure expr we look at the list of unsolved goals
+// to determine if there are any bounds on the closure type to infer a signature from.
+//
+// We attempt to discard goals that name the closure type so as to avoid inferring the
+// closure type to something like `?x = closure(sig=fn(?x))`. This test checks that when
+// such a goal names the closure type inside of an ambiguous alias and there exists another
+// potential goal to infer the closure signature from, we do that.
+
+trait Trait<'a> {
+    type Assoc;
+}
+
+impl<'a, F> Trait<'a> for F {
+    type Assoc = u32;
+}
+
+fn closure_typer1<F>(_: F)
+where
+    F: Fn(u32) + for<'a> Fn(<F as Trait<'a>>::Assoc),
+{
+}
+
+fn closure_typer2<F>(_: F)
+where
+    F: for<'a> Fn(<F as Trait<'a>>::Assoc) + Fn(u32),
+{
+}
+
+fn main() {
+    // Here we have some closure with a yet to be inferred type of `?c`. There are two goals
+    // involving `?c` that can be used to determine the closure signature:
+    // - `?c: for<'a> Fn<(<?c as Trait<'a>>::Assoc,), Output = ()>`
+    // - `?c: Fn<(u32,), Output = ()>`
+    //
+    // If we were to infer the argument of the closure (`x` below) to `<?c as Trait<'a>>::Assoc`
+    // then we would not be able to call `x.into()` as `x` is some unknown type. Instead we must
+    // use the `?c: Fn(u32)` goal to infer a signature in order for this code to compile.
+    //
+    // As the algorithm for picking a goal to infer the signature from is dependent on the ordering
+    // of pending goals in the type checker, we test both orderings of bounds to ensure we aren't
+    // testing that we just *happen* to pick `?c: Fn(u32)`.
+    closure_typer1(move |x| {
+        let _: u32 = x.into();
+    });
+    closure_typer2(move |x| {
+        let _: u32 = x.into();
+    });
+}


### PR DESCRIPTION
Fixes rust-lang/trait-system-refactor-initiative#138

r? @lcnr

Tbh I wrote so much comments I don't feel like writing it all again but as a description. 
 