### PR TITLE
Remove extra whitespace from rustdoc breadcrumbs for copypasting

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -192,15 +192,12 @@ h1, h2, h3, h4 {
 .rustdoc-breadcrumbs {
 	grid-area: main-heading-breadcrumbs;
 	line-height: 1.25;
-	display: flex;
-	flex-wrap: wrap;
-	align-items: end;
 	padding-top: 5px;
+	position: relative;
+	z-index: 1;
 }
 .rustdoc-breadcrumbs a {
-	padding: 4px 0;
-	margin: -4px 0;
-	z-index: 1;
+	padding: 5px 0 7px;
 }
 /* The only headings that get underlines are:
 	 Markdown-generated headings within the top-doc

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -1,13 +1,13 @@
 <div class="main-heading">
     {% if !path_components.is_empty() %}
-    <span class="rustdoc-breadcrumbs">
+    <div class="rustdoc-breadcrumbs">
         {% for (i, component) in path_components.iter().enumerate() %}
             {% if i != 0 %}
                 ::<wbr>
             {% endif %}
             <a href="{{component.path|safe}}index.html">{{component.name}}</a>
         {% endfor %}
-    </span>
+    </div>
     {% endif %}
     <h1>
         {{typ}}


### PR DESCRIPTION
The docs header used to display [item names with their full path](https://doc.rust-lang.org/1.82.0/std/os/unix/ffi/trait.OsStrExt.html), but a [recent design change](https://doc.rust-lang.org/1.83.0/std/os/unix/ffi/trait.OsStrExt.html) has split the path and added extra styling to it.

The problem is the new styling affects how this text is copied to clipboard. I used to copy and paste the paths into `use` statements in the code, but the new styling has extra formatting and whitespace that makes copied text unusable in Rust source code.

Instead of:

>  std::os::unix::ffi::OsStrExt

I now get:

> std   
> ::   
> os   
> ::   
> unix   
> ::   
> ffi   
> Trait OsStrExt

This change removes extra whitespace from the markup, and removes `display: flex`. Paths (now in small text) are unlikely to be that long to wrap, and even then regular text wrapping should be sufficient.