### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       # intensive jobs to run on free runners, which however also have
       # less disk space.
       - name: free up disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        run: src/ci/scripts/free-disk-space.sh
         if: matrix.free_disk
 
       # Rust Log Analyzer can't currently detect the PR number of a GitHub

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -269,6 +269,7 @@ fn configure_and_expand(
 
     resolver.resolve_crate(&krate);
 
+    CStore::from_tcx(tcx).report_incompatible_target_modifiers(tcx, &krate);
     krate
 }
 

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -113,6 +113,14 @@ metadata_incompatible_rustc =
     found crate `{$crate_name}` compiled by an incompatible version of rustc{$add_info}
     .help = please recompile that crate using this compiler ({$rustc_version}) (consider running `cargo clean` first)
 
+metadata_incompatible_target_modifiers =
+    mixing `{$flag_name_prefixed}` will cause an ABI mismatch in crate `{$local_crate}`
+    .note = `{$flag_name_prefixed}={$flag_local_value}` in this crate is incompatible with `{$flag_name_prefixed}={$flag_extern_value}` in dependency `{$extern_crate}`
+    .help = the `{$flag_name_prefixed}` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+
+metadata_incompatible_target_modifiers_help_allow = if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch={$flag_name}` to silence this error
+metadata_incompatible_target_modifiers_help_fix = set `{$flag_name_prefixed}={$flag_extern_value}` in this crate or `{$flag_name_prefixed}={$flag_local_value}` in `{$extern_crate}`
+
 metadata_incompatible_wasm_link =
     `wasm_import_module` is incompatible with other arguments in `#[link]` attributes
 
@@ -283,6 +291,8 @@ metadata_unknown_link_kind =
 
 metadata_unknown_link_modifier =
     unknown linking modifier `{$modifier}`, expected one of: bundle, verbatim, whole-archive, as-needed
+
+metadata_unknown_target_modifier_unsafe_allowed = unknown target modifier `{$flag_name}`, requested by `-Cunsafe-allow-abi-mismatch={$flag_name}`
 
 metadata_unsupported_abi =
     ABI not supported by `#[link(kind = "raw-dylib")]` on this architecture

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -23,7 +23,10 @@ use rustc_hir::definitions::Definitions;
 use rustc_index::IndexVec;
 use rustc_middle::bug;
 use rustc_middle::ty::{TyCtxt, TyCtxtFeed};
-use rustc_session::config::{self, CrateType, ExternLocation};
+use rustc_session::config::{
+    self, CrateType, ExtendedTargetModifierInfo, ExternLocation, OptionsTargetModifiers,
+    TargetModifier,
+};
 use rustc_session::cstore::{CrateDepKind, CrateSource, ExternCrate, ExternCrateSource};
 use rustc_session::lint::{self, BuiltinLintDiag};
 use rustc_session::output::validate_crate_name;
@@ -35,7 +38,9 @@ use tracing::{debug, info, trace};
 
 use crate::errors;
 use crate::locator::{CrateError, CrateLocator, CratePaths};
-use crate::rmeta::{CrateDep, CrateMetadata, CrateNumMap, CrateRoot, MetadataBlob};
+use crate::rmeta::{
+    CrateDep, CrateMetadata, CrateNumMap, CrateRoot, MetadataBlob, TargetModifiers,
+};
 
 /// The backend's way to give the crate store access to the metadata in a library.
 /// Note that it returns the raw metadata bytes stored in the library file, whether
@@ -296,6 +301,96 @@ impl CStore {
         }
     }
 
+    fn report_target_modifiers_extended(
+        tcx: TyCtxt<'_>,
+        krate: &Crate,
+        mods: &Vec<TargetModifier>,
+        data: &CrateMetadata,
+    ) {
+        let span = krate.spans.inner_span.shrink_to_lo();
+        let allowed_flag_mismatches = &tcx.sess.opts.cg.unsafe_allow_abi_mismatch;
+        let name = tcx.crate_name(LOCAL_CRATE);
+        let tmod_extender = |tmod: &TargetModifier| (tmod.extend(), tmod.clone());
+        let report_diff = |prefix: &String,
+                           opt_name: &String,
+                           flag_local_value: &String,
+                           flag_extern_value: &String| {
+            if allowed_flag_mismatches.contains(&opt_name) {
+                return;
+            }
+            tcx.dcx().emit_err(errors::IncompatibleTargetModifiers {
+                span,
+                extern_crate: data.name(),
+                local_crate: name,
+                flag_name: opt_name.clone(),
+                flag_name_prefixed: format!("-{}{}", prefix, opt_name),
+                flag_local_value: flag_local_value.to_string(),
+                flag_extern_value: flag_extern_value.to_string(),
+            });
+        };
+        let mut it1 = mods.iter().map(tmod_extender);
+        let mut it2 = data.target_modifiers().iter().map(tmod_extender);
+        let mut left_name_val: Option<(ExtendedTargetModifierInfo, TargetModifier)> = None;
+        let mut right_name_val: Option<(ExtendedTargetModifierInfo, TargetModifier)> = None;
+        let no_val = "*".to_string();
+        loop {
+            left_name_val = left_name_val.or_else(|| it1.next());
+            right_name_val = right_name_val.or_else(|| it2.next());
+            match (&left_name_val, &right_name_val) {
+                (Some(l), Some(r)) => match l.1.opt.cmp(&r.1.opt) {
+                    cmp::Ordering::Equal => {
+                        if l.0.tech_value != r.0.tech_value {
+                            report_diff(&l.0.prefix, &l.0.name, &l.1.value_name, &r.1.value_name);
+                        }
+                        left_name_val = None;
+                        right_name_val = None;
+                    }
+                    cmp::Ordering::Greater => {
+                        report_diff(&r.0.prefix, &r.0.name, &no_val, &r.1.value_name);
+                        right_name_val = None;
+                    }
+                    cmp::Ordering::Less => {
+                        report_diff(&l.0.prefix, &l.0.name, &l.1.value_name, &no_val);
+                        left_name_val = None;
+                    }
+                },
+                (Some(l), None) => {
+                    report_diff(&l.0.prefix, &l.0.name, &l.1.value_name, &no_val);
+                    left_name_val = None;
+                }
+                (None, Some(r)) => {
+                    report_diff(&r.0.prefix, &r.0.name, &no_val, &r.1.value_name);
+                    right_name_val = None;
+                }
+                (None, None) => break,
+            }
+        }
+    }
+
+    pub fn report_incompatible_target_modifiers(&self, tcx: TyCtxt<'_>, krate: &Crate) {
+        for flag_name in &tcx.sess.opts.cg.unsafe_allow_abi_mismatch {
+            if !OptionsTargetModifiers::is_target_modifier(flag_name) {
+                tcx.dcx().emit_err(errors::UnknownTargetModifierUnsafeAllowed {
+                    span: krate.spans.inner_span.shrink_to_lo(),
+                    flag_name: flag_name.clone(),
+                });
+            }
+        }
+
+        if tcx.crate_types().contains(&CrateType::ProcMacro) {
+            return;
+        }
+        let mods = tcx.sess.opts.gather_target_modifiers();
+        for (_cnum, data) in self.iter_crate_data() {
+            if data.is_proc_macro_crate() {
+                continue;
+            }
+            if mods != *data.target_modifiers() {
+                Self::report_target_modifiers_extended(tcx, krate, &mods, data);
+            }
+        }
+    }
+
     pub fn new(metadata_loader: Box<MetadataLoaderDyn>) -> CStore {
         CStore {
             metadata_loader,
@@ -470,6 +565,7 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
         };
 
         let cnum_map = self.resolve_crate_deps(dep_root, &crate_root, &metadata, cnum, dep_kind)?;
+        let target_modifiers = self.resolve_target_modifiers(&crate_root, &metadata, cnum)?;
 
         let raw_proc_macros = if crate_root.is_proc_macro_crate() {
             let temp_root;
@@ -494,6 +590,7 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
             raw_proc_macros,
             cnum,
             cnum_map,
+            target_modifiers,
             dep_kind,
             source,
             private_dep,
@@ -735,6 +832,25 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
 
         debug!("resolve_crate_deps: cnum_map for {:?} is {:?}", krate, crate_num_map);
         Ok(crate_num_map)
+    }
+
+    fn resolve_target_modifiers(
+        &mut self,
+        crate_root: &CrateRoot,
+        metadata: &MetadataBlob,
+        krate: CrateNum,
+    ) -> Result<TargetModifiers, CrateError> {
+        debug!("resolving target modifiers of external crate");
+        if crate_root.is_proc_macro_crate() {
+            return Ok(TargetModifiers::new());
+        }
+        let mods = crate_root.decode_target_modifiers(metadata);
+        let mut target_modifiers = TargetModifiers::with_capacity(mods.len());
+        for modifier in mods {
+            target_modifiers.push(modifier);
+        }
+        debug!("resolve_target_modifiers: target mods for {:?} is {:?}", krate, target_modifiers);
+        Ok(target_modifiers)
     }
 
     fn dlsym_proc_macros(

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -732,3 +732,28 @@ pub struct ImportNameTypeRaw {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(metadata_incompatible_target_modifiers)]
+#[help]
+#[note]
+#[help(metadata_incompatible_target_modifiers_help_fix)]
+#[help(metadata_incompatible_target_modifiers_help_allow)]
+pub struct IncompatibleTargetModifiers {
+    #[primary_span]
+    pub span: Span,
+    pub extern_crate: Symbol,
+    pub local_crate: Symbol,
+    pub flag_name: String,
+    pub flag_name_prefixed: String,
+    pub flag_local_value: String,
+    pub flag_extern_value: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(metadata_unknown_target_modifier_unsafe_allowed)]
+pub struct UnknownTargetModifierUnsafeAllowed {
+    #[primary_span]
+    pub span: Span,
+    pub flag_name: String,
+}

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -29,6 +29,7 @@ use rustc_middle::{bug, implement_ty_decoder};
 use rustc_serialize::opaque::MemDecoder;
 use rustc_serialize::{Decodable, Decoder};
 use rustc_session::Session;
+use rustc_session::config::TargetModifier;
 use rustc_session::cstore::{CrateSource, ExternCrate};
 use rustc_span::hygiene::HygieneDecodeContext;
 use rustc_span::{BytePos, DUMMY_SP, Pos, SpanData, SpanDecoder, SyntaxContext, kw};
@@ -73,6 +74,9 @@ impl MetadataBlob {
 /// own crate numbers.
 pub(crate) type CrateNumMap = IndexVec<CrateNum, CrateNum>;
 
+/// Target modifiers - abi or exploit mitigations flags
+pub(crate) type TargetModifiers = Vec<TargetModifier>;
+
 pub(crate) struct CrateMetadata {
     /// The primary crate data - binary metadata blob.
     blob: MetadataBlob,
@@ -110,6 +114,8 @@ pub(crate) struct CrateMetadata {
     cnum_map: CrateNumMap,
     /// Same ID set as `cnum_map` plus maybe some injected crates like panic runtime.
     dependencies: Vec<CrateNum>,
+    /// Target modifiers - abi and exploit mitigation flags the crate was compiled with
+    target_modifiers: TargetModifiers,
     /// How to link (or not link) this crate to the currently compiled crate.
     dep_kind: CrateDepKind,
     /// Filesystem location of this crate.
@@ -960,6 +966,13 @@ impl CrateRoot {
         metadata: &'a MetadataBlob,
     ) -> impl ExactSizeIterator<Item = CrateDep> + Captures<'a> {
         self.crate_deps.decode(metadata)
+    }
+
+    pub(crate) fn decode_target_modifiers<'a>(
+        &self,
+        metadata: &'a MetadataBlob,
+    ) -> impl ExactSizeIterator<Item = TargetModifier> + Captures<'a> {
+        self.target_modifiers.decode(metadata)
     }
 }
 
@@ -1823,6 +1836,7 @@ impl CrateMetadata {
         raw_proc_macros: Option<&'static [ProcMacro]>,
         cnum: CrateNum,
         cnum_map: CrateNumMap,
+        target_modifiers: TargetModifiers,
         dep_kind: CrateDepKind,
         source: CrateSource,
         private_dep: bool,
@@ -1854,6 +1868,7 @@ impl CrateMetadata {
             cnum,
             cnum_map,
             dependencies,
+            target_modifiers,
             dep_kind,
             source: Lrc::new(source),
             private_dep,
@@ -1881,6 +1896,10 @@ impl CrateMetadata {
 
     pub(crate) fn add_dependency(&mut self, cnum: CrateNum) {
         self.dependencies.push(cnum);
+    }
+
+    pub(crate) fn target_modifiers(&self) -> &TargetModifiers {
+        &self.target_modifiers
     }
 
     pub(crate) fn update_extern_crate(&mut self, new_extern_crate: ExternCrate) -> bool {

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -25,7 +25,7 @@ use rustc_middle::ty::{AssocItemContainer, SymbolName};
 use rustc_middle::util::common::to_readable_str;
 use rustc_middle::{bug, span_bug};
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder, opaque};
-use rustc_session::config::{CrateType, OptLevel};
+use rustc_session::config::{CrateType, OptLevel, TargetModifier};
 use rustc_span::hygiene::HygieneEncodeContext;
 use rustc_span::{
     ExternalSource, FileName, SourceFile, SpanData, SpanEncoder, StableSourceFileId, SyntaxContext,
@@ -692,6 +692,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         // Encode source_map. This needs to be done last, because encoding `Span`s tells us which
         // `SourceFiles` we actually need to encode.
         let source_map = stat!("source-map", || self.encode_source_map());
+        let target_modifiers = stat!("target-modifiers", || self.encode_target_modifiers());
 
         let root = stat!("final", || {
             let attrs = tcx.hir().krate_attrs();
@@ -735,6 +736,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 native_libraries,
                 foreign_modules,
                 source_map,
+                target_modifiers,
                 traits,
                 impls,
                 incoherent_impls,
@@ -2007,6 +2009,12 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         // FIXME (#2166): This is not nearly enough to support correct versioning
         // but is enough to get transitive crate dependencies working.
         self.lazy_array(deps.iter().map(|(_, dep)| dep))
+    }
+
+    fn encode_target_modifiers(&mut self) -> LazyArray<TargetModifier> {
+        empty_proc_macro!(self);
+        let tcx = self.tcx;
+        self.lazy_array(tcx.sess.opts.gather_target_modifiers())
     }
 
     fn encode_lib_features(&mut self) -> LazyArray<(Symbol, FeatureStability)> {

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 use std::num::NonZero;
 
-pub(crate) use decoder::{CrateMetadata, CrateNumMap, MetadataBlob};
+pub(crate) use decoder::{CrateMetadata, CrateNumMap, MetadataBlob, TargetModifiers};
 use decoder::{DecodeContext, Metadata};
 use def_path_hash_map::DefPathHashMapRef;
 use encoder::EncodeContext;
@@ -32,7 +32,7 @@ use rustc_middle::ty::{
 use rustc_middle::util::Providers;
 use rustc_middle::{mir, trivially_parameterized_over_tcx};
 use rustc_serialize::opaque::FileEncoder;
-use rustc_session::config::SymbolManglingVersion;
+use rustc_session::config::{SymbolManglingVersion, TargetModifier};
 use rustc_session::cstore::{CrateDepKind, ForeignModule, LinkagePreference, NativeLib};
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{ExpnIndex, MacroKind, SyntaxContextData};
@@ -282,6 +282,7 @@ pub(crate) struct CrateRoot {
     def_path_hash_map: LazyValue<DefPathHashMapRef<'static>>,
 
     source_map: LazyTable<u32, Option<LazyValue<rustc_span::SourceFile>>>,
+    target_modifiers: LazyArray<TargetModifier>,
 
     compiler_builtins: bool,
     needs_allocator: bool,

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -101,6 +101,7 @@ trivially_parameterized_over_tcx! {
     rustc_session::cstore::ForeignModule,
     rustc_session::cstore::LinkagePreference,
     rustc_session::cstore::NativeLib,
+    rustc_session::config::TargetModifier,
     rustc_span::ExpnData,
     rustc_span::ExpnHash,
     rustc_span::ExpnId,

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -189,8 +189,9 @@ pub struct Parser<'a> {
 }
 
 // This type is used a lot, e.g. it's cloned when matching many declarative macro rules with
-// nonterminals. Make sure it doesn't unintentionally get bigger.
-#[cfg(all(target_pointer_width = "64", not(target_arch = "s390x")))]
+// nonterminals. Make sure it doesn't unintentionally get bigger. We only check a few arches
+// though, because `TokenTypeSet(u128)` alignment varies on others, changing the total size.
+#[cfg(all(target_pointer_width = "64", any(target_arch = "aarch64", target_arch = "x86_64")))]
 rustc_data_structures::static_assert_size!(Parser<'_>, 288);
 
 /// Stores span information about a closure.

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -24,6 +24,7 @@ use rustc_session::lint::builtin::{
     MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
 };
 use rustc_session::lint::{AmbiguityErrorDiag, BuiltinLintDiag};
+use rustc_session::utils::was_invoked_from_cargo;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::MacroKind;
@@ -809,7 +810,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     }
                     err.multipart_suggestion(msg, suggestions, applicability);
                 }
-
                 if let Some(ModuleOrUniformRoot::Module(module)) = module
                     && let Some(module) = module.opt_def_id()
                     && let Some(segment) = segment
@@ -2044,13 +2044,23 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 (format!("`_` is not a valid crate or module name"), None)
             } else if self.tcx.sess.is_rust_2015() {
                 (
-                    format!("you might be missing crate `{ident}`"),
+                    format!("use of unresolved module or unlinked crate `{ident}`"),
                     Some((
                         vec![(
                             self.current_crate_outer_attr_insert_span,
                             format!("extern crate {ident};\n"),
                         )],
-                        format!("consider importing the `{ident}` crate"),
+                        if was_invoked_from_cargo() {
+                            format!(
+                                "if you wanted to use a crate named `{ident}`, use `cargo add {ident}` \
+                             to add it to your `Cargo.toml` and import it in your code",
+                            )
+                        } else {
+                            format!(
+                                "you might be missing a crate named `{ident}`, add it to your \
+                                 project and import it in your code",
+                            )
+                        },
                         Applicability::MaybeIncorrect,
                     )),
                 )
@@ -2229,7 +2239,25 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 let descr = binding.res().descr();
                 (format!("{descr} `{ident}` is not a crate or module"), suggestion)
             } else {
-                (format!("use of undeclared crate or module `{ident}`"), suggestion)
+                let suggestion = if suggestion.is_some() {
+                    suggestion
+                } else if was_invoked_from_cargo() {
+                    Some((
+                        vec![],
+                        format!(
+                            "if you wanted to use a crate named `{ident}`, use `cargo add {ident}` \
+                             to add it to your `Cargo.toml`",
+                        ),
+                        Applicability::MaybeIncorrect,
+                    ))
+                } else {
+                    Some((
+                        vec![],
+                        format!("you might be missing a crate named `{ident}`",),
+                        Applicability::MaybeIncorrect,
+                    ))
+                };
+                (format!("use of unresolved module or unlinked crate `{ident}`"), suggestion)
             }
         }
     }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1198,6 +1198,7 @@ impl Default for Options {
             color: ColorConfig::Auto,
             logical_env: FxIndexMap::default(),
             verbose: false,
+            target_modifiers: BTreeMap::default(),
         }
     }
 }
@@ -2341,14 +2342,16 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
     let crate_types = parse_crate_types_from_list(unparsed_crate_types)
         .unwrap_or_else(|e| early_dcx.early_fatal(e));
 
-    let mut unstable_opts = UnstableOptions::build(early_dcx, matches);
+    let mut target_modifiers = BTreeMap::<OptionsTargetModifiers, String>::new();
+
+    let mut unstable_opts = UnstableOptions::build(early_dcx, matches, &mut target_modifiers);
     let (lint_opts, describe_lints, lint_cap) = get_cmd_lint_options(early_dcx, matches);
 
     check_error_format_stability(early_dcx, &unstable_opts, error_format);
 
     let output_types = parse_output_types(early_dcx, &unstable_opts, matches);
 
-    let mut cg = CodegenOptions::build(early_dcx, matches);
+    let mut cg = CodegenOptions::build(early_dcx, matches, &mut target_modifiers);
     let (disable_local_thinlto, codegen_units) = should_override_cgus_and_disable_thinlto(
         early_dcx,
         &output_types,
@@ -2619,6 +2622,7 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
         color,
         logical_env,
         verbose,
+        target_modifiers,
     }
 }
 

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -4,6 +4,9 @@
 #![feature(let_chains)]
 #![feature(map_many_mut)]
 #![feature(rustc_attrs)]
+// To generate CodegenOptionsTargetModifiers and UnstableOptionsTargetModifiers enums
+// with macro_rules, it is necessary to use recursive mechanic ("Incremental TT Munchers").
+#![recursion_limit = "256"]
 #![warn(unreachable_pub)]
 // tidy-alphabetical-end
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -10,6 +10,7 @@ use rustc_data_structures::profiling::TimePassesFormat;
 use rustc_data_structures::stable_hasher::Hash64;
 use rustc_errors::{ColorConfig, LanguageIdentifier, TerminalUrl};
 use rustc_feature::UnstableFeatures;
+use rustc_macros::{Decodable, Encodable};
 use rustc_span::edition::Edition;
 use rustc_span::{RealFileName, SourceFileHashAlgorithm};
 use rustc_target::spec::{
@@ -59,18 +60,194 @@ macro_rules! hash_substruct {
     };
 }
 
+/// Extended target modifier info.
+/// For example, when external target modifier is '-Zregparm=2':
+/// Target modifier enum value + user value ('2') from external crate
+/// is converted into description: prefix ('Z'), name ('regparm'), tech value ('Some(2)').
+pub struct ExtendedTargetModifierInfo {
+    /// Flag prefix (usually, 'C' for codegen flags or 'Z' for unstable flags)
+    pub prefix: String,
+    /// Flag name
+    pub name: String,
+    /// Flag parsed technical value
+    pub tech_value: String,
+}
+
+/// A recorded -Zopt_name=opt_value (or -Copt_name=opt_value)
+/// which alter the ABI or effectiveness of exploit mitigations.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Encodable, Decodable)]
+pub struct TargetModifier {
+    /// Option enum value
+    pub opt: OptionsTargetModifiers,
+    /// User-provided option value (before parsing)
+    pub value_name: String,
+}
+
+impl TargetModifier {
+    pub fn extend(&self) -> ExtendedTargetModifierInfo {
+        self.opt.reparse(&self.value_name)
+    }
+}
+
+fn tmod_push_impl(
+    opt: OptionsTargetModifiers,
+    tmod_vals: &BTreeMap<OptionsTargetModifiers, String>,
+    tmods: &mut Vec<TargetModifier>,
+) {
+    tmods.push(TargetModifier { opt, value_name: tmod_vals.get(&opt).cloned().unwrap_or_default() })
+}
+
+macro_rules! tmod_push {
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $mods:expr, $tmod_vals:expr) => {
+        tmod_push_impl(
+            OptionsTargetModifiers::$struct_name($tmod_enum_name::$opt_name),
+            $tmod_vals,
+            $mods,
+        );
+    };
+}
+
+macro_rules! gather_tmods {
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr,
+        [SUBSTRUCT], [TARGET_MODIFIER]) => {
+        compile_error!("SUBSTRUCT can't be target modifier");
+    };
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr,
+        [UNTRACKED], [TARGET_MODIFIER]) => {
+        tmod_push!($struct_name, $tmod_enum_name, $opt_name, $mods, $tmod_vals)
+    };
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr,
+        [TRACKED], [TARGET_MODIFIER]) => {
+        tmod_push!($struct_name, $tmod_enum_name, $opt_name, $mods, $tmod_vals)
+    };
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr,
+        [TRACKED_NO_CRATE_HASH], [TARGET_MODIFIER]) => {
+        tmod_push!($struct_name, $tmod_enum_name, $opt_name, $mods, $tmod_vals)
+    };
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr,
+        [SUBSTRUCT], []) => {
+        $opt_expr.gather_target_modifiers($mods, $tmod_vals);
+    };
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr,
+        [UNTRACKED], []) => {{}};
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr,
+        [TRACKED], []) => {{}};
+    ($struct_name:ident, $tmod_enum_name:ident, $opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr,
+        [TRACKED_NO_CRATE_HASH], []) => {{}};
+}
+
+macro_rules! gather_tmods_top_level {
+    ($_opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr, [SUBSTRUCT $substruct_enum:ident]) => {
+        $opt_expr.gather_target_modifiers($mods, $tmod_vals);
+    };
+    ($opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr, [$non_substruct:ident TARGET_MODIFIER]) => {
+        compile_error!("Top level option can't be target modifier");
+    };
+    ($opt_name:ident, $opt_expr:expr, $mods:expr, $tmod_vals:expr, [$non_substruct:ident]) => {};
+}
+
+/// Macro for generating OptionsTargetsModifiers top-level enum with impl.
+/// Will generate something like:
+/// ```rust,ignore (illustrative)
+/// pub enum OptionsTargetModifiers {
+///     CodegenOptions(CodegenOptionsTargetModifiers),
+///     UnstableOptions(UnstableOptionsTargetModifiers),
+/// }
+/// impl OptionsTargetModifiers {
+///     pub fn reparse(&self, user_value: &str) -> ExtendedTargetModifierInfo {
+///         match self {
+///             Self::CodegenOptions(v) => v.reparse(user_value),
+///             Self::UnstableOptions(v) => v.reparse(user_value),
+///         }
+///     }
+///     pub fn is_target_modifier(flag_name: &str) -> bool {
+///         CodegenOptionsTargetModifiers::is_target_modifier(flag_name) ||
+///         UnstableOptionsTargetModifiers::is_target_modifier(flag_name)
+///     }
+/// }
+/// ```
+macro_rules! top_level_tmod_enum {
+    ($( {$($optinfo:tt)*} ),* $(,)*) => {
+        top_level_tmod_enum! { @parse {}, (user_value){}; $($($optinfo)*|)* }
+    };
+    // Termination
+    (
+        @parse
+        {$($variant:tt($substruct_enum:tt))*},
+        ($user_value:ident){$($pout:tt)*};
+    ) => {
+        #[allow(non_camel_case_types)]
+        #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone, Encodable, Decodable)]
+        pub enum OptionsTargetModifiers {
+            $($variant($substruct_enum)),*
+        }
+        impl OptionsTargetModifiers {
+            #[allow(unused_variables)]
+            pub fn reparse(&self, $user_value: &str) -> ExtendedTargetModifierInfo {
+                #[allow(unreachable_patterns)]
+                match self {
+                    $($pout)*
+                    _ => panic!("unknown target modifier option: {:?}", *self)
+                }
+            }
+            pub fn is_target_modifier(flag_name: &str) -> bool {
+                $($substruct_enum::is_target_modifier(flag_name))||*
+            }
+        }
+    };
+    // Adding SUBSTRUCT option group into $eout
+    (
+        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*};
+            [SUBSTRUCT $substruct_enum:ident $variant:ident] |
+        $($tail:tt)*
+    ) => {
+        top_level_tmod_enum! {
+            @parse
+            {
+                $($eout)*
+                $variant($substruct_enum)
+            },
+            ($puser_value){
+                $($pout)*
+                Self::$variant(v) => v.reparse($puser_value),
+            };
+            $($tail)*
+        }
+    };
+    // Skipping non-target-modifier and non-substruct
+    (
+        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*};
+            [$non_substruct:ident] |
+        $($tail:tt)*
+    ) => {
+        top_level_tmod_enum! {
+            @parse
+            {
+                $($eout)*
+            },
+            ($puser_value){
+                $($pout)*
+            };
+            $($tail)*
+        }
+    };
+}
+
 macro_rules! top_level_options {
     ( $( #[$top_level_attr:meta] )* pub struct Options { $(
         $( #[$attr:meta] )*
-        $opt:ident : $t:ty [$dep_tracking_marker:ident],
+        $opt:ident : $t:ty [$dep_tracking_marker:ident $( $tmod:ident $variant:ident )?],
     )* } ) => (
+        top_level_tmod_enum!( {$([$dep_tracking_marker $($tmod $variant),*])|*} );
+
         #[derive(Clone)]
         $( #[$top_level_attr] )*
         pub struct Options {
             $(
                 $( #[$attr] )*
                 pub $opt: $t
-            ),*
+            ),*,
+            pub target_modifiers: BTreeMap<OptionsTargetModifiers, String>,
         }
 
         impl Options {
@@ -97,6 +274,17 @@ macro_rules! top_level_options {
                         [$dep_tracking_marker]);
                 })*
                 hasher.finish()
+            }
+
+            pub fn gather_target_modifiers(&self) -> Vec<TargetModifier> {
+                let mut mods = Vec::<TargetModifier>::new();
+                $({
+                    gather_tmods_top_level!($opt,
+                        &self.$opt, &mut mods, &self.target_modifiers,
+                        [$dep_tracking_marker $($tmod),*]);
+                })*
+                mods.sort_by(|a, b| a.opt.cmp(&b.opt));
+                mods
             }
         }
     );
