### PR TITLE
Add X86 target support for NuttX

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2004,6 +2004,8 @@ supported_targets! {
 
     ("x86_64-unknown-linux-none", x86_64_unknown_linux_none),
 
+    ("i686-unknown-nuttx", i686_unknown_nuttx),
+    ("x86_64-unknown-nuttx", x86_64_unknown_nuttx),
     ("thumbv6m-nuttx-eabi", thumbv6m_nuttx_eabi),
     ("thumbv7a-nuttx-eabi", thumbv7a_nuttx_eabi),
     ("thumbv7a-nuttx-eabihf", thumbv7a_nuttx_eabihf),

--- a/compiler/rustc_target/src/spec/targets/i686_unknown_nuttx.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_unknown_nuttx.rs
@@ -1,0 +1,37 @@
+use crate::spec::{Cc, LinkerFlavor, Lld, RelocModel, StackProbeType, Target, TargetOptions, cvs};
+
+pub(crate) fn target() -> Target {
+    let mut base = TargetOptions {
+        os: "nuttx".into(),
+        dynamic_linking: false,
+        families: cvs!["unix"],
+        no_default_libraries: true,
+        has_rpath: false,
+        position_independent_executables: false,
+        relocation_model: RelocModel::Static,
+        relro_level: crate::spec::RelroLevel::Full,
+        has_thread_local: true,
+        use_ctors_section: true,
+        ..Default::default()
+    };
+    base.cpu = "pentium4".into();
+    base.max_atomic_width = Some(64);
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32"]);
+    base.stack_probes = StackProbeType::Inline;
+
+    Target {
+        llvm_target: "i686-unknown-nuttx".into(),
+        metadata: crate::spec::TargetMetadata {
+            description: Some("NuttX/x86".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(true),
+        },
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-\
+            i128:128-f64:32:64-f80:32-n8:16:32-S128"
+            .into(),
+        arch: "x86".into(),
+        options: base,
+    }
+}

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_nuttx.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_nuttx.rs
@@ -1,0 +1,41 @@
+// Generic x86-64 target for NuttX RTOS
+//
+// Can be used in conjunction with the `target-feature` and
+// `target-cpu` compiler flags to opt-in more hardware-specific
+// features.
+
+use crate::spec::{RelocModel, StackProbeType, Target, TargetOptions, cvs};
+
+pub(crate) fn target() -> Target {
+    let mut base = TargetOptions {
+        os: "nuttx".into(),
+        dynamic_linking: false,
+        families: cvs!["unix"],
+        no_default_libraries: true,
+        has_rpath: false,
+        position_independent_executables: false,
+        relocation_model: RelocModel::Static,
+        relro_level: crate::spec::RelroLevel::Full,
+        has_thread_local: true,
+        use_ctors_section: true,
+        ..Default::default()
+    };
+    base.cpu = "x86-64".into();
+    base.max_atomic_width = Some(64);
+    base.stack_probes = StackProbeType::Inline;
+
+    Target {
+        llvm_target: "x86_64-unknown-nuttx".into(),
+        metadata: crate::spec::TargetMetadata {
+            description: Some("NuttX/x86_64".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(true),
+        },
+        pointer_width: 64,
+        data_layout:
+            "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128".into(),
+        arch: "x86_64".into(),
+        options: base,
+    }
+}

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -314,6 +314,7 @@ target | std | host | notes
 `i686-unknown-haiku` | ✓ | ✓ | 32-bit Haiku (Pentium 4) [^x86_32-floats-return-ABI]
 [`i686-unknown-hurd-gnu`](platform-support/hurd.md) | ✓ | ✓ | 32-bit GNU/Hurd (PentiumPro) [^x86_32-floats-x87]
 [`i686-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | NetBSD/i386 (Pentium 4) [^x86_32-floats-return-ABI]
+[`i686-unknown-nuttx`](platform-support/nuttx.md) | ✓ |  | 32-bit x86 with NuttX
 [`i686-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | 32-bit OpenBSD (Pentium 4) [^x86_32-floats-return-ABI]
 [`i686-unknown-redox`](platform-support/redox.md) | ✓ |  | i686 Redox OS (PentiumPro) [^x86_32-floats-x87]
 `i686-uwp-windows-gnu` | ✓ |  | [^x86_32-floats-return-ABI]
@@ -417,6 +418,7 @@ target | std | host | notes
 `x86_64-unknown-l4re-uclibc` | ? |  |
 [`x86_64-unknown-linux-none`](platform-support/x86_64-unknown-linux-none.md) | * |  | 64-bit Linux with no libc
 [`x86_64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | 64-bit OpenBSD
+[`x86_64-unknown-nuttx`](platform-support/nuttx.md) | ✓ |  | 64-bit x86 with NuttX
 [`x86_64-unknown-trusty`](platform-support/trusty.md) | ? |  |
 `x86_64-uwp-windows-gnu` | ✓ |  |
 [`x86_64-uwp-windows-msvc`](platform-support/uwp-windows-msvc.md) | ✓ |  |

--- a/src/doc/rustc/src/platform-support/nuttx.md
+++ b/src/doc/rustc/src/platform-support/nuttx.md
@@ -20,6 +20,8 @@ The target name follow this format: `ARCH[-VENDOR]-nuttx-ABI`, where `ARCH` is t
 
 The following target names are defined:
 
+- `i686-unknown-nuttx`
+- `x86_64-unknown-nuttx`
 - `aarch64-unknown-nuttx`
 - `armv7a-nuttx-eabi`
 - `armv7a-nuttx-eabihf`
@@ -52,12 +54,21 @@ linker = "riscv-none-elf-gcc"
 
 The toolchain for the target can be found in [NuttX's quick start guide](https://nuttx.apache.org/docs/latest/quickstart/install.html).
 
-
 ## Testing
 
 This is a cross-compiled `no-std` target, which must be run either in a simulator
 or by programming them onto suitable hardware. It is not possible to run the
 Rust test-suite on this target.
+
+## Note for Floating-Point support on X86/X86_64
+
+For the NuttX platform, X86/X86_64 targets have two usage scenarios:
+1. Linked to a "SIM" running in a POSIX environment (more common)
+2. Running directly on baremetal hardware
+
+In the SIM environment, the FPU (Floating Point Unit) configuration is fixed and not configurable. For baremetal scenarios:
+- On i686 (targeting i486 in NuttX), the FPU is typically disabled
+- On x86_64, the FPU is enabled by default but can be disabled if needed
 
 ## Cross-compilation toolchains and C code
 

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -249,6 +249,9 @@
 //@ revisions: i686_unknown_netbsd
 //@ [i686_unknown_netbsd] compile-flags: --target i686-unknown-netbsd
 //@ [i686_unknown_netbsd] needs-llvm-components: x86
+//@ revisions: i686_unknown_nuttx
+//@ [i686_unknown_nuttx] compile-flags: --target i686-unknown-nuttx
+//@ [i686_unknown_nuttx] needs-llvm-components: x86
 //@ revisions: i686_unknown_openbsd
 //@ [i686_unknown_openbsd] compile-flags: --target i686-unknown-openbsd
 //@ [i686_unknown_openbsd] needs-llvm-components: x86
@@ -627,6 +630,9 @@
 //@ revisions: x86_64_unknown_none
 //@ [x86_64_unknown_none] compile-flags: --target x86_64-unknown-none
 //@ [x86_64_unknown_none] needs-llvm-components: x86
+//@ revisions: x86_64_unknown_nuttx
+//@ [x86_64_unknown_nuttx] compile-flags: --target x86_64-unknown-nuttx
+//@ [x86_64_unknown_nuttx] needs-llvm-components: x86
 //@ revisions: x86_64_unknown_openbsd
 //@ [x86_64_unknown_openbsd] compile-flags: --target x86_64-unknown-openbsd
 //@ [x86_64_unknown_openbsd] needs-llvm-components: x86


### PR DESCRIPTION
* Implement `i686-unknown-nuttx` and `x86_64-unknown-nuttx` target definitions
* Integrate new targets into the platform support documentation
* Update tests to include new target revisions

This change introduces support for 32-bit and 64-bit x86 architectures on the NuttX operating system, enhancing the range of platforms Rust can target. The targets are defined as tier 3, indicating that they are supported but not automatically tested by the Rust project. The `i686-unknown-nuttx` target uses the `pentium4` CPU and 32-bit pointers, while the `x86_64-unknown-nuttx` target uses the `x86-64` CPU and 64-bit pointers. Both targets disable dynamic linking and use inline stack probes for improved performance and reliability in a bare-metal environment.

Additionally, this commit updates the platform support documentation to list the new targets and includes them in the test suite to ensure that they build correctly.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
