### PR TITLE
ci: Remove the power to skip tests from opt-dist

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -84,8 +84,8 @@ envs:
     #   builds)
     # - not running `opt-dist`'s post-optimization smoke tests on the resulting toolchain
     #
-    # If you *want* these to happen however, temporarily uncomment it before triggering a try build.
-    DIST_TRY_BUILD: 1
+    # If you *want* these to happen however, temporarily comment it before triggering a try build.
+    # DIST_TRY_BUILD: 1
 
   auto:
     <<: *production

--- a/src/tools/opt-dist/src/environment.rs
+++ b/src/tools/opt-dist/src/environment.rs
@@ -15,8 +15,6 @@ pub struct Environment {
     artifact_dir: Utf8PathBuf,
     /// Path to the host LLVM used to compile LLVM in `src/llvm-project`.
     host_llvm_dir: Utf8PathBuf,
-    /// List of test paths that should be skipped when testing the optimized artifacts.
-    skipped_tests: Vec<String>,
     /// Arguments passed to `rustc-perf --cargo-config <value>` when running benchmarks.
     #[builder(default)]
     benchmark_cargo_config: Vec<String>,
@@ -92,10 +90,6 @@ impl Environment {
 
     pub fn supports_shared_llvm(&self) -> bool {
         self.shared_llvm
-    }
-
-    pub fn skipped_tests(&self) -> &[String] {
-        &self.skipped_tests
     }
 
     pub fn benchmark_cargo_config(&self) -> &[String] {

--- a/src/tools/opt-dist/src/tests.rs
+++ b/src/tools/opt-dist/src/tests.rs
@@ -89,7 +89,7 @@ llvm-config = "{llvm_config}"
     std::fs::write("config.toml", config_content)?;
 
     let x_py = env.checkout_path().join("x.py");
-    let mut args = vec![
+    let args = vec![
         env.python_binary(),
         x_py.as_str(),
         "test",
@@ -107,9 +107,6 @@ llvm-config = "{llvm_config}"
         "tests/ui",
         "tests/crashes",
     ];
-    for test_path in env.skipped_tests() {
-        args.extend(["--skip", test_path]);
-    }
     cmd(&args)
         .env("COMPILETEST_FORCE_STAGE0", "1")
         // Also run dist-only tests


### PR DESCRIPTION
This will probably take a bit of testing against the dist pipelines to make it pass.

r? @ghost

<!-- homu-ignore:start -->
<!-- homu-ignore:end -->

try-job: dist-aarch64-linux
try-job: dist-x86_64-linux
try-job: dist-x86_64-msvc