### PR TITLE
Upgrade elsa to the newest version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "elsa"
-version = "1.7.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848fe615fbb0a74d9ae68dcaa510106d32e37d9416207bbea4bd008bd89c47ed"
+checksum = "2343daaeabe09879d4ea058bb4f1e63da3fc07dadc6634e01bda1b3d6a9d9d2b"
 dependencies = [
  "stable_deref_trait",
 ]

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.4.1"
 either = "1.0"
-elsa = "=1.7.1"
+elsa = "1.11.0"
 ena = "0.14.3"
 indexmap = { version = "2.4.0", features = ["rustc-rayon"] }
 jobserver_crate = { version = "0.1.28", package = "jobserver" }


### PR DESCRIPTION
This was locked to 1.7.1 because of an error in the elsa release process that has since been fixed. Upgrading has the advantage that the elsa code runs properly in miri, at least with tree borrows.

This was spawned from https://github.com/rust-lang/rust/issues/135870#issuecomment-2612470540