### PR TITLE
Trait methods inherit trait const stability, do not inherit const stability from their own regular stability

### DIFF
--- a/tests/ui/traits/const-traits/auxiliary/staged-api.rs
+++ b/tests/ui/traits/const-traits/auxiliary/staged-api.rs
@@ -9,6 +9,13 @@
 pub trait MyTrait {
     #[stable(feature = "rust1", since = "1.0.0")]
     fn func();
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn default<T: ~const MyTrait>() {
+        // This call is const-unstable, but permitted here since we inherit
+        // the `rustc_const_unstable` above.
+        T::func();
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -18,6 +25,12 @@ pub struct Unstable;
 #[rustc_const_unstable(feature = "unstable", issue = "none")]
 impl const MyTrait for Unstable {
     fn func() {}
+
+    fn default<T: ~const MyTrait>() {
+        // This call is const-unstable, but permitted here since we inherit
+        // the `rustc_const_unstable` above.
+        T::func();
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Needed to constify `PartialEq`:

```
#[stable(feature = "rust1", since = "1.0.0")]
#[rustc_const_unstable(feature = "const_cmp", issue = "none")]
#[const_trait]
pub trait PartialEq<Rhs: ?Sized = Self> {
    #[stable(feature = "rust1", since = "1.0.0")]
    fn eq(&self, other: &Rhs) -> bool;

    #[stable(feature = "rust1", since = "1.0.0")]
    fn ne(&self, other: &Rhs) -> bool {
        !self.eq(other)
    }
}
```

Since currently, we get const stability errors in `fn ne`, since it's currently considered to be const stable via inheriting const stability from its own *regular* stability, rather than from the parent trait, and thus we can't call `Self::eq` b/c it requires the `const_trait_impl` and `const_cmp` features.

We do two changes:
1. Do not inherit const stability from regular stability if there's parent stability.
2. Make sure to set `InheritConstStability::Yes` for trait items.

cc @rust-lang/project-const-generics 
r? RalfJung

This stability computation code is kinda jank, maybe it should get rewritten :S