### PR TITLE
Fix 2/4 tests skipped by opt-dist

### DIFF
--- a/src/ci/docker/host-aarch64/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/host-aarch64/dist-aarch64-linux/Dockerfile
@@ -20,6 +20,7 @@ RUN yum upgrade -y && \
       gcc-c++ \
       git \
       glibc-devel \
+      glibc-static \
       libedit-devel \
       libstdc++-devel \
       make \

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -21,6 +21,8 @@ RUN yum upgrade -y && \
       git \
       glibc-devel.i686 \
       glibc-devel.x86_64 \
+      glibc-static.i686 \
+      glibc-static.x86_64 \
       libedit-devel \
       libstdc++-devel.i686 \
       libstdc++-devel.x86_64 \

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -86,7 +86,7 @@ envs:
     #   builds)
     # - not running `opt-dist`'s post-optimization smoke tests on the resulting toolchain
     #
-    # If you *want* these to happen however, temporarily uncomment it before triggering a try build.
+    # If you *want* these to happen however, temporarily comment it before triggering a try build.
     DIST_TRY_BUILD: 1
 
   auto:

--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -148,18 +148,15 @@ fn create_environment(args: Args) -> anyhow::Result<(Environment, Vec<String>)> 
 
             let is_aarch64 = target_triple.starts_with("aarch64");
 
-            let mut skip_tests = vec![
-                // Fails because of linker errors, as of June 2023.
-                "tests/ui/process/nofile-limit.rs".to_string(),
-            ];
-
-            if is_aarch64 {
-                skip_tests.extend([
+            let skip_tests = if is_aarch64 {
+                vec![
                     // Those tests fail only inside of Docker on aarch64, as of December 2024
                     "tests/ui/consts/promoted_running_out_of_memory_issue-130687.rs".to_string(),
                     "tests/ui/consts/large_const_alloc.rs".to_string(),
-                ]);
-            }
+                ]
+            } else {
+                vec![]
+            };
 
             let checkout_dir = Utf8PathBuf::from("/checkout");
             let env = EnvironmentBuilder::default()
@@ -191,10 +188,7 @@ fn create_environment(args: Args) -> anyhow::Result<(Environment, Vec<String>)> 
                 .build_dir(checkout_dir)
                 .shared_llvm(false)
                 .use_bolt(false)
-                .skipped_tests(vec![
-                    // Fails as of June 2023.
-                    "tests\\codegen\\vec-shrink-panik.rs".to_string(),
-                ])
+                .skipped_tests(vec![])
                 .build()?;
 
             (env, shared.build_args)


### PR DESCRIPTION
The linker errors were because this one test, strangely, wants itself compiled with `-Ctarget-features=+crt-static`, and yet it looks like the runner image is simply missing static libraries for libc and libm.

Eyeballing the output of
```
rustc +nightly --target=x86_64-pc-windows-msvc -O tests/codegen/vec-shrink-panik.rs --emit=llvm-ir
```
suggests that vec-shrink-panik should pass on Windows. And it's quite disturbing that such a test would have failed only on Windows to start with. Exactly why that was would require some advanced digging, but it looks clean now.