### PR TITLE
Fix `FormattingOptions` instantiation with `Default`

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -288,7 +288,7 @@ pub enum DebugAsHex {
 ///
 /// `FormattingOptions` is a [`Formatter`] without an attached [`Write`] trait.
 /// It is mainly used to construct `Formatter` instances.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[unstable(feature = "formatting_options", issue = "118117")]
 pub struct FormattingOptions {
     flags: u32,
@@ -505,6 +505,15 @@ impl FormattingOptions {
     /// Flags for formatting
     pub fn get_flags(&self) -> u32 {
         self.flags
+    }
+}
+
+#[unstable(feature = "formatting_options", issue = "118117")]
+impl Default for FormattingOptions {
+    /// Same as [`FormattingOptions::new()`].
+    fn default() -> Self {
+        // The `#[derive(Default)]` implementation would set `fill` to `\0` instead of space.
+        Self::new()
     }
 }
 

--- a/library/core/tests/fmt/mod.rs
+++ b/library/core/tests/fmt/mod.rs
@@ -52,6 +52,12 @@ fn test_maybe_uninit_short() {
 }
 
 #[test]
+fn formatting_options_ctor() {
+    use core::fmt::FormattingOptions;
+    assert_eq!(FormattingOptions::new(), FormattingOptions::default());
+}
+
+#[test]
 fn formatting_options_flags() {
     use core::fmt::*;
     for sign in [None, Some(Sign::Plus), Some(Sign::Minus)] {


### PR DESCRIPTION
The `fill` value by default should be set to `' '` (space), but the current implementation uses `#[derive(Default)]` which sets it to `\0`. 

Note that `FormattingOptions` is being released as part of 1.85 (unstable) - so this might warrant a backport to that branch.

Tracking issue: https://github.com/rust-lang/rust/issues/118117

Follow up from https://github.com/rust-lang/rust/pull/118159

CC: @EliasHolzmann @programmerjake

r? @m-ou-se 
