### PR TITLE
Check Sizedness of return type in WF

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1061,6 +1061,7 @@ fn check_associated_item(
                 let ty = tcx.type_of(item.def_id).instantiate_identity();
                 let ty = wfcx.normalize(span, Some(WellFormedLoc::Ty(item_id)), ty);
                 wfcx.register_wf_obligation(span, loc, ty.into());
+                check_sized_if_body(wfcx, item.def_id.expect_local(), ty, Some(span));
                 Ok(())
             }
             ty::AssocKind::Fn => {
@@ -1185,7 +1186,7 @@ fn check_type_defn<'tcx>(
                     ),
                     wfcx.param_env,
                     ty,
-                    tcx.require_lang_item(LangItem::Sized, None),
+                    tcx.require_lang_item(LangItem::Sized, Some(hir_ty.span)),
                 );
             }
 
@@ -1312,7 +1313,7 @@ fn check_item_type(
                 ),
                 wfcx.param_env,
                 item_ty,
-                tcx.require_lang_item(LangItem::Sized, None),
+                tcx.require_lang_item(LangItem::Sized, Some(ty_span)),
             );
         }
 
@@ -1641,6 +1642,31 @@ fn check_fn_or_method<'tcx>(
                 "functions with the \"rust-call\" ABI must take a single non-self tuple argument",
             );
         }
+    }
+
+    // If the function has a body, additionally require that the return type is sized.
+    check_sized_if_body(wfcx, def_id, sig.output(), match hir_decl.output {
+        hir::FnRetTy::Return(ty) => Some(ty.span),
+        hir::FnRetTy::DefaultReturn(_) => None,
+    });
+}
+
+fn check_sized_if_body<'tcx>(
+    wfcx: &WfCheckingCtxt<'_, 'tcx>,
+    def_id: LocalDefId,
+    ty: Ty<'tcx>,
+    maybe_span: Option<Span>,
+) {
+    let tcx = wfcx.tcx();
+    if let Some(body) = tcx.hir().maybe_body_owned_by(def_id) {
+        let span = maybe_span.unwrap_or(body.value.span);
+
+        wfcx.register_bound(
+            ObligationCause::new(span, def_id, traits::ObligationCauseCode::SizedReturnType),
+            wfcx.param_env,
+            ty,
+            tcx.require_lang_item(LangItem::Sized, Some(span)),
+        );
     }
 }
 

--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -122,12 +122,7 @@ pub(super) fn check_fn<'a, 'tcx>(
         hir::FnRetTy::Return(ty) => ty.span,
     };
 
-    fcx.require_type_is_sized(
-        declared_ret_ty,
-        return_or_body_span,
-        ObligationCauseCode::SizedReturnType,
-    );
-    // We checked the root's signature during wfcheck, but not the child.
+    // We checked the root's ret ty during wfcheck, but not the child.
     if fcx.tcx.is_typeck_child(fn_def_id.to_def_id()) {
         fcx.require_type_is_sized(
             declared_ret_ty,

--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -117,17 +117,17 @@ pub(super) fn check_fn<'a, 'tcx>(
 
     fcx.typeck_results.borrow_mut().liberated_fn_sigs_mut().insert(fn_id, fn_sig);
 
-    let return_or_body_span = match decl.output {
-        hir::FnRetTy::DefaultReturn(_) => body.value.span,
-        hir::FnRetTy::Return(ty) => ty.span,
-    };
-
     // We checked the root's ret ty during wfcheck, but not the child.
     if fcx.tcx.is_typeck_child(fn_def_id.to_def_id()) {
+        let return_or_body_span = match decl.output {
+            hir::FnRetTy::DefaultReturn(_) => body.value.span,
+            hir::FnRetTy::Return(ty) => ty.span,
+        };
+
         fcx.require_type_is_sized(
             declared_ret_ty,
             return_or_body_span,
-            ObligationCauseCode::WellFormed(None),
+            ObligationCauseCode::SizedReturnType,
         );
     }
 

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -186,8 +186,6 @@ fn typeck_with_inspect<'tcx>(
         let wf_code = ObligationCauseCode::WellFormed(Some(WellFormedLoc::Ty(def_id)));
         fcx.register_wf_obligation(expected_type.into(), body.value.span, wf_code);
 
-        fcx.require_type_is_sized(expected_type, body.value.span, ObligationCauseCode::ConstSized);
-
         // Gather locals in statics (because of block expressions).
         GatherLocalsVisitor::new(&fcx).visit_body(body);
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -703,7 +703,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         };
 
         self.note_obligation_cause(&mut err, &obligation);
-        self.point_at_returns_when_relevant(&mut err, &obligation);
         err.emit()
     }
 }
@@ -806,7 +805,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     "Async",
                 );
                 self.note_obligation_cause(&mut err, &obligation);
-                self.point_at_returns_when_relevant(&mut err, &obligation);
                 return Some(err.emit());
             }
         }
@@ -852,7 +850,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     "",
                 );
                 self.note_obligation_cause(&mut err, &obligation);
-                self.point_at_returns_when_relevant(&mut err, &obligation);
                 return Some(err.emit());
             }
 
@@ -868,7 +865,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     kind: expected_kind.as_str(),
                 });
                 self.note_obligation_cause(&mut err, &obligation);
-                self.point_at_returns_when_relevant(&mut err, &obligation);
                 return Some(err.emit());
             }
         }
@@ -2826,7 +2822,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         err.span_note(self.tcx.def_span(def_id), "opaque type is declared here");
 
         self.note_obligation_cause(&mut err, &obligation);
-        self.point_at_returns_when_relevant(&mut err, &obligation);
         self.dcx().try_steal_replace_and_emit_err(self.tcx.def_span(def_id), StashKey::Cycle, err)
     }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
@@ -185,7 +185,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             suggest_increasing_limit,
         );
         self.note_obligation_cause(&mut err, &obligation);
-        self.point_at_returns_when_relevant(&mut err, &obligation);
         err.emit()
     }
 }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -1765,7 +1765,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         };
 
         err.code(E0746);
-        err.primary_message("return type cannot have an unboxed trait object");
+        err.primary_message("return type cannot be a trait object without pointer indirection");
         err.children.clear();
 
         let span = obligation.cause.span;

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -1781,25 +1781,13 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         } else {
             ("dyn ", span.shrink_to_lo())
         };
