### PR TITLE
Account for mutable borrow in argument suggestion

### DIFF
--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1789,7 +1789,7 @@ pub(crate) struct UnusedAssign {
 pub(crate) struct UnusedAssignSuggestion {
     pub pre: &'static str,
     #[suggestion_part(code = "{pre}mut ")]
-    pub ty_span: Span,
+    pub ty_span: Option<Span>,
     #[suggestion_part(code = "")]
     pub ty_ref_span: Span,
     #[suggestion_part(code = "*")]

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.fixed
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.fixed
@@ -1,17 +1,26 @@
 //@ run-rustfix
 #![deny(unused_assignments, unused_variables)]
+#![allow(unused_mut)]
 struct Object;
 
 fn change_object(object: &mut Object) { //~ HELP you might have meant to mutate
-    let object2 = Object;
-    *object = object2; //~ ERROR mismatched types
+   let object2 = Object;
+   *object = object2; //~ ERROR mismatched types
 }
 
 fn change_object2(object: &mut Object) { //~ ERROR variable `object` is assigned to, but never used
+   //~^ HELP you might have meant to mutate
+   let object2 = Object;
+   *object = object2;
+   //~^ ERROR `object2` does not live long enough
+   //~| ERROR value assigned to `object` is never read
+}
+
+fn change_object3(object: &mut Object) { //~ ERROR variable `object` is assigned to, but never used
     //~^ HELP you might have meant to mutate
-    let object2 = Object;
+    let mut object2 = Object; //~ HELP consider changing this to be mutable
     *object = object2;
-    //~^ ERROR `object2` does not live long enough
+    //~^ ERROR cannot borrow `object2` as mutable
     //~| ERROR value assigned to `object` is never read
 }
 
@@ -19,4 +28,5 @@ fn main() {
     let mut object = Object;
     change_object(&mut object);
     change_object2(&mut object);
+    change_object3(&mut object);
 }

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs
@@ -1,17 +1,26 @@
 //@ run-rustfix
 #![deny(unused_assignments, unused_variables)]
+#![allow(unused_mut)]
 struct Object;
 
 fn change_object(mut object: &Object) { //~ HELP you might have meant to mutate
-    let object2 = Object;
-    object = object2; //~ ERROR mismatched types
+   let object2 = Object;
+   object = object2; //~ ERROR mismatched types
 }
 
 fn change_object2(mut object: &Object) { //~ ERROR variable `object` is assigned to, but never used
+   //~^ HELP you might have meant to mutate
+   let object2 = Object;
+   object = &object2;
+   //~^ ERROR `object2` does not live long enough
+   //~| ERROR value assigned to `object` is never read
+}
+
+fn change_object3(mut object: &mut Object) { //~ ERROR variable `object` is assigned to, but never used
     //~^ HELP you might have meant to mutate
-    let object2 = Object;
-    object = &object2;
-    //~^ ERROR `object2` does not live long enough
+    let object2 = Object; //~ HELP consider changing this to be mutable
+    object = &mut object2;
+    //~^ ERROR cannot borrow `object2` as mutable
     //~| ERROR value assigned to `object` is never read
 }
 
@@ -19,4 +28,5 @@ fn main() {
     let mut object = Object;
     change_object(&mut object);
     change_object2(&mut object);
+    change_object3(&mut object);
 }

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
@@ -1,24 +1,24 @@
 error[E0308]: mismatched types
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:7:14
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:8:13
    |
 LL | fn change_object(mut object: &Object) {
    |                              ------- expected due to this parameter type
-LL |     let object2 = Object;
-LL |     object = object2;
-   |              ^^^^^^^ expected `&Object`, found `Object`
+LL |    let object2 = Object;
+LL |    object = object2;
+   |             ^^^^^^^ expected `&Object`, found `Object`
    |
 help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
    |
 LL ~ fn change_object(object: &mut Object) {
-LL |     let object2 = Object;
-LL ~     *object = object2;
+LL |    let object2 = Object;
+LL ~    *object = object2;
    |
 
 error: value assigned to `object` is never read
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:13:5
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:14:4
    |
-LL |     object = &object2;
-   |     ^^^^^^
+LL |    object = &object2;
+   |    ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:2:9
@@ -29,12 +29,12 @@ help: you might have meant to mutate the pointed at value being passed in, inste
    |
 LL ~ fn change_object2(object: &mut Object) {
 LL |
-LL |     let object2 = Object;
-LL ~     *object = object2;
+LL |    let object2 = Object;
+LL ~    *object = object2;
    |
 
 error: variable `object` is assigned to, but never used
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:10:23
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:11:23
    |
 LL | fn change_object2(mut object: &Object) {
    |                       ^^^^^^
@@ -47,23 +47,56 @@ LL | #![deny(unused_assignments, unused_variables)]
    |                             ^^^^^^^^^^^^^^^^
 
 error[E0597]: `object2` does not live long enough
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:13:14
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:14:13
    |
 LL | fn change_object2(mut object: &Object) {
    |                               - let's call the lifetime of this reference `'1`
 LL |
-LL |     let object2 = Object;
-   |         ------- binding `object2` declared here
-LL |     object = &object2;
-   |     ---------^^^^^^^^
-   |     |        |
-   |     |        borrowed value does not live long enough
-   |     assignment requires that `object2` is borrowed for `'1`
+LL |    let object2 = Object;
+   |        ------- binding `object2` declared here
+LL |    object = &object2;
+   |    ---------^^^^^^^^
+   |    |        |
+   |    |        borrowed value does not live long enough
+   |    assignment requires that `object2` is borrowed for `'1`
 ...
 LL | }
    | - `object2` dropped here while still borrowed
 
-error: aborting due to 4 previous errors
+error: value assigned to `object` is never read
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:22:5
+   |
+LL |     object = &mut object2;
+   |     ^^^^^^
+   |
+help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
+   |
+LL ~ fn change_object3(object: &mut Object) {
+LL |
+LL |     let object2 = Object;
+LL ~     *object = object2;
+   |
 
-Some errors have detailed explanations: E0308, E0597.
+error: variable `object` is assigned to, but never used
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:19:23
+   |
+LL | fn change_object3(mut object: &mut Object) {
+   |                       ^^^^^^
+   |
+   = note: consider using `_object` instead
+
+error[E0596]: cannot borrow `object2` as mutable, as it is not declared as mutable
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:22:14
+   |
+LL |     object = &mut object2;
+   |              ^^^^^^^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut object2 = Object;
+   |         +++
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0308, E0596, E0597.
 For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
```
error: value assigned to `object` is never read
  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:21:5
   |
LL |     object = &mut object2;
   |     ^^^^^^
   |
help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
   |
LL ~ fn change_object3(object: &mut Object) {
LL |
LL |     let object2 = Object;
LL ~     *object = object2;
   |
```
instead of
```
error: value assigned to `object` is never read
  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:21:5
   |
LL |     object = &mut object2;
   |     ^^^^^^
   |
help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
   |
LL ~ fn change_object3(object: &mut mut Object) {
LL |
LL |     let object2 = Object;
LL ~     *object = object2;
   |
```

Fix #136028.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
