### PR TITLE
Fix malformed error annotations in a UI test

### DIFF
--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.rs
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.rs
@@ -5,6 +5,6 @@ fn main() {
     let page_size = page_size::get();
     //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `page_size`
     //~| NOTE use of unresolved module or unlinked crate `page_size`
-    //@[cargo-invoked]~^^^ HELP if you wanted to use a crate named `page_size`, use `cargo add
-    //@[only-rustc]~^^^^ HELP you might be missing a crate named `page_size`
+    //[cargo-invoked]~^^^ HELP if you wanted to use a crate named `page_size`, use `cargo add
+    //[only-rustc]~^^^^ HELP you might be missing a crate named `page_size`
 }


### PR DESCRIPTION
The compiletest DSL still features a historical remnant from the time when its directives were merely prefixed with `//` instead of `//@` when unknown directive names weren't rejected since they could just as well be part of prose:

As an "optimization", it stops looking for directives once it stumbles upon a line which starts with either `fn` or `mod`. This allowed a malformed error annotation of the form `//@[…]~^^^` to go undetected & unexercised (as it's placed below `fn main() {`).

Obviously a character other than `@` would've mangled the error annotation, too (but it might've caught the reviewer's eye). I specifically found this file because I ran `rg '^(fn|mod)[\s\S]*?//@' tests/ui --multiline -trust` to check how footgun-y that "special feature" of compiletest is.