### PR TITLE
Disable some incorrect rust-analyzer diagnostics on beta

### DIFF
--- a/src/tools/rust-analyzer/crates/hir-def/src/data.rs
+++ b/src/tools/rust-analyzer/crates/hir-def/src/data.rs
@@ -94,7 +94,7 @@ impl FunctionData {
             .map(Box::new);
         let rustc_allow_incoherent_impl = attrs.by_key(&sym::rustc_allow_incoherent_impl).exists();
         if flags.contains(FnFlags::HAS_UNSAFE_KW)
-            && !crate_graph[krate].edition.at_least_2024()
+            // && !crate_graph[krate].edition.at_least_2024()
             && attrs.by_key(&sym::rustc_deprecated_safe_2024).exists()
         {
             flags.remove(FnFlags::HAS_UNSAFE_KW);

--- a/src/tools/rust-analyzer/crates/hir-ty/src/lower.rs
+++ b/src/tools/rust-analyzer/crates/hir-ty/src/lower.rs
@@ -226,8 +226,8 @@ impl<'a> TyLoweringContext<'a> {
         self
     }
 
-    pub fn push_diagnostic(&mut self, type_ref: TypeRefId, kind: TyLoweringDiagnosticKind) {
-        let source = match self.types_source_map {
+    pub fn push_diagnostic(&mut self, type_ref: TypeRefId, _kind: TyLoweringDiagnosticKind) {
+        let _source = match self.types_source_map {
             Some(source_map) => {
                 let Ok(source) = source_map.type_syntax(type_ref) else {
                     stdx::never!("error in synthetic type");
@@ -237,7 +237,7 @@ impl<'a> TyLoweringContext<'a> {
             }
             None => Either::Left(type_ref),
         };
-        self.diagnostics.push(TyLoweringDiagnostic { source, kind });
+        // self.diagnostics.push(TyLoweringDiagnostic { source, kind });
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
https://github.com/rust-lang/rust-analyzer/pull/19044 and https://github.com/rust-lang/rust-analyzer/pull/18976/ both need backporting, but their diffs don't apply cleanly. So instead I opted for disabling one of the problematic diagnostics as well as unconditionally treating `rustc_deprecated_safe_2024` items to be safe for now.

r? @cuviper 
