### PR TITLE
Allow transmuting generic pattern types to and from their base

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -504,6 +504,9 @@ impl<'tcx> SizeSkeleton<'tcx> {
                 }
             }
 
+            // Pattern types are always the same size as their base.
+            ty::Pat(base, _) => SizeSkeleton::compute(base, tcx, typing_env),
+
             _ => Err(err),
         }
     }

--- a/tests/ui/type/pattern_types/transmute.rs
+++ b/tests/ui/type/pattern_types/transmute.rs
@@ -6,13 +6,11 @@ use std::pat::pattern_type;
 // ok
 fn create<const S: u32, const E: u32>(x: u32) -> pattern_type!(u32 is S..=E) {
     unsafe { std::mem::transmute(x) }
-    //~^ ERROR types of different sizes
 }
 
 // ok
 fn unwrap<const S: u32, const E: u32>(x: pattern_type!(u32 is S..=E)) -> u32 {
     unsafe { std::mem::transmute(x) }
-    //~^ ERROR types of different sizes
 }
 
 // bad, only when S != u32::MIN or E != u32::MAX will this ok

--- a/tests/ui/type/pattern_types/transmute.rs
+++ b/tests/ui/type/pattern_types/transmute.rs
@@ -1,0 +1,34 @@
+#![feature(pattern_types)]
+#![feature(pattern_type_macro)]
+
+use std::pat::pattern_type;
+
+// ok
+fn create<const S: u32, const E: u32>(x: u32) -> pattern_type!(u32 is S..=E) {
+    unsafe { std::mem::transmute(x) }
+    //~^ ERROR types of different sizes
+}
+
+// ok
+fn unwrap<const S: u32, const E: u32>(x: pattern_type!(u32 is S..=E)) -> u32 {
+    unsafe { std::mem::transmute(x) }
+    //~^ ERROR types of different sizes
+}
+
+// bad, only when S != u32::MIN or E != u32::MAX will this ok
+fn non_base_ty_transmute<const S: u32, const E: u32>(
+    x: Option<pattern_type!(u32 is S..=E)>,
+) -> u32 {
+    unsafe { std::mem::transmute(x) }
+    //~^ ERROR types of different sizes
+}
+
+// bad, only when S = u32::MIN and E = u32::MAX will this ok
+fn wrapped_transmute<const S: u32, const E: u32>(
+    x: Option<pattern_type!(u32 is S..=E)>,
+) -> Option<u32> {
+    unsafe { std::mem::transmute(x) }
+    //~^ ERROR types of different sizes
+}
+
+fn main() {}

--- a/tests/ui/type/pattern_types/transmute.stderr
+++ b/tests/ui/type/pattern_types/transmute.stderr
@@ -1,0 +1,39 @@
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute.rs:8:14
+   |
+LL |     unsafe { std::mem::transmute(x) }
+   |              ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `u32` (32 bits)
+   = note: target type: `(u32) is S..=E` (size can vary because of u32)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute.rs:14:14
+   |
+LL |     unsafe { std::mem::transmute(x) }
+   |              ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `(u32) is S..=E` (size can vary because of u32)
+   = note: target type: `u32` (32 bits)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute.rs:22:14
+   |
+LL |     unsafe { std::mem::transmute(x) }
+   |              ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `Option<(u32) is S..=E>` (size can vary because of u32)
+   = note: target type: `u32` (32 bits)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+  --> $DIR/transmute.rs:30:14
+   |
+LL |     unsafe { std::mem::transmute(x) }
+   |              ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: source type: `Option<(u32) is S..=E>` (size can vary because of u32)
+   = note: target type: `Option<u32>` (64 bits)
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0512`.

--- a/tests/ui/type/pattern_types/transmute.stderr
+++ b/tests/ui/type/pattern_types/transmute.stderr
@@ -1,23 +1,5 @@
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute.rs:8:14
-   |
-LL |     unsafe { std::mem::transmute(x) }
-   |              ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: source type: `u32` (32 bits)
-   = note: target type: `(u32) is S..=E` (size can vary because of u32)
-
-error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute.rs:14:14
-   |
-LL |     unsafe { std::mem::transmute(x) }
-   |              ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: source type: `(u32) is S..=E` (size can vary because of u32)
-   = note: target type: `u32` (32 bits)
-
-error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute.rs:22:14
+  --> $DIR/transmute.rs:20:14
    |
 LL |     unsafe { std::mem::transmute(x) }
    |              ^^^^^^^^^^^^^^^^^^^
@@ -26,7 +8,7 @@ LL |     unsafe { std::mem::transmute(x) }
    = note: target type: `u32` (32 bits)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute.rs:30:14
+  --> $DIR/transmute.rs:28:14
    |
 LL |     unsafe { std::mem::transmute(x) }
    |              ^^^^^^^^^^^^^^^^^^^
@@ -34,6 +16,6 @@ LL |     unsafe { std::mem::transmute(x) }
    = note: source type: `Option<(u32) is S..=E>` (size can vary because of u32)
    = note: target type: `Option<u32>` (64 bits)
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0512`.


### PR DESCRIPTION
Pattern types always have the same size as their base type, so we can just ignore the pattern and look at the base type for figuring out whether transmuting is possible.