### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -974,6 +974,3 @@ lint_use_let_underscore_ignore_suggestion = use `let _ = ...` to ignore the expr
 
 lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest
-
-lint_wasm_c_abi =
-    older versions of the `wasm-bindgen` crate will be incompatible with future versions of Rust; please update to `wasm-bindgen` v0.2.88

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -430,7 +430,6 @@ pub(super) fn decorate_lint(
         BuiltinLintDiag::UnusedCrateDependency { extern_crate, local_crate } => {
             lints::UnusedCrateDependency { extern_crate, local_crate }.decorate_lint(diag)
         }
-        BuiltinLintDiag::WasmCAbi => lints::WasmCAbi.decorate_lint(diag),
         BuiltinLintDiag::IllFormedAttributeInput { suggestions } => {
             lints::IllFormedAttributeInput {
                 num_suggestions: suggestions.len(),

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2562,10 +2562,6 @@ pub(crate) struct UnusedCrateDependency {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(lint_wasm_c_abi)]
-pub(crate) struct WasmCAbi;
-
-#[derive(LintDiagnostic)]
 #[diag(lint_ill_formed_attribute_input)]
 pub(crate) struct IllFormedAttributeInput {
     pub num_suggestions: usize,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -143,7 +143,6 @@ declare_lint_pass! {
         UNUSED_VARIABLES,
         USELESS_DEPRECATED,
         WARNINGS,
-        WASM_C_ABI,
         // tidy-alphabetical-end
     ]
 }
@@ -4645,44 +4644,6 @@ declare_lint! {
         reason: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps,
         reference: "issue #120192 <https://github.com/rust-lang/rust/issues/120192>",
     };
-}
-
-declare_lint! {
-    /// The `wasm_c_abi` lint detects crate dependencies that are incompatible
-    /// with future versions of Rust that will emit spec-compliant C ABI.
-    ///
-    /// ### Example
-    ///
-    /// ```rust,ignore (needs extern crate)
-    /// #![deny(wasm_c_abi)]
-    /// ```
-    ///
-    /// This will produce:
-    ///
-    /// ```text
-    /// error: the following packages contain code that will be rejected by a future version of Rust: wasm-bindgen v0.2.87
-    ///   |
-    /// note: the lint level is defined here
-    ///  --> src/lib.rs:1:9
-    ///   |
-    /// 1 | #![deny(wasm_c_abi)]
-    ///   |         ^^^^^^^^^^
-    /// ```
-    ///
-    /// ### Explanation
-    ///
-    /// Rust has historically emitted non-spec-compliant C ABI. This has caused
-    /// incompatibilities between other compilers and Wasm targets. In a future
-    /// version of Rust this will be fixed and therefore dependencies relying
-    /// on the non-spec-compliant C ABI will stop functioning.
-    pub WASM_C_ABI,
-    Deny,
-    "detects dependencies that are incompatible with the Wasm C ABI",
-    @future_incompatible = FutureIncompatibleInfo {
-        reason: FutureIncompatibilityReason::FutureReleaseErrorReportInDeps,
-        reference: "issue #71871 <https://github.com/rust-lang/rust/issues/71871>",
-    };
-    crate_level_only
 }
 
 declare_lint! {

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -783,7 +783,6 @@ pub enum BuiltinLintDiag {
         extern_crate: Symbol,
         local_crate: Symbol,
     },
-    WasmCAbi,
     IllFormedAttributeInput {
         suggestions: Vec<String>,
     },

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -290,6 +290,9 @@ metadata_unsupported_abi =
 metadata_unsupported_abi_i686 =
     ABI not supported by `#[link(kind = "raw-dylib")]` on i686
 
+metadata_wasm_c_abi =
+    older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
+
 metadata_wasm_import_form =
     wasm import module must be of the form `wasm_import_module = "string"`
 

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -1076,12 +1076,7 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
             // Make a point span rather than covering the whole file
             let span = krate.spans.inner_span.shrink_to_lo();
 
-            self.sess.psess.buffer_lint(
-                lint::builtin::WASM_C_ABI,
-                span,
-                ast::CRATE_NODE_ID,
-                BuiltinLintDiag::WasmCAbi,
-            );
+            self.sess.dcx().emit_err(errors::WasmCAbi { span });
         }
     }
 

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -732,3 +732,10 @@ pub struct ImportNameTypeRaw {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(metadata_wasm_c_abi)]
+pub(crate) struct WasmCAbi {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -581,9 +581,11 @@ impl<'tcx> TerminatorKind<'tcx> {
 pub enum TerminatorEdges<'mir, 'tcx> {
     /// For terminators that have no successor, like `return`.
     None,
-    /// For terminators that a single successor, like `goto`, and `assert` without cleanup block.
+    /// For terminators that have a single successor, like `goto`, and `assert` without a cleanup
+    /// block.
     Single(BasicBlock),
-    /// For terminators that two successors, `assert` with cleanup block and `falseEdge`.
+    /// For terminators that have two successors, like `assert` with a cleanup block, and
+    /// `falseEdge`.
     Double(BasicBlock, BasicBlock),
     /// Special action for `Yield`, `Call` and `InlineAsm` terminators.
     AssignOnReturn {

--- a/compiler/rustc_target/src/spec/base/nto_qnx.rs
+++ b/compiler/rustc_target/src/spec/base/nto_qnx.rs
@@ -1,4 +1,6 @@
-use crate::spec::{RelroLevel, TargetOptions, cvs};
+use crate::spec::{
+    Cc, LinkArgs, LinkerFlavor, Lld, RelroLevel, Target, TargetMetadata, TargetOptions, cvs,
+};
 
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
@@ -15,4 +17,97 @@ pub(crate) fn opts() -> TargetOptions {
         relro_level: RelroLevel::Full,
         ..Default::default()
     }
+}
+
+pub(crate) fn meta() -> TargetMetadata {
+    TargetMetadata { description: None, tier: Some(3), host_tools: Some(false), std: Some(true) }
+}
+
+pub(crate) fn aarch64() -> Target {
+    Target {
+        llvm_target: "aarch64-unknown-unknown".into(),
+        metadata: meta(),
+        pointer_width: 64,
+        // from: https://llvm.org/docs/LangRef.html#data-layout
+        // e         = little endian
+        // m:e       = ELF mangling: Private symbols get a .L prefix
+        // i8:8:32   = 8-bit-integer, minimum_alignment=8, preferred_alignment=32
+        // i16:16:32 = 16-bit-integer, minimum_alignment=16, preferred_alignment=32
+        // i64:64    = 64-bit-integer, minimum_alignment=64, preferred_alignment=64
+        // i128:128  = 128-bit-integer, minimum_alignment=128, preferred_alignment=128
+        // n32:64    = 32 and 64 are native integer widths; Elements of this set are considered to support most general arithmetic operations efficiently.
+        // S128      = 128 bits are the natural alignment of the stack in bits.
+        data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
+        arch: "aarch64".into(),
+        options: TargetOptions {
+            features: "+v8a".into(),
+            max_atomic_width: Some(128),
+            ..opts()
+        }
+    }
+}
+
+pub(crate) fn x86_64() -> Target {
+    Target {
+        llvm_target: "x86_64-pc-unknown".into(),
+        metadata: meta(),
+        pointer_width: 64,
+        data_layout:
+            "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128".into(),
+        arch: "x86_64".into(),
+        options: TargetOptions {
+            cpu: "x86-64".into(),
+            plt_by_default: false,
+            max_atomic_width: Some(64),
+            vendor: "pc".into(),
+            ..opts()
+        },
+    }
+}
+
+pub(crate) fn pre_link_args(api_var: ApiVariant, arch: Arch) -> LinkArgs {
+    let (qcc_arg, arch_lib_dir) = match arch {
+        Arch::Aarch64 => ("-Vgcc_ntoaarch64le_cxx", "aarch64le"),
+        Arch::I586 => {
+            ("-Vgcc_ntox86_cxx", "notSupportedByQnx_compiler/rustc_target/src/spec/base/nto_qnx.rs")
+        }
+        Arch::X86_64 => ("-Vgcc_ntox86_64_cxx", "x86_64"),
+    };
+    match api_var {
+        ApiVariant::Default => {
+            TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[qcc_arg])
+        }
+        ApiVariant::IoSock => TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
+            qcc_arg,
+            get_iosock_param(arch_lib_dir),
+        ]),
+    }
+}
+
+pub(crate) enum ApiVariant {
+    Default,
+    IoSock,
+}
+
+pub(crate) enum Arch {
+    Aarch64,
+    I586,
+    X86_64,
+}
+
+// When using `io-sock` on QNX, we must add a search path for the linker so
+// that it prefers the io-sock version.
+// The path depends on the host, i.e. we cannot hard-code it here, but have
+// to determine it when the compiler runs.
+// When using the QNX toolchain, the environment variable QNX_TARGET is always set.
+// More information:
+// https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.io_sock/topic/migrate_app.html
+fn get_iosock_param(arch_lib_dir: &str) -> &'static str {
+    let target_dir = std::env::var("QNX_TARGET")
+        .unwrap_or_else(|_| "QNX_TARGET_not_set_please_source_qnxsdp-env.sh".into());
+    let linker_param = format!("-L{target_dir}/{arch_lib_dir}/io-sock/lib");
+
+    // FIXME: leaking this is kind of weird: we're feeding these into something that expects an
+    // `AsRef<OsStr>`, but often converts to `OsString` anyways, so shouldn't we just demand an `OsString`?
+    linker_param.leak()
 }

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1965,6 +1965,7 @@ supported_targets! {
     ("aarch64-unknown-nto-qnx710", aarch64_unknown_nto_qnx710),
     ("aarch64-unknown-nto-qnx710_iosock", aarch64_unknown_nto_qnx710_iosock),
     ("x86_64-pc-nto-qnx710", x86_64_pc_nto_qnx710),
+    ("x86_64-pc-nto-qnx710_iosock", x86_64_pc_nto_qnx710_iosock),
     ("i586-pc-nto-qnx700", i586_pc_nto_qnx700),
 
     ("aarch64-unknown-linux-ohos", aarch64_unknown_linux_ohos),

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1964,8 +1964,10 @@ supported_targets! {
     ("aarch64-unknown-nto-qnx700", aarch64_unknown_nto_qnx700),
     ("aarch64-unknown-nto-qnx710", aarch64_unknown_nto_qnx710),
     ("aarch64-unknown-nto-qnx710_iosock", aarch64_unknown_nto_qnx710_iosock),
+    ("aarch64-unknown-nto-qnx800", aarch64_unknown_nto_qnx800),
     ("x86_64-pc-nto-qnx710", x86_64_pc_nto_qnx710),
     ("x86_64-pc-nto-qnx710_iosock", x86_64_pc_nto_qnx710_iosock),
+    ("x86_64-pc-nto-qnx800", x86_64_pc_nto_qnx800),
     ("i586-pc-nto-qnx700", i586_pc_nto_qnx700),
 
     ("aarch64-unknown-linux-ohos", aarch64_unknown_linux_ohos),

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1963,6 +1963,7 @@ supported_targets! {
 
     ("aarch64-unknown-nto-qnx700", aarch64_unknown_nto_qnx700),
     ("aarch64-unknown-nto-qnx710", aarch64_unknown_nto_qnx710),
+    ("aarch64-unknown-nto-qnx710_iosock", aarch64_unknown_nto_qnx710_iosock),
     ("x86_64-pc-nto-qnx710", x86_64_pc_nto_qnx710),
     ("i586-pc-nto-qnx700", i586_pc_nto_qnx700),
 

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx700.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx700.rs
@@ -1,37 +1,11 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, Target, TargetOptions, base};
+use crate::spec::Target;
+use crate::spec::base::nto_qnx;
 
 pub(crate) fn target() -> Target {
-    // In QNX, libc does not provide a compatible ABI between versions.
-    // To distinguish between QNX versions, we needed a stable conditional compilation switch,
-    // which is why we needed to implement different targets in the compiler.
-    Target {
-        llvm_target: "aarch64-unknown-unknown".into(),
-        metadata: crate::spec::TargetMetadata {
-            description: Some("ARM64 QNX Neutrino 7.0 RTOS".into()),
-            tier: Some(3),
-            host_tools: Some(false),
-            std: Some(true),
-        },
-        pointer_width: 64,
-        // from: https://llvm.org/docs/LangRef.html#data-layout
-        // e         = little endian
-        // m:e       = ELF mangling: Private symbols get a .L prefix
-        // i8:8:32   = 8-bit-integer, minimum_alignment=8, preferred_alignment=32
-        // i16:16:32 = 16-bit-integer, minimum_alignment=16, preferred_alignment=32
-        // i64:64    = 64-bit-integer, minimum_alignment=64, preferred_alignment=64
-        // i128:128  = 128-bit-integer, minimum_alignment=128, preferred_alignment=128
-        // n32:64    = 32 and 64 are native integer widths; Elements of this set are considered to support most general arithmetic operations efficiently.
-        // S128      = 128 bits are the natural alignment of the stack in bits.
-        data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
-        arch: "aarch64".into(),
-        options: TargetOptions {
-            features: "+v8a".into(),
-            max_atomic_width: Some(128),
-            pre_link_args: TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
-                "-Vgcc_ntoaarch64le_cxx",
-            ]),
-            env: "nto70".into(),
-            ..base::nto_qnx::opts()
-        },
-    }
+    let mut target = nto_qnx::aarch64();
+    target.metadata.description = Some("ARM64 QNX Neutrino 7.0 RTOS".into());
+    target.options.pre_link_args =
+        nto_qnx::pre_link_args(nto_qnx::ApiVariant::Default, nto_qnx::Arch::Aarch64);
+    target.options.env = "nto70".into();
+    target
 }

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx710.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx710.rs
@@ -1,8 +1,12 @@
 use crate::spec::Target;
