### PR TITLE
fix: correct small grammar and typo issues in compiler docs/tests

### DIFF
--- a/compiler/rustc_lint/src/if_let_rescope.rs
+++ b/compiler/rustc_lint/src/if_let_rescope.rs
@@ -211,7 +211,7 @@ impl IfLetRescope {
                     }
                 }
             }
-            // At this point, any `if let` fragment in the cascade is definitely preceeded by `else`,
+            // At this point, any `if let` fragment in the cascade is definitely preceded by `else`,
             // so a opening bracket is mandatory before each `match`.
             add_bracket_to_match_head = true;
             if let Some(alt) = alt {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3155,17 +3155,17 @@ declare_lint! {
     /// ```
     ///
     /// ```rust,ignore (needs command line option)
-    /// #[cfg(widnows)]
+    /// #[cfg(windows)]
     /// fn foo() {}
     /// ```
     ///
     /// This will produce:
     ///
     /// ```text
-    /// warning: unexpected `cfg` condition name: `widnows`
+    /// warning: unexpected `cfg` condition name: `windows`
     ///  --> lint_example.rs:1:7
     ///   |
-    /// 1 | #[cfg(widnows)]
+    /// 1 | #[cfg(windows)]
     ///   |       ^^^^^^^
     ///   |
     ///   = note: `#[warn(unexpected_cfgs)]` on by default

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -529,7 +529,7 @@ fn collect_items_rec<'tcx>(
         });
     }
     // Only updating `usage_map` for used items as otherwise we may be inserting the same item
-    // multiple times (if it is first 'mentioned' and then later actuall used), and the usage map
+    // multiple times (if it is first 'mentioned' and then later actually used), and the usage map
     // logic does not like that.
     // This is part of the output of collection and hence only relevant for "used" items.
     // ("Mentioned" items are only considered internally during collection.)

--- a/src/etc/test-float-parse/src/gen/integers.rs
+++ b/src/etc/test-float-parse/src/gen/integers.rs
@@ -15,7 +15,7 @@ const SMALL_VALUES: RangeInclusive<i32> = {
 /// Large values only get tested around powers of two
 const LARGE_POWERS: Range<u32> = SMALL_MAX_POW2..128;
 
-/// We perturbe each large value around these ranges
+/// We perturb each large value around these ranges
 const LARGE_PERTURBATIONS: RangeInclusive<i128> = -256..=256;
 
 /// Test all integers up to `2 ^ MAX_POW2`

--- a/src/etc/test-float-parse/src/validate.rs
+++ b/src/etc/test-float-parse/src/validate.rs
@@ -279,7 +279,7 @@ fn decode<F: Float>(f: F) -> FloatRes<F> {
 
     let mut exponent = i32::try_from(exponent_biased).unwrap();
 
-    // Adjust for bias and the rnage of the mantissa
+    // Adjust for bias and the range of the mantissa
     exponent -= i32::try_from(F::EXP_BIAS + F::MAN_BITS).unwrap();
 
     if f.is_sign_negative() {

--- a/src/etc/test-float-parse/src/validate.rs
+++ b/src/etc/test-float-parse/src/validate.rs
@@ -317,7 +317,7 @@ impl Rational {
             return Rational::NegInf;
         }
 
-        // Fast path; no decimals or exponents ot parse
+        // Fast path; no decimals or exponents to parse
         if s.bytes().all(|b| b.is_ascii_digit() || b == b'-') {
             return Rational::Finite(BigRational::from_str(s).unwrap());
         }

--- a/src/librustdoc/html/markdown/footnotes.rs
+++ b/src/librustdoc/html/markdown/footnotes.rs
@@ -38,7 +38,7 @@ impl<'a, I: Iterator<Item = SpannedEvent<'a>>> Footnotes<'a, I> {
         let key = key.to_owned();
         let FootnoteDef { content, id } =
             self.footnotes.entry(key).or_insert(FootnoteDef { content: Vec::new(), id: new_id });
-        // Don't allow changing the ID of existing entrys, but allow changing the contents.
+        // Don't allow changing the ID of existing entries, but allow changing the contents.
         (content, *id)
     }
 

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -211,7 +211,7 @@ declare namespace rustdoc {
      *
      *     fn something() -> Result<usize, usize>
      *
-     * If output was allowed to be any RawFunctionType, it would look like thi
+     * If output was allowed to be any RawFunctionType, it would look like this
      *
      *     [[], [50, [3, 3]]]
      *
@@ -221,7 +221,7 @@ declare namespace rustdoc {
      * in favor of the pair of types interpretation. This is why the `(number|Array<RawFunctionType>)`
      * is used instead of `(RawFunctionType|Array<RawFunctionType>)`.
      *
-     * The output can be skipped if it's actually unit and there's no type constraints. If thi
+     * The output can be skipped if it's actually unit and there's no type constraints. If this
      * function accepts constrained generics, then the output will be unconditionally emitted, and
      * after it will come a list of trait constraints. The position of the item in the list will
      * determine which type parameter it is. For example:

--- a/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-sse42.rs
+++ b/src/tools/miri/tests/pass/shims/x86/intrinsics-x86-sse42.rs
@@ -375,7 +375,7 @@ unsafe fn test_str() {
     }
     test_ranges();
 
-    // Confirm that the polarity bits work as indended.
+    // Confirm that the polarity bits work as intended.
     #[target_feature(enable = "sse4.2")]
     unsafe fn test_polarity() {
         let a = str_to_m128i(b"Hello!");


### PR DESCRIPTION
- Changed “preceded” and “intended” typos.
- Replaced “thi” → “this” and fixed a few minor grammar points across various comments.
- No functional code changes, just documentation cleanup.