### PR TITLE
WIP/ POC Add `no_iu128_fmt` config to disable 128 bit integer formatting.

### DIFF
--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -29,6 +29,7 @@ level = "warn"
 check-cfg = [
     'cfg(bootstrap)',
     'cfg(no_fp_fmt_parse)',
+    'cfg(no_iu128_fmt)',
     'cfg(stdarch_intel_sde)',
     'cfg(target_arch, values("xtensa"))',
     # core use #[path] imports to portable-simd `core_simd` crate

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -546,6 +546,7 @@ mod imp {
     impl_Exp!(i8, u8, i16, u16, i32, u32, isize, usize as u32 via to_u32 named exp_u32);
     impl_Exp!(i64, u64 as u64 via to_u64 named exp_u64);
 }
+#[cfg(not(no_iu128_fmt))]
 impl_Exp!(i128, u128 as u128 via to_u128 named exp_u128);
 
 /// Helper function for writing a u64 into `buf` going from last to first, with `curr`.
@@ -638,21 +639,29 @@ fn parse_u64_into<const N: usize>(mut n: u64, buf: &mut [MaybeUninit<u8>; N], cu
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for u128 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt_u128(*self, true, f)
+        if cfg!(no_iu128_fmt) {
+            panic!("u128 formatting support is turned off")
+        } else {
+            fmt_u128(*self, true, f)
+        }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for i128 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let is_nonnegative = *self >= 0;
-        let n = if is_nonnegative {
-            self.to_u128()
+        if cfg!(no_iu128_fmt) {
+            panic!("u128 formatting support is turned off")
         } else {
-            // convert the negative num to positive by summing 1 to its 2s complement
-            (!self.to_u128()).wrapping_add(1)
-        };
-        fmt_u128(n, is_nonnegative, f)
+            let is_nonnegative = *self >= 0;
+            let n = if is_nonnegative {
+                self.to_u128()
+            } else {
+                // convert the negative num to positive by summing 1 to its 2s complement
+                (!self.to_u128()).wrapping_add(1)
+            };
+            fmt_u128(n, is_nonnegative, f)
+        }
     }
 }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -66,6 +66,7 @@
 #![doc(cfg_hide(
     not(test),
     no_fp_fmt_parse,
+    no_iu128_fmt,
     target_pointer_width = "16",
     target_pointer_width = "32",
     target_pointer_width = "64",

--- a/library/coretests/Cargo.toml
+++ b/library/coretests/Cargo.toml
@@ -25,3 +25,8 @@ test = true
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false }
 rand_xorshift = { version = "0.3.0", default-features = false }
+
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(no_iu128_fmt)']

--- a/library/coretests/benches/fmt.rs
+++ b/library/coretests/benches/fmt.rs
@@ -122,6 +122,7 @@ fn write_str_macro_debug_ascii(bh: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(not(no_iu128_fmt))]
 fn write_u128_max(bh: &mut Bencher) {
     bh.iter(|| {
         test::black_box(format!("{}", u128::MAX));

--- a/library/coretests/tests/num/int_sqrt.rs
+++ b/library/coretests/tests/num/int_sqrt.rs
@@ -244,5 +244,8 @@ macro_rules! unsigned_check {
     };
 }
 
-tests!(signed_check: i8 i16 i32 i64 i128);
+tests!(signed_check: i8 i16 i32 i64);
+#[cfg(not(no_iu128_fmt))]
+tests!(signed_check: i128);
+
 tests!(unsigned_check: u8 u16 u32 u64 u128);


### PR DESCRIPTION
Add a new config option  `no_iu128_fmt` to core, which disables some u/i 128 formatting in order to reduce the need for some division intrinsics in the linux kernel.

RFC patch for linux that uses this:
https://lore.kernel.org/rust-for-linux/20250201-remove_intrinsic-v1-1-4283ce8e4764@gmail.com/T/#u