### PR TITLE
Remove a footgun-y feature / relic of the past from the compiletest DSL

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -882,14 +882,6 @@ fn iter_header(
         }
         let ln = ln.trim();
 
-        // Assume that any directives will be found before the first module or function. This
-        // doesn't seem to be an optimization with a warm page cache. Maybe with a cold one.
-        // FIXME(jieyouxu): this will cause `//@` directives in the rest of the test file to
-        // not be checked.
-        if ln.starts_with("fn") || ln.starts_with("mod") {
-            return;
-        }
-
         let Some(directive_line) = line_directive(line_number, comment, ln) else {
             continue;
         };

--- a/tests/assembly/small_data_threshold.rs
+++ b/tests/assembly/small_data_threshold.rs
@@ -58,35 +58,35 @@ static mut Z: u64 = 0;
 // Currently, only MIPS and RISCV successfully put any objects in the small data
 // sections so the U/V/W/X tests are skipped on Hexagon and M68K
 
-//@ RISCV: .section .sdata
-//@ RISCV-NOT: .section
-//@ RISCV: U:
-//@ RISCV: .section .sbss
-//@ RISCV-NOT: .section
-//@ RISCV: V:
-//@ RISCV: .section .sdata
-//@ RISCV-NOT: .section
-//@ RISCV: W:
-//@ RISCV: .section .sbss
-//@ RISCV-NOT: .section
-//@ RISCV: X:
+// RISCV: .section .sdata
+// RISCV-NOT: .section
+// RISCV: U:
+// RISCV: .section .sbss
+// RISCV-NOT: .section
+// RISCV: V:
+// RISCV: .section .sdata
+// RISCV-NOT: .section
+// RISCV: W:
+// RISCV: .section .sbss
+// RISCV-NOT: .section
+// RISCV: X:
 
-//@ MIPS: .section .sdata
-//@ MIPS-NOT: .section
-//@ MIPS: U:
-//@ MIPS: .section .sbss
-//@ MIPS-NOT: .section
-//@ MIPS: V:
-//@ MIPS: .section .sdata
-//@ MIPS-NOT: .section
-//@ MIPS: W:
-//@ MIPS: .section .sbss
-//@ MIPS-NOT: .section
-//@ MIPS: X:
+// MIPS: .section .sdata
+// MIPS-NOT: .section
+// MIPS: U:
+// MIPS: .section .sbss
+// MIPS-NOT: .section
+// MIPS: V:
+// MIPS: .section .sdata
+// MIPS-NOT: .section
+// MIPS: W:
+// MIPS: .section .sbss
+// MIPS-NOT: .section
+// MIPS: X:
 
-//@ CHECK: .section .data.Y,
-//@ CHECK-NOT: .section
-//@ CHECK: Y:
-//@ CHECK: .section .bss.Z,
-//@ CHECK-NOT: .section
-//@ CHECK: Z:
+// CHECK: .section .data.Y,
+// CHECK-NOT: .section
+// CHECK: Y:
+// CHECK: .section .bss.Z,
+// CHECK-NOT: .section
+// CHECK: Z:


### PR DESCRIPTION
The compiletest DSL still features a historical remnant from the time when its directives were merely prefixed with `//` instead of `//@` when unknown directive names weren't rejected since they could just as well be part of prose:

As an "optimization", it stops looking for directives once it stumbles upon a line which starts with either `fn` or `mod`. This is super footgun-y as it obviously leads to any seeming compiletest directives below `fn` and `mod` items getting completely ignored.

See #136403 for a practical example. As well the assembly test updated in this PR.

~~Blocked on #136403.~~ (merged)