### PR TITLE
Reject function items as const arguments

### DIFF
--- a/tests/ui/const-generics/fn-item-as-const-arg.rs
+++ b/tests/ui/const-generics/fn-item-as-const-arg.rs
@@ -1,0 +1,10 @@
+// src/test/ui/const-generics/fn-item-as-const-arg.rs
+
+#![feature(min_generic_const_args)] //~ WARNING the feature `min_generic_const_args` is incomplete
+
+fn func() {}
+
+fn test<F>() where [(); func]: {}
+//~^ ERROR function items cannot be used as const arguments
+
+fn main() {}

--- a/tests/ui/const-generics/fn-item-as-const-arg.stderr
+++ b/tests/ui/const-generics/fn-item-as-const-arg.stderr
@@ -1,0 +1,17 @@
+warning: the feature `min_generic_const_args` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/fn-item-as-const-arg.rs:3:12
+   |
+LL | #![feature(min_generic_const_args)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: function items cannot be used as const arguments
+  --> $DIR/fn-item-as-const-arg.rs:7:25
+   |
+LL | fn test<F>() where [(); func]: {}
+   |                         ^^^^
+
+error: aborting due to 1 previous error; 1 warning emitted
+


### PR DESCRIPTION
This commit addresses an ICE caused by using function items as const arguments in generic contexts. Previously, the compiler would panic when encountering such cases due to unsupported behavior in `min_generic_const_args`. This fix improves error handling by detecting function items in `lower_const_arg` and emitting a user-friendly error message instead of crashing.

Changes:
- Added logic in `hir_ty_lowering::lower_const_arg` to detect and reject function items as const arguments.
- Introduced a new UI test (`fn-item-as-const-arg.rs`) to validate the fix.

Fixes #136337