### PR TITLE
Update iterator.rs to use arrays by value

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -56,12 +56,12 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// let mut iter = a.iter();
+    /// let mut iter = a.into_iter();
     ///
     /// // A call to next() returns the next value...
-    /// assert_eq!(Some(&1), iter.next());
-    /// assert_eq!(Some(&2), iter.next());
-    /// assert_eq!(Some(&3), iter.next());
+    /// assert_eq!(Some(1), iter.next());
+    /// assert_eq!(Some(2), iter.next());
+    /// assert_eq!(Some(3), iter.next());
     ///
     /// // ... and then None once it's over.
     /// assert_eq!(None, iter.next());
@@ -239,10 +239,10 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [1, 2, 3];
-    /// assert_eq!(a.iter().last(), Some(&3));
+    /// assert_eq!(a.into_iter().last(), Some(3));
     ///
     /// let a = [1, 2, 3, 4, 5];
-    /// assert_eq!(a.iter().last(), Some(&5));
+    /// assert_eq!(a.into_iter().last(), Some(5));
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -284,12 +284,12 @@ pub trait Iterator {
     /// use std::num::NonZero;
     ///
     /// let a = [1, 2, 3, 4];
-    /// let mut iter = a.iter();
+    /// let mut iter = a.into_iter();
     ///
     /// assert_eq!(iter.advance_by(2), Ok(()));
-    /// assert_eq!(iter.next(), Some(&3));
+    /// assert_eq!(iter.next(), Some(3));
     /// assert_eq!(iter.advance_by(0), Ok(()));
-    /// assert_eq!(iter.advance_by(100), Err(NonZero::new(99).unwrap())); // only `&4` was skipped
+    /// assert_eq!(iter.advance_by(100), Err(NonZero::new(99).unwrap())); // only `4` was skipped
     /// ```
     #[inline]
     #[unstable(feature = "iter_advance_by", reason = "recently added", issue = "77404")]
@@ -322,7 +322,7 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [1, 2, 3];
-    /// assert_eq!(a.iter().nth(1), Some(&2));
+    /// assert_eq!(a.into_iter().nth(1), Some(2));
     /// ```
     ///
     /// Calling `nth()` multiple times doesn't rewind the iterator:
@@ -330,9 +330,9 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// let mut iter = a.iter();
+    /// let mut iter = a.into_iter();
     ///
-    /// assert_eq!(iter.nth(1), Some(&2));
+    /// assert_eq!(iter.nth(1), Some(2));
     /// assert_eq!(iter.nth(1), None);
     /// ```
     ///
@@ -340,7 +340,7 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [1, 2, 3];
-    /// assert_eq!(a.iter().nth(10), None);
+    /// assert_eq!(a.into_iter().nth(10), None);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -385,11 +385,11 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [0, 1, 2, 3, 4, 5];
-    /// let mut iter = a.iter().step_by(2);
+    /// let mut iter = a.into_iter().step_by(2);
     ///
-    /// assert_eq!(iter.next(), Some(&0));
-    /// assert_eq!(iter.next(), Some(&2));
-    /// assert_eq!(iter.next(), Some(&4));
+    /// assert_eq!(iter.next(), Some(0));
+    /// assert_eq!(iter.next(), Some(2));
+    /// assert_eq!(iter.next(), Some(4));
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline]
@@ -417,37 +417,37 @@ pub trait Iterator {
     /// Basic usage:
     ///
     /// ```
-    /// let a1 = [1, 2, 3];
-    /// let a2 = [4, 5, 6];
+    /// let s1 = "abc".chars();
+    /// let s2 = "def".chars();
     ///
-    /// let mut iter = a1.iter().chain(a2.iter());
+    /// let mut iter = s1.chain(s2);
     ///
-    /// assert_eq!(iter.next(), Some(&1));
-    /// assert_eq!(iter.next(), Some(&2));
-    /// assert_eq!(iter.next(), Some(&3));
-    /// assert_eq!(iter.next(), Some(&4));
-    /// assert_eq!(iter.next(), Some(&5));
-    /// assert_eq!(iter.next(), Some(&6));
+    /// assert_eq!(iter.next(), Some('a'));
+    /// assert_eq!(iter.next(), Some('b'));
+    /// assert_eq!(iter.next(), Some('c'));
+    /// assert_eq!(iter.next(), Some('d'));
+    /// assert_eq!(iter.next(), Some('e'));
+    /// assert_eq!(iter.next(), Some('f'));
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
     /// Since the argument to `chain()` uses [`IntoIterator`], we can pass
     /// anything that can be converted into an [`Iterator`], not just an
-    /// [`Iterator`] itself. For example, slices (`&[T]`) implement
+    /// [`Iterator`] itself. For example, arrays (`[T]`) implement
     /// [`IntoIterator`], and so can be passed to `chain()` directly:
     ///
     /// ```
-    /// let s1 = &[1, 2, 3];
-    /// let s2 = &[4, 5, 6];
+    /// let a1 = [1, 2, 3];
+    /// let a2 = [4, 5, 6];
     ///
-    /// let mut iter = s1.iter().chain(s2);
+    /// let mut iter = a1.into_iter().chain(a2);
     ///
-    /// assert_eq!(iter.next(), Some(&1));
-    /// assert_eq!(iter.next(), Some(&2));
-    /// assert_eq!(iter.next(), Some(&3));
-    /// assert_eq!(iter.next(), Some(&4));
-    /// assert_eq!(iter.next(), Some(&5));
-    /// assert_eq!(iter.next(), Some(&6));
+    /// assert_eq!(iter.next(), Some(1));
+    /// assert_eq!(iter.next(), Some(2));
+    /// assert_eq!(iter.next(), Some(3));
+    /// assert_eq!(iter.next(), Some(4));
+    /// assert_eq!(iter.next(), Some(5));
+    /// assert_eq!(iter.next(), Some(6));
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
@@ -496,31 +496,31 @@ pub trait Iterator {
     /// Basic usage:
     ///
     /// ```
-    /// let a1 = [1, 2, 3];
-    /// let a2 = [4, 5, 6];
+    /// let s1 = "abc".chars();
+    /// let s2 = "def".chars();
     ///
-    /// let mut iter = a1.iter().zip(a2.iter());
+    /// let mut iter = s1.zip(s2);
     ///
-    /// assert_eq!(iter.next(), Some((&1, &4)));
-    /// assert_eq!(iter.next(), Some((&2, &5)));
-    /// assert_eq!(iter.next(), Some((&3, &6)));
+    /// assert_eq!(iter.next(), Some(('a', 'd')));
+    /// assert_eq!(iter.next(), Some(('b', 'e')));
+    /// assert_eq!(iter.next(), Some(('c', 'f')));
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
     /// Since the argument to `zip()` uses [`IntoIterator`], we can pass
     /// anything that can be converted into an [`Iterator`], not just an
-    /// [`Iterator`] itself. For example, slices (`&[T]`) implement
+    /// [`Iterator`] itself. For example, arrays (`[T]`) implement
     /// [`IntoIterator`], and so can be passed to `zip()` directly:
     ///
     /// ```
-    /// let s1 = &[1, 2, 3];
-    /// let s2 = &[4, 5, 6];
+    /// let a1 = [1, 2, 3];
+    /// let a2 = [4, 5, 6];
     ///
-    /// let mut iter = s1.iter().zip(s2);
+    /// let mut iter = a1.into_iter().zip(a2);
     ///
-    /// assert_eq!(iter.next(), Some((&1, &4)));
-    /// assert_eq!(iter.next(), Some((&2, &5)));
-    /// assert_eq!(iter.next(), Some((&3, &6)));
+    /// assert_eq!(iter.next(), Some((1, 4)));
+    /// assert_eq!(iter.next(), Some((2, 5)));
+    /// assert_eq!(iter.next(), Some((3, 6)));
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
@@ -604,12 +604,12 @@ pub trait Iterator {
     /// ```
     /// #![feature(iter_intersperse)]
     ///
-    /// let mut a = [0, 1, 2].iter().intersperse(&100);
-    /// assert_eq!(a.next(), Some(&0));   // The first element from `a`.
-    /// assert_eq!(a.next(), Some(&100)); // The separator.
-    /// assert_eq!(a.next(), Some(&1));   // The next element from `a`.
-    /// assert_eq!(a.next(), Some(&100)); // The separator.
-    /// assert_eq!(a.next(), Some(&2));   // The last element from `a`.
+    /// let mut a = [0, 1, 2].into_iter().intersperse(100);
+    /// assert_eq!(a.next(), Some(0));   // The first element from `a`.
+    /// assert_eq!(a.next(), Some(100)); // The separator.
+    /// assert_eq!(a.next(), Some(1));   // The next element from `a`.
+    /// assert_eq!(a.next(), Some(100)); // The separator.
+    /// assert_eq!(a.next(), Some(2));   // The last element from `a`.
     /// assert_eq!(a.next(), None);       // The iterator is finished.
     /// ```
     ///
@@ -617,7 +617,8 @@ pub trait Iterator {
     /// ```
     /// #![feature(iter_intersperse)]
     ///
-    /// let hello = ["Hello", "World", "!"].iter().copied().intersperse(" ").collect::<String>();
+    /// let words = ["Hello", "World", "!"];
+    /// let hello: String = words.into_iter().intersperse(" ").collect();
     /// assert_eq!(hello, "Hello World !");
     /// ```
     ///
@@ -673,7 +674,7 @@ pub trait Iterator {
     /// let src = ["Hello", "to", "all", "people", "!!"].iter().copied();
     ///
     /// // The closure mutably borrows its context to generate an item.
-    /// let mut happy_emojis = [" ❤️ ", " 😀 "].iter().copied();
+    /// let mut happy_emojis = [" ❤️ ", " 😀 "].into_iter();
     /// let separator = || happy_emojis.next().unwrap_or(" 🦀 ");
     ///
     /// let result = src.intersperse_with(separator).collect::<String>();
@@ -734,7 +735,7 @@ pub trait Iterator {
     ///
     /// // it won't even execute, as it is lazy. Rust will warn you about this.
     ///
-    /// // Instead, use for:
+    /// // Instead, use a for-loop:
     /// for x in 0..5 {
     ///     println!("{x}");
     /// }
@@ -814,10 +815,10 @@ pub trait Iterator {
     /// ```
     /// let a = [0i32, 1, 2];
     ///
-    /// let mut iter = a.iter().filter(|x| x.is_positive());
+    /// let mut iter = a.into_iter().filter(|x| x.is_positive());
     ///
-    /// assert_eq!(iter.next(), Some(&1));
-    /// assert_eq!(iter.next(), Some(&2));
+    /// assert_eq!(iter.next(), Some(1));
+    /// assert_eq!(iter.next(), Some(2));
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
@@ -826,21 +827,20 @@ pub trait Iterator {
     /// situation, where the type of the closure is a double reference:
     ///
     /// ```
-    /// let a = [0, 1, 2];
+    /// let s = &[0, 1, 2];
     ///
-    /// let mut iter = a.iter().filter(|x| **x > 1); // need two *s!
+    /// let mut iter = s.iter().filter(|x| **x > 1); // needs two *s!
     ///
     /// assert_eq!(iter.next(), Some(&2));
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
-    /// It's common to instead use destructuring on the argument to strip away
-    /// one:
+    /// It's common to instead use destructuring on the argument to strip away one:
     ///
     /// ```
-    /// let a = [0, 1, 2];
+    /// let s = &[0, 1, 2];
     ///
-    /// let mut iter = a.iter().filter(|&x| *x > 1); // both & and *
+    /// let mut iter = s.iter().filter(|&x| *x > 1); // both & and *
     ///
     /// assert_eq!(iter.next(), Some(&2));
     /// assert_eq!(iter.next(), None);
@@ -849,9 +849,9 @@ pub trait Iterator {
     /// or both:
     ///
     /// ```
-    /// let a = [0, 1, 2];
+    /// let s = &[0, 1, 2];
     ///
-    /// let mut iter = a.iter().filter(|&&x| x > 1); // two &s
+    /// let mut iter = s.iter().filter(|&&x| x > 1); // two &s
     ///
     /// assert_eq!(iter.next(), Some(&2));
     /// assert_eq!(iter.next(), None);
@@ -945,11 +945,11 @@ pub trait Iterator {
     /// ```
     /// let a = ['a', 'b', 'c'];
     ///
-    /// let mut iter = a.iter().enumerate();
+    /// let mut iter = a.into_iter().enumerate();
     ///
-    /// assert_eq!(iter.next(), Some((0, &'a')));
-    /// assert_eq!(iter.next(), Some((1, &'b')));
-    /// assert_eq!(iter.next(), Some((2, &'c')));
+    /// assert_eq!(iter.next(), Some((0, 'a')));
+    /// assert_eq!(iter.next(), Some((1, 'b')));
+    /// assert_eq!(iter.next(), Some((2, 'c')));
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline]
@@ -980,19 +980,19 @@ pub trait Iterator {
     /// ```
     /// let xs = [1, 2, 3];
     ///
-    /// let mut iter = xs.iter().peekable();
+    /// let mut iter = xs.into_iter().peekable();
     ///
     /// // peek() lets us see into the future
-    /// assert_eq!(iter.peek(), Some(&&1));
-    /// assert_eq!(iter.next(), Some(&1));
+    /// assert_eq!(iter.peek(), Some(&1));
+    /// assert_eq!(iter.next(), Some(1));
     ///
-    /// assert_eq!(iter.next(), Some(&2));
+    /// assert_eq!(iter.next(), Some(2));
     ///
     /// // we can peek() multiple times, the iterator won't advance
-    /// assert_eq!(iter.peek(), Some(&&3));
-    /// assert_eq!(iter.peek(), Some(&&3));
+    /// assert_eq!(iter.peek(), Some(&3));
+    /// assert_eq!(iter.peek(), Some(&3));
     ///
-    /// assert_eq!(iter.next(), Some(&3));
+    /// assert_eq!(iter.next(), Some(3));
     ///
     /// // after the iterator is finished, so is peek()
     /// assert_eq!(iter.peek(), None);
@@ -1005,21 +1005,21 @@ pub trait Iterator {
     /// ```
     /// let xs = [1, 2, 3];
     ///
-    /// let mut iter = xs.iter().peekable();
+    /// let mut iter = xs.into_iter().peekable();
     ///
     /// // `peek_mut()` lets us see into the future
-    /// assert_eq!(iter.peek_mut(), Some(&mut &1));
-    /// assert_eq!(iter.peek_mut(), Some(&mut &1));
-    /// assert_eq!(iter.next(), Some(&1));
+    /// assert_eq!(iter.peek_mut(), Some(&mut 1));
+    /// assert_eq!(iter.peek_mut(), Some(&mut 1));
+    /// assert_eq!(iter.next(), Some(1));
     ///
-    /// if let Some(mut p) = iter.peek_mut() {
-    ///     assert_eq!(*p, &2);
+    /// if let Some(p) = iter.peek_mut() {
+    ///     assert_eq!(*p, 2);
     ///     // put a value into the iterator
-    ///     *p = &1000;
+    ///     *p = 1000;
     /// }
     ///
     /// // The value reappears as the iterator continues
-    /// assert_eq!(iter.collect::<Vec<_>>(), vec![&1000, &3]);
+    /// assert_eq!(iter.collect::<Vec<_>>(), vec![1000, 3]);
     /// ```
     /// [`peek`]: Peekable::peek
     /// [`peek_mut`]: Peekable::peek_mut
@@ -1051,10 +1051,10 @@ pub trait Iterator {
     /// ```
     /// let a = [-1i32, 0, 1];
     ///
-    /// let mut iter = a.iter().skip_while(|x| x.is_negative());
+    /// let mut iter = a.into_iter().skip_while(|x| x.is_negative());
     ///
-    /// assert_eq!(iter.next(), Some(&0));
-    /// assert_eq!(iter.next(), Some(&1));
+    /// assert_eq!(iter.next(), Some(0));
+    /// assert_eq!(iter.next(), Some(1));
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
@@ -1063,9 +1063,9 @@ pub trait Iterator {
     /// situation, where the type of the closure argument is a double reference:
     ///
     /// ```
-    /// let a = [-1, 0, 1];
+    /// let s = &[-1, 0, 1];
     ///
-    /// let mut iter = a.iter().skip_while(|x| **x < 0); // need two *s!
+    /// let mut iter = s.iter().skip_while(|x| **x < 0); // need two *s!
     ///
     /// assert_eq!(iter.next(), Some(&0));
     /// assert_eq!(iter.next(), Some(&1));
@@ -1077,14 +1077,14 @@ pub trait Iterator {
     /// ```
     /// let a = [-1, 0, 1, -2];
     ///
-    /// let mut iter = a.iter().skip_while(|x| **x < 0);
+    /// let mut iter = a.into_iter().skip_while(|&x| x < 0);
     ///
-    /// assert_eq!(iter.next(), Some(&0));
-    /// assert_eq!(iter.next(), Some(&1));
+    /// assert_eq!(iter.next(), Some(0));
+    /// assert_eq!(iter.next(), Some(1));
     ///
     /// // while this would have been false, since we already got a false,
     /// // skip_while() isn't used any more
-    /// assert_eq!(iter.next(), Some(&-2));
+    /// assert_eq!(iter.next(), Some(-2));
     ///
     /// assert_eq!(iter.next(), None);
     /// ```
@@ -1115,9 +1115,9 @@ pub trait Iterator {
     /// ```
     /// let a = [-1i32, 0, 1];
     ///
-    /// let mut iter = a.iter().take_while(|x| x.is_negative());
+    /// let mut iter = a.into_iter().take_while(|x| x.is_negative());
     ///
-    /// assert_eq!(iter.next(), Some(&-1));
+    /// assert_eq!(iter.next(), Some(-1));
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
@@ -1126,9 +1126,9 @@ pub trait Iterator {
     /// situation, where the type of the closure is a double reference:
     ///
     /// ```
-    /// let a = [-1, 0, 1];
+    /// let s = &[-1, 0, 1];
     ///
-    /// let mut iter = a.iter().take_while(|x| **x < 0); // need two *s!
+    /// let mut iter = s.iter().take_while(|x| **x < 0); // need two *s!
     ///
     /// assert_eq!(iter.next(), Some(&-1));
     /// assert_eq!(iter.next(), None);
@@ -1139,12 +1139,12 @@ pub trait Iterator {
     /// ```
     /// let a = [-1, 0, 1, -2];
     ///
-    /// let mut iter = a.iter().take_while(|x| **x < 0);
+    /// let mut iter = a.into_iter().take_while(|&x| x < 0);
     ///
-    /// assert_eq!(iter.next(), Some(&-1));
+    /// assert_eq!(iter.next(), Some(-1));
     ///
     /// // We have more elements that are less than zero, but since we already
-    /// // got a false, take_while() isn't used any more
+    /// // got a false, take_while() ignores the remaining elements.
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
@@ -1154,18 +1154,15 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [1, 2, 3, 4];
-    /// let mut iter = a.iter();
+    /// let mut iter = a.into_iter();
     ///
-    /// let result: Vec<i32> = iter.by_ref()
-    ///                            .take_while(|n| **n != 3)
-    ///                            .cloned()
-    ///                            .collect();
+    /// let result: Vec<i32> = iter.by_ref().take_while(|&n| n != 3).collect();
     ///
-    /// assert_eq!(result, &[1, 2]);
+    /// assert_eq!(result, [1, 2]);
     ///
-    /// let result: Vec<i32> = iter.cloned().collect();
+    /// let result: Vec<i32> = iter.collect();
     ///
-    /// assert_eq!(result, &[4]);
+    /// assert_eq!(result, [4]);
     /// ```
     ///
     /// The `3` is no longer there, because it was consumed in order to see if
@@ -1193,7 +1190,7 @@ pub trait Iterator {
     /// ```
     /// let a = [-1i32, 4, 0, 1];
     ///
-    /// let mut iter = a.iter().map_while(|x| 16i32.checked_div(*x));
+    /// let mut iter = a.into_iter().map_while(|x| 16i32.checked_div(x));
     ///
     /// assert_eq!(iter.next(), Some(-16));
     /// assert_eq!(iter.next(), Some(4));
@@ -1208,8 +1205,8 @@ pub trait Iterator {
     /// ```
     /// let a = [-1i32, 4, 0, 1];
     ///
-    /// let mut iter = a.iter()
-    ///                 .map(|x| 16i32.checked_div(*x))
+    /// let mut iter = a.into_iter()
+    ///                 .map(|x| 16i32.checked_div(x))
     ///                 .take_while(|x| x.is_some())
     ///                 .map(|x| x.unwrap());
     ///
@@ -1223,12 +1220,12 @@ pub trait Iterator {
     /// ```
     /// let a = [0, 1, 2, -3, 4, 5, -6];
     ///
-    /// let iter = a.iter().map_while(|x| u32::try_from(*x).ok());
-    /// let vec = iter.collect::<Vec<_>>();
+    /// let iter = a.into_iter().map_while(|x| u32::try_from(x).ok());
+    /// let vec: Vec<_> = iter.collect();
     ///
-    /// // We have more elements which could fit in u32 (4, 5), but `map_while` returned `None` for `-3`
+    /// // We have more elements that could fit in u32 (such as 4, 5), but `map_while` returned `None` for `-3`
     /// // (as the `predicate` returned `None`) and `collect` stops at the first `None` encountered.
-    /// assert_eq!(vec, vec![0, 1, 2]);
+    /// assert_eq!(vec, [0, 1, 2]);
     /// ```
     ///
     /// Because `map_while()` needs to look at the value in order to see if it
@@ -1237,17 +1234,17 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [1, 2, -3, 4];
-    /// let mut iter = a.iter();
+    /// let mut iter = a.into_iter();
     ///
     /// let result: Vec<u32> = iter.by_ref()
-    ///                            .map_while(|n| u32::try_from(*n).ok())
+    ///                            .map_while(|n| u32::try_from(n).ok())
     ///                            .collect();
     ///
-    /// assert_eq!(result, &[1, 2]);
+    /// assert_eq!(result, [1, 2]);
     ///
-    /// let result: Vec<i32> = iter.cloned().collect();
+    /// let result: Vec<i32> = iter.collect();
     ///
-    /// assert_eq!(result, &[4]);
+    /// assert_eq!(result, [4]);
     /// ```
     ///
     /// The `-3` is no longer there, because it was consumed in order to see if
@@ -1255,7 +1252,7 @@ pub trait Iterator {
     ///
     /// Note that unlike [`take_while`] this iterator is **not** fused.
     /// It is also not specified what this iterator returns after the first [`None`] is returned.
-    /// If you need fused iterator, use [`fuse`].
+    /// If you need a fused iterator, use [`fuse`].
     ///
     /// [`fuse`]: Iterator::fuse
     #[inline]
@@ -1282,9 +1279,9 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// let mut iter = a.iter().skip(2);
+    /// let mut iter = a.into_iter().skip(2);
     ///
-    /// assert_eq!(iter.next(), Some(&3));
+    /// assert_eq!(iter.next(), Some(3));
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline]
@@ -1312,10 +1309,10 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// let mut iter = a.iter().take(2);
+    /// let mut iter = a.into_iter().take(2);
     ///
-    /// assert_eq!(iter.next(), Some(&1));
-    /// assert_eq!(iter.next(), Some(&2));
+    /// assert_eq!(iter.next(), Some(1));
+    /// assert_eq!(iter.next(), Some(2));
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
@@ -1370,7 +1367,7 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3, 4];
     ///
-    /// let mut iter = a.iter().scan(1, |state, &x| {
+    /// let mut iter = a.into_iter().scan(1, |state, x| {
     ///     // each iteration, we'll multiply the state by the element ...
     ///     *state = *state * x;
     ///
@@ -1448,8 +1445,8 @@ pub trait Iterator {
     ///
     /// ```
     /// let data = vec![vec![1, 2, 3, 4], vec![5, 6]];
-    /// let flattened = data.into_iter().flatten().collect::<Vec<u8>>();
-    /// assert_eq!(flattened, &[1, 2, 3, 4, 5, 6]);
+    /// let flattened: Vec<_> = data.into_iter().flatten().collect();
+    /// assert_eq!(flattened, [1, 2, 3, 4, 5, 6]);
     /// ```
     ///
     /// Mapping and then flattening:
@@ -1483,11 +1480,11 @@ pub trait Iterator {
     /// ```
     /// let options = vec![Some(123), Some(321), None, Some(231)];
     /// let flattened_options: Vec<_> = options.into_iter().flatten().collect();
-    /// assert_eq!(flattened_options, vec![123, 321, 231]);
+    /// assert_eq!(flattened_options, [123, 321, 231]);
     ///
     /// let results = vec![Ok(123), Ok(321), Err(456), Ok(231)];
     /// let flattened_results: Vec<_> = results.into_iter().flatten().collect();
-    /// assert_eq!(flattened_results, vec![123, 321, 231]);
+    /// assert_eq!(flattened_results, [123, 321, 231]);
     /// ```
     ///
     /// Flattening only removes one level of nesting at a time:
@@ -1495,11 +1492,11 @@ pub trait Iterator {
     /// ```
     /// let d3 = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
     ///
-    /// let d2 = d3.iter().flatten().collect::<Vec<_>>();
-    /// assert_eq!(d2, [&[1, 2], &[3, 4], &[5, 6], &[7, 8]]);
+    /// let d2: Vec<_> = d3.into_iter().flatten().collect();
+    /// assert_eq!(d2, [[1, 2], [3, 4], [5, 6], [7, 8]]);
     ///
-    /// let d1 = d3.iter().flatten().flatten().collect::<Vec<_>>();
-    /// assert_eq!(d1, [&1, &2, &3, &4, &5, &6, &7, &8]);
+    /// let d1: Vec<_> = d3.into_iter().flatten().flatten().collect();
+    /// assert_eq!(d1, [1, 2, 3, 4, 5, 6, 7, 8]);
     /// ```
     ///
     /// Here we see that `flatten()` does not perform a "deep" flatten.
@@ -1881,7 +1878,7 @@ pub trait Iterator {
     /// let a = [1, 2, 3];
     ///
     /// let doubled: Vec<i32> = a.iter()
-    ///                          .map(|&x| x * 2)
+    ///                          .map(|x| x * 2)
     ///                          .collect();
     ///
     /// assert_eq!(vec![2, 4, 6], doubled);
@@ -1897,7 +1894,7 @@ pub trait Iterator {
     ///
     /// let a = [1, 2, 3];
     ///
-    /// let doubled: VecDeque<i32> = a.iter().map(|&x| x * 2).collect();
+    /// let doubled: VecDeque<i32> = a.iter().map(|x| x * 2).collect();
     ///
     /// assert_eq!(2, doubled[0]);
     /// assert_eq!(4, doubled[1]);
@@ -1930,8 +1927,8 @@ pub trait Iterator {
     /// ```
     /// let chars = ['g', 'd', 'k', 'k', 'n'];
     ///
-    /// let hello: String = chars.iter()
-    ///     .map(|&x| x as u8)
+    /// let hello: String = chars.into_iter()
+    ///     .map(|x| x as u8)
     ///     .map(|x| (x + 1) as char)
     ///     .collect();
     ///
@@ -1944,14 +1941,14 @@ pub trait Iterator {
     /// ```
     /// let results = [Ok(1), Err("nope"), Ok(3), Err("bad")];
     ///
-    /// let result: Result<Vec<_>, &str> = results.iter().cloned().collect();
+    /// let result: Result<Vec<_>, &str> = results.into_iter().collect();
     ///
     /// // gives us the first error
     /// assert_eq!(Err("nope"), result);
     ///
     /// let results = [Ok(1), Ok(3)];
     ///
-    /// let result: Result<Vec<_>, &str> = results.iter().cloned().collect();
+    /// let result: Result<Vec<_>, &str> = results.into_iter().collect();
     ///
     /// // gives us the list of answers
     /// assert_eq!(Ok(vec![1, 3]), result);
@@ -2073,8 +2070,8 @@ pub trait Iterator {
     /// let a = [1, 2, 3];
     /// let mut vec: Vec::<i32> = vec![0, 1];
     ///
-    /// a.iter().map(|&x| x * 2).collect_into(&mut vec);
-    /// a.iter().map(|&x| x * 10).collect_into(&mut vec);
+    /// a.iter().map(|x| x * 2).collect_into(&mut vec);
+    /// a.iter().map(|x| x * 10).collect_into(&mut vec);
     ///
     /// assert_eq!(vec, vec![0, 1, 2, 4, 6, 10, 20, 30]);
     /// ```
@@ -2087,8 +2084,8 @@ pub trait Iterator {
     /// let a = [1, 2, 3];
     /// let mut vec: Vec::<i32> = Vec::with_capacity(6);
     ///
-    /// a.iter().map(|&x| x * 2).collect_into(&mut vec);
-    /// a.iter().map(|&x| x * 10).collect_into(&mut vec);
+    /// a.iter().map(|x| x * 2).collect_into(&mut vec);
+    /// a.iter().map(|x| x * 10).collect_into(&mut vec);
     ///
     /// assert_eq!(6, vec.capacity());
     /// assert_eq!(vec, vec![2, 4, 6, 10, 20, 30]);
@@ -2142,8 +2139,8 @@ pub trait Iterator {
     ///     .into_iter()
     ///     .partition(|n| n % 2 == 0);
     ///
-    /// assert_eq!(even, vec![2]);
-    /// assert_eq!(odd, vec![1, 3]);
+    /// assert_eq!(even, [2]);
+    /// assert_eq!(odd, [1, 3]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     fn partition<B, F>(self, f: F) -> (B, B)
@@ -2201,11 +2198,11 @@ pub trait Iterator {
     /// let mut a = [1, 2, 3, 4, 5, 6, 7];
     ///
     /// // Partition in-place between evens and odds
-    /// let i = a.iter_mut().partition_in_place(|&n| n % 2 == 0);
+    /// let i = a.iter_mut().partition_in_place(|n| n % 2 == 0);
     ///
     /// assert_eq!(i, 3);
-    /// assert!(a[..i].iter().all(|&n| n % 2 == 0)); // evens
-    /// assert!(a[i..].iter().all(|&n| n % 2 == 1)); // odds
+    /// assert!(a[..i].iter().all(|n| n % 2 == 0)); // evens
+    /// assert!(a[i..].iter().all(|n| n % 2 == 1)); // odds
     /// ```
     #[unstable(feature = "iter_partition_in_place", reason = "new API", issue = "62543")]
     fn partition_in_place<'a, T: 'a, P>(mut self, ref mut predicate: P) -> usize
@@ -2312,7 +2309,7 @@ pub trait Iterator {
     /// let a = [1, 2, 3];
     ///
     /// // the checked sum of all of the elements of the array
-    /// let sum = a.iter().try_fold(0i8, |acc, &x| acc.checked_add(x));
+    /// let sum = a.into_iter().try_fold(0i8, |acc, x| acc.checked_add(x));
     ///
     /// assert_eq!(sum, Some(6));
     /// ```
@@ -2321,16 +2318,16 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [10, 20, 30, 100, 40, 50];
-    /// let mut it = a.iter();
+    /// let mut iter = a.into_iter();
     ///
     /// // This sum overflows when adding the 100 element
-    /// let sum = it.try_fold(0i8, |acc, &x| acc.checked_add(x));
+    /// let sum = iter.try_fold(0i8, |acc, x| acc.checked_add(x));
     /// assert_eq!(sum, None);
     ///
     /// // Because it short-circuited, the remaining elements are still
     /// // available through the iterator.
-    /// assert_eq!(it.len(), 2);
-    /// assert_eq!(it.next(), Some(&40));
+    /// assert_eq!(iter.len(), 2);
+    /// assert_eq!(iter.next(), Some(40));
     /// ```
     ///
     /// While you cannot `break` from a closure, the [`ControlFlow`] type allows
@@ -2683,9 +2680,9 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// assert!(a.iter().all(|&x| x > 0));
+    /// assert!(a.into_iter().all(|x| x > 0));
     ///
-    /// assert!(!a.iter().all(|&x| x > 2));
+    /// assert!(!a.into_iter().all(|x| x > 2));
     /// ```
     ///
     /// Stopping at the first `false`:
@@ -2693,12 +2690,12 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// let mut iter = a.iter();
+    /// let mut iter = a.into_iter();
     ///
-    /// assert!(!iter.all(|&x| x != 2));
+    /// assert!(!iter.all(|x| x != 2));
     ///
     /// // we can still use `iter`, as there are more elements.
-    /// assert_eq!(iter.next(), Some(&3));
+    /// assert_eq!(iter.next(), Some(3));
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -2736,9 +2733,9 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// assert!(a.iter().any(|&x| x > 0));
+    /// assert!(a.into_iter().any(|x| x > 0));
     ///
-    /// assert!(!a.iter().any(|&x| x > 5));
+    /// assert!(!a.into_iter().any(|x| x > 5));
     /// ```
     ///
     /// Stopping at the first `true`:
@@ -2746,12 +2743,12 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// let mut iter = a.iter();
+    /// let mut iter = a.into_iter();
     ///
-    /// assert!(iter.any(|&x| x != 2));
+    /// assert!(iter.any(|x| x != 2));
     ///
     /// // we can still use `iter`, as there are more elements.
-    /// assert_eq!(iter.next(), Some(&2));
+    /// assert_eq!(iter.next(), Some(2));
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -2797,9 +2794,8 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// assert_eq!(a.iter().find(|&&x| x == 2), Some(&2));
-    ///
-    /// assert_eq!(a.iter().find(|&&x| x == 5), None);
+    /// assert_eq!(a.into_iter().find(|&x| x == 2), Some(2));
+    /// assert_eq!(a.into_iter().find(|&x| x == 5), None);
     /// ```
     ///
     /// Stopping at the first `true`:
@@ -2807,12 +2803,12 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// let mut iter = a.iter();
+    /// let mut iter = a.into_iter();
     ///
-    /// assert_eq!(iter.find(|&&x| x == 2), Some(&2));
+    /// assert_eq!(iter.find(|&x| x == 2), Some(2));
     ///
     /// // we can still use `iter`, as there are more elements.
-    /// assert_eq!(iter.next(), Some(&3));
+    /// assert_eq!(iter.next(), Some(3));
     /// ```
     ///
     /// Note that `iter.find(f)` is equivalent to `iter.filter(f).next()`.
@@ -2880,13 +2876,13 @@ pub trait Iterator {
     /// let a = ["1", "2", "lol", "NaN", "5"];
     ///
     /// let is_my_num = |s: &str, search: i32| -> Result<bool, std::num::ParseIntError> {
-    ///     Ok(s.parse::<i32>()?  == search)
+    ///     Ok(s.parse::<i32>()? == search)
     /// };
     ///
-    /// let result = a.iter().try_find(|&&s| is_my_num(s, 2));
-    /// assert_eq!(result, Ok(Some(&"2")));
+    /// let result = a.into_iter().try_find(|&s| is_my_num(s, 2));
+    /// assert_eq!(result, Ok(Some("2")));
     ///
-    /// let result = a.iter().try_find(|&&s| is_my_num(s, 5));
+    /// let result = a.into_iter().try_find(|&s| is_my_num(s, 5));
     /// assert!(result.is_err());
     /// ```
     ///
@@ -2898,11 +2894,11 @@ pub trait Iterator {
     /// use std::num::NonZero;
     ///
     /// let a = [3, 5, 7, 4, 9, 0, 11u32];
-    /// let result = a.iter().try_find(|&&x| NonZero::new(x).map(|y| y.is_power_of_two()));
-    /// assert_eq!(result, Some(Some(&4)));
-    /// let result = a.iter().take(3).try_find(|&&x| NonZero::new(x).map(|y| y.is_power_of_two()));
+    /// let result = a.into_iter().try_find(|&x| NonZero::new(x).map(|y| y.is_power_of_two()));
+    /// assert_eq!(result, Some(Some(4)));
+    /// let result = a.into_iter().take(3).try_find(|&x| NonZero::new(x).map(|y| y.is_power_of_two()));
     /// assert_eq!(result, Some(None));
-    /// let result = a.iter().rev().try_find(|&&x| NonZero::new(x).map(|y| y.is_power_of_two()));
+    /// let result = a.into_iter().rev().try_find(|&x| NonZero::new(x).map(|y| y.is_power_of_two()));
     /// assert_eq!(result, None);
     /// ```
     #[inline]
@@ -2967,9 +2963,9 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// assert_eq!(a.iter().position(|&x| x == 2), Some(1));
+    /// assert_eq!(a.into_iter().position(|x| x == 2), Some(1));
     ///
-    /// assert_eq!(a.iter().position(|&x| x == 5), None);
+    /// assert_eq!(a.into_iter().position(|x| x == 5), None);
     /// ```
     ///
     /// Stopping at the first `true`:
@@ -2977,15 +2973,15 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3, 4];
     ///
-    /// let mut iter = a.iter();
+    /// let mut iter = a.into_iter();
     ///
-    /// assert_eq!(iter.position(|&x| x >= 2), Some(1));
+    /// assert_eq!(iter.position(|x| x >= 2), Some(1));
     ///
     /// // we can still use `iter`, as there are more elements.
-    /// assert_eq!(iter.next(), Some(&3));
+    /// assert_eq!(iter.next(), Some(3));
     ///
     /// // The returned index depends on iterator state
-    /// assert_eq!(iter.position(|&x| x == 4), Some(0));
+    /// assert_eq!(iter.position(|x| x == 4), Some(0));
     ///
     /// ```
     #[inline]
@@ -3035,9 +3031,9 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// assert_eq!(a.iter().rposition(|&x| x == 3), Some(2));
+    /// assert_eq!(a.into_iter().rposition(|x| x == 3), Some(2));
     ///
-    /// assert_eq!(a.iter().rposition(|&x| x == 5), None);
+    /// assert_eq!(a.into_iter().rposition(|x| x == 5), None);
     /// ```
     ///
     /// Stopping at the first `true`:
@@ -3045,13 +3041,13 @@ pub trait Iterator {
     /// ```
     /// let a = [-1, 2, 3, 4];
     ///
-    /// let mut iter = a.iter();
+    /// let mut iter = a.into_iter();
     ///
-    /// assert_eq!(iter.rposition(|&x| x >= 2), Some(3));
+    /// assert_eq!(iter.rposition(|x| x >= 2), Some(3));
     ///
     /// // we can still use `iter`, as there are more elements.
-    /// assert_eq!(iter.next(), Some(&-1));
-    /// assert_eq!(iter.next_back(), Some(&3));
+    /// assert_eq!(iter.next(), Some(-1));
+    /// assert_eq!(iter.next_back(), Some(3));
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -3097,10 +3093,10 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [1, 2, 3];
-    /// let b: Vec<u32> = Vec::new();
+    /// let b: [u32; 0] = [];
     ///
-    /// assert_eq!(a.iter().max(), Some(&3));
-    /// assert_eq!(b.iter().max(), None);
+    /// assert_eq!(a.into_iter().max(), Some(3));
+    /// assert_eq!(b.into_iter().max(), None);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -3133,10 +3129,10 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [1, 2, 3];
-    /// let b: Vec<u32> = Vec::new();
+    /// let b: [u32; 0] = [];
     ///
-    /// assert_eq!(a.iter().min(), Some(&1));
-    /// assert_eq!(b.iter().min(), None);
+    /// assert_eq!(a.into_iter().min(), Some(1));
+    /// assert_eq!(b.into_iter().min(), None);
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -3158,7 +3154,7 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [-3_i32, 0, 1, 5, -10];
-    /// assert_eq!(*a.iter().max_by_key(|x| x.abs()).unwrap(), -10);
+    /// assert_eq!(a.into_iter().max_by_key(|x| x.abs()).unwrap(), -10);
     /// ```
     #[inline]
     #[stable(feature = "iter_cmp_by_key", since = "1.6.0")]
@@ -3191,7 +3187,7 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [-3_i32, 0, 1, 5, -10];
-    /// assert_eq!(*a.iter().max_by(|x, y| x.cmp(y)).unwrap(), 5);
+    /// assert_eq!(a.into_iter().max_by(|x, y| x.cmp(y)).unwrap(), 5);
     /// ```
     #[inline]
     #[stable(feature = "iter_max_by", since = "1.15.0")]
@@ -3218,7 +3214,7 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [-3_i32, 0, 1, 5, -10];
-    /// assert_eq!(*a.iter().min_by_key(|x| x.abs()).unwrap(), 0);
+    /// assert_eq!(a.into_iter().min_by_key(|x| x.abs()).unwrap(), 0);
     /// ```
     #[inline]
     #[stable(feature = "iter_cmp_by_key", since = "1.6.0")]
@@ -3251,7 +3247,7 @@ pub trait Iterator {
     ///
     /// ```
     /// let a = [-3_i32, 0, 1, 5, -10];
-    /// assert_eq!(*a.iter().min_by(|x, y| x.cmp(y)).unwrap(), -10);
+    /// assert_eq!(a.into_iter().min_by(|x, y| x.cmp(y)).unwrap(), -10);
     /// ```
     #[inline]
     #[stable(feature = "iter_min_by", since = "1.15.0")]
@@ -3281,11 +3277,11 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// let mut iter = a.iter().rev();
+    /// let mut iter = a.into_iter().rev();
     ///
-    /// assert_eq!(iter.next(), Some(&3));
-    /// assert_eq!(iter.next(), Some(&2));
-    /// assert_eq!(iter.next(), Some(&1));
+    /// assert_eq!(iter.next(), Some(3));
+    /// assert_eq!(iter.next(), Some(2));
+    /// assert_eq!(iter.next(), Some(1));
     ///
     /// assert_eq!(iter.next(), None);
     /// ```
@@ -3314,7 +3310,7 @@ pub trait Iterator {
     /// ```
     /// let a = [(1, 2), (3, 4), (5, 6)];
     ///
-    /// let (left, right): (Vec<_>, Vec<_>) = a.iter().cloned().unzip();
+    /// let (left, right): (Vec<_>, Vec<_>) = a.into_iter().unzip();
     ///
     /// assert_eq!(left, [1, 3, 5]);
     /// assert_eq!(right, [2, 4, 6]);
@@ -3322,7 +3318,7 @@ pub trait Iterator {
     /// // you can also unzip multiple nested tuples at once
     /// let a = [(1, (2, 3)), (4, (5, 6))];
     ///
-    /// let (x, (y, z)): (Vec<_>, (Vec<_>, Vec<_>)) = a.iter().cloned().unzip();
+    /// let (x, (y, z)): (Vec<_>, (Vec<_>, Vec<_>)) = a.into_iter().unzip();
     /// assert_eq!(x, [1, 4]);
     /// assert_eq!(y, [2, 5]);
     /// assert_eq!(z, [3, 6]);
@@ -3354,8 +3350,8 @@ pub trait Iterator {
     /// // copied is the same as .map(|&x| x)
     /// let v_map: Vec<_> = a.iter().map(|&x| x).collect();
     ///
-    /// assert_eq!(v_copied, vec![1, 2, 3]);
-    /// assert_eq!(v_map, vec![1, 2, 3]);
+    /// assert_eq!(v_copied, [1, 2, 3]);
+    /// assert_eq!(v_map, [1, 2, 3]);
     /// ```
     #[stable(feature = "iter_copied", since = "1.36.0")]
     #[cfg_attr(not(test), rustc_diagnostic_item = "iter_copied")]
@@ -3390,8 +3386,8 @@ pub trait Iterator {
     /// // cloned is the same as .map(|&x| x), for integers
     /// let v_map: Vec<_> = a.iter().map(|&x| x).collect();
     ///
-    /// assert_eq!(v_cloned, vec![1, 2, 3]);
-    /// assert_eq!(v_map, vec![1, 2, 3]);
+    /// assert_eq!(v_cloned, [1, 2, 3]);
+    /// assert_eq!(v_map, [1, 2, 3]);
     /// ```
     ///
     /// To get the best performance, try to clone late:
@@ -3427,15 +3423,14 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3];
     ///
-    /// let mut it = a.iter().cycle();
+    /// let mut iter = a.into_iter().cycle();
     ///
-    /// assert_eq!(it.next(), Some(&1));
-    /// assert_eq!(it.next(), Some(&2));
-    /// assert_eq!(it.next(), Some(&3));
-    /// assert_eq!(it.next(), Some(&1));
-    /// assert_eq!(it.next(), Some(&2));
-    /// assert_eq!(it.next(), Some(&3));
-    /// assert_eq!(it.next(), Some(&1));
+    /// loop {
+    ///     assert_eq!(iter.next(), Some(1));
+    ///     assert_eq!(iter.next(), Some(2));
+    ///     assert_eq!(iter.next(), Some(3));
+    /// #   break;
+    /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
@@ -3588,9 +3583,9 @@ pub trait Iterator {
     /// let xs = [1, 2, 3, 4];
     /// let ys = [1, 4, 9, 16];
     ///
-    /// assert_eq!(xs.iter().cmp_by(&ys, |&x, &y| x.cmp(&y)), Ordering::Less);
-    /// assert_eq!(xs.iter().cmp_by(&ys, |&x, &y| (x * x).cmp(&y)), Ordering::Equal);
-    /// assert_eq!(xs.iter().cmp_by(&ys, |&x, &y| (2 * x).cmp(&y)), Ordering::Greater);
+    /// assert_eq!(xs.into_iter().cmp_by(ys, |x, y| x.cmp(&y)), Ordering::Less);
+    /// assert_eq!(xs.into_iter().cmp_by(ys, |x, y| (x * x).cmp(&y)), Ordering::Equal);
+    /// assert_eq!(xs.into_iter().cmp_by(ys, |x, y| (2 * x).cmp(&y)), Ordering::Greater);
     /// ```
     #[unstable(feature = "iter_order_by", issue = "64295")]
     fn cmp_by<I, F>(self, other: I, cmp: F) -> Ordering
@@ -3672,15 +3667,15 @@ pub trait Iterator {
     /// let ys = [1.0, 4.0, 9.0, 16.0];
     ///
     /// assert_eq!(
-    ///     xs.iter().partial_cmp_by(&ys, |&x, &y| x.partial_cmp(&y)),
+    ///     xs.iter().partial_cmp_by(ys, |x, y| x.partial_cmp(&y)),
     ///     Some(Ordering::Less)
     /// );
     /// assert_eq!(
-    ///     xs.iter().partial_cmp_by(&ys, |&x, &y| (x * x).partial_cmp(&y)),
+    ///     xs.iter().partial_cmp_by(ys, |x, y| (x * x).partial_cmp(&y)),
     ///     Some(Ordering::Equal)
     /// );
     /// assert_eq!(
-    ///     xs.iter().partial_cmp_by(&ys, |&x, &y| (2.0 * x).partial_cmp(&y)),
+    ///     xs.iter().partial_cmp_by(ys, |x, y| (2.0 * x).partial_cmp(&y)),
     ///     Some(Ordering::Greater)
     /// );
     /// ```
@@ -3738,7 +3733,7 @@ pub trait Iterator {
     /// let xs = [1, 2, 3, 4];
     /// let ys = [1, 4, 9, 16];
     ///
-    /// assert!(xs.iter().eq_by(&ys, |&x, &y| x * x == y));
+    /// assert!(xs.iter().eq_by(ys, |x, y| x * x == y));
     /// ```
     #[unstable(feature = "iter_order_by", issue = "64295")]
     fn eq_by<I, F>(self, other: I, eq: F) -> bool


### PR DESCRIPTION
Update examples to no longer avoid iterating arrays for #84513

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
