### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1285,13 +1285,13 @@ impl fmt::Debug for OwnerNodes<'_> {
             .field("node", &self.nodes[ItemLocalId::ZERO])
             .field(
                 "parents",
-                &self
-                    .nodes
-                    .iter_enumerated()
-                    .map(|(id, parented_node)| {
-                        debug_fn(move |f| write!(f, "({id:?}, {:?})", parented_node.parent))
-                    })
-                    .collect::<Vec<_>>(),
+                &fmt::from_fn(|f| {
+                    f.debug_list()
+                        .entries(self.nodes.iter_enumerated().map(|(id, parented_node)| {
+                            fmt::from_fn(move |f| write!(f, "({id:?}, {:?})", parented_node.parent))
+                        }))
+                        .finish()
+                }),
             )
             .field("bodies", &self.bodies)
             .field("opt_hash_including_bodies", &self.opt_hash_including_bodies)
@@ -4636,16 +4636,6 @@ mod size_asserts {
     static_assert_size!(Ty<'_>, 48);
     static_assert_size!(TyKind<'_>, 32);
     // tidy-alphabetical-end
-}
-
-fn debug_fn(f: impl Fn(&mut fmt::Formatter<'_>) -> fmt::Result) -> impl fmt::Debug {
-    struct DebugFn<F>(F);
-    impl<F: Fn(&mut fmt::Formatter<'_>) -> fmt::Result> fmt::Debug for DebugFn<F> {
-        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-            (self.0)(fmt)
-        }
-    }
-    DebugFn(f)
 }
 
 #[cfg(test)]

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(internal_features)]
 #![feature(associated_type_defaults)]
 #![feature(closure_track_caller)]
+#![feature(debug_closure_helpers)]
 #![feature(exhaustive_patterns)]
 #![feature(let_chains)]
 #![feature(never_type)]

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -63,6 +63,7 @@ This API is completely unstable and subject to change.
 #![doc(rust_logo)]
 #![feature(assert_matches)]
 #![feature(coroutines)]
+#![feature(debug_closure_helpers)]
 #![feature(if_let_guard)]
 #![feature(iter_from_coroutine)]
 #![feature(iter_intersperse)]

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -974,6 +974,3 @@ lint_use_let_underscore_ignore_suggestion = use `let _ = ...` to ignore the expr
 
 lint_variant_size_differences =
     enum variant is more than three times larger ({$largest} bytes) than the next largest
-
-lint_wasm_c_abi =
-    older versions of the `wasm-bindgen` crate will be incompatible with future versions of Rust; please update to `wasm-bindgen` v0.2.88

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -430,7 +430,6 @@ pub(super) fn decorate_lint(
         BuiltinLintDiag::UnusedCrateDependency { extern_crate, local_crate } => {
             lints::UnusedCrateDependency { extern_crate, local_crate }.decorate_lint(diag)
         }
-        BuiltinLintDiag::WasmCAbi => lints::WasmCAbi.decorate_lint(diag),
         BuiltinLintDiag::IllFormedAttributeInput { suggestions } => {
             lints::IllFormedAttributeInput {
                 num_suggestions: suggestions.len(),

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2562,10 +2562,6 @@ pub(crate) struct UnusedCrateDependency {
 }
 
 #[derive(LintDiagnostic)]
-#[diag(lint_wasm_c_abi)]
-pub(crate) struct WasmCAbi;
-
-#[derive(LintDiagnostic)]
 #[diag(lint_ill_formed_attribute_input)]
 pub(crate) struct IllFormedAttributeInput {
     pub num_suggestions: usize,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -143,7 +143,6 @@ declare_lint_pass! {
         UNUSED_VARIABLES,
         USELESS_DEPRECATED,
         WARNINGS,
-        WASM_C_ABI,
         // tidy-alphabetical-end
     ]
 }
@@ -4645,44 +4644,6 @@ declare_lint! {
         reason: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps,
         reference: "issue #120192 <https://github.com/rust-lang/rust/issues/120192>",
     };
-}
-
-declare_lint! {
-    /// The `wasm_c_abi` lint detects crate dependencies that are incompatible
-    /// with future versions of Rust that will emit spec-compliant C ABI.
-    ///
-    /// ### Example
-    ///
-    /// ```rust,ignore (needs extern crate)
-    /// #![deny(wasm_c_abi)]
-    /// ```
-    ///
-    /// This will produce:
-    ///
-    /// ```text
-    /// error: the following packages contain code that will be rejected by a future version of Rust: wasm-bindgen v0.2.87
-    ///   |
-    /// note: the lint level is defined here
-    ///  --> src/lib.rs:1:9
-    ///   |
-    /// 1 | #![deny(wasm_c_abi)]
-    ///   |         ^^^^^^^^^^
-    /// ```
-    ///
-    /// ### Explanation
-    ///
-    /// Rust has historically emitted non-spec-compliant C ABI. This has caused
-    /// incompatibilities between other compilers and Wasm targets. In a future
-    /// version of Rust this will be fixed and therefore dependencies relying
-    /// on the non-spec-compliant C ABI will stop functioning.
-    pub WASM_C_ABI,
-    Deny,
-    "detects dependencies that are incompatible with the Wasm C ABI",
-    @future_incompatible = FutureIncompatibleInfo {
-        reason: FutureIncompatibilityReason::FutureReleaseErrorReportInDeps,
-        reference: "issue #71871 <https://github.com/rust-lang/rust/issues/71871>",
-    };
-    crate_level_only
 }
 
 declare_lint! {

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -783,7 +783,6 @@ pub enum BuiltinLintDiag {
         extern_crate: Symbol,
         local_crate: Symbol,
     },
-    WasmCAbi,
     IllFormedAttributeInput {
         suggestions: Vec<String>,
     },

--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -290,6 +290,9 @@ metadata_unsupported_abi =
 metadata_unsupported_abi_i686 =
     ABI not supported by `#[link(kind = "raw-dylib")]` on i686
 
+metadata_wasm_c_abi =
+    older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
+
 metadata_wasm_import_form =
     wasm import module must be of the form `wasm_import_module = "string"`
 

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -1076,12 +1076,7 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
             // Make a point span rather than covering the whole file
             let span = krate.spans.inner_span.shrink_to_lo();
 
-            self.sess.psess.buffer_lint(
-                lint::builtin::WASM_C_ABI,
-                span,
-                ast::CRATE_NODE_ID,
-                BuiltinLintDiag::WasmCAbi,
-            );
+            self.sess.dcx().emit_err(errors::WasmCAbi { span });
         }
     }
 

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -732,3 +732,10 @@ pub struct ImportNameTypeRaw {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(metadata_wasm_c_abi)]
+pub(crate) struct WasmCAbi {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -40,6 +40,7 @@
 #![feature(const_type_name)]
 #![feature(core_intrinsics)]
 #![feature(coroutines)]
+#![feature(debug_closure_helpers)]
 #![feature(decl_macro)]
 #![feature(discriminant_kind)]
 #![feature(extern_types)]

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -581,9 +581,11 @@ impl<'tcx> TerminatorKind<'tcx> {
 pub enum TerminatorEdges<'mir, 'tcx> {
     /// For terminators that have no successor, like `return`.
     None,
-    /// For terminators that a single successor, like `goto`, and `assert` without cleanup block.
+    /// For terminators that have a single successor, like `goto`, and `assert` without a cleanup
+    /// block.
     Single(BasicBlock),
-    /// For terminators that two successors, `assert` with cleanup block and `falseEdge`.
+    /// For terminators that have two successors, like `assert` with a cleanup block, and
+    /// `falseEdge`.
     Double(BasicBlock, BasicBlock),
     /// Special action for `Yield`, `Call` and `InlineAsm` terminators.
     AssignOnReturn {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2325,51 +2325,41 @@ macro_rules! sty_debug_print {
 }
 
 impl<'tcx> TyCtxt<'tcx> {
-    pub fn debug_stats(self) -> impl std::fmt::Debug + 'tcx {
-        struct DebugStats<'tcx>(TyCtxt<'tcx>);
+    pub fn debug_stats(self) -> impl fmt::Debug + 'tcx {
+        fmt::from_fn(move |fmt| {
+            sty_debug_print!(
+                fmt,
+                self,
+                Adt,
+                Array,
+                Slice,
+                RawPtr,
+                Ref,
+                FnDef,
+                FnPtr,
+                UnsafeBinder,
+                Placeholder,
+                Coroutine,
+                CoroutineWitness,
+                Dynamic,
+                Closure,
+                CoroutineClosure,
+                Tuple,
+                Bound,
+                Param,
+                Infer,
+                Alias,
+                Pat,
+                Foreign
+            )?;
 
-        impl<'tcx> std::fmt::Debug for DebugStats<'tcx> {
-            fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                sty_debug_print!(
-                    fmt,
-                    self.0,
-                    Adt,
-                    Array,
-                    Slice,
-                    RawPtr,
-                    Ref,
-                    FnDef,
-                    FnPtr,
-                    UnsafeBinder,
-                    Placeholder,
-                    Coroutine,
-                    CoroutineWitness,
-                    Dynamic,
-                    Closure,
-                    CoroutineClosure,
-                    Tuple,
-                    Bound,
-                    Param,
-                    Infer,
-                    Alias,
-                    Pat,
-                    Foreign
-                )?;
+            writeln!(fmt, "GenericArgs interner: #{}", self.interners.args.len())?;
+            writeln!(fmt, "Region interner: #{}", self.interners.region.len())?;
+            writeln!(fmt, "Const Allocation interner: #{}", self.interners.const_allocation.len())?;
+            writeln!(fmt, "Layout interner: #{}", self.interners.layout.len())?;
 
-                writeln!(fmt, "GenericArgs interner: #{}", self.0.interners.args.len())?;
-                writeln!(fmt, "Region interner: #{}", self.0.interners.region.len())?;
-                writeln!(
-                    fmt,
-                    "Const Allocation interner: #{}",
-                    self.0.interners.const_allocation.len()
-                )?;
-                writeln!(fmt, "Layout interner: #{}", self.0.interners.layout.len())?;
-
-                Ok(())
-            }
-        }
-
-        DebugStats(self)
+            Ok(())
+        })
     }
 }
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1789,7 +1789,7 @@ pub(crate) struct UnusedAssign {
 pub(crate) struct UnusedAssignSuggestion {
     pub pre: &'static str,
     #[suggestion_part(code = "{pre}mut ")]
-    pub ty_span: Span,
+    pub ty_span: Option<Span>,
     #[suggestion_part(code = "")]
     pub ty_ref_span: Span,
     #[suggestion_part(code = "*")]

--- a/compiler/rustc_target/src/callconv/s390x.rs
+++ b/compiler/rustc_target/src/callconv/s390x.rs
@@ -38,9 +38,17 @@ where
     }
 
     let size = arg.layout.size;
-    if size.bits() <= 128 && arg.layout.is_single_vector_element(cx, size) {
-        arg.cast_to(Reg { kind: RegKind::Vector, size });
-        return;
+    if size.bits() <= 128 {
+        if let BackendRepr::Vector { .. } = arg.layout.backend_repr {
+            // pass non-wrapped vector types using `PassMode::Direct`
+            return;
+        }
+
+        if arg.layout.is_single_vector_element(cx, size) {
+            // pass non-transparant wrappers around a vector as `PassMode::Cast`
+            arg.cast_to(Reg { kind: RegKind::Vector, size });
+            return;
+        }
     }
     if !arg.layout.is_aggregate() && size.bits() <= 64 {
         arg.extend_integer_width_to(64);

--- a/library/alloc/benches/btree/map.rs
+++ b/library/alloc/benches/btree/map.rs
@@ -353,6 +353,7 @@ pub fn iter_10k(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg_attr(target_os = "emscripten", ignore)] // hits an OOM
 pub fn iter_1m(b: &mut Bencher) {
     bench_iter(b, 1_000, 1_000_000);
 }

--- a/library/alloc/benches/slice.rs
+++ b/library/alloc/benches/slice.rs
@@ -366,14 +366,25 @@ rotate!(rotate_medium_half, gen_random, 9158, 9158 / 2);
 rotate!(rotate_medium_half_plus_one, gen_random, 9158, 9158 / 2 + 1);
 
 // Intended to use more RAM than the machine has cache
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by1, gen_random, 5 * 1024 * 1024, 1);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by9199_u64, gen_random, 5 * 1024 * 1024, 9199);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by9199_bytes, gen_random_bytes, 5 * 1024 * 1024, 9199);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by9199_strings, gen_strings, 5 * 1024 * 1024, 9199);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by9199_big, gen_big_random, 5 * 1024 * 1024, 9199);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by1234577_u64, gen_random, 5 * 1024 * 1024, 1234577);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by1234577_bytes, gen_random_bytes, 5 * 1024 * 1024, 1234577);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by1234577_strings, gen_strings, 5 * 1024 * 1024, 1234577);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_by1234577_big, gen_big_random, 5 * 1024 * 1024, 1234577);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_half, gen_random, 5 * 1024 * 1024, 5 * 1024 * 1024 / 2);
+#[cfg(not(target_os = "emscripten"))] // hits an OOM
 rotate!(rotate_huge_half_plus_one, gen_random, 5 * 1024 * 1024, 5 * 1024 * 1024 / 2 + 1);

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -547,6 +547,11 @@ fn bench_in_place_collect_droppable(b: &mut Bencher) {
     })
 }
 
