### PR TITLE
Include missing item in the 1.81 release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -573,6 +573,7 @@ Libraries
 - [Replace sort implementations with stable `driftsort` and unstable `ipnsort`.](https://github.com/rust-lang/rust/pull/124032/) All `slice::sort*` and `slice::select_nth*` methods are expected to see significant performance improvements. See the [research project](https://github.com/Voultapher/sort-research-rs) for more details.
 - [Document behavior of `create_dir_all` with respect to empty paths.](https://github.com/rust-lang/rust/pull/125112/)
 - [Fix interleaved output in the default panic hook when multiple threads panic simultaneously.](https://github.com/rust-lang/rust/pull/127397/)
+- Fix `Command`'s batch files argument escaping not working when file name has trailing whitespace or periods (CVE-2024-43402).
 
 <a id="1.81.0-Stabilized-APIs"></a>
 


### PR DESCRIPTION
It was pointed out to me that when I prepared the CVE-2024-43402 fix in the stable branch, I added the release notes in the stable PR (https://github.com/rust-lang/rust/pull/129960), but I forgot to do so in the beta or nightly PR. Because of that, the relnotes line only appeared in 1.81, and disappeared afterwards.