+use crate::spec::base::nto_qnx;
 
 pub(crate) fn target() -> Target {
-    let mut base = super::aarch64_unknown_nto_qnx700::target();
-    base.metadata.description = Some("ARM64 QNX Neutrino 7.1 RTOS".into());
-    base.options.env = "nto71".into();
-    base
+    let mut target = nto_qnx::aarch64();
+    target.metadata.description =
+        Some("ARM64 QNX Neutrino 7.1 RTOS with io-pkt network stack".into());
+    target.options.pre_link_args =
+        nto_qnx::pre_link_args(nto_qnx::ApiVariant::Default, nto_qnx::Arch::Aarch64);
+    target.options.env = "nto71".into();
+    target
 }

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx710_iosock.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx710_iosock.rs
@@ -1,0 +1,27 @@
+use crate::spec::{Cc, LinkerFlavor, Lld, Target, TargetOptions};
+
+pub(crate) fn target() -> Target {
+    let mut target = super::aarch64_unknown_nto_qnx710::target();
+    target.options.env = "nto71_iosock".into();
+    target.options.pre_link_args =
+        TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
+            "-Vgcc_ntoaarch64le_cxx",
+            get_iosock_param(),
+        ]);
+    target
+}
+
+// When using `io-sock` on QNX, we must add a search path for the linker so
+// that it prefers the io-sock version.
+// The path depends on the host, i.e. we cannot hard-code it here, but have
+// to determine it when the compiler runs.
+// When using the QNX toolchain, the environment variable QNX_TARGET is always set.
+// More information:
+// https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.io_sock/topic/migrate_app.html
+fn get_iosock_param() -> &'static str {
+    let target_dir =
+        std::env::var("QNX_TARGET").unwrap_or_else(|_| "PLEASE_SET_ENV_VAR_QNX_TARGET".into());
+    let linker_param = format!("-L{target_dir}/aarch64le/io-sock/lib");
+
+    linker_param.leak()
+}

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx710_iosock.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx710_iosock.rs
@@ -1,27 +1,12 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, Target, TargetOptions};
+use crate::spec::Target;
+use crate::spec::base::nto_qnx;
 
 pub(crate) fn target() -> Target {
-    let mut target = super::aarch64_unknown_nto_qnx710::target();
-    target.options.env = "nto71_iosock".into();
+    let mut target = nto_qnx::aarch64();
+    target.metadata.description =
+        Some("ARM64 QNX Neutrino 7.1 RTOS with io-sock network stack".into());
     target.options.pre_link_args =
-        TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
-            "-Vgcc_ntoaarch64le_cxx",
-            get_iosock_param(),
-        ]);
+        nto_qnx::pre_link_args(nto_qnx::ApiVariant::IoSock, nto_qnx::Arch::Aarch64);
+    target.options.env = "nto71_iosock".into();
     target
-}
-
-// When using `io-sock` on QNX, we must add a search path for the linker so
-// that it prefers the io-sock version.
-// The path depends on the host, i.e. we cannot hard-code it here, but have
-// to determine it when the compiler runs.
-// When using the QNX toolchain, the environment variable QNX_TARGET is always set.
-// More information:
-// https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.io_sock/topic/migrate_app.html
-fn get_iosock_param() -> &'static str {
-    let target_dir =
-        std::env::var("QNX_TARGET").unwrap_or_else(|_| "PLEASE_SET_ENV_VAR_QNX_TARGET".into());
-    let linker_param = format!("-L{target_dir}/aarch64le/io-sock/lib");
-
-    linker_param.leak()
 }

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx800.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_nto_qnx800.rs
@@ -1,0 +1,11 @@
+use crate::spec::Target;
+use crate::spec::base::nto_qnx;
+
+pub(crate) fn target() -> Target {
+    let mut target = nto_qnx::aarch64();
+    target.metadata.description = Some("ARM64 QNX Neutrino 8.0 RTOS".into());
+    target.options.pre_link_args =
+        nto_qnx::pre_link_args(nto_qnx::ApiVariant::Default, nto_qnx::Arch::Aarch64);
+    target.options.env = "nto80".into();
+    target
+}

--- a/compiler/rustc_target/src/spec/targets/i586_pc_nto_qnx700.rs
+++ b/compiler/rustc_target/src/spec/targets/i586_pc_nto_qnx700.rs
@@ -1,14 +1,13 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target, TargetOptions, base};
+use crate::spec::base::nto_qnx;
+use crate::spec::{StackProbeType, Target, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
+    let mut meta = nto_qnx::meta();
+    meta.description = Some("32-bit x86 QNX Neutrino 7.0 RTOS".into());
+    meta.std = Some(false);
     Target {
         llvm_target: "i586-pc-unknown".into(),
-        metadata: crate::spec::TargetMetadata {
-            description: Some("32-bit x86 QNX Neutrino 7.0 RTOS".into()),
-            tier: Some(3),
-            host_tools: Some(false),
-            std: Some(false),
-        },
+        metadata: meta,
         pointer_width: 32,
         data_layout: "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-\
             i128:128-f64:32:64-f80:32-n8:16:32-S128"
@@ -17,9 +16,10 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             cpu: "pentium4".into(),
             max_atomic_width: Some(64),
-            pre_link_args: TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
-                "-Vgcc_ntox86_cxx",
-            ]),
+            pre_link_args: nto_qnx::pre_link_args(
+                nto_qnx::ApiVariant::Default,
+                nto_qnx::Arch::I586,
+            ),
             env: "nto70".into(),
             vendor: "pc".into(),
             stack_probes: StackProbeType::Inline,

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710.rs
@@ -1,28 +1,12 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, Target, TargetOptions, base};
+use crate::spec::Target;
+use crate::spec::base::nto_qnx;
 
 pub(crate) fn target() -> Target {
-    Target {
-        llvm_target: "x86_64-pc-unknown".into(),
-        metadata: crate::spec::TargetMetadata {
-            description: Some("x86 64-bit QNX Neutrino 7.1 RTOS".into()),
-            tier: Some(3),
-            host_tools: Some(false),
-            std: Some(true),
-        },
-        pointer_width: 64,
-        data_layout:
-            "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128".into(),
-        arch: "x86_64".into(),
-        options: TargetOptions {
-            cpu: "x86-64".into(),
-            plt_by_default: false,
-            max_atomic_width: Some(64),
-            pre_link_args: TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
-                "-Vgcc_ntox86_64_cxx",
-            ]),
-            env: "nto71".into(),
-            vendor: "pc".into(),
-            ..base::nto_qnx::opts()
-        },
-    }
+    let mut target = nto_qnx::x86_64();
+    target.metadata.description =
+        Some("x86 64-bit QNX Neutrino 7.1 RTOS with io-pkt network stack".into());
+    target.options.pre_link_args =
+        nto_qnx::pre_link_args(nto_qnx::ApiVariant::Default, nto_qnx::Arch::X86_64);
+    target.options.env = "nto71".into();
+    target
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710_iosock.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710_iosock.rs
@@ -1,27 +1,12 @@
-use crate::spec::{Cc, LinkerFlavor, Lld, Target, TargetOptions};
+use crate::spec::Target;
+use crate::spec::base::nto_qnx;
 
 pub(crate) fn target() -> Target {
-    let mut target = super::x86_64_pc_nto_qnx710::target();
-    target.options.env = "nto71_iosock".into();
+    let mut target = nto_qnx::x86_64();
+    target.metadata.description =
+        Some("x86 64-bit QNX Neutrino 7.1 RTOS with io-sock network stack".into());
     target.options.pre_link_args =
-        TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
-            "-Vgcc_ntox86_64_cxx",
-            get_iosock_param(),
-        ]);
+        nto_qnx::pre_link_args(nto_qnx::ApiVariant::IoSock, nto_qnx::Arch::X86_64);
+    target.options.env = "nto71_iosock".into();
     target