@@ -165,9 +353,9 @@ top_level_options!(
         #[rustc_lint_opt_deny_field_access("should only be used via `Config::hash_untracked_state`")]
         untracked_state_hash: Hash64 [TRACKED_NO_CRATE_HASH],
 
-        unstable_opts: UnstableOptions [SUBSTRUCT],
+        unstable_opts: UnstableOptions [SUBSTRUCT UnstableOptionsTargetModifiers UnstableOptions],
         prints: Vec<PrintRequest> [UNTRACKED],
-        cg: CodegenOptions [SUBSTRUCT],
+        cg: CodegenOptions [SUBSTRUCT CodegenOptionsTargetModifiers CodegenOptions],
         externs: Externs [UNTRACKED],
         crate_name: Option<String> [TRACKED],
         /// Indicates how the compiler should treat unstable features.
@@ -226,6 +414,98 @@ top_level_options!(
     }
 );
 
+macro_rules! tmod_enum_opt {
+    ($struct_name:ident, $tmod_enum_name:ident, $opt:ident, $v:ident) => {
+        Some(OptionsTargetModifiers::$struct_name($tmod_enum_name::$opt))
+    };
+    ($struct_name:ident, $tmod_enum_name:ident, $opt:ident, ) => {
+        None
+    };
+}
+
+macro_rules! tmod_enum {
+    ($tmod_enum_name:ident, $prefix:expr, $( {$($optinfo:tt)*} ),* $(,)*) => {
+        tmod_enum! { $tmod_enum_name, $prefix, @parse {}, (user_value){}; $($($optinfo)*|)* }
+    };
+    // Termination
+    (
+        $tmod_enum_name:ident, $prefix:expr,
+        @parse
+        {$($eout:tt)*},
+        ($user_value:ident){$($pout:tt)*};
+    ) => {
+        #[allow(non_camel_case_types)]
+        #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone, Encodable, Decodable)]
+        pub enum $tmod_enum_name {
+            $($eout),*
+        }
+        impl $tmod_enum_name {
+            #[allow(unused_variables)]
+            pub fn reparse(&self, $user_value: &str) -> ExtendedTargetModifierInfo {
+                #[allow(unreachable_patterns)]
+                match self {
+                    $($pout)*
+                    _ => panic!("unknown target modifier option: {:?}", *self)
+                }
+            }
+            pub fn is_target_modifier(flag_name: &str) -> bool {
+                match flag_name.replace('-', "_").as_str() {
+                    $(stringify!($eout) => true,)*
+                    _ => false,
+                }
+            }
+        }
+    };
+    // Adding target-modifier option into $eout
+    (
+        $tmod_enum_name:ident, $prefix:expr,
+        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*};
+            $opt:ident, $parse:ident, $t:ty, [TARGET_MODIFIER] |
+        $($tail:tt)*
+    ) => {
+        tmod_enum! {
+            $tmod_enum_name, $prefix,
+            @parse
+            {
+                $($eout)*
+                $opt
+            },
+            ($puser_value){
+                $($pout)*
+                Self::$opt => {
+                    let mut parsed : $t = Default::default();
+                    parse::$parse(&mut parsed, Some($puser_value));
+                    ExtendedTargetModifierInfo {
+                        prefix: $prefix.to_string(),
+                        name: stringify!($opt).to_string().replace('_', "-"),
+                        tech_value: format!("{:?}", parsed),
+                    }
+                },
+            };
+            $($tail)*
+        }
+    };
+    // Skipping non-target-modifier
+    (
+        $tmod_enum_name:ident, $prefix:expr,
+        @parse {$($eout:tt)*}, ($puser_value:ident){$($pout:tt)*};
+            $opt:ident, $parse:ident, $t:ty, [] |
+        $($tail:tt)*
+    ) => {
+        tmod_enum! {
+            $tmod_enum_name, $prefix,
+            @parse
+            {
+                $($eout)*
+            },
+            ($puser_value){
+                $($pout)*
+            };
+            $($tail)*
+        }
+    };
+}
+
 /// Defines all `CodegenOptions`/`DebuggingOptions` fields and parsers all at once. The goal of this
 /// macro is to define an interface that can be programmatically used by the option parser
 /// to initialize the struct without hardcoding field names all over the place.
