### PR TITLE
Pass deployment target to cc linker with `-m*-version-min=`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/apple/tests.rs
+++ b/compiler/rustc_codegen_ssa/src/back/apple/tests.rs
@@ -1,4 +1,4 @@
-use super::{add_version_to_llvm_target, parse_version};
+use super::{add_version_to_llvm_target, cc_os_version_min_flag, parse_version};
 
 #[test]
 fn test_add_version_to_llvm_target() {
@@ -18,4 +18,14 @@ fn test_parse_version() {
     assert_eq!(parse_version("10.12"), Ok((10, 12, 0)));
     assert_eq!(parse_version("10.12.6"), Ok((10, 12, 6)));
     assert_eq!(parse_version("9999.99.99"), Ok((9999, 99, 99)));
+}
+
+#[test]
+fn test_cc_os_version_min_flag() {
+    assert_eq!(cc_os_version_min_flag("macos", "", (10, 14, 1)), "-mmacosx-version-min=10.14.1");
+    assert_eq!(cc_os_version_min_flag("ios", "macabi", (13, 1, 0)), "-mtargetos=ios13.1.0-macabi");
+    assert_eq!(
+        cc_os_version_min_flag("visionos", "sim", (1, 0, 0)),
+        "-mtargetos=xros1.0.0-simulator"
+    );
 }


### PR DESCRIPTION
Clang supports many ways of passing the deployment target, [and prefers](https://github.com/llvm/llvm-project/issues/88271#issuecomment-2050425068) that you use the `-target` flag for doing so. This, however, works poorly work with Clang configuration files (at least before https://github.com/llvm/llvm-project/pull/111387) and [Zig CC](https://github.com/ziglang/zig/issues/4911).

To support GCC, we already passed the deployment target using the older, more widely supported `-arch` + `-mmacosx-version-min=` flag combination when compiling for macOS; let's do a similar thing for the other Apple targets too using `-miphoneos-version-min=`, `-mtargetos=` etc.

Note that when passing the target triple to the LLVM backend, we still have to merge the deployment target into that.

See also [the similar fix in `cc-rs`](https://github.com/rust-lang/cc-rs/pull/1339) where the problem is more prominent, exactly because we did not already do it for macOS.

@rustbot label O-apple
r? compiler
CC @thomcc @BlackHoleFox