### PR TITLE
ci: use ubuntu 24 on free runners

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -5,7 +5,7 @@ runners:
     env: { }
 
   - &job-linux-4c
-    os: ubuntu-22.04
+    os: ubuntu-24.04
     # Free some disk space to avoid running out of space during the build.
     free_disk: true
     <<: *base-job
@@ -50,7 +50,7 @@ runners:
   - &job-aarch64-linux
     # Free some disk space to avoid running out of space during the build.
     free_disk: true
-    os: ubuntu-22.04-arm
+    os: ubuntu-24.04-arm
 
   - &job-aarch64-linux-8c
     os: ubuntu-22.04-arm64-8core-32gb


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Updating to the newest ubuntu to take advantage of newer software and kernel version.
You can see the difference between the two images here:
- [ubuntu 22](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)
- [ubuntu 24](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md)

As you can see, ubuntu 24 installs less software by default, which makes cleaning the disk for unused stuff easier.
All the linux jobs run in docker containers, so this change don't affect the rust builds.
After we merge this, I'll switch the large runners, too.

I'm not sure this is going to work for all jobs, so please merge this as a single PR in the auto build.

<!-- homu-ignore:end -->
try-job: aarch64-gnu
try-job: aarch64-gnu-debug
