### PR TITLE
GCI: Don't try to eval / collect mono items inside overly generic free const items

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1454,11 +1454,14 @@ impl<'v> RootCollector<'_, 'v> {
                 self.output.push(dummy_spanned(MonoItem::Static(def_id)));
             }
             DefKind::Const => {
-                // const items only generate mono items if they are
-                // actually used somewhere. Just declaring them is insufficient.
+                // Const items only generate mono items if they are actually used somewhere.
+                // Just declaring them is insufficient.
 
-                // but even just declaring them must collect the items they refer to
-                if let Ok(val) = self.tcx.const_eval_poly(id.owner_id.to_def_id()) {
+                // But even just declaring them must collect the items they refer to
+                // unless their generics require monomorphization.
+                if !self.tcx.generics_of(id.owner_id).requires_monomorphization(self.tcx)
+                    && let Ok(val) = self.tcx.const_eval_poly(id.owner_id.to_def_id())
+                {
                     collect_const_value(self.tcx, val, self.output);
                 }
             }

--- a/tests/ui/generic-const-items/def-site-eval.fail.stderr
+++ b/tests/ui/generic-const-items/def-site-eval.fail.stderr
@@ -1,0 +1,11 @@
+error[E0080]: evaluation of `_::<'_>` failed
+  --> $DIR/def-site-eval.rs:14:20
+   |
+LL | const _<'_a>: () = panic!();
+   |                    ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/def-site-eval.rs:14:20
+   |
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/generic-const-items/def-site-eval.rs
+++ b/tests/ui/generic-const-items/def-site-eval.rs
@@ -1,0 +1,16 @@
+//! Test that we only evaluate free const items (their def site to be clear)
+//! whose generics don't require monomorphization.
+#![feature(generic_const_items)]
+#![allow(incomplete_features)]
+
+//@ revisions: fail pass
+//@[fail] build-fail (we require monomorphization)
+//@[pass] build-pass (we require monomorphization)
+
+const _<_T>: () = panic!();
+const _<const _N: usize>: () = panic!();
+
+#[cfg(fail)]
+const _<'_a>: () = panic!(); //[fail]~ ERROR evaluation of `_::<'_>` failed
+
+fn main() {}

--- a/tests/ui/generic-const-items/def-site-mono.rs
+++ b/tests/ui/generic-const-items/def-site-mono.rs
@@ -1,0 +1,13 @@
+//! Ensure that we don't try to collect monomorphizeable items inside free const
+//! items (their def site to be clear) whose generics require monomorphization.
+//!
+//! Such items are to be collected at instantiation sites of free consts.
+
+#![feature(generic_const_items)]
+#![allow(incomplete_features)]
+
+//@ build-pass (we require monomorphization)
+
+const _IDENTITY<T>: fn(T) -> T = |x| x;
+
+fn main() {}


### PR DESCRIPTION
Fixes #136156. Thanks for the pointers, errs!

There's one (preexisting) thing of note (maybe?). There's a difference between `const _: () = panic!();` and `const _<'a>: () = panic!();`: The former is a pre-mono error, the latter is a post-mono error. For comparison, both `fn _f() { const { panic!() } }` and `fn _f<'a: 'a>() { const { panic!() } }` are post-mono errors.

cc @oli-obk
r? compiler-errors or reassign