### PR TITLE
librustdoc: create a helper for separating elements of an iterator instead of implementing it multiple times

### DIFF
--- a/src/librustdoc/joined.rs
+++ b/src/librustdoc/joined.rs
@@ -1,0 +1,29 @@
+use std::fmt::{self, Display, Formatter};
+
+pub(crate) trait Joined: IntoIterator {
+    /// Takes an iterator over elements that implement [`Display`], and format them into `f`, separated by `sep`.
+    ///
+    /// This is similar to [`Itertools::format`](itertools::Itertools::format), but instead of returning an implementation of `Display`,
+    /// it formats directly into a [`Formatter`].
+    ///
+    /// The performance of `joined` is slightly better than `format`, since it doesn't need to use a `Cell` to keep track of whether [`fmt`](Display::fmt)
+    /// was already called (`joined`'s API doesn't allow it be called more than once).
+    fn joined(self, sep: &str, f: &mut Formatter<'_>) -> fmt::Result;
+}
+
+impl<I, T> Joined for I
+where
+    I: IntoIterator<Item = T>,
+    T: Display,
+{
+    fn joined(self, sep: &str, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut iter = self.into_iter();
+        let Some(first) = iter.next() else { return Ok(()) };
+        first.fmt(f)?;
+        while let Some(item) = iter.next() {
+            f.write_str(sep)?;
+            item.fmt(f)?;
+        }
+        Ok(())
+    }
+}

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -113,6 +113,7 @@ mod fold;
 mod formats;
 // used by the error-index generator, so it needs to be public
 pub mod html;
+mod joined;
 mod json;
 pub(crate) mod lint;
 mod markdown;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
This implements something similar to [`Itertools::format`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.format), but on `Fn`s returning iterators instead of directly on iterators, to allow implementing `Display` without the use of a `Cell` (to handle the possibility of `fmt` being called multiple times while receiving `&self`).

~This is WIP, I just want to get a perf run first to see if the regression I saw in #135494 is fixed~

This was originally part of #135494 , but originally caused a perf regression that was since fixed:
https://github.com/rust-lang/rust/blob/7d5ae1863aa66847a4edf8d2ef9420717df65c5d/src/librustdoc/html/format.rs#L507