### PR TITLE
Update emscripten std tests

### DIFF
--- a/library/alloc/benches/btree/map.rs
+++ b/library/alloc/benches/btree/map.rs
@@ -353,6 +353,7 @@ pub fn iter_10k(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg_attr(target_os = "emscripten", ignore)] // hits an OOM
 pub fn iter_1m(b: &mut Bencher) {
     bench_iter(b, 1_000, 1_000_000);
 }

--- a/library/alloc/benches/slice.rs
+++ b/library/alloc/benches/slice.rs
@@ -366,14 +366,25 @@ rotate!(rotate_medium_half, gen_random, 9158, 9158 / 2);
 rotate!(rotate_medium_half_plus_one, gen_random, 9158, 9158 / 2 + 1);
 
 // Intended to use more RAM than the machine has cache
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by1, gen_random, 5 * 1024 * 1024, 1);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by9199_u64, gen_random, 5 * 1024 * 1024, 9199);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by9199_bytes, gen_random_bytes, 5 * 1024 * 1024, 9199);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by9199_strings, gen_strings, 5 * 1024 * 1024, 9199);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by9199_big, gen_big_random, 5 * 1024 * 1024, 9199);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by1234577_u64, gen_random, 5 * 1024 * 1024, 1234577);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by1234577_bytes, gen_random_bytes, 5 * 1024 * 1024, 1234577);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by1234577_strings, gen_strings, 5 * 1024 * 1024, 1234577);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by1234577_big, gen_big_random, 5 * 1024 * 1024, 1234577);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_half, gen_random, 5 * 1024 * 1024, 5 * 1024 * 1024 / 2);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_half_plus_one, gen_random, 5 * 1024 * 1024, 5 * 1024 * 1024 / 2 + 1);

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -547,6 +547,11 @@ fn bench_in_place_collect_droppable(b: &mut Bencher) {
     })
 }
 
+// node.js gives out of memory error to use with length 1_100_000
+#[cfg(target_os = "emscripten")]
+const LEN: usize = 4096;
+
+#[cfg(not(target_os = "emscripten"))]
 const LEN: usize = 16384;
 
 #[bench]

