### PR TITLE
Add link attribute for Enzyme's LLVMRust FFI

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/enzyme_ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/enzyme_ffi.rs
@@ -4,6 +4,8 @@ use libc::{c_char, c_uint};
 
 use super::ffi::{BasicBlock, Metadata, Module, Type, Value};
 use crate::llvm::Bool;
+
+#[link(name = "llvm-wrapper", kind = "static")]
 extern "C" {
     // Enzyme
     pub fn LLVMRustHasMetadata(I: &Value, KindID: c_uint) -> bool;
@@ -12,10 +14,13 @@ extern "C" {
     pub fn LLVMRustDIGetInstMetadata(I: &Value) -> Option<&Metadata>;
     pub fn LLVMRustEraseInstFromParent(V: &Value);
     pub fn LLVMRustGetTerminator<'a>(B: &BasicBlock) -> &'a Value;
+    pub fn LLVMRustVerifyFunction(V: &Value, action: LLVMRustVerifierFailureAction) -> Bool;
+}
+
+extern "C" {
+    // Enzyme
     pub fn LLVMDumpModule(M: &Module);
     pub fn LLVMDumpValue(V: &Value);
-    pub fn LLVMRustVerifyFunction(V: &Value, action: LLVMRustVerifierFailureAction) -> Bool;
-
     pub fn LLVMGetFunctionCallConv(F: &Value) -> c_uint;
     pub fn LLVMGetReturnType(T: &Type) -> &Type;
     pub fn LLVMGetParams(Fnc: &Value, parms: *mut &Value);


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/133429 landed, the compiler doesn't build with `-Zcross-crate-inline-threshold=always`. I don't expect anyone else to test or fix issues with that goofy configuration, so I'm fixing it.

This PR adds a link attribute just like https://github.com/rust-lang/rust/pull/118142 for all the new LLVMRust functions. They were actually added in https://github.com/rust-lang/rust/pull/130060 but weren't used until just now.