### PR TITLE
bootstrap: add wrapper macros for `feature = "tracing"`-gated `tracing` macros

### DIFF
--- a/src/bootstrap/src/utils/mod.rs
+++ b/src/bootstrap/src/utils/mod.rs
@@ -14,6 +14,8 @@ pub(crate) mod render_tests;
 pub(crate) mod shared_helpers;
 pub(crate) mod tarball;
 
+pub(crate) mod tracing;
+
 #[cfg(feature = "build-metrics")]
 pub(crate) mod metrics;
 

--- a/src/bootstrap/src/utils/tracing.rs
+++ b/src/bootstrap/src/utils/tracing.rs
@@ -1,0 +1,49 @@
+//! Wrapper macros for `tracing` macros to avoid having to write `cfg(feature = "tracing")`-gated
+//! `debug!`/`trace!` everytime, e.g.
+//!
+//! ```rust,ignore (example)
+//! #[cfg(feature = "tracing")]
+//! trace!("...");
+//! ```
+//!
+//! When `feature = "tracing"` is inactive, these macros expand to nothing.
+
+#[macro_export]
+macro_rules! trace {
+    ($($tokens:tt)*) => {
+        #[cfg(feature = "tracing")]
+        ::tracing::trace!($($tokens)*)
+    }
+}
+
+#[macro_export]
+macro_rules! debug {
+    ($($tokens:tt)*) => {
+        #[cfg(feature = "tracing")]
+        ::tracing::debug!($($tokens)*)
+    }
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($tokens:tt)*) => {
+        #[cfg(feature = "tracing")]
+        ::tracing::warn!($($tokens)*)
+    }
+}
+
+#[macro_export]
+macro_rules! info {
+    ($($tokens:tt)*) => {
+        #[cfg(feature = "tracing")]
+        ::tracing::info!($($tokens)*)
+    }
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($tokens:tt)*) => {
+        #[cfg(feature = "tracing")]
+        ::tracing::error!($($tokens)*)
+    }
+}


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/136091#discussion_r1930219425.

- Add wrapper macros for `error!`, `warn!`, `info!`, `debug!` and `trace!`, which `cfg(feature = "tracing")`-gates the underlying `tracing` macros. They expand to nothing if `"tracing"` feature is not enabled.
- This is not done for `span!` or `event!` because they can return span guards, and you can't really wrap that.
- This is also not possible for `tracing::instrument` attribute proc-macro unless you use another attribute proc-macro to wrap that.

It's not *great*, because `tracing::instrument` and `tracing::{span,event}` can't be wrapped this way.

Can test locally with:

```bash
$ BOOTSTRAP_TRACING=bootstrap=TRACE ./x check src/bootstrap/ 
```

r? @onur-ozkan (or reroll)