--- a/library/alloc/tests/collections/binary_heap.rs
+++ b/library/alloc/tests/collections/binary_heap.rs
@@ -502,9 +502,7 @@ fn test_retain_catch_unwind() {
 // even if the order might not be correct.
 //
 // Destructors must be called exactly once per element.
-// FIXME: re-enable emscripten once it can unwind again
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn panic_safe() {
     use std::cmp;

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -93,9 +93,6 @@ fn test_rng() -> rand_xorshift::XorShiftRng {
     rand::SeedableRng::from_seed(seed)
 }
 
-// FIXME: Instantiated functions with i128 in the signature is not supported in Emscripten.
-// See https://github.com/kripken/emscripten-fastcomp/issues/169
-#[cfg(not(target_os = "emscripten"))]
 #[test]
 fn test_boxed_hasher() {
     let ordinary_hash = hash(&5u32);

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1414,7 +1414,6 @@ fn test_box_slice_clone() {
 
 #[test]
 #[allow(unused_must_use)] // here, we care about the side effects of `.clone()`
-#[cfg_attr(target_os = "emscripten", ignore)]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_box_slice_clone_panics() {
     use std::sync::Arc;

--- a/library/alloc/tests/sort/tests.rs
+++ b/library/alloc/tests/sort/tests.rs
@@ -11,7 +11,14 @@ use crate::sort::{Sort, known_good_stable_sort, patterns};
 #[cfg(miri)]
 const TEST_LENGTHS: &[usize] = &[2, 3, 4, 7, 10, 15, 20, 24, 33, 50, 100, 171, 300];
 
-#[cfg(not(miri))]
+// node.js gives out of memory error to use with length 1_100_000
+#[cfg(all(not(miri), target_os = "emscripten"))]
+const TEST_LENGTHS: &[usize] = &[
+    2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 20, 24, 30, 32, 33, 35, 50, 100, 200, 500, 1_000,
+    2_048, 5_000, 10_000, 100_000,
+];
+
+#[cfg(all(not(miri), not(target_os = "emscripten")))]
 const TEST_LENGTHS: &[usize] = &[
     2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 20, 24, 30, 32, 33, 35, 50, 100, 200, 500, 1_000,
     2_048, 5_000, 10_000, 100_000, 1_100_000,

--- a/library/alloc/tests/sync.rs
+++ b/library/alloc/tests/sync.rs
@@ -128,6 +128,7 @@ fn try_unwrap() {
 }
 
 #[test]
+#[cfg_attr(any(target_os = "emscripten", target_os = "wasi"), ignore)] // no threads
 fn into_inner() {
     for _ in 0..100
     // ^ Increase chances of hitting potential race conditions

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1587,9 +1587,7 @@ fn extract_if_complex() {
     }
 }
 
-// FIXME: re-enable emscripten once it can unwind again
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn extract_if_consumed_panic() {
     use std::rc::Rc;
@@ -1640,9 +1638,7 @@ fn extract_if_consumed_panic() {
     }
 }
 
-// FIXME: Re-enable emscripten once it can catch panics
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn extract_if_unconsumed_panic() {
     use std::rc::Rc;

--- a/library/core/tests/hash/mod.rs
+++ b/library/core/tests/hash/mod.rs
@@ -141,9 +141,6 @@ fn test_custom_state() {
     // const { assert!(hash(&Custom { hash: 6 }) == 6) };
 }
 
-// FIXME: Instantiated functions with i128 in the signature is not supported in Emscripten.
-// See https://github.com/kripken/emscripten-fastcomp/issues/169
-#[cfg(not(target_os = "emscripten"))]
 #[test]
 fn test_indirect_hasher() {
     let mut hasher = MyHasher { hash: 0 };

--- a/library/core/tests/num/flt2dec/random.rs
+++ b/library/core/tests/num/flt2dec/random.rs
@@ -84,9 +84,6 @@ where
     F: for<'a> FnMut(&Decoded, &'a mut [MaybeUninit<u8>]) -> Option<(&'a [u8], i16)>,
     G: for<'a> FnMut(&Decoded, &'a mut [MaybeUninit<u8>]) -> (&'a [u8], i16),
 {
-    if cfg!(target_os = "emscripten") {
-        return; // using rng pulls in i128 support, which doesn't work
-    }
     let mut rng = crate::test_rng();
     let f32_range = Uniform::new(0x0000_0001u32, 0x7f80_0000);
     iterate("f32_random_equivalence_test", k, n, f, g, |_| {
@@ -100,9 +97,6 @@ where
     F: for<'a> FnMut(&Decoded, &'a mut [MaybeUninit<u8>]) -> Option<(&'a [u8], i16)>,
     G: for<'a> FnMut(&Decoded, &'a mut [MaybeUninit<u8>]) -> (&'a [u8], i16),
 {
-    if cfg!(target_os = "emscripten") {
-        return; // using rng pulls in i128 support, which doesn't work
-    }
     let mut rng = crate::test_rng();
     let f64_range = Uniform::new(0x0000_0000_0000_0001u64, 0x7ff0_0000_0000_0000);
     iterate("f64_random_equivalence_test", k, n, f, g, |_| {

--- a/library/core/tests/num/ops.rs
+++ b/library/core/tests/num/ops.rs
@@ -51,9 +51,7 @@ macro_rules! test_op {
     };
 }
 
-test_op!(test_neg_defined, Neg::neg(0), 0, i8, i16, i32, i64, f32, f64);
-#[cfg(not(target_os = "emscripten"))]
-test_op!(test_neg_defined_128, Neg::neg(0), 0, i128);
+test_op!(test_neg_defined, Neg::neg(0), 0, i8, i16, i32, i64, i128, f32, f64);
 
 test_op!(test_not_defined_bool, Not::not(true), false, bool);
 
@@ -69,17 +67,17 @@ macro_rules! test_arith_op {
                 i16,
                 i32,
                 i64,
+                i128,
                 isize,
                 u8,
                 u16,
                 u32,
                 u64,
+                u128,
                 usize,
                 f32,
                 f64
             );
-            #[cfg(not(target_os = "emscripten"))]
-            impls_defined!($op, $method($lhs, $rhs), 0, i128, u128);
         }
     };
     ($fn_name:ident, $op:ident::$method:ident(&mut $lhs:literal, $rhs:literal)) => {
@@ -93,17 +91,17 @@ macro_rules! test_arith_op {
                 i16,
                 i32,
                 i64,
+                i128,
                 isize,
                 u8,
                 u16,
                 u32,
                 u64,
+                u128,
                 usize,
                 f32,
                 f64
             );
-            #[cfg(not(target_os = "emscripten"))]
-            impls_defined!($op, $method(&mut $lhs, $rhs), 0, i128, u128);
         }
     };
 }
@@ -131,15 +129,15 @@ macro_rules! test_bitop {
                 i16,
                 i32,
                 i64,
+                i128,
                 isize,
                 u8,
                 u16,
                 u32,
                 u64,
+                u128,
                 usize
             );
-            #[cfg(not(target_os = "emscripten"))]
-            impls_defined!($op, $method(0, 0), 0, i128, u128);
             impls_defined!($op, $method(false, false), false, bool);
         }
     };
@@ -156,15 +154,15 @@ macro_rules! test_bitop_assign {
                 i16,
                 i32,
                 i64,
+                i128,
                 isize,
                 u8,
                 u16,
                 u32,
                 u64,
+                u128,
                 usize
             );
-            #[cfg(not(target_os = "emscripten"))]
-            impls_defined!($op, $method(&mut 0, 0), 0, i128, u128);
             impls_defined!($op, $method(&mut false, false), false, bool);
         }
     };
@@ -182,9 +180,11 @@ macro_rules! test_shift_inner {
         $(impl_defined!($op, $method(0,0), 0, $lt, $rt);)+
     };
     ($op:ident::$method:ident, $lt:ty) => {
-        test_shift_inner!($op::$method, $lt, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
-        #[cfg(not(target_os = "emscripten"))]
-        test_shift_inner!($op::$method, $lt, i128, u128);
+        test_shift_inner!(
+            $op::$method, $lt,
+            i8, i16, i32, i64, i128, isize,
+            u8, u16, u32, u64, u128, usize
+        );
     };
 }
 
@@ -195,9 +195,11 @@ macro_rules! test_shift {
     ($test_name:ident, $op:ident::$method:ident) => {
         #[test]
         fn $test_name() {
-            test_shift!($op::$method, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
-            #[cfg(not(target_os = "emscripten"))]
-            test_shift!($op::$method, i128, u128);
+            test_shift!(
+                $op::$method,
+                i8, i16, i32, i64, i128, isize,
+                u8, u16, u32, u64, u128, usize
+            );
         }
     };
 }
@@ -207,9 +209,11 @@ macro_rules! test_shift_assign_inner {
         $(impl_defined!($op, $method(&mut 0,0), 0, $lt, $rt);)+
     };
     ($op:ident::$method:ident, $lt:ty) => {
-        test_shift_assign_inner!($op::$method, $lt, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
-        #[cfg(not(target_os = "emscripten"))]
-        test_shift_assign_inner!($op::$method, $lt, i128, u128);
+        test_shift_assign_inner!(
+            $op::$method, $lt,
+            i8, i16, i32, i64, i128, isize,
+            u8, u16, u32, u64, u128, usize
+        );
     };
 }
 
@@ -220,9 +224,11 @@ macro_rules! test_shift_assign {
     ($test_name:ident, $op:ident::$method:ident) => {
         #[test]
         fn $test_name() {
-            test_shift_assign!($op::$method, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
-            #[cfg(not(target_os = "emscripten"))]
-            test_shift_assign!($op::$method, i128, u128);
+            test_shift_assign!(
+                $op::$method,
+                i8, i16, i32, i64, i128, isize,
+                u8, u16, u32, u64, u128, usize
+            );
         }
     };
 }

--- a/library/core/tests/num/wrapping.rs
+++ b/library/core/tests/num/wrapping.rs
@@ -64,14 +64,12 @@ wrapping_test!(test_wrapping_i8, i8, i8::MIN, i8::MAX);
 wrapping_test!(test_wrapping_i16, i16, i16::MIN, i16::MAX);
 wrapping_test!(test_wrapping_i32, i32, i32::MIN, i32::MAX);
 wrapping_test!(test_wrapping_i64, i64, i64::MIN, i64::MAX);
-#[cfg(not(target_os = "emscripten"))]
 wrapping_test!(test_wrapping_i128, i128, i128::MIN, i128::MAX);
 wrapping_test!(test_wrapping_isize, isize, isize::MIN, isize::MAX);
 wrapping_test!(test_wrapping_u8, u8, u8::MIN, u8::MAX);
 wrapping_test!(test_wrapping_u16, u16, u16::MIN, u16::MAX);
 wrapping_test!(test_wrapping_u32, u32, u32::MIN, u32::MAX);
 wrapping_test!(test_wrapping_u64, u64, u64::MIN, u64::MAX);
-#[cfg(not(target_os = "emscripten"))]
 wrapping_test!(test_wrapping_u128, u128, u128::MIN, u128::MAX);
 wrapping_test!(test_wrapping_usize, usize, usize::MIN, usize::MAX);
 

--- a/library/std/src/f64/tests.rs
+++ b/library/std/src/f64/tests.rs
@@ -112,7 +112,6 @@ fn test_neg_zero() {
     assert_eq!(Fp::Zero, neg_zero.classify());
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn test_one() {
     let one: f64 = 1.0f64;
@@ -165,7 +164,6 @@ fn test_is_finite() {
     assert!((-109.2f64).is_finite());
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn test_is_normal() {
     let nan: f64 = f64::NAN;
@@ -183,7 +181,6 @@ fn test_is_normal() {
     assert!(!1e-308f64.is_normal());
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn test_classify() {
     let nan: f64 = f64::NAN;

--- a/library/std/src/io/copy/tests.rs
+++ b/library/std/src/io/copy/tests.rs
@@ -126,6 +126,7 @@ mod io_benches {
     use crate::io::prelude::*;
 
     #[bench]
+    #[cfg_attr(target_os = "emscripten", ignore)] // no /dev
     fn bench_copy_buf_reader(b: &mut Bencher) {
         let mut file_in = File::open("/dev/zero").expect("opening /dev/zero failed");
         // use dyn to avoid specializations unrelated to readbuf

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -7,7 +7,6 @@ use crate::mem::MaybeUninit;
 use crate::ops::Deref;
 
 #[test]
-#[cfg_attr(target_os = "emscripten", ignore)]
 fn read_until() {
     let mut buf = Cursor::new(&b"12"[..]);
     let mut v = Vec::new();
@@ -359,7 +358,6 @@ fn chain_zero_length_read_is_not_eof() {
 }
 
 #[bench]
-#[cfg_attr(target_os = "emscripten", ignore)]
 #[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_read_to_end(b: &mut test::Bencher) {
     b.iter(|| {

--- a/library/std/src/sys/alloc/wasm.rs
+++ b/library/std/src/sys/alloc/wasm.rs
@@ -1,6 +1,6 @@
 //! This is an implementation of a global allocator on wasm targets when
-//! emscripten is not in use. In that situation there's no actual runtime for us
-//! to lean on for allocation, so instead we provide our own!
+//! emscripten or wasi is not in use. In that situation there's no actual runtime
+//! for us to lean on for allocation, so instead we provide our own!
 //!
 //! The wasm instruction set has two instructions for getting the current
 //! amount of memory and growing the amount of memory. These instructions are the

--- a/library/std/src/sys/pal/wasi/mod.rs
+++ b/library/std/src/sys/pal/wasi/mod.rs
@@ -1,8 +1,7 @@
 //! System bindings for the wasm/web platform
 //!
 //! This module contains the facade (aka platform-specific) implementations of
-//! OS level functionality for wasm. Note that this wasm is *not* the emscripten
-//! wasm, so we have no runtime here.
+//! OS level functionality for wasm.
 //!
 //! This is all super highly experimental and not actually intended for
 //! wide/production use yet, it's still all in the experimental category. This

--- a/library/std/src/sys/pal/wasm/mod.rs
+++ b/library/std/src/sys/pal/wasm/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains the facade (aka platform-specific) implementations of
 //! OS level functionality for wasm. Note that this wasm is *not* the emscripten
-//! wasm, so we have no runtime here.
+//! or wasi wasm, so we have no runtime here.
 //!
 //! This is all super highly experimental and not actually intended for
 //! wide/production use yet, it's still all in the experimental category. This

--- a/library/std/tests/pipe_subprocess.rs
+++ b/library/std/tests/pipe_subprocess.rs
@@ -1,7 +1,7 @@
 #![feature(anonymous_pipe)]
 
 fn main() {
-    #[cfg(all(not(miri), any(unix, windows)))]
+    #[cfg(all(not(miri), any(unix, windows), not(target_os = "emscripten")))]
     {
         use std::io::{Read, pipe};
         use std::{env, process};

--- a/library/std/tests/process_spawning.rs
+++ b/library/std/tests/process_spawning.rs
@@ -5,7 +5,8 @@ use std::{env, fs, process, str};
 mod common;
 
 #[test]
-#[cfg_attr(any(miri, target_os = "wasi"), ignore)] // Process spawning not supported by Miri and wasi
+// Process spawning not supported by Miri, Emscripten and wasi
+#[cfg_attr(any(miri, target_os = "emscripten", target_os = "wasi"), ignore)]
 fn issue_15149() {
     // If we're the parent, copy our own binary to a new directory.
     let my_path = env::current_exe().unwrap();

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -133,9 +133,7 @@ fn ignored_tests_result_in_ignored() {
     assert_eq!(result, TrIgnored);
 }
 
-// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic() {
     fn f() -> Result<(), String> {
@@ -164,9 +162,7 @@ fn test_should_panic() {
     assert_eq!(result, TrOk);
 }
 
-// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_good_message() {
     fn f() -> Result<(), String> {
@@ -195,9 +191,7 @@ fn test_should_panic_good_message() {
     assert_eq!(result, TrOk);
 }
 
-// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_bad_message() {
     use crate::tests::TrFailedMsg;
@@ -231,9 +225,7 @@ fn test_should_panic_bad_message() {
     assert_eq!(result, TrFailedMsg(failed_msg.to_string()));
 }
 
-// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_non_string_message_type() {
     use std::any::TypeId;
@@ -272,9 +264,7 @@ fn test_should_panic_non_string_message_type() {
     assert_eq!(result, TrFailedMsg(failed_msg));
 }
 
-// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_but_succeeds() {
     let should_panic_variants = [ShouldPanic::Yes, ShouldPanic::YesWithMessage("error message")];

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md
@@ -118,7 +118,7 @@ This target is not extensively tested in CI for the rust-lang/rust repository. I
 can be tested locally, for example, with:
 
 ```sh
-./x.py test --target wasm32-unknown-emscripten --skip src/tools/linkchecker
+EMCC_CFLAGS="-s MAXIMUM_MEMORY=2GB" ./x.py test --target wasm32-unknown-emscripten --skip src/tools/linkchecker
 ```
 
 To run these tests, both `emcc` and `node` need to be in your `$PATH`. You can


### PR DESCRIPTION
This disables a bunch of emscripten tests that test things emscripten doesn't support and re-enables a whole bunch of tests which now work just fine on emscripten.

Tested with `EMCC_CFLAGS="-s MAXIMUM_MEMORY=2GB" ./x.py test library/ --target wasm32-unknown-emscripten`.