### PR TITLE
`#[optimize(none)]` implies `#[inline(never)]`

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -4,7 +4,7 @@ use std::iter;
 use std::ops::{Range, RangeFrom};
 
 use rustc_abi::{ExternAbi, FieldIdx};
-use rustc_attr_parsing::InlineAttr;
+use rustc_attr_parsing::{InlineAttr, OptimizeAttr};
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_index::Idx;
@@ -768,6 +768,10 @@ fn check_codegen_attributes<'tcx, I: Inliner<'tcx>>(
     let tcx = inliner.tcx();
     if let InlineAttr::Never = callee_attrs.inline {
         return Err("never inline attribute");
+    }
+
+    if let OptimizeAttr::DoNotOptimize = callee_attrs.optimize {
+        return Err("has DoNotOptimize attribute");
     }
 
     // Reachability pass defines which functions are eligible for inlining. Generally inlining

--- a/tests/codegen/issues/issue-136329-optnone-noinline.rs
+++ b/tests/codegen/issues/issue-136329-optnone-noinline.rs
@@ -1,0 +1,21 @@
+//! Ensure that `#[optimize(none)]` functions are never inlined
+
+//@ compile-flags: -Copt-level=3
+
+#![feature(optimize_attribute)]
+
+#[optimize(none)]
+pub fn foo() {
+    let _x = 123;
+}
+
+// CHECK-LABEL: define{{.*}}void @bar
+// CHECK: start:
+// CHECK: {{.*}}call {{.*}}void
+// CHECK: ret void
+#[no_mangle]
+pub fn bar() {
+    foo();
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #136329