-        let alternatively = if visitor
-            .returns
-            .iter()
-            .map(|expr| self.typeck_results.as_ref().unwrap().expr_ty_adjusted_opt(expr))
-            .collect::<FxHashSet<_>>()
-            .len()
-            <= 1
-        {
-            err.span_suggestion_verbose(
-                impl_span,
-                "consider returning an `impl Trait` instead of a `dyn Trait`",
-                "impl ",
-                Applicability::MaybeIncorrect,
-            );
-            "alternatively, "
-        } else {
-            err.help("if there were a single returned type, you could use `impl Trait` instead");
-            ""
-        };
+
+        err.span_suggestion_verbose(
+            impl_span,
+            "consider returning an `impl Trait` instead of a `dyn Trait`",
+            "impl ",
+            Applicability::MaybeIncorrect,
+        );
 
         let mut sugg = vec![
             (span.shrink_to_lo(), format!("Box<{pre}")),
@@ -1831,7 +1819,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         err.multipart_suggestion(
             format!(
-                "{alternatively}box the return type, and wrap all of the returned values in \
+                "alternatively, box the return type, and wrap all of the returned values in \
                  `Box::new`",
             ),
             sugg,
@@ -1839,41 +1827,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         );
 
         true
-    }
-
-    pub(super) fn point_at_returns_when_relevant(
-        &self,
-        err: &mut Diag<'_>,
-        obligation: &PredicateObligation<'tcx>,
-    ) {
-        match obligation.cause.code().peel_derives() {
-            ObligationCauseCode::SizedReturnType => {}
-            _ => return,
-        }
-
-        let hir = self.tcx.hir();
-        let node = self.tcx.hir_node_by_def_id(obligation.cause.body_id);
-        if let hir::Node::Item(hir::Item {
-            kind: hir::ItemKind::Fn { body: body_id, .. }, ..
-        }) = node
-        {
-            let body = hir.body(*body_id);
-            // Point at all the `return`s in the function as they have failed trait bounds.
-            let mut visitor = ReturnsVisitor::default();
-            visitor.visit_body(body);
-            let typeck_results = self.typeck_results.as_ref().unwrap();
-            for expr in &visitor.returns {
-                if let Some(returned_ty) = typeck_results.node_type_opt(expr.hir_id) {
-                    let ty = self.resolve_vars_if_possible(returned_ty);
-                    if ty.references_error() {
-                        // don't print out the [type error] here
-                        err.downgrade_to_delayed_bug();
-                    } else {
-                        err.span_label(expr.span, format!("this returned value is of type `{ty}`"));
-                    }
-                }
-            }
-        }
     }
 
     pub(super) fn report_closure_arg_mismatch(

--- a/tests/crashes/134355.rs
+++ b/tests/crashes/134355.rs
@@ -1,6 +1,0 @@
-//@ known-bug: #134355
-
-//@compile-flags: --crate-type=lib
-fn digit() -> str {
-    return { i32::MIN };
-}

--- a/tests/rustdoc-json/primitives/primitive_impls.rs
+++ b/tests/rustdoc-json/primitives/primitive_impls.rs
@@ -1,10 +1,13 @@
-#![feature(no_core)]
+#![feature(no_core, lang_items)]
 #![feature(rustc_attrs)]
 #![feature(rustdoc_internals)]
 #![no_core]
 #![rustc_coherence_is_core]
 
 //@ set impl_i32 = "$.index[*][?(@.docs=='Only core can do this')].id"
+
+#[lang = "sized"]
+trait Sized {}
 
 /// Only core can do this
 impl i32 {

--- a/tests/rustdoc-ui/custom_code_classes_in_docs-warning3.rs
+++ b/tests/rustdoc-ui/custom_code_classes_in_docs-warning3.rs
@@ -2,8 +2,11 @@
 // feature.
 
 #![deny(warnings)]
-#![feature(no_core)]
+#![feature(no_core, lang_items)]
 #![no_core]
+
+#[lang = "sized"]
+trait Sized {}
 
 /// ```{class="}
 /// main;

--- a/tests/rustdoc-ui/custom_code_classes_in_docs-warning3.stderr
+++ b/tests/rustdoc-ui/custom_code_classes_in_docs-warning3.stderr
@@ -1,5 +1,5 @@
 error: unclosed quote string `"`
-  --> $DIR/custom_code_classes_in_docs-warning3.rs:8:1
+  --> $DIR/custom_code_classes_in_docs-warning3.rs:11:1
    |
 LL | / /// ```{class="}
 LL | | /// main;
@@ -17,7 +17,7 @@ LL | #![deny(warnings)]
    = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(warnings)]`
 
 error: unclosed quote string `"`
-  --> $DIR/custom_code_classes_in_docs-warning3.rs:8:1
+  --> $DIR/custom_code_classes_in_docs-warning3.rs:11:1
    |
 LL | / /// ```{class="}
 LL | | /// main;

--- a/tests/rustdoc/cfg_doc_reexport.rs
+++ b/tests/rustdoc/cfg_doc_reexport.rs
@@ -1,8 +1,11 @@
 #![feature(doc_cfg)]
-#![feature(no_core)]
+#![feature(no_core, lang_items)]
 
 #![crate_name = "foo"]
 #![no_core]
+
+#[lang = "sized"]
+trait Sized {}
 
 //@ has 'foo/index.html'
 //@ has - '//dt/*[@class="stab portability"]' 'foobar'

--- a/tests/rustdoc/cross-crate-primitive-doc.rs
+++ b/tests/rustdoc/cross-crate-primitive-doc.rs
@@ -2,8 +2,11 @@
 //@ compile-flags: --extern-html-root-url=primitive_doc=../ -Z unstable-options
 //@ only-linux
 
-#![feature(no_core)]
+#![feature(no_core, lang_items)]
 #![no_core]
+
+#[lang = "sized"]
+trait Sized {}
 
 extern crate primitive_doc;
 

--- a/tests/rustdoc/intra-doc/no-doc-primitive.rs
+++ b/tests/rustdoc/intra-doc/no-doc-primitive.rs
@@ -6,8 +6,13 @@
 #![rustc_coherence_is_core]
 #![crate_type = "rlib"]
 
+
 //@ has no_doc_primitive/index.html
 //! A [`char`] and its [`char::len_utf8`].
+
+#[lang = "sized"]
+trait Sized {}
+
 impl char {
     pub fn len_utf8(self) -> usize {
         42

--- a/tests/rustdoc/reexport-trait-from-hidden-111064-2.rs
+++ b/tests/rustdoc/reexport-trait-from-hidden-111064-2.rs
@@ -1,7 +1,10 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/111064>.
-#![feature(no_core)]
+#![feature(no_core, lang_items)]
 #![no_core]
 #![crate_name = "foo"]
+
+#[lang = "sized"]
+trait Sized {}
 
 //@ files "foo" "['sidebar-items.js', 'all.html', 'hidden', 'index.html', 'struct.Bar.html', \
 //        'visible']"

--- a/tests/rustdoc/safe-intrinsic.rs
+++ b/tests/rustdoc/safe-intrinsic.rs
@@ -1,9 +1,12 @@
 #![feature(intrinsics)]
-#![feature(no_core)]
+#![feature(no_core, lang_items)]
 #![feature(rustc_attrs)]
 
 #![no_core]
 #![crate_name = "foo"]
+
+#[lang = "sized"]
+trait Sized {}
 
 //@ has 'foo/fn.abort.html'
 //@ has - '//pre[@class="rust item-decl"]' 'pub fn abort() -> !'

--- a/tests/ui/associated-consts/issue-58022.stderr
+++ b/tests/ui/associated-consts/issue-58022.stderr
@@ -1,12 +1,3 @@
-error[E0790]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
-  --> $DIR/issue-58022.rs:4:25
-   |
-LL |     const SIZE: usize;
-   |     ------------------ `Foo::SIZE` defined here
-LL |
-LL |     fn new(slice: &[u8; Foo::SIZE]) -> Self;
-   |                         ^^^^^^^^^ cannot refer to the associated constant of trait
-
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/issue-58022.rs:13:41
    |
@@ -20,6 +11,15 @@ note: required because it appears within the type `Bar<[u8]>`
 LL | pub struct Bar<T: ?Sized>(T);
    |            ^^^
    = note: the return type of a function must have a statically known size
+
+error[E0790]: cannot refer to the associated constant on trait without specifying the corresponding `impl` type
+  --> $DIR/issue-58022.rs:4:25
+   |
+LL |     const SIZE: usize;
+   |     ------------------ `Foo::SIZE` defined here
+LL |
+LL |     fn new(slice: &[u8; Foo::SIZE]) -> Self;
+   |                         ^^^^^^^^^ cannot refer to the associated constant of trait
 
 error[E0423]: expected function, tuple struct or tuple variant, found trait `Foo`
   --> $DIR/issue-58022.rs:15:9

--- a/tests/ui/consts/const-slice-array-deref.rs
+++ b/tests/ui/consts/const-slice-array-deref.rs
@@ -1,6 +1,5 @@
 const ONE: [u16] = [1];
 //~^ ERROR the size for values of type `[u16]` cannot be known at compilation time
-//~| ERROR the size for values of type `[u16]` cannot be known at compilation time
 //~| ERROR mismatched types
 
 const TWO: &'static u16 = &ONE[0];

--- a/tests/ui/consts/const-slice-array-deref.stderr
+++ b/tests/ui/consts/const-slice-array-deref.stderr
@@ -12,22 +12,13 @@ error[E0308]: mismatched types
 LL | const ONE: [u16] = [1];
    |                    ^^^ expected `[u16]`, found `[u16; 1]`
 
-error[E0277]: the size for values of type `[u16]` cannot be known at compilation time
-  --> $DIR/const-slice-array-deref.rs:1:20
-   |
-LL | const ONE: [u16] = [1];
-   |                    ^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u16]`
-   = note: constant expressions must have a statically known size
-
 error[E0161]: cannot move a value of type `[u16]`
-  --> $DIR/const-slice-array-deref.rs:6:28
+  --> $DIR/const-slice-array-deref.rs:5:28
    |
 LL | const TWO: &'static u16 = &ONE[0];
    |                            ^^^ the size of `[u16]` cannot be statically determined
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0161, E0277, E0308.
 For more information about an error, try `rustc --explain E0161`.

--- a/tests/ui/consts/const-unsized.rs
+++ b/tests/ui/consts/const-unsized.rs
@@ -2,19 +2,19 @@ use std::fmt::Debug;
 
 const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
 //~^ ERROR the size for values of type
-//~| ERROR the size for values of type
+//~| ERROR cannot move out of a shared reference
 
 const CONST_FOO: str = *"foo";
 //~^ ERROR the size for values of type
-//~| ERROR the size for values of type
+//~| ERROR cannot move out of a shared reference
 
 static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
 //~^ ERROR the size for values of type
-//~| ERROR the size for values of type
+//~| ERROR cannot move out of a shared reference
 
 static STATIC_BAR: str = *"bar";
 //~^ ERROR the size for values of type
-//~| ERROR the size for values of type
+//~| ERROR cannot move out of a shared reference
 
 fn main() {
     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);

--- a/tests/ui/consts/const-unsized.stderr
+++ b/tests/ui/consts/const-unsized.stderr
@@ -6,15 +6,6 @@ LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
    |
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
 
-error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
-  --> $DIR/const-unsized.rs:3:35
-   |
-LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
-   = note: constant expressions must have a statically known size
-
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:7:18
    |
@@ -22,15 +13,6 @@ LL | const CONST_FOO: str = *"foo";
    |                  ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-
-error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/const-unsized.rs:7:24
-   |
-LL | const CONST_FOO: str = *"foo";
-   |                        ^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `str`
-   = note: constant expressions must have a statically known size
 
 error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
   --> $DIR/const-unsized.rs:11:18
@@ -40,15 +22,6 @@ LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
    |
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
 
-error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
-  --> $DIR/const-unsized.rs:11:37
-   |
-LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
-   = note: constant expressions must have a statically known size
-
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:15:20
    |
@@ -57,14 +30,29 @@ LL | static STATIC_BAR: str = *"bar";
    |
    = help: the trait `Sized` is not implemented for `str`
 
-error[E0277]: the size for values of type `str` cannot be known at compilation time
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/const-unsized.rs:3:35
+   |
+LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `dyn Debug + Sync`, which does not implement the `Copy` trait
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/const-unsized.rs:7:24
+   |
+LL | const CONST_FOO: str = *"foo";
+   |                        ^^^^^^ move occurs because value has type `str`, which does not implement the `Copy` trait
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/const-unsized.rs:11:37
+   |
+LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `dyn Debug + Sync`, which does not implement the `Copy` trait
+
+error[E0507]: cannot move out of a shared reference
   --> $DIR/const-unsized.rs:15:26
    |
 LL | static STATIC_BAR: str = *"bar";
-   |                          ^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `str`
-   = note: constant expressions must have a statically known size
+   |                          ^^^^^^ move occurs because value has type `str`, which does not implement the `Copy` trait
 
 error[E0161]: cannot move a value of type `str`
   --> $DIR/const-unsized.rs:20:48
@@ -80,5 +68,5 @@ LL |     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATI
 
 error: aborting due to 10 previous errors
 
-Some errors have detailed explanations: E0161, E0277.
+Some errors have detailed explanations: E0161, E0277, E0507.
 For more information about an error, try `rustc --explain E0161`.

--- a/tests/ui/consts/const_refs_to_static-ice-121413.rs
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.rs
@@ -9,10 +9,8 @@ const REF_INTERIOR_MUT: &usize = {
     //~^ ERROR failed to resolve: use of undeclared type `AtomicUsize`
     //~| WARN trait objects without an explicit `dyn` are deprecated
     //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
-    //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| HELP if this is a dyn-compatible trait, use `dyn`
-    //~| HELP the trait `Sized` is not implemented for `(dyn Sync + 'static)`
     //~| HELP the trait `Sized` is not implemented for `(dyn Sync + 'static)`
     unsafe { &*(&FOO as *const _ as *const usize) }
 };

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -31,16 +31,7 @@ LL |     static FOO: Sync = AtomicUsize::new(0);
    |
    = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
 
-error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
-  --> $DIR/const_refs_to_static-ice-121413.rs:8:24
-   |
-LL |     static FOO: Sync = AtomicUsize::new(0);
-   |                        ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
-   = note: constant expressions must have a statically known size
-
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0277, E0433.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/error-codes/E0746.stderr
+++ b/tests/ui/error-codes/E0746.stderr
@@ -1,4 +1,4 @@
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/E0746.rs:8:13
    |
 LL | fn foo() -> dyn Trait { Struct }
@@ -13,7 +13,7 @@ help: alternatively, box the return type, and wrap all of the returned values in
 LL | fn foo() -> Box<dyn Trait> { Box::new(Struct) }
    |             ++++         +   +++++++++      +
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/E0746.rs:11:13
    |
 LL | fn bar() -> dyn Trait {

--- a/tests/ui/extern-flag/empty-extern-arg.stderr
+++ b/tests/ui/extern-flag/empty-extern-arg.stderr
@@ -8,6 +8,10 @@ error: unwinding panics are not supported without std
    = note: since the core library is usually precompiled with panic="unwind", rebuilding your crate with panic="abort" may not be enough to fix the problem
 
 error: requires `sized` lang_item
+  --> $DIR/empty-extern-arg.rs:6:11
+   |
+LL | fn main() {}
+   |           ^^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.rs
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.rs
@@ -20,7 +20,7 @@ impl DynIncompatible for B {
 }
 
 fn car() -> dyn DynIncompatible { //~ ERROR the trait `DynIncompatible` is not dyn compatible
-//~^ ERROR return type cannot have an unboxed trait object
+//~^ ERROR return type cannot be a trait object without pointer indirection
     if true {
         return A;
     }

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
@@ -26,7 +26,7 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:22:13
    |
 LL | fn car() -> dyn DynIncompatible {

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
@@ -26,6 +26,26 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:22:13
+   |
+LL | fn car() -> dyn DynIncompatible {
+   |             ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn car() -> impl DynIncompatible {
+   |             ~~~~
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn car() -> Box<dyn DynIncompatible> {
+LL |
+LL |     if true {
+LL ~         return Box::new(A);
+LL |     }
+LL ~     Box::new(B)
+   |
+
 error[E0038]: the trait `DynIncompatible` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:30:17
    |
@@ -53,23 +73,6 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
    |
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
-
-error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:22:13
-   |
-LL | fn car() -> dyn DynIncompatible {
-   |             ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: if there were a single returned type, you could use `impl Trait` instead
-help: box the return type, and wrap all of the returned values in `Box::new`
-   |
-LL ~ fn car() -> Box<dyn DynIncompatible> {
-LL |
-LL |     if true {
-LL ~         return Box::new(A);
-LL |     }
-LL ~     Box::new(B)
-   |
 
 error[E0038]: the trait `DynIncompatible` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:32:16

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.rs
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.rs
@@ -6,9 +6,11 @@ impl Trait for u32 {}
 
 fn fuz() -> (usize, Trait) { (42, Struct) }
 //~^ ERROR E0277
+//~| ERROR E0277
 //~| ERROR E0308
 fn bar() -> (usize, dyn Trait) { (42, Struct) }
 //~^ ERROR E0277
+//~| ERROR E0277
 //~| ERROR E0308
 fn bap() -> Trait { Struct }
 //~^ ERROR E0746

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
@@ -18,7 +18,7 @@ LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
    = note: the return type of a function must have a statically known size
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:13
    |
 LL | fn bap() -> Trait { Struct }
@@ -33,7 +33,7 @@ help: alternatively, box the return type, and wrap all of the returned values in
 LL | fn bap() -> Box<dyn Trait> { Box::new(Struct) }
    |             +++++++      +   +++++++++      +
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:17:13
    |
 LL | fn ban() -> dyn Trait { Struct }
@@ -48,7 +48,7 @@ help: alternatively, box the return type, and wrap all of the returned values in
 LL | fn ban() -> Box<dyn Trait> { Box::new(Struct) }
    |             ++++         +   +++++++++      +
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:19:13
    |
 LL | fn bak() -> dyn Trait { unimplemented!() }
@@ -63,7 +63,7 @@ help: alternatively, box the return type, and wrap all of the returned values in
 LL | fn bak() -> Box<dyn Trait> { Box::new(unimplemented!()) }
    |             ++++         +   +++++++++                +
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:21:13
    |
 LL | fn bal() -> dyn Trait {
@@ -82,7 +82,7 @@ LL |     }
 LL ~     Box::new(42)
    |
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:27:13
    |
 LL | fn bax() -> dyn Trait {
@@ -101,7 +101,7 @@ LL |     } else {
 LL ~         Box::new(42)
    |
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:62:13
    |
 LL | fn bat() -> dyn Trait {
@@ -120,7 +120,7 @@ LL |     }
 LL ~     Box::new(42)
    |
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:68:13
    |
 LL | fn bay() -> dyn Trait {

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
@@ -1,49 +1,25 @@
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:7:35
-   |
-LL | fn fuz() -> (usize, Trait) { (42, Struct) }
-   |                                   ^^^^^^ expected `dyn Trait`, found `Struct`
-   |
-   = note: expected trait object `(dyn Trait + 'static)`
-                    found struct `Struct`
-   = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
-
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
   --> $DIR/dyn-trait-return-should-be-impl-trait.rs:7:13
    |
 LL | fn fuz() -> (usize, Trait) { (42, Struct) }
-   |             ^^^^^^^^^^^^^^   ------------ this returned value is of type `(usize, (dyn Trait + 'static))`
-   |             |
-   |             doesn't have a size known at compile-time
+   |             ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
    = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
    = note: the return type of a function must have a statically known size
 
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:10:39
-   |
-LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
-   |                                       ^^^^^^ expected `dyn Trait`, found `Struct`
-   |
-   = note: expected trait object `(dyn Trait + 'static)`
-                    found struct `Struct`
-   = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
-
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:10:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:11:13
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
-   |             ^^^^^^^^^^^^^^^^^^   ------------ this returned value is of type `(usize, (dyn Trait + 'static))`
-   |             |
-   |             doesn't have a size known at compile-time
+   |             ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
    = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
    = note: the return type of a function must have a statically known size
 
 error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:13:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:13
    |
 LL | fn bap() -> Trait { Struct }
    |             ^^^^^ doesn't have a size known at compile-time
@@ -58,7 +34,7 @@ LL | fn bap() -> Box<dyn Trait> { Box::new(Struct) }
    |             +++++++      +   +++++++++      +
 
 error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:17:13
    |
 LL | fn ban() -> dyn Trait { Struct }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -73,7 +49,7 @@ LL | fn ban() -> Box<dyn Trait> { Box::new(Struct) }
    |             ++++         +   +++++++++      +
 
 error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:17:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:19:13
    |
 LL | fn bak() -> dyn Trait { unimplemented!() }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -88,13 +64,16 @@ LL | fn bak() -> Box<dyn Trait> { Box::new(unimplemented!()) }
    |             ++++         +   +++++++++                +
 
 error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:19:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:21:13
    |
 LL | fn bal() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: if there were a single returned type, you could use `impl Trait` instead
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn bal() -> impl Trait {
+   |             ~~~~
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bal() -> Box<dyn Trait> {
 LL |     if true {
@@ -104,13 +83,16 @@ LL ~     Box::new(42)
    |
 
 error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:25:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:27:13
    |
 LL | fn bax() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
    |
-   = help: if there were a single returned type, you could use `impl Trait` instead
-help: box the return type, and wrap all of the returned values in `Box::new`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn bax() -> impl Trait {
+   |             ~~~~
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bax() -> Box<dyn Trait> {
 LL |     if true {
@@ -119,144 +101,8 @@ LL |     } else {
 LL ~         Box::new(42)
    |
 
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:34:16
-   |
-LL | fn bam() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
-LL |     if true {
-LL |         return Struct;
-   |                ^^^^^^ expected `Box<dyn Trait>`, found `Struct`
-   |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
-              found struct `Struct`
-   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
-help: store this in the heap by calling `Box::new`
-   |
-LL |         return Box::new(Struct);
-   |                +++++++++      +
-
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:36:5
-   |
-LL | fn bam() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
-...
-LL |     42
-   |     ^^ expected `Box<dyn Trait>`, found integer
-   |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
-                found type `{integer}`
-   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
-help: store this in the heap by calling `Box::new`
-   |
-LL |     Box::new(42)
-   |     +++++++++  +
-
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:40:16
-   |
-LL | fn baq() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
-LL |     if true {
-LL |         return 0;
-   |                ^ expected `Box<dyn Trait>`, found integer
-   |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
-                found type `{integer}`
-   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
-help: store this in the heap by calling `Box::new`
-   |
-LL |         return Box::new(0);
-   |                +++++++++ +
-
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:42:5
-   |
-LL | fn baq() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
-...
-LL |     42
-   |     ^^ expected `Box<dyn Trait>`, found integer
-   |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
-                found type `{integer}`
-   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
-help: store this in the heap by calling `Box::new`
-   |
-LL |     Box::new(42)
-   |     +++++++++  +
-
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:46:9
-   |
-LL | fn baz() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
-LL |     if true {
-LL |         Struct
-   |         ^^^^^^ expected `Box<dyn Trait>`, found `Struct`
-   |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
-              found struct `Struct`
-   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
-help: store this in the heap by calling `Box::new`
-   |
-LL |         Box::new(Struct)
-   |         +++++++++      +
-
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:48:9
-   |
-LL | fn baz() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
-...
-LL |         42
-   |         ^^ expected `Box<dyn Trait>`, found integer
-   |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
-                found type `{integer}`
-   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
-help: store this in the heap by calling `Box::new`
-   |
-LL |         Box::new(42)
-   |         +++++++++  +
-
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:53:9
-   |
-LL | fn baw() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
-LL |     if true {
-LL |         0
-   |         ^ expected `Box<dyn Trait>`, found integer
-   |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
-                found type `{integer}`
-   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
-help: store this in the heap by calling `Box::new`
-   |
-LL |         Box::new(0)
-   |         +++++++++ +
-
-error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:55:9
-   |
-LL | fn baw() -> Box<dyn Trait> {
-   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
-...
-LL |         42
-   |         ^^ expected `Box<dyn Trait>`, found integer
-   |
-   = note: expected struct `Box<(dyn Trait + 'static)>`
-                found type `{integer}`
-   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
-help: store this in the heap by calling `Box::new`
-   |
-LL |         Box::new(42)
-   |         +++++++++  +
-
 error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:60:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:62:13
    |
 LL | fn bat() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -275,7 +121,7 @@ LL ~     Box::new(42)
    |
 
 error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:66:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:68:13
    |
 LL | fn bay() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -293,7 +139,183 @@ LL |     } else {
 LL ~         Box::new(42)
    |
 
-error: aborting due to 19 previous errors
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:7:35
+   |
+LL | fn fuz() -> (usize, Trait) { (42, Struct) }
+   |                                   ^^^^^^ expected `dyn Trait`, found `Struct`
+   |
+   = note: expected trait object `(dyn Trait + 'static)`
+                    found struct `Struct`
+   = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
+
+error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:7:30
+   |
+LL | fn fuz() -> (usize, Trait) { (42, Struct) }
+   |                              ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = note: tuples must have a statically known size to be initialized
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:11:39
+   |
+LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
+   |                                       ^^^^^^ expected `dyn Trait`, found `Struct`
+   |
+   = note: expected trait object `(dyn Trait + 'static)`
+                    found struct `Struct`
+   = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
+
+error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:11:34
+   |
+LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
+   |                                  ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
+   = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
+   = note: tuples must have a statically known size to be initialized
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:36:16
+   |
+LL | fn bam() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+LL |     if true {
+LL |         return Struct;
+   |                ^^^^^^ expected `Box<dyn Trait>`, found `Struct`
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+              found struct `Struct`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         return Box::new(Struct);
+   |                +++++++++      +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:38:5
+   |
+LL | fn bam() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+...
+LL |     42
+   |     ^^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |     Box::new(42)
+   |     +++++++++  +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:42:16
+   |
+LL | fn baq() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+LL |     if true {
+LL |         return 0;
+   |                ^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         return Box::new(0);
+   |                +++++++++ +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:44:5
+   |
+LL | fn baq() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+...
+LL |     42
+   |     ^^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |     Box::new(42)
+   |     +++++++++  +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:48:9
+   |
+LL | fn baz() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+LL |     if true {
+LL |         Struct
+   |         ^^^^^^ expected `Box<dyn Trait>`, found `Struct`
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+              found struct `Struct`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         Box::new(Struct)
+   |         +++++++++      +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:50:9
+   |
+LL | fn baz() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+...
+LL |         42
+   |         ^^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         Box::new(42)
+   |         +++++++++  +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:55:9
+   |
+LL | fn baw() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+LL |     if true {
+LL |         0
+   |         ^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         Box::new(0)
+   |         +++++++++ +
+
+error[E0308]: mismatched types
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:57:9
+   |
+LL | fn baw() -> Box<dyn Trait> {
+   |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
+...
+LL |         42
+   |         ^^ expected `Box<dyn Trait>`, found integer
+   |
+   = note: expected struct `Box<(dyn Trait + 'static)>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |         Box::new(42)
+   |         +++++++++  +
+
+error: aborting due to 21 previous errors
 
 Some errors have detailed explanations: E0277, E0308, E0746.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.rs
+++ b/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.rs
@@ -63,7 +63,7 @@ fn dog() -> impl std::fmt::Display {
     }
 }
 
-fn hat() -> dyn std::fmt::Display { //~ ERROR return type cannot have an unboxed trait object
+fn hat() -> dyn std::fmt::Display { //~ ERROR return type cannot be a trait object without pointer indirection
     match 13 {
         0 => {
             return 0i32;
@@ -74,7 +74,7 @@ fn hat() -> dyn std::fmt::Display { //~ ERROR return type cannot have an unboxed
     }
 }
 
-fn pug() -> dyn std::fmt::Display { //~ ERROR return type cannot have an unboxed trait object
+fn pug() -> dyn std::fmt::Display { //~ ERROR return type cannot be a trait object without pointer indirection
     match 13 {
         0 => 0i32,
         1 => 1u32,
@@ -82,7 +82,7 @@ fn pug() -> dyn std::fmt::Display { //~ ERROR return type cannot have an unboxed
     }
 }
 
-fn man() -> dyn std::fmt::Display { //~ ERROR return type cannot have an unboxed trait object
+fn man() -> dyn std::fmt::Display { //~ ERROR return type cannot be a trait object without pointer indirection
     if false {
         0i32
     } else {

--- a/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
+++ b/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
@@ -1,3 +1,62 @@
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:66:13
+   |
+LL | fn hat() -> dyn std::fmt::Display {
+   |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn hat() -> impl std::fmt::Display {
+   |             ~~~~
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn hat() -> Box<dyn std::fmt::Display> {
+LL |     match 13 {
+LL |         0 => {
+LL ~             return Box::new(0i32);
+LL |         }
+LL |         _ => {
+LL ~             Box::new(1u32)
+   |
+
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:77:13
+   |
+LL | fn pug() -> dyn std::fmt::Display {
+   |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn pug() -> impl std::fmt::Display {
+   |             ~~~~
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn pug() -> Box<dyn std::fmt::Display> {
+LL |     match 13 {
+LL ~         0 => Box::new(0i32),
+LL ~         1 => Box::new(1u32),
+LL ~         _ => Box::new(2u32),
+   |
+
+error[E0746]: return type cannot have an unboxed trait object
+  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:85:13
+   |
+LL | fn man() -> dyn std::fmt::Display {
+   |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn man() -> impl std::fmt::Display {
+   |             ~~~~
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn man() -> Box<dyn std::fmt::Display> {
+LL |     if false {
+LL ~         Box::new(0i32)
+LL |     } else {
+LL ~         Box::new(1u32)
+   |
+
 error[E0308]: mismatched types
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:5:5
    |
@@ -164,62 +223,6 @@ help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |         1i32
    |          ~~~
-
-error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:66:13
-   |
-LL | fn hat() -> dyn std::fmt::Display {
-   |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-help: consider returning an `impl Trait` instead of a `dyn Trait`
-   |
-LL | fn hat() -> impl std::fmt::Display {
-   |             ~~~~
-help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
-   |
-LL ~ fn hat() -> Box<dyn std::fmt::Display> {
-LL |     match 13 {
-LL |         0 => {
-LL ~             return Box::new(0i32);
-LL |         }
-LL |         _ => {
-LL ~             Box::new(1u32)
-   |
-
-error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:77:13
-   |
-LL | fn pug() -> dyn std::fmt::Display {
-   |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-help: consider returning an `impl Trait` instead of a `dyn Trait`
-   |
-LL | fn pug() -> impl std::fmt::Display {
-   |             ~~~~
-help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
-   |
-LL ~ fn pug() -> Box<dyn std::fmt::Display> {
-LL |     match 13 {
-LL ~         0 => Box::new(0i32),
-LL ~         1 => Box::new(1u32),
-LL ~         _ => Box::new(2u32),
-   |
-
-error[E0746]: return type cannot have an unboxed trait object
-  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:85:13
-   |
-LL | fn man() -> dyn std::fmt::Display {
-   |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: if there were a single returned type, you could use `impl Trait` instead
-help: box the return type, and wrap all of the returned values in `Box::new`
-   |
-LL ~ fn man() -> Box<dyn std::fmt::Display> {
-LL |     if false {
-LL ~         Box::new(0i32)
-LL |     } else {
-LL ~         Box::new(1u32)
-   |
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
+++ b/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
@@ -1,4 +1,4 @@
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:66:13
    |
 LL | fn hat() -> dyn std::fmt::Display {
@@ -19,7 +19,7 @@ LL |         _ => {
 LL ~             Box::new(1u32)
    |
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:77:13
    |
 LL | fn pug() -> dyn std::fmt::Display {
@@ -38,7 +38,7 @@ LL ~         1 => Box::new(1u32),
 LL ~         _ => Box::new(2u32),
    |
 
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:85:13
    |
 LL | fn man() -> dyn std::fmt::Display {

--- a/tests/ui/issues/issue-18107.rs
+++ b/tests/ui/issues/issue-18107.rs
@@ -2,7 +2,7 @@ pub trait AbstractRenderer {}
 
 fn _create_render(_: &()) ->
     dyn AbstractRenderer
-//~^ ERROR return type cannot have an unboxed trait object
+//~^ ERROR return type cannot be a trait object without pointer indirection
 {
     match 0 {
         _ => unimplemented!()

--- a/tests/ui/issues/issue-18107.stderr
+++ b/tests/ui/issues/issue-18107.stderr
@@ -1,4 +1,4 @@
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/issue-18107.rs:4:5
    |
 LL |     dyn AbstractRenderer

--- a/tests/ui/issues/issue-5883.rs
+++ b/tests/ui/issues/issue-5883.rs
@@ -6,7 +6,7 @@ struct Struct {
 
 fn new_struct(
     r: dyn A + 'static //~ ERROR the size for values of type
-) -> Struct {
+) -> Struct { //~ ERROR the size for values of type
     Struct { r: r }
 }
 

--- a/tests/ui/issues/issue-5883.stderr
+++ b/tests/ui/issues/issue-5883.stderr
@@ -1,4 +1,18 @@
 error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+  --> $DIR/issue-5883.rs:9:6
+   |
+LL | ) -> Struct {
+   |      ^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `Struct`, the trait `Sized` is not implemented for `(dyn A + 'static)`
+note: required because it appears within the type `Struct`
+  --> $DIR/issue-5883.rs:3:8
+   |
+LL | struct Struct {
+   |        ^^^^^^
+   = note: the return type of a function must have a statically known size
+
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
   --> $DIR/issue-5883.rs:8:8
    |
 LL |     r: dyn A + 'static
@@ -15,6 +29,6 @@ help: function arguments must have a statically known size, borrowed types alway
 LL |     r: &dyn A + 'static
    |        +
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/lang-items/lang-item-missing.stderr
+++ b/tests/ui/lang-items/lang-item-missing.stderr
@@ -1,4 +1,8 @@
 error: requires `sized` lang_item
+  --> $DIR/lang-item-missing.rs:11:60
+   |
+LL | extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+   |                                                            ^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/privacy2.rs
+++ b/tests/ui/privacy/privacy2.rs
@@ -14,16 +14,20 @@ mod bar {
 }
 
 pub fn foo() {}
+//~^ ERROR requires `sized` lang_item
 
 fn test1() {
+    //~^ ERROR requires `sized` lang_item
     use bar::foo;
     //~^ ERROR unresolved import `bar::foo` [E0432]
     //~| no `foo` in `bar`
 }
 
 fn test2() {
+    //~^ ERROR requires `sized` lang_item
     use bar::glob::foo;
     //~^ ERROR `foo` is private
 }
 
 fn main() {}
+//~^ ERROR requires `sized` lang_item

--- a/tests/ui/privacy/privacy2.stderr
+++ b/tests/ui/privacy/privacy2.stderr
@@ -1,11 +1,11 @@
 error[E0432]: unresolved import `bar::foo`
-  --> $DIR/privacy2.rs:19:9
+  --> $DIR/privacy2.rs:21:9
    |
 LL |     use bar::foo;
    |         ^^^^^^^^ no `foo` in `bar`
 
 error[E0603]: function import `foo` is private
-  --> $DIR/privacy2.rs:25:20
+  --> $DIR/privacy2.rs:28:20
    |
 LL |     use bar::glob::foo;
    |                    ^^^ private function import
@@ -22,8 +22,40 @@ LL | pub fn foo() {}
    | ^^^^^^^^^^^^ you could import this directly
 
 error: requires `sized` lang_item
+  --> $DIR/privacy2.rs:16:14
+   |
+LL | pub fn foo() {}
+   |              ^^
 
-error: aborting due to 3 previous errors
+error: requires `sized` lang_item
+  --> $DIR/privacy2.rs:19:12
+   |
+LL |   fn test1() {
+   |  ____________^
+LL | |
+LL | |     use bar::foo;
+...  |
+LL | | }
+   | |_^
+
+error: requires `sized` lang_item
+  --> $DIR/privacy2.rs:26:12
+   |
+LL |   fn test2() {
+   |  ____________^
+LL | |
+LL | |     use bar::glob::foo;
+LL | |
+LL | | }
+   | |_^
+
+error: requires `sized` lang_item
+  --> $DIR/privacy2.rs:32:11
+   |
+LL | fn main() {}
+   |           ^^
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0432, E0603.
 For more information about an error, try `rustc --explain E0432`.

--- a/tests/ui/privacy/privacy3.rs
+++ b/tests/ui/privacy/privacy3.rs
@@ -11,12 +11,15 @@ mod bar {
 
     mod glob {
         fn gpriv() {}
+    //~^ ERROR requires `sized` lang_item
     }
 }
 
 pub fn foo() {}
+//~^ ERROR requires `sized` lang_item
 
 fn test1() {
+    //~^ ERROR requires `sized` lang_item
     use bar::gpriv;
     //~^ ERROR unresolved import `bar::gpriv` [E0432]
     //~| no `gpriv` in `bar`
@@ -27,3 +30,4 @@ fn test1() {
 }
 
 fn main() {}
+//~^ ERROR requires `sized` lang_item

--- a/tests/ui/privacy/privacy3.stderr
+++ b/tests/ui/privacy/privacy3.stderr
@@ -1,11 +1,39 @@
 error[E0432]: unresolved import `bar::gpriv`
-  --> $DIR/privacy3.rs:20:9
+  --> $DIR/privacy3.rs:23:9
    |
 LL |     use bar::gpriv;
    |         ^^^^^^^^^^ no `gpriv` in `bar`
 
 error: requires `sized` lang_item
+  --> $DIR/privacy3.rs:18:14
+   |
+LL | pub fn foo() {}
+   |              ^^
 
-error: aborting due to 2 previous errors
+error: requires `sized` lang_item
+  --> $DIR/privacy3.rs:21:12
+   |
+LL |   fn test1() {
+   |  ____________^
+LL | |
+LL | |     use bar::gpriv;
+...  |
+LL | |     gpriv();
+LL | | }
+   | |_^
+
+error: requires `sized` lang_item
+  --> $DIR/privacy3.rs:32:11
+   |
+LL | fn main() {}
+   |           ^^
+
+error: requires `sized` lang_item
+  --> $DIR/privacy3.rs:13:20
+   |
+LL |         fn gpriv() {}
+   |                    ^^
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/proc-macro/issue-59191-replace-root-with-fn.stderr
+++ b/tests/ui/proc-macro/issue-59191-replace-root-with-fn.stderr
@@ -1,4 +1,10 @@
 error: requires `sized` lang_item
+  --> $DIR/issue-59191-replace-root-with-fn.rs:9:1
+   |
+LL | #![issue_59191::no_main]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `issue_59191::no_main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/issue-24446.rs
+++ b/tests/ui/static/issue-24446.rs
@@ -2,7 +2,6 @@ fn main() {
     static foo: dyn Fn() -> u32 = || -> u32 {
         //~^ ERROR the size for values of type
         //~| ERROR cannot be shared between threads safely
-        //~| ERROR the size for values of type
         //~| ERROR mismatched types
         0
     };

--- a/tests/ui/static/issue-24446.stderr
+++ b/tests/ui/static/issue-24446.stderr
@@ -15,33 +15,19 @@ LL |     static foo: dyn Fn() -> u32 = || -> u32 {
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
 
-error[E0277]: the size for values of type `(dyn Fn() -> u32 + 'static)` cannot be known at compilation time
-  --> $DIR/issue-24446.rs:2:35
-   |
-LL |       static foo: dyn Fn() -> u32 = || -> u32 {
-   |  ___________________________________^
-...  |
-LL | |         0
-LL | |     };
-   | |_____^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
-   = note: constant expressions must have a statically known size
-
 error[E0308]: mismatched types
   --> $DIR/issue-24446.rs:2:35
    |
 LL |       static foo: dyn Fn() -> u32 = || -> u32 {
    |  ___________________________________^
 ...  |
-LL | |         0
 LL | |     };
    | |_____^ expected `dyn Fn`, found closure
    |
    = note: expected trait object `(dyn Fn() -> u32 + 'static)`
                    found closure `{closure@$DIR/issue-24446.rs:2:35: 2:44}`
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/statics/unsized_type2.stderr
+++ b/tests/ui/statics/unsized_type2.stderr
@@ -11,6 +11,12 @@ note: required because it appears within the type `Foo`
 LL | pub struct Foo {
    |            ^^^
 
+error[E0308]: mismatched types
+  --> $DIR/unsized_type2.rs:14:45
+   |
+LL | pub static WITH_ERROR: Foo = Foo { version: 0 };
+   |                                             ^ expected `str`, found integer
+
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/unsized_type2.rs:14:30
    |
@@ -23,13 +29,7 @@ note: required because it appears within the type `Foo`
    |
 LL | pub struct Foo {
    |            ^^^
-   = note: constant expressions must have a statically known size
-
-error[E0308]: mismatched types
-  --> $DIR/unsized_type2.rs:14:45
-   |
-LL | pub static WITH_ERROR: Foo = Foo { version: 0 };
-   |                                             ^ expected `str`, found integer
+   = note: structs must have a statically known size to be initialized
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/dyn-incompatible-trait-references-self.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-references-self.stderr
@@ -34,6 +34,18 @@ LL | trait Other: Sized {}
    |       this trait is not dyn compatible...
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/dyn-incompatible-trait-references-self.rs:4:22
+   |
+LL |     fn bat(&self) -> Self {}
+   |                      ^^^^ doesn't have a size known at compile-time
+   |
+   = note: the return type of a function must have a statically known size
+help: consider further restricting `Self`
+   |
+LL |     fn bat(&self) -> Self where Self: Sized {}
+   |                           +++++++++++++++++
+
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
   --> $DIR/dyn-incompatible-trait-references-self.rs:2:22
    |
 LL |     fn baz(&self, _: Self) {}
@@ -60,18 +72,6 @@ LL |     fn bat(&self) -> Self {}
    |
    = note: expected type parameter `Self`
                    found unit type `()`
-
-error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/dyn-incompatible-trait-references-self.rs:4:22
-   |
-LL |     fn bat(&self) -> Self {}
-   |                      ^^^^ doesn't have a size known at compile-time
-   |
-   = note: the return type of a function must have a statically known size
-help: consider further restricting `Self`
-   |
-LL |     fn bat(&self) -> Self where Self: Sized {}
-   |                           +++++++++++++++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.rs
+++ b/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.rs
@@ -8,7 +8,6 @@ type Fn = dyn FnOnce() -> u8;
 const TEST: Fn = some_fn;
 //~^ ERROR cannot find value `some_fn` in this scope
 //~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
-//~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
 const TEST2: (Fn, u8) = (TEST, 0);
 //~^ ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
 //~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time

--- a/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
+++ b/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
@@ -13,16 +13,7 @@ LL | const TEST: Fn = some_fn;
    = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
 
 error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
-  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:8:18
-   |
-LL | const TEST: Fn = some_fn;
-   |                  ^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
-   = note: constant expressions must have a statically known size
-
-error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
-  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:12:14
+  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:11:14
    |
 LL | const TEST2: (Fn, u8) = (TEST, 0);
    |              ^^^^^^^^ doesn't have a size known at compile-time
@@ -31,7 +22,7 @@ LL | const TEST2: (Fn, u8) = (TEST, 0);
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
-  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:12:25
+  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:11:25
    |
 LL | const TEST2: (Fn, u8) = (TEST, 0);
    |                         ^^^^^^^^^ doesn't have a size known at compile-time
@@ -39,7 +30,7 @@ LL | const TEST2: (Fn, u8) = (TEST, 0);
    = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/span-bug-issue-121418.stderr
+++ b/tests/ui/traits/const-traits/span-bug-issue-121418.stderr
@@ -8,17 +8,6 @@ LL | impl const dyn T {
    |
    = note: only trait implementations may be annotated with `const`
 
-error[E0308]: mismatched types
-  --> $DIR/span-bug-issue-121418.rs:8:27
-   |
-LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
-   |                  ---      ^^^^^^^^^^^^^^^^^^^^^^^ expected `Mutex<dyn T>`, found `()`
-   |                  |
-   |                  implicitly returns `()` as its body has no tail or `return` expression
-   |
-   = note: expected struct `Mutex<(dyn T + 'static)>`
-           found unit type `()`
-
 error[E0277]: the size for values of type `(dyn T + 'static)` cannot be known at compilation time
   --> $DIR/span-bug-issue-121418.rs:8:27
    |
@@ -29,6 +18,17 @@ LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
 note: required because it appears within the type `Mutex<(dyn T + 'static)>`
   --> $SRC_DIR/std/src/sync/poison/mutex.rs:LL:COL
    = note: the return type of a function must have a statically known size
+
+error[E0308]: mismatched types
+  --> $DIR/span-bug-issue-121418.rs:8:27
+   |
+LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
+   |                  ---      ^^^^^^^^^^^^^^^^^^^^^^^ expected `Mutex<dyn T>`, found `()`
+   |                  |
+   |                  implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note: expected struct `Mutex<(dyn T + 'static)>`
+           found unit type `()`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.rs
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.rs
@@ -13,8 +13,9 @@ fn main() {
 }
 
 fn weird0() -> impl Sized + !Sized {}
-//~^ ERROR the trait bound `(): !Sized` is not satisfied
+//~^ ERROR type mismatch resolving
 fn weird1() -> impl !Sized + Sized {}
-//~^ ERROR the trait bound `(): !Sized` is not satisfied
+//~^ ERROR type mismatch resolving
 fn weird2() -> impl !Sized {}
-//~^ ERROR the trait bound `(): !Sized` is not satisfied
+//~^ ERROR type mismatch resolving
+//~| ERROR the size for values of type

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.stderr
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.stderr
@@ -1,20 +1,29 @@
-error[E0277]: the trait bound `(): !Sized` is not satisfied
-  --> $DIR/opaque-type-unsatisfied-bound.rs:15:16
-   |
-LL | fn weird0() -> impl Sized + !Sized {}
-   |                ^^^^^^^^^^^^^^^^^^^ the trait bound `(): !Sized` is not satisfied
-
-error[E0277]: the trait bound `(): !Sized` is not satisfied
-  --> $DIR/opaque-type-unsatisfied-bound.rs:17:16
-   |
-LL | fn weird1() -> impl !Sized + Sized {}
-   |                ^^^^^^^^^^^^^^^^^^^ the trait bound `(): !Sized` is not satisfied
-
-error[E0277]: the trait bound `(): !Sized` is not satisfied
+error[E0277]: the size for values of type `impl !Sized` cannot be known at compilation time
   --> $DIR/opaque-type-unsatisfied-bound.rs:19:16
    |
 LL | fn weird2() -> impl !Sized {}
-   |                ^^^^^^^^^^^ the trait bound `(): !Sized` is not satisfied
+   |                ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `impl !Sized`
+   = note: the return type of a function must have a statically known size
+
+error[E0271]: type mismatch resolving `impl !Sized + Sized == ()`
+  --> $DIR/opaque-type-unsatisfied-bound.rs:15:16
+   |
+LL | fn weird0() -> impl Sized + !Sized {}
+   |                ^^^^^^^^^^^^^^^^^^^ types differ
+
+error[E0271]: type mismatch resolving `impl !Sized + Sized == ()`
+  --> $DIR/opaque-type-unsatisfied-bound.rs:17:16
+   |
+LL | fn weird1() -> impl !Sized + Sized {}
+   |                ^^^^^^^^^^^^^^^^^^^ types differ
+
+error[E0271]: type mismatch resolving `impl !Sized == ()`
+  --> $DIR/opaque-type-unsatisfied-bound.rs:19:16
+   |
+LL | fn weird2() -> impl !Sized {}
+   |                ^^^^^^^^^^^ types differ
 
 error[E0277]: the trait bound `impl !Trait: Trait` is not satisfied
   --> $DIR/opaque-type-unsatisfied-bound.rs:12:13
@@ -30,6 +39,7 @@ note: required by a bound in `consume`
 LL | fn consume(_: impl Trait) {}
    |                    ^^^^^ required by this bound in `consume`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.rs
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.rs
@@ -3,6 +3,6 @@
 #![feature(negative_bounds, unboxed_closures)]
 
 fn produce() -> impl !Fn<(u32,)> {}
-//~^ ERROR the trait bound `(): !Fn(u32)` is not satisfied
+//~^ ERROR type mismatch resolving
 
 fn main() {}

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.stderr
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.stderr
@@ -1,9 +1,9 @@
-error[E0277]: the trait bound `(): !Fn(u32)` is not satisfied
+error[E0271]: type mismatch resolving `impl !Fn<(u32,)> == ()`
   --> $DIR/opaque-type-unsatisfied-fn-bound.rs:5:17
    |
 LL | fn produce() -> impl !Fn<(u32,)> {}
-   |                 ^^^^^^^^^^^^^^^^ the trait bound `(): !Fn(u32)` is not satisfied
+   |                 ^^^^^^^^^^^^^^^^ types differ
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/typeck/issue-105946.rs
+++ b/tests/ui/typeck/issue-105946.rs
@@ -1,4 +1,5 @@
 fn digit() -> str {
+    //~^ ERROR the size for values of type
     return {};
     //~^ ERROR: mismatched types [E0308]
 }

--- a/tests/ui/typeck/issue-105946.stderr
+++ b/tests/ui/typeck/issue-105946.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `_y` in this scope
-  --> $DIR/issue-105946.rs:6:10
+  --> $DIR/issue-105946.rs:7:10
    |
 LL |     let [_y..] = [Box::new(1), Box::new(2)];
    |          ^^ not found in this scope
@@ -10,7 +10,7 @@ LL |     let [_y @ ..] = [Box::new(1), Box::new(2)];
    |             +
 
 error[E0658]: `X..` patterns in slices are experimental
-  --> $DIR/issue-105946.rs:6:10
+  --> $DIR/issue-105946.rs:7:10
    |
 LL |     let [_y..] = [Box::new(1), Box::new(2)];
    |          ^^^^
@@ -19,19 +19,28 @@ LL |     let [_y..] = [Box::new(1), Box::new(2)];
    = help: add `#![feature(half_open_range_patterns_in_slices)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/issue-105946.rs:1:15
+   |
+LL | fn digit() -> str {
+   |               ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: the return type of a function must have a statically known size
+
 error[E0308]: mismatched types
-  --> $DIR/issue-105946.rs:2:12
+  --> $DIR/issue-105946.rs:3:12
    |
 LL |     return {};
    |            ^^ expected `str`, found `()`
 
 error[E0527]: pattern requires 1 element but array has 2
-  --> $DIR/issue-105946.rs:6:9
+  --> $DIR/issue-105946.rs:7:9
    |
 LL |     let [_y..] = [Box::new(1), Box::new(2)];
    |         ^^^^^^ expected 2 elements
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0308, E0425, E0527, E0658.
-For more information about an error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0277, E0308, E0425, E0527, E0658.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/unsized/box-instead-of-dyn-fn.rs
+++ b/tests/ui/unsized/box-instead-of-dyn-fn.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 // Test to suggest boxing the return type, and the closure branch of the `if`
 
 fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> dyn Fn() + 'a {
-    //~^ ERROR return type cannot have an unboxed trait object
+    //~^ ERROR return type cannot be a trait object without pointer indirection
     if a % 2 == 0 {
         move || println!("{a}")
     } else {

--- a/tests/ui/unsized/box-instead-of-dyn-fn.stderr
+++ b/tests/ui/unsized/box-instead-of-dyn-fn.stderr
@@ -1,4 +1,4 @@
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/box-instead-of-dyn-fn.rs:5:56
    |
 LL | fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> dyn Fn() + 'a {

--- a/tests/ui/unsized/issue-91801.rs
+++ b/tests/ui/unsized/issue-91801.rs
@@ -6,7 +6,7 @@ pub static ALL_VALIDATORS: &[(&'static str, &'static Validator)] =
     &[("validate that credits and debits balance", &validate_something)];
 
 fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Validator<'a> {
-    //~^ ERROR return type cannot have an unboxed trait object
+    //~^ ERROR return type cannot be a trait object without pointer indirection
     return Box::new(move |something: &'_ Something| -> Result<(), ()> {
         first(something).or_else(|_| second(something))
     });

--- a/tests/ui/unsized/issue-91801.stderr
+++ b/tests/ui/unsized/issue-91801.stderr
@@ -1,4 +1,4 @@
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/issue-91801.rs:8:77
    |
 LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Validator<'a> {

--- a/tests/ui/unsized/issue-91803.rs
+++ b/tests/ui/unsized/issue-91803.rs
@@ -1,7 +1,7 @@
 trait Foo<'a> {}
 
 fn or<'a>(first: &'static dyn Foo<'a>) -> dyn Foo<'a> {
-    //~^ ERROR return type cannot have an unboxed trait object
+    //~^ ERROR return type cannot be a trait object without pointer indirection
     return Box::new(panic!());
 }
 

--- a/tests/ui/unsized/issue-91803.stderr
+++ b/tests/ui/unsized/issue-91803.stderr
@@ -1,4 +1,4 @@
-error[E0746]: return type cannot have an unboxed trait object
+error[E0746]: return type cannot be a trait object without pointer indirection
   --> $DIR/issue-91803.rs:3:43
    |
 LL | fn or<'a>(first: &'static dyn Foo<'a>) -> dyn Foo<'a> {

--- a/tests/ui/where-clauses/ignore-err-clauses.rs
+++ b/tests/ui/where-clauses/ignore-err-clauses.rs
@@ -1,6 +1,7 @@
 use std::ops::Add;
 
 fn dbl<T>(x: T) -> <T as Add>::Output
+//~^ ERROR type annotations needed
 where
     T: Copy + Add,
     UUU: Copy,

--- a/tests/ui/where-clauses/ignore-err-clauses.stderr
+++ b/tests/ui/where-clauses/ignore-err-clauses.stderr
@@ -1,9 +1,16 @@
 error[E0412]: cannot find type `UUU` in this scope
-  --> $DIR/ignore-err-clauses.rs:6:5
+  --> $DIR/ignore-err-clauses.rs:7:5
    |
 LL |     UUU: Copy,
    |     ^^^ not found in this scope
 
-error: aborting due to 1 previous error
+error[E0282]: type annotations needed
+  --> $DIR/ignore-err-clauses.rs:3:14
+   |
+LL | fn dbl<T>(x: T) -> <T as Add>::Output
+   |              ^ cannot infer type for type parameter `T`
 
-For more information about this error, try `rustc --explain E0412`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0282, E0412.
+For more information about an error, try `rustc --explain E0282`.


### PR DESCRIPTION
Still need to clean this up a bit. This should fix https://github.com/rust-lang/trait-system-refactor-initiative/issues/150.

r? lcnr