### PR TITLE
Fix `PostBorrowckAnalysis` for old solver

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -711,7 +711,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             // Already reported.
             Overflow(OverflowError::Error(guar)) => {
                 self.set_tainted_by_errors(guar);
-                return guar
+                return guar;
             },
 
             Overflow(_) => {
@@ -719,6 +719,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
 
             SelectionError::ConstArgHasWrongType { ct, ct_ty, expected_ty } => {
+                if let Err(guar) = expected_ty.error_reported() {
+                    return guar;
+                }
+
                 let mut diag = self.dcx().struct_span_err(
                     span,
                     format!("the constant `{ct}` is not of type `{expected_ty}`"),

--- a/tests/ui/impl-trait/failed-to-resolve-instance-ice-123145.rs
+++ b/tests/ui/impl-trait/failed-to-resolve-instance-ice-123145.rs
@@ -1,7 +1,5 @@
 // ICE failed to resolve instance for ...
 // issue: rust-lang/rust#123145
-//@ build-fail
-//~^^^ ERROR overflow evaluating the requirement `(fn() -> impl Handler
 
 trait Handler {
     fn handle(&self) {}
@@ -13,6 +11,7 @@ impl<L: Handler> Handler for (L,) {}
 
 fn one() -> impl Handler {
     (one,)
+    //~^ ERROR overflow evaluating the requirement `(fn() -> impl Handler
 }
 
 fn main() {

--- a/tests/ui/impl-trait/failed-to-resolve-instance-ice-123145.stderr
+++ b/tests/ui/impl-trait/failed-to-resolve-instance-ice-123145.stderr
@@ -1,14 +1,28 @@
 error[E0275]: overflow evaluating the requirement `(fn() -> impl Handler {one},): Handler`
+  --> $DIR/failed-to-resolve-instance-ice-123145.rs:13:5
+   |
+LL |     (one,)
+   |     ^^^^^^
    |
 note: required for `fn() -> impl Handler {one}` to implement `Handler`
-  --> $DIR/failed-to-resolve-instance-ice-123145.rs:10:32
+  --> $DIR/failed-to-resolve-instance-ice-123145.rs:8:32
    |
 LL | impl<H: Handler, F: Fn() -> H> Handler for F {}
    |         -------                ^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: 2 redundant requirements hidden
-   = note: required for `fn() -> impl Handler {one}` to implement `Handler`
+   = note: 1 redundant requirement hidden
+   = note: required for `(fn() -> impl Handler {one},)` to implement `Handler`
+note: required by a bound in an opaque type
+  --> $DIR/failed-to-resolve-instance-ice-123145.rs:12:18
+   |
+LL | fn one() -> impl Handler {
+   |                  ^^^^^^^
+note: this definition site has more where clauses than the opaque type
+  --> $DIR/failed-to-resolve-instance-ice-123145.rs:12:1
+   |
+LL | fn one() -> impl Handler {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/stranded-opaque.rs
+++ b/tests/ui/impl-trait/stranded-opaque.rs
@@ -8,6 +8,7 @@ impl Trait for i32 {}
 fn produce<T>() -> impl Trait<Assoc = impl Trait> {
     //~^ ERROR associated type `Assoc` not found for `Trait`
     //~| ERROR associated type `Assoc` not found for `Trait`
+    //~| ERROR the trait bound `(): Trait` is not satisfied
     16
 }
 

--- a/tests/ui/impl-trait/stranded-opaque.stderr
+++ b/tests/ui/impl-trait/stranded-opaque.stderr
@@ -12,6 +12,20 @@ LL | fn produce<T>() -> impl Trait<Assoc = impl Trait> {
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `(): Trait` is not satisfied
+  --> $DIR/stranded-opaque.rs:8:39
+   |
+LL | fn produce<T>() -> impl Trait<Assoc = impl Trait> {
+   |                                       ^^^^^^^^^^ the trait `Trait` is not implemented for `()`
+   |
+   = help: the trait `Trait` is implemented for `i32`
+note: required by a bound in an opaque type
+  --> $DIR/stranded-opaque.rs:8:44
+   |
+LL | fn produce<T>() -> impl Trait<Assoc = impl Trait> {
+   |                                            ^^^^^
 
-For more information about this error, try `rustc --explain E0220`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0220, E0277.
+For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/type-alias-impl-trait/const_generic_type.infer.stderr
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.infer.stderr
@@ -6,5 +6,21 @@ LL | async fn test<const N: Bar>() {
    |
    = note: the only supported types are integers, `bool`, and `char`
 
-error: aborting due to 1 previous error
+error: the constant `N` is not of type `u32`
+  --> $DIR/const_generic_type.rs:8:31
+   |
+LL |   async fn test<const N: Bar>() {
+   |  _______________________________^
+...  |
+LL | |     let x: u32 = N;
+LL | | }
+   | |_^ expected `u32`, found opaque type
+   |
+note: required by a const generic parameter in `test`
+  --> $DIR/const_generic_type.rs:8:15
+   |
+LL | async fn test<const N: Bar>() {
+   |               ^^^^^^^^^^^^ required by this const generic parameter in `test`
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-impl-trait/const_generic_type.rs
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.rs
@@ -7,7 +7,8 @@ type Bar = impl std::fmt::Display;
 #[define_opaque(Bar)]
 async fn test<const N: Bar>() {
     //~^ ERROR: `Bar` is forbidden as the type of a const generic parameter
-    //[no_infer]~^^ ERROR item does not constrain
+    //[infer]~| ERROR: the constant `N` is not of type `u32`
+    //[no_infer]~| ERROR item does not constrain
     #[cfg(infer)]
     let x: u32 = N;
 }


### PR DESCRIPTION
~~branch name is typo'd~~

This "fixes" the `PostBorrowckAnalysis` mode for the old solver, and begins to use it in `check_opaque_well_formed` and `check_coroutine_obligations`.

There are several curiosities here that result.

r? lcnr