### PR TITLE
Remove backticks from `ShouldPanic::YesWithMessage`'s `TrFailedMsg`

### DIFF
--- a/library/test/src/test_result.rs
+++ b/library/test/src/test_result.rs
@@ -61,16 +61,15 @@ pub(crate) fn calc_result(
             } else if let Some(panic_str) = maybe_panic_str {
                 TestResult::TrFailedMsg(format!(
                     r#"panic did not contain expected string
-      panic message: `{panic_str:?}`,
- expected substring: `{msg:?}`"#
+      panic message: {panic_str:?}
+ expected substring: {msg:?}"#
                 ))
             } else {
                 TestResult::TrFailedMsg(format!(
                     r#"expected panic with string value,
  found non-string value: `{:?}`
-     expected substring: `{:?}`"#,
-                    (*err).type_id(),
-                    msg
+     expected substring: {msg:?}"#,
+                    (*err).type_id()
                 ))
             }
         }

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -200,8 +200,8 @@ fn test_should_panic_bad_message() {
     }
     let expected = "foobar";
     let failed_msg = r#"panic did not contain expected string
-      panic message: `"an error message"`,
- expected substring: `"foobar"`"#;
+      panic message: "an error message"
+ expected substring: "foobar""#;
     let desc = TestDescAndFn {
         desc: TestDesc {
             name: StaticTestName("whatever"),
@@ -238,7 +238,7 @@ fn test_should_panic_non_string_message_type() {
     let failed_msg = format!(
         r#"expected panic with string value,
  found non-string value: `{:?}`
-     expected substring: `"foobar"`"#,
+     expected substring: "foobar""#,
         TypeId::of::<i32>()
     );
     let desc = TestDescAndFn {

--- a/tests/ui/test-attrs/test-should-panic-failed-show-span.run.stdout
+++ b/tests/ui/test-attrs/test-should-panic-failed-show-span.run.stdout
@@ -15,12 +15,12 @@ note: test did not panic as expected at $DIR/test-should-panic-failed-show-span.
 note: test did not panic as expected at $DIR/test-should-panic-failed-show-span.rs:31:4
 ---- should_panic_with_substring_panics_with_incorrect_string stdout ----
 note: panic did not contain expected string
-      panic message: `"ZOMGWTFBBQ"`,
- expected substring: `"message"`
+      panic message: "ZOMGWTFBBQ"
+ expected substring: "message"
 ---- should_panic_with_substring_panics_with_non_string_value stdout ----
 note: expected panic with string value,
  found non-string value: `TypeId($HEX)`
-     expected substring: `"message"`
+     expected substring: "message"
 
 failures:
     should_panic_with_any_message_does_not_panic


### PR DESCRIPTION
More legible imo
```rs
#[test]
#[should_panic = "love"]
fn foo() {
    assert!(1 == 2);
}
```
Before:
```
note: panic did not contain expected string
      panic message: `"assertion failed: 1 == 2"`,
 expected substring: `"love"`
```
After:
```
note: panic did not contain expected string
      panic message: "assertion failed: 1 == 2"
 expected substring: "love"
```
Also removed the comma as `assert_eq!` / `assert_ne!` don't use one.

@rustbot label +A-libtest