### PR TITLE
Don't drop types with no drop glue when building drops for tailcalls

### DIFF
--- a/src/tools/miri/tests/fail/tail_calls/dangling-local-var.stderr
+++ b/src/tools/miri/tests/fail/tail_calls/dangling-local-var.stderr
@@ -14,8 +14,8 @@ LL |     let local = 0;
 help: ALLOC was deallocated here:
   --> tests/fail/tail_calls/dangling-local-var.rs:LL:CC
    |
-LL | }
-   | ^
+LL |     become g(ptr)
+   |     ^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `g` at tests/fail/tail_calls/dangling-local-var.rs:LL:CC
 note: inside `main`

--- a/tests/crashes/128097.rs
+++ b/tests/crashes/128097.rs
@@ -1,6 +1,0 @@
-//@ known-bug: #128097
-#![feature(explicit_tail_calls)]
-fn f(x: &mut ()) {
-    let _y: String;
-    become f(x);
-}

--- a/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-abort.diff
@@ -66,7 +66,6 @@
       bb6: {
 +         _8 = const false;
           StorageDead(_4);
-          StorageDead(_3);
           drop(_2) -> [return: bb7, unwind: bb12];
       }
   

--- a/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f.ElaborateDrops.panic-unwind.diff
@@ -66,7 +66,6 @@
       bb6: {
 +         _8 = const false;
           StorageDead(_4);
-          StorageDead(_3);
 -         drop(_2) -> [return: bb7, unwind continue];
 +         drop(_2) -> [return: bb7, unwind: bb12];
       }

--- a/tests/mir-opt/tail_call_drops.f.built.after.panic-abort.mir
+++ b/tests/mir-opt/tail_call_drops.f.built.after.panic-abort.mir
@@ -63,7 +63,6 @@ fn f() -> () {
 
     bb6: {
         StorageDead(_4);
-        StorageDead(_3);
         drop(_2) -> [return: bb7, unwind: bb17];
     }
 

--- a/tests/mir-opt/tail_call_drops.f.built.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_call_drops.f.built.after.panic-unwind.mir
@@ -63,7 +63,6 @@ fn f() -> () {
 
     bb6: {
         StorageDead(_4);
-        StorageDead(_3);
         drop(_2) -> [return: bb7, unwind: bb17];
     }
 

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-abort.diff
@@ -80,7 +80,6 @@
       bb8: {
 +         _12 = const false;
           StorageDead(_6);
-          StorageDead(_5);
           drop(_4) -> [return: bb9, unwind: bb16];
       }
   

--- a/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.ElaborateDrops.panic-unwind.diff
@@ -80,7 +80,6 @@
       bb8: {
 +         _12 = const false;
           StorageDead(_6);
-          StorageDead(_5);
           drop(_4) -> [return: bb9, unwind: bb16];
       }
   

--- a/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-abort.mir
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-abort.mir
@@ -77,7 +77,6 @@ fn f_with_arg(_1: String, _2: String) -> () {
 
     bb8: {
         StorageDead(_6);
-        StorageDead(_5);
         drop(_4) -> [return: bb9, unwind: bb23];
     }
 

--- a/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-unwind.mir
+++ b/tests/mir-opt/tail_call_drops.f_with_arg.built.after.panic-unwind.mir
@@ -77,7 +77,6 @@ fn f_with_arg(_1: String, _2: String) -> () {
 
     bb8: {
         StorageDead(_6);
-        StorageDead(_5);
         drop(_4) -> [return: bb9, unwind: bb23];
     }
 

--- a/tests/ui/explicit-tail-calls/ctfe-arg-bad-borrow.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-arg-bad-borrow.stderr
@@ -4,10 +4,9 @@ error[E0597]: `local` does not live long enough
 LL |     let local = Type;
    |         ----- binding `local` declared here
 LL |     become takes_borrow(&local);
-   |                         ^^^^^^ borrowed value does not live long enough
-LL |
-LL | }
-   | - `local` dropped here while still borrowed
+   |                         ^^^^^^- `local` dropped here while still borrowed
+   |                         |
+   |                         borrowed value does not live long enough
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/explicit-tail-calls/two-phase.rs
+++ b/tests/ui/explicit-tail-calls/two-phase.rs
@@ -1,0 +1,14 @@
+// regression test for <https://github.com/rust-lang/rust/issues/112788>.
+// this test used to ICE because we tried to run drop glue of `x`
+// if dropping `_y` (happening at the `become` site) panicked and caused an unwind.
+//
+//@ check-pass
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+
+fn f(x: &mut ()) {
+    let _y = String::new();
+    become f(x);
+}
+
+fn main() {}


### PR DESCRIPTION
this is required as otherwise drops of `&mut` refs count as a usage of a
'two-phase temporary' causing an ICE.<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

fixes #128097

The underlying issue is that the current code generates drops for `&mut` which are later counted as a second use of a two-phase temporary:


`bat t.rs -p`
```rust
#![expect(incomplete_features)]
#![feature(explicit_tail_calls)]

fn f(x: &mut ()) {
    let _y = String::new();
    become f(x);
}

fn main() {}
```
`rustc t.rs -Zdump_mir=f`
```text
error: internal compiler error: compiler/rustc_borrowck/src/borrow_set.rs:298:17: found two uses for 2-phase borrow temporary _4: bb2[1] and bb3[0]
 --> t.rs:6:5
  |
6 |     become f(x);
  |     ^^^^^^^^^^^


thread 'rustc' panicked at compiler/rustc_borrowck/src/borrow_set.rs:298:17:
Box<dyn Any>
stack backtrace:
[REDACTED]

error: aborting due to 1 previous error
```
`bat ./mir_dump/t.f.-------.renumber.0.mir -p -lrust`
```rust
// MIR for `f` 0 renumber

fn f(_1: &mut ()) -> () {
    debug x => _1;
    let mut _0: ();
    let mut _2: !;
    let _3: std::string::String;
    let mut _4: &mut ();
    scope 1 {
        debug _y => _3;
    }

    bb0: {
        StorageLive(_3);
        _3 = String::new() -> [return: bb1, unwind: bb4];
    }

    bb1: {
        FakeRead(ForLet(None), _3);
        StorageLive(_4);
        _4 = &mut (*_1);
        drop(_3) -> [return: bb2, unwind: bb3];
    }

    bb2: {
        StorageDead(_3);
        tailcall f(Spanned { node: move _4, span: t.rs:6:14: 6:15 (#0) });
    }

    bb3 (cleanup): {
        drop(_4) -> [return: bb4, unwind terminate(cleanup)];
    }

    bb4 (cleanup): {
        resume;
    }
}
```

Note how `_4 is moved into the tail call in `bb2` and dropped in `bb3`.

This PR adds a check that the locals we drop need dropping.

r? @oli-obk (feel free to reassign, I'm not sure who would be a good reviewer, but thought you might have an idea)
cc @beepster4096, since you wrote the original drop implementation.