### PR TITLE
Fix a couple Emscripten tests

### DIFF
--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -177,6 +177,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "only-bpf",
     "only-cdb",
     "only-dist",
+    "only-emscripten",
     "only-gnu",
     "only-i686-pc-windows-gnu",
     "only-i686-pc-windows-msvc",

--- a/tests/codegen/float/f128.rs
+++ b/tests/codegen/float/f128.rs
@@ -1,11 +1,15 @@
 // 32-bit x86 returns float types differently to avoid the x87 stack.
 // 32-bit systems will return 128bit values using a return area pointer.
-//@ revisions: x86 bit32 bit64
+// Emscripten aligns f128 to 8 bytes, not 16.
+//@ revisions: x86 bit32 bit64 emscripten
 //@[x86] only-x86
 //@[bit32] ignore-x86
+//@[bit32] ignore-emscripten
 //@[bit32] only-32bit
 //@[bit64] ignore-x86
+//@[bit64] ignore-emscripten
 //@[bit64] only-64bit
+//@[emscripten] only-emscripten
 
 // Verify that our intrinsics generate the correct LLVM calls for f128
 
@@ -59,6 +63,7 @@ pub fn f128_le(a: f128, b: f128) -> bool {
 // x86-LABEL: void @f128_neg({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f128_neg({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @f128_neg(
+// emscripten-LABEL: void @f128_neg({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f128_neg(a: f128) -> f128 {
     // CHECK: fneg fp128
@@ -68,6 +73,7 @@ pub fn f128_neg(a: f128) -> f128 {
 // x86-LABEL: void @f128_add({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f128_add({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @f128_add(
+// emscripten-LABEL: void @f128_add({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f128_add(a: f128, b: f128) -> f128 {
     // CHECK: fadd fp128 %{{.+}}, %{{.+}}
@@ -77,6 +83,7 @@ pub fn f128_add(a: f128, b: f128) -> f128 {
 // x86-LABEL: void @f128_sub({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f128_sub({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @f128_sub(
+// emscripten-LABEL: void @f128_sub({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f128_sub(a: f128, b: f128) -> f128 {
     // CHECK: fsub fp128 %{{.+}}, %{{.+}}
@@ -86,6 +93,7 @@ pub fn f128_sub(a: f128, b: f128) -> f128 {
 // x86-LABEL: void @f128_mul({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f128_mul({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @f128_mul(
+// emscripten-LABEL: void @f128_mul({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f128_mul(a: f128, b: f128) -> f128 {
     // CHECK: fmul fp128 %{{.+}}, %{{.+}}
@@ -95,6 +103,7 @@ pub fn f128_mul(a: f128, b: f128) -> f128 {
 // x86-LABEL: void @f128_div({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f128_div({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @f128_div(
+// emscripten-LABEL: void @f128_div({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f128_div(a: f128, b: f128) -> f128 {
     // CHECK: fdiv fp128 %{{.+}}, %{{.+}}
@@ -104,6 +113,7 @@ pub fn f128_div(a: f128, b: f128) -> f128 {
 // x86-LABEL: void @f128_rem({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f128_rem({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @f128_rem(
+// emscripten-LABEL: void @f128_rem({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f128_rem(a: f128, b: f128) -> f128 {
     // CHECK: frem fp128 %{{.+}}, %{{.+}}
@@ -164,6 +174,7 @@ pub fn f128_as_f16(a: f128) -> f16 {
 // x86-LABEL: i32 @f128_as_f32(
 // bit32-LABEL: float @f128_as_f32(
 // bit64-LABEL: float @f128_as_f32(
+// emscripten-LABEL: float @f128_as_f32(
 #[no_mangle]
 pub fn f128_as_f32(a: f128) -> f32 {
     // CHECK: fptrunc fp128 %{{.+}} to float
@@ -173,6 +184,7 @@ pub fn f128_as_f32(a: f128) -> f32 {
 // x86-LABEL: void @f128_as_f64(
 // bit32-LABEL: double @f128_as_f64(
 // bit64-LABEL: double @f128_as_f64(
+// emscripten-LABEL: double @f128_as_f64(
 #[no_mangle]
 pub fn f128_as_f64(a: f128) -> f64 {
     // CHECK: fptrunc fp128 %{{.+}} to double
@@ -182,17 +194,20 @@ pub fn f128_as_f64(a: f128) -> f64 {
 // x86-LABEL: void @f128_as_self({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f128_as_self({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @f128_as_self(
+// emscripten-LABEL: void @f128_as_self({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f128_as_self(a: f128) -> f128 {
     // x86: store fp128 %a, ptr %_0, align 16
     // bit32: store fp128 %a, ptr %_0, align 16
     // bit64: ret fp128 %{{.+}}
+    // emscripten: store fp128 %a, ptr %_0, align 8
     a as f128
 }
 
 // x86-LABEL: void @f16_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f16_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @f16_as_f128(
+// emscripten-LABEL: void @f16_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f16_as_f128(a: f16) -> f128 {
     // CHECK: fpext half %{{.+}} to fp128
@@ -202,6 +217,7 @@ pub fn f16_as_f128(a: f16) -> f128 {
 // x86-LABEL: void @f32_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f32_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @f32_as_f128(
+// emscripten-LABEL: void @f32_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f32_as_f128(a: f32) -> f128 {
     // CHECK: fpext float %{{.+}} to fp128
@@ -211,6 +227,7 @@ pub fn f32_as_f128(a: f32) -> f128 {
 // x86-LABEL: void @f64_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f64_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @f64_as_f128(
+// emscripten-LABEL: void @f64_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f64_as_f128(a: f64) -> f128 {
     // CHECK: fpext double %{{.+}} to fp128
@@ -249,6 +266,7 @@ pub fn f128_as_u64(a: f128) -> u64 {
 // x86-LABEL: void @f128_as_u128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f128_as_u128({{.*}}sret([16 x i8])
 // bit64-LABEL: i128 @f128_as_u128(
+// emscripten-LABEL: void @f128_as_u128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f128_as_u128(a: f128) -> u128 {
     // CHECK: call i128 @llvm.fptoui.sat.i128.f128(fp128 %{{.+}})
@@ -285,6 +303,7 @@ pub fn f128_as_i64(a: f128) -> i64 {
 // x86-LABEL: void @f128_as_i128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @f128_as_i128({{.*}}sret([16 x i8])
 // bit64-LABEL: i128 @f128_as_i128(
+// emscripten-LABEL: void @f128_as_i128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn f128_as_i128(a: f128) -> i128 {
     // CHECK: call i128 @llvm.fptosi.sat.i128.f128(fp128 %{{.+}})
@@ -296,6 +315,7 @@ pub fn f128_as_i128(a: f128) -> i128 {
 // x86-LABEL: void @u8_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @u8_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @u8_as_f128(
+// emscripten-LABEL: void @u8_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn u8_as_f128(a: u8) -> f128 {
     // CHECK: uitofp i8 %{{.+}} to fp128
@@ -305,6 +325,7 @@ pub fn u8_as_f128(a: u8) -> f128 {
 // x86-LABEL: void @u16_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @u16_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @u16_as_f128(
+// emscripten-LABEL: void @u16_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn u16_as_f128(a: u16) -> f128 {
     // CHECK: uitofp i16 %{{.+}} to fp128
@@ -314,6 +335,7 @@ pub fn u16_as_f128(a: u16) -> f128 {
 // x86-LABEL: void @u32_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @u32_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @u32_as_f128(
+// emscripten-LABEL: void @u32_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn u32_as_f128(a: u32) -> f128 {
     // CHECK: uitofp i32 %{{.+}} to fp128
@@ -323,6 +345,7 @@ pub fn u32_as_f128(a: u32) -> f128 {
 // x86-LABEL: void @u64_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @u64_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @u64_as_f128(
+// emscripten-LABEL: void @u64_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn u64_as_f128(a: u64) -> f128 {
     // CHECK: uitofp i64 %{{.+}} to fp128
@@ -332,6 +355,7 @@ pub fn u64_as_f128(a: u64) -> f128 {
 // x86-LABEL: void @u128_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @u128_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @u128_as_f128(
+// emscripten-LABEL: void @u128_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn u128_as_f128(a: u128) -> f128 {
     // CHECK: uitofp i128 %{{.+}} to fp128
@@ -341,6 +365,7 @@ pub fn u128_as_f128(a: u128) -> f128 {
 // x86-LABEL: void @i8_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @i8_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @i8_as_f128(
+// emscripten-LABEL: void @i8_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn i8_as_f128(a: i8) -> f128 {
     // CHECK: sitofp i8 %{{.+}} to fp128
@@ -350,6 +375,7 @@ pub fn i8_as_f128(a: i8) -> f128 {
 // x86-LABEL: void @i16_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @i16_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @i16_as_f128(
+// emscripten-LABEL: void @i16_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn i16_as_f128(a: i16) -> f128 {
     // CHECK: sitofp i16 %{{.+}} to fp128
@@ -359,6 +385,7 @@ pub fn i16_as_f128(a: i16) -> f128 {
 // x86-LABEL: void @i32_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @i32_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @i32_as_f128(
+// emscripten-LABEL: void @i32_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn i32_as_f128(a: i32) -> f128 {
     // CHECK: sitofp i32 %{{.+}} to fp128
@@ -368,6 +395,7 @@ pub fn i32_as_f128(a: i32) -> f128 {
 // x86-LABEL: void @i64_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @i64_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @i64_as_f128(
+// emscripten-LABEL: void @i64_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn i64_as_f128(a: i64) -> f128 {
     // CHECK: sitofp i64 %{{.+}} to fp128
@@ -377,6 +405,7 @@ pub fn i64_as_f128(a: i64) -> f128 {
 // x86-LABEL: void @i128_as_f128({{.*}}sret([16 x i8])
 // bit32-LABEL: void @i128_as_f128({{.*}}sret([16 x i8])
 // bit64-LABEL: fp128 @i128_as_f128(
+// emscripten-LABEL: void @i128_as_f128({{.*}}sret([16 x i8])
 #[no_mangle]
 pub fn i128_as_f128(a: i128) -> f128 {
     // CHECK: sitofp i128 %{{.+}} to fp128

--- a/tests/codegen/wasm_exceptions.rs
+++ b/tests/codegen/wasm_exceptions.rs
@@ -1,5 +1,5 @@
 //@ only-wasm32
-//@ compile-flags: -C panic=unwind
+//@ compile-flags: -C panic=unwind -Z emscripten-wasm-eh
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]

--- a/tests/ui/privacy/sysroot-private.default.stderr
+++ b/tests/ui/privacy/sysroot-private.default.stderr
@@ -1,11 +1,11 @@
 error[E0405]: cannot find trait `Equivalent` in this scope
-  --> $DIR/sysroot-private.rs:26:18
+  --> $DIR/sysroot-private.rs:27:18
    |
 LL | trait Trait2<K>: Equivalent<K> {}
    |                  ^^^^^^^^^^ not found in this scope
 
 error[E0412]: cannot find type `K` in this scope
-  --> $DIR/sysroot-private.rs:31:35
+  --> $DIR/sysroot-private.rs:32:35
    |
 LL | fn trait_member<T>(val: &T, key: &K) -> bool {
    |                 -                 ^
@@ -22,13 +22,13 @@ LL | fn trait_member<T, K>(val: &T, key: &K) -> bool {
    |                  +++
 
 error[E0220]: associated type `ExpressionStack` not found for `Trait`
-  --> $DIR/sysroot-private.rs:21:31
+  --> $DIR/sysroot-private.rs:22:31
    |
 LL | type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
    |                               ^^^^^^^^^^^^^^^ help: `Trait` has the following associated type: `Bar`
 
 error[E0425]: cannot find function `memchr2` in this scope
-  --> $DIR/sysroot-private.rs:39:5
+  --> $DIR/sysroot-private.rs:40:5
    |
 LL |     memchr2(b'a', b'b', buf)
    |     ^^^^^^^ not found in this scope

--- a/tests/ui/privacy/sysroot-private.rs
+++ b/tests/ui/privacy/sysroot-private.rs
@@ -7,6 +7,7 @@
 //! of `std`'s dependencies, but may not be robust against dependency upgrades/changes.
 
 //@ only-unix Windows sysroots seem to not expose this dependency
+//@ ignore-emscripten neither does Emscripten
 //@ revisions: default rustc_private_enabled
 
 // Enabling `rustc_private` should `std`'s dependencies accessible, so they should show up

--- a/tests/ui/privacy/sysroot-private.rustc_private_enabled.stderr
+++ b/tests/ui/privacy/sysroot-private.rustc_private_enabled.stderr
@@ -1,11 +1,11 @@
 error[E0405]: cannot find trait `Equivalent` in this scope
-  --> $DIR/sysroot-private.rs:26:18
+  --> $DIR/sysroot-private.rs:27:18
    |
 LL | trait Trait2<K>: Equivalent<K> {}
    |                  ^^^^^^^^^^ not found in this scope
 
 error[E0412]: cannot find type `K` in this scope
-  --> $DIR/sysroot-private.rs:31:35
+  --> $DIR/sysroot-private.rs:32:35
    |
 LL | fn trait_member<T>(val: &T, key: &K) -> bool {
    |                 -                 ^
@@ -22,13 +22,13 @@ LL | fn trait_member<T, K>(val: &T, key: &K) -> bool {
    |                  +++
 
 error[E0220]: associated type `ExpressionStack` not found for `Trait`
-  --> $DIR/sysroot-private.rs:21:31
+  --> $DIR/sysroot-private.rs:22:31
    |
 LL | type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
    |                               ^^^^^^^^^^^^^^^ there is an associated type `ExpressionStack` in the trait `gimli::read::op::EvaluationStorage`
 
 error[E0425]: cannot find function `memchr2` in this scope
-  --> $DIR/sysroot-private.rs:39:5
+  --> $DIR/sysroot-private.rs:40:5
    |
 LL |     memchr2(b'a', b'b', buf)
    |     ^^^^^^^ not found in this scope


### PR DESCRIPTION
This fixes a couple Emscripten tests where the correct fix is more or less obvious. A couple UI tests are still broken with this PR:

- `tests/ui/abi/numbers-arithmetic/return-float.rs` (#136197)
- `tests/ui/no_std/no-std-unwind-binary.rs` (haven't debugged yet)
- `tests/ui/test-attrs/test-passed.rs` (haven't debugged this either)

@rustbot label +T-compiler +O-emscripten