### PR TITLE
rustdoc-json-types: Document that crate name isn't package name.

### DIFF
--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -61,6 +61,13 @@ pub struct Crate {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ExternalCrate {
     /// The name of the crate.
+    ///
+    /// Note: This is the [*crate* name][crate-name], which may not be the same as the
+    /// [*package* name][package-name]. For example, for <https://crates.io/crates/regex-syntax>,
+    /// this field will be `regex_syntax` (which uses an `_`, not a `-`).
+    ///
+    /// [crate-name]: https://doc.rust-lang.org/stable/cargo/reference/cargo-targets.html#the-name-field
+    /// [package-name]: https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-name-field
     pub name: String,
     /// The root URL at which the crate's documentation lives.
     pub html_root_url: Option<String>,


### PR DESCRIPTION
This wasn't clear from the docs before: https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc/topic/.E2.9C.94.20Getting.20external.20crate.20names.20as.20defined. CC @kpreid

r? @GuillaumeGomez 