### PR TITLE
Move `try_to_bits` from `Const` to `Valtree`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -676,17 +676,15 @@ fn push_const_param<'tcx>(tcx: TyCtxt<'tcx>, ct: ty::Const<'tcx>, output: &mut S
         ty::ConstKind::Value(ty, valtree) => {
             match ty.kind() {
                 ty::Int(ity) => {
-                    // FIXME: directly extract the bits from a valtree instead of evaluating an
-                    // already evaluated `Const` in order to get the bits.
-                    let bits = ct
-                        .try_to_bits(tcx, ty::TypingEnv::fully_monomorphized())
+                    let bits = valtree
+                        .try_to_bits(tcx, ty, ty::TypingEnv::fully_monomorphized())
                         .expect("expected monomorphic const in codegen");
                     let val = Integer::from_int_ty(&tcx, *ity).size().sign_extend(bits) as i128;
                     write!(output, "{val}")
                 }
                 ty::Uint(_) => {
-                    let val = ct
-                        .try_to_bits(tcx, ty::TypingEnv::fully_monomorphized())
+                    let val = valtree
+                        .try_to_bits(tcx, ty, ty::TypingEnv::fully_monomorphized())
                         .expect("expected monomorphic const in codegen");
                     write!(output, "{val}")
                 }

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -245,18 +245,6 @@ impl<'tcx> Const<'tcx> {
         self.try_to_valtree()?.0.try_to_target_usize(tcx)
     }
 
-    /// Attempts to evaluate the given constant to bits. Can fail to evaluate in the presence of
-    /// generics (or erroneous code) or if the value can't be represented as bits (e.g. because it
-    /// contains const generic parameters or pointers).
-    #[inline]
-    pub fn try_to_bits(self, tcx: TyCtxt<'tcx>, typing_env: ty::TypingEnv<'tcx>) -> Option<u128> {
-        let (scalar, ty) = self.try_to_scalar()?;
-        let scalar = scalar.try_to_scalar_int().ok()?;
-        let input = typing_env.with_post_analysis_normalized(tcx).as_query_input(ty);
-        let size = tcx.layout_of(input).ok()?.size;
-        Some(scalar.to_bits(size))
-    }
-
     pub fn is_ct_infer(self) -> bool {
         matches!(self.kind(), ty::ConstKind::Infer(_))
     }

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -83,6 +83,21 @@ impl<'tcx> ValTree<'tcx> {
         self.try_to_scalar_int().map(|s| s.to_target_usize(tcx))
     }
 
+    /// Attempts to extract the raw bits of the valtree.
+    ///
+    /// Can fail if the value can't be represented as bits (e.g. because it is an aggregate).
+    pub fn try_to_bits(
+        self,
+        tcx: TyCtxt<'tcx>,
+        ty: Ty<'tcx>,
+        typing_env: ty::TypingEnv<'tcx>,
+    ) -> Option<u128> {
+        let input = typing_env.with_post_analysis_normalized(tcx).as_query_input(ty);
+        let size = tcx.layout_of(input).ok()?.size;
+        let scalar = self.try_to_scalar_int()?;
+        Some(scalar.to_bits(size))
+    }
+
     /// Get the values inside the ValTree as a slice of bytes. This only works for
     /// constants with types &str, &[u8], or [u8; _].
     pub fn try_to_raw_bytes(self, tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<&'tcx [u8]> {

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/encode.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/encode.rs
@@ -121,7 +121,7 @@ fn encode_const<'tcx>(
         }
 
         // Literal arguments
-        ty::ConstKind::Value(ct_ty, ..) => {
+        ty::ConstKind::Value(ct_ty, valtree) => {
             // L<element-type>[n]<element-value>E as literal argument
 
             // Element type
@@ -132,8 +132,8 @@ fn encode_const<'tcx>(
             // bool value false is encoded as 0 and true as 1.
             match ct_ty.kind() {
                 ty::Int(ity) => {
-                    let bits = c
-                        .try_to_bits(tcx, ty::TypingEnv::fully_monomorphized())
+                    let bits = valtree
+                        .try_to_bits(tcx, ct_ty, ty::TypingEnv::fully_monomorphized())
                         .expect("expected monomorphic const in cfi");
                     let val = Integer::from_int_ty(&tcx, *ity).size().sign_extend(bits) as i128;
                     if val < 0 {
@@ -142,8 +142,8 @@ fn encode_const<'tcx>(
                     let _ = write!(s, "{val}");
                 }
                 ty::Uint(_) => {
-                    let val = c
-                        .try_to_bits(tcx, ty::TypingEnv::fully_monomorphized())
+                    let val = valtree
+                        .try_to_bits(tcx, ct_ty, ty::TypingEnv::fully_monomorphized())
                         .expect("expected monomorphic const in cfi");
                     let _ = write!(s, "{val}");
                 }

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -625,8 +625,8 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
             ty::Uint(_) | ty::Int(_) | ty::Bool | ty::Char => {
                 ct_ty.print(self)?;
 
-                let mut bits = ct
-                    .try_to_bits(self.tcx, ty::TypingEnv::fully_monomorphized())
+                let mut bits = valtree
+                    .try_to_bits(self.tcx, ct_ty, ty::TypingEnv::fully_monomorphized())
                     .expect("expected const to be monomorphic");
 
                 // Negative integer values are mangled using `n` as a "sign prefix".


### PR DESCRIPTION
**This PR is a follow-up to #135158**

### What's in this PR?

- **Move `try_to_bits`**: Transitioned from `Const` to `Valtree`.
- **Rename `validate_const_with_value`**: Renamed to `extract_valtree_and_ty` for better clarity.

### Benefits

- Extracting bits directly from `Valtree` avoids the need to re-evaluate a `Const`, improving efficiency where this re-evaluation was previously performed. For instance, in:
  -  [compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs](https://github.com/rust-lang/rust/compare/master...FedericoBruzzone:rust:follow-up-135158?expand=1#diff-e0465b23357962aaea9ec60b764de458bda0e9e9b55f745328078cebc0d02f68) (a FIXME was left behind), and
  - [compiler/rustc_ty_utils/src/layout.rs](https://github.com/rust-lang/rust/compare/master...FedericoBruzzone:rust:follow-up-135158?expand=1#diff-d5c6f94594e21dda2a9e3717a8b245c481fd461d8eece9c7bc960693cb0c368a) (introduced in #135158).

---

r? @lukas-code @oli-obk