### PR TITLE
set DEPLOY=1 automatically on dist images

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -27,6 +27,10 @@ do
   shift
 done
 
+if [[ $image == dist* ]]; then
+    DEPLOY=1
+fi
+
 # MacOS reports "arm64" while Linux reports "aarch64". Commonize this.
 machine="$(uname -m | sed 's/arm64/aarch64/')"
 
@@ -343,7 +347,7 @@ docker \
   $extra_env \
   $args \
   --env CARGO_HOME=/cargo \
-  --env DEPLOY \
+  --env DEPLOY=$DEPLOY \
   --env DEPLOY_ALT \
   --env CI \
   --env GITHUB_ACTIONS \


### PR DESCRIPTION
From https://github.com/rust-lang/rust/issues/136249#issuecomment-2624153176:

> The dist-* docker images only work if you set DEPLOY=1.

This makes that happen automatically.

Fixes #136249.