### PR TITLE
fix reify-intrinsic test

### DIFF
--- a/tests/ui/intrinsics/reify-intrinsic.rs
+++ b/tests/ui/intrinsics/reify-intrinsic.rs
@@ -3,17 +3,17 @@
 #![feature(core_intrinsics, intrinsics)]
 
 fn a() {
-    let _: unsafe extern "rust-intrinsic" fn(isize) -> usize = std::mem::transmute;
+    let _: unsafe fn(isize) -> usize = std::mem::transmute;
     //~^ ERROR cannot coerce
 }
 
 fn b() {
-    let _ = std::mem::transmute as unsafe extern "rust-intrinsic" fn(isize) -> usize;
+    let _ = std::mem::transmute as unsafe fn(isize) -> usize;
     //~^ ERROR casting
 }
 
 fn c() {
-    let _: [unsafe extern "rust-intrinsic" fn(f32) -> f32; 2] = [
+    let _: [unsafe fn(f32) -> f32; 2] = [
         std::intrinsics::floorf32, //~ ERROR cannot coerce
         std::intrinsics::log2f32,
     ];

--- a/tests/ui/intrinsics/reify-intrinsic.stderr
+++ b/tests/ui/intrinsics/reify-intrinsic.stderr
@@ -1,19 +1,19 @@
 error[E0308]: cannot coerce intrinsics to function pointers
-  --> $DIR/reify-intrinsic.rs:6:64
+  --> $DIR/reify-intrinsic.rs:6:40
    |
-LL |     let _: unsafe extern "rust-intrinsic" fn(isize) -> usize = std::mem::transmute;
-   |            -------------------------------------------------   ^^^^^^^^^^^^^^^^^^^ cannot coerce intrinsics to function pointers
+LL |     let _: unsafe fn(isize) -> usize = std::mem::transmute;
+   |            -------------------------   ^^^^^^^^^^^^^^^^^^^ cannot coerce intrinsics to function pointers
    |            |
    |            expected due to this
    |
-   = note: expected fn pointer `unsafe extern "rust-intrinsic" fn(isize) -> usize`
+   = note: expected fn pointer `unsafe fn(isize) -> usize`
                  found fn item `unsafe fn(_) -> _ {std::intrinsics::transmute::<_, _>}`
 
-error[E0606]: casting `unsafe fn(_) -> _ {std::intrinsics::transmute::<_, _>}` as `unsafe extern "rust-intrinsic" fn(isize) -> usize` is invalid
+error[E0606]: casting `unsafe fn(_) -> _ {std::intrinsics::transmute::<_, _>}` as `unsafe fn(isize) -> usize` is invalid
   --> $DIR/reify-intrinsic.rs:11:13
    |
-LL |     let _ = std::mem::transmute as unsafe extern "rust-intrinsic" fn(isize) -> usize;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     let _ = std::mem::transmute as unsafe fn(isize) -> usize;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: cannot coerce intrinsics to function pointers
   --> $DIR/reify-intrinsic.rs:17:9
@@ -21,7 +21,7 @@ error[E0308]: cannot coerce intrinsics to function pointers
 LL |         std::intrinsics::floorf32,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot coerce intrinsics to function pointers
    |
-   = note: expected fn pointer `unsafe extern "rust-intrinsic" fn(_) -> _`
+   = note: expected fn pointer `unsafe fn(_) -> _`
                  found fn item `unsafe fn(_) -> _ {floorf32}`
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
These are no longer `extern "rust-intrinsic"` functions so it no longer makes sense to try to cast them to that type.

r? @oli-obk 