### PR TITLE
Reject unsound toggling of Arm atomics-32 target feature

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -137,6 +137,11 @@ const ARM_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start
     ("aclass", Unstable(sym::arm_target_feature), &[]),
     ("aes", Unstable(sym::arm_target_feature), &["neon"]),
+    (
+        "atomics-32",
+        Stability::Forbidden { reason: "unsound because it changes the ABI of atomic operations" },
+        &[],
+    ),
     ("crc", Unstable(sym::arm_target_feature), &[]),
     ("d32", Unstable(sym::arm_target_feature), &[]),
     ("dotprod", Unstable(sym::arm_target_feature), &["neon"]),


### PR DESCRIPTION
This target feature has the same semantics as RISC-V `forced-atomics` target feature that already marked as Forbidden  (https://github.com/llvm/llvm-project/commit/f5ed0cb217a9988f97b55f2ccb053bca7b41cc0c) and toggling it can cause ABI incompatibility.

https://github.com/rust-lang/rust/blob/2f348cb7ce4063fa4eb40038e6ada3c5214717bd/compiler/rustc_target/src/target_features.rs#L479-L483

[Comment on feature definition in LLVM](https://github.com/llvm/llvm-project/blob/7109f521975e9cc2e8ba4f52ac2a8e1140bd49b5/llvm/lib/Target/ARM/ARMFeatures.td#L572-L574) also says:

> Code built with this feature is not ABI-compatible with code built without this feature, if atomic variables are exposed across the ABI boundary.


r? @workingjubilee or @RalfJung

@rustbot label +O-Arm