### PR TITLE
Use short ty string for binop and unop errors

### DIFF
--- a/tests/ui/diagnostic-width/binop.rs
+++ b/tests/ui/diagnostic-width/binop.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: --diagnostic-width=60 -Zwrite-long-types-to-disk=yes
+// The regex below normalizes the long type file name to make it suitable for compare-modes.
+//@ normalize-stderr: "'\$TEST_BUILD_DIR/.*\.long-type-\d+.txt'" -> "'$$TEST_BUILD_DIR/$$FILE.long-type-hash.txt'"
+type A = (i32, i32, i32, i32);
+type B = (A, A, A, A);
+type C = (B, B, B, B);
+type D = (C, C, C, C);
+
+fn foo(x: D) {
+    x + x; //~ ERROR cannot add `(...
+}
+
+fn bar(x: D) {
+    !x; //~ ERROR cannot apply unary operator `!` to type `(...
+}
+
+fn main() {}

--- a/tests/ui/diagnostic-width/binop.stderr
+++ b/tests/ui/diagnostic-width/binop.stderr
@@ -1,0 +1,24 @@
+error[E0369]: cannot add `(..., ..., ..., ...)` to `(..., ..., ..., ...)`
+  --> $DIR/binop.rs:10:7
+   |
+LL |     x + x;
+   |     - ^ - (..., ..., ..., ...)
+   |     |
+   |     (..., ..., ..., ...)
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
+error[E0600]: cannot apply unary operator `!` to type `(..., ..., ..., ...)`
+  --> $DIR/binop.rs:14:5
+   |
+LL |     !x;
+   |     ^^ cannot apply unary operator `!`
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0369, E0600.
+For more information about an error, try `rustc --explain E0369`.


### PR DESCRIPTION
```
error[E0369]: cannot add `(..., ..., ..., ...)` to `(..., ..., ..., ...)`
  --> $DIR/binop.rs:10:7
   |
LL |     x + x;
   |     - ^ - (..., ..., ..., ...)
   |     |
   |     (..., ..., ..., ...)
   |
   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
   = note: consider using `--verbose` to print the full type name to the console
```
```
error[E0600]: cannot apply unary operator `!` to type `(..., ..., ..., ...)`
  --> $DIR/binop.rs:14:5
   |
LL |     !x;
   |     ^^ cannot apply unary operator `!`
   |
   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
   = note: consider using `--verbose` to print the full type name to the console
```

CC #135919.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
