### PR TITLE
ci.py: check the return code in `run-local`

### DIFF
--- a/src/ci/github-actions/ci.py
+++ b/src/ci/github-actions/ci.py
@@ -249,7 +249,7 @@ def run_workflow_locally(job_data: Dict[str, Any], job_name: str, pr_jobs: bool)
     env = os.environ.copy()
     env.update(custom_env)
 
-    subprocess.run(args, env=env)
+    subprocess.run(args, env=env, check=True)
 
 
 def calculate_job_matrix(job_data: Dict[str, Any]):


### PR DESCRIPTION
If the run fails, it should report that and return a non-zero exit
status. The simplest way to do that is with `run(..., check=True)`,
which raises a `CalledProcessError`.
