### PR TITLE
Use +secure-plt for powerpc-unknown-linux-gnu{,spe}

### DIFF
--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnu.rs
@@ -18,6 +18,11 @@ pub(crate) fn target() -> Target {
         pointer_width: 32,
         data_layout: "E-m:e-p:32:32-Fn32-i64:64-n32".into(),
         arch: "powerpc".into(),
-        options: TargetOptions { endian: Endian::Big, mcount: "_mcount".into(), ..base },
+        options: TargetOptions {
+            endian: Endian::Big,
+            features: "+secure-plt".into(),
+            mcount: "_mcount".into(),
+            ..base
+        },
     }
 }

--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnuspe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnuspe.rs
@@ -21,6 +21,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: "spe".into(),
             endian: Endian::Big,
+            features: "+secure-plt".into(),
             mcount: "_mcount".into(),
             ..base
         },


### PR DESCRIPTION
Fixes #136131
See that issue for details.

I'm not sure about the policy about baseline on these platforms (there is no [platform support doc](https://doc.rust-lang.org/nightly/rustc/platform-support.html) for them), but it seems that the Debian/Ubuntu's cross-compiler (powerpc-linux-gnu-gcc) already uses --enable-secureplt at least as of Debian 9 (stretch) and Ubuntu 14.04.

```
$ cat /etc/os-release | grep VERSION_ID
VERSION_ID="9"
$ powerpc-linux-gnu-gcc -v
Using built-in specs.
COLLECT_GCC=powerpc-linux-gnu-gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc-cross/powerpc-linux-gnu/6/lto-wrapper
Target: powerpc-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 6.3.0-18' --with-bugurl=file:///usr/share/doc/gcc-6/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-6 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libitm --disable-libquadmath --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-6-powerpc-cross/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-6-powerpc-cross --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-6-powerpc-cross --with-arch-directory=ppc --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --disable-libgcj --enable-objc-gc=auto --enable-secureplt --disable-softfloat --with-cpu=default32 --disable-softfloat --enable-targets=powerpc-linux,powerpc64-linux --enable-multiarch --with-long-double-128 --enable-multilib --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=powerpc-linux-gnu --program-prefix=powerpc-linux-gnu- --includedir=/usr/powerpc-linux-gnu/include
Thread model: posix
gcc version 6.3.0 20170516 (Debian 6.3.0-18) 
```

```
$ cat /etc/os-release | grep VERSION_ID
VERSION_ID="14.04"
$ cat /etc/debian_version 
jessie/sid
$ powerpc-linux-gnu-gcc -v
Using built-in specs.
COLLECT_GCC=powerpc-linux-gnu-gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc-cross/powerpc-linux-gnu/4.8/lto-wrapper
Target: powerpc-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 4.8.4-2ubuntu1~14.04.1' --with-bugurl=file:///usr/share/doc/gcc-4.8/README.Bugs --enable-languages=c,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-4.8 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --with-gxx-include-dir=/usr/powerpc-linux-gnu/include/c++/4.8.4 --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --disable-libmudflap --disable-libitm --disable-libsanitizer --disable-libquadmath --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-4.8-powerpc-cross/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-4.8-powerpc-cross --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-4.8-powerpc-cross --with-arch-directory=ppc --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --disable-libgcj --enable-objc-gc --enable-secureplt --disable-softfloat --with-cpu=default32 --disable-softfloat --enable-targets=powerpc-linux,powerpc64-linux --enable-multiarch --disable-werror --with-long-double-128 --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=powerpc-linux-gnu --program-prefix=powerpc-linux-gnu- --includedir=/usr/powerpc-linux-gnu/include
Thread model: posix
gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.1) 
```

cc @glaubitz (who added powerpc-unknown-linux-gnuspe in https://github.com/rust-lang/rust/pull/48484)

r? tgross35

@rustbot label +O-PowerPC +O-linux-gnu

try-job: dist-powerpc-linux
try-job: dist-powerpc64-linux
try-job: dist-powerpc64le-linux
try-job: dist-various-1
try-job: dist-various-2
try-job: aarch64-gnu