-}
-
-// When using `io-sock` on QNX, we must add a search path for the linker so
-// that it prefers the io-sock version.
-// The path depends on the host, i.e. we cannot hard-code it here, but have
-// to determine it when the compiler runs.
-// When using the QNX toolchain, the environment variable QNX_TARGET is always set.
-// More information:
-// https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.io_sock/topic/migrate_app.html
-fn get_iosock_param() -> &'static str {
-    let target_dir =
-        std::env::var("QNX_TARGET").unwrap_or_else(|_| "PLEASE_SET_ENV_VAR_QNX_TARGET".into());
-    let linker_param = format!("-L{target_dir}/x86_64/io-sock/lib");
-
-    linker_param.leak()
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710_iosock.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710_iosock.rs
@@ -1,0 +1,27 @@
+use crate::spec::{Cc, LinkerFlavor, Lld, Target, TargetOptions};
+
+pub(crate) fn target() -> Target {
+    let mut target = super::x86_64_pc_nto_qnx710::target();
+    target.options.env = "nto71_iosock".into();
+    target.options.pre_link_args =
+        TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
+            "-Vgcc_ntox86_64_cxx",
+            get_iosock_param(),
+        ]);
+    target
+}
+
+// When using `io-sock` on QNX, we must add a search path for the linker so
+// that it prefers the io-sock version.
+// The path depends on the host, i.e. we cannot hard-code it here, but have
+// to determine it when the compiler runs.
+// When using the QNX toolchain, the environment variable QNX_TARGET is always set.
+// More information:
+// https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.io_sock/topic/migrate_app.html
+fn get_iosock_param() -> &'static str {
+    let target_dir =
+        std::env::var("QNX_TARGET").unwrap_or_else(|_| "PLEASE_SET_ENV_VAR_QNX_TARGET".into());
+    let linker_param = format!("-L{target_dir}/x86_64/io-sock/lib");
+
+    linker_param.leak()
+}

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx800.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx800.rs
@@ -1,0 +1,11 @@
+use crate::spec::Target;
+use crate::spec::base::nto_qnx;
+
+pub(crate) fn target() -> Target {
+    let mut target = nto_qnx::x86_64();
+    target.metadata.description = Some("x86 64-bit QNX Neutrino 8.0 RTOS".into());
+    target.options.pre_link_args =
+        nto_qnx::pre_link_args(nto_qnx::ApiVariant::Default, nto_qnx::Arch::X86_64);
+    target.options.env = "nto80".into();
+    target
+}

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -139,7 +139,8 @@ test = true
 level = "warn"
 check-cfg = [
     'cfg(bootstrap)',
-    'cfg(target_arch, values("xtensa"))',
+    'cfg(target_arch, values("xtensa", "aarch64-unknown-nto-qnx710_iosock"))',
+    'cfg(target_env, values("nto71_iosock"))',
     # std use #[path] imports to portable-simd `std_float` crate
     # and to the `backtrace` crate which messes-up with Cargo list
     # of declared features, we therefor expect any feature cfg

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -139,8 +139,8 @@ test = true
 level = "warn"
 check-cfg = [
     'cfg(bootstrap)',
-    'cfg(target_arch, values("xtensa", "aarch64-unknown-nto-qnx710_iosock", "x86_64-pc-nto-qnx710_iosock"))',
-    'cfg(target_env, values("nto71_iosock"))',
+    'cfg(target_arch, values("xtensa", "aarch64-unknown-nto-qnx710_iosock", "x86_64-pc-nto-qnx710_iosock", "x86_64-pc-nto-qnx800","aarch64-unknown-nto-qnx800"))',
+    'cfg(target_env, values("nto71_iosock", "nto80"))',
     # std use #[path] imports to portable-simd `std_float` crate
     # and to the `backtrace` crate which messes-up with Cargo list
     # of declared features, we therefor expect any feature cfg

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -139,7 +139,7 @@ test = true
 level = "warn"
 check-cfg = [
     'cfg(bootstrap)',
-    'cfg(target_arch, values("xtensa", "aarch64-unknown-nto-qnx710_iosock"))',
+    'cfg(target_arch, values("xtensa", "aarch64-unknown-nto-qnx710_iosock", "x86_64-pc-nto-qnx710_iosock"))',
     'cfg(target_env, values("nto71_iosock"))',
     # std use #[path] imports to portable-simd `std_float` crate
     # and to the `backtrace` crate which messes-up with Cargo list

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -310,6 +310,8 @@ pub use self::error::RawOsError;
 pub use self::error::SimpleMessage;
 #[unstable(feature = "io_const_error", issue = "133448")]
 pub use self::error::const_error;
+#[unstable(feature = "anonymous_pipe", issue = "127154")]
+pub use self::pipe::{PipeReader, PipeWriter, pipe};
 #[stable(feature = "is_terminal", since = "1.70.0")]
 pub use self::stdio::IsTerminal;
 pub(crate) use self::stdio::attempt_print_to_stderr;
@@ -330,7 +332,6 @@ pub use self::{
 };
 use crate::mem::take;
 use crate::ops::{Deref, DerefMut};
-use crate::sys::anonymous_pipe::{AnonPipe, pipe as pipe_inner};
 use crate::{cmp, fmt, slice, str, sys};
 
 mod buffered;
@@ -338,6 +339,7 @@ pub(crate) mod copy;
 mod cursor;
 mod error;
 mod impls;
+mod pipe;
 pub mod prelude;
 mod stdio;
 mod util;
@@ -3249,253 +3251,5 @@ impl<B: BufRead> Iterator for Lines<B> {
             }
             Err(e) => Some(Err(e)),
         }
-    }
-}
-
-/// Create anonymous pipe that is close-on-exec and blocking.
-///
-/// # Behavior
-///
-/// A pipe is a synchronous, unidirectional data channel between two or more processes, like an
-/// interprocess [`mpsc`](crate::sync::mpsc) provided by the OS. In particular:
-///
-/// * A read on a [`PipeReader`] blocks until the pipe is non-empty.
-/// * A write on a [`PipeWriter`] blocks when the pipe is full.
-/// * When all copies of a [`PipeWriter`] are closed, a read on the corresponding [`PipeReader`]
-///   returns EOF.
-/// * [`PipeReader`] can be shared, but only one process will consume the data in the pipe.
-///
-/// # Capacity
-///
-/// Pipe capacity is platform dependent. To quote the Linux [man page]:
-///
-/// > Different implementations have different limits for the pipe capacity. Applications should
-/// > not rely on a particular capacity: an application should be designed so that a reading process
-/// > consumes data as soon as it is available, so that a writing process does not remain blocked.
-///
-/// # Examples
-///
-/// ```no_run
-/// #![feature(anonymous_pipe)]
-/// # #[cfg(miri)] fn main() {}
-/// # #[cfg(not(miri))]
-/// # fn main() -> std::io::Result<()> {
-/// # use std::process::Command;
-/// # use std::io::{Read, Write};
-/// let (ping_rx, mut ping_tx) = std::io::pipe()?;
-/// let (mut pong_rx, pong_tx) = std::io::pipe()?;
-///
-/// // Spawn a process that echoes its input.
-/// let mut echo_server = Command::new("cat").stdin(ping_rx).stdout(pong_tx).spawn()?;
-///
-/// ping_tx.write_all(b"hello")?;
-/// // Close to unblock echo_server's reader.
-/// drop(ping_tx);
-///
-/// let mut buf = String::new();
-/// // Block until echo_server's writer is closed.
-/// pong_rx.read_to_string(&mut buf)?;
-/// assert_eq!(&buf, "hello");
-///
-/// echo_server.wait()?;
-/// # Ok(())
-/// # }
-/// ```
-/// [pipe]: https://man7.org/linux/man-pages/man2/pipe.2.html
-/// [CreatePipe]: https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-createpipe
-/// [man page]: https://man7.org/linux/man-pages/man7/pipe.7.html
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
-#[inline]
-pub fn pipe() -> Result<(PipeReader, PipeWriter)> {
-    pipe_inner().map(|(reader, writer)| (PipeReader(reader), PipeWriter(writer)))
-}
-
-/// Read end of the anonymous pipe.
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
-#[derive(Debug)]
-pub struct PipeReader(pub(crate) AnonPipe);
-
-/// Write end of the anonymous pipe.
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
-#[derive(Debug)]
-pub struct PipeWriter(pub(crate) AnonPipe);
-
-impl PipeReader {
-    /// Create a new [`PipeReader`] instance that shares the same underlying file description.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// #![feature(anonymous_pipe)]
-    /// # #[cfg(miri)] fn main() {}
-    /// # #[cfg(not(miri))]
-    /// # fn main() -> std::io::Result<()> {
-    /// # use std::fs;
-    /// # use std::io::Write;
-    /// # use std::process::Command;
-    /// const NUM_SLOT: u8 = 2;
-    /// const NUM_PROC: u8 = 5;
-    /// const OUTPUT: &str = "work.txt";
-    ///
-    /// let mut jobs = vec![];
-    /// let (reader, mut writer) = std::io::pipe()?;
-    ///
-    /// // Write NUM_SLOT characters the pipe.
-    /// writer.write_all(&[b'|'; NUM_SLOT as usize])?;
-    ///
-    /// // Spawn several processes that read a character from the pipe, do some work, then
-    /// // write back to the pipe. When the pipe is empty, the processes block, so only
-    /// // NUM_SLOT processes can be working at any given time.
-    /// for _ in 0..NUM_PROC {
-    ///     jobs.push(
-    ///         Command::new("bash")
-    ///             .args(["-c",
-    ///                 &format!(
-    ///                      "read -n 1\n\
-    ///                       echo -n 'x' >> '{OUTPUT}'\n\
-    ///                       echo -n '|'",
-    ///                 ),
-    ///             ])
-    ///             .stdin(reader.try_clone()?)
-    ///             .stdout(writer.try_clone()?)
-    ///             .spawn()?,
-    ///     );
-    /// }
-    ///
-    /// // Wait for all jobs to finish.
-    /// for mut job in jobs {
-    ///     job.wait()?;
-    /// }
-    ///
-    /// // Check our work and clean up.
-    /// let xs = fs::read_to_string(OUTPUT)?;
-    /// fs::remove_file(OUTPUT)?;
-    /// assert_eq!(xs, "x".repeat(NUM_PROC.into()));
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[unstable(feature = "anonymous_pipe", issue = "127154")]
-    pub fn try_clone(&self) -> Result<Self> {
-        self.0.try_clone().map(Self)
-    }
-}
-
-impl PipeWriter {
-    /// Create a new [`PipeWriter`] instance that shares the same underlying file description.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// #![feature(anonymous_pipe)]
-    /// # #[cfg(miri)] fn main() {}
-    /// # #[cfg(not(miri))]
-    /// # fn main() -> std::io::Result<()> {
-    /// # use std::process::Command;
-    /// # use std::io::Read;
-    /// let (mut reader, writer) = std::io::pipe()?;
-    ///
-    /// // Spawn a process that writes to stdout and stderr.
-    /// let mut peer = Command::new("bash")
-    ///     .args([
-    ///         "-c",
-    ///         "echo -n foo\n\
-    ///          echo -n bar >&2"
-    ///     ])
-    ///     .stdout(writer.try_clone()?)
-    ///     .stderr(writer)
-    ///     .spawn()?;
-    ///
-    /// // Read and check the result.
-    /// let mut msg = String::new();
-    /// reader.read_to_string(&mut msg)?;
-    /// assert_eq!(&msg, "foobar");
-    ///
-    /// peer.wait()?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[unstable(feature = "anonymous_pipe", issue = "127154")]
-    pub fn try_clone(&self) -> Result<Self> {
-        self.0.try_clone().map(Self)
-    }
-}
-
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
-impl Read for &PipeReader {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.0.read(buf)
-    }
-    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> Result<usize> {
-        self.0.read_vectored(bufs)
-    }
-    #[inline]
-    fn is_read_vectored(&self) -> bool {
-        self.0.is_read_vectored()
-    }
-    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
-        self.0.read_to_end(buf)
-    }
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> Result<()> {
-        self.0.read_buf(buf)
-    }
-}
-
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
-impl Read for PipeReader {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.0.read(buf)
-    }
-    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> Result<usize> {
-        self.0.read_vectored(bufs)
-    }
-    #[inline]
-    fn is_read_vectored(&self) -> bool {
-        self.0.is_read_vectored()
-    }
-    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> Result<usize> {
-        self.0.read_to_end(buf)
-    }
-    fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> Result<()> {
-        self.0.read_buf(buf)
-    }
-}
-
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
-impl Write for &PipeWriter {
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.0.write(buf)
-    }
-    #[inline]
-    fn flush(&mut self) -> Result<()> {
-        Ok(())
-    }
-
-    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
-        self.0.write_vectored(bufs)
-    }
-
-    #[inline]
-    fn is_write_vectored(&self) -> bool {
-        self.0.is_write_vectored()
-    }
-}
-
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
-impl Write for PipeWriter {
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.0.write(buf)
-    }
-    #[inline]
-    fn flush(&mut self) -> Result<()> {
-        Ok(())
-    }
-
-    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
-        self.0.write_vectored(bufs)
-    }
-
-    #[inline]
-    fn is_write_vectored(&self) -> bool {
-        self.0.is_write_vectored()
     }
 }

