### PR TITLE
Add a workaround for parallel rustc crashing when there are delayed bugs

### DIFF
--- a/tests/ui/parallel-rustc/cycle_crash.rs
+++ b/tests/ui/parallel-rustc/cycle_crash.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -Z threads=2
+
+const FOO: usize = FOO; //~ERROR cycle detected when simplifying constant for the type system `FOO`
+
+fn main() {}

--- a/tests/ui/parallel-rustc/cycle_crash.stderr
+++ b/tests/ui/parallel-rustc/cycle_crash.stderr
@@ -1,0 +1,18 @@
+error[E0391]: cycle detected when simplifying constant for the type system `FOO`
+  --> $DIR/cycle_crash.rs:3:1
+   |
+LL | const FOO: usize = FOO;
+   | ^^^^^^^^^^^^^^^^
+   |
+note: ...which requires const-evaluating + checking `FOO`...
+  --> $DIR/cycle_crash.rs:3:20
+   |
+LL | const FOO: usize = FOO;
+   |                    ^^^
+   = note: ...which again requires simplifying constant for the type system `FOO`, completing the cycle
+   = note: cycle used when running analysis passes on this crate
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
This doesn't fix the root cause of this crash, but at least stops it from happening for the time being.

Workaround for https://github.com/rust-lang/rust/issues/135870