### PR TITLE
Downgrade `linker-warnings` to allow-by-default

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4091,6 +4091,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust,ignore (needs CLI args, platform-specific)
+    /// #[warn(linker_messages)]
     /// extern "C" {
     ///   fn foo();
     /// }
@@ -4104,17 +4105,24 @@ declare_lint! {
     ///          >>> referenced by rust_out.69edbd30df4ae57d-cgu.0
     ///          >>>               rust_out.rust_out.69edbd30df4ae57d-cgu.0.rcgu.o:(rust_out::main::h3a90094b06757803)
     ///   |
-    ///   = note: `#[warn(linker_messages)]` on by default
-    ///
+    /// note: the lint level is defined here
+    ///  --> warn.rs:1:9
+    ///   |
+    /// 1 | #![warn(linker_messages)]
+    ///   |         ^^^^^^^^^^^^^^^
     /// warning: 1 warning emitted
     /// ```
     ///
     /// ### Explanation
     ///
-    /// Linkers emit platform-specific and program-specific warnings that cannot be predicted in advance by the rust compiler.
-    /// They are forwarded by default, but can be disabled by adding `#![allow(linker_messages)]` at the crate root.
+    /// Linkers emit platform-specific and program-specific warnings that cannot be predicted in
+    /// advance by the Rust compiler. Such messages are ignored by default for now. While linker
+    /// warnings could be very useful they have been ignored for many years by essentially all
+    /// users, so we need to do a bit more work than just surfacing their text to produce a clear
+    /// and actionable warning of similar quality to our other diagnostics. See this tracking
+    /// issue for more details: <https://github.com/rust-lang/rust/issues/136096>.
     pub LINKER_MESSAGES,
-    Warn,
+    Allow,
     "warnings emitted at runtime by the target-specific linker program"
 }
 

--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -8,6 +8,7 @@ fn run_rustc() -> Rustc {
         // Make sure we use a consistent value.
         .arg("-Clink-self-contained=-linker")
         .arg("-Zunstable-options")
+        .arg("-Wlinker-messages")
         .output("main")
         .linker("./fake-linker");
     if run_make_support::target() == "x86_64-unknown-linux-gnu" {

--- a/tests/run-make/rust-lld-by-default-beta-stable/rmake.rs
+++ b/tests/run-make/rust-lld-by-default-beta-stable/rmake.rs
@@ -12,7 +12,7 @@ use run_make_support::rustc;
 fn main() {
     // A regular compilation should not use rust-lld by default. We'll check that by asking the
     // linker to display its version number with a link-arg.
-    let output = rustc().link_arg("-Wl,-v").input("main.rs").run();
+    let output = rustc().arg("-Wlinker-messages").link_arg("-Wl,-v").input("main.rs").run();
     assert!(
         !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",

--- a/tests/run-make/rust-lld-by-default-nightly/rmake.rs
+++ b/tests/run-make/rust-lld-by-default-nightly/rmake.rs
@@ -12,7 +12,7 @@ use run_make_support::rustc;
 fn main() {
     // A regular compilation should use rust-lld by default. We'll check that by asking the linker
     // to display its version number with a link-arg.
-    let output = rustc().link_arg("-Wl,-v").input("main.rs").run();
+    let output = rustc().arg("-Wlinker-messages").link_arg("-Wl,-v").input("main.rs").run();
     assert!(
         find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should be present in the output logs:\n{}",
@@ -20,7 +20,12 @@ fn main() {
     );
 
     // But it can still be disabled by turning the linker feature off.
-    let output = rustc().link_arg("-Wl,-v").arg("-Zlinker-features=-lld").input("main.rs").run();
+    let output = rustc()
+        .arg("-Wlinker-messages")
+        .link_arg("-Wl,-v")
+        .arg("-Zlinker-features=-lld")
+        .input("main.rs")
+        .run();
     assert!(
         !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",

--- a/tests/run-make/rust-lld-custom-target/rmake.rs
+++ b/tests/run-make/rust-lld-custom-target/rmake.rs
@@ -16,6 +16,7 @@ fn main() {
     // the linker to display its version number with a link-arg.
     let output = rustc()
         .crate_type("cdylib")
+        .arg("-Wlinker-messages")
         .target("custom-target.json")
         .link_arg("-Wl,-v")
         .input("lib.rs")
@@ -29,6 +30,7 @@ fn main() {
     // But it can also be disabled via linker features.
     let output = rustc()
         .crate_type("cdylib")
+        .arg("-Wlinker-messages")
         .target("custom-target.json")
         .arg("-Zlinker-features=-lld")
         .link_arg("-Wl,-v")

--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -17,6 +17,7 @@ fn main() {
         .arg("-Zlinker-features=+lld")
         .arg("-Clink-self-contained=+linker")
         .arg("-Zunstable-options")
+        .arg("-Wlinker-messages")
         .link_arg(linker_version_flag)
         .input("main.rs")
         .run();
@@ -27,8 +28,12 @@ fn main() {
     );
 
     // It should not be used when we explicitly opt-out of lld.
-    let output =
-        rustc().link_arg(linker_version_flag).arg("-Zlinker-features=-lld").input("main.rs").run();
+    let output = rustc()
+        .link_arg(linker_version_flag)
+        .arg("-Zlinker-features=-lld")
+        .arg("-Wlinker-messages")
+        .input("main.rs")
+        .run();
     assert!(
         !find_lld_version_in_logs(output.stderr_utf8()),
         "the LLD version string should not be present in the output logs:\n{}",
@@ -44,6 +49,7 @@ fn main() {
         .arg("-Zlinker-features=-lld")
         .arg("-Zlinker-features=+lld")
         .arg("-Zlinker-features=-lld,+lld")
+        .arg("-Wlinker-messages")
         .input("main.rs")
         .run();
     assert!(


### PR DESCRIPTION
This needs more time to bake before we turn it on. Turning it on early risks people silencing the warning indefinitely, before we have the chance to make it less noisy.

cc https://github.com/rust-lang/rust/issues/136096
fixes https://github.com/rust-lang/rust/issues/136086#issuecomment-2614476308

r? @saethlin cc @Noratrieb @bjorn3 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->


@rustbot label A-linkage L-linker_messages