--- a/library/std/src/io/pipe.rs
+++ b/library/std/src/io/pipe.rs
@@ -1,0 +1,253 @@
+use crate::io;
+use crate::sys::anonymous_pipe::{AnonPipe, pipe as pipe_inner};
+
+/// Create anonymous pipe that is close-on-exec and blocking.
+///
+/// This function provides support for anonymous OS pipes, like [pipe] on Linux or [CreatePipe] on
+/// Windows.
+///
+/// # Behavior
+///
+/// A pipe is a synchronous, unidirectional data channel between two or more processes, like an
+/// interprocess [`mpsc`](crate::sync::mpsc) provided by the OS. In particular:
+///
+/// * A read on a [`PipeReader`] blocks until the pipe is non-empty.
+/// * A write on a [`PipeWriter`] blocks when the pipe is full.
+/// * When all copies of a [`PipeWriter`] are closed, a read on the corresponding [`PipeReader`]
+///   returns EOF.
+/// * [`PipeReader`] can be shared, but only one process will consume the data in the pipe.
+///
+/// # Capacity
+///
+/// Pipe capacity is platform dependent. To quote the Linux [man page]:
+///
+/// > Different implementations have different limits for the pipe capacity. Applications should
+/// > not rely on a particular capacity: an application should be designed so that a reading process
+/// > consumes data as soon as it is available, so that a writing process does not remain blocked.
+///
+/// # Examples
+///
+/// ```no_run
+/// #![feature(anonymous_pipe)]
+/// # #[cfg(miri)] fn main() {}
+/// # #[cfg(not(miri))]
+/// # fn main() -> std::io::Result<()> {
+/// # use std::process::Command;
+/// # use std::io::{Read, Write};
+/// let (ping_rx, mut ping_tx) = std::pipe::pipe()?;
+/// let (mut pong_rx, pong_tx) = std::pipe::pipe()?;
+///
+/// // Spawn a process that echoes its input.
+/// let mut echo_server = Command::new("cat").stdin(ping_rx).stdout(pong_tx).spawn()?;
+///
+/// ping_tx.write_all(b"hello")?;
+/// // Close to unblock echo_server's reader.
+/// drop(ping_tx);
+///
+/// let mut buf = String::new();
+/// // Block until echo_server's writer is closed.
+/// pong_rx.read_to_string(&mut buf)?;
+/// assert_eq!(&buf, "hello");
+///
+/// echo_server.wait()?;
+/// # Ok(())
+/// # }
+/// ```
+/// [pipe]: https://man7.org/linux/man-pages/man2/pipe.2.html
+/// [CreatePipe]: https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-createpipe
+/// [man page]: https://man7.org/linux/man-pages/man7/pipe.7.html
+#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[inline]
+pub fn pipe() -> io::Result<(PipeReader, PipeWriter)> {
+    pipe_inner().map(|(reader, writer)| (PipeReader(reader), PipeWriter(writer)))
+}
+
+/// Read end of the anonymous pipe.
+#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[derive(Debug)]
+pub struct PipeReader(pub(crate) AnonPipe);
+
+/// Write end of the anonymous pipe.
+#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[derive(Debug)]
+pub struct PipeWriter(pub(crate) AnonPipe);
+
+impl PipeReader {
+    /// Create a new [`PipeReader`] instance that shares the same underlying file description.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(anonymous_pipe)]
+    /// # #[cfg(miri)] fn main() {}
+    /// # #[cfg(not(miri))]
+    /// # fn main() -> std::io::Result<()> {
+    /// # use std::fs;
+    /// # use std::io::Write;
+    /// # use std::process::Command;
+    /// const NUM_SLOT: u8 = 2;
+    /// const NUM_PROC: u8 = 5;
+    /// const OUTPUT: &str = "work.txt";
+    ///
+    /// let mut jobs = vec![];
+    /// let (reader, mut writer) = std::pipe::pipe()?;
+    ///
+    /// // Write NUM_SLOT characters the pipe.
+    /// writer.write_all(&[b'|'; NUM_SLOT as usize])?;
+    ///
+    /// // Spawn several processes that read a character from the pipe, do some work, then
+    /// // write back to the pipe. When the pipe is empty, the processes block, so only
+    /// // NUM_SLOT processes can be working at any given time.
+    /// for _ in 0..NUM_PROC {
+    ///     jobs.push(
+    ///         Command::new("bash")
+    ///             .args(["-c",
+    ///                 &format!(
+    ///                      "read -n 1\n\
+    ///                       echo -n 'x' >> '{OUTPUT}'\n\
+    ///                       echo -n '|'",
+    ///                 ),
+    ///             ])
+    ///             .stdin(reader.try_clone()?)
+    ///             .stdout(writer.try_clone()?)
+    ///             .spawn()?,
+    ///     );
+    /// }
+    ///
+    /// // Wait for all jobs to finish.
+    /// for mut job in jobs {
+    ///     job.wait()?;
+    /// }
+    ///
+    /// // Check our work and clean up.
+    /// let xs = fs::read_to_string(OUTPUT)?;
+    /// fs::remove_file(OUTPUT)?;
+    /// assert_eq!(xs, "x".repeat(NUM_PROC.into()));
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[unstable(feature = "anonymous_pipe", issue = "127154")]
+    pub fn try_clone(&self) -> io::Result<Self> {
+        self.0.try_clone().map(Self)
+    }
+}
+
+impl PipeWriter {
+    /// Create a new [`PipeWriter`] instance that shares the same underlying file description.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(anonymous_pipe)]
+    /// # #[cfg(miri)] fn main() {}
+    /// # #[cfg(not(miri))]
+    /// # fn main() -> std::io::Result<()> {
+    /// # use std::process::Command;
+    /// # use std::io::Read;
+    /// let (mut reader, writer) = std::pipe::pipe()?;
+    ///
+    /// // Spawn a process that writes to stdout and stderr.
+    /// let mut peer = Command::new("bash")
+    ///     .args([
+    ///         "-c",
+    ///         "echo -n foo\n\
+    ///          echo -n bar >&2"
+    ///     ])
+    ///     .stdout(writer.try_clone()?)
+    ///     .stderr(writer)
+    ///     .spawn()?;
+    ///
+    /// // Read and check the result.
+    /// let mut msg = String::new();
+    /// reader.read_to_string(&mut msg)?;
+    /// assert_eq!(&msg, "foobar");
+    ///
+    /// peer.wait()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[unstable(feature = "anonymous_pipe", issue = "127154")]
+    pub fn try_clone(&self) -> io::Result<Self> {
+        self.0.try_clone().map(Self)
+    }
+}
+
+#[unstable(feature = "anonymous_pipe", issue = "127154")]
+impl io::Read for &PipeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        self.0.read_vectored(bufs)
+    }
+    #[inline]
+    fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
+    }
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.0.read_to_end(buf)
+    }
+    fn read_buf(&mut self, buf: io::BorrowedCursor<'_>) -> io::Result<()> {
+        self.0.read_buf(buf)
+    }
+}
+
+#[unstable(feature = "anonymous_pipe", issue = "127154")]
+impl io::Read for PipeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        self.0.read_vectored(bufs)
+    }
+    #[inline]
+    fn is_read_vectored(&self) -> bool {
+        self.0.is_read_vectored()
+    }
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.0.read_to_end(buf)
+    }
+    fn read_buf(&mut self, buf: io::BorrowedCursor<'_>) -> io::Result<()> {
+        self.0.read_buf(buf)
+    }
+}
+
+#[unstable(feature = "anonymous_pipe", issue = "127154")]
+impl io::Write for &PipeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
+    }
+}
+
+#[unstable(feature = "anonymous_pipe", issue = "127154")]
+impl io::Write for PipeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
+    }
+}

--- a/library/std/src/io/pipe.rs
+++ b/library/std/src/io/pipe.rs
@@ -1,10 +1,7 @@
 use crate::io;
 use crate::sys::anonymous_pipe::{AnonPipe, pipe as pipe_inner};
 
-/// Create anonymous pipe that is close-on-exec and blocking.
-///
-/// This function provides support for anonymous OS pipes, like [pipe] on Linux or [CreatePipe] on
-/// Windows.
+/// Create an anonymous pipe.
 ///
 /// # Behavior
 ///
@@ -16,6 +13,13 @@ use crate::sys::anonymous_pipe::{AnonPipe, pipe as pipe_inner};
 /// * When all copies of a [`PipeWriter`] are closed, a read on the corresponding [`PipeReader`]
 ///   returns EOF.
 /// * [`PipeReader`] can be shared, but only one process will consume the data in the pipe.
+///
+/// # Platform-specific behavior
+///
+/// This function currently corresponds to the `pipe` function on Unix and the
+/// `CreatePipe` function on Windows.
+///
+/// Note that this [may change in the future][changes].
 ///
 /// # Capacity
 ///
@@ -32,10 +36,10 @@ use crate::sys::anonymous_pipe::{AnonPipe, pipe as pipe_inner};
 /// # #[cfg(miri)] fn main() {}
 /// # #[cfg(not(miri))]
 /// # fn main() -> std::io::Result<()> {
