### PR TITLE
Use short type string in E0308 secondary span label

### DIFF
--- a/tests/ui/diagnostic-width/secondary-label-with-long-type.rs
+++ b/tests/ui/diagnostic-width/secondary-label-with-long-type.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: --diagnostic-width=100 -Zwrite-long-types-to-disk=yes
+//@ normalize-stderr: "long-type-\d+" -> "long-type-hash"
+type A = (i32, i32, i32, i32);
+type B = (A, A, A, A);
+type C = (B, B, B, B);
+type D = (C, C, C, C);
+
+fn foo(x: D) {
+    let () = x; //~ ERROR mismatched types
+    //~^ NOTE this expression has type `((...,
+    //~| NOTE expected `((...,
+    //~| NOTE expected tuple
+    //~| NOTE the full type name has been written to
+    //~| NOTE consider using `--verbose` to print the full type name to the console
+}
+
+fn main() {}

--- a/tests/ui/diagnostic-width/secondary-label-with-long-type.stderr
+++ b/tests/ui/diagnostic-width/secondary-label-with-long-type.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/secondary-label-with-long-type.rs:9:9
+   |
+LL |     let () = x;
+   |         ^^   - this expression has type `((..., ..., ..., ...), ..., ..., ...)`
+   |         |
+   |         expected `((..., ..., ..., ...), ..., ..., ...)`, found `()`
+   |
+   = note:  expected tuple `((..., ..., ..., ...), ..., ..., ...)`
+           found unit type `()`
+   = note: the full type name has been written to '$TEST_BUILD_DIR/diagnostic-width/secondary-label-with-long-type/secondary-label-with-long-type.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
We were previously printing the full type on the "this expression has type" label.

```
error[E0308]: mismatched types
  --> $DIR/secondary-label-with-long-type.rs:8:9
   |
LL |     let () = x;
   |         ^^   - this expression has type `((..., ..., ..., ...), ..., ..., ...)`
   |         |
   |         expected `((..., ..., ..., ...), ..., ..., ...)`, found `()`
   |
   = note:  expected tuple `((..., ..., ..., ...), ..., ..., ...)`
           found unit type `()`
   = note: the full type name has been written to '$TEST_BUILD_DIR/diagnostic-width/secondary-label-with-long-type/secondary-label-with-long-type.long-type-3987761834644699448.txt'
   = note: consider using `--verbose` to print the full type name to the console
```

Reported in a comment of #135919.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
