### PR TITLE
Ensure that we never try to monomorphize the upcasting or vtable calls of impossible dyn types

### DIFF
--- a/tests/ui/traits/trait-upcasting/mono-impossible.rs
+++ b/tests/ui/traits/trait-upcasting/mono-impossible.rs
@@ -1,0 +1,26 @@
+//@ build-pass
+
+#![feature(trait_upcasting)]
+
+trait Supertrait<T> {
+    fn method(&self) {}
+}
+impl<T> Supertrait<T> for () {}
+
+trait WithAssoc {
+    type Assoc;
+}
+trait Trait<P: WithAssoc>: Supertrait<P::Assoc> + Supertrait<()> {}
+
+fn upcast<P>(x: &dyn Trait<P>) -> &dyn Supertrait<()> {
+    x
+}
+
+fn call<P>(x: &dyn Trait<P>) {
+    x.method();
+}
+
+fn main() {
+    println!("{:p}", upcast::<()> as *const ());
+    println!("{:p}", call::<()> as *const ());
+}


### PR DESCRIPTION
Check for impossible obligations in the `dyn Trait` type we're trying to compute its the vtable upcasting and method call slots.

r? lcnr