-/// # use std::process::Command;
-/// # use std::io::{Read, Write};
-/// let (ping_rx, mut ping_tx) = std::pipe::pipe()?;
-/// let (mut pong_rx, pong_tx) = std::pipe::pipe()?;
+/// use std::process::Command;
+/// use std::io::{pipe, Read, Write};
+/// let (ping_rx, mut ping_tx) = pipe()?;
+/// let (mut pong_rx, pong_tx) = pipe()?;
 ///
 /// // Spawn a process that echoes its input.
 /// let mut echo_server = Command::new("cat").stdin(ping_rx).stdout(pong_tx).spawn()?;
@@ -53,8 +57,7 @@ use crate::sys::anonymous_pipe::{AnonPipe, pipe as pipe_inner};
 /// # Ok(())
 /// # }
 /// ```
-/// [pipe]: https://man7.org/linux/man-pages/man2/pipe.2.html
-/// [CreatePipe]: https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-createpipe
+/// [changes]: io#platform-specific-behavior
 /// [man page]: https://man7.org/linux/man-pages/man7/pipe.7.html
 #[unstable(feature = "anonymous_pipe", issue = "127154")]
 #[inline]
@@ -82,15 +85,15 @@ impl PipeReader {
     /// # #[cfg(miri)] fn main() {}
     /// # #[cfg(not(miri))]
     /// # fn main() -> std::io::Result<()> {
-    /// # use std::fs;
-    /// # use std::io::Write;
-    /// # use std::process::Command;
+    /// use std::fs;
+    /// use std::io::{pipe, Write};
+    /// use std::process::Command;
     /// const NUM_SLOT: u8 = 2;
     /// const NUM_PROC: u8 = 5;
     /// const OUTPUT: &str = "work.txt";
     ///
     /// let mut jobs = vec![];
-    /// let (reader, mut writer) = std::pipe::pipe()?;
+    /// let (reader, mut writer) = pipe()?;
     ///
     /// // Write NUM_SLOT characters the pipe.
     /// writer.write_all(&[b'|'; NUM_SLOT as usize])?;
@@ -142,9 +145,9 @@ impl PipeWriter {
     /// # #[cfg(miri)] fn main() {}
     /// # #[cfg(not(miri))]
     /// # fn main() -> std::io::Result<()> {
-    /// # use std::process::Command;
-    /// # use std::io::Read;
-    /// let (mut reader, writer) = std::pipe::pipe()?;
+    /// use std::process::Command;
+    /// use std::io::{pipe, Read};
+    /// let (mut reader, writer) = pipe()?;
     ///
     /// // Spawn a process that writes to stdout and stderr.
     /// let mut peer = Command::new("bash")
@@ -221,11 +224,9 @@ impl io::Write for &PipeWriter {
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
-
     fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
     }
-
     #[inline]
     fn is_write_vectored(&self) -> bool {
         self.0.is_write_vectored()
@@ -241,11 +242,9 @@ impl io::Write for PipeWriter {
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
-
     fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
     }
-
     #[inline]
     fn is_write_vectored(&self) -> bool {
         self.0.is_write_vectored()

--- a/library/std/src/io/pipe/tests.rs
+++ b/library/std/src/io/pipe/tests.rs
@@ -1,0 +1,18 @@
+use crate::io::{Read, Write, pipe};
+
+#[test]
+#[cfg(all(windows, unix, not(miri)))]
+fn pipe_creation_clone_and_rw() {
+    let (rx, tx) = pipe().unwrap();
+
+    tx.try_clone().unwrap().write_all(b"12345").unwrap();
+    drop(tx);
+
+    let mut rx2 = rx.try_clone().unwrap();
+    drop(rx);
+
+    let mut s = String::new();
+    rx2.read_to_string(&mut s).unwrap();
+    drop(rx2);
+    assert_eq!(s, "12345");
+}

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -823,20 +823,3 @@ fn try_oom_error() {
     let io_err = io::Error::from(reserve_err);
     assert_eq!(io::ErrorKind::OutOfMemory, io_err.kind());
 }
-
-#[test]
-#[cfg(all(windows, unix, not(miri)))]
-fn pipe_creation_clone_and_rw() {
-    let (rx, tx) = std::io::pipe().unwrap();
-
-    tx.try_clone().unwrap().write_all(b"12345").unwrap();
-    drop(tx);
-
-    let mut rx2 = rx.try_clone().unwrap();
-    drop(rx);
-
-    let mut s = String::new();
-    rx2.read_to_string(&mut s).unwrap();
-    drop(rx2);
-    assert_eq!(s, "12345");
-}

--- a/library/std/src/sys/pal/unix/process/process_unix.rs
+++ b/library/std/src/sys/pal/unix/process/process_unix.rs
@@ -20,7 +20,7 @@ use crate::{fmt, mem, sys};
 
 cfg_if::cfg_if! {
     // This workaround is only needed for QNX 7.0 and 7.1. The bug should have been fixed in 8.0
-    if #[cfg(any(target_env = "nto70", target_env = "nto71"))] {
+    if #[cfg(any(target_env = "nto70", target_env = "nto71", target_env = "nto71_iosock"))] {
         use crate::thread;
         use libc::{c_char, posix_spawn_file_actions_t, posix_spawnattr_t};
         use crate::time::Duration;
@@ -191,7 +191,8 @@ impl Command {
         target_os = "watchos",
         target_os = "tvos",
         target_env = "nto70",
-        target_env = "nto71"
+        target_env = "nto71",
+        target_env = "nto71_iosock",
     )))]
     unsafe fn do_fork(&mut self) -> Result<pid_t, io::Error> {
         cvt(libc::fork())
@@ -202,7 +203,7 @@ impl Command {
     // Documentation says "... or try calling fork() again". This is what we do here.
     // See also https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/f/fork.html
     // This workaround is only needed for QNX 7.0 and 7.1. The bug should have been fixed in 8.0
-    #[cfg(any(target_env = "nto70", target_env = "nto71"))]
+    #[cfg(any(target_env = "nto70", target_env = "nto71", target_env = "nto71_iosock"))]
     unsafe fn do_fork(&mut self) -> Result<pid_t, io::Error> {
         use crate::sys::os::errno;
 

--- a/library/std/src/sys/pal/unix/process/process_unix.rs
+++ b/library/std/src/sys/pal/unix/process/process_unix.rs
@@ -19,8 +19,7 @@ use crate::sys::process::process_common::*;
 use crate::{fmt, mem, sys};
 
 cfg_if::cfg_if! {
-    // This workaround is only needed for QNX 7.0 and 7.1. The bug should have been fixed in 8.0
-    if #[cfg(any(target_env = "nto70", target_env = "nto71", target_env = "nto71_iosock"))] {
+    if #[cfg(target_os = "nto")] {
         use crate::thread;
         use libc::{c_char, posix_spawn_file_actions_t, posix_spawnattr_t};
         use crate::time::Duration;
@@ -187,13 +186,7 @@ impl Command {
 
     // Attempts to fork the process. If successful, returns Ok((0, -1))
     // in the child, and Ok((child_pid, -1)) in the parent.
-    #[cfg(not(any(
-        target_os = "watchos",
-        target_os = "tvos",
-        target_env = "nto70",
-        target_env = "nto71",
-        target_env = "nto71_iosock",
-    )))]
+    #[cfg(not(any(target_os = "watchos", target_os = "tvos", target_os = "nto")))]
     unsafe fn do_fork(&mut self) -> Result<pid_t, io::Error> {
         cvt(libc::fork())
     }
@@ -202,8 +195,7 @@ impl Command {
     // or closed a file descriptor while the fork() was occurring".
     // Documentation says "... or try calling fork() again". This is what we do here.
     // See also https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.lib_ref/topic/f/fork.html
-    // This workaround is only needed for QNX 7.0 and 7.1. The bug should have been fixed in 8.0
-    #[cfg(any(target_env = "nto70", target_env = "nto71", target_env = "nto71_iosock"))]
+    #[cfg(target_os = "nto")]
     unsafe fn do_fork(&mut self) -> Result<pid_t, io::Error> {
         use crate::sys::os::errno;
 

--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -1,7 +1,7 @@
 //! Module converting command-line arguments into test configuration.
 
 use std::env;
-use std::io::{self, IsTerminal};
+use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
 
 use super::options::{ColorConfig, Options, OutputFormat, RunIgnored};
@@ -58,7 +58,7 @@ fn optgroups() -> getopts::Options {
         .optflag("", "bench", "Run benchmarks instead of tests")
         .optflag("", "list", "List all tests and benchmarks")
         .optflag("h", "help", "Display this message")
-        .optopt("", "logfile", "Write logs to the specified file", "PATH")
+        .optopt("", "logfile", "Write logs to the specified file (deprecated)", "PATH")
         .optflag(
             "",
             "nocapture",
@@ -280,6 +280,10 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
     let format = get_format(&matches, quiet, allow_unstable)?;
 
     let options = Options::new().display_output(matches.opt_present("show-output"));
+
+    if logfile.is_some() {
+        let _ = write!(io::stderr(), "warning: `--logfile` is deprecated");
+    }
 
     let test_opts = TestOpts {
         list,

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -34,6 +34,7 @@ pub struct Finder {
 // Targets can be removed from this list once they are present in the stage0 compiler (usually by updating the beta compiler of the bootstrap).
 const STAGE0_MISSING_TARGETS: &[&str] = &[
     // just a dummy comment so the list doesn't get onelined
+    "aarch64-unknown-nto-qnx710_iosock",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -35,6 +35,7 @@ pub struct Finder {
 const STAGE0_MISSING_TARGETS: &[&str] = &[
     // just a dummy comment so the list doesn't get onelined
     "aarch64-unknown-nto-qnx710_iosock",
+    "x86_64-pc-nto-qnx710_iosock",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -36,6 +36,8 @@ const STAGE0_MISSING_TARGETS: &[&str] = &[
     // just a dummy comment so the list doesn't get onelined
     "aarch64-unknown-nto-qnx710_iosock",
     "x86_64-pc-nto-qnx710_iosock",
+    "x86_64-pc-nto-qnx800",
+    "aarch64-unknown-nto-qnx800",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/ci/github-actions/ci.py
+++ b/src/ci/github-actions/ci.py
@@ -249,7 +249,7 @@ def run_workflow_locally(job_data: Dict[str, Any], job_name: str, pr_jobs: bool)
     env = os.environ.copy()
     env.update(custom_env)
 
-    subprocess.run(args, env=env)
+    subprocess.run(args, env=env, check=True)
 
 
 def calculate_job_matrix(job_data: Dict[str, Any]):

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -406,7 +406,8 @@ target | std | host | notes
 [`wasm64-unknown-unknown`](platform-support/wasm64-unknown-unknown.md) | ? |  | WebAssembly
 [`x86_64-apple-tvos`](platform-support/apple-tvos.md) | ✓ |  | x86 64-bit tvOS
 [`x86_64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ |  | x86 64-bit Apple WatchOS simulator
-[`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS |
+[`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with default network stack (io-pkt) |
+[`x86_64-pc-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with new network stack (io-sock) |
 [`x86_64-unikraft-linux-musl`](platform-support/unikraft-linux-musl.md) | ✓ |   | 64-bit Unikraft with musl 1.2.3
 `x86_64-unknown-dragonfly` | ✓ | ✓ | 64-bit DragonFlyBSD
 `x86_64-unknown-haiku` | ✓ | ✓ | 64-bit Haiku

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -254,14 +254,14 @@ target | std | host | notes
 [`aarch64-kmc-solid_asp3`](platform-support/kmc-solid.md) | ✓ |  | ARM64 SOLID with TOPPERS/ASP3
 [`aarch64-nintendo-switch-freestanding`](platform-support/aarch64-nintendo-switch-freestanding.md) | * |  | ARM64 Nintendo Switch, Horizon
 [`aarch64-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | ARM64 FreeBSD
-`aarch64-unknown-freebsd` | ✓ | ✓ | ARM64 FreeBSD
 [`aarch64-unknown-hermit`](platform-support/hermit.md) | ✓ |  | ARM64 Hermit
 [`aarch64-unknown-illumos`](platform-support/illumos.md) | ✓ | ✓ | ARM64 illumos
 `aarch64-unknown-linux-gnu_ilp32` | ✓ | ✓ | ARM64 Linux (ILP32 ABI)
 [`aarch64-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | ARM64 NetBSD
-[`aarch64-unknown-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS with new network stack (io-sock) |
-[`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS |
+[`aarch64-unknown-nto-qnx700`](platform-support/nto-qnx.md) | ? |  | ARM64 QNX Neutrino 7.0 RTOS |
 [`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS with default network stack (io-pkt) |
+[`aarch64-unknown-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS with new network stack (io-sock) |
+[`aarch64-unknown-nto-qnx800`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 8.0 RTOS |
 [`aarch64-unknown-nuttx`](platform-support/nuttx.md) | * |  | ARM64 with NuttX
 [`aarch64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | ARM64 OpenBSD
 [`aarch64-unknown-redox`](platform-support/redox.md) | ✓ |  | ARM64 Redox OS
@@ -408,6 +408,7 @@ target | std | host | notes
 [`x86_64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ |  | x86 64-bit Apple WatchOS simulator
 [`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with default network stack (io-pkt) |
 [`x86_64-pc-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with new network stack (io-sock) |
+[`x86_64-pc-nto-qnx800`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 8.0 RTOS |
 [`x86_64-unikraft-linux-musl`](platform-support/unikraft-linux-musl.md) | ✓ |   | 64-bit Unikraft with musl 1.2.3
 `x86_64-unknown-dragonfly` | ✓ | ✓ | 64-bit DragonFlyBSD
 `x86_64-unknown-haiku` | ✓ | ✓ | 64-bit Haiku

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -254,12 +254,14 @@ target | std | host | notes
 [`aarch64-kmc-solid_asp3`](platform-support/kmc-solid.md) | ✓ |  | ARM64 SOLID with TOPPERS/ASP3
 [`aarch64-nintendo-switch-freestanding`](platform-support/aarch64-nintendo-switch-freestanding.md) | * |  | ARM64 Nintendo Switch, Horizon
 [`aarch64-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | ARM64 FreeBSD
+`aarch64-unknown-freebsd` | ✓ | ✓ | ARM64 FreeBSD
 [`aarch64-unknown-hermit`](platform-support/hermit.md) | ✓ |  | ARM64 Hermit
 [`aarch64-unknown-illumos`](platform-support/illumos.md) | ✓ | ✓ | ARM64 illumos
 `aarch64-unknown-linux-gnu_ilp32` | ✓ | ✓ | ARM64 Linux (ILP32 ABI)
 [`aarch64-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | ARM64 NetBSD
-[`aarch64-unknown-nto-qnx700`](platform-support/nto-qnx.md) | ? |  | ARM64 QNX Neutrino 7.0 RTOS |
+[`aarch64-unknown-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS with new network stack (io-sock) |
 [`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS |
+[`aarch64-unknown-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | ARM64 QNX Neutrino 7.1 RTOS with default network stack (io-pkt) |
 [`aarch64-unknown-nuttx`](platform-support/nuttx.md) | * |  | ARM64 with NuttX
 [`aarch64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | ARM64 OpenBSD
 [`aarch64-unknown-redox`](platform-support/redox.md) | ✓ |  | ARM64 Redox OS

--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -22,11 +22,12 @@ Currently, the following QNX Neutrino versions and compilation targets are suppo
 
 | QNX Neutrino Version | Target Architecture | Full support | `no_std` support |
 |----------------------|---------------------|:------------:|:----------------:|
-| 7.1 with io-pkt | AArch64 | ✓ | ✓ |
-| 7.1 with io-sock | AArch64 | ✓ | ✓ |
-| 7.1 | x86_64  | ✓ | ✓ |
-| 7.0 | AArch64 | ? | ✓ |
-| 7.0 | x86     |   | ✓ |
+| 7.1 with io-pkt  | AArch64  | ✓ | ✓ |
+| 7.1 with io-sock | AArch64  | ? | ✓ |
+| 7.1 with io-pkt  | x86_64   | ✓ | ✓ |
+| 7.1 with io-sock | x86_64   | ? | ✓ |
+| 7.0              | AArch64  | ? | ✓ |
+| 7.0              | x86      |   | ✓ |
 
 On QNX 7.0 and 7.1, `io-pkt` is used as network stack by default. QNX 7.1 includes
 the optional network stack `io-sock`.

--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -136,18 +136,31 @@ To compile for QNX Neutrino (aarch64 and x86_64) and Linux (x86_64):
 
 ```bash
 export build_env='
-    CC_aarch64-unknown-nto-qnx710=qcc
-    CFLAGS_aarch64-unknown-nto-qnx710=-Vgcc_ntoaarch64le_cxx
-    CXX_aarch64-unknown-nto-qnx710=qcc
+    CC_i586_pc_nto_qnx700=qcc
+    CFLAGS_i586_pc_nto_qnx700=-Vgcc_ntox86_cxx
+    CXX_i586_pc_nto_qnx700=qcc
+    AR_i586_pc_nto_qnx700=ntox86-ar
+
+    CC_aarch64_unknown_nto_qnx710=qcc
+    CFLAGS_aarch64_unknown_nto_qnx710=-Vgcc_ntoaarch64le_cxx
+    CXX_aarch64_unknown_nto_qnx710=qcc
     AR_aarch64_unknown_nto_qnx710=ntoaarch64-ar
-    CC_aarch64-unknown-nto-qnx710_iosock=qcc
-    CFLAGS_aarch64-unknown-nto-qnx710_iosock=-Vgcc_ntoaarch64le_cxx
-    CXX_aarch64-unknown-nto-qnx710_iosock=qcc
+
+    CC_aarch64_unknown_nto_qnx710_iosock=qcc
+    CFLAGS_aarch64_unknown_nto_qnx710_iosock=-Vgcc_ntoaarch64le_cxx
+    CXX_aarch64_unknown_nto_qnx710_iosock=qcc
     AR_aarch64_unknown_nto_qnx710_iosock=ntoaarch64-ar
-    CC_x86_64-pc-nto-qnx710=qcc
-    CFLAGS_x86_64-pc-nto-qnx710=-Vgcc_ntox86_64_cxx
-    CXX_x86_64-pc-nto-qnx710=qcc
-    AR_x86_64_pc_nto_qnx710=ntox86_64-ar'
+
+    CC_aarch64_unknown_nto_qnx700=qcc
+    CFLAGS_aarch64_unknown_nto_qnx700=-Vgcc_ntoaarch64le_cxx
+    CXX_aarch64_unknown_nto_qnx700=qcc
+    AR_aarch64_unknown_nto_qnx700=ntoaarch64-ar
+
+    CC_x86_64_pc_nto_qnx710=qcc
+    CFLAGS_x86_64_pc_nto_qnx710=-Vgcc_ntox86_64_cxx
+    CXX_x86_64_pc_nto_qnx710=qcc
+    AR_x86_64_pc_nto_qnx710=ntox86_64-ar
+    '
 
 env $build_env \
     ./x.py build \
@@ -167,15 +180,7 @@ To run all tests on a x86_64 QNX Neutrino target:
 
 ```bash
 export TEST_DEVICE_ADDR="localhost:12345" # must address the test target, can be a SSH tunnel
-export build_env='
-    CC_aarch64-unknown-nto-qnx710=qcc
-    CFLAGS_aarch64-unknown-nto-qnx710=-Vgcc_ntoaarch64le_cxx
-    CXX_aarch64-unknown-nto-qnx710=qcc
-    AR_aarch64_unknown_nto_qnx710=ntoaarch64-ar
-    CC_x86_64-pc-nto-qnx710=qcc
-    CFLAGS_x86_64-pc-nto-qnx710=-Vgcc_ntox86_64_cxx
-    CXX_x86_64-pc-nto-qnx710=qcc
-    AR_x86_64_pc_nto_qnx710=ntox86_64-ar'
+export build_env=<see above>
 
 # Disable tests that only work on the host or don't make sense for this target.
 # See also:

--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -22,10 +22,14 @@ Currently, the following QNX Neutrino versions and compilation targets are suppo
 
 | QNX Neutrino Version | Target Architecture | Full support | `no_std` support |
 |----------------------|---------------------|:------------:|:----------------:|
-| 7.1 | AArch64 | ✓ | ✓ |
+| 7.1 with io-pkt | AArch64 | ✓ | ✓ |
+| 7.1 with io-sock | AArch64 | ✓ | ✓ |
 | 7.1 | x86_64  | ✓ | ✓ |
 | 7.0 | AArch64 | ? | ✓ |
 | 7.0 | x86     |   | ✓ |
+
+On QNX 7.0 and 7.1, `io-pkt` is used as network stack by default. QNX 7.1 includes
+the optional network stack `io-sock`.
 
 Adding other architectures that are supported by QNX Neutrino is possible.
 
@@ -107,7 +111,8 @@ There are no further known requirements.
 For conditional compilation, following QNX Neutrino specific attributes are defined:
 
 - `target_os` = `"nto"`
-- `target_env` = `"nto71"` (for QNX Neutrino 7.1)
+- `target_env` = `"nto71"` (for QNX Neutrino 7.1 with "classic" network stack "io_pkt")
+- `target_env` = `"nto71_iosock"` (for QNX Neutrino 7.1 with network stack "io_sock")
 - `target_env` = `"nto70"` (for QNX Neutrino 7.0)
 
 ## Building the target
@@ -134,6 +139,10 @@ export build_env='
     CFLAGS_aarch64-unknown-nto-qnx710=-Vgcc_ntoaarch64le_cxx
     CXX_aarch64-unknown-nto-qnx710=qcc
     AR_aarch64_unknown_nto_qnx710=ntoaarch64-ar
+    CC_aarch64-unknown-nto-qnx710_iosock=qcc
+    CFLAGS_aarch64-unknown-nto-qnx710_iosock=-Vgcc_ntoaarch64le_cxx
+    CXX_aarch64-unknown-nto-qnx710_iosock=qcc
+    AR_aarch64_unknown_nto_qnx710_iosock=ntoaarch64-ar
     CC_x86_64-pc-nto-qnx710=qcc
     CFLAGS_x86_64-pc-nto-qnx710=-Vgcc_ntox86_64_cxx
     CXX_x86_64-pc-nto-qnx710=qcc
@@ -141,7 +150,7 @@ export build_env='
 
 env $build_env \
     ./x.py build \
-        --target aarch64-unknown-nto-qnx710,x86_64-pc-nto-qnx710,x86_64-unknown-linux-gnu \
+        --target aarch64-unknown-nto-qnx710_iosock,aarch64-unknown-nto-qnx710,x86_64-pc-nto-qnx710,x86_64-unknown-linux-gnu \
         rustc library/core library/alloc library/std
 ```
 

--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -115,6 +115,7 @@ For conditional compilation, following QNX Neutrino specific attributes are defi
 - `target_env` = `"nto71"` (for QNX Neutrino 7.1 with "classic" network stack "io_pkt")
 - `target_env` = `"nto71_iosock"` (for QNX Neutrino 7.1 with network stack "io_sock")
 - `target_env` = `"nto70"` (for QNX Neutrino 7.0)
+- `target_env` = `"nto80"` (for QNX Neutrino 8.0)
 
 ## Building the target
 

--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -22,6 +22,8 @@ Currently, the following QNX Neutrino versions and compilation targets are suppo
 
 | QNX Neutrino Version | Target Architecture | Full support | `no_std` support |
 |----------------------|---------------------|:------------:|:----------------:|
+| 8.0              | AArch64  | ? | ✓ |
+| 8.0              | x86      | ? | ✓ |
 | 7.1 with io-pkt  | AArch64  | ✓ | ✓ |
 | 7.1 with io-sock | AArch64  | ? | ✓ |
 | 7.1 with io-pkt  | x86_64   | ✓ | ✓ |
@@ -31,6 +33,8 @@ Currently, the following QNX Neutrino versions and compilation targets are suppo
 
 On QNX 7.0 and 7.1, `io-pkt` is used as network stack by default. QNX 7.1 includes
 the optional network stack `io-sock`.
+QNX 8.0 always uses `io-sock`. QNX 8.0 support is currently in development
+and not tested.
 
 Adding other architectures that are supported by QNX Neutrino is possible.
 
@@ -121,53 +125,55 @@ For conditional compilation, following QNX Neutrino specific attributes are defi
 
 1. Create a `config.toml`
 
-Example content:
+    Example content:
 
-```toml
-profile = "compiler"
-change-id = 115898
-```
+    ```toml
+    profile = "compiler"
+    change-id = 999999
+    ```
 
-2. Compile the Rust toolchain for an `x86_64-unknown-linux-gnu` host (for both `aarch64` and `x86_64` targets)
+2. Compile the Rust toolchain for an `x86_64-unknown-linux-gnu` host
 
-Compiling the Rust toolchain requires the same environment variables used for compiling C binaries.
-Refer to the [QNX developer manual](https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.prog/topic/devel_OS_version.html).
+    Compiling the Rust toolchain requires the same environment variables used for compiling C binaries.
+    Refer to the [QNX developer manual](https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.prog/topic/devel_OS_version.html).
 
-To compile for QNX Neutrino (aarch64 and x86_64) and Linux (x86_64):
+    To compile for QNX Neutrino, environment variables must be set to use the correct tools and compiler switches:
 
-```bash
-export build_env='
-    CC_i586_pc_nto_qnx700=qcc
-    CFLAGS_i586_pc_nto_qnx700=-Vgcc_ntox86_cxx
-    CXX_i586_pc_nto_qnx700=qcc
-    AR_i586_pc_nto_qnx700=ntox86-ar
+    - `CC_<target>=qcc`
+    - `CFLAGS_<target>=<nto_cflag>`
+    - `CXX_<target>=qcc`
+    - `AR_<target>=<nto_ar>`
 
-    CC_aarch64_unknown_nto_qnx710=qcc
-    CFLAGS_aarch64_unknown_nto_qnx710=-Vgcc_ntoaarch64le_cxx
-    CXX_aarch64_unknown_nto_qnx710=qcc
-    AR_aarch64_unknown_nto_qnx710=ntoaarch64-ar
+    With:
 
-    CC_aarch64_unknown_nto_qnx710_iosock=qcc
-    CFLAGS_aarch64_unknown_nto_qnx710_iosock=-Vgcc_ntoaarch64le_cxx
-    CXX_aarch64_unknown_nto_qnx710_iosock=qcc
-    AR_aarch64_unknown_nto_qnx710_iosock=ntoaarch64-ar
+    - `<target>` target triplet using underscores instead of hyphens, e.g. `aarch64_unknown_nto_qnx710`
+    - `<nto_cflag>`
 
-    CC_aarch64_unknown_nto_qnx700=qcc
-    CFLAGS_aarch64_unknown_nto_qnx700=-Vgcc_ntoaarch64le_cxx
-    CXX_aarch64_unknown_nto_qnx700=qcc
-    AR_aarch64_unknown_nto_qnx700=ntoaarch64-ar
+      - `-Vgcc_ntox86_cxx` for x86 (32 bit)
+      - `-Vgcc_ntox86_64_cxx` for x86_64 (64 bit)
+      - `-Vgcc_ntoaarch64le_cxx` for Aarch64 (64 bit)
 
-    CC_x86_64_pc_nto_qnx710=qcc
-    CFLAGS_x86_64_pc_nto_qnx710=-Vgcc_ntox86_64_cxx
-    CXX_x86_64_pc_nto_qnx710=qcc
-    AR_x86_64_pc_nto_qnx710=ntox86_64-ar
-    '
+    - `<nto_ar>`
 
-env $build_env \
-    ./x.py build \
-        --target aarch64-unknown-nto-qnx710_iosock,aarch64-unknown-nto-qnx710,x86_64-pc-nto-qnx710,x86_64-unknown-linux-gnu \
-        rustc library/core library/alloc library/std
-```
+      - `ntox86-ar` for x86 (32 bit)
+      - `ntox86_64-ar` for x86_64 (64 bit)
+      - `ntoaarch64-ar` for Aarch64 (64 bit)
+
+    Example to build the Rust toolchain including a standard library for x86_64-linux-gnu and Aarch64-QNX-7.1:
+
+    ```bash
+    export build_env='
+        CC_aarch64_unknown_nto_qnx710=qcc
+        CFLAGS_aarch64_unknown_nto_qnx710=-Vgcc_ntoaarch64le_cxx
+        CXX_aarch64_unknown_nto_qnx710=qcc
+        AR_aarch64_unknown_nto_qnx710=ntoaarch64-ar
+        '
+
+    env $build_env \
+        ./x.py build \
+            --target x86_64-unknown-linux-gnu,aarch64-unknown-nto-qnx710 \
+            rustc library/core library/alloc library/std
+    ```
 
 ## Running the Rust test suite
 

--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -2,11 +2,13 @@
 
 **Tier: 3**
 
-[QNX®][BlackBerry] Neutrino (nto) Real-time operating system.
-The support has been implemented jointly by [Elektrobit Automotive GmbH][Elektrobit]
-and [Blackberry QNX][BlackBerry].
+The [QNX®][qnx.com] Neutrino (nto) Real-time operating system. Known as QNX OS
+from version 8 onwards.
 
-[BlackBerry]: https://blackberry.qnx.com
+This support has been implemented jointly by [Elektrobit Automotive GmbH][Elektrobit]
+and [QNX][qnx.com].
+
+[qnx.com]: https://blackberry.qnx.com
 [Elektrobit]: https://www.elektrobit.com
 
 ## Target maintainers
@@ -18,30 +20,29 @@ and [Blackberry QNX][BlackBerry].
 
 ## Requirements
 
-Currently, the following QNX Neutrino versions and compilation targets are supported:
+Currently, the following QNX versions and compilation targets are supported:
 
-| QNX Neutrino Version | Target Architecture | Full support | `no_std` support |
-|----------------------|---------------------|:------------:|:----------------:|
-| 8.0              | AArch64  | ? | ✓ |
-| 8.0              | x86      | ? | ✓ |
-| 7.1 with io-pkt  | AArch64  | ✓ | ✓ |
-| 7.1 with io-sock | AArch64  | ? | ✓ |
-| 7.1 with io-pkt  | x86_64   | ✓ | ✓ |
-| 7.1 with io-sock | x86_64   | ? | ✓ |
-| 7.0              | AArch64  | ? | ✓ |
-| 7.0              | x86      |   | ✓ |
+| Target Tuple                        | QNX Version                   | Target Architecture | Full support | `no_std` support |
+| ----------------------------------- | ----------------------------- | ------------------- | :----------: | :--------------: |
+| `aarch64-unknown-nto-qnx800`        | QNX OS 8.0                    | AArch64             |      ?       |        ✓         |
+| `x86_64-pc-nto-qnx800`              | QNX OS 8.0                    | x86_64              |      ?       |        ✓         |
+| `aarch64-unknown-nto-qnx710`        | QNX Neutrino 7.1 with io-pkt  | AArch64             |      ✓       |        ✓         |
+| `x86_64-pc-nto-qnx710`              | QNX Neutrino 7.1 with io-pkt  | x86_64              |      ✓       |        ✓         |
+| `aarch64-unknown-nto-qnx710_iosock` | QNX Neutrino 7.1 with io-sock | AArch64             |      ?       |        ✓         |
+| `x86_64-pc-nto-qnx710_iosock`       | QNX Neutrino 7.1 with io-sock | x86_64              |      ?       |        ✓         |
+| `aarch64-unknown-nto-qnx700`        | QNX Neutrino 7.0              | AArch64             |      ?       |        ✓         |
+| `i586-pc-nto-qnx700`                | QNX Neutrino 7.0              | x86                 |              |        ✓         |
 
-On QNX 7.0 and 7.1, `io-pkt` is used as network stack by default. QNX 7.1 includes
-the optional network stack `io-sock`.
-QNX 8.0 always uses `io-sock`. QNX 8.0 support is currently in development
-and not tested.
+On QNX Neutrino 7.0 and 7.1, `io-pkt` is used as network stack by default.
+QNX Neutrino 7.1 includes the optional network stack `io-sock`.
+QNX OS 8.0 always uses `io-sock`. QNX OS 8.0 support is currently work in progress.
 
-Adding other architectures that are supported by QNX Neutrino is possible.
+Adding other architectures that are supported by QNX is possible.
 
-In the table above, 'full support' indicates support for building Rust applications with the full standard library.
-'`no_std` support' indicates that only `core` and `alloc` are available.
+In the table above, 'full support' indicates support for building Rust applications with the full standard library. A '?' means that support is in-progress.
+'`no_std` support' is for building `#![no_std]` applications where only `core` and `alloc` are available.
 
-For building or using the Rust toolchain for QNX Neutrino, the
+For building or using the Rust toolchain for QNX, the
 [QNX Software Development Platform (SDP)](https://blackberry.qnx.com/en/products/foundation-software/qnx-software-development-platform)
 must be installed and initialized.
 Initialization is usually done by sourcing `qnxsdp-env.sh` (this will be installed as part of the SDP, see also installation instruction provided with the SDP).
@@ -107,19 +108,19 @@ fn panic(_panic: &PanicInfo<'_>) -> ! {
 pub extern "C" fn rust_eh_personality() {}
 ```
 
-The QNX Neutrino support of Rust has been tested with QNX Neutrino 7.0 and 7.1.
+The QNX support in Rust has been tested with QNX Neutrino 7.0 and 7.1. Support for QNX OS 8.0 is a work in progress.
 
 There are no further known requirements.
 
 ## Conditional compilation
 
-For conditional compilation, following QNX Neutrino specific attributes are defined:
+For conditional compilation, following QNX specific attributes are defined:
 
 - `target_os` = `"nto"`
 - `target_env` = `"nto71"` (for QNX Neutrino 7.1 with "classic" network stack "io_pkt")
 - `target_env` = `"nto71_iosock"` (for QNX Neutrino 7.1 with network stack "io_sock")
 - `target_env` = `"nto70"` (for QNX Neutrino 7.0)
-- `target_env` = `"nto80"` (for QNX Neutrino 8.0)
+- `target_env` = `"nto80"` (for QNX OS 8.0)
 
 ## Building the target
 
@@ -137,7 +138,7 @@ For conditional compilation, following QNX Neutrino specific attributes are defi
     Compiling the Rust toolchain requires the same environment variables used for compiling C binaries.
     Refer to the [QNX developer manual](https://www.qnx.com/developers/docs/7.1/#com.qnx.doc.neutrino.prog/topic/devel_OS_version.html).
 
-    To compile for QNX Neutrino, environment variables must be set to use the correct tools and compiler switches:
+    To compile for QNX, environment variables must be set to use the correct tools and compiler switches:
 
     - `CC_<target>=qcc`
     - `CFLAGS_<target>=<nto_cflag>`
@@ -183,7 +184,7 @@ addition of the TEST_DEVICE_ADDR environment variable.
 The TEST_DEVICE_ADDR variable controls the remote runner and should point to the target, despite localhost being shown in the following example.
 Note that some tests are failing which is why they are currently excluded by the target maintainers which can be seen in the following example.
 
-To run all tests on a x86_64 QNX Neutrino target:
+To run all tests on a x86_64 QNX Neutrino 7.1 target:
 
 ```bash
 export TEST_DEVICE_ADDR="localhost:12345" # must address the test target, can be a SSH tunnel
@@ -217,7 +218,7 @@ or build your own copy of `core` by using `build-std` or similar.
 
 ## Testing
 
-Compiled executables can run directly on QNX Neutrino.
+Compiled executables can run directly on QNX.
 
 ### Rust std library test suite
 

--- a/src/doc/rustc/src/tests/index.md
+++ b/src/doc/rustc/src/tests/index.md
@@ -268,6 +268,8 @@ Controls the format of the output. Valid options:
 
 Writes the results of the tests to the given file.
 
+This option is deprecated.
+
 #### `--report-time`
 
 ⚠️ 🚧 This option is [unstable](#unstable-options), and requires the `-Z

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -57,6 +57,9 @@
 //@ revisions: aarch64_unknown_nto_qnx710
 //@ [aarch64_unknown_nto_qnx710] compile-flags: --target aarch64-unknown-nto-qnx710
 //@ [aarch64_unknown_nto_qnx710] needs-llvm-components: aarch64
+//@ revisions: aarch64_unknown_nto_qnx710_iosock
+//@ [aarch64_unknown_nto_qnx710_iosock] compile-flags: --target aarch64-unknown-nto-qnx710_iosock
+//@ [aarch64_unknown_nto_qnx710_iosock] needs-llvm-components: aarch64
 //@ revisions: aarch64_unknown_openbsd
 //@ [aarch64_unknown_openbsd] compile-flags: --target aarch64-unknown-openbsd
 //@ [aarch64_unknown_openbsd] needs-llvm-components: aarch64

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -60,6 +60,9 @@
 //@ revisions: aarch64_unknown_nto_qnx710_iosock
 //@ [aarch64_unknown_nto_qnx710_iosock] compile-flags: --target aarch64-unknown-nto-qnx710_iosock
 //@ [aarch64_unknown_nto_qnx710_iosock] needs-llvm-components: aarch64
+//@ revisions: aarch64_unknown_nto_qnx800
+//@ [aarch64_unknown_nto_qnx800] compile-flags: --target aarch64-unknown-nto-qnx800
+//@ [aarch64_unknown_nto_qnx800] needs-llvm-components: aarch64
 //@ revisions: aarch64_unknown_openbsd
 //@ [aarch64_unknown_openbsd] compile-flags: --target aarch64-unknown-openbsd
 //@ [aarch64_unknown_openbsd] needs-llvm-components: aarch64
@@ -570,6 +573,9 @@
 //@ revisions: x86_64_pc_nto_qnx710_iosock
 //@ [x86_64_pc_nto_qnx710_iosock] compile-flags: --target x86_64-pc-nto-qnx710_iosock
 //@ [x86_64_pc_nto_qnx710_iosock] needs-llvm-components: x86
+//@ revisions: x86_64_pc_nto_qnx800
+//@ [x86_64_pc_nto_qnx800] compile-flags: --target x86_64-pc-nto-qnx800
+//@ [x86_64_pc_nto_qnx800] needs-llvm-components: x86
 //@ revisions: x86_64_pc_solaris
 //@ [x86_64_pc_solaris] compile-flags: --target x86_64-pc-solaris
 //@ [x86_64_pc_solaris] needs-llvm-components: x86

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -567,6 +567,9 @@
 //@ revisions: x86_64_pc_nto_qnx710
 //@ [x86_64_pc_nto_qnx710] compile-flags: --target x86_64-pc-nto-qnx710
 //@ [x86_64_pc_nto_qnx710] needs-llvm-components: x86
+//@ revisions: x86_64_pc_nto_qnx710_iosock
+//@ [x86_64_pc_nto_qnx710_iosock] compile-flags: --target x86_64-pc-nto-qnx710_iosock
+//@ [x86_64_pc_nto_qnx710_iosock] needs-llvm-components: x86
 //@ revisions: x86_64_pc_solaris
 //@ [x86_64_pc_solaris] compile-flags: --target x86_64-pc-solaris
 //@ [x86_64_pc_solaris] needs-llvm-components: x86

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -156,7 +156,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_env = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_env` are: ``, `gnu`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `ohos`, `p1`, `p2`, `relibc`, `sgx`, and `uclibc`
+   = note: expected values for `target_env` are: ``, `gnu`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `nto71_iosock`, `ohos`, `p1`, `p2`, `relibc`, `sgx`, and `uclibc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -156,7 +156,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_env = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_env` are: ``, `gnu`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `nto71_iosock`, `ohos`, `p1`, `p2`, `relibc`, `sgx`, and `uclibc`
+   = note: expected values for `target_env` are: ``, `gnu`, `msvc`, `musl`, `newlib`, `nto70`, `nto71`, `nto71_iosock`, `nto80`, `ohos`, `p1`, `p2`, `relibc`, `sgx`, and `uclibc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`

--- a/tests/ui/wasm/wasm-bindgen-broken-error.rs
+++ b/tests/ui/wasm/wasm-bindgen-broken-error.rs
@@ -1,0 +1,28 @@
+//@ only-wasm32
+//@ revisions: v0_1_0 v0_2_87 v0_2_88 v0_3_0 v1_0_0
+//@[v0_1_0] check-fail
+//@[v0_1_0] rustc-env:CARGO_PKG_VERSION_MAJOR=0
+//@[v0_1_0] rustc-env:CARGO_PKG_VERSION_MINOR=1
+//@[v0_1_0] rustc-env:CARGO_PKG_VERSION_PATCH=0
+//@[v0_2_87] check-fail
+//@[v0_2_87] rustc-env:CARGO_PKG_VERSION_MAJOR=0
+//@[v0_2_87] rustc-env:CARGO_PKG_VERSION_MINOR=2
+//@[v0_2_87] rustc-env:CARGO_PKG_VERSION_PATCH=87
+//@[v0_2_88] check-pass
+//@[v0_2_88] rustc-env:CARGO_PKG_VERSION_MAJOR=0
+//@[v0_2_88] rustc-env:CARGO_PKG_VERSION_MINOR=2
+//@[v0_2_88] rustc-env:CARGO_PKG_VERSION_PATCH=88
+//@[v0_3_0] check-pass
+//@[v0_3_0] rustc-env:CARGO_PKG_VERSION_MAJOR=0
+//@[v0_3_0] rustc-env:CARGO_PKG_VERSION_MINOR=3
+//@[v0_3_0] rustc-env:CARGO_PKG_VERSION_PATCH=0
+//@[v1_0_0] check-pass
+//@[v1_0_0] rustc-env:CARGO_PKG_VERSION_MAJOR=1
+//@[v1_0_0] rustc-env:CARGO_PKG_VERSION_MINOR=0
+//@[v1_0_0] rustc-env:CARGO_PKG_VERSION_PATCH=0
+
+#![crate_name = "wasm_bindgen"]
+//[v0_1_0]~^ ERROR: older versions of the `wasm-bindgen` crate
+//[v0_2_87]~^^ ERROR: older versions of the `wasm-bindgen` crate
+
+fn main() {}

--- a/tests/ui/wasm/wasm-bindgen-broken-error.v0_1_0.stderr
+++ b/tests/ui/wasm/wasm-bindgen-broken-error.v0_1_0.stderr
@@ -1,0 +1,8 @@
+error: older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
+  --> $DIR/wasm-bindgen-broken-error.rs:24:1
+   |
+LL | #![crate_name = "wasm_bindgen"]
+   | ^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/wasm/wasm-bindgen-broken-error.v0_2_87.stderr
+++ b/tests/ui/wasm/wasm-bindgen-broken-error.v0_2_87.stderr
@@ -1,0 +1,8 @@
+error: older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
+  --> $DIR/wasm-bindgen-broken-error.rs:24:1
+   |
+LL | #![crate_name = "wasm_bindgen"]
+   | ^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - #133631 (Support QNX 7.1 with `io-sock`+libstd and QNX 8.0 (`no_std` only))
 - #133951 (Make the wasm_c_abi future compat warning a hard error)
 - #134283 (fix(libtest): Deprecate '--logfile')
 - #135635 (Move `std::io::pipe` code into its own file)
 - #135842 (TRPL: more backward-compatible Edition changes)
 - #135953 (ci.py: check the return code in `run-local`)
 - #136031 (Expand polonius MIR dump)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=133631,133951,134283,135635,135842,135953,136031)
<!-- homu-ignore:end -->