### PR TITLE
elaborate: avoid projections with unconstrained bound regions

### DIFF
--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -44,6 +44,8 @@ pub mod token;
 pub mod tokenstream;
 pub mod visit;
 
+pub use rustc_ast_ir::Limit;
+
 pub use self::ast::*;
 pub use self::ast_traits::{AstDeref, AstNodeWrapper, HasAttrs, HasNodeId, HasTokens};
 

--- a/compiler/rustc_errors/src/diagnostic_impls.rs
+++ b/compiler/rustc_errors/src/diagnostic_impls.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 
 use rustc_abi::TargetDataLayoutErrors;
+use rustc_ast::Limit;
 use rustc_ast::util::parser::ExprPrecedence;
 use rustc_ast_pretty::pprust;
 use rustc_macros::Subdiagnostic;
@@ -187,6 +188,12 @@ impl<'a> IntoDiagArg for &'a Path {
 impl IntoDiagArg for PathBuf {
     fn into_diag_arg(self) -> DiagArgValue {
         DiagArgValue::Str(Cow::Owned(self.display().to_string()))
+    }
+}
+
+impl IntoDiagArg for Limit {
+    fn into_diag_arg(self) -> rustc_errors::DiagArgValue {
+        self.to_string().into_diag_arg()
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -42,6 +42,7 @@ use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 use rustc_trait_selection::error_reporting::traits::suggestions::NextTypeParamName;
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::traits::ObligationCtxt;
+use rustc_type_ir::visit::collect_referenced_late_bound_regions;
 use tracing::{debug, instrument};
 
 use crate::check::intrinsic::intrinsic_operation_unsafety;
@@ -635,11 +636,10 @@ fn get_new_lifetime_name<'tcx>(
     poly_trait_ref: ty::PolyTraitRef<'tcx>,
     generics: &hir::Generics<'tcx>,
 ) -> String {
-    let existing_lifetimes = tcx
-        .collect_referenced_late_bound_regions(poly_trait_ref)
+    let existing_lifetimes = collect_referenced_late_bound_regions(tcx, poly_trait_ref)
         .into_iter()
         .filter_map(|lt| {
-            if let ty::BoundRegionKind::Named(_, name) = lt {
+            if let ty::BoundRegionKind::Named(_, name) = lt.kind {
                 Some(name.as_str().to_string())
             } else {
                 None

--- a/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
+++ b/compiler/rustc_hir_analysis/src/constrained_generic_params.rs
@@ -3,7 +3,7 @@ use rustc_middle::bug;
 use rustc_middle::ty::visit::{TypeSuperVisitable, TypeVisitor};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::Span;
-use rustc_type_ir::fold::TypeFoldable;
+use rustc_type_ir::fold::{TypeFoldable, expand_weak_alias_tys};
 use tracing::debug;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -51,7 +51,7 @@ pub(crate) fn parameters_for<'tcx>(
     include_nonconstraining: bool,
 ) -> Vec<Parameter> {
     let mut collector = ParameterCollector { parameters: vec![], include_nonconstraining };
-    let value = if !include_nonconstraining { tcx.expand_weak_alias_tys(value) } else { value };
+    let value = if !include_nonconstraining { expand_weak_alias_tys(tcx, value) } else { value };
     value.visit_with(&mut collector);
     collector.parameters
 }

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -11,7 +11,10 @@ use rustc_middle::bug;
 use rustc_middle::ty::{self as ty, IsSuggestable, Ty, TyCtxt};
 use rustc_span::{ErrorGuaranteed, Ident, Span, Symbol, kw, sym};
 use rustc_trait_selection::traits;
-use rustc_type_ir::visit::{TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor};
+use rustc_type_ir::visit::{
+    TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
+    collect_constrained_late_bound_regions, collect_referenced_late_bound_regions,
+};
 use smallvec::SmallVec;
 use tracing::{debug, instrument};
 
@@ -358,9 +361,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 //     for<'a> <T as Iterator>::Item = &'a str // <-- 'a is bad
                 //     for<'a> <T as FnMut<(&'a u32,)>>::Output = &'a str // <-- 'a is ok
                 let late_bound_in_projection_ty =
-                    tcx.collect_constrained_late_bound_regions(projection_term);
+                    collect_constrained_late_bound_regions(tcx, projection_term);
                 let late_bound_in_term =
-                    tcx.collect_referenced_late_bound_regions(trait_ref.rebind(term));
+                    collect_referenced_late_bound_regions(tcx, trait_ref.rebind(term));
                 debug!(?late_bound_in_projection_ty);
                 debug!(?late_bound_in_term);
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -305,8 +305,8 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.parent(def_id)
     }
 
-    fn recursion_limit(self) -> usize {
-        self.recursion_limit().0
+    fn recursion_limit(self) -> Limit {
+        self.recursion_limit()
     }
 
     type Features = &'tcx rustc_feature::Features;

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -6,7 +6,6 @@ use rustc_abi::{ExternAbi, Float, Integer, IntegerType, Size};
 use rustc_apfloat::Float as _;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::stable_hasher::{Hash128, HashStable, StableHasher};
-use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
 use rustc_hir::def::{CtorOf, DefKind, Res};
@@ -895,30 +894,6 @@ impl<'tcx> TyCtxt<'tcx> {
             || self.extern_crate(key).is_some_and(|e| e.is_direct())
     }
 
-    /// Expand any [weak alias types][weak] contained within the given `value`.
-    ///
-    /// This should be used over other normalization routines in situations where
-    /// it's important not to normalize other alias types and where the predicates
-    /// on the corresponding type alias shouldn't be taken into consideration.
-    ///
-    /// Whenever possible **prefer not to use this function**! Instead, use standard
-    /// normalization routines or if feasible don't normalize at all.
-    ///
-    /// This function comes in handy if you want to mimic the behavior of eager
-    /// type alias expansion in a localized manner.
-    ///
-    /// <div class="warning">
-    /// This delays a bug on overflow! Therefore you need to be certain that the
-    /// contained types get fully normalized at a later stage. Note that even on
-    /// overflow all well-behaved weak alias types get expanded correctly, so the
-    /// result is still useful.
-    /// </div>
-    ///
-    /// [weak]: ty::Weak
-    pub fn expand_weak_alias_tys<T: TypeFoldable<TyCtxt<'tcx>>>(self, value: T) -> T {
-        value.fold_with(&mut WeakAliasTypeExpander { tcx: self, depth: 0 })
-    }
-
     /// Peel off all [weak alias types] in this type until there are none left.
     ///
     /// This only expands weak alias types in “head” / outermost positions. It can
@@ -1085,42 +1060,6 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for OpaqueTypeExpander<'tcx> {
         } else {
             p.super_fold_with(self)
         }
-    }
-}
-
-struct WeakAliasTypeExpander<'tcx> {
-    tcx: TyCtxt<'tcx>,
-    depth: usize,
-}
-
-impl<'tcx> TypeFolder<TyCtxt<'tcx>> for WeakAliasTypeExpander<'tcx> {
-    fn cx(&self) -> TyCtxt<'tcx> {
-        self.tcx
-    }
-
-    fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
-        if !ty.has_type_flags(ty::TypeFlags::HAS_TY_WEAK) {
-            return ty;
-        }
-        let ty::Alias(ty::Weak, alias) = ty.kind() else {
-            return ty.super_fold_with(self);
-        };
-        if !self.tcx.recursion_limit().value_within_limit(self.depth) {
-            let guar = self.tcx.dcx().delayed_bug("overflow expanding weak alias type");
-            return Ty::new_error(self.tcx, guar);
-        }
-
-        self.depth += 1;
-        ensure_sufficient_stack(|| {
-            self.tcx.type_of(alias.def_id).instantiate(self.tcx, alias.args).fold_with(self)
-        })
-    }
-
-    fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
-        if !ct.has_type_flags(ty::TypeFlags::HAS_TY_WEAK) {
-            return ct;
-        }
-        ct.super_fold_with(self)
     }
 }
 

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/canonical.rs
@@ -168,7 +168,7 @@ where
         if !self.is_normalizes_to_goal {
             let num_non_region_vars =
                 canonical.variables.iter().filter(|c| !c.is_region() && c.is_existential()).count();
-            if num_non_region_vars > self.cx().recursion_limit() {
+            if !self.cx().recursion_limit().value_within_limit(num_non_region_vars) {
                 debug!(?num_non_region_vars, "too many inference variables -> overflow");
                 return Ok(self.make_ambiguous_response_no_constraints(MaybeCause::Overflow {
                     suggest_increasing_limit: true,

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1,6 +1,7 @@
 use std::ops::ControlFlow;
 
 use derive_where::derive_where;
+use rustc_ast_ir::Limit;
 #[cfg(feature = "nightly")]
 use rustc_macros::{HashStable_NoContext, TyDecodable, TyEncodable};
 use rustc_type_ir::data_structures::{HashMap, HashSet, ensure_sufficient_stack};
@@ -148,7 +149,7 @@ pub trait SolverDelegateEvalExt: SolverDelegate {
     /// in coherence checking.
     fn root_goal_may_hold_with_depth(
         &self,
-        root_depth: usize,
+        root_depth: Limit,
         goal: Goal<Self::Interner, <Self::Interner as Interner>::Predicate>,
     ) -> bool;
 
@@ -182,7 +183,7 @@ where
 
     fn root_goal_may_hold_with_depth(
         &self,
-        root_depth: usize,
+        root_depth: Limit,
         goal: Goal<Self::Interner, <Self::Interner as Interner>::Predicate>,
     ) -> bool {
         self.probe(|| {
@@ -227,7 +228,7 @@ where
     /// over using this manually (such as [`SolverDelegateEvalExt::evaluate_root_goal`]).
     pub(super) fn enter_root<R>(
         delegate: &D,
-        root_depth: usize,
+        root_depth: Limit,
         generate_proof_tree: GenerateProofTree,
         f: impl FnOnce(&mut EvalCtxt<'_, D>) -> R,
     ) -> (R, Option<inspect::GoalEvaluation<I>>) {

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1,11 +1,11 @@
 use std::any::Any;
-use std::ops::{Div, Mul};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::{env, fmt, io};
+use std::{env, io};
 
+pub use rustc_ast::Limit;
 use rustc_data_structures::flock;
 use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
 use rustc_data_structures::profiling::{SelfProfiler, SelfProfilerRef};
@@ -56,59 +56,6 @@ pub enum CtfeBacktrace {
     Capture,
     /// Capture a backtrace at the point the error is created and immediately print it out.
     Immediate,
-}
-
-/// New-type wrapper around `usize` for representing limits. Ensures that comparisons against
-/// limits are consistent throughout the compiler.
-#[derive(Clone, Copy, Debug, HashStable_Generic)]
-pub struct Limit(pub usize);
-
-impl Limit {
-    /// Create a new limit from a `usize`.
-    pub fn new(value: usize) -> Self {
-        Limit(value)
-    }
-
-    /// Check that `value` is within the limit. Ensures that the same comparisons are used
-    /// throughout the compiler, as mismatches can cause ICEs, see #72540.
-    #[inline]
-    pub fn value_within_limit(&self, value: usize) -> bool {
-        value <= self.0
-    }
-}
-
-impl From<usize> for Limit {
-    fn from(value: usize) -> Self {
-        Self::new(value)
-    }
-}
-
-impl fmt::Display for Limit {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl Div<usize> for Limit {
-    type Output = Limit;
-
-    fn div(self, rhs: usize) -> Self::Output {
-        Limit::new(self.0 / rhs)
-    }
-}
-
-impl Mul<usize> for Limit {
-    type Output = Limit;
-
-    fn mul(self, rhs: usize) -> Self::Output {
-        Limit::new(self.0 * rhs)
-    }
-}
-
-impl rustc_errors::IntoDiagArg for Limit {
-    fn into_diag_arg(self) -> rustc_errors::DiagArgValue {
-        self.to_string().into_diag_arg()
-    }
 }
 
 #[derive(Clone, Copy, Debug, HashStable_Generic)]

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -6,6 +6,7 @@
 
 use std::fmt::Debug;
 
+use rustc_ast_ir::Limit;
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_errors::{Diag, EmissionGuarantee};
 use rustc_hir::def::DefKind;
@@ -350,8 +351,10 @@ fn impl_intersection_has_impossible_obligation<'a, 'cx, 'tcx>(
         // a very low recursion depth and bail if any of them don't
         // hold.
         if !obligations.iter().all(|o| {
-            <&SolverDelegate<'tcx>>::from(infcx)
-                .root_goal_may_hold_with_depth(8, Goal::new(infcx.tcx, o.param_env, o.predicate))
+            <&SolverDelegate<'tcx>>::from(infcx).root_goal_may_hold_with_depth(
+                Limit(8),
+                Goal::new(infcx.tcx, o.param_env, o.predicate),
+            )
         }) {
             return IntersectionHasImpossibleObligations::Yes;
         }

--- a/compiler/rustc_type_ir/src/data_structures/mod.rs
+++ b/compiler/rustc_type_ir/src/data_structures/mod.rs
@@ -11,6 +11,9 @@ mod delayed_map;
 #[cfg(feature = "nightly")]
 mod impl_ {
     pub use rustc_data_structures::sso::{SsoHashMap, SsoHashSet};
+    pub mod fx {
+        pub use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
+    }
     pub use rustc_data_structures::stack::ensure_sufficient_stack;
     pub use rustc_data_structures::sync::Lrc;
 }
@@ -19,6 +22,11 @@ mod impl_ {
 mod impl_ {
     pub use std::collections::{HashMap as SsoHashMap, HashSet as SsoHashSet};
     pub use std::sync::Arc as Lrc;
+    pub mod fx {
+        pub use std::collections::{HashMap as FxHashMap, HashSet as FxHashSet};
+
+        pub use indexmap::{IndexMap as FxIndexMap, IndexSet as FxIndexSet};
+    }
 
     #[inline]
     pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Deref;
 
-use rustc_ast_ir::Movability;
+use rustc_ast_ir::{Limit, Movability};
 use rustc_index::bit_set::DenseBitSet;
 use smallvec::SmallVec;
 
@@ -177,7 +177,7 @@ pub trait Interner:
 
     fn parent(self, def_id: Self::DefId) -> Self::DefId;
 
-    fn recursion_limit(self) -> usize;
+    fn recursion_limit(self) -> Limit;
 
     type Features: Features<Self>;
     fn features(self) -> Self::Features;

--- a/compiler/rustc_type_ir/src/search_graph/mod.rs
+++ b/compiler/rustc_type_ir/src/search_graph/mod.rs
@@ -18,6 +18,7 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 
 use derive_where::derive_where;
+use rustc_ast_ir::Limit;
 use rustc_index::{Idx, IndexVec};
 use tracing::debug;
 
@@ -142,6 +143,11 @@ impl UsageKind {
 
 #[derive(Debug, Clone, Copy)]
 struct AvailableDepth(usize);
+impl From<Limit> for AvailableDepth {
+    fn from(Limit(value): Limit) -> AvailableDepth {
+        AvailableDepth(value)
+    }
+}
 impl AvailableDepth {
     /// Returns the remaining depth allowed for nested goals.
     ///
@@ -368,9 +374,9 @@ pub struct SearchGraph<D: Delegate<Cx = X>, X: Cx = <D as Delegate>::Cx> {
 }
 
 impl<D: Delegate<Cx = X>, X: Cx> SearchGraph<D> {
-    pub fn new(root_depth: usize) -> SearchGraph<D> {
+    pub fn new(recursion_limit: Limit) -> SearchGraph<D> {
         Self {
-            root_depth: AvailableDepth(root_depth),
+            root_depth: recursion_limit.into(),
             stack: Default::default(),
             provisional_cache: Default::default(),
             _marker: PhantomData,

--- a/src/tools/miri/src/shims/alloc.rs
+++ b/src/tools/miri/src/shims/alloc.rs
@@ -81,7 +81,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn malloc(&mut self, size: u64, init: AllocInit) -> InterpResult<'tcx, Pointer> {
         let this = self.eval_context_mut();
         let align = this.malloc_align(size);
-        let ptr = this.allocate_ptr(Size::from_bytes(size), align, MiriMemoryKind::C.into(), init)?;
+        let ptr =
+            this.allocate_ptr(Size::from_bytes(size), align, MiriMemoryKind::C.into(), init)?;
         interp_ok(ptr.into())
     }
 
@@ -105,7 +106,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 Size::from_bytes(size),
                 Align::from_bytes(align).unwrap(),
                 MiriMemoryKind::C.into(),
-                AllocInit::Uninit
+                AllocInit::Uninit,
             )?;
             this.write_pointer(ptr, &memptr)?;
             interp_ok(Scalar::from_i32(0))
@@ -138,7 +139,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     Size::from_bytes(new_size),
                     new_align,
                     MiriMemoryKind::C.into(),
-                    AllocInit::Uninit
+                    AllocInit::Uninit,
                 )?;
                 interp_ok(new_ptr.into())
             }
@@ -179,7 +180,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     Size::from_bytes(size),
                     Align::from_bytes(align).unwrap(),
                     MiriMemoryKind::C.into(),
-                    AllocInit::Uninit
+                    AllocInit::Uninit,
                 )?;
                 interp_ok(ptr.into())
             }

--- a/src/tools/miri/src/shims/foreign_items.rs
+++ b/src/tools/miri/src/shims/foreign_items.rs
@@ -509,7 +509,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         Size::from_bytes(size),
                         Align::from_bytes(align).unwrap(),
                         memory_kind.into(),
-                        AllocInit::Uninit
+                        AllocInit::Uninit,
                     )?;
 
                     ecx.write_pointer(ptr, dest)
@@ -538,7 +538,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         Size::from_bytes(size),
                         Align::from_bytes(align).unwrap(),
                         MiriMemoryKind::Rust.into(),
-                        AllocInit::Zero
+                        AllocInit::Zero,
                     )?;
                     this.write_pointer(ptr, dest)
                 });
@@ -599,7 +599,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         Size::from_bytes(new_size),
                         align,
                         MiriMemoryKind::Rust.into(),
-                        AllocInit::Uninit
+                        AllocInit::Uninit,
                     )?;
                     this.write_pointer(new_ptr, dest)
                 });

--- a/src/tools/miri/src/shims/unix/fs.rs
+++ b/src/tools/miri/src/shims/unix/fs.rs
@@ -1109,7 +1109,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     Size::from_bytes(size),
                     dirent_layout.align.abi,
                     MiriMemoryKind::Runtime.into(),
-                    AllocInit::Uninit
+                    AllocInit::Uninit,
                 )?;
                 let entry: Pointer = entry.into();
 

--- a/src/tools/miri/src/shims/unix/linux/mem.rs
+++ b/src/tools/miri/src/shims/unix/linux/mem.rs
@@ -49,7 +49,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Size::from_bytes(new_size),
             align,
             MiriMemoryKind::Mmap.into(),
-            AllocInit::Zero
+            AllocInit::Zero,
         )?;
 
         interp_ok(Scalar::from_pointer(ptr, this))

--- a/src/tools/miri/src/shims/unix/mem.rs
+++ b/src/tools/miri/src/shims/unix/mem.rs
@@ -116,7 +116,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             align,
             MiriMemoryKind::Mmap.into(),
             // mmap guarantees new mappings are zero-init.
-            AllocInit::Zero
+            AllocInit::Zero,
         )?;
 
         interp_ok(Scalar::from_pointer(ptr, this))

--- a/src/tools/miri/src/shims/windows/foreign_items.rs
+++ b/src/tools/miri/src/shims/windows/foreign_items.rs
@@ -266,7 +266,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     Size::from_bytes(size),
                     Align::from_bytes(align).unwrap(),
                     MiriMemoryKind::WinHeap.into(),
-                    init
+                    init,
                 )?;
                 this.write_pointer(ptr, dest)?;
             }
@@ -299,7 +299,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     Size::from_bytes(size),
                     Align::from_bytes(align).unwrap(),
                     MiriMemoryKind::WinHeap.into(),
-                    AllocInit::Uninit
+                    AllocInit::Uninit,
                 )?;
                 this.write_pointer(new_ptr, dest)?;
             }


### PR DESCRIPTION
Should only do this for where-bounds and item bounds. Gonna rewrite later I think.

This means we'll no longer need to support unconstrained regions in implied bounds, see https://github.com/lcnr/random-rust-snippets/issues/15. This fixes
```rust
trait Super {
    type SAssoc;
}
trait Trait<'a>: Super<SAssoc = <Self as Trait<'a>>::TAssoc> {
    type TAssoc;
}

fn test<'a, T: 'a>() {}

fn unconstrained_lt<'arg, T: for<'a> Trait<'a>>(x: &'arg <T as Super>::SAssoc) {
    test::<'arg, <T as Super>::SAssoc>();
}
```
but breaks
```rust
trait Super {
    type SAssoc;
}
trait Trait<'a>: Super<SAssoc = <Self as Trait<'a>>::TAssoc> {
    type TAssoc;
}

fn test<'a, T: 'a>() {}

fn unconstrained_lt<'arg, T: for<'a> Trait<'a, TAssoc = usize>>(x: <T as Super>::SAssoc) -> usize {
    x
}
```

r? @compiler-errors 