### PR TITLE
rustdoc: run css and html minifier at build instead of runtime

### DIFF
--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -33,6 +33,7 @@ features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"]
 
 [build-dependencies]
 sha2 = "0.10.8"
+minifier = { version = "0.3.2", default-features = false }
 
 [dev-dependencies]
 expect-test = "1.4.0"

--- a/src/librustdoc/build.rs
+++ b/src/librustdoc/build.rs
@@ -1,3 +1,6 @@
+use std::str;
+
+use sha2::Digest;
 fn main() {
     // generate sha256 files
     // this avoids having to perform hashing at runtime
@@ -35,14 +38,27 @@ fn main() {
     for path in files {
         let inpath = format!("html/{path}");
         println!("cargo::rerun-if-changed={inpath}");
-        let bytes = std::fs::read(inpath).expect("static path exists");
-        use sha2::Digest;
-        let bytes = sha2::Sha256::digest(bytes);
-        let mut digest = format!("-{bytes:x}");
+        let data_bytes = std::fs::read(&inpath).expect("static path exists");
+        let hash_bytes = sha2::Sha256::digest(&data_bytes);
+        let mut digest = format!("-{hash_bytes:x}");
         digest.truncate(9);
         let outpath = std::path::PathBuf::from(format!("{out_dir}/{path}.sha256"));
         std::fs::create_dir_all(outpath.parent().expect("all file paths are in a directory"))
             .expect("should be able to write to out_dir");
         std::fs::write(&outpath, digest.as_bytes()).expect("write to out_dir");
+        let minified_path = std::path::PathBuf::from(format!("{out_dir}/{path}.min"));
+        if path.ends_with(".js") || path.ends_with(".css") {
+            let minified: String = if path.ends_with(".css") {
+                minifier::css::minify(str::from_utf8(&data_bytes).unwrap())
+                    .unwrap()
+                    .to_string()
+                    .into()
+            } else {
+                minifier::js::minify(str::from_utf8(&data_bytes).unwrap()).to_string().into()
+            };
+            std::fs::write(&minified_path, minified.as_bytes()).expect("write to out_dir");
+        } else {
+            std::fs::copy(&inpath, &minified_path).unwrap();
+        }
     }
 }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -458,7 +458,7 @@ impl Options {
         let to_check = matches.opt_strs("check-theme");
         if !to_check.is_empty() {
             let mut content =
-                std::str::from_utf8(static_files::STATIC_FILES.rustdoc_css.bytes).unwrap();
+                std::str::from_utf8(static_files::STATIC_FILES.rustdoc_css.src_bytes).unwrap();
             if let Some((_, inside)) = content.split_once("/* Begin theme: light */") {
                 content = inside;
             }
@@ -607,7 +607,7 @@ impl Options {
         let mut themes = Vec::new();
         if matches.opt_present("theme") {
             let mut content =
-                std::str::from_utf8(static_files::STATIC_FILES.rustdoc_css.bytes).unwrap();
+                std::str::from_utf8(static_files::STATIC_FILES.rustdoc_css.src_bytes).unwrap();
             if let Some((_, inside)) = content.split_once("/* Begin theme: light */") {
                 content = inside;
             }

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -207,14 +207,8 @@ fn write_static_files(
     if opt.emit.is_empty() || opt.emit.contains(&EmitType::Toolchain) {
         static_files::for_each(|f: &static_files::StaticFile| {
             let filename = static_dir.join(f.output_filename());
-            let contents: &[u8];
-            let contents_vec: Vec<u8>;
-            if opt.disable_minification {
-                contents = f.bytes;
-            } else {
-                contents_vec = f.minified();
-                contents = &contents_vec;
-            };
+            let contents: &[u8] =
+                if opt.disable_minification { f.src_bytes } else { f.minified_bytes };
             fs::write(&filename, contents).map_err(|e| PathError::new(e, &filename))
         })?;
     }


### PR DESCRIPTION
This way, adding a bunch of comments to the JS files won't make rustdoc slower.

Meant to address https://github.com/rust-lang/rust/pull/136161#issuecomment-2622069453