### PR TITLE
Fuchsia: Allow Rust to use a number of libc filesystem calls

### DIFF
--- a/library/std/src/sys/pal/unix/fs.rs
+++ b/library/std/src/sys/pal/unix/fs.rs
@@ -9,9 +9,12 @@ use libc::c_char;
 #[cfg(any(
     all(target_os = "linux", not(target_env = "musl")),
     target_os = "android",
+    target_os = "fuchsia",
     target_os = "hurd"
 ))]
 use libc::dirfd;
+#[cfg(target_os = "fuchsia")]
+use libc::fstatat as fstatat64;
 #[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "hurd"))]
 use libc::fstatat64;
 #[cfg(any(
@@ -850,7 +853,6 @@ impl Drop for Dir {
             target_os = "vita",
             target_os = "hurd",
             target_os = "espidf",
-            target_os = "fuchsia",
             target_os = "horizon",
             target_os = "vxworks",
             target_os = "rtems",
@@ -882,6 +884,7 @@ impl DirEntry {
         any(
             all(target_os = "linux", not(target_env = "musl")),
             target_os = "android",
+            target_os = "fuchsia",
             target_os = "hurd"
         ),
         not(miri) // no dirfd on Miri
@@ -910,6 +913,7 @@ impl DirEntry {
         not(any(
             all(target_os = "linux", not(target_env = "musl")),
             target_os = "android",
+            target_os = "fuchsia",
             target_os = "hurd",
         )),
         miri
@@ -1213,6 +1217,7 @@ impl File {
         }
         #[cfg(any(
             target_os = "freebsd",
+            target_os = "fuchsia",
             target_os = "linux",
             target_os = "android",
             target_os = "netbsd",
@@ -1225,6 +1230,7 @@ impl File {
         }
         #[cfg(not(any(
             target_os = "android",
+            target_os = "fuchsia",
             target_os = "freebsd",
             target_os = "linux",
             target_os = "netbsd",
@@ -1240,6 +1246,7 @@ impl File {
 
     #[cfg(any(
         target_os = "freebsd",
+        target_os = "fuchsia",
         target_os = "linux",
         target_os = "netbsd",
         target_vendor = "apple",
@@ -1251,6 +1258,7 @@ impl File {
 
     #[cfg(not(any(
         target_os = "freebsd",
+        target_os = "fuchsia",
         target_os = "linux",
         target_os = "netbsd",
         target_vendor = "apple",
@@ -1261,6 +1269,7 @@ impl File {
 
     #[cfg(any(
         target_os = "freebsd",
+        target_os = "fuchsia",
         target_os = "linux",
         target_os = "netbsd",
         target_vendor = "apple",
@@ -1272,6 +1281,7 @@ impl File {
 
     #[cfg(not(any(
         target_os = "freebsd",
+        target_os = "fuchsia",
         target_os = "linux",
         target_os = "netbsd",
         target_vendor = "apple",
@@ -1282,6 +1292,7 @@ impl File {
 
     #[cfg(any(
         target_os = "freebsd",
+        target_os = "fuchsia",
         target_os = "linux",
         target_os = "netbsd",
         target_vendor = "apple",
@@ -1299,6 +1310,7 @@ impl File {
 
     #[cfg(not(any(
         target_os = "freebsd",
+        target_os = "fuchsia",
         target_os = "linux",
         target_os = "netbsd",
         target_vendor = "apple",
@@ -1309,6 +1321,7 @@ impl File {
 
     #[cfg(any(
         target_os = "freebsd",
+        target_os = "fuchsia",
         target_os = "linux",
         target_os = "netbsd",
         target_vendor = "apple",
@@ -1326,6 +1339,7 @@ impl File {
 
     #[cfg(not(any(
         target_os = "freebsd",
+        target_os = "fuchsia",
         target_os = "linux",
         target_os = "netbsd",
         target_vendor = "apple",
@@ -1336,6 +1350,7 @@ impl File {
 
     #[cfg(any(
         target_os = "freebsd",
+        target_os = "fuchsia",
         target_os = "linux",
         target_os = "netbsd",
         target_vendor = "apple",
@@ -1347,6 +1362,7 @@ impl File {
 
     #[cfg(not(any(
         target_os = "freebsd",
+        target_os = "fuchsia",
         target_os = "linux",
         target_os = "netbsd",
         target_vendor = "apple",


### PR DESCRIPTION
This allows Rust on Fuchsia to use a number of function calls from libc:

* dirfd
* fdatasync
* flock with LOCK_EX, LOCK_SH, LOCK_NB, LOCK_UN
* fstatat

cc #120426

try-job: dist-various-2