### PR TITLE
Use proper type when applying deref adjustment in const

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -253,6 +253,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         }
 
+        let mut expr_ty = self.typeck_results.borrow().expr_ty_adjusted(expr);
+
         for a in &adj {
             match a.kind {
                 Adjust::NeverToAny => {
@@ -266,7 +268,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         None,
                         expr.span,
                         overloaded_deref.method_call(self.tcx),
-                        self.tcx.mk_args(&[a.target.into()]),
+                        self.tcx.mk_args(&[expr_ty.into()]),
                     );
                 }
                 Adjust::Deref(None) => {
@@ -283,6 +285,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // No effects to enforce here.
                 }
             }
+
+            expr_ty = a.target;
         }
 
         let autoborrow_mut = adj.iter().any(|adj| {

--- a/tests/crashes/135210.rs
+++ b/tests/crashes/135210.rs
@@ -1,8 +1,0 @@
-//@ known-bug: #135210
-
-#![feature(const_trait_impl)]
-const _: fn(&String) = |s| {
-    &*s as &str;
-};
-
-fn main() {}

--- a/tests/ui/traits/const-traits/enforce-deref-on-adjust.rs
+++ b/tests/ui/traits/const-traits/enforce-deref-on-adjust.rs
@@ -1,0 +1,28 @@
+//@ check-pass
+
+#![feature(const_deref)]
+#![feature(const_trait_impl)]
+
+use std::ops::Deref;
+
+struct Wrap<T>(T);
+struct Foo;
+
+impl Foo {
+    const fn call(&self) {}
+}
+
+impl<T> const Deref for Wrap<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+const fn foo() {
+    let x = Wrap(Foo);
+    x.call();
+}
+
+fn main() {}


### PR DESCRIPTION
When applying a deref adjustment to some type `Wrap<T>` which derefs to `T`, we were checking that `T: ~const Deref`, not `Wrap<T>: ~const Deref` like we should have been.

r? project-const-traits

Fixes #136273
Fixes #135210 -- I just deleted the test since the regression test is uninteresting