+// node.js gives out of memory error to use with length 1_100_000
+#[cfg(target_os = "emscripten")]
+const LEN: usize = 4096;
+
+#[cfg(not(target_os = "emscripten"))]
 const LEN: usize = 16384;
 
 #[bench]

--- a/library/alloc/tests/collections/binary_heap.rs
+++ b/library/alloc/tests/collections/binary_heap.rs
@@ -502,9 +502,7 @@ fn test_retain_catch_unwind() {
 // even if the order might not be correct.
 //
 // Destructors must be called exactly once per element.
-// FIXME: re-enable emscripten once it can unwind again
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn panic_safe() {
     use std::cmp;

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -93,9 +93,6 @@ fn test_rng() -> rand_xorshift::XorShiftRng {
     rand::SeedableRng::from_seed(seed)
 }
 
-// FIXME: Instantiated functions with i128 in the signature is not supported in Emscripten.
-// See https://github.com/kripken/emscripten-fastcomp/issues/169
-#[cfg(not(target_os = "emscripten"))]
 #[test]
 fn test_boxed_hasher() {
     let ordinary_hash = hash(&5u32);

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1414,7 +1414,6 @@ fn test_box_slice_clone() {
 
 #[test]
 #[allow(unused_must_use)] // here, we care about the side effects of `.clone()`
-#[cfg_attr(target_os = "emscripten", ignore)]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_box_slice_clone_panics() {
     use std::sync::Arc;

--- a/library/alloc/tests/sort/tests.rs
+++ b/library/alloc/tests/sort/tests.rs
@@ -11,7 +11,14 @@ use crate::sort::{Sort, known_good_stable_sort, patterns};
 #[cfg(miri)]
 const TEST_LENGTHS: &[usize] = &[2, 3, 4, 7, 10, 15, 20, 24, 33, 50, 100, 171, 300];
 
-#[cfg(not(miri))]
+// node.js gives out of memory error to use with length 1_100_000
+#[cfg(all(not(miri), target_os = "emscripten"))]
+const TEST_LENGTHS: &[usize] = &[
+    2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 20, 24, 30, 32, 33, 35, 50, 100, 200, 500, 1_000,
+    2_048, 5_000, 10_000, 100_000,
+];
+
+#[cfg(all(not(miri), not(target_os = "emscripten")))]
 const TEST_LENGTHS: &[usize] = &[
     2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 20, 24, 30, 32, 33, 35, 50, 100, 200, 500, 1_000,
     2_048, 5_000, 10_000, 100_000, 1_100_000,

--- a/library/alloc/tests/sync.rs
+++ b/library/alloc/tests/sync.rs
@@ -128,6 +128,7 @@ fn try_unwrap() {
 }
 
 #[test]
+#[cfg_attr(any(target_os = "emscripten", target_os = "wasi"), ignore)] // no threads
 fn into_inner() {
     for _ in 0..100
     // ^ Increase chances of hitting potential race conditions

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1587,9 +1587,7 @@ fn extract_if_complex() {
     }
 }
 
-// FIXME: re-enable emscripten once it can unwind again
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn extract_if_consumed_panic() {
     use std::rc::Rc;
@@ -1640,9 +1638,7 @@ fn extract_if_consumed_panic() {
     }
 }
 
-// FIXME: Re-enable emscripten once it can catch panics
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn extract_if_unconsumed_panic() {
     use std::rc::Rc;

--- a/library/core/tests/hash/mod.rs
+++ b/library/core/tests/hash/mod.rs
@@ -141,9 +141,6 @@ fn test_custom_state() {
     // const { assert!(hash(&Custom { hash: 6 }) == 6) };
 }
 
-// FIXME: Instantiated functions with i128 in the signature is not supported in Emscripten.
-// See https://github.com/kripken/emscripten-fastcomp/issues/169
-#[cfg(not(target_os = "emscripten"))]
 #[test]
 fn test_indirect_hasher() {
     let mut hasher = MyHasher { hash: 0 };

--- a/library/core/tests/num/flt2dec/random.rs
+++ b/library/core/tests/num/flt2dec/random.rs
@@ -84,9 +84,6 @@ where
     F: for<'a> FnMut(&Decoded, &'a mut [MaybeUninit<u8>]) -> Option<(&'a [u8], i16)>,
     G: for<'a> FnMut(&Decoded, &'a mut [MaybeUninit<u8>]) -> (&'a [u8], i16),
 {
-    if cfg!(target_os = "emscripten") {
-        return; // using rng pulls in i128 support, which doesn't work
-    }
     let mut rng = crate::test_rng();
     let f32_range = Uniform::new(0x0000_0001u32, 0x7f80_0000);
     iterate("f32_random_equivalence_test", k, n, f, g, |_| {
@@ -100,9 +97,6 @@ where
     F: for<'a> FnMut(&Decoded, &'a mut [MaybeUninit<u8>]) -> Option<(&'a [u8], i16)>,
     G: for<'a> FnMut(&Decoded, &'a mut [MaybeUninit<u8>]) -> (&'a [u8], i16),
 {
-    if cfg!(target_os = "emscripten") {
-        return; // using rng pulls in i128 support, which doesn't work
-    }
     let mut rng = crate::test_rng();
     let f64_range = Uniform::new(0x0000_0000_0000_0001u64, 0x7ff0_0000_0000_0000);
     iterate("f64_random_equivalence_test", k, n, f, g, |_| {

--- a/library/core/tests/num/ops.rs
+++ b/library/core/tests/num/ops.rs
@@ -51,9 +51,7 @@ macro_rules! test_op {
     };
 }
 
-test_op!(test_neg_defined, Neg::neg(0), 0, i8, i16, i32, i64, f32, f64);
-#[cfg(not(target_os = "emscripten"))]
-test_op!(test_neg_defined_128, Neg::neg(0), 0, i128);
+test_op!(test_neg_defined, Neg::neg(0), 0, i8, i16, i32, i64, i128, f32, f64);
 
 test_op!(test_not_defined_bool, Not::not(true), false, bool);
 
@@ -69,17 +67,17 @@ macro_rules! test_arith_op {
                 i16,
                 i32,
                 i64,
+                i128,
                 isize,
                 u8,
                 u16,
                 u32,
                 u64,
+                u128,
                 usize,
                 f32,
                 f64
             );
-            #[cfg(not(target_os = "emscripten"))]
-            impls_defined!($op, $method($lhs, $rhs), 0, i128, u128);
         }
     };
     ($fn_name:ident, $op:ident::$method:ident(&mut $lhs:literal, $rhs:literal)) => {
@@ -93,17 +91,17 @@ macro_rules! test_arith_op {
                 i16,
                 i32,
                 i64,
+                i128,
                 isize,
                 u8,
                 u16,
                 u32,
                 u64,
+                u128,
                 usize,
                 f32,
                 f64
             );
-            #[cfg(not(target_os = "emscripten"))]
-            impls_defined!($op, $method(&mut $lhs, $rhs), 0, i128, u128);
         }
     };
 }
@@ -131,15 +129,15 @@ macro_rules! test_bitop {
                 i16,
                 i32,
                 i64,
+                i128,
                 isize,
                 u8,
                 u16,
                 u32,
                 u64,
+                u128,
                 usize
             );
-            #[cfg(not(target_os = "emscripten"))]
-            impls_defined!($op, $method(0, 0), 0, i128, u128);
             impls_defined!($op, $method(false, false), false, bool);
         }
     };
@@ -156,15 +154,15 @@ macro_rules! test_bitop_assign {
                 i16,
                 i32,
                 i64,
+                i128,
                 isize,
                 u8,
                 u16,
                 u32,
                 u64,
+                u128,
                 usize
             );
-            #[cfg(not(target_os = "emscripten"))]
-            impls_defined!($op, $method(&mut 0, 0), 0, i128, u128);
             impls_defined!($op, $method(&mut false, false), false, bool);
         }
     };
@@ -182,9 +180,11 @@ macro_rules! test_shift_inner {
         $(impl_defined!($op, $method(0,0), 0, $lt, $rt);)+
     };
     ($op:ident::$method:ident, $lt:ty) => {
-        test_shift_inner!($op::$method, $lt, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
-        #[cfg(not(target_os = "emscripten"))]
-        test_shift_inner!($op::$method, $lt, i128, u128);
+        test_shift_inner!(
+            $op::$method, $lt,
+            i8, i16, i32, i64, i128, isize,
+            u8, u16, u32, u64, u128, usize
+        );
     };
 }
 
@@ -195,9 +195,11 @@ macro_rules! test_shift {
     ($test_name:ident, $op:ident::$method:ident) => {
         #[test]
         fn $test_name() {
-            test_shift!($op::$method, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
-            #[cfg(not(target_os = "emscripten"))]
-            test_shift!($op::$method, i128, u128);
+            test_shift!(
+                $op::$method,
+                i8, i16, i32, i64, i128, isize,
+                u8, u16, u32, u64, u128, usize
+            );
         }
     };
 }
@@ -207,9 +209,11 @@ macro_rules! test_shift_assign_inner {
         $(impl_defined!($op, $method(&mut 0,0), 0, $lt, $rt);)+
     };
     ($op:ident::$method:ident, $lt:ty) => {
-        test_shift_assign_inner!($op::$method, $lt, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
-        #[cfg(not(target_os = "emscripten"))]
-        test_shift_assign_inner!($op::$method, $lt, i128, u128);
+        test_shift_assign_inner!(
+            $op::$method, $lt,
+            i8, i16, i32, i64, i128, isize,
+            u8, u16, u32, u64, u128, usize
+        );
     };
 }
 
@@ -220,9 +224,11 @@ macro_rules! test_shift_assign {
     ($test_name:ident, $op:ident::$method:ident) => {
         #[test]
         fn $test_name() {
-            test_shift_assign!($op::$method, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
-            #[cfg(not(target_os = "emscripten"))]
-            test_shift_assign!($op::$method, i128, u128);
+            test_shift_assign!(
+                $op::$method,
+                i8, i16, i32, i64, i128, isize,
+                u8, u16, u32, u64, u128, usize
+            );
         }
     };
 }

--- a/library/core/tests/num/wrapping.rs
+++ b/library/core/tests/num/wrapping.rs
@@ -64,14 +64,12 @@ wrapping_test!(test_wrapping_i8, i8, i8::MIN, i8::MAX);
 wrapping_test!(test_wrapping_i16, i16, i16::MIN, i16::MAX);
 wrapping_test!(test_wrapping_i32, i32, i32::MIN, i32::MAX);
 wrapping_test!(test_wrapping_i64, i64, i64::MIN, i64::MAX);
-#[cfg(not(target_os = "emscripten"))]
 wrapping_test!(test_wrapping_i128, i128, i128::MIN, i128::MAX);
 wrapping_test!(test_wrapping_isize, isize, isize::MIN, isize::MAX);
 wrapping_test!(test_wrapping_u8, u8, u8::MIN, u8::MAX);
 wrapping_test!(test_wrapping_u16, u16, u16::MIN, u16::MAX);
 wrapping_test!(test_wrapping_u32, u32, u32::MIN, u32::MAX);
 wrapping_test!(test_wrapping_u64, u64, u64::MIN, u64::MAX);
-#[cfg(not(target_os = "emscripten"))]
 wrapping_test!(test_wrapping_u128, u128, u128::MIN, u128::MAX);
 wrapping_test!(test_wrapping_usize, usize, usize::MIN, usize::MAX);
 

--- a/library/std/src/f64/tests.rs
+++ b/library/std/src/f64/tests.rs
@@ -112,7 +112,6 @@ fn test_neg_zero() {
     assert_eq!(Fp::Zero, neg_zero.classify());
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn test_one() {
     let one: f64 = 1.0f64;
@@ -165,7 +164,6 @@ fn test_is_finite() {
     assert!((-109.2f64).is_finite());
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn test_is_normal() {
     let nan: f64 = f64::NAN;
@@ -183,7 +181,6 @@ fn test_is_normal() {
     assert!(!1e-308f64.is_normal());
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn test_classify() {
     let nan: f64 = f64::NAN;

--- a/library/std/src/io/copy/tests.rs
+++ b/library/std/src/io/copy/tests.rs
@@ -126,6 +126,7 @@ mod io_benches {
     use crate::io::prelude::*;
 
     #[bench]
+    #[cfg_attr(target_os = "emscripten", ignore)] // no /dev
     fn bench_copy_buf_reader(b: &mut Bencher) {
         let mut file_in = File::open("/dev/zero").expect("opening /dev/zero failed");
         // use dyn to avoid specializations unrelated to readbuf

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -7,7 +7,6 @@ use crate::mem::MaybeUninit;
 use crate::ops::Deref;
 
 #[test]
-#[cfg_attr(target_os = "emscripten", ignore)]
 fn read_until() {
     let mut buf = Cursor::new(&b"12"[..]);
     let mut v = Vec::new();
@@ -359,7 +358,6 @@ fn chain_zero_length_read_is_not_eof() {
 }
 
 #[bench]
-#[cfg_attr(target_os = "emscripten", ignore)]
 #[cfg_attr(miri, ignore)] // Miri isn't fast...
 fn bench_read_to_end(b: &mut test::Bencher) {
     b.iter(|| {

--- a/library/std/src/sys/alloc/wasm.rs
+++ b/library/std/src/sys/alloc/wasm.rs
@@ -1,6 +1,6 @@
 //! This is an implementation of a global allocator on wasm targets when
-//! emscripten is not in use. In that situation there's no actual runtime for us
-//! to lean on for allocation, so instead we provide our own!
+//! emscripten or wasi is not in use. In that situation there's no actual runtime
+//! for us to lean on for allocation, so instead we provide our own!
 //!
 //! The wasm instruction set has two instructions for getting the current
 //! amount of memory and growing the amount of memory. These instructions are the

--- a/library/std/src/sys/pal/wasi/mod.rs
+++ b/library/std/src/sys/pal/wasi/mod.rs
@@ -1,8 +1,7 @@
 //! System bindings for the wasm/web platform
 //!
 //! This module contains the facade (aka platform-specific) implementations of
-//! OS level functionality for wasm. Note that this wasm is *not* the emscripten
-//! wasm, so we have no runtime here.
+//! OS level functionality for wasm.
 //!
 //! This is all super highly experimental and not actually intended for
 //! wide/production use yet, it's still all in the experimental category. This

--- a/library/std/src/sys/pal/wasm/mod.rs
+++ b/library/std/src/sys/pal/wasm/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains the facade (aka platform-specific) implementations of
 //! OS level functionality for wasm. Note that this wasm is *not* the emscripten
-//! wasm, so we have no runtime here.
+//! or wasi wasm, so we have no runtime here.
 //!
 //! This is all super highly experimental and not actually intended for
 //! wide/production use yet, it's still all in the experimental category. This

--- a/library/std/tests/pipe_subprocess.rs
+++ b/library/std/tests/pipe_subprocess.rs
@@ -1,7 +1,7 @@
 #![feature(anonymous_pipe)]
 
 fn main() {
-    #[cfg(all(not(miri), any(unix, windows)))]
+    #[cfg(all(not(miri), any(unix, windows), not(target_os = "emscripten")))]
     {
         use std::io::{Read, pipe};
         use std::{env, process};

--- a/library/std/tests/process_spawning.rs
+++ b/library/std/tests/process_spawning.rs
@@ -5,7 +5,8 @@ use std::{env, fs, process, str};
 mod common;
 
 #[test]
-#[cfg_attr(any(miri, target_os = "wasi"), ignore)] // Process spawning not supported by Miri and wasi
+// Process spawning not supported by Miri, Emscripten and wasi
+#[cfg_attr(any(miri, target_os = "emscripten", target_os = "wasi"), ignore)]
 fn issue_15149() {
     // If we're the parent, copy our own binary to a new directory.
     let my_path = env::current_exe().unwrap();

--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -1,7 +1,7 @@
 //! Module converting command-line arguments into test configuration.
 
 use std::env;
-use std::io::{self, IsTerminal};
+use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
 
 use super::options::{ColorConfig, Options, OutputFormat, RunIgnored};
@@ -58,7 +58,7 @@ fn optgroups() -> getopts::Options {
         .optflag("", "bench", "Run benchmarks instead of tests")
         .optflag("", "list", "List all tests and benchmarks")
         .optflag("h", "help", "Display this message")
-        .optopt("", "logfile", "Write logs to the specified file", "PATH")
+        .optopt("", "logfile", "Write logs to the specified file (deprecated)", "PATH")
         .optflag(
             "",
             "nocapture",
@@ -280,6 +280,10 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
     let format = get_format(&matches, quiet, allow_unstable)?;
 
     let options = Options::new().display_output(matches.opt_present("show-output"));
+
+    if logfile.is_some() {
+        let _ = write!(io::stderr(), "warning: `--logfile` is deprecated");
+    }
 
     let test_opts = TestOpts {
         list,

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -133,9 +133,7 @@ fn ignored_tests_result_in_ignored() {
     assert_eq!(result, TrIgnored);
 }
 
-// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic() {
     fn f() -> Result<(), String> {
@@ -164,9 +162,7 @@ fn test_should_panic() {
     assert_eq!(result, TrOk);
 }
 
-// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_good_message() {
     fn f() -> Result<(), String> {
@@ -195,9 +191,7 @@ fn test_should_panic_good_message() {
     assert_eq!(result, TrOk);
 }
 
-// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_bad_message() {
     use crate::tests::TrFailedMsg;
@@ -231,9 +225,7 @@ fn test_should_panic_bad_message() {
     assert_eq!(result, TrFailedMsg(failed_msg.to_string()));
 }
 
-// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_non_string_message_type() {
     use std::any::TypeId;
@@ -272,9 +264,7 @@ fn test_should_panic_non_string_message_type() {
     assert_eq!(result, TrFailedMsg(failed_msg));
 }
 
-// FIXME: Re-enable emscripten once it can catch panics again (introduced by #65251)
 #[test]
-#[cfg(not(target_os = "emscripten"))]
 #[cfg_attr(not(panic = "unwind"), ignore = "test requires unwinding support")]
 fn test_should_panic_but_succeeds() {
     let should_panic_variants = [ShouldPanic::Yes, ShouldPanic::YesWithMessage("error message")];

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md
@@ -118,7 +118,7 @@ This target is not extensively tested in CI for the rust-lang/rust repository. I
 can be tested locally, for example, with:
 
 ```sh
-./x.py test --target wasm32-unknown-emscripten --skip src/tools/linkchecker
+EMCC_CFLAGS="-s MAXIMUM_MEMORY=2GB" ./x.py test --target wasm32-unknown-emscripten --skip src/tools/linkchecker
 ```
 
 To run these tests, both `emcc` and `node` need to be in your `$PATH`. You can

--- a/src/doc/rustc/src/tests/index.md
+++ b/src/doc/rustc/src/tests/index.md
@@ -268,6 +268,8 @@ Controls the format of the output. Valid options:
 
 Writes the results of the tests to the given file.
 
+This option is deprecated.
+
 #### `--report-time`
 
 ⚠️ 🚧 This option is [unstable](#unstable-options), and requires the `-Z

--- a/tests/codegen/s390x-simd.rs
+++ b/tests/codegen/s390x-simd.rs
@@ -1,0 +1,143 @@
+//! test that s390x vector types are passed using `PassMode::Direct`
+//! see also https://github.com/rust-lang/rust/issues/135744
+//@ add-core-stubs
+//@ compile-flags: --target s390x-unknown-linux-gnu -O
+//@ needs-llvm-components: systemz
+
+#![crate_type = "rlib"]
+#![feature(no_core, asm_experimental_arch)]
+#![feature(s390x_target_feature, simd_ffi, link_llvm_intrinsics, repr_simd)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+#[repr(simd)]
+struct i8x16([i8; 16]);
+
+#[repr(simd)]
+struct i16x8([i16; 8]);
+
+#[repr(simd)]
+struct i32x4([i32; 4]);
+
+#[repr(simd)]
+struct i64x2([i64; 2]);
+
+#[repr(simd)]
+struct f32x4([f32; 4]);
+
+#[repr(simd)]
+struct f64x2([f64; 2]);
+
+#[allow(improper_ctypes)]
+extern "C" {
+    #[link_name = "llvm.smax.v16i8"]
+    fn vmxb(a: i8x16, b: i8x16) -> i8x16;
+    #[link_name = "llvm.smax.v8i16"]
+    fn vmxh(a: i16x8, b: i16x8) -> i16x8;
+    #[link_name = "llvm.smax.v4i32"]
+    fn vmxf(a: i32x4, b: i32x4) -> i32x4;
+    #[link_name = "llvm.smax.v2i64"]
+    fn vmxg(a: i64x2, b: i64x2) -> i64x2;
+}
+
+// CHECK-LABEL: define <16 x i8> @max_i8x16
+// CHECK-SAME: <16 x i8> %a, <16 x i8> %b
+// CHECK: call <16 x i8> @llvm.smax.v16i8(<16 x i8> %a, <16 x i8> %b)
+#[no_mangle]
+#[target_feature(enable = "vector")]
+pub unsafe extern "C" fn max_i8x16(a: i8x16, b: i8x16) -> i8x16 {
+    vmxb(a, b)
+}
+
+// CHECK-LABEL: define <8 x i16> @max_i16x8
+// CHECK-SAME: <8 x i16> %a, <8 x i16> %b
+// CHECK: call <8 x i16> @llvm.smax.v8i16(<8 x i16> %a, <8 x i16> %b)
+#[no_mangle]
+#[target_feature(enable = "vector")]
+pub unsafe extern "C" fn max_i16x8(a: i16x8, b: i16x8) -> i16x8 {
+    vmxh(a, b)
+}
+
+// CHECK-LABEL: define <4 x i32> @max_i32x4
+// CHECK-SAME: <4 x i32> %a, <4 x i32> %b
+// CHECK: call <4 x i32> @llvm.smax.v4i32(<4 x i32> %a, <4 x i32> %b)
+#[no_mangle]
+#[target_feature(enable = "vector")]
+pub unsafe extern "C" fn max_i32x4(a: i32x4, b: i32x4) -> i32x4 {
+    vmxf(a, b)
+}
+
+// CHECK-LABEL: define <2 x i64> @max_i64x2
+// CHECK-SAME: <2 x i64> %a, <2 x i64> %b
+// CHECK: call <2 x i64> @llvm.smax.v2i64(<2 x i64> %a, <2 x i64> %b)
+#[no_mangle]
+#[target_feature(enable = "vector")]
+pub unsafe extern "C" fn max_i64x2(a: i64x2, b: i64x2) -> i64x2 {
+    vmxg(a, b)
+}
+
+// CHECK-LABEL: define <4 x float> @choose_f32x4
+// CHECK-SAME: <4 x float> %a, <4 x float> %b
+#[no_mangle]
+#[target_feature(enable = "vector")]
+pub unsafe extern "C" fn choose_f32x4(a: f32x4, b: f32x4, c: bool) -> f32x4 {
+    if c { a } else { b }
+}
+
+// CHECK-LABEL: define <2 x double> @choose_f64x2
+// CHECK-SAME: <2 x double> %a, <2 x double> %b
+#[no_mangle]
+#[target_feature(enable = "vector")]
+pub unsafe extern "C" fn choose_f64x2(a: f64x2, b: f64x2, c: bool) -> f64x2 {
+    if c { a } else { b }
+}
+
+#[repr(C)]
+struct Wrapper<T>(T);
+
+#[no_mangle]
+#[inline(never)]
+#[target_feature(enable = "vector")]
+pub unsafe extern "C" fn max_wrapper_i8x16(a: Wrapper<i8x16>, b: Wrapper<i8x16>) -> Wrapper<i8x16> {
+    // CHECK-LABEL: max_wrapper_i8x16
+    // CHECK-SAME: sret([16 x i8])
+    // CHECK-SAME: <16 x i8>
+    // CHECK-SAME: <16 x i8>
+    // CHECK: call <16 x i8> @llvm.smax.v16i8
+    // CHECK-SAME: <16 x i8>
+    // CHECK-SAME: <16 x i8>
+    Wrapper(vmxb(a.0, b.0))
+}
+
+#[no_mangle]
+#[inline(never)]
+#[target_feature(enable = "vector")]
+pub unsafe extern "C" fn max_wrapper_i64x2(a: Wrapper<i64x2>, b: Wrapper<i64x2>) -> Wrapper<i64x2> {
+    // CHECK-LABEL: max_wrapper_i64x2
+    // CHECK-SAME: sret([16 x i8])
+    // CHECK-SAME: <16 x i8>
+    // CHECK-SAME: <16 x i8>
+    // CHECK: call <2 x i64> @llvm.smax.v2i64
+    // CHECK-SAME: <2 x i64>
+    // CHECK-SAME: <2 x i64>
+    Wrapper(vmxg(a.0, b.0))
+}
+
+#[no_mangle]
+#[inline(never)]
+#[target_feature(enable = "vector")]
+pub unsafe extern "C" fn choose_wrapper_f64x2(
+    a: Wrapper<f64x2>,
+    b: Wrapper<f64x2>,
+    c: bool,
+) -> Wrapper<f64x2> {
+    // CHECK-LABEL: choose_wrapper_f64x2
+    // CHECK-SAME: sret([16 x i8])
+    // CHECK-SAME: <16 x i8>
+    // CHECK-SAME: <16 x i8>
+    Wrapper(choose_f64x2(a.0, b.0, c))
+}
+
+// CHECK: declare <2 x i64> @llvm.smax.v2i64(<2 x i64>, <2 x i64>)

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.fixed
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.fixed
@@ -1,17 +1,26 @@
 //@ run-rustfix
 #![deny(unused_assignments, unused_variables)]
+#![allow(unused_mut)]
 struct Object;
 
 fn change_object(object: &mut Object) { //~ HELP you might have meant to mutate
-    let object2 = Object;
-    *object = object2; //~ ERROR mismatched types
+   let object2 = Object;
+   *object = object2; //~ ERROR mismatched types
 }
 
 fn change_object2(object: &mut Object) { //~ ERROR variable `object` is assigned to, but never used
+   //~^ HELP you might have meant to mutate
+   let object2 = Object;
+   *object = object2;
+   //~^ ERROR `object2` does not live long enough
+   //~| ERROR value assigned to `object` is never read
+}
+
+fn change_object3(object: &mut Object) { //~ ERROR variable `object` is assigned to, but never used
     //~^ HELP you might have meant to mutate
-    let object2 = Object;
+    let mut object2 = Object; //~ HELP consider changing this to be mutable
     *object = object2;
-    //~^ ERROR `object2` does not live long enough
+    //~^ ERROR cannot borrow `object2` as mutable
     //~| ERROR value assigned to `object` is never read
 }
 
@@ -19,4 +28,5 @@ fn main() {
     let mut object = Object;
     change_object(&mut object);
     change_object2(&mut object);
+    change_object3(&mut object);
 }

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs
@@ -1,17 +1,26 @@
 //@ run-rustfix
 #![deny(unused_assignments, unused_variables)]
+#![allow(unused_mut)]
 struct Object;
 
 fn change_object(mut object: &Object) { //~ HELP you might have meant to mutate
-    let object2 = Object;
-    object = object2; //~ ERROR mismatched types
+   let object2 = Object;
+   object = object2; //~ ERROR mismatched types
 }
 
 fn change_object2(mut object: &Object) { //~ ERROR variable `object` is assigned to, but never used
+   //~^ HELP you might have meant to mutate
+   let object2 = Object;
+   object = &object2;
+   //~^ ERROR `object2` does not live long enough
+   //~| ERROR value assigned to `object` is never read
+}
+
+fn change_object3(mut object: &mut Object) { //~ ERROR variable `object` is assigned to, but never used
     //~^ HELP you might have meant to mutate
-    let object2 = Object;
-    object = &object2;
-    //~^ ERROR `object2` does not live long enough
+    let object2 = Object; //~ HELP consider changing this to be mutable
+    object = &mut object2;
+    //~^ ERROR cannot borrow `object2` as mutable
     //~| ERROR value assigned to `object` is never read
 }
 
@@ -19,4 +28,5 @@ fn main() {
     let mut object = Object;
     change_object(&mut object);
     change_object2(&mut object);
+    change_object3(&mut object);
 }

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
@@ -1,24 +1,24 @@
 error[E0308]: mismatched types
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:7:14
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:8:13
    |
 LL | fn change_object(mut object: &Object) {
    |                              ------- expected due to this parameter type
-LL |     let object2 = Object;
-LL |     object = object2;
-   |              ^^^^^^^ expected `&Object`, found `Object`
+LL |    let object2 = Object;
+LL |    object = object2;
+   |             ^^^^^^^ expected `&Object`, found `Object`
    |
 help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
    |
 LL ~ fn change_object(object: &mut Object) {
-LL |     let object2 = Object;
-LL ~     *object = object2;
+LL |    let object2 = Object;
+LL ~    *object = object2;
    |
 
 error: value assigned to `object` is never read
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:13:5
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:14:4
    |
-LL |     object = &object2;
-   |     ^^^^^^
+LL |    object = &object2;
+   |    ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:2:9
@@ -29,12 +29,12 @@ help: you might have meant to mutate the pointed at value being passed in, inste
    |
 LL ~ fn change_object2(object: &mut Object) {
 LL |
-LL |     let object2 = Object;
-LL ~     *object = object2;
+LL |    let object2 = Object;
+LL ~    *object = object2;
    |
 
 error: variable `object` is assigned to, but never used
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:10:23
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:11:23
    |
 LL | fn change_object2(mut object: &Object) {
    |                       ^^^^^^
@@ -47,23 +47,56 @@ LL | #![deny(unused_assignments, unused_variables)]
    |                             ^^^^^^^^^^^^^^^^
 
 error[E0597]: `object2` does not live long enough
-  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:13:14
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:14:13
    |
 LL | fn change_object2(mut object: &Object) {
    |                               - let's call the lifetime of this reference `'1`
 LL |
-LL |     let object2 = Object;
-   |         ------- binding `object2` declared here
-LL |     object = &object2;
-   |     ---------^^^^^^^^
-   |     |        |
-   |     |        borrowed value does not live long enough
-   |     assignment requires that `object2` is borrowed for `'1`
+LL |    let object2 = Object;
+   |        ------- binding `object2` declared here
+LL |    object = &object2;
+   |    ---------^^^^^^^^
+   |    |        |
+   |    |        borrowed value does not live long enough
+   |    assignment requires that `object2` is borrowed for `'1`
 ...
 LL | }
    | - `object2` dropped here while still borrowed
 
-error: aborting due to 4 previous errors
+error: value assigned to `object` is never read
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:22:5
+   |
+LL |     object = &mut object2;
+   |     ^^^^^^
+   |
+help: you might have meant to mutate the pointed at value being passed in, instead of changing the reference in the local binding
+   |
+LL ~ fn change_object3(object: &mut Object) {
+LL |
+LL |     let object2 = Object;
+LL ~     *object = object2;
+   |
 
-Some errors have detailed explanations: E0308, E0597.
+error: variable `object` is assigned to, but never used
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:19:23
+   |
+LL | fn change_object3(mut object: &mut Object) {
+   |                       ^^^^^^
+   |
+   = note: consider using `_object` instead
+
+error[E0596]: cannot borrow `object2` as mutable, as it is not declared as mutable
+  --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:22:14
+   |
+LL |     object = &mut object2;
+   |              ^^^^^^^^^^^^ cannot borrow as mutable
+   |
+help: consider changing this to be mutable
+   |
+LL |     let mut object2 = Object;
+   |         +++
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0308, E0596, E0597.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/wasm/wasm-bindgen-broken-error.rs
+++ b/tests/ui/wasm/wasm-bindgen-broken-error.rs
@@ -1,0 +1,28 @@
+//@ only-wasm32
+//@ revisions: v0_1_0 v0_2_87 v0_2_88 v0_3_0 v1_0_0
+//@[v0_1_0] check-fail
+//@[v0_1_0] rustc-env:CARGO_PKG_VERSION_MAJOR=0
+//@[v0_1_0] rustc-env:CARGO_PKG_VERSION_MINOR=1
+//@[v0_1_0] rustc-env:CARGO_PKG_VERSION_PATCH=0
+//@[v0_2_87] check-fail
+//@[v0_2_87] rustc-env:CARGO_PKG_VERSION_MAJOR=0
+//@[v0_2_87] rustc-env:CARGO_PKG_VERSION_MINOR=2
+//@[v0_2_87] rustc-env:CARGO_PKG_VERSION_PATCH=87
+//@[v0_2_88] check-pass
+//@[v0_2_88] rustc-env:CARGO_PKG_VERSION_MAJOR=0
+//@[v0_2_88] rustc-env:CARGO_PKG_VERSION_MINOR=2
+//@[v0_2_88] rustc-env:CARGO_PKG_VERSION_PATCH=88
+//@[v0_3_0] check-pass
+//@[v0_3_0] rustc-env:CARGO_PKG_VERSION_MAJOR=0
+//@[v0_3_0] rustc-env:CARGO_PKG_VERSION_MINOR=3
+//@[v0_3_0] rustc-env:CARGO_PKG_VERSION_PATCH=0
+//@[v1_0_0] check-pass
+//@[v1_0_0] rustc-env:CARGO_PKG_VERSION_MAJOR=1
+//@[v1_0_0] rustc-env:CARGO_PKG_VERSION_MINOR=0
+//@[v1_0_0] rustc-env:CARGO_PKG_VERSION_PATCH=0
+
+#![crate_name = "wasm_bindgen"]
+//[v0_1_0]~^ ERROR: older versions of the `wasm-bindgen` crate
+//[v0_2_87]~^^ ERROR: older versions of the `wasm-bindgen` crate
+
+fn main() {}

--- a/tests/ui/wasm/wasm-bindgen-broken-error.v0_1_0.stderr
+++ b/tests/ui/wasm/wasm-bindgen-broken-error.v0_1_0.stderr
@@ -1,0 +1,8 @@
+error: older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
+  --> $DIR/wasm-bindgen-broken-error.rs:24:1
+   |
+LL | #![crate_name = "wasm_bindgen"]
+   | ^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/wasm/wasm-bindgen-broken-error.v0_2_87.stderr
+++ b/tests/ui/wasm/wasm-bindgen-broken-error.v0_2_87.stderr
@@ -1,0 +1,8 @@
+error: older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
+  --> $DIR/wasm-bindgen-broken-error.rs:24:1
+   |
+LL | #![crate_name = "wasm_bindgen"]
+   | ^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - #133951 (Make the wasm_c_abi future compat warning a hard error)
 - #134283 (fix(libtest): Deprecate '--logfile')
 - #135785 (use `PassMode::Direct` for vector types on `s390x`)
 - #135948 (Update emscripten std tests)
 - #135951 (Use `fmt::from_fn` in more places in the compiler)
 - #136031 (Expand polonius MIR dump)
 - #136032 (Account for mutable borrow in argument suggestion)

Failed merges:

 - #135635 (Move `std::io::pipe` code into its own file)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=133951,134283,135785,135948,135951,136031,136032)
<!-- homu-ignore:end -->