### PR TITLE
[DO NOT MERGE] perf run for only mul/add-reordering parts of #136095

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,7 +1982,7 @@ dependencies = [
  "anyhow",
  "clap",
  "fs-err",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
  "rustdoc-json-types",
  "serde",
  "serde_json",
@@ -3151,7 +3151,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rinja_parser",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "syn 2.0.96",
 ]
@@ -3218,6 +3218,11 @@ name = "rustc-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663#3a89863922cb4ba5237a5bef65a9535b3d598663"
 
 [[package]]
 name = "rustc-main"
@@ -3621,7 +3626,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "portable-atomic",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
  "rustc-rayon",
  "rustc-stable-hash",
  "rustc_arena",
@@ -4324,7 +4329,7 @@ dependencies = [
 name = "rustc_pattern_analysis"
 version = "0.0.0"
 dependencies = [
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
  "rustc_abi",
  "rustc_apfloat",
  "rustc_arena",
@@ -4647,7 +4652,7 @@ dependencies = [
  "bitflags",
  "derive-where",
  "indexmap",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
  "rustc_ast_ir",
  "rustc_data_structures",
  "rustc_index",
@@ -4720,7 +4725,7 @@ name = "rustdoc-json-types"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
  "serde",
  "serde_json",
 ]
@@ -5371,7 +5376,7 @@ dependencies = [
  "ignore",
  "miropt-test-tools",
  "regex",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
  "semver",
  "similar",
  "termcolor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,7 +1982,7 @@ dependencies = [
  "anyhow",
  "clap",
  "fs-err",
- "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
+ "rustc-hash 2.2.0",
  "rustdoc-json-types",
  "serde",
  "serde_json",
@@ -3151,7 +3151,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rinja_parser",
- "rustc-hash 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 2.1.0",
  "serde",
  "syn 2.0.96",
 ]
@@ -3221,8 +3221,8 @@ checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
-source = "git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663#3a89863922cb4ba5237a5bef65a9535b3d598663"
+version = "2.2.0"
+source = "git+https://github.com/orlp/rustc-hash?rev=2ccde1ec8a948b5463011d3c7363c273fc2bb80e#2ccde1ec8a948b5463011d3c7363c273fc2bb80e"
 
 [[package]]
 name = "rustc-main"
@@ -3626,7 +3626,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "portable-atomic",
- "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
+ "rustc-hash 2.2.0",
  "rustc-rayon",
  "rustc-stable-hash",
  "rustc_arena",
@@ -4329,7 +4329,7 @@ dependencies = [
 name = "rustc_pattern_analysis"
 version = "0.0.0"
 dependencies = [
- "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
+ "rustc-hash 2.2.0",
  "rustc_abi",
  "rustc_apfloat",
  "rustc_arena",
@@ -4652,7 +4652,7 @@ dependencies = [
  "bitflags",
  "derive-where",
  "indexmap",
- "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
+ "rustc-hash 2.2.0",
  "rustc_ast_ir",
  "rustc_data_structures",
  "rustc_index",
@@ -4725,7 +4725,7 @@ name = "rustdoc-json-types"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
+ "rustc-hash 2.2.0",
  "serde",
  "serde_json",
 ]
@@ -5376,7 +5376,7 @@ dependencies = [
  "ignore",
  "miropt-test-tools",
  "regex",
- "rustc-hash 2.1.0 (git+https://github.com/orlp/rustc-hash?rev=3a89863922cb4ba5237a5bef65a9535b3d598663)",
+ "rustc-hash 2.2.0",
  "semver",
  "similar",
  "termcolor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,7 +3222,7 @@ checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 [[package]]
 name = "rustc-hash"
 version = "2.2.0"
-source = "git+https://github.com/orlp/rustc-hash?rev=2ccde1ec8a948b5463011d3c7363c273fc2bb80e#2ccde1ec8a948b5463011d3c7363c273fc2bb80e"
+source = "git+https://github.com/steffahn/rustc-hash?rev=1028035a81ec84e9fe25e39daeccb9d9ff7245d8#1028035a81ec84e9fe25e39daeccb9d9ff7245d8"
 
 [[package]]
 name = "rustc-main"

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -13,7 +13,7 @@ ena = "0.14.3"
 indexmap = { version = "2.4.0", features = ["rustc-rayon"] }
 jobserver_crate = { version = "0.1.28", package = "jobserver" }
 measureme = "11"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
 rustc-rayon = "0.5.0"
 rustc-stable-hash = { version = "0.1.0", features = ["nightly"] }
 rustc_arena = { path = "../rustc_arena" }

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -13,7 +13,7 @@ ena = "0.14.3"
 indexmap = { version = "2.4.0", features = ["rustc-rayon"] }
 jobserver_crate = { version = "0.1.28", package = "jobserver" }
 measureme = "11"
-rustc-hash = "2.0.0"
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
 rustc-rayon = "0.5.0"
 rustc-stable-hash = { version = "0.1.0", features = ["nightly"] }
 rustc_arena = { path = "../rustc_arena" }

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -13,7 +13,7 @@ ena = "0.14.3"
 indexmap = { version = "2.4.0", features = ["rustc-rayon"] }
 jobserver_crate = { version = "0.1.28", package = "jobserver" }
 measureme = "11"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
 rustc-rayon = "0.5.0"
 rustc-stable-hash = { version = "0.1.0", features = ["nightly"] }
 rustc_arena = { path = "../rustc_arena" }

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -13,7 +13,7 @@ ena = "0.14.3"
 indexmap = { version = "2.4.0", features = ["rustc-rayon"] }
 jobserver_crate = { version = "0.1.28", package = "jobserver" }
 measureme = "11"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
+rustc-hash = { git = "https://github.com/steffahn/rustc-hash", rev = "1028035a81ec84e9fe25e39daeccb9d9ff7245d8" }
 rustc-rayon = "0.5.0"
 rustc-stable-hash = { version = "0.1.0", features = ["nightly"] }
 rustc_arena = { path = "../rustc_arena" }

--- a/compiler/rustc_pattern_analysis/Cargo.toml
+++ b/compiler/rustc_pattern_analysis/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
 
 rustc_abi = { path = "../rustc_abi", optional = true }
 rustc_apfloat = "0.2.0"

--- a/compiler/rustc_pattern_analysis/Cargo.toml
+++ b/compiler/rustc_pattern_analysis/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
+rustc-hash = { git = "https://github.com/steffahn/rustc-hash", rev = "1028035a81ec84e9fe25e39daeccb9d9ff7245d8" }
 
 rustc_abi = { path = "../rustc_abi", optional = true }
 rustc_apfloat = "0.2.0"

--- a/compiler/rustc_pattern_analysis/Cargo.toml
+++ b/compiler/rustc_pattern_analysis/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
-rustc-hash = "2.0.0"
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
 
 rustc_abi = { path = "../rustc_abi", optional = true }
 rustc_apfloat = "0.2.0"

--- a/compiler/rustc_pattern_analysis/Cargo.toml
+++ b/compiler/rustc_pattern_analysis/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
 
 rustc_abi = { path = "../rustc_abi", optional = true }
 rustc_apfloat = "0.2.0"

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 bitflags = "2.4.1"
 derive-where = "1.2.7"
 indexmap = "2.0.0"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
+rustc-hash = { git = "https://github.com/steffahn/rustc-hash", rev = "1028035a81ec84e9fe25e39daeccb9d9ff7245d8" }
 rustc_ast_ir = { path = "../rustc_ast_ir", default-features = false }
 rustc_data_structures = { path = "../rustc_data_structures", optional = true }
 rustc_index = { path = "../rustc_index", default-features = false }

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 bitflags = "2.4.1"
 derive-where = "1.2.7"
 indexmap = "2.0.0"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
 rustc_ast_ir = { path = "../rustc_ast_ir", default-features = false }
 rustc_data_structures = { path = "../rustc_data_structures", optional = true }
 rustc_index = { path = "../rustc_index", default-features = false }

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 bitflags = "2.4.1"
 derive-where = "1.2.7"
 indexmap = "2.0.0"
-rustc-hash = "1.1.0"
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
 rustc_ast_ir = { path = "../rustc_ast_ir", default-features = false }
 rustc_data_structures = { path = "../rustc_data_structures", optional = true }
 rustc_index = { path = "../rustc_index", default-features = false }

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 bitflags = "2.4.1"
 derive-where = "1.2.7"
 indexmap = "2.0.0"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
 rustc_ast_ir = { path = "../rustc_ast_ir", default-features = false }
 rustc_data_structures = { path = "../rustc_data_structures", optional = true }
 rustc_index = { path = "../rustc_index", default-features = false }

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -11,7 +11,7 @@ default = ["rustc-hash"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rustc-hash = { version = "2.0", optional = true }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"], optional=true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -11,7 +11,7 @@ default = ["rustc-hash"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e", optional=true }
+rustc-hash = { git = "https://github.com/steffahn/rustc-hash", rev = "1028035a81ec84e9fe25e39daeccb9d9ff7245d8", optional=true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -11,7 +11,7 @@ default = ["rustc-hash"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"], optional=true }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", optional=true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -11,7 +11,7 @@ default = ["rustc-hash"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", optional=true }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e", optional=true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/tools/jsondoclint/Cargo.toml
+++ b/src/tools/jsondoclint/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.62"
 clap = { version = "4.0.15", features = ["derive"] }
 fs-err = "2.8.1"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
 rustdoc-json-types = { version = "0.1.0", path = "../../rustdoc-json-types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"

--- a/src/tools/jsondoclint/Cargo.toml
+++ b/src/tools/jsondoclint/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.62"
 clap = { version = "4.0.15", features = ["derive"] }
 fs-err = "2.8.1"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
 rustdoc-json-types = { version = "0.1.0", path = "../../rustdoc-json-types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"

--- a/src/tools/jsondoclint/Cargo.toml
+++ b/src/tools/jsondoclint/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.62"
 clap = { version = "4.0.15", features = ["derive"] }
 fs-err = "2.8.1"
-rustc-hash = "2.0.0"
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
 rustdoc-json-types = { version = "0.1.0", path = "../../rustdoc-json-types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"

--- a/src/tools/jsondoclint/Cargo.toml
+++ b/src/tools/jsondoclint/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.62"
 clap = { version = "4.0.15", features = ["derive"] }
 fs-err = "2.8.1"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
+rustc-hash = { git = "https://github.com/steffahn/rustc-hash", rev = "1028035a81ec84e9fe25e39daeccb9d9ff7245d8" }
 rustdoc-json-types = { version = "0.1.0", path = "../../rustdoc-json-types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"

--- a/src/tools/rust-analyzer/Cargo.toml
+++ b/src/tools/rust-analyzer/Cargo.toml
@@ -136,7 +136,7 @@ process-wrap = { version = "8.0.2", features = ["std"] }
 pulldown-cmark-to-cmark = "10.0.4"
 pulldown-cmark = { version = "0.9.0", default-features = false }
 rayon = "1.8.0"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
 semver = "1.0.14"
 serde = { version = "1.0.192" }
 serde_derive = { version = "1.0.192" }

--- a/src/tools/rust-analyzer/Cargo.toml
+++ b/src/tools/rust-analyzer/Cargo.toml
@@ -136,7 +136,7 @@ process-wrap = { version = "8.0.2", features = ["std"] }
 pulldown-cmark-to-cmark = "10.0.4"
 pulldown-cmark = { version = "0.9.0", default-features = false }
 rayon = "1.8.0"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
 semver = "1.0.14"
 serde = { version = "1.0.192" }
 serde_derive = { version = "1.0.192" }

--- a/src/tools/rust-analyzer/Cargo.toml
+++ b/src/tools/rust-analyzer/Cargo.toml
@@ -136,7 +136,7 @@ process-wrap = { version = "8.0.2", features = ["std"] }
 pulldown-cmark-to-cmark = "10.0.4"
 pulldown-cmark = { version = "0.9.0", default-features = false }
 rayon = "1.8.0"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
+rustc-hash = { git = "https://github.com/steffahn/rustc-hash", rev = "1028035a81ec84e9fe25e39daeccb9d9ff7245d8" }
 semver = "1.0.14"
 serde = { version = "1.0.192" }
 serde_derive = { version = "1.0.192" }

--- a/src/tools/rust-analyzer/Cargo.toml
+++ b/src/tools/rust-analyzer/Cargo.toml
@@ -136,7 +136,7 @@ process-wrap = { version = "8.0.2", features = ["std"] }
 pulldown-cmark-to-cmark = "10.0.4"
 pulldown-cmark = { version = "0.9.0", default-features = false }
 rayon = "1.8.0"
-rustc-hash = "2.0.0"
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
 semver = "1.0.14"
 serde = { version = "1.0.192" }
 serde_derive = { version = "1.0.192" }

--- a/src/tools/rust-analyzer/crates/ra-salsa/Cargo.toml
+++ b/src/tools/rust-analyzer/crates/ra-salsa/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = "2.1.0"
 lock_api = "0.4"
 tracing = "0.1"
 parking_lot = "0.12.1"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
+rustc-hash = { git = "https://github.com/steffahn/rustc-hash", rev = "1028035a81ec84e9fe25e39daeccb9d9ff7245d8" }
 smallvec = "1.0.0"
 oorandom = "11"
 triomphe.workspace = true

--- a/src/tools/rust-analyzer/crates/ra-salsa/Cargo.toml
+++ b/src/tools/rust-analyzer/crates/ra-salsa/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = "2.1.0"
 lock_api = "0.4"
 tracing = "0.1"
 parking_lot = "0.12.1"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
 smallvec = "1.0.0"
 oorandom = "11"
 triomphe.workspace = true

--- a/src/tools/rust-analyzer/crates/ra-salsa/Cargo.toml
+++ b/src/tools/rust-analyzer/crates/ra-salsa/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = "2.1.0"
 lock_api = "0.4"
 tracing = "0.1"
 parking_lot = "0.12.1"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
 smallvec = "1.0.0"
 oorandom = "11"
 triomphe.workspace = true

--- a/src/tools/rust-analyzer/crates/ra-salsa/Cargo.toml
+++ b/src/tools/rust-analyzer/crates/ra-salsa/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = "2.1.0"
 lock_api = "0.4"
 tracing = "0.1"
 parking_lot = "0.12.1"
-rustc-hash = "2.0.0"
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
 smallvec = "1.0.0"
 oorandom = "11"
 triomphe.workspace = true

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -13,7 +13,7 @@ walkdir = "2"
 ignore = "0.4.18"
 semver = "1.0"
 termcolor = "1.1.3"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
+rustc-hash = { git = "https://github.com/steffahn/rustc-hash", rev = "1028035a81ec84e9fe25e39daeccb9d9ff7245d8" }
 fluent-syntax = "0.11.1"
 similar = "2.5.0"
 

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -13,7 +13,7 @@ walkdir = "2"
 ignore = "0.4.18"
 semver = "1.0"
 termcolor = "1.1.3"
-rustc-hash = "2.0.0"
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
 fluent-syntax = "0.11.1"
 similar = "2.5.0"
 

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -13,7 +13,7 @@ walkdir = "2"
 ignore = "0.4.18"
 semver = "1.0"
 termcolor = "1.1.3"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663", features = ["nightly"] }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
 fluent-syntax = "0.11.1"
 similar = "2.5.0"
 

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -13,7 +13,7 @@ walkdir = "2"
 ignore = "0.4.18"
 semver = "1.0"
 termcolor = "1.1.3"
-rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "3a89863922cb4ba5237a5bef65a9535b3d598663" }
+rustc-hash = { git = "https://github.com/orlp/rustc-hash", rev = "2ccde1ec8a948b5463011d3c7363c273fc2bb80e" }
 fluent-syntax = "0.11.1"
 similar = "2.5.0"
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/136095#issuecomment-2614605474

---

*For good comparability with the performance of #136095, I'm keeping the `rustc-hasher` in `rustc_type_ir` at the "newly modified 2.\*"… just noting this down in case it might be a difference from master that matters much.*

---

([link to the `rustc-hash` commits for context](https://github.com/rust-lang/rustc-hash/compare/43e17905ba97af250ea2514c79cc25af0e04dfe5...1028035a81ec84e9fe25e39daeccb9d9ff7245d8))