### PR TITLE
Use `widening_mul` instead of a separate function

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -726,28 +726,9 @@ fn udiv_1e19(n: u128) -> (u128, u64) {
     let quot = if n < 1 << 83 {
         ((n >> 19) as u64 / (DIV >> 19)) as u128
     } else {
-        u128_mulhi(n, FACTOR) >> 62
+        n.widening_mul(FACTOR).1 >> 62
     };
 
     let rem = (n - quot * DIV as u128) as u64;
     (quot, rem)
-}
-
-/// Multiply unsigned 128 bit integers, return upper 128 bits of the result
-#[inline]
-fn u128_mulhi(x: u128, y: u128) -> u128 {
-    let x_lo = x as u64;
-    let x_hi = (x >> 64) as u64;
-    let y_lo = y as u64;
-    let y_hi = (y >> 64) as u64;
-
-    // handle possibility of overflow
-    let carry = (x_lo as u128 * y_lo as u128) >> 64;
-    let m = x_lo as u128 * y_hi as u128 + carry;
-    let high1 = m >> 64;
-
-    let m_lo = m as u64;
-    let high2 = (x_hi as u128 * y_lo as u128 + m_lo as u128) >> 64;
-
-    x_hi as u128 * y_hi as u128 + high1 + high2
 }


### PR DESCRIPTION
A helper function became obsolete after `widening_mul` became available for `u128` values.
