### PR TITLE
Document powf and powi values that are always 1.0 (f128)

### DIFF
--- a/library/std/src/f128.rs
+++ b/library/std/src/f128.rs
@@ -324,6 +324,16 @@ impl f128 {
     ///
     /// The precision of this function is non-deterministic. This means it varies by platform,
     /// Rust version, and can even differ within the same execution from one invocation to the next.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let x = 2.0_f128;
+    /// let abs_difference = (x.powi(2) - (x * x)).abs();
+    /// assert!(abs_difference < f128::EPSILON);
+    ///
+    /// assert_eq!(f128::powi(f128::NAN, 0), 1.0);
+    /// ```
     #[inline]
     #[rustc_allow_incoherent_impl]
     #[unstable(feature = "f128", issue = "116909")]
@@ -347,8 +357,10 @@ impl f128 {
     ///
     /// let x = 2.0_f128;
     /// let abs_difference = (x.powf(2.0) - (x * x)).abs();
-    ///
     /// assert!(abs_difference <= f128::EPSILON);
+    ///
+    /// assert_eq!(f128::powf(1.0, f128::NAN), 1.0)
+    /// assert_eq!(f128::powf(f128::NAN, 0.0), 1.0)
     /// # }
     /// ```
     #[inline]

--- a/library/std/src/f128.rs
+++ b/library/std/src/f128.rs
@@ -328,6 +328,8 @@ impl f128 {
     /// # Examples
     ///
     /// ```
+    /// #![feature(f128)]
+    ///
     /// let x = 2.0_f128;
     /// let abs_difference = (x.powi(2) - (x * x)).abs();
     /// assert!(abs_difference < f128::EPSILON);

--- a/library/std/src/f128.rs
+++ b/library/std/src/f128.rs
@@ -359,8 +359,8 @@ impl f128 {
     /// let abs_difference = (x.powf(2.0) - (x * x)).abs();
     /// assert!(abs_difference <= f128::EPSILON);
     ///
-    /// assert_eq!(f128::powf(1.0, f128::NAN), 1.0)
-    /// assert_eq!(f128::powf(f128::NAN, 0.0), 1.0)
+    /// assert_eq!(f128::powf(1.0, f128::NAN), 1.0);
+    /// assert_eq!(f128::powf(f128::NAN, 0.0), 1.0);
     /// # }
     /// ```
     #[inline]


### PR DESCRIPTION
f128 part for bug #90429

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
