### PR TITLE
[AIX] Allow different sized load and store in `tests/assembly/powerpc64-struct-abi.rs`

### DIFF
--- a/tests/assembly/powerpc64-struct-abi.rs
+++ b/tests/assembly/powerpc64-struct-abi.rs
@@ -50,9 +50,9 @@ struct ThreeU8s(u8, u8, u8);
 
 // CHECK-LABEL: read_large
 // aix: lwz [[REG1:.*]], 16(4)
-// aix-NEXT: lxvd2x 0, 0, 4
+// aix-NEXT: lxv{{d2x|w4x}} 0, 0, 4
 // aix-NEXT: stw [[REG1]], 16(3)
-// aix-NEXT: stxvd2x 0, 0, 3
+// aix-NEXT: stxv{{d2x|w4x}} 0, 0, 3
 // be: lwz [[REG1:.*]], 16(4)
 // be-NEXT: stw [[REG1]], 16(3)
 // be-NEXT: ld [[REG2:.*]], 8(4)
@@ -118,8 +118,8 @@ extern "C" fn read_small(x: &ThreeU8s) -> ThreeU8s {
 // aix-NEXT: std 4, 56(1)
 // aix-NEXT: stw [[REG1]], 16(6)
 // aix-NEXT: addi [[REG2:.*]], 1, 48
-// aix-NEXT: lxvd2x 0, 0, [[REG2]]
-// aix-NEXT: stxvd2x 0, 0, 6
+// aix-NEXT: lxv{{d2x|w4x}} 0, 0, [[REG2]]
+// aix-NEXT: stxv{{d2x|w4x}} 0, 0, 6
 // elf: std 3, 0(6)
 // be-NEXT: rldicl [[REG1:.*]], 5, 32, 32
 // elf-NEXT: std 4, 8(6)


### PR DESCRIPTION
Sometimes in the llvm backend generates 2 different copy assembly sequence.

1. `lxvd2x` followed immediately by `stxvd2x` (Load VSX Vector 2 Dword, Store VSX Vector 2 Dword) is semantically equivalent to;
2. `lxvw4x` followed immediately by `stxvw4x` (Load VSX Vector 4 Word, Store VSX Vector 4 Word)