### PR TITLE
Pretty print pattern type values with transmute if they don't satisfy their pattern

### DIFF
--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -51,6 +51,8 @@ pub fn provide(providers: &mut Providers) {
     providers.check_validity_requirement = |tcx, (init_kind, param_env_and_ty)| {
         util::check_validity_requirement(tcx, init_kind, param_env_and_ty)
     };
+    providers.hooks.validate_scalar_in_layout =
+        |tcx, scalar, layout| util::validate_scalar_in_layout(tcx, scalar, layout);
 }
 
 /// `rustc_driver::main` installs a handler that will set this to `true` if

--- a/compiler/rustc_const_eval/src/util/mod.rs
+++ b/compiler/rustc_const_eval/src/util/mod.rs
@@ -8,6 +8,7 @@ mod type_name;
 
 pub use self::alignment::{is_disaligned, is_within_packed};
 pub use self::check_validity_requirement::check_validity_requirement;
+pub(crate) use self::check_validity_requirement::validate_scalar_in_layout;
 pub use self::compare_types::{relate_types, sub_types};
 pub use self::type_name::type_name;
 

--- a/compiler/rustc_middle/src/hooks/mod.rs
+++ b/compiler/rustc_middle/src/hooks/mod.rs
@@ -98,6 +98,10 @@ declare_hooks! {
     hook save_dep_graph() -> ();
 
     hook query_key_hash_verify_all() -> ();
+
+    /// Ensure the given scalar is valid for the given type.
+    /// This checks non-recursive runtime validity.
+    hook validate_scalar_in_layout(scalar: crate::ty::ScalarInt, ty: Ty<'tcx>) -> bool;
 }
 
 #[cold]

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1741,7 +1741,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                     " as ",
                 )?;
             }
-            ty::Pat(base_ty, pat) => {
+            ty::Pat(base_ty, pat) if self.tcx().validate_scalar_in_layout(int, ty) => {
                 self.pretty_print_const_scalar_int(int, *base_ty, print_ty)?;
                 p!(write(" is {pat:?}"));
             }

--- a/tests/mir-opt/pattern_types.main.PreCodegen.after.mir
+++ b/tests/mir-opt/pattern_types.main.PreCodegen.after.mir
@@ -5,7 +5,7 @@ fn main() -> () {
     scope 1 {
         debug x => const 2_u32 is 1..=;
         scope 2 {
-            debug y => const 0_u32 is 1..=;
+            debug y => const {transmute(0x00000000): (u32) is 1..=};
         }
     }
 

--- a/tests/mir-opt/pattern_types.rs
+++ b/tests/mir-opt/pattern_types.rs
@@ -7,6 +7,6 @@ use std::pat::pattern_type;
 fn main() {
     // CHECK: debug x => const 2_u32 is 1..=
     let x: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(2) };
-    // CHECK: debug y => const 0_u32 is 1..=
+    // CHECK: debug y => const {transmute(0x00000000): (u32) is 1..=}
     let y: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(0) };
 }


### PR DESCRIPTION
Instead of printing `0_u32 is 1..`, we now print the default fallback rendering that we also use for invalid bools, chars, ...: `{transmute(0x00000000): (u32) is 1..=}`.

These cases can occur in mir dumps when const prop propagates a constant across a safety check that would prevent the actually UB value from existing. That's fine though, as it's dead code and we always need to allow UB in dead code.

follow-up to https://github.com/rust-lang/rust/pull/136176

cc @compiler-errors @scottmcm 

r? @RalfJung because of the interpreter changes
