### PR TITLE
Fix set_name in thread mod for NuttX

### DIFF
--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -130,7 +130,12 @@ impl Thread {
         }
     }
 
-    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "nuttx"
+    ))]
     pub fn set_name(name: &CStr) {
         unsafe {
             cfg_if::cfg_if! {
@@ -139,7 +144,7 @@ impl Thread {
                     const TASK_COMM_LEN: usize = 16;
                     let name = truncate_cstr::<{ TASK_COMM_LEN }>(name);
                 } else {
-                    // FreeBSD and DragonFly BSD do not enforce length limits.
+                    // FreeBSD, DragonFly, FreeBSD and NuttX do not enforce length limits.
                 }
             };
             // Available since glibc 2.12, musl 1.1.16, and uClibc 1.0.20 for Linux,
@@ -150,7 +155,7 @@ impl Thread {
         }
     }
 
-    #[cfg(any(target_os = "openbsd", target_os = "nuttx"))]
+    #[cfg(target_os = "openbsd")]
     pub fn set_name(name: &CStr) {
         unsafe {
             libc::pthread_set_name_np(libc::pthread_self(), name.as_ptr());


### PR DESCRIPTION
Replace `pthread_set_name_np` with `pthread_setname_np` for NuttX in the `set_name` function, this change aligns the implementation with the correct API available on NuttX

This patch ensures thread naming works correctly on NuttX platforms.

See also:
https://github.com/rust-lang/libc/blob/0f9f8c91adb0365c0d13b34ec27ac8019818cf1f/src/unix/nuttx/mod.rs#L562
https://github.com/apache/nuttx/blob/8f3a2a6f7645dd95b6a7608b9cde3cb693b118c2/include/pthread.h#L511-L514

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
