### PR TITLE
fix(libtest): Enable Instant on Emscripten targets

### DIFF
--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -314,9 +314,10 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
     let mut st = ConsoleTestState::new(opts)?;
 
     // Prevent the usage of `Instant` in some cases:
-    // - It's currently not supported for wasm targets.
+    // - It's currently not supported for wasm targets without Emscripten nor WASI.
+    // - It's currently not supported for zkvm targets.
     let is_instant_unsupported =
-        (cfg!(target_family = "wasm") && !cfg!(target_os = "wasi")) || cfg!(target_os = "zkvm");
+        (cfg!(target_family = "wasm") && cfg!(target_os = "unknown")) || cfg!(target_os = "zkvm");
 
     let start_time = (!is_instant_unsupported).then(Instant::now);
     run_tests(opts, tests, |x| on_test_event(&x, &mut st, &mut *out))?;


### PR DESCRIPTION
`Instant::now()` works correctly on Emscripten since https://github.com/rust-lang/libc/pull/3962. All wasm-family targets with OS support can now handle instants.

Improves #131738.

~~This changes the behavior of libtest on `unknown-unknown`/`unknown-none` wasm targets, but as far as I can see, libtest doesn't support them anyway. (Can anyone double-check?)~~ UPD: this patch no longer affects `unknown-unknown` targets.

@rustbot label +A-libtest +T-testing-devex +O-emscripten +O-wasm -needs-triage