### PR TITLE
Render pattern types nicely in mir dumps

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1740,6 +1740,10 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     " as ",
                 )?;
             }
+            ty::Pat(base_ty, pat) => {
+                self.pretty_print_const_scalar_int(int, *base_ty, print_ty)?;
+                p!(write(" is {pat:?}"));
+            }
             // Nontrivial types with scalar bit representation
             _ => {
                 let print = |this: &mut Self| {

--- a/tests/mir-opt/pattern_types.main.PreCodegen.after.mir
+++ b/tests/mir-opt/pattern_types.main.PreCodegen.after.mir
@@ -3,9 +3,9 @@
 fn main() -> () {
     let mut _0: ();
     scope 1 {
-        debug x => const {transmute(0x00000002): (u32) is 1..=};
+        debug x => const 2_u32 is 1..=;
         scope 2 {
-            debug y => const {transmute(0x00000000): (u32) is 1..=};
+            debug y => const 0_u32 is 1..=;
         }
     }
 

--- a/tests/mir-opt/pattern_types.main.PreCodegen.after.mir
+++ b/tests/mir-opt/pattern_types.main.PreCodegen.after.mir
@@ -1,0 +1,15 @@
+// MIR for `main` after PreCodegen
+
+fn main() -> () {
+    let mut _0: ();
+    scope 1 {
+        debug x => const {transmute(0x00000002): (u32) is 1..=};
+        scope 2 {
+            debug y => const {transmute(0x00000000): (u32) is 1..=};
+        }
+    }
+
+    bb0: {
+        return;
+    }
+}

--- a/tests/mir-opt/pattern_types.rs
+++ b/tests/mir-opt/pattern_types.rs
@@ -1,0 +1,12 @@
+#![feature(pattern_types)]
+#![feature(pattern_type_macro)]
+
+use std::pat::pattern_type;
+
+// EMIT_MIR pattern_types.main.PreCodegen.after.mir
+fn main() {
+    // CHECK: debug x => const {transmute(0x00000002): (u32) is 1..=}
+    let x: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(2) };
+    // CHECK: debug y => const {transmute(0x00000000): (u32) is 1..=}
+    let y: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(0) };
+}

--- a/tests/mir-opt/pattern_types.rs
+++ b/tests/mir-opt/pattern_types.rs
@@ -5,8 +5,8 @@ use std::pat::pattern_type;
 
 // EMIT_MIR pattern_types.main.PreCodegen.after.mir
 fn main() {
-    // CHECK: debug x => const {transmute(0x00000002): (u32) is 1..=}
+    // CHECK: debug x => const 2_u32 is 1..=
     let x: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(2) };
-    // CHECK: debug y => const {transmute(0x00000000): (u32) is 1..=}
+    // CHECK: debug y => const 0_u32 is 1..=
     let y: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(0) };
 }


### PR DESCRIPTION
avoid falling through to the fallback rendering that just does a hex dump

r? @scottmcm 

best reviewed commit by commit
