### PR TITLE
rustdoc: use semantic code tag in item_info.html

### DIFF
--- a/src/librustdoc/html/templates/item_info.html
+++ b/src/librustdoc/html/templates/item_info.html
@@ -1,7 +1,7 @@
 {% if !items.is_empty() %}
-    <span class="item-info">
+    <code class="item-info">
         {% for item in items %}
             {{item|safe}}
         {% endfor %}
-    </span>
+    </code>
 {% endif %}


### PR DESCRIPTION
r? @GuillaumeGomez

# Description
Prevent automatic translation of technical content by browser.

# Changes
- Update item_info.html template to use `code` tag instead of `span`

## Reproduction translated to Thai
<img width="755" alt="image" src="https://github.com/user-attachments/assets/d285b175-469d-43d1-a7e0-f69e2fb43377" />

## Note
During manual testing, I found that some languages could not reproduce the problem.