### PR TITLE
ci: use windows 2025 for i686-mingw

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -43,6 +43,10 @@ runners:
     os: windows-2022-8core-32gb
     <<: *base-job
 
+  - &job-windows-25-8c
+    os: windows-2025-8core-32gb
+    <<: *base-job
+
   - &job-aarch64-linux
     # Free some disk space to avoid running out of space during the build.
     free_disk: true
@@ -524,7 +528,7 @@ auto:
       # We are intentionally allowing an old toolchain on this builder (and that's
       # incompatible with LLVM downloads today).
       NO_DOWNLOAD_CI_LLVM: 1
-    <<: *job-windows-8c
+    <<: *job-windows-25-8c
 
   # x86_64-mingw is split into two jobs to run tests in parallel.
   - name: x86_64-mingw-1


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Lately, the flakiness of the job `i686-mingw` increased.
In https://github.com/rust-lang/rust/pull/135632 windows 2025 helped decrease the flakiness so we want to try to do the same here.

<!-- homu-ignore:end -->
try-job: i686-mingw