### PR TITLE
Tweak `&mut self` suggestion span

### DIFF
--- a/tests/ui/borrowck/issue-93093.rs
+++ b/tests/ui/borrowck/issue-93093.rs
@@ -4,7 +4,7 @@ struct S {
 }
 impl S {
     async fn bar(&self) { //~ HELP consider changing this to be a mutable reference
-        //~| SUGGESTION &mut self
+        //~| SUGGESTION mut
         self.foo += 1; //~ ERROR cannot assign to `self.foo`, which is behind a `&` reference [E0594]
     }
 }

--- a/tests/ui/borrowck/issue-93093.stderr
+++ b/tests/ui/borrowck/issue-93093.stderr
@@ -7,7 +7,7 @@ LL |         self.foo += 1;
 help: consider changing this to be a mutable reference
    |
 LL |     async fn bar(&mut self) {
-   |                  ~~~~~~~~~
+   |                   +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/trait-impl-argument-difference-ice.stderr
+++ b/tests/ui/borrowck/trait-impl-argument-difference-ice.stderr
@@ -41,7 +41,7 @@ LL |         let a16 = self.read_word() as u16;
 help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
    |
 LL |     extern "C" fn read_dword(&'_ mut self) -> u16 {
-   |                              ~~~~~~~~~~~~
+   |                                  +++
 
 error[E0596]: cannot borrow `*self` as mutable, as it is behind a `&` reference
   --> $DIR/trait-impl-argument-difference-ice.rs:18:19
@@ -52,7 +52,7 @@ LL |         let b16 = self.read_word() as u16;
 help: consider changing this to be a mutable reference in the `impl` method and the `trait` definition
    |
 LL |     extern "C" fn read_dword(&'_ mut self) -> u16 {
-   |                              ~~~~~~~~~~~~
+   |                                  +++
 
 error: aborting due to 5 previous errors; 1 warning emitted
 

--- a/tests/ui/did_you_mean/issue-38147-1.stderr
+++ b/tests/ui/did_you_mean/issue-38147-1.stderr
@@ -7,7 +7,7 @@ LL |         self.s.push('x');
 help: consider changing this to be a mutable reference
    |
 LL |     fn f(&mut self) {
-   |          ~~~~~~~~~
+   |           +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/did_you_mean/issue-39544.stderr
+++ b/tests/ui/did_you_mean/issue-39544.stderr
@@ -18,7 +18,7 @@ LL |         let _ = &mut self.x;
 help: consider changing this to be a mutable reference
    |
 LL |     fn foo<'z>(&'z mut self) {
-   |                ~~~~~~~~~~~~
+   |                    +++
 
 error[E0596]: cannot borrow `self.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:20:17
@@ -29,7 +29,7 @@ LL |         let _ = &mut self.x;
 help: consider changing this to be a mutable reference
    |
 LL |     fn foo1(&mut self, other: &Z) {
-   |             ~~~~~~~~~
+   |              +++
 
 error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:21:17
@@ -51,7 +51,7 @@ LL |         let _ = &mut self.x;
 help: consider changing this to be a mutable reference
    |
 LL |     fn foo2<'a>(&'a mut self, other: &Z) {
-   |                 ~~~~~~~~~~~~
+   |                     +++
 
 error[E0596]: cannot borrow `other.x` as mutable, as it is behind a `&` reference
   --> $DIR/issue-39544.rs:26:17

--- a/tests/ui/mut/mutable-class-fields-2.stderr
+++ b/tests/ui/mut/mutable-class-fields-2.stderr
@@ -7,7 +7,7 @@ LL |     self.how_hungry -= 5;
 help: consider changing this to be a mutable reference
    |
 LL |   pub fn eat(&mut self) {
-   |              ~~~~~~~~~
+   |               +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/suggest-ref-mut.rs
+++ b/tests/ui/suggestions/suggest-ref-mut.rs
@@ -3,7 +3,7 @@ struct X(usize);
 impl X {
     fn zap(&self) {
         //~^ HELP
-        //~| SUGGESTION &mut self
+        //~| SUGGESTION mut
         self.0 = 32;
         //~^ ERROR
     }

--- a/tests/ui/suggestions/suggest-ref-mut.stderr
+++ b/tests/ui/suggestions/suggest-ref-mut.stderr
@@ -7,7 +7,7 @@ LL |         self.0 = 32;
 help: consider changing this to be a mutable reference
    |
 LL |     fn zap(&mut self) {
-   |            ~~~~~~~~~
+   |             +++
 
 error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
   --> $DIR/suggest-ref-mut.rs:15:5


### PR DESCRIPTION
```
error[E0596]: cannot borrow `*self.s` as mutable, as it is behind a `&` reference
  --> $DIR/issue-38147-1.rs:17:9
   |
LL |         self.s.push('x');
   |         ^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
   |
help: consider changing this to be a mutable reference
   |
LL |     fn f(&mut self) {
   |           +++
```

Note the suggestion to add `mut` instead of replacing the entire `&self` with `&mut self`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
