### PR TITLE
[rustdoc] Merge `<code>` tags into one whenever possible

### DIFF
--- a/tests/rustdoc-gui/docblock-big-code-mobile.goml
+++ b/tests/rustdoc-gui/docblock-big-code-mobile.goml
@@ -12,4 +12,5 @@ assert-size: (".docblock p > code", {"height": 48})
 
 // Same check, but where the long code block is also a link
 go-to: "file://" + |DOC_PATH| + "/test_docs/long_code_block_link/index.html"
-assert-size: (".docblock p > a > code", {"height": 48})
+assert-size: (".docblock p > code", {"height": 48})
+assert-size: (".docblock p > code > a", {"height": 44})

--- a/tests/rustdoc/code-tags-merge.rs
+++ b/tests/rustdoc/code-tags-merge.rs
@@ -1,0 +1,28 @@
+// This test checks that rustdoc is combining `<code>` tags as expected.
+
+#![crate_name = "foo"]
+
+//@ has 'foo/index.html'
+
+// First we check that summary lines also get the `<code>` merge.
+//@ has - '//dd/code' 'Stream<Item = io::Result<Bytes>>'
+//@ !has - '//dd/code/code' 'Stream<Item = io::Result<Bytes>>'
+// Then we check that the docblocks have it too.
+//@ has 'foo/struct.Foo.html'
+//@ has - '//*[@class="docblock"]//code' 'Stream<Item = io::Result<Bytes>>'
+//@ has - '//*[@class="docblock"]//code' 'Stream<Item = io::Result<Bytes>>'
+/// [`Stream`](crate::Foo)`<Item = `[`io::Result`](crate::Foo)`<`[`Bytes`](crate::Foo)`>>`
+pub struct Foo;
+
+impl Foo {
+    //@ has - '//*[@class="impl-items"]//*[@class="docblock"]//code' '<Stream>'
+    /// A `<`[`Stream`](crate::Foo)`>` stuff.
+    pub fn bar() {}
+
+    //@ has - '//*[@class="impl-items"]//*[@class="docblock"]//code' '<'
+    //@ has - '//*[@class="impl-items"]//*[@class="docblock"]//a' 'Stream a'
+    //@ has - '//*[@class="impl-items"]//*[@class="docblock"]//code' 'Stream'
+    //@ has - '//*[@class="impl-items"]//*[@class="docblock"]//code' '>'
+    /// A `<`[`Stream` a](crate::Foo)`>` stuff.
+    pub fn foo() {}
+}

--- a/tests/rustdoc/intra-doc/disambiguators-removed.rs
+++ b/tests/rustdoc/intra-doc/disambiguators-removed.rs
@@ -2,15 +2,15 @@
 // first try backticks
 /// Trait: [`trait@Name`], fn: [`fn@Name`], [`Name`][`macro@Name`]
 //@ has disambiguators_removed/struct.AtDisambiguator.html
-//@ has - '//a[@href="trait.Name.html"][code]' "Name"
-//@ has - '//a[@href="fn.Name.html"][code]' "Name"
-//@ has - '//a[@href="macro.Name.html"][code]' "Name"
+//@ has - '//code/a[@href="trait.Name.html"]' "Name"
+//@ has - '//code/a[@href="fn.Name.html"]' "Name"
+//@ has - '//code/a[@href="macro.Name.html"]' "Name"
 pub struct AtDisambiguator;
 
 /// fn: [`Name()`], macro: [`Name!`]
 //@ has disambiguators_removed/struct.SymbolDisambiguator.html
-//@ has - '//a[@href="fn.Name.html"][code]' "Name()"
-//@ has - '//a[@href="macro.Name.html"][code]' "Name!"
+//@ has - '//code/a[@href="fn.Name.html"]' "Name()"
+//@ has - '//code/a[@href="macro.Name.html"]' "Name!"
 pub struct SymbolDisambiguator;
 
 // Now make sure that backticks aren't added if they weren't already there

--- a/tests/rustdoc/primitive-link.rs
+++ b/tests/rustdoc/primitive-link.rs
@@ -1,12 +1,11 @@
 #![crate_name = "foo"]
 
-
-//@ has foo/struct.Foo.html '//*[@class="docblock"]/p/a[@href="{{channel}}/std/primitive.u32.html"]' 'u32'
+//@ has foo/struct.Foo.html '//*[@class="docblock"]/p/code/a[@href="{{channel}}/std/primitive.u32.html"]' 'u32'
 //@ has foo/struct.Foo.html '//*[@class="docblock"]/p/a[@href="{{channel}}/std/primitive.i64.html"]' 'i64'
 //@ has foo/struct.Foo.html '//*[@class="docblock"]/p/a[@href="{{channel}}/std/primitive.i32.html"]' 'std::primitive::i32'
 //@ has foo/struct.Foo.html '//*[@class="docblock"]/p/a[@href="{{channel}}/std/primitive.str.html"]' 'std::primitive::str'
 
-//@ has foo/struct.Foo.html '//*[@class="docblock"]/p/a[@href="{{channel}}/std/primitive.i32.html#associatedconstant.MAX"]' 'std::primitive::i32::MAX'
+//@ has foo/struct.Foo.html '//*[@class="docblock"]/p/code/a[@href="{{channel}}/std/primitive.i32.html#associatedconstant.MAX"]' 'std::primitive::i32::MAX'
 
 /// It contains [`u32`] and [i64].
 /// It also links to [std::primitive::i32], [std::primitive::str],

--- a/tests/rustdoc/short-docblock.rs
+++ b/tests/rustdoc/short-docblock.rs
@@ -20,7 +20,7 @@ pub fn foo() {}
 /// foo mod
 pub mod foo {}
 
-//@ has foo/index.html '//dd/a[@href="https://nougat.world"]/code' 'nougat'
+//@ has foo/index.html '//dd/code/a[@href="https://nougat.world"]' 'nougat'
 
 /// [`nougat`](https://nougat.world)
 pub struct Bar;


### PR DESCRIPTION
Fixes #62867.
Fixes #83997.

When we have multiple `<code>` tags following each others, we never tried merging them into one, especially when a `<code>` is inside a `<a>`. This PR merges them into one `<code>`, making the generated HTML shorter. And it has the nice side-effect of also making it look nicer.

Before:

![image](https://github.com/user-attachments/assets/b28b2e81-88d8-4fce-8d12-2b0f11e996a8)

After:

![image](https://github.com/user-attachments/assets/588e2590-f711-433e-ab2c-1701a79b2bcd)

You can test it [here](https://rustdoc.crud.net/imperio/merge-code-tags/foo/index.html).

r? @notriddle 