@@ -235,11 +515,11 @@ top_level_options!(
 /// generated code to parse an option into its respective field in the struct. There are a few
 /// hand-written parsers for parsing specific types of values in this module.
 macro_rules! options {
-    ($struct_name:ident, $stat:ident, $optmod:ident, $prefix:expr, $outputname:expr,
+    ($struct_name:ident, $tmod_enum_name:ident, $stat:ident, $optmod:ident, $prefix:expr, $outputname:expr,
      $($( #[$attr:meta] )* $opt:ident : $t:ty = (
         $init:expr,
         $parse:ident,
-        [$dep_tracking_marker:ident],
+        [$dep_tracking_marker:ident $( $tmod:ident )?],
         $desc:expr
         $(, deprecated_do_nothing: $dnn:literal )?)
      ),* ,) =>
@@ -247,6 +527,8 @@ macro_rules! options {
     #[derive(Clone)]
     #[rustc_lint_opt_ty]
     pub struct $struct_name { $( $( #[$attr] )* pub $opt: $t),* }
+
+    tmod_enum!( $tmod_enum_name, $prefix, {$($opt, $parse, $t, [$($tmod),*])|*} );
 
     impl Default for $struct_name {
         fn default() -> $struct_name {
@@ -258,8 +540,9 @@ macro_rules! options {
         pub fn build(
             early_dcx: &EarlyDiagCtxt,
             matches: &getopts::Matches,
+            target_modifiers: &mut BTreeMap<OptionsTargetModifiers, String>,
         ) -> $struct_name {
-            build_options(early_dcx, matches, $stat, $prefix, $outputname)
+            build_options(early_dcx, matches, target_modifiers, $stat, $prefix, $outputname)
         }
 
         fn dep_tracking_hash(&self, for_crate_hash: bool, error_format: ErrorOutputType) -> u64 {
@@ -279,11 +562,23 @@ macro_rules! options {
                                         );
             hasher.finish()
         }
+
+        pub fn gather_target_modifiers(
+            &self,
+            _mods: &mut Vec<TargetModifier>,
+            _tmod_vals: &BTreeMap<OptionsTargetModifiers, String>,
+        ) {
+            $({
+                gather_tmods!($struct_name, $tmod_enum_name, $opt, &self.$opt, _mods, _tmod_vals,
+                    [$dep_tracking_marker], [$($tmod),*]);
+            })*
+        }
     }
 
     pub const $stat: OptionDescrs<$struct_name> =
         &[ $( OptionDesc{ name: stringify!($opt), setter: $optmod::$opt,
-            type_desc: desc::$parse, desc: $desc, is_deprecated_and_do_nothing: false $( || $dnn )? } ),* ];
+            type_desc: desc::$parse, desc: $desc, is_deprecated_and_do_nothing: false $( || $dnn )?,
+            tmod: tmod_enum_opt!($struct_name, $tmod_enum_name, $opt, $($tmod),*) } ),* ];
 
     mod $optmod {
     $(
@@ -328,6 +623,7 @@ pub struct OptionDesc<O> {
     // description for option from options table
     desc: &'static str,
     is_deprecated_and_do_nothing: bool,
+    tmod: Option<OptionsTargetModifiers>,
 }
 
 impl<O> OptionDesc<O> {
@@ -344,6 +640,7 @@ impl<O> OptionDesc<O> {
 fn build_options<O: Default>(
     early_dcx: &EarlyDiagCtxt,
     matches: &getopts::Matches,
+    target_modifiers: &mut BTreeMap<OptionsTargetModifiers, String>,
     descrs: OptionDescrs<O>,
     prefix: &str,
     outputname: &str,
@@ -357,7 +654,14 @@ fn build_options<O: Default>(
 
         let option_to_lookup = key.replace('-', "_");
         match descrs.iter().find(|opt_desc| opt_desc.name == option_to_lookup) {
-            Some(OptionDesc { name: _, setter, type_desc, desc, is_deprecated_and_do_nothing }) => {
+            Some(OptionDesc {
+                name: _,
+                setter,
+                type_desc,
+                desc,
+                is_deprecated_and_do_nothing,
+                tmod,
+            }) => {
                 if *is_deprecated_and_do_nothing {
                     // deprecation works for prefixed options only
                     assert!(!prefix.is_empty());
@@ -376,6 +680,11 @@ fn build_options<O: Default>(
                             ),
                         ),
                     }
+                }
+                if let Some(tmod) = *tmod
+                    && let Some(value) = value
+                {
+                    target_modifiers.insert(tmod, value.to_string());
                 }
             }
             None => early_dcx.early_fatal(format!("unknown {outputname} option: `{key}`")),
@@ -1581,7 +1890,7 @@ pub mod parse {
 }
 
 options! {
-    CodegenOptions, CG_OPTIONS, cgopts, "C", "codegen",
+    CodegenOptions, CodegenOptionsTargetModifiers, CG_OPTIONS, cgopts, "C", "codegen",
 
     // If you add a new option, please update:
     // - compiler/rustc_interface/src/tests.rs
@@ -1712,6 +2021,8 @@ options! {
     target_feature: String = (String::new(), parse_target_feature, [TRACKED],
         "target specific attributes. (`rustc --print target-features` for details). \
         This feature is unsafe."),
+    unsafe_allow_abi_mismatch: Vec<String> = (Vec::new(), parse_comma_list, [UNTRACKED],
+        "Allow incompatible target modifiers in dependency crates (comma separated list)"),
     // tidy-alphabetical-end
 
     // If you add a new option, please update:
@@ -1720,7 +2031,7 @@ options! {
 }
 
 options! {
-    UnstableOptions, Z_OPTIONS, dbopts, "Z", "unstable",
+    UnstableOptions, UnstableOptionsTargetModifiers, Z_OPTIONS, dbopts, "Z", "unstable",
 
     // If you add a new option, please update:
     // - compiler/rustc_interface/src/tests.rs
@@ -2052,10 +2363,10 @@ options! {
         "enable queries of the dependency graph for regression testing (default: no)"),
     randomize_layout: bool = (false, parse_bool, [TRACKED],
         "randomize the layout of types (default: no)"),
-    reg_struct_return: bool = (false, parse_bool, [TRACKED],
+    reg_struct_return: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER],
         "On x86-32 targets, it overrides the default ABI to return small structs in registers.
         It is UNSOUND to link together crates that use different values for this flag!"),
-    regparm: Option<u32> = (None, parse_opt_number, [TRACKED],
+    regparm: Option<u32> = (None, parse_opt_number, [TRACKED TARGET_MODIFIER],
         "On x86-32 targets, setting this to N causes the compiler to pass N arguments \
         in registers EAX, EDX, and ECX instead of on the stack for\
         \"C\", \"cdecl\", and \"stdcall\" fn.\

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_none_softfloat.rs
@@ -7,7 +7,8 @@
 // For example, `-C target-cpu=cortex-a53`.
 
 use crate::spec::{
-    Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, StackProbeType, Target, TargetOptions,
+    Cc, LinkerFlavor, Lld, PanicStrategy, RelocModel, SanitizerSet, StackProbeType, Target,
+    TargetOptions,
 };
 
 pub(crate) fn target() -> Target {
@@ -19,6 +20,7 @@ pub(crate) fn target() -> Target {
         relocation_model: RelocModel::Static,
         disable_redzone: true,
         max_atomic_width: Some(128),
+        supported_sanitizers: SanitizerSet::KCFI | SanitizerSet::KERNELADDRESS,
         stack_probes: StackProbeType::Inline,
         panic_strategy: PanicStrategy::Abort,
         ..Default::default()

--- a/library/proc_macro/src/bridge/closure.rs
+++ b/library/proc_macro/src/bridge/closure.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 #[repr(C)]
-pub struct Closure<'a, A, R> {
+pub(super) struct Closure<'a, A, R> {
     call: unsafe extern "C" fn(*mut Env, A) -> R,
     env: *mut Env,
     // Prevent Send and Sync impls. `!Send`/`!Sync` is the usual way of doing
@@ -26,7 +26,7 @@ impl<'a, A, R, F: FnMut(A) -> R> From<&'a mut F> for Closure<'a, A, R> {
 }
 
 impl<'a, A, R> Closure<'a, A, R> {
-    pub fn call(&mut self, arg: A) -> R {
+    pub(super) fn call(&mut self, arg: A) -> R {
         unsafe { (self.call)(self.env, arg) }
     }
 }

--- a/library/proc_macro/src/bridge/fxhash.rs
+++ b/library/proc_macro/src/bridge/fxhash.rs
@@ -9,7 +9,7 @@ use std::hash::{BuildHasherDefault, Hasher};
 use std::ops::BitXor;
 
 /// Type alias for a hashmap using the `fx` hash algorithm.
-pub type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+pub(super) type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
 
 /// A speedy hash algorithm for use within rustc. The hashmap in alloc by
 /// default uses SipHash which isn't quite as speedy as we want. In the compiler
@@ -23,7 +23,7 @@ pub type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
 /// similar or slightly worse than FNV, but the speed of the hash function
 /// itself is much higher because it works on up to 8 bytes at a time.
 #[derive(Default)]
-pub struct FxHasher {
+pub(super) struct FxHasher {
     hash: usize,
 }
 

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -67,7 +67,7 @@ macro_rules! rpc_encode_decode {
                 mod tag {
                     #[repr(u8)] enum Tag { $($variant),* }
 
-                    $(pub const $variant: u8 = Tag::$variant as u8;)*
+                    $(pub(crate) const $variant: u8 = Tag::$variant as u8;)*
                 }
 
                 match self {
@@ -89,7 +89,7 @@ macro_rules! rpc_encode_decode {
                 mod tag {
                     #[repr(u8)] enum Tag { $($variant),* }
 
-                    $(pub const $variant: u8 = Tag::$variant as u8;)*
+                    $(pub(crate) const $variant: u8 = Tag::$variant as u8;)*
                 }
 
                 match u8::decode(r, s) {

--- a/library/proc_macro/src/bridge/selfless_reify.rs
+++ b/library/proc_macro/src/bridge/selfless_reify.rs
@@ -44,7 +44,7 @@ macro_rules! define_reify_functions {
         fn $name:ident $(<$($param:ident),*>)?
             for $(extern $abi:tt)? fn($($arg:ident: $arg_ty:ty),*) -> $ret_ty:ty;
     )+) => {
-        $(pub const fn $name<
+        $(pub(super) const fn $name<
             $($($param,)*)?
             F: Fn($($arg_ty),*) -> $ret_ty + Copy
         >(f: F) -> $(extern $abi)? fn($($arg_ty),*) -> $ret_ty {

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -32,6 +32,7 @@
 #![allow(internal_features)]
 #![deny(ffi_unwind_calls)]
 #![warn(rustdoc::unescaped_backticks)]
+#![warn(unreachable_pub)]
 
 #[unstable(feature = "proc_macro_internals", issue = "27812")]
 #[doc(hidden)]

--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -44,7 +44,7 @@ impl TestOpts {
 }
 
 /// Result of parsing the options.
-pub type OptRes = Result<TestOpts, String>;
+pub(crate) type OptRes = Result<TestOpts, String>;
 /// Result of parsing the option part.
 type OptPartRes<T> = Result<T, String>;
 

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -20,7 +20,7 @@ use super::types::{NamePadding, TestDesc, TestDescAndFn};
 use super::{filter_tests, run_tests, term};
 
 /// Generic wrapper over stdout.
-pub enum OutputLocation<T> {
+pub(crate) enum OutputLocation<T> {
     Pretty(Box<term::StdoutTerminal>),
     Raw(T),
 }
@@ -41,7 +41,7 @@ impl<T: Write> Write for OutputLocation<T> {
     }
 }
 
-pub struct ConsoleTestDiscoveryState {
+pub(crate) struct ConsoleTestDiscoveryState {
     pub log_out: Option<File>,
     pub tests: usize,
     pub benchmarks: usize,
@@ -49,7 +49,7 @@ pub struct ConsoleTestDiscoveryState {
 }
 
 impl ConsoleTestDiscoveryState {
-    pub fn new(opts: &TestOpts) -> io::Result<ConsoleTestDiscoveryState> {
+    pub(crate) fn new(opts: &TestOpts) -> io::Result<ConsoleTestDiscoveryState> {
         let log_out = match opts.logfile {
             Some(ref path) => Some(File::create(path)?),
             None => None,
@@ -58,7 +58,7 @@ impl ConsoleTestDiscoveryState {
         Ok(ConsoleTestDiscoveryState { log_out, tests: 0, benchmarks: 0, ignored: 0 })
     }
 
-    pub fn write_log<F, S>(&mut self, msg: F) -> io::Result<()>
+    pub(crate) fn write_log<F, S>(&mut self, msg: F) -> io::Result<()>
     where
         S: AsRef<str>,
         F: FnOnce() -> S,
@@ -74,7 +74,7 @@ impl ConsoleTestDiscoveryState {
     }
 }
 
-pub struct ConsoleTestState {
+pub(crate) struct ConsoleTestState {
     pub log_out: Option<File>,
     pub total: usize,
     pub passed: usize,
@@ -92,7 +92,7 @@ pub struct ConsoleTestState {
 }
 
 impl ConsoleTestState {
-    pub fn new(opts: &TestOpts) -> io::Result<ConsoleTestState> {
+    pub(crate) fn new(opts: &TestOpts) -> io::Result<ConsoleTestState> {
         let log_out = match opts.logfile {
             Some(ref path) => Some(File::create(path)?),
             None => None,
@@ -116,7 +116,7 @@ impl ConsoleTestState {
         })
     }
 
-    pub fn write_log<F, S>(&mut self, msg: F) -> io::Result<()>
+    pub(crate) fn write_log<F, S>(&mut self, msg: F) -> io::Result<()>
     where
         S: AsRef<str>,
         F: FnOnce() -> S,
@@ -131,7 +131,7 @@ impl ConsoleTestState {
         }
     }
 
-    pub fn write_log_result(
+    pub(crate) fn write_log_result(
         &mut self,
         test: &TestDesc,
         result: &TestResult,
@@ -170,7 +170,7 @@ impl ConsoleTestState {
 }
 
 // List the tests to console, and optionally to logfile. Filters are honored.
-pub fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Result<()> {
+pub(crate) fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Result<()> {
     let output = match term::stdout() {
         None => OutputLocation::Raw(io::stdout().lock()),
         Some(t) => OutputLocation::Pretty(t),

--- a/library/test/src/formatters/json.rs
+++ b/library/test/src/formatters/json.rs
@@ -13,7 +13,7 @@ pub(crate) struct JsonFormatter<T> {
 }
 
 impl<T: Write> JsonFormatter<T> {
-    pub fn new(out: OutputLocation<T>) -> Self {
+    pub(crate) fn new(out: OutputLocation<T>) -> Self {
         Self { out }
     }
 

--- a/library/test/src/formatters/junit.rs
+++ b/library/test/src/formatters/junit.rs
@@ -8,13 +8,13 @@ use crate::test_result::TestResult;
 use crate::time;
 use crate::types::{TestDesc, TestType};
 
-pub struct JunitFormatter<T> {
+pub(crate) struct JunitFormatter<T> {
     out: OutputLocation<T>,
     results: Vec<(TestDesc, TestResult, Duration, Vec<u8>)>,
 }
 
 impl<T: Write> JunitFormatter<T> {
-    pub fn new(out: OutputLocation<T>) -> Self {
+    pub(crate) fn new(out: OutputLocation<T>) -> Self {
         Self { out, results: Vec::new() }
     }
 

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -20,7 +20,7 @@ pub(crate) struct PrettyFormatter<T> {
 }
 
 impl<T: Write> PrettyFormatter<T> {
-    pub fn new(
+    pub(crate) fn new(
         out: OutputLocation<T>,
         use_color: bool,
         max_name_len: usize,
@@ -31,19 +31,19 @@ impl<T: Write> PrettyFormatter<T> {
     }
 
     #[cfg(test)]
-    pub fn output_location(&self) -> &OutputLocation<T> {
+    pub(crate) fn output_location(&self) -> &OutputLocation<T> {
         &self.out
     }
 
-    pub fn write_ok(&mut self) -> io::Result<()> {
+    pub(crate) fn write_ok(&mut self) -> io::Result<()> {
         self.write_short_result("ok", term::color::GREEN)
     }
 
-    pub fn write_failed(&mut self) -> io::Result<()> {
+    pub(crate) fn write_failed(&mut self) -> io::Result<()> {
         self.write_short_result("FAILED", term::color::RED)
     }
 
-    pub fn write_ignored(&mut self, message: Option<&'static str>) -> io::Result<()> {
+    pub(crate) fn write_ignored(&mut self, message: Option<&'static str>) -> io::Result<()> {
         if let Some(message) = message {
             self.write_short_result(&format!("ignored, {message}"), term::color::YELLOW)
         } else {
@@ -51,15 +51,15 @@ impl<T: Write> PrettyFormatter<T> {
         }
     }
 
-    pub fn write_time_failed(&mut self) -> io::Result<()> {
+    pub(crate) fn write_time_failed(&mut self) -> io::Result<()> {
         self.write_short_result("FAILED (time limit exceeded)", term::color::RED)
     }
 
-    pub fn write_bench(&mut self) -> io::Result<()> {
+    pub(crate) fn write_bench(&mut self) -> io::Result<()> {
         self.write_pretty("bench", term::color::CYAN)
     }
 
-    pub fn write_short_result(
+    pub(crate) fn write_short_result(
         &mut self,
         result: &str,
         color: term::color::Color,
@@ -67,7 +67,7 @@ impl<T: Write> PrettyFormatter<T> {
         self.write_pretty(result, color)
     }
 
-    pub fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
+    pub(crate) fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
         match self.out {
             OutputLocation::Pretty(ref mut term) => {
                 if self.use_color {
@@ -86,7 +86,7 @@ impl<T: Write> PrettyFormatter<T> {
         }
     }
 
-    pub fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
+    pub(crate) fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
         let s = s.as_ref();
         self.out.write_all(s.as_bytes())?;
         self.out.flush()
@@ -154,15 +154,15 @@ impl<T: Write> PrettyFormatter<T> {
         Ok(())
     }
 
-    pub fn write_successes(&mut self, state: &ConsoleTestState) -> io::Result<()> {
+    pub(crate) fn write_successes(&mut self, state: &ConsoleTestState) -> io::Result<()> {
         self.write_results(&state.not_failures, "successes")
     }
 
-    pub fn write_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
+    pub(crate) fn write_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
         self.write_results(&state.failures, "failures")
     }
 
-    pub fn write_time_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
+    pub(crate) fn write_time_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
         self.write_results(&state.time_failures, "failures (time limit exceeded)")
     }
 

--- a/library/test/src/formatters/terse.rs
+++ b/library/test/src/formatters/terse.rs
@@ -25,7 +25,7 @@ pub(crate) struct TerseFormatter<T> {
 }
 
 impl<T: Write> TerseFormatter<T> {
-    pub fn new(
+    pub(crate) fn new(
         out: OutputLocation<T>,
         use_color: bool,
         max_name_len: usize,
@@ -42,11 +42,11 @@ impl<T: Write> TerseFormatter<T> {
         }
     }
 
-    pub fn write_ok(&mut self) -> io::Result<()> {
+    pub(crate) fn write_ok(&mut self) -> io::Result<()> {
         self.write_short_result(".", term::color::GREEN)
     }
 
-    pub fn write_failed(&mut self, name: &str) -> io::Result<()> {
+    pub(crate) fn write_failed(&mut self, name: &str) -> io::Result<()> {
         // Put failed tests on their own line and include the test name, so that it's faster
         // to see which test failed without having to wait for them all to run.
 
@@ -62,15 +62,15 @@ impl<T: Write> TerseFormatter<T> {
         self.write_plain("\n")
     }
 
-    pub fn write_ignored(&mut self) -> io::Result<()> {
+    pub(crate) fn write_ignored(&mut self) -> io::Result<()> {
         self.write_short_result("i", term::color::YELLOW)
     }
 
-    pub fn write_bench(&mut self) -> io::Result<()> {
+    pub(crate) fn write_bench(&mut self) -> io::Result<()> {
         self.write_pretty("bench", term::color::CYAN)
     }
 
-    pub fn write_short_result(
+    pub(crate) fn write_short_result(
         &mut self,
         result: &str,
         color: term::color::Color,
@@ -95,7 +95,7 @@ impl<T: Write> TerseFormatter<T> {
         Ok(())
     }
 
-    pub fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
+    pub(crate) fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
         match self.out {
             OutputLocation::Pretty(ref mut term) => {
                 if self.use_color {
@@ -114,13 +114,13 @@ impl<T: Write> TerseFormatter<T> {
         }
     }
 
-    pub fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
+    pub(crate) fn write_plain<S: AsRef<str>>(&mut self, s: S) -> io::Result<()> {
         let s = s.as_ref();
         self.out.write_all(s.as_bytes())?;
         self.out.flush()
     }
 
-    pub fn write_outputs(&mut self, state: &ConsoleTestState) -> io::Result<()> {
+    pub(crate) fn write_outputs(&mut self, state: &ConsoleTestState) -> io::Result<()> {
         self.write_plain("\nsuccesses:\n")?;
         let mut successes = Vec::new();
         let mut stdouts = String::new();
@@ -146,7 +146,7 @@ impl<T: Write> TerseFormatter<T> {
         Ok(())
     }
 
-    pub fn write_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
+    pub(crate) fn write_failures(&mut self, state: &ConsoleTestState) -> io::Result<()> {
         self.write_plain("\nfailures:\n")?;
         let mut failures = Vec::new();
         let mut fail_out = String::new();

--- a/library/test/src/helpers/concurrency.rs
+++ b/library/test/src/helpers/concurrency.rs
@@ -4,7 +4,7 @@
 use std::num::NonZero;
 use std::{env, thread};
 
-pub fn get_concurrency() -> usize {
+pub(crate) fn get_concurrency() -> usize {
     if let Ok(value) = env::var("RUST_TEST_THREADS") {
         match value.parse::<NonZero<usize>>().ok() {
             Some(n) => n.get(),

--- a/library/test/src/helpers/mod.rs
+++ b/library/test/src/helpers/mod.rs
@@ -1,6 +1,6 @@
 //! Module with common helpers not directly related to tests
 //! but used in `libtest`.
 
-pub mod concurrency;
-pub mod metrics;
-pub mod shuffle;
+pub(crate) mod concurrency;
+pub(crate) mod metrics;
+pub(crate) mod shuffle;

--- a/library/test/src/helpers/shuffle.rs
+++ b/library/test/src/helpers/shuffle.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::cli::TestOpts;
 use crate::types::{TestDescAndFn, TestId, TestName};
 
-pub fn get_shuffle_seed(opts: &TestOpts) -> Option<u64> {
+pub(crate) fn get_shuffle_seed(opts: &TestOpts) -> Option<u64> {
     opts.shuffle_seed.or_else(|| {
         if opts.shuffle {
             Some(
@@ -19,7 +19,7 @@ pub fn get_shuffle_seed(opts: &TestOpts) -> Option<u64> {
     })
 }
 
-pub fn shuffle_tests(shuffle_seed: u64, tests: &mut [(TestId, TestDescAndFn)]) {
+pub(crate) fn shuffle_tests(shuffle_seed: u64, tests: &mut [(TestId, TestDescAndFn)]) {
     let test_names: Vec<&TestName> = tests.iter().map(|test| &test.1.desc.name).collect();
     let test_names_hash = calculate_hash(&test_names);
     let mut rng = Rng::new(shuffle_seed, test_names_hash);

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -27,6 +27,7 @@
 #![feature(thread_spawn_hook)]
 #![allow(internal_features)]
 #![warn(rustdoc::unescaped_backticks)]
+#![warn(unreachable_pub)]
 
 pub use cli::TestOpts;
 

--- a/library/test/src/options.rs
+++ b/library/test/src/options.rs
@@ -2,7 +2,7 @@
 
 /// Number of times to run a benchmarked function
 #[derive(Clone, PartialEq, Eq)]
-pub enum BenchMode {
+pub(crate) enum BenchMode {
     Auto,
     Single,
 }

--- a/library/test/src/stats/tests.rs
+++ b/library/test/src/stats/tests.rs
@@ -573,13 +573,13 @@ fn test_sum_f64_between_ints_that_sum_to_0() {
 }
 
 #[bench]
-pub fn sum_three_items(b: &mut Bencher) {
+fn sum_three_items(b: &mut Bencher) {
     b.iter(|| {
         [1e20f64, 1.5f64, -1e20f64].sum();
     })
 }
 #[bench]
-pub fn sum_many_f64(b: &mut Bencher) {
+fn sum_many_f64(b: &mut Bencher) {
     let nums = [-1e30f64, 1e60, 1e30, 1.0, -1e60];
     let v = (0..500).map(|i| nums[i % 5]).collect::<Vec<_>>();
 
@@ -589,4 +589,4 @@ pub fn sum_many_f64(b: &mut Bencher) {
 }
 
 #[bench]
-pub fn no_iter(_: &mut Bencher) {}
+fn no_iter(_: &mut Bencher) {}

--- a/library/test/src/term.rs
+++ b/library/test/src/term.rs
@@ -62,7 +62,7 @@ pub(crate) mod color {
 
 /// A terminal with similar capabilities to an ANSI Terminal
 /// (foreground/background colors etc).
-pub trait Terminal: Write {
+pub(crate) trait Terminal: Write {
     /// Sets the foreground color to the given color.
     ///
     /// If the color is a bright color, but the terminal only supports 8 colors,

--- a/library/test/src/test_result.rs
+++ b/library/test/src/test_result.rs
@@ -12,7 +12,7 @@ use super::types::TestDesc;
 // Return code for secondary process.
 // Start somewhere other than 0 so we know the return code means what we think
 // it means.
-pub const TR_OK: i32 = 50;
+pub(crate) const TR_OK: i32 = 50;
 
 // On Windows we use __fastfail to abort, which is documented to use this
 // exception code.
@@ -39,7 +39,7 @@ pub enum TestResult {
 
 /// Creates a `TestResult` depending on the raw result of test execution
 /// and associated data.
-pub fn calc_result<'a>(
+pub(crate) fn calc_result<'a>(
     desc: &TestDesc,
     task_result: Result<(), &'a (dyn Any + 'static + Send)>,
     time_opts: Option<&time::TestTimeOptions>,
@@ -93,7 +93,7 @@ pub fn calc_result<'a>(
 }
 
 /// Creates a `TestResult` depending on the exit code of test subprocess.
-pub fn get_result_from_exit_code(
+pub(crate) fn get_result_from_exit_code(
     desc: &TestDesc,
     status: ExitStatus,
     time_opts: Option<&time::TestTimeOptions>,

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -78,7 +78,7 @@ fn one_ignored_one_unignored_test() -> Vec<TestDescAndFn> {
 }
 
 #[test]
-pub fn do_not_run_ignored_tests() {
+fn do_not_run_ignored_tests() {
     fn f() -> Result<(), String> {
         panic!();
     }
@@ -106,7 +106,7 @@ pub fn do_not_run_ignored_tests() {
 }
 
 #[test]
-pub fn ignored_tests_result_in_ignored() {
+fn ignored_tests_result_in_ignored() {
     fn f() -> Result<(), String> {
         Ok(())
     }
@@ -479,7 +479,7 @@ fn parse_include_ignored_flag() {
 }
 
 #[test]
-pub fn filter_for_ignored_option() {
+fn filter_for_ignored_option() {
     // When we run ignored tests the test filter should filter out all the
     // unignored tests and flip the ignore flag on the rest to false
 
@@ -496,7 +496,7 @@ pub fn filter_for_ignored_option() {
 }
 
 #[test]
-pub fn run_include_ignored_option() {
+fn run_include_ignored_option() {
     // When we "--include-ignored" tests, the ignore flag should be set to false on
     // all tests and no test filtered out
 
@@ -513,7 +513,7 @@ pub fn run_include_ignored_option() {
 }
 
 #[test]
-pub fn exclude_should_panic_option() {
+fn exclude_should_panic_option() {
     let mut opts = TestOpts::new();
     opts.run_tests = true;
     opts.exclude_should_panic = true;
@@ -544,7 +544,7 @@ pub fn exclude_should_panic_option() {
 }
 
 #[test]
-pub fn exact_filter_match() {
+fn exact_filter_match() {
     fn tests() -> Vec<TestDescAndFn> {
         ["base", "base::test", "base::test1", "base::test2"]
             .into_iter()
@@ -667,7 +667,7 @@ fn sample_tests() -> Vec<TestDescAndFn> {
 }
 
 #[test]
-pub fn shuffle_tests() {
+fn shuffle_tests() {
     let mut opts = TestOpts::new();
     opts.shuffle = true;
 
@@ -686,7 +686,7 @@ pub fn shuffle_tests() {
 }
 
 #[test]
-pub fn shuffle_tests_with_seed() {
+fn shuffle_tests_with_seed() {
     let mut opts = TestOpts::new();
     opts.shuffle = true;
 
@@ -704,7 +704,7 @@ pub fn shuffle_tests_with_seed() {
 }
 
 #[test]
-pub fn order_depends_on_more_than_seed() {
+fn order_depends_on_more_than_seed() {
     let mut opts = TestOpts::new();
     opts.shuffle = true;
 
@@ -732,7 +732,7 @@ pub fn order_depends_on_more_than_seed() {
 }
 
 #[test]
-pub fn test_metricmap_compare() {
+fn test_metricmap_compare() {
     let mut m1 = MetricMap::new();
     let mut m2 = MetricMap::new();
     m1.insert_metric("in-both-noise", 1000.0, 200.0);
@@ -755,7 +755,7 @@ pub fn test_metricmap_compare() {
 }
 
 #[test]
-pub fn test_bench_once_no_iter() {
+fn test_bench_once_no_iter() {
     fn f(_: &mut Bencher) -> Result<(), String> {
         Ok(())
     }
@@ -763,7 +763,7 @@ pub fn test_bench_once_no_iter() {
 }
 
 #[test]
-pub fn test_bench_once_iter() {
+fn test_bench_once_iter() {
     fn f(b: &mut Bencher) -> Result<(), String> {
         b.iter(|| {});
         Ok(())
@@ -772,7 +772,7 @@ pub fn test_bench_once_iter() {
 }
 
 #[test]
-pub fn test_bench_no_iter() {
+fn test_bench_no_iter() {
     fn f(_: &mut Bencher) -> Result<(), String> {
         Ok(())
     }
@@ -799,7 +799,7 @@ pub fn test_bench_no_iter() {
 }
 
 #[test]
-pub fn test_bench_iter() {
+fn test_bench_iter() {
     fn f(b: &mut Bencher) -> Result<(), String> {
         b.iter(|| {});
         Ok(())

--- a/library/test/src/time.rs
+++ b/library/test/src/time.rs
@@ -11,7 +11,7 @@ use std::{env, fmt};
 
 use super::types::{TestDesc, TestType};
 
-pub const TEST_WARN_TIMEOUT_S: u64 = 60;
+pub(crate) const TEST_WARN_TIMEOUT_S: u64 = 60;
 
 /// This small module contains constants used by `report-time` option.
 /// Those constants values will be used if corresponding environment variables are not set.
@@ -22,42 +22,42 @@ pub const TEST_WARN_TIMEOUT_S: u64 = 60;
 ///
 /// Example of the expected format is `RUST_TEST_TIME_xxx=100,200`, where 100 means
 /// warn time, and 200 means critical time.
-pub mod time_constants {
+pub(crate) mod time_constants {
     use std::time::Duration;
 
     use super::TEST_WARN_TIMEOUT_S;
 
     /// Environment variable for overriding default threshold for unit-tests.
-    pub const UNIT_ENV_NAME: &str = "RUST_TEST_TIME_UNIT";
+    pub(crate) const UNIT_ENV_NAME: &str = "RUST_TEST_TIME_UNIT";
 
     // Unit tests are supposed to be really quick.
-    pub const UNIT_WARN: Duration = Duration::from_millis(50);
-    pub const UNIT_CRITICAL: Duration = Duration::from_millis(100);
+    pub(crate) const UNIT_WARN: Duration = Duration::from_millis(50);
+    pub(crate) const UNIT_CRITICAL: Duration = Duration::from_millis(100);
 
     /// Environment variable for overriding default threshold for unit-tests.
-    pub const INTEGRATION_ENV_NAME: &str = "RUST_TEST_TIME_INTEGRATION";
+    pub(crate) const INTEGRATION_ENV_NAME: &str = "RUST_TEST_TIME_INTEGRATION";
 
     // Integration tests may have a lot of work, so they can take longer to execute.
-    pub const INTEGRATION_WARN: Duration = Duration::from_millis(500);
-    pub const INTEGRATION_CRITICAL: Duration = Duration::from_millis(1000);
+    pub(crate) const INTEGRATION_WARN: Duration = Duration::from_millis(500);
+    pub(crate) const INTEGRATION_CRITICAL: Duration = Duration::from_millis(1000);
 
     /// Environment variable for overriding default threshold for unit-tests.
-    pub const DOCTEST_ENV_NAME: &str = "RUST_TEST_TIME_DOCTEST";
+    pub(crate) const DOCTEST_ENV_NAME: &str = "RUST_TEST_TIME_DOCTEST";
 
     // Doctests are similar to integration tests, because they can include a lot of
     // initialization code.
-    pub const DOCTEST_WARN: Duration = INTEGRATION_WARN;
-    pub const DOCTEST_CRITICAL: Duration = INTEGRATION_CRITICAL;
+    pub(crate) const DOCTEST_WARN: Duration = INTEGRATION_WARN;
+    pub(crate) const DOCTEST_CRITICAL: Duration = INTEGRATION_CRITICAL;
 
     // Do not suppose anything about unknown tests, base limits on the
     // `TEST_WARN_TIMEOUT_S` constant.
-    pub const UNKNOWN_WARN: Duration = Duration::from_secs(TEST_WARN_TIMEOUT_S);
-    pub const UNKNOWN_CRITICAL: Duration = Duration::from_secs(TEST_WARN_TIMEOUT_S * 2);
+    pub(crate) const UNKNOWN_WARN: Duration = Duration::from_secs(TEST_WARN_TIMEOUT_S);
+    pub(crate) const UNKNOWN_CRITICAL: Duration = Duration::from_secs(TEST_WARN_TIMEOUT_S * 2);
 }
 
 /// Returns an `Instance` object denoting when the test should be considered
 /// timed out.
-pub fn get_default_test_timeout() -> Instant {
+pub(crate) fn get_default_test_timeout() -> Instant {
     Instant::now() + Duration::from_secs(TEST_WARN_TIMEOUT_S)
 }
 
@@ -73,7 +73,7 @@ impl fmt::Display for TestExecTime {
 
 /// The measured execution time of the whole test suite.
 #[derive(Debug, Clone, Default, PartialEq)]
-pub struct TestSuiteExecTime(pub Duration);
+pub(crate) struct TestSuiteExecTime(pub Duration);
 
 impl fmt::Display for TestSuiteExecTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -34,6 +34,7 @@ RUN yum upgrade -y && \
       python3 \
       unzip \
       wget \
+      flex \
       xz \
       zlib-devel.i686 \
       zlib-devel.x86_64 \

--- a/src/ci/docker/scripts/build-zstd.sh
+++ b/src/ci/docker/scripts/build-zstd.sh
@@ -25,5 +25,11 @@ cd zstd-$ZSTD
 CFLAGS=-fPIC hide_output make -j$(nproc) VERBOSE=1
 hide_output make install
 
+# It doesn't seem to be possible to move destination directory
+# of the `make install` above. We thus copy the built artifacts
+# manually to our custom rustroot, so that it can be found through
+# LD_LIBRARY_PATH.
+cp /usr/local/lib/libzstd* /rustroot/lib64
+
 cd ..
 rm -rf zstd-$ZSTD

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -50,6 +50,8 @@ runners:
   - &job-aarch64-linux
     os: ubuntu-22.04-arm
 
+  - &job-aarch64-linux-8c
+    os: ubuntu-22.04-arm64-8core-32gb
 envs:
   env-x86_64-apple-tests: &env-x86_64-apple-tests
     SCRIPT: ./x.py --stage 2 test --skip tests/ui --skip tests/rustdoc -- --exact
@@ -142,7 +144,7 @@ auto:
   - name: dist-aarch64-linux
     env:
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-aarch64-linux
+    <<: *job-aarch64-linux-8c
 
   - name: dist-android
     <<: *job-linux-4c

--- a/src/ci/scripts/free-disk-space.sh
+++ b/src/ci/scripts/free-disk-space.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# Free disk space on Linux GitHub action runners
+# Script inspired by https://github.com/jlumbroso/free-disk-space
+
+# print a line of the specified character
+printSeparationLine() {
+    for ((i = 0; i < 80; i++)); do
+        printf "%s" "$1"
+    done
+    printf "\n"
+}
+
+# compute available space
+# REF: https://unix.stackexchange.com/a/42049/60849
+# REF: https://stackoverflow.com/a/450821/408734
+getAvailableSpace() { echo $(df -a | awk 'NR > 1 {avail+=$4} END {print avail}'); }
+
+# make Kb human readable (assume the input is Kb)
+# REF: https://unix.stackexchange.com/a/44087/60849
+formatByteCount() { echo $(numfmt --to=iec-i --suffix=B --padding=7 $1'000'); }
+
+# macro to output saved space
+printSavedSpace() {
+    # Disk space before the operation
+    local before=${1}
+    local title=${2:-}
+
+    local after
+    after=$(getAvailableSpace)
+    local saved=$((after - before))
+
+    echo ""
+    printSeparationLine "*"
+    if [ -n "${title}" ]; then
+        echo "=> ${title}: Saved $(formatByteCount "$saved")"
+    else
+        echo "=> Saved $(formatByteCount "$saved")"
+    fi
+    printSeparationLine "*"
+    echo ""
+}
+
+# macro to print output of df with caption
+printDF() {
+    local caption=${1}
+
+    printSeparationLine "="
+    echo "${caption}"
+    echo ""
+    echo "$ df -h"
+    echo ""
+    df -h
+    printSeparationLine "="
+}
+
+removeDir() {
+    dir=${1}
+
+    local before
+    before=$(getAvailableSpace)
+
+    sudo rm -rf "$dir" || true
+
+    printSavedSpace "$before" "$dir"
+}
+
+execAndMeasureSpaceChange() {
+    local operation=${1} # Function to execute
+    local title=${2}
+
+    local before
+    before=$(getAvailableSpace)
+    $operation
+
+    printSavedSpace "$before" "$title"
+}
+
+# Remove large packages
+# REF: https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+cleanPackages() {
+    sudo apt-get -qq remove -y --fix-missing \
+        '^aspnetcore-.*'       \
+        '^dotnet-.*'           \
+        '^llvm-.*'             \
+        'php.*'                \
+        '^mongodb-.*'          \
+        '^mysql-.*'            \
+        'azure-cli'            \
+        'google-chrome-stable' \
+        'firefox'              \
+        'powershell'           \
+        'mono-devel'           \
+        'libgl1-mesa-dri'      \
+        'google-cloud-sdk'     \
+        'google-cloud-cli'
+
+    sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed"
+    sudo apt-get clean || echo "::warning::The command [sudo apt-get clean] failed failed"
+}
+
+# Remove Docker images
+cleanDocker() {
+    echo "Removing the following docker images:"
+    sudo docker image ls
+    echo "Removing docker images..."
+    sudo docker image prune --all --force || true
+}
+
+# Remove Swap storage
+cleanSwap() {
+    sudo swapoff -a || true
+    sudo rm -rf /mnt/swapfile || true
+    free -h
+}
+
+# Display initial disk space stats
+
+AVAILABLE_INITIAL=$(getAvailableSpace)
+
+printDF "BEFORE CLEAN-UP:"
+echo ""
+
+removeDir /usr/local/lib/android
+removeDir /usr/share/dotnet
+
+# Haskell runtime
+removeDir /opt/ghc
+removeDir /usr/local/.ghcup
+
+execAndMeasureSpaceChange cleanPackages "Large misc. packages"
+execAndMeasureSpaceChange cleanDocker "Docker images"
+execAndMeasureSpaceChange cleanSwap "Swap storage"
+
+# Output saved space statistic
+echo ""
+printDF "AFTER CLEAN-UP:"
+
+echo ""
+echo ""
+
+printSavedSpace "$AVAILABLE_INITIAL" "Total saved"

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -9,8 +9,8 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_errors::DiagCtxtHandle;
 use rustc_session::config::{
     self, CodegenOptions, CrateType, ErrorOutputType, Externs, Input, JsonUnusedExterns,
-    UnstableOptions, get_cmd_lint_options, nightly_options, parse_crate_types_from_list,
-    parse_externs, parse_target_triple,
+    OptionsTargetModifiers, UnstableOptions, get_cmd_lint_options, nightly_options,
+    parse_crate_types_from_list, parse_externs, parse_target_triple,
 };
 use rustc_session::lint::Level;
 use rustc_session::search_paths::SearchPath;
@@ -387,8 +387,9 @@ impl Options {
             config::parse_error_format(early_dcx, matches, color, json_color, json_rendered);
         let diagnostic_width = matches.opt_get("diagnostic-width").unwrap_or_default();
 
-        let codegen_options = CodegenOptions::build(early_dcx, matches);
-        let unstable_opts = UnstableOptions::build(early_dcx, matches);
+        let mut target_modifiers = BTreeMap::<OptionsTargetModifiers, String>::new();
+        let codegen_options = CodegenOptions::build(early_dcx, matches, &mut target_modifiers);
+        let unstable_opts = UnstableOptions::build(early_dcx, matches, &mut target_modifiers);
 
         let remap_path_prefix = match parse_remap_path_prefix(matches) {
             Ok(prefix_mappings) => prefix_mappings,

--- a/src/tools/miri/tests/fail/rustc-error2.rs
+++ b/src/tools/miri/tests/fail/rustc-error2.rs
@@ -4,7 +4,7 @@ struct Struct<T>(T);
 impl<T> std::ops::Deref for Struct<T> {
     type Target = dyn Fn(T);
     fn deref(&self) -> &assert_mem_uninitialized_valid::Target {
-        //~^ERROR: undeclared crate or module
+        //~^ERROR: use of unresolved module or unlinked crate
         unimplemented!()
     }
 }

--- a/src/tools/miri/tests/fail/rustc-error2.stderr
+++ b/src/tools/miri/tests/fail/rustc-error2.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `assert_mem_uninitialized_valid`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `assert_mem_uninitialized_valid`
   --> tests/fail/rustc-error2.rs:LL:CC
    |
 LL |     fn deref(&self) -> &assert_mem_uninitialized_valid::Target {
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `assert_mem_uninitialized_valid`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `assert_mem_uninitialized_valid`
+   |
+   = help: you might be missing a crate named `assert_mem_uninitialized_valid`
 
 error: aborting due to 1 previous error
 

--- a/tests/assembly/wasm32-naked-fn.rs
+++ b/tests/assembly/wasm32-naked-fn.rs
@@ -1,0 +1,198 @@
+//@ revisions: wasm32-unknown wasm64-unknown wasm32-wasip1
+//@ add-core-stubs
+//@ assembly-output: emit-asm
+//@ [wasm32-unknown] compile-flags: --target wasm32-unknown-unknown
+//@ [wasm64-unknown] compile-flags: --target wasm64-unknown-unknown
+//@ [wasm32-wasip1] compile-flags: --target wasm32-wasip1
+//@ [wasm32-unknown] needs-llvm-components: webassembly
+//@ [wasm64-unknown] needs-llvm-components: webassembly
+//@ [wasm32-wasip1] needs-llvm-components: webassembly
+
+#![crate_type = "lib"]
+#![feature(no_core, naked_functions, asm_experimental_arch, f128, linkage, fn_align)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+// CHECK: .section  .text.nop,"",@
+// CHECK: .globl nop
+// CHECK-LABEL: nop:
+// CHECK: .functype nop () -> ()
+// CHECK-NOT: .size
+// CHECK: end_function
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn nop() {
+    naked_asm!("nop")
+}
+
+// CHECK: .section  .text.weak_aligned_nop,"",@
+// CHECK: .weak weak_aligned_nop
+// CHECK-LABEL: nop:
+// CHECK: .functype weak_aligned_nop () -> ()
+// CHECK-NOT: .size
+// CHECK: end_function
+#[no_mangle]
+#[naked]
+#[linkage = "weak"]
+// wasm functions cannot be aligned, so this has no effect
+#[repr(align(32))]
+unsafe extern "C" fn weak_aligned_nop() {
+    naked_asm!("nop")
+}
+
+// CHECK-LABEL: fn_i8_i8:
+// CHECK-NEXT: .functype fn_i8_i8 (i32) -> (i32)
+//
+// CHECK-NEXT: local.get 0
+// CHECK-NEXT: local.get 0
+// CHECK-NEXT: i32.mul
+//
+// CHECK-NEXT: end_function
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_i8_i8(num: i8) -> i8 {
+    naked_asm!("local.get 0", "local.get 0", "i32.mul")
+}
+
+// CHECK-LABEL: fn_i8_i8_i8:
+// CHECK: .functype fn_i8_i8_i8 (i32, i32) -> (i32)
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_i8_i8_i8(a: i8, b: i8) -> i8 {
+    naked_asm!("local.get 1", "local.get 0", "i32.mul")
+}
+
+// CHECK-LABEL: fn_unit_i8:
+// CHECK: .functype fn_unit_i8 () -> (i32)
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_unit_i8() -> i8 {
+    naked_asm!("i32.const 42")
+}
+
+// CHECK-LABEL: fn_i8_unit:
+// CHECK: .functype fn_i8_unit (i32) -> ()
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_i8_unit(_: i8) {
+    naked_asm!("nop")
+}
+
+// CHECK-LABEL: fn_i32_i32:
+// CHECK: .functype fn_i32_i32 (i32) -> (i32)
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_i32_i32(num: i32) -> i32 {
+    naked_asm!("local.get 0", "local.get 0", "i32.mul")
+}
+
+// CHECK-LABEL: fn_i64_i64:
+// CHECK: .functype fn_i64_i64 (i64) -> (i64)
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_i64_i64(num: i64) -> i64 {
+    naked_asm!("local.get 0", "local.get 0", "i64.mul")
+}
+
+// CHECK-LABEL: fn_i128_i128:
+// wasm32-unknown,wasm32-wasip1: .functype fn_i128_i128 (i32, i64, i64) -> ()
+// wasm64-unknown: .functype fn_i128_i128 (i64, i64, i64) -> ()
+#[allow(improper_ctypes_definitions)]
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_i128_i128(num: i128) -> i128 {
+    naked_asm!(
+        "local.get       0",
+        "local.get       2",
+        "i64.store       8",
+        "local.get       0",
+        "local.get       1",
+        "i64.store       0",
+    )
+}
+
+// CHECK-LABEL: fn_f128_f128:
+// wasm32-unknown,wasm32-wasip1: .functype fn_f128_f128 (i32, i64, i64) -> ()
+// wasm64-unknown: .functype fn_f128_f128 (i64, i64, i64) -> ()
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_f128_f128(num: f128) -> f128 {
+    naked_asm!(
+        "local.get       0",
+        "local.get       2",
+        "i64.store       8",
+        "local.get       0",
+        "local.get       1",
+        "i64.store       0",
+    )
+}
+
+#[repr(C)]
+struct Compound {
+    a: u16,
+    b: i64,
+}
+
+// CHECK-LABEL: fn_compound_compound:
+// wasm32-wasip1: .functype fn_compound_compound (i32, i32) -> ()
+// wasm32-unknown: .functype fn_compound_compound (i32, i32, i64) -> ()
+// wasm64-unknown: .functype fn_compound_compound (i64, i64) -> ()
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_compound_compound(_: Compound) -> Compound {
+    // this is the wasm32-unknown-unknown assembly
+    naked_asm!(
+        "local.get       0",
+        "local.get       2",
+        "i64.store       8",
+        "local.get       0",
+        "local.get       1",
+        "i32.store16     0",
+    )
+}
+
+#[repr(C)]
+struct WrapperI32(i32);
+
+// CHECK-LABEL: fn_wrapperi32_wrapperi32:
+// CHECK: .functype fn_wrapperi32_wrapperi32 (i32) -> (i32)
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_wrapperi32_wrapperi32(_: WrapperI32) -> WrapperI32 {
+    naked_asm!("local.get       0")
+}
+
+#[repr(C)]
+struct WrapperI64(i64);
+
+// CHECK-LABEL: fn_wrapperi64_wrapperi64:
+// CHECK: .functype fn_wrapperi64_wrapperi64 (i64) -> (i64)
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_wrapperi64_wrapperi64(_: WrapperI64) -> WrapperI64 {
+    naked_asm!("local.get       0")
+}
+
+#[repr(C)]
+struct WrapperF32(f32);
+
+// CHECK-LABEL: fn_wrapperf32_wrapperf32:
+// CHECK: .functype fn_wrapperf32_wrapperf32 (f32) -> (f32)
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_wrapperf32_wrapperf32(_: WrapperF32) -> WrapperF32 {
+    naked_asm!("local.get       0")
+}
+
+#[repr(C)]
+struct WrapperF64(f64);
+
+// CHECK-LABEL: fn_wrapperf64_wrapperf64:
+// CHECK: .functype fn_wrapperf64_wrapperf64 (f64) -> (f64)
+#[no_mangle]
+#[naked]
+unsafe extern "C" fn fn_wrapperf64_wrapperf64(_: WrapperF64) -> WrapperF64 {
+    naked_asm!("local.get       0")
+}

--- a/tests/assembly/wasm32-naked-fn.rs
+++ b/tests/assembly/wasm32-naked-fn.rs
@@ -1,10 +1,10 @@
-//@ revisions: wasm32-unknown wasm64-unknown wasm32-wasip1
+// FIXME: add wasm32-unknown when the wasm32-unknown-unknown ABI is fixed
+// see https://github.com/rust-lang/rust/issues/115666
+//@ revisions: wasm64-unknown wasm32-wasip1
 //@ add-core-stubs
 //@ assembly-output: emit-asm
-//@ [wasm32-unknown] compile-flags: --target wasm32-unknown-unknown
 //@ [wasm64-unknown] compile-flags: --target wasm64-unknown-unknown
 //@ [wasm32-wasip1] compile-flags: --target wasm32-wasip1
-//@ [wasm32-unknown] needs-llvm-components: webassembly
 //@ [wasm64-unknown] needs-llvm-components: webassembly
 //@ [wasm32-wasip1] needs-llvm-components: webassembly
 
@@ -97,7 +97,7 @@ unsafe extern "C" fn fn_i64_i64(num: i64) -> i64 {
 }
 
 // CHECK-LABEL: fn_i128_i128:
-// wasm32-unknown,wasm32-wasip1: .functype fn_i128_i128 (i32, i64, i64) -> ()
+// wasm32-wasip1: .functype fn_i128_i128 (i32, i64, i64) -> ()
 // wasm64-unknown: .functype fn_i128_i128 (i64, i64, i64) -> ()
 #[allow(improper_ctypes_definitions)]
 #[no_mangle]
@@ -114,7 +114,7 @@ unsafe extern "C" fn fn_i128_i128(num: i128) -> i128 {
 }
 
 // CHECK-LABEL: fn_f128_f128:
-// wasm32-unknown,wasm32-wasip1: .functype fn_f128_f128 (i32, i64, i64) -> ()
+// wasm32-wasip1: .functype fn_f128_f128 (i32, i64, i64) -> ()
 // wasm64-unknown: .functype fn_f128_f128 (i64, i64, i64) -> ()
 #[no_mangle]
 #[naked]
@@ -137,18 +137,19 @@ struct Compound {
 
 // CHECK-LABEL: fn_compound_compound:
 // wasm32-wasip1: .functype fn_compound_compound (i32, i32) -> ()
-// wasm32-unknown: .functype fn_compound_compound (i32, i32, i64) -> ()
 // wasm64-unknown: .functype fn_compound_compound (i64, i64) -> ()
 #[no_mangle]
 #[naked]
 unsafe extern "C" fn fn_compound_compound(_: Compound) -> Compound {
-    // this is the wasm32-unknown-unknown assembly
+    // this is the wasm32-wasip1 assembly
     naked_asm!(
         "local.get       0",
-        "local.get       2",
+        "local.get       1",
+        "i64.load        8",
         "i64.store       8",
         "local.get       0",
         "local.get       1",
+        "i32.load16_u    0",
         "i32.store16     0",
     )
 }

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `inner`
   --> $DIR/ice-unresolved-import-100241.rs:9:13
    |
 LL |     pub use inner::S;
-   |             ^^^^^ you might be missing crate `inner`
+   |             ^^^^^ use of unresolved module or unlinked crate `inner`
    |
-help: consider importing the `inner` crate
+help: you might be missing a crate named `inner`, add it to your project and import it in your code
    |
 LL + extern crate inner;
    |

--- a/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
+++ b/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: you might be missing crate `unresolved_crate`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved_crate`
   --> $DIR/unresolved-import-recovery.rs:3:5
    |
 LL | use unresolved_crate::module::Name;
-   |     ^^^^^^^^^^^^^^^^ you might be missing crate `unresolved_crate`
+   |     ^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved_crate`
    |
-help: consider importing the `unresolved_crate` crate
+help: you might be missing a crate named `unresolved_crate`, add it to your project and import it in your code
    |
 LL + extern crate unresolved_crate;
    |

--- a/tests/rustdoc-ui/issues/issue-61732.rs
+++ b/tests/rustdoc-ui/issues/issue-61732.rs
@@ -1,4 +1,4 @@
 // This previously triggered an ICE.
 
 pub(in crate::r#mod) fn main() {}
-//~^ ERROR failed to resolve: you might be missing crate `r#mod`
+//~^ ERROR failed to resolve: use of unresolved module or unlinked crate `r#mod`

--- a/tests/rustdoc-ui/issues/issue-61732.stderr
+++ b/tests/rustdoc-ui/issues/issue-61732.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: you might be missing crate `r#mod`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `r#mod`
   --> $DIR/issue-61732.rs:3:15
    |
 LL | pub(in crate::r#mod) fn main() {}
-   |               ^^^^^ you might be missing crate `r#mod`
+   |               ^^^^^ use of unresolved module or unlinked crate `r#mod`
    |
-help: consider importing the `r#mod` crate
+help: you might be missing a crate named `r#mod`, add it to your project and import it in your code
    |
 LL + extern crate r#mod;
    |

--- a/tests/ui/attributes/check-builtin-attr-ice.stderr
+++ b/tests/ui/attributes/check-builtin-attr-ice.stderr
@@ -1,20 +1,20 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `should_panic`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `should_panic`
   --> $DIR/check-builtin-attr-ice.rs:43:7
    |
 LL |     #[should_panic::skip]
-   |       ^^^^^^^^^^^^ use of undeclared crate or module `should_panic`
+   |       ^^^^^^^^^^^^ use of unresolved module or unlinked crate `should_panic`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `should_panic`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `should_panic`
   --> $DIR/check-builtin-attr-ice.rs:47:7
    |
 LL |     #[should_panic::a::b::c]
-   |       ^^^^^^^^^^^^ use of undeclared crate or module `should_panic`
+   |       ^^^^^^^^^^^^ use of unresolved module or unlinked crate `should_panic`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `deny`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `deny`
   --> $DIR/check-builtin-attr-ice.rs:55:7
    |
 LL |     #[deny::skip]
-   |       ^^^^ use of undeclared crate or module `deny`
+   |       ^^^^ use of unresolved module or unlinked crate `deny`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/attributes/check-cfg_attr-ice.stderr
+++ b/tests/ui/attributes/check-cfg_attr-ice.stderr
@@ -17,83 +17,83 @@ LL |         #[cfg_attr::no_such_thing]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:52:3
    |
 LL | #[cfg_attr::no_such_thing]
-   |   ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:55:7
    |
 LL |     #[cfg_attr::no_such_thing]
-   |       ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:57:17
    |
 LL |     GiveYouUp(#[cfg_attr::no_such_thing] u8),
-   |                 ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |                 ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:64:11
    |
 LL |         #[cfg_attr::no_such_thing]
-   |           ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |           ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:41:7
    |
 LL |     #[cfg_attr::no_such_thing]
-   |       ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:43:15
    |
 LL |     fn from(#[cfg_attr::no_such_thing] any_other_guy: AnyOtherGuy) -> This {
-   |               ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |               ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:45:11
    |
 LL |         #[cfg_attr::no_such_thing]
-   |           ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |           ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:32:3
    |
 LL | #[cfg_attr::no_such_thing]
-   |   ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:24:3
    |
 LL | #[cfg_attr::no_such_thing]
-   |   ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:27:7
    |
 LL |     #[cfg_attr::no_such_thing]
-   |       ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:16:3
    |
 LL | #[cfg_attr::no_such_thing]
-   |   ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:19:7
    |
 LL |     #[cfg_attr::no_such_thing]
-   |       ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:12:3
    |
 LL | #[cfg_attr::no_such_thing]
-   |   ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/attributes/field-attributes-vis-unresolved.stderr
+++ b/tests/ui/attributes/field-attributes-vis-unresolved.stderr
@@ -1,21 +1,21 @@
-error[E0433]: failed to resolve: you might be missing crate `nonexistent`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistent`
   --> $DIR/field-attributes-vis-unresolved.rs:17:12
    |
 LL |     pub(in nonexistent) field: u8
-   |            ^^^^^^^^^^^ you might be missing crate `nonexistent`
+   |            ^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistent`
    |
-help: consider importing the `nonexistent` crate
+help: you might be missing a crate named `nonexistent`, add it to your project and import it in your code
    |
 LL + extern crate nonexistent;
    |
 
-error[E0433]: failed to resolve: you might be missing crate `nonexistent`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistent`
   --> $DIR/field-attributes-vis-unresolved.rs:22:12
    |
 LL |     pub(in nonexistent) u8
-   |            ^^^^^^^^^^^ you might be missing crate `nonexistent`
+   |            ^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistent`
    |
-help: consider importing the `nonexistent` crate
+help: you might be missing a crate named `nonexistent`, add it to your project and import it in your code
    |
 LL + extern crate nonexistent;
    |

--- a/tests/ui/coherence/conflicting-impl-with-err.stderr
+++ b/tests/ui/coherence/conflicting-impl-with-err.stderr
@@ -1,14 +1,18 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `nope`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nope`
   --> $DIR/conflicting-impl-with-err.rs:4:11
    |
 LL | impl From<nope::Thing> for Error {
-   |           ^^^^ use of undeclared crate or module `nope`
+   |           ^^^^ use of unresolved module or unlinked crate `nope`
+   |
+   = help: you might be missing a crate named `nope`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `nope`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nope`
   --> $DIR/conflicting-impl-with-err.rs:5:16
    |
 LL |     fn from(_: nope::Thing) -> Self {
-   |                ^^^^ use of undeclared crate or module `nope`
+   |                ^^^^ use of unresolved module or unlinked crate `nope`
+   |
+   = help: you might be missing a crate named `nope`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/delegation/bad-resolve.rs
+++ b/tests/ui/delegation/bad-resolve.rs
@@ -40,7 +40,7 @@ impl Trait for S {
 }
 
 mod prefix {}
-reuse unresolved_prefix::{a, b, c}; //~ ERROR use of undeclared crate or module `unresolved_prefix`
+reuse unresolved_prefix::{a, b, c}; //~ ERROR use of unresolved module or unlinked crate
 reuse prefix::{self, super, crate}; //~ ERROR `crate` in paths can only be used in start position
 
 fn main() {}

--- a/tests/ui/delegation/bad-resolve.stderr
+++ b/tests/ui/delegation/bad-resolve.stderr
@@ -81,11 +81,13 @@ LL |     type Type;
 LL | impl Trait for S {
    | ^^^^^^^^^^^^^^^^ missing `Type` in implementation
 
-error[E0433]: failed to resolve: use of undeclared crate or module `unresolved_prefix`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved_prefix`
   --> $DIR/bad-resolve.rs:43:7
    |
 LL | reuse unresolved_prefix::{a, b, c};
-   |       ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `unresolved_prefix`
+   |       ^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved_prefix`
+   |
+   = help: you might be missing a crate named `unresolved_prefix`
 
 error[E0433]: failed to resolve: `crate` in paths can only be used in start position
   --> $DIR/bad-resolve.rs:44:29

--- a/tests/ui/delegation/glob-bad-path.rs
+++ b/tests/ui/delegation/glob-bad-path.rs
@@ -5,7 +5,7 @@ trait Trait {}
 struct S;
 
 impl Trait for u8 {
-    reuse unresolved::*; //~ ERROR failed to resolve: use of undeclared crate or module `unresolved`
+    reuse unresolved::*; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `unresolved`
     reuse S::*; //~ ERROR expected trait, found struct `S`
 }
 

--- a/tests/ui/delegation/glob-bad-path.stderr
+++ b/tests/ui/delegation/glob-bad-path.stderr
@@ -4,11 +4,11 @@ error: expected trait, found struct `S`
 LL |     reuse S::*;
    |           ^ not a trait
 
-error[E0433]: failed to resolve: use of undeclared crate or module `unresolved`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved`
   --> $DIR/glob-bad-path.rs:8:11
    |
 LL |     reuse unresolved::*;
-   |           ^^^^^^^^^^ use of undeclared crate or module `unresolved`
+   |           ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0432.stderr
+++ b/tests/ui/error-codes/E0432.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `something`
   --> $DIR/E0432.rs:1:5
    |
 LL | use something::Foo;
-   |     ^^^^^^^^^ you might be missing crate `something`
+   |     ^^^^^^^^^ use of unresolved module or unlinked crate `something`
    |
-help: consider importing the `something` crate
+help: you might be missing a crate named `something`, add it to your project and import it in your code
    |
 LL + extern crate something;
    |

--- a/tests/ui/extern-flag/multiple-opts.stderr
+++ b/tests/ui/extern-flag/multiple-opts.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `somedep`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `somedep`
   --> $DIR/multiple-opts.rs:19:5
    |
 LL |     somedep::somefun();
-   |     ^^^^^^^ use of undeclared crate or module `somedep`
+   |     ^^^^^^^ use of unresolved module or unlinked crate `somedep`
+   |
+   = help: you might be missing a crate named `somedep`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/extern-flag/noprelude.stderr
+++ b/tests/ui/extern-flag/noprelude.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `somedep`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `somedep`
   --> $DIR/noprelude.rs:6:5
    |
 LL |     somedep::somefun();
-   |     ^^^^^^^ use of undeclared crate or module `somedep`
+   |     ^^^^^^^ use of unresolved module or unlinked crate `somedep`
+   |
+   = help: you might be missing a crate named `somedep`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/foreign/stashed-issue-121451.rs
+++ b/tests/ui/foreign/stashed-issue-121451.rs
@@ -1,4 +1,4 @@
 extern "C" fn _f() -> libc::uintptr_t {}
-//~^ ERROR failed to resolve: use of undeclared crate or module `libc`
+//~^ ERROR failed to resolve
 
 fn main() {}

--- a/tests/ui/foreign/stashed-issue-121451.stderr
+++ b/tests/ui/foreign/stashed-issue-121451.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `libc`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
   --> $DIR/stashed-issue-121451.rs:1:23
    |
 LL | extern "C" fn _f() -> libc::uintptr_t {}
-   |                       ^^^^ use of undeclared crate or module `libc`
+   |                       ^^^^ use of unresolved module or unlinked crate `libc`
+   |
+   = help: you might be missing a crate named `libc`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.rs
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.rs
@@ -10,7 +10,7 @@ macro a() {
     mod u {
         // Late resolution.
         fn f() { my_core::mem::drop(0); }
-        //~^ ERROR failed to resolve: use of undeclared crate or module `my_core`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
     }
 }
 
@@ -23,7 +23,7 @@ mod v {
 mod u {
     // Late resolution.
     fn f() { my_core::mem::drop(0); }
-    //~^ ERROR failed to resolve: use of undeclared crate or module `my_core`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
 }
 
 fn main() {}

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.stderr
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.stderr
@@ -15,25 +15,27 @@ LL | a!();
    |
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
   --> $DIR/extern-prelude-from-opaque-fail-2018.rs:12:18
    |
 LL |         fn f() { my_core::mem::drop(0); }
-   |                  ^^^^^^^ use of undeclared crate or module `my_core`
+   |                  ^^^^^^^ use of unresolved module or unlinked crate `my_core`
 ...
 LL | a!();
    | ---- in this macro invocation
    |
+   = help: you might be missing a crate named `my_core`
    = help: consider importing this module:
            std::mem
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
   --> $DIR/extern-prelude-from-opaque-fail-2018.rs:25:14
    |
 LL |     fn f() { my_core::mem::drop(0); }
-   |              ^^^^^^^ use of undeclared crate or module `my_core`
+   |              ^^^^^^^ use of unresolved module or unlinked crate `my_core`
    |
+   = help: you might be missing a crate named `my_core`
 help: consider importing this module
    |
 LL +     use std::mem;

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail.rs
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail.rs
@@ -10,7 +10,7 @@ macro a() {
     mod u {
         // Late resolution.
         fn f() { my_core::mem::drop(0); }
-        //~^ ERROR failed to resolve: use of undeclared crate or module `my_core`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
     }
 }
 
@@ -23,7 +23,7 @@ mod v {
 mod u {
     // Late resolution.
     fn f() { my_core::mem::drop(0); }
-    //~^ ERROR failed to resolve: use of undeclared crate or module `my_core`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
 }
 
 fn main() {}

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail.stderr
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail.stderr
@@ -15,25 +15,27 @@ LL | a!();
    |
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
   --> $DIR/extern-prelude-from-opaque-fail.rs:12:18
    |
 LL |         fn f() { my_core::mem::drop(0); }
-   |                  ^^^^^^^ use of undeclared crate or module `my_core`
+   |                  ^^^^^^^ use of unresolved module or unlinked crate `my_core`
 ...
 LL | a!();
    | ---- in this macro invocation
    |
+   = help: you might be missing a crate named `my_core`
    = help: consider importing this module:
            my_core::mem
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
   --> $DIR/extern-prelude-from-opaque-fail.rs:25:14
    |
 LL |     fn f() { my_core::mem::drop(0); }
-   |              ^^^^^^^ use of undeclared crate or module `my_core`
+   |              ^^^^^^^ use of unresolved module or unlinked crate `my_core`
    |
+   = help: you might be missing a crate named `my_core`
 help: consider importing this module
    |
 LL +     use my_core::mem;

--- a/tests/ui/impl-trait/issue-72911.stderr
+++ b/tests/ui/impl-trait/issue-72911.stderr
@@ -1,14 +1,18 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/issue-72911.rs:11:33
    |
 LL | fn gather_from_file(dir_entry: &foo::MissingItem) -> impl Iterator<Item = Lint> {
-   |                                 ^^^ use of undeclared crate or module `foo`
+   |                                 ^^^ use of unresolved module or unlinked crate `foo`
+   |
+   = help: you might be missing a crate named `foo`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/issue-72911.rs:16:41
    |
 LL | fn lint_files() -> impl Iterator<Item = foo::MissingItem> {
-   |                                         ^^^ use of undeclared crate or module `foo`
+   |                                         ^^^ use of unresolved module or unlinked crate `foo`
+   |
+   = help: you might be missing a crate named `foo`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/stashed-diag-issue-121504.rs
+++ b/tests/ui/impl-trait/stashed-diag-issue-121504.rs
@@ -4,7 +4,7 @@ trait MyTrait {
     async fn foo(self) -> (Self, i32);
 }
 
-impl MyTrait for xyz::T { //~ ERROR failed to resolve: use of undeclared crate or module `xyz`
+impl MyTrait for xyz::T { //~ ERROR failed to resolve: use of unresolved module or unlinked crate `xyz`
     async fn foo(self, key: i32) -> (u32, i32) {
         (self, key)
     }

--- a/tests/ui/impl-trait/stashed-diag-issue-121504.stderr
+++ b/tests/ui/impl-trait/stashed-diag-issue-121504.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `xyz`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `xyz`
   --> $DIR/stashed-diag-issue-121504.rs:7:18
    |
 LL | impl MyTrait for xyz::T {
-   |                  ^^^ use of undeclared crate or module `xyz`
+   |                  ^^^ use of unresolved module or unlinked crate `xyz`
+   |
+   = help: you might be missing a crate named `xyz`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/extern-prelude-extern-crate-fail.rs
+++ b/tests/ui/imports/extern-prelude-extern-crate-fail.rs
@@ -7,7 +7,7 @@ mod n {
 
 mod m {
     fn check() {
-        two_macros::m!(); //~ ERROR failed to resolve: use of undeclared crate or module `two_macros`
+        two_macros::m!(); //~ ERROR failed to resolve: use of unresolved module or unlinked crate `two_macros`
     }
 }
 

--- a/tests/ui/imports/extern-prelude-extern-crate-fail.stderr
+++ b/tests/ui/imports/extern-prelude-extern-crate-fail.stderr
@@ -9,11 +9,11 @@ LL | define_std_as_non_existent!();
    |
    = note: this error originates in the macro `define_std_as_non_existent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `two_macros`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `two_macros`
   --> $DIR/extern-prelude-extern-crate-fail.rs:10:9
    |
 LL |         two_macros::m!();
-   |         ^^^^^^^^^^ use of undeclared crate or module `two_macros`
+   |         ^^^^^^^^^^ use of unresolved module or unlinked crate `two_macros`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/imports/import-from-missing-star-2.stderr
+++ b/tests/ui/imports/import-from-missing-star-2.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star-2.rs:2:9
    |
 LL |     use spam::*;
-   |         ^^^^ you might be missing crate `spam`
+   |         ^^^^ use of unresolved module or unlinked crate `spam`
    |
-help: consider importing the `spam` crate
+help: you might be missing a crate named `spam`, add it to your project and import it in your code
    |
 LL + extern crate spam;
    |

--- a/tests/ui/imports/import-from-missing-star-3.stderr
+++ b/tests/ui/imports/import-from-missing-star-3.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star-3.rs:2:9
    |
 LL |     use spam::*;
-   |         ^^^^ you might be missing crate `spam`
+   |         ^^^^ use of unresolved module or unlinked crate `spam`
    |
-help: consider importing the `spam` crate
+help: you might be missing a crate named `spam`, add it to your project and import it in your code
    |
 LL + extern crate spam;
    |
@@ -13,9 +13,9 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star-3.rs:27:13
    |
 LL |         use spam::*;
-   |             ^^^^ you might be missing crate `spam`
+   |             ^^^^ use of unresolved module or unlinked crate `spam`
    |
-help: consider importing the `spam` crate
+help: you might be missing a crate named `spam`, add it to your project and import it in your code
    |
 LL + extern crate spam;
    |

--- a/tests/ui/imports/import-from-missing-star.stderr
+++ b/tests/ui/imports/import-from-missing-star.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star.rs:1:5
    |
 LL | use spam::*;
-   |     ^^^^ you might be missing crate `spam`
+   |     ^^^^ use of unresolved module or unlinked crate `spam`
    |
-help: consider importing the `spam` crate
+help: you might be missing a crate named `spam`, add it to your project and import it in your code
    |
 LL + extern crate spam;
    |

--- a/tests/ui/imports/import3.stderr
+++ b/tests/ui/imports/import3.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `main`
   --> $DIR/import3.rs:2:5
    |
 LL | use main::bar;
-   |     ^^^^ you might be missing crate `main`
+   |     ^^^^ use of unresolved module or unlinked crate `main`
    |
-help: consider importing the `main` crate
+help: you might be missing a crate named `main`, add it to your project and import it in your code
    |
 LL + extern crate main;
    |

--- a/tests/ui/imports/issue-109343.stderr
+++ b/tests/ui/imports/issue-109343.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `unresolved`
   --> $DIR/issue-109343.rs:4:9
    |
 LL | pub use unresolved::f;
-   |         ^^^^^^^^^^ you might be missing crate `unresolved`
+   |         ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
    |
-help: consider importing the `unresolved` crate
+help: you might be missing a crate named `unresolved`, add it to your project and import it in your code
    |
 LL + extern crate unresolved;
    |

--- a/tests/ui/imports/issue-1697.rs
+++ b/tests/ui/imports/issue-1697.rs
@@ -2,7 +2,7 @@
 
 use unresolved::*;
 //~^ ERROR unresolved import `unresolved` [E0432]
-//~| NOTE you might be missing crate `unresolved`
-//~| HELP consider importing the `unresolved` crate
+//~| NOTE use of unresolved module or unlinked crate `unresolved`
+//~| HELP you might be missing a crate named `unresolved`
 
 fn main() {}

--- a/tests/ui/imports/issue-1697.stderr
+++ b/tests/ui/imports/issue-1697.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `unresolved`
   --> $DIR/issue-1697.rs:3:5
    |
 LL | use unresolved::*;
-   |     ^^^^^^^^^^ you might be missing crate `unresolved`
+   |     ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
    |
-help: consider importing the `unresolved` crate
+help: you might be missing a crate named `unresolved`, add it to your project and import it in your code
    |
 LL + extern crate unresolved;
    |

--- a/tests/ui/imports/issue-33464.stderr
+++ b/tests/ui/imports/issue-33464.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `abc`
   --> $DIR/issue-33464.rs:3:5
    |
 LL | use abc::one_el;
-   |     ^^^ you might be missing crate `abc`
+   |     ^^^ use of unresolved module or unlinked crate `abc`
    |
-help: consider importing the `abc` crate
+help: you might be missing a crate named `abc`, add it to your project and import it in your code
    |
 LL + extern crate abc;
    |
@@ -13,9 +13,9 @@ error[E0432]: unresolved import `abc`
   --> $DIR/issue-33464.rs:5:5
    |
 LL | use abc::{a, bbb, cccccc};
-   |     ^^^ you might be missing crate `abc`
+   |     ^^^ use of unresolved module or unlinked crate `abc`
    |
-help: consider importing the `abc` crate
+help: you might be missing a crate named `abc`, add it to your project and import it in your code
    |
 LL + extern crate abc;
    |
@@ -24,9 +24,9 @@ error[E0432]: unresolved import `a_very_long_name`
   --> $DIR/issue-33464.rs:7:5
    |
 LL | use a_very_long_name::{el, el2};
-   |     ^^^^^^^^^^^^^^^^ you might be missing crate `a_very_long_name`
+   |     ^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `a_very_long_name`
    |
-help: consider importing the `a_very_long_name` crate
+help: you might be missing a crate named `a_very_long_name`, add it to your project and import it in your code
    |
 LL + extern crate a_very_long_name;
    |

--- a/tests/ui/imports/issue-36881.stderr
+++ b/tests/ui/imports/issue-36881.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `issue_36881_aux`
   --> $DIR/issue-36881.rs:5:9
    |
 LL |     use issue_36881_aux::Foo;
-   |         ^^^^^^^^^^^^^^^ you might be missing crate `issue_36881_aux`
+   |         ^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `issue_36881_aux`
    |
-help: consider importing the `issue_36881_aux` crate
+help: you might be missing a crate named `issue_36881_aux`, add it to your project and import it in your code
    |
 LL + extern crate issue_36881_aux;
    |

--- a/tests/ui/imports/issue-37887.stderr
+++ b/tests/ui/imports/issue-37887.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `test`
   --> $DIR/issue-37887.rs:3:9
    |
 LL |     use test::*;
-   |         ^^^^ you might be missing crate `test`
+   |         ^^^^ use of unresolved module or unlinked crate `test`
    |
-help: consider importing the `test` crate
+help: you might be missing a crate named `test`, add it to your project and import it in your code
    |
 LL + extern crate test;
    |

--- a/tests/ui/imports/issue-53269.stderr
+++ b/tests/ui/imports/issue-53269.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `nonexistent_module`
   --> $DIR/issue-53269.rs:6:9
    |
 LL |     use nonexistent_module::mac;
-   |         ^^^^^^^^^^^^^^^^^^ you might be missing crate `nonexistent_module`
+   |         ^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistent_module`
    |
-help: consider importing the `nonexistent_module` crate
+help: you might be missing a crate named `nonexistent_module`, add it to your project and import it in your code
    |
 LL + extern crate nonexistent_module;
    |

--- a/tests/ui/imports/issue-55457.stderr
+++ b/tests/ui/imports/issue-55457.stderr
@@ -11,9 +11,9 @@ error[E0432]: unresolved import `non_existent`
   --> $DIR/issue-55457.rs:2:5
    |
 LL | use non_existent::non_existent;
-   |     ^^^^^^^^^^^^ you might be missing crate `non_existent`
+   |     ^^^^^^^^^^^^ use of unresolved module or unlinked crate `non_existent`
    |
-help: consider importing the `non_existent` crate
+help: you might be missing a crate named `non_existent`, add it to your project and import it in your code
    |
 LL + extern crate non_existent;
    |

--- a/tests/ui/imports/issue-81413.stderr
+++ b/tests/ui/imports/issue-81413.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `doesnt_exist`
   --> $DIR/issue-81413.rs:7:9
    |
 LL | pub use doesnt_exist::*;
-   |         ^^^^^^^^^^^^ you might be missing crate `doesnt_exist`
+   |         ^^^^^^^^^^^^ use of unresolved module or unlinked crate `doesnt_exist`
    |
-help: consider importing the `doesnt_exist` crate
+help: you might be missing a crate named `doesnt_exist`, add it to your project and import it in your code
    |
 LL + extern crate doesnt_exist;
    |

--- a/tests/ui/imports/tool-mod-child.rs
+++ b/tests/ui/imports/tool-mod-child.rs
@@ -1,7 +1,7 @@
 use clippy::a; //~ ERROR unresolved import `clippy`
-use clippy::a::b; //~ ERROR failed to resolve: you might be missing crate `clippy`
+use clippy::a::b; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `clippy`
 
 use rustdoc::a; //~ ERROR unresolved import `rustdoc`
-use rustdoc::a::b; //~ ERROR failed to resolve: you might be missing crate `rustdoc`
+use rustdoc::a::b; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `rustdoc`
 
 fn main() {}

--- a/tests/ui/imports/tool-mod-child.stderr
+++ b/tests/ui/imports/tool-mod-child.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: you might be missing crate `clippy`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `clippy`
   --> $DIR/tool-mod-child.rs:2:5
    |
 LL | use clippy::a::b;
-   |     ^^^^^^ you might be missing crate `clippy`
+   |     ^^^^^^ use of unresolved module or unlinked crate `clippy`
    |
-help: consider importing the `clippy` crate
+help: you might be missing a crate named `clippy`, add it to your project and import it in your code
    |
 LL + extern crate clippy;
    |
@@ -13,20 +13,20 @@ error[E0432]: unresolved import `clippy`
   --> $DIR/tool-mod-child.rs:1:5
    |
 LL | use clippy::a;
-   |     ^^^^^^ you might be missing crate `clippy`
+   |     ^^^^^^ use of unresolved module or unlinked crate `clippy`
    |
-help: consider importing the `clippy` crate
+help: you might be missing a crate named `clippy`, add it to your project and import it in your code
    |
 LL + extern crate clippy;
    |
 
-error[E0433]: failed to resolve: you might be missing crate `rustdoc`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rustdoc`
   --> $DIR/tool-mod-child.rs:5:5
    |
 LL | use rustdoc::a::b;
-   |     ^^^^^^^ you might be missing crate `rustdoc`
+   |     ^^^^^^^ use of unresolved module or unlinked crate `rustdoc`
    |
-help: consider importing the `rustdoc` crate
+help: you might be missing a crate named `rustdoc`, add it to your project and import it in your code
    |
 LL + extern crate rustdoc;
    |
@@ -35,9 +35,9 @@ error[E0432]: unresolved import `rustdoc`
   --> $DIR/tool-mod-child.rs:4:5
    |
 LL | use rustdoc::a;
-   |     ^^^^^^^ you might be missing crate `rustdoc`
+   |     ^^^^^^^ use of unresolved module or unlinked crate `rustdoc`
    |
-help: consider importing the `rustdoc` crate
+help: you might be missing a crate named `rustdoc`, add it to your project and import it in your code
    |
 LL + extern crate rustdoc;
    |

--- a/tests/ui/imports/unresolved-imports-used.stderr
+++ b/tests/ui/imports/unresolved-imports-used.stderr
@@ -14,9 +14,9 @@ error[E0432]: unresolved import `foo`
   --> $DIR/unresolved-imports-used.rs:11:5
    |
 LL | use foo::bar;
-   |     ^^^ you might be missing crate `foo`
+   |     ^^^ use of unresolved module or unlinked crate `foo`
    |
-help: consider importing the `foo` crate
+help: you might be missing a crate named `foo`, add it to your project and import it in your code
    |
 LL + extern crate foo;
    |
@@ -25,9 +25,9 @@ error[E0432]: unresolved import `baz`
   --> $DIR/unresolved-imports-used.rs:12:5
    |
 LL | use baz::*;
-   |     ^^^ you might be missing crate `baz`
+   |     ^^^ use of unresolved module or unlinked crate `baz`
    |
-help: consider importing the `baz` crate
+help: you might be missing a crate named `baz`, add it to your project and import it in your code
    |
 LL + extern crate baz;
    |
@@ -36,9 +36,9 @@ error[E0432]: unresolved import `foo2`
   --> $DIR/unresolved-imports-used.rs:14:5
    |
 LL | use foo2::bar2;
-   |     ^^^^ you might be missing crate `foo2`
+   |     ^^^^ use of unresolved module or unlinked crate `foo2`
    |
-help: consider importing the `foo2` crate
+help: you might be missing a crate named `foo2`, add it to your project and import it in your code
    |
 LL + extern crate foo2;
    |
@@ -47,9 +47,9 @@ error[E0432]: unresolved import `baz2`
   --> $DIR/unresolved-imports-used.rs:15:5
    |
 LL | use baz2::*;
-   |     ^^^^ you might be missing crate `baz2`
+   |     ^^^^ use of unresolved module or unlinked crate `baz2`
    |
-help: consider importing the `baz2` crate
+help: you might be missing a crate named `baz2`, add it to your project and import it in your code
    |
 LL + extern crate baz2;
    |

--- a/tests/ui/issues/issue-33293.rs
+++ b/tests/ui/issues/issue-33293.rs
@@ -1,6 +1,6 @@
 fn main() {
     match 0 {
         aaa::bbb(_) => ()
-        //~^ ERROR failed to resolve: use of undeclared crate or module `aaa`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `aaa`
     };
 }

--- a/tests/ui/issues/issue-33293.stderr
+++ b/tests/ui/issues/issue-33293.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `aaa`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `aaa`
   --> $DIR/issue-33293.rs:3:9
    |
 LL |         aaa::bbb(_) => ()
-   |         ^^^ use of undeclared crate or module `aaa`
+   |         ^^^ use of unresolved module or unlinked crate `aaa`
+   |
+   = help: you might be missing a crate named `aaa`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
+++ b/tests/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
@@ -13,9 +13,9 @@ error[E0432]: unresolved import `r#extern`
   --> $DIR/keyword-extern-as-identifier-use.rs:1:5
    |
 LL | use extern::foo;
-   |     ^^^^^^ you might be missing crate `r#extern`
+   |     ^^^^^^ use of unresolved module or unlinked crate `r#extern`
    |
-help: consider importing the `r#extern` crate
+help: you might be missing a crate named `r#extern`, add it to your project and import it in your code
    |
 LL + extern crate r#extern;
    |

--- a/tests/ui/macros/builtin-prelude-no-accidents.rs
+++ b/tests/ui/macros/builtin-prelude-no-accidents.rs
@@ -2,7 +2,7 @@
 // because macros with the same names are in prelude.
 
 fn main() {
-    env::current_dir; //~ ERROR use of undeclared crate or module `env`
-    type A = panic::PanicInfo; //~ ERROR use of undeclared crate or module `panic`
-    type B = vec::Vec<u8>; //~ ERROR use of undeclared crate or module `vec`
+    env::current_dir; //~ ERROR use of unresolved module or unlinked crate `env`
+    type A = panic::PanicInfo; //~ ERROR use of unresolved module or unlinked crate `panic`
+    type B = vec::Vec<u8>; //~ ERROR use of unresolved module or unlinked crate `vec`
 }

--- a/tests/ui/macros/builtin-prelude-no-accidents.stderr
+++ b/tests/ui/macros/builtin-prelude-no-accidents.stderr
@@ -1,31 +1,34 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `env`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `env`
   --> $DIR/builtin-prelude-no-accidents.rs:5:5
    |
 LL |     env::current_dir;
-   |     ^^^ use of undeclared crate or module `env`
+   |     ^^^ use of unresolved module or unlinked crate `env`
    |
+   = help: you might be missing a crate named `env`
 help: consider importing this module
    |
 LL + use std::env;
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `panic`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `panic`
   --> $DIR/builtin-prelude-no-accidents.rs:6:14
    |
 LL |     type A = panic::PanicInfo;
-   |              ^^^^^ use of undeclared crate or module `panic`
+   |              ^^^^^ use of unresolved module or unlinked crate `panic`
    |
+   = help: you might be missing a crate named `panic`
 help: consider importing this module
    |
 LL + use std::panic;
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `vec`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `vec`
   --> $DIR/builtin-prelude-no-accidents.rs:7:14
    |
 LL |     type B = vec::Vec<u8>;
-   |              ^^^ use of undeclared crate or module `vec`
+   |              ^^^ use of unresolved module or unlinked crate `vec`
    |
+   = help: you might be missing a crate named `vec`
 help: consider importing this module
    |
 LL + use std::vec;

--- a/tests/ui/macros/macro-inner-attributes.rs
+++ b/tests/ui/macros/macro-inner-attributes.rs
@@ -15,6 +15,6 @@ test!(b,
 #[rustc_dummy]
 fn main() {
     a::bar();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `a`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `a`
     b::bar();
 }

--- a/tests/ui/macros/macro-inner-attributes.stderr
+++ b/tests/ui/macros/macro-inner-attributes.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `a`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `a`
   --> $DIR/macro-inner-attributes.rs:17:5
    |
 LL |     a::bar();
-   |     ^ use of undeclared crate or module `a`
+   |     ^ use of unresolved module or unlinked crate `a`
    |
 help: there is a crate or module with a similar name
    |

--- a/tests/ui/macros/macro_path_as_generic_bound.stderr
+++ b/tests/ui/macros/macro_path_as_generic_bound.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `m`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `m`
   --> $DIR/macro_path_as_generic_bound.rs:7:6
    |
 LL | foo!(m::m2::A);
-   |      ^ use of undeclared crate or module `m`
+   |      ^ use of unresolved module or unlinked crate `m`
+   |
+   = help: you might be missing a crate named `m`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/meta-item-absolute-path.stderr
+++ b/tests/ui/macros/meta-item-absolute-path.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: you might be missing crate `Absolute`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `Absolute`
   --> $DIR/meta-item-absolute-path.rs:1:12
    |
 LL | #[derive(::Absolute)]
-   |            ^^^^^^^^ you might be missing crate `Absolute`
+   |            ^^^^^^^^ use of unresolved module or unlinked crate `Absolute`
 
-error[E0433]: failed to resolve: you might be missing crate `Absolute`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `Absolute`
   --> $DIR/meta-item-absolute-path.rs:1:12
    |
 LL | #[derive(::Absolute)]
-   |            ^^^^^^^^ you might be missing crate `Absolute`
+   |            ^^^^^^^^ use of unresolved module or unlinked crate `Absolute`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/mir/issue-121103.rs
+++ b/tests/ui/mir/issue-121103.rs
@@ -1,3 +1,3 @@
 fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
-//~^ ERROR failed to resolve: use of undeclared crate or module `lib2`
-//~| ERROR failed to resolve: use of undeclared crate or module `lib2`
+//~^ ERROR failed to resolve: use of unresolved module or unlinked crate `lib2`
+//~| ERROR failed to resolve: use of unresolved module or unlinked crate `lib2`

--- a/tests/ui/mir/issue-121103.stderr
+++ b/tests/ui/mir/issue-121103.stderr
@@ -1,14 +1,18 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `lib2`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `lib2`
   --> $DIR/issue-121103.rs:1:38
    |
 LL | fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
-   |                                      ^^^^ use of undeclared crate or module `lib2`
+   |                                      ^^^^ use of unresolved module or unlinked crate `lib2`
+   |
+   = help: you might be missing a crate named `lib2`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `lib2`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `lib2`
   --> $DIR/issue-121103.rs:1:13
    |
 LL | fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
-   |             ^^^^ use of undeclared crate or module `lib2`
+   |             ^^^^ use of unresolved module or unlinked crate `lib2`
+   |
+   = help: you might be missing a crate named `lib2`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/modules_and_files_visibility/mod_file_disambig.rs
+++ b/tests/ui/modules_and_files_visibility/mod_file_disambig.rs
@@ -2,5 +2,5 @@ mod mod_file_disambig_aux; //~ ERROR file for module `mod_file_disambig_aux` fou
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of undeclared crate or module `mod_file_aux`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
 }

--- a/tests/ui/modules_and_files_visibility/mod_file_disambig.stderr
+++ b/tests/ui/modules_and_files_visibility/mod_file_disambig.stderr
@@ -6,11 +6,13 @@ LL | mod mod_file_disambig_aux;
    |
    = help: delete or rename one of them to remove the ambiguity
 
-error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
   --> $DIR/mod_file_disambig.rs:4:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
-   |                ^^^^^^^^^^^^ use of undeclared crate or module `mod_file_aux`
+   |                ^^^^^^^^^^^^ use of unresolved module or unlinked crate `mod_file_aux`
+   |
+   = help: you might be missing a crate named `mod_file_aux`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/const-param-decl-on-type-instead-of-impl.rs
+++ b/tests/ui/parser/const-param-decl-on-type-instead-of-impl.rs
@@ -11,5 +11,5 @@ fn banana(a: <T<const N: usize>>::BAR) {}
 fn chaenomeles() {
     path::path::Struct::<const N: usize>()
     //~^ ERROR unexpected `const` parameter declaration
-    //~| ERROR failed to resolve: use of undeclared crate or module `path`
+    //~| ERROR failed to resolve: use of unresolved module or unlinked crate `path`
 }

--- a/tests/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
+++ b/tests/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
@@ -21,11 +21,13 @@ error: unexpected `const` parameter declaration
 LL |     path::path::Struct::<const N: usize>()
    |                          ^^^^^^^^^^^^^^ expected a `const` expression, not a parameter declaration
 
-error[E0433]: failed to resolve: use of undeclared crate or module `path`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `path`
   --> $DIR/const-param-decl-on-type-instead-of-impl.rs:12:5
    |
 LL |     path::path::Struct::<const N: usize>()
-   |     ^^^^ use of undeclared crate or module `path`
+   |     ^^^^ use of unresolved module or unlinked crate `path`
+   |
+   = help: you might be missing a crate named `path`
 
 error[E0412]: cannot find type `T` in this scope
   --> $DIR/const-param-decl-on-type-instead-of-impl.rs:8:15

--- a/tests/ui/parser/dyn-trait-compatibility.rs
+++ b/tests/ui/parser/dyn-trait-compatibility.rs
@@ -1,7 +1,7 @@
 type A0 = dyn;
 //~^ ERROR cannot find type `dyn` in this scope
 type A1 = dyn::dyn;
-//~^ ERROR use of undeclared crate or module `dyn`
+//~^ ERROR use of unresolved module or unlinked crate `dyn`
 type A2 = dyn<dyn, dyn>;
 //~^ ERROR cannot find type `dyn` in this scope
 //~| ERROR cannot find type `dyn` in this scope

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -40,11 +40,13 @@ error[E0412]: cannot find type `dyn` in this scope
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                ^^^ not found in this scope
 
-error[E0433]: failed to resolve: use of undeclared crate or module `dyn`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `dyn`
   --> $DIR/dyn-trait-compatibility.rs:3:11
    |
 LL | type A1 = dyn::dyn;
-   |           ^^^ use of undeclared crate or module `dyn`
+   |           ^^^ use of unresolved module or unlinked crate `dyn`
+   |
+   = help: you might be missing a crate named `dyn`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/parser/mod_file_not_exist.rs
+++ b/tests/ui/parser/mod_file_not_exist.rs
@@ -5,5 +5,6 @@ mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of undeclared crate or module `mod_file_aux`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
+    //~| HELP you might be missing a crate named `mod_file_aux`
 }

--- a/tests/ui/parser/mod_file_not_exist.stderr
+++ b/tests/ui/parser/mod_file_not_exist.stderr
@@ -7,11 +7,13 @@ LL | mod not_a_real_file;
    = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs" or "$DIR/not_a_real_file/mod.rs"
    = note: if there is a `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::...` instead
 
-error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
   --> $DIR/mod_file_not_exist.rs:7:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
-   |                ^^^^^^^^^^^^ use of undeclared crate or module `mod_file_aux`
+   |                ^^^^^^^^^^^^ use of unresolved module or unlinked crate `mod_file_aux`
+   |
+   = help: you might be missing a crate named `mod_file_aux`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/mod_file_not_exist_windows.rs
+++ b/tests/ui/parser/mod_file_not_exist_windows.rs
@@ -5,5 +5,5 @@ mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of undeclared crate or module `mod_file_aux`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
 }

--- a/tests/ui/parser/mod_file_not_exist_windows.stderr
+++ b/tests/ui/parser/mod_file_not_exist_windows.stderr
@@ -7,11 +7,13 @@ LL | mod not_a_real_file;
    = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs" or "$DIR/not_a_real_file/mod.rs"
    = note: if there is a `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::...` instead
 
-error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
   --> $DIR/mod_file_not_exist_windows.rs:7:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
-   |                ^^^^^^^^^^^^ use of undeclared crate or module `mod_file_aux`
+   |                ^^^^^^^^^^^^ use of unresolved module or unlinked crate `mod_file_aux`
+   |
+   = help: you might be missing a crate named `mod_file_aux`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/privacy/restricted/test.rs
+++ b/tests/ui/privacy/restricted/test.rs
@@ -47,6 +47,6 @@ fn main() {
 }
 
 mod pathological {
-    pub(in bad::path) mod m1 {} //~ ERROR failed to resolve: you might be missing crate `bad`
+    pub(in bad::path) mod m1 {} //~ ERROR failed to resolve: use of unresolved module or unlinked crate `bad`
     pub(in foo) mod m2 {} //~ ERROR visibilities can only be restricted to ancestor modules
 }

--- a/tests/ui/privacy/restricted/test.stderr
+++ b/tests/ui/privacy/restricted/test.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: you might be missing crate `bad`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `bad`
   --> $DIR/test.rs:50:12
    |
 LL |     pub(in bad::path) mod m1 {}
-   |            ^^^ you might be missing crate `bad`
+   |            ^^^ use of unresolved module or unlinked crate `bad`
    |
-help: consider importing the `bad` crate
+help: you might be missing a crate named `bad`, add it to your project and import it in your code
    |
 LL + extern crate bad;
    |

--- a/tests/ui/resolve/112590-2.stderr
+++ b/tests/ui/resolve/112590-2.stderr
@@ -14,12 +14,13 @@ LL -         let _: Vec<i32> = super::foo::baf::baz::MyVec::new();
 LL +         let _: Vec<i32> = MyVec::new();
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `fox`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fox`
   --> $DIR/112590-2.rs:18:27
    |
 LL |         let _: Vec<i32> = fox::bar::baz::MyVec::new();
-   |                           ^^^ use of undeclared crate or module `fox`
+   |                           ^^^ use of unresolved module or unlinked crate `fox`
    |
+   = help: you might be missing a crate named `fox`
 help: consider importing this struct through its public re-export
    |
 LL +     use foo::bar::baz::MyVec;
@@ -30,12 +31,13 @@ LL -         let _: Vec<i32> = fox::bar::baz::MyVec::new();
 LL +         let _: Vec<i32> = MyVec::new();
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `vec`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `vec`
   --> $DIR/112590-2.rs:24:15
    |
 LL |     type _B = vec::Vec::<u8>;
-   |               ^^^ use of undeclared crate or module `vec`
+   |               ^^^ use of unresolved module or unlinked crate `vec`
    |
+   = help: you might be missing a crate named `vec`
 help: consider importing this module
    |
 LL + use std::vec;
@@ -57,14 +59,16 @@ LL -     let _t = std::sync_error::atomic::AtomicBool::new(true);
 LL +     let _t = AtomicBool::new(true);
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `vec`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `vec`
   --> $DIR/112590-2.rs:23:24
    |
 LL |     let _t: Vec<i32> = vec::new();
    |                        ^^^
    |                        |
-   |                        use of undeclared crate or module `vec`
+   |                        use of unresolved module or unlinked crate `vec`
    |                        help: a struct with a similar name exists (notice the capitalization): `Vec`
+   |
+   = help: you might be missing a crate named `vec`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/resolve/bad-module.rs
+++ b/tests/ui/resolve/bad-module.rs
@@ -1,7 +1,7 @@
 fn main() {
     let foo = thing::len(Vec::new());
-    //~^ ERROR failed to resolve: use of undeclared crate or module `thing`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `thing`
 
     let foo = foo::bar::baz();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `foo`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
 }

--- a/tests/ui/resolve/bad-module.stderr
+++ b/tests/ui/resolve/bad-module.stderr
@@ -1,14 +1,18 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/bad-module.rs:5:15
    |
 LL |     let foo = foo::bar::baz();
-   |               ^^^ use of undeclared crate or module `foo`
+   |               ^^^ use of unresolved module or unlinked crate `foo`
+   |
+   = help: you might be missing a crate named `foo`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `thing`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `thing`
   --> $DIR/bad-module.rs:2:15
    |
 LL |     let foo = thing::len(Vec::new());
-   |               ^^^^^ use of undeclared crate or module `thing`
+   |               ^^^^^ use of unresolved module or unlinked crate `thing`
+   |
+   = help: you might be missing a crate named `thing`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/editions-crate-root-2015.rs
+++ b/tests/ui/resolve/editions-crate-root-2015.rs
@@ -2,10 +2,10 @@
 
 mod inner {
     fn global_inner(_: ::nonexistant::Foo) {
-        //~^ ERROR failed to resolve: you might be missing crate `nonexistant`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `nonexistant`
     }
     fn crate_inner(_: crate::nonexistant::Foo) {
-        //~^ ERROR failed to resolve: you might be missing crate `nonexistant`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `nonexistant`
     }
 
     fn bare_global(_: ::nonexistant) {

--- a/tests/ui/resolve/editions-crate-root-2015.stderr
+++ b/tests/ui/resolve/editions-crate-root-2015.stderr
@@ -1,21 +1,21 @@
-error[E0433]: failed to resolve: you might be missing crate `nonexistant`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistant`
   --> $DIR/editions-crate-root-2015.rs:4:26
    |
 LL |     fn global_inner(_: ::nonexistant::Foo) {
-   |                          ^^^^^^^^^^^ you might be missing crate `nonexistant`
+   |                          ^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistant`
    |
-help: consider importing the `nonexistant` crate
+help: you might be missing a crate named `nonexistant`, add it to your project and import it in your code
    |
 LL + extern crate nonexistant;
    |
 
-error[E0433]: failed to resolve: you might be missing crate `nonexistant`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistant`
   --> $DIR/editions-crate-root-2015.rs:7:30
    |
 LL |     fn crate_inner(_: crate::nonexistant::Foo) {
-   |                              ^^^^^^^^^^^ you might be missing crate `nonexistant`
+   |                              ^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistant`
    |
-help: consider importing the `nonexistant` crate
+help: you might be missing a crate named `nonexistant`, add it to your project and import it in your code
    |
 LL + extern crate nonexistant;
    |

--- a/tests/ui/resolve/export-fully-qualified-2018.rs
+++ b/tests/ui/resolve/export-fully-qualified-2018.rs
@@ -5,7 +5,7 @@
 // want to change eventually.
 
 mod foo {
-    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of undeclared crate or module `foo`
+    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
 
     fn baz() { }
 }

--- a/tests/ui/resolve/export-fully-qualified-2018.stderr
+++ b/tests/ui/resolve/export-fully-qualified-2018.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/export-fully-qualified-2018.rs:8:20
    |
 LL |     pub fn bar() { foo::baz(); }
-   |                    ^^^ use of undeclared crate or module `foo`
+   |                    ^^^ use of unresolved module or unlinked crate `foo`
+   |
+   = help: you might be missing a crate named `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/export-fully-qualified.rs
+++ b/tests/ui/resolve/export-fully-qualified.rs
@@ -5,7 +5,7 @@
 // want to change eventually.
 
 mod foo {
-    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of undeclared crate or module `foo`
+    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
 
     fn baz() { }
 }

--- a/tests/ui/resolve/export-fully-qualified.stderr
+++ b/tests/ui/resolve/export-fully-qualified.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/export-fully-qualified.rs:8:20
    |
 LL |     pub fn bar() { foo::baz(); }
-   |                    ^^^ use of undeclared crate or module `foo`
+   |                    ^^^ use of unresolved module or unlinked crate `foo`
+   |
+   = help: you might be missing a crate named `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/extern-prelude-fail.stderr
+++ b/tests/ui/resolve/extern-prelude-fail.stderr
@@ -2,20 +2,20 @@ error[E0432]: unresolved import `extern_prelude`
   --> $DIR/extern-prelude-fail.rs:7:9
    |
 LL |     use extern_prelude::S;
-   |         ^^^^^^^^^^^^^^ you might be missing crate `extern_prelude`
+   |         ^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `extern_prelude`
    |
-help: consider importing the `extern_prelude` crate
+help: you might be missing a crate named `extern_prelude`, add it to your project and import it in your code
    |
 LL + extern crate extern_prelude;
    |
 
-error[E0433]: failed to resolve: you might be missing crate `extern_prelude`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `extern_prelude`
   --> $DIR/extern-prelude-fail.rs:8:15
    |
 LL |     let s = ::extern_prelude::S;
-   |               ^^^^^^^^^^^^^^ you might be missing crate `extern_prelude`
+   |               ^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `extern_prelude`
    |
-help: consider importing the `extern_prelude` crate
+help: you might be missing a crate named `extern_prelude`, add it to your project and import it in your code
    |
 LL + extern crate extern_prelude;
    |

--- a/tests/ui/resolve/issue-101749-2.rs
+++ b/tests/ui/resolve/issue-101749-2.rs
@@ -12,5 +12,5 @@ fn main() {
     let rect = Rectangle::new(3, 4);
     // `area` is not implemented for `Rectangle`, so this should not suggest
     let _ = rect::area();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `rect`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `rect`
 }

--- a/tests/ui/resolve/issue-101749-2.stderr
+++ b/tests/ui/resolve/issue-101749-2.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `rect`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rect`
   --> $DIR/issue-101749-2.rs:14:13
    |
 LL |     let _ = rect::area();
-   |             ^^^^ use of undeclared crate or module `rect`
+   |             ^^^^ use of unresolved module or unlinked crate `rect`
+   |
+   = help: you might be missing a crate named `rect`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-101749.fixed
+++ b/tests/ui/resolve/issue-101749.fixed
@@ -15,5 +15,5 @@ impl Rectangle {
 fn main() {
     let rect = Rectangle::new(3, 4);
     let _ = rect.area();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `rect`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `rect`
 }

--- a/tests/ui/resolve/issue-101749.rs
+++ b/tests/ui/resolve/issue-101749.rs
@@ -15,5 +15,5 @@ impl Rectangle {
 fn main() {
     let rect = Rectangle::new(3, 4);
     let _ = rect::area();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `rect`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `rect`
 }

--- a/tests/ui/resolve/issue-101749.stderr
+++ b/tests/ui/resolve/issue-101749.stderr
@@ -1,9 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `rect`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rect`
   --> $DIR/issue-101749.rs:17:13
    |
 LL |     let _ = rect::area();
-   |             ^^^^ use of undeclared crate or module `rect`
+   |             ^^^^ use of unresolved module or unlinked crate `rect`
    |
+   = help: you might be missing a crate named `rect`
 help: you may have meant to call an instance method
    |
 LL |     let _ = rect.area();

--- a/tests/ui/resolve/issue-82865.rs
+++ b/tests/ui/resolve/issue-82865.rs
@@ -2,7 +2,7 @@
 
 #![feature(decl_macro)]
 
-use x::y::z; //~ ERROR: failed to resolve: you might be missing crate `x`
+use x::y::z; //~ ERROR: failed to resolve: use of unresolved module or unlinked crate `x`
 
 macro mac () {
     Box::z //~ ERROR: no function or associated item

--- a/tests/ui/resolve/issue-82865.stderr
+++ b/tests/ui/resolve/issue-82865.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: you might be missing crate `x`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `x`
   --> $DIR/issue-82865.rs:5:5
    |
 LL | use x::y::z;
-   |     ^ you might be missing crate `x`
+   |     ^ use of unresolved module or unlinked crate `x`
    |
-help: consider importing the `x` crate
+help: you might be missing a crate named `x`, add it to your project and import it in your code
    |
 LL + extern crate x;
    |

--- a/tests/ui/resolve/resolve-bad-visibility.stderr
+++ b/tests/ui/resolve/resolve-bad-visibility.stderr
@@ -16,24 +16,24 @@ error[E0742]: visibilities can only be restricted to ancestor modules
 LL | pub(in std::vec) struct F;
    |        ^^^^^^^^
 
-error[E0433]: failed to resolve: you might be missing crate `nonexistent`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistent`
   --> $DIR/resolve-bad-visibility.rs:7:8
    |
 LL | pub(in nonexistent) struct G;
-   |        ^^^^^^^^^^^ you might be missing crate `nonexistent`
+   |        ^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistent`
    |
-help: consider importing the `nonexistent` crate
+help: you might be missing a crate named `nonexistent`, add it to your project and import it in your code
    |
 LL + extern crate nonexistent;
    |
 
-error[E0433]: failed to resolve: you might be missing crate `too_soon`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `too_soon`
   --> $DIR/resolve-bad-visibility.rs:8:8
    |
 LL | pub(in too_soon) struct H;
-   |        ^^^^^^^^ you might be missing crate `too_soon`
+   |        ^^^^^^^^ use of unresolved module or unlinked crate `too_soon`
    |
-help: consider importing the `too_soon` crate
+help: you might be missing a crate named `too_soon`, add it to your project and import it in your code
    |
 LL + extern crate too_soon;
    |

--- a/tests/ui/resolve/typo-suggestion-mistyped-in-path.rs
+++ b/tests/ui/resolve/typo-suggestion-mistyped-in-path.rs
@@ -29,8 +29,8 @@ fn main() {
     //~| NOTE use of undeclared type `Struc`
 
     modul::foo();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `modul`
-    //~| NOTE use of undeclared crate or module `modul`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `modul`
+    //~| NOTE use of unresolved module or unlinked crate `modul`
 
     module::Struc::foo();
     //~^ ERROR failed to resolve: could not find `Struc` in `module`

--- a/tests/ui/resolve/typo-suggestion-mistyped-in-path.stderr
+++ b/tests/ui/resolve/typo-suggestion-mistyped-in-path.stderr
@@ -30,11 +30,11 @@ LL |     Struc::foo();
    |     use of undeclared type `Struc`
    |     help: a struct with a similar name exists: `Struct`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `modul`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `modul`
   --> $DIR/typo-suggestion-mistyped-in-path.rs:31:5
    |
 LL |     modul::foo();
-   |     ^^^^^ use of undeclared crate or module `modul`
+   |     ^^^^^ use of unresolved module or unlinked crate `modul`
    |
 help: there is a crate or module with a similar name
    |

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/non-existent-1.stderr
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/non-existent-1.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `xcrate`
   --> $DIR/non-existent-1.rs:3:5
    |
 LL | use xcrate::S;
-   |     ^^^^^^ use of undeclared crate or module `xcrate`
+   |     ^^^^^^ use of unresolved module or unlinked crate `xcrate`
+   |
+   = help: you might be missing a crate named `xcrate`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rust-2018/unresolved-asterisk-imports.stderr
+++ b/tests/ui/rust-2018/unresolved-asterisk-imports.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `not_existing_crate`
   --> $DIR/unresolved-asterisk-imports.rs:3:5
    |
 LL | use not_existing_crate::*;
-   |     ^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `not_existing_crate`
+   |     ^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `not_existing_crate`
+   |
+   = help: you might be missing a crate named `not_existing_crate`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/crate-or-module-typo.rs
+++ b/tests/ui/suggestions/crate-or-module-typo.rs
@@ -1,6 +1,6 @@
 //@ edition:2018
 
-use st::cell::Cell; //~ ERROR failed to resolve: use of undeclared crate or module `st`
+use st::cell::Cell; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `st`
 
 mod bar {
     pub fn bar() { bar::baz(); } //~ ERROR failed to resolve: function `bar` is not a crate or module
@@ -11,7 +11,7 @@ mod bar {
 use bas::bar; //~ ERROR unresolved import `bas`
 
 struct Foo {
-    bar: st::cell::Cell<bool> //~ ERROR failed to resolve: use of undeclared crate or module `st`
+    bar: st::cell::Cell<bool> //~ ERROR failed to resolve: use of unresolved module or unlinked crate `st`
 }
 
 fn main() {}

--- a/tests/ui/suggestions/crate-or-module-typo.stderr
+++ b/tests/ui/suggestions/crate-or-module-typo.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `st`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `st`
   --> $DIR/crate-or-module-typo.rs:3:5
    |
 LL | use st::cell::Cell;
-   |     ^^ use of undeclared crate or module `st`
+   |     ^^ use of unresolved module or unlinked crate `st`
    |
 help: there is a crate or module with a similar name
    |
@@ -13,18 +13,18 @@ error[E0432]: unresolved import `bas`
   --> $DIR/crate-or-module-typo.rs:11:5
    |
 LL | use bas::bar;
-   |     ^^^ use of undeclared crate or module `bas`
+   |     ^^^ use of unresolved module or unlinked crate `bas`
    |
 help: there is a crate or module with a similar name
    |
 LL | use bar::bar;
    |     ~~~
 
-error[E0433]: failed to resolve: use of undeclared crate or module `st`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `st`
   --> $DIR/crate-or-module-typo.rs:14:10
    |
 LL |     bar: st::cell::Cell<bool>
-   |          ^^ use of undeclared crate or module `st`
+   |          ^^ use of unresolved module or unlinked crate `st`
    |
 help: there is a crate or module with a similar name
    |

--- a/tests/ui/suggestions/issue-112590-suggest-import.rs
+++ b/tests/ui/suggestions/issue-112590-suggest-import.rs
@@ -1,8 +1,8 @@
 pub struct S;
 
-impl fmt::Debug for S { //~ ERROR failed to resolve: use of undeclared crate or module `fmt`
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result { //~ ERROR failed to resolve: use of undeclared crate or module `fmt`
-        //~^ ERROR failed to resolve: use of undeclared crate or module `fmt`
+impl fmt::Debug for S { //~ ERROR failed to resolve: use of unresolved module or unlinked crate `fmt`
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result { //~ ERROR failed to resolve: use of unresolved module or unlinked crate `fmt`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `fmt`
         Ok(())
     }
 }

--- a/tests/ui/suggestions/issue-112590-suggest-import.stderr
+++ b/tests/ui/suggestions/issue-112590-suggest-import.stderr
@@ -1,31 +1,34 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `fmt`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fmt`
   --> $DIR/issue-112590-suggest-import.rs:3:6
    |
 LL | impl fmt::Debug for S {
-   |      ^^^ use of undeclared crate or module `fmt`
+   |      ^^^ use of unresolved module or unlinked crate `fmt`
    |
+   = help: you might be missing a crate named `fmt`
 help: consider importing this module
    |
 LL + use std::fmt;
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `fmt`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fmt`
   --> $DIR/issue-112590-suggest-import.rs:4:28
    |
 LL |     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-   |                            ^^^ use of undeclared crate or module `fmt`
+   |                            ^^^ use of unresolved module or unlinked crate `fmt`
    |
+   = help: you might be missing a crate named `fmt`
 help: consider importing this module
    |
 LL + use std::fmt;
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `fmt`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fmt`
   --> $DIR/issue-112590-suggest-import.rs:4:51
    |
 LL |     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-   |                                                   ^^^ use of undeclared crate or module `fmt`
+   |                                                   ^^^ use of unresolved module or unlinked crate `fmt`
    |
+   = help: you might be missing a crate named `fmt`
 help: consider importing this module
    |
 LL + use std::fmt;

--- a/tests/ui/suggestions/undeclared-module-alloc.rs
+++ b/tests/ui/suggestions/undeclared-module-alloc.rs
@@ -1,5 +1,5 @@
 //@ edition:2018
 
-use alloc::rc::Rc; //~ ERROR failed to resolve: use of undeclared crate or module `alloc`
+use alloc::rc::Rc; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `alloc`
 
 fn main() {}

--- a/tests/ui/suggestions/undeclared-module-alloc.stderr
+++ b/tests/ui/suggestions/undeclared-module-alloc.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `alloc`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `alloc`
   --> $DIR/undeclared-module-alloc.rs:3:5
    |
 LL | use alloc::rc::Rc;
-   |     ^^^^^ use of undeclared crate or module `alloc`
+   |     ^^^^^ use of unresolved module or unlinked crate `alloc`
    |
    = help: add `extern crate alloc` to use the `alloc` crate
 

--- a/tests/ui/target_modifiers/auxiliary/default_reg_struct_return.rs
+++ b/tests/ui/target_modifiers/auxiliary/default_reg_struct_return.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: --target i686-unknown-linux-gnu -Cpanic=abort
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![no_core]
+#![feature(no_core, lang_items, repr_simd)]
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}
+
+pub fn somefun() {}
+
+pub struct S;

--- a/tests/ui/target_modifiers/auxiliary/wrong_regparm.rs
+++ b/tests/ui/target_modifiers/auxiliary/wrong_regparm.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: --target i686-unknown-linux-gnu -Zregparm=2 -Cpanic=abort
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![no_core]
+#![feature(no_core, lang_items, repr_simd)]
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}
+
+pub fn somefun() {}
+
+pub struct S;

--- a/tests/ui/target_modifiers/auxiliary/wrong_regparm_and_ret.rs
+++ b/tests/ui/target_modifiers/auxiliary/wrong_regparm_and_ret.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: --target i686-unknown-linux-gnu -Zregparm=2 -Zreg-struct-return=true -Cpanic=abort
+//@ needs-llvm-components: x86
+#![crate_type = "lib"]
+#![no_core]
+#![feature(no_core, lang_items, repr_simd)]
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}
+
+pub fn somefun() {}
+
+pub struct S;

--- a/tests/ui/target_modifiers/defaults_check.error.stderr
+++ b/tests/ui/target_modifiers/defaults_check.error.stderr
@@ -1,0 +1,13 @@
+error: mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `defaults_check`
+  --> $DIR/defaults_check.rs:13:1
+   |
+LL | #![crate_type = "lib"]
+   | ^
+   |
+   = help: the `-Zreg-struct-return` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: `-Zreg-struct-return=true` in this crate is incompatible with `-Zreg-struct-return=` in dependency `default_reg_struct_return`
+   = help: set `-Zreg-struct-return=` in this crate or `-Zreg-struct-return=true` in `default_reg_struct_return`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=reg-struct-return` to silence this error
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/target_modifiers/defaults_check.rs
+++ b/tests/ui/target_modifiers/defaults_check.rs
@@ -1,0 +1,20 @@
+// Tests that default unspecified target modifier value in dependency crate is ok linked
+// with the same value, explicitly specified
+//@ aux-crate:default_reg_struct_return=default_reg_struct_return.rs
+//@ compile-flags: --target i686-unknown-linux-gnu -Cpanic=abort
+//@ revisions:error ok ok_explicit
+//@[ok] compile-flags:
+//@[ok_explicit] compile-flags: -Zreg-struct-return=false
+//@[error] compile-flags: -Zreg-struct-return=true
+//@ needs-llvm-components: x86
+//@[ok] build-pass
+//@[ok_explicit] build-pass
+
+#![crate_type = "lib"]
+//[error]~^ ERROR mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `defaults_check`
+#![no_core]
+#![feature(no_core, lang_items, repr_simd)]
+
+fn foo() {
+    default_reg_struct_return::somefun();
+}

--- a/tests/ui/target_modifiers/incompatible_regparm.allow_no_value.stderr
+++ b/tests/ui/target_modifiers/incompatible_regparm.allow_no_value.stderr
@@ -1,0 +1,2 @@
+error: codegen option `unsafe-allow-abi-mismatch` requires a comma-separated list of strings (C unsafe-allow-abi-mismatch=<value>)
+

--- a/tests/ui/target_modifiers/incompatible_regparm.error_generated.stderr
+++ b/tests/ui/target_modifiers/incompatible_regparm.error_generated.stderr
@@ -1,0 +1,13 @@
+error: mixing `-Zregparm` will cause an ABI mismatch in crate `incompatible_regparm`
+  --> $DIR/incompatible_regparm.rs:10:1
+   |
+LL | #![crate_type = "lib"]
+   | ^
+   |
+   = help: the `-Zregparm` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely
+   = note: `-Zregparm=1` in this crate is incompatible with `-Zregparm=2` in dependency `wrong_regparm`
+   = help: set `-Zregparm=2` in this crate or `-Zregparm=1` in `wrong_regparm`
+   = help: if you are sure this will not cause problems, you may use `-Cunsafe-allow-abi-mismatch=regparm` to silence this error
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/target_modifiers/incompatible_regparm.rs
+++ b/tests/ui/target_modifiers/incompatible_regparm.rs
@@ -1,0 +1,17 @@
+//@ aux-crate:wrong_regparm=wrong_regparm.rs
+//@ compile-flags: --target i686-unknown-linux-gnu -Zregparm=1 -Cpanic=abort
+//@ needs-llvm-components: x86
+//@ revisions:error_generated allow_regparm_mismatch allow_no_value
+
+//@[allow_regparm_mismatch] compile-flags: -Cunsafe-allow-abi-mismatch=regparm
+//@[allow_regparm_mismatch] build-pass
+//@[allow_no_value] compile-flags: -Cunsafe-allow-abi-mismatch
+
+#![crate_type = "lib"]
+//[error_generated]~^ ERROR mixing `-Zregparm` will cause an ABI mismatch in crate `incompatible_regparm`
+#![no_core]
+#![feature(no_core, lang_items, repr_simd)]
+
+fn foo() {
+    wrong_regparm::somefun();
+}

--- a/tests/ui/target_modifiers/two_flags.rs
+++ b/tests/ui/target_modifiers/two_flags.rs
@@ -1,0 +1,17 @@
+//@ aux-crate:wrong_regparm_and_ret=wrong_regparm_and_ret.rs
+//@ compile-flags: --target i686-unknown-linux-gnu -Cpanic=abort
+//@ needs-llvm-components: x86
+//@ revisions:two_allowed unknown_allowed
+
+//@[two_allowed] compile-flags: -Cunsafe-allow-abi-mismatch=regparm,reg-struct-return
+//@[two_allowed] build-pass
+//@[unknown_allowed] compile-flags: -Cunsafe-allow-abi-mismatch=unknown_flag -Zregparm=2 -Zreg-struct-return=true
+
+#![crate_type = "lib"]
+//[unknown_allowed]~^ ERROR unknown target modifier `unknown_flag`, requested by `-Cunsafe-allow-abi-mismatch=unknown_flag`
+#![no_core]
+#![feature(no_core, lang_items, repr_simd)]
+
+fn foo() {
+    wrong_regparm_and_ret::somefun();
+}

--- a/tests/ui/target_modifiers/two_flags.unknown_allowed.stderr
+++ b/tests/ui/target_modifiers/two_flags.unknown_allowed.stderr
@@ -1,0 +1,8 @@
+error: unknown target modifier `unknown_flag`, requested by `-Cunsafe-allow-abi-mismatch=unknown_flag`
+  --> $DIR/two_flags.rs:10:1
+   |
+LL | #![crate_type = "lib"]
+   | ^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/tool-attributes/unknown-tool-name.rs
+++ b/tests/ui/tool-attributes/unknown-tool-name.rs
@@ -1,2 +1,2 @@
-#[foo::bar] //~ ERROR failed to resolve: use of undeclared crate or module `foo`
+#[foo::bar] //~ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
 fn main() {}

--- a/tests/ui/tool-attributes/unknown-tool-name.stderr
+++ b/tests/ui/tool-attributes/unknown-tool-name.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/unknown-tool-name.rs:1:3
    |
 LL | #[foo::bar]
-   |   ^^^ use of undeclared crate or module `foo`
+   |   ^^^ use of unresolved module or unlinked crate `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-120856.rs
+++ b/tests/ui/typeck/issue-120856.rs
@@ -1,5 +1,5 @@
 pub type Archived<T> = <m::Alias as n::Trait>::Archived;
-//~^ ERROR failed to resolve: use of undeclared crate or module `m`
-//~| ERROR failed to resolve: use of undeclared crate or module `n`
+//~^ ERROR failed to resolve: use of unresolved module or unlinked crate `m`
+//~| ERROR failed to resolve: use of unresolved module or unlinked crate `n`
 
 fn main() {}

--- a/tests/ui/typeck/issue-120856.stderr
+++ b/tests/ui/typeck/issue-120856.stderr
@@ -1,20 +1,24 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `n`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `n`
   --> $DIR/issue-120856.rs:1:37
    |
 LL | pub type Archived<T> = <m::Alias as n::Trait>::Archived;
    |                                     ^
    |                                     |
-   |                                     use of undeclared crate or module `n`
+   |                                     use of unresolved module or unlinked crate `n`
    |                                     help: a trait with a similar name exists: `Fn`
+   |
+   = help: you might be missing a crate named `n`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `m`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `m`
   --> $DIR/issue-120856.rs:1:25
    |
 LL | pub type Archived<T> = <m::Alias as n::Trait>::Archived;
    |                         ^
    |                         |
-   |                         use of undeclared crate or module `m`
+   |                         use of unresolved module or unlinked crate `m`
    |                         help: a type parameter with a similar name exists: `T`
+   |
+   = help: you might be missing a crate named `m`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.cargo-invoked.stderr
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.cargo-invoked.stderr
@@ -1,0 +1,11 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `page_size`
+  --> $DIR/path-to-method-sugg-unresolved-expr.rs:5:21
+   |
+LL |     let page_size = page_size::get();
+   |                     ^^^^^^^^^ use of unresolved module or unlinked crate `page_size`
+   |
+   = help: if you wanted to use a crate named `page_size`, use `cargo add page_size` to add it to your `Cargo.toml`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.only-rustc.stderr
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.only-rustc.stderr
@@ -1,0 +1,11 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `page_size`
+  --> $DIR/path-to-method-sugg-unresolved-expr.rs:5:21
+   |
+LL |     let page_size = page_size::get();
+   |                     ^^^^^^^^^ use of unresolved module or unlinked crate `page_size`
+   |
+   = help: you might be missing a crate named `page_size`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.rs
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.rs
@@ -1,4 +1,10 @@
+//@ revisions: only-rustc cargo-invoked
+//@[only-rustc] unset-rustc-env:CARGO_CRATE_NAME
+//@[cargo-invoked] rustc-env:CARGO_CRATE_NAME=foo
 fn main() {
     let page_size = page_size::get();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `page_size`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `page_size`
+    //~| NOTE use of unresolved module or unlinked crate `page_size`
+    //@[cargo-invoked]~^^^ HELP if you wanted to use a crate named `page_size`, use `cargo add
+    //@[only-rustc]~^^^^ HELP you might be missing a crate named `page_size`
 }

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.stderr
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.stderr
@@ -1,9 +1,0 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `page_size`
-  --> $DIR/path-to-method-sugg-unresolved-expr.rs:2:21
-   |
-LL |     let page_size = page_size::get();
-   |                     ^^^^^^^^^ use of undeclared crate or module `page_size`
-
-error: aborting due to 1 previous error
-
-For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/unresolved/unresolved-asterisk-imports.stderr
+++ b/tests/ui/unresolved/unresolved-asterisk-imports.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `not_existing_crate`
   --> $DIR/unresolved-asterisk-imports.rs:1:5
    |
 LL | use not_existing_crate::*;
-   |     ^^^^^^^^^^^^^^^^^^ you might be missing crate `not_existing_crate`
+   |     ^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `not_existing_crate`
    |
-help: consider importing the `not_existing_crate` crate
+help: you might be missing a crate named `not_existing_crate`, add it to your project and import it in your code
    |
 LL + extern crate not_existing_crate;
    |

--- a/tests/ui/unresolved/unresolved-import.rs
+++ b/tests/ui/unresolved/unresolved-import.rs
@@ -1,7 +1,7 @@
 use foo::bar;
 //~^ ERROR unresolved import `foo` [E0432]
-//~| NOTE you might be missing crate `foo`
-//~| HELP consider importing the `foo` crate
+//~| NOTE use of unresolved module or unlinked crate `foo`
+//~| HELP you might be missing a crate named `foo`
 //~| SUGGESTION extern crate foo;
 
 use bar::Baz as x;

--- a/tests/ui/unresolved/unresolved-import.stderr
+++ b/tests/ui/unresolved/unresolved-import.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `foo`
   --> $DIR/unresolved-import.rs:1:5
    |
 LL | use foo::bar;
-   |     ^^^ you might be missing crate `foo`
+   |     ^^^ use of unresolved module or unlinked crate `foo`
    |
-help: consider importing the `foo` crate
+help: you might be missing a crate named `foo`, add it to your project and import it in your code
    |
 LL + extern crate foo;
    |


### PR DESCRIPTION
Successful merges:

 - #133138 (Target modifiers (special marked options) are recorded in metainfo)
 - #133154 (Reword resolve errors caused by likely missing crate in dep tree)
 - #135366 (Enable `unreachable_pub` lint in `test` and `proc_macro` crates)
 - #135638 (Make it possible to build GCC on CI)
 - #135648 (support wasm inline assembly in `naked_asm!`)
 - #135827 (CI: free disk with in-tree script instead of GitHub Action)
 - #135855 (Only assert the `Parser` size on specific arches)
 - #135878 (ci: use 8 core arm runner for dist-aarch64-linux)
 - #135905 (Enable kernel sanitizers for aarch64-unknown-none-softfloat)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=133138,133154,135366,135638,135648,135827,135855,135878,135905)
<!-- homu-ignore:end -->