### PR TITLE
Remove `opt_item_ident`

### DIFF
--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -600,7 +600,7 @@ pub(crate) enum PtrNullChecksDiag<'a> {
         label: Span,
     },
     #[diag(lint_ptr_null_checks_fn_ret)]
-    FnRet { fn_name: Ident },
+    FnRet { fn_name: Symbol },
 }
 
 // for_loops_over_fallibles.rs

--- a/compiler/rustc_lint/src/ptr_nulls.rs
+++ b/compiler/rustc_lint/src/ptr_nulls.rs
@@ -48,14 +48,14 @@ fn incorrect_check<'a, 'tcx: 'a>(
         if let ExprKind::MethodCall(_, _expr, [], _) = e.kind
             && let Some(def_id) = cx.typeck_results().type_dependent_def_id(e.hir_id)
             && cx.tcx.has_attr(def_id, sym::rustc_never_returns_null_ptr)
-            && let Some(fn_name) = cx.tcx.opt_item_ident(def_id)
+            && let Some(fn_name) = cx.tcx.opt_item_name(def_id)
         {
             return Some(PtrNullChecksDiag::FnRet { fn_name });
         } else if let ExprKind::Call(path, _args) = e.kind
             && let ExprKind::Path(ref qpath) = path.kind
             && let Some(def_id) = cx.qpath_res(qpath, path.hir_id).opt_def_id()
             && cx.tcx.has_attr(def_id, sym::rustc_never_returns_null_ptr)
-            && let Some(fn_name) = cx.tcx.opt_item_ident(def_id)
+            && let Some(fn_name) = cx.tcx.opt_item_name(def_id)
         {
             return Some(PtrNullChecksDiag::FnRet { fn_name });
         }

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -999,8 +999,8 @@ impl<'a> CrateMetadataRef<'a> {
         self.opt_item_name(item_index).expect("no encoded ident for item")
     }
 
-    fn opt_item_ident(self, item_index: DefIndex, sess: &Session) -> Option<Ident> {
-        let name = self.opt_item_name(item_index)?;
+    fn item_ident(self, item_index: DefIndex, sess: &Session) -> Ident {
+        let name = self.opt_item_name(item_index).expect("no encoded ident for item");
         let span = self
             .root
             .tables
@@ -1008,11 +1008,7 @@ impl<'a> CrateMetadataRef<'a> {
             .get(self, item_index)
             .unwrap_or_else(|| self.missing("def_ident_span", item_index))
             .decode((self, sess));
-        Some(Ident::new(name, span))
-    }
-
-    fn item_ident(self, item_index: DefIndex, sess: &Session) -> Ident {
-        self.opt_item_ident(item_index, sess).expect("no encoded ident for item")
+        Ident::new(name, span)
     }
 
     #[inline]

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1585,17 +1585,6 @@ impl<'tcx> TyCtxt<'tcx> {
         })
     }
 
-    /// Look up the name and span of a definition.
-    ///
-    /// See [`item_name`][Self::item_name] for more information.
-    pub fn opt_item_ident(self, def_id: DefId) -> Option<Ident> {
-        let def = self.opt_item_name(def_id)?;
-        let span = self
-            .def_ident_span(def_id)
-            .unwrap_or_else(|| bug!("missing ident span for {def_id:?}"));
-        Some(Ident::new(def, span))
-    }
-
     pub fn opt_associated_item(self, def_id: DefId) -> Option<AssocItem> {
         if let DefKind::AssocConst | DefKind::AssocFn | DefKind::AssocTy = self.def_kind(def_id) {
             Some(self.associated_item(def_id))

--- a/src/tools/clippy/clippy_lints/src/error_impl_error.rs
+++ b/src/tools/clippy/clippy_lints/src/error_impl_error.rs
@@ -56,8 +56,7 @@ impl<'tcx> LateLintPass<'tcx> for ErrorImplError {
                     && let Some(error_def_id) = cx.tcx.get_diagnostic_item(sym::Error)
                     && error_def_id == trait_def_id
                     && let Some(def_id) = path_res(cx, imp.self_ty).opt_def_id().and_then(DefId::as_local)
-                    && let Some(ident) = cx.tcx.opt_item_ident(def_id.to_def_id())
-                    && ident.name == sym::Error
+                    && let Some(sym::Error) = cx.tcx.opt_item_name(def_id.to_def_id())
                     && is_visible_outside_module(cx, def_id) =>
             {
                 span_lint_hir_and_then(


### PR DESCRIPTION
The only usages in diagnostics can be replaced by `opt_item_name` or `def_ident_span`.