### PR TITLE
Skip suggestions in `derive`d code

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -185,6 +185,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         rhs_ty: Ty<'tcx>,
         can_satisfy: impl FnOnce(Ty<'tcx>, Ty<'tcx>) -> bool,
     ) -> bool {
+        if lhs_expr.span.in_derive_expansion() || rhs_expr.span.in_derive_expansion() {
+            return false;
+        }
         let Some((_, lhs_output_ty, lhs_inputs)) = self.extract_callable_info(lhs_ty) else {
             return false;
         };

--- a/tests/ui/deriving/do-not-suggest-calling-fn-in-derive-macro.rs
+++ b/tests/ui/deriving/do-not-suggest-calling-fn-in-derive-macro.rs
@@ -1,0 +1,8 @@
+use std::rc::Rc;
+
+#[derive(PartialEq)] //~ NOTE in this expansion
+pub struct Function {
+    callback: Rc<dyn Fn()>, //~ ERROR binary operation `==` cannot be applied to type `Rc<dyn Fn()>`
+}
+
+fn main() {}

--- a/tests/ui/deriving/do-not-suggest-calling-fn-in-derive-macro.stderr
+++ b/tests/ui/deriving/do-not-suggest-calling-fn-in-derive-macro.stderr
@@ -1,0 +1,14 @@
+error[E0369]: binary operation `==` cannot be applied to type `Rc<dyn Fn()>`
+  --> $DIR/do-not-suggest-calling-fn-in-derive-macro.rs:5:5
+   |
+LL | #[derive(PartialEq)]
+   |          --------- in this derive macro expansion
+LL | pub struct Function {
+LL |     callback: Rc<dyn Fn()>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0369`.


### PR DESCRIPTION
Do not suggest

```
help: use parentheses to call these
  |
5 |     (callback: Rc<dyn Fn()>)(),
  |     +                      +++
```

Skip all "call function for this binop" suggestions when in a derive context.

Fix #135989.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
