### PR TITLE
Omit argument names from function pointers that do not have argument names

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1408,7 +1408,9 @@ impl clean::Arguments {
     ) -> impl Display + 'a + Captures<'tcx> {
         fmt::from_fn(move |f| {
             for (i, input) in self.values.iter().enumerate() {
-                write!(f, "{}: ", input.name)?;
+                if !input.name.is_empty() {
+                    write!(f, "{}: ", input.name)?;
+                }
                 input.type_.print(cx).fmt(f)?;
                 if i + 1 < self.values.len() {
                     write!(f, ", ")?;

--- a/tests/rustdoc/assoc-consts.rs
+++ b/tests/rustdoc/assoc-consts.rs
@@ -45,7 +45,7 @@ pub fn f(_: &(ToString + 'static)) {}
 
 impl Bar {
     //@ has assoc_consts/struct.Bar.html '//*[@id="associatedconstant.F"]' \
-    //      "const F: fn(_: &(dyn ToString + 'static))"
+    //      "const F: fn(&(dyn ToString + 'static))"
     pub const F: fn(_: &(ToString + 'static)) = f;
 }
 

--- a/tests/rustdoc/fn-pointer-arg-name.rs
+++ b/tests/rustdoc/fn-pointer-arg-name.rs
@@ -3,3 +3,11 @@
 //@ has foo/fn.f.html
 //@ has - '//pre[@class="rust item-decl"]' 'pub fn f(callback: fn(len: usize, foo: u32))'
 pub fn f(callback: fn(len: usize, foo: u32)) {}
+
+//@ has foo/fn.g.html
+//@ has - '//pre[@class="rust item-decl"]' 'pub fn g(_: fn(_: usize, _: u32))'
+pub fn g(_: fn(usize, _: u32)) {}
+
+//@ has foo/fn.mixed.html
+//@ has - '//pre[@class="rust item-decl"]' 'pub fn mixed(_: fn(_: usize, foo: u32))'
+pub fn mixed(_: fn(usize, foo: u32)) {}

--- a/tests/rustdoc/fn-pointer-arg-name.rs
+++ b/tests/rustdoc/fn-pointer-arg-name.rs
@@ -5,7 +5,7 @@
 pub fn f(callback: fn(len: usize, foo: u32)) {}
 
 //@ has foo/fn.g.html
-//@ has - '//pre[@class="rust item-decl"]' 'pub fn g(_: fn(_: usize, _: u32))'
+//@ has - '//pre[@class="rust item-decl"]' 'pub fn g(_: fn(usize, u32))'
 pub fn g(_: fn(usize, _: u32)) {}
 
 //@ has foo/fn.mixed.html

--- a/tests/rustdoc/inherent-projections.rs
+++ b/tests/rustdoc/inherent-projections.rs
@@ -13,7 +13,7 @@ impl Owner {
 }
 
 // Make sure we handle bound vars correctly.
-//@ has 'inherent_projections/fn.user.html' '//pre[@class="rust item-decl"]' "user(_: for<'a> fn(_: Carrier<'a>::Focus))"
+//@ has 'inherent_projections/fn.user.html' '//pre[@class="rust item-decl"]' "user(_: for<'a> fn(Carrier<'a>::Focus))"
 pub fn user(_: for<'a> fn(Carrier<'a>::Focus)) {}
 
 pub struct Carrier<'a>(&'a ());

--- a/tests/rustdoc/macro-higher-kinded-function.rs
+++ b/tests/rustdoc/macro-higher-kinded-function.rs
@@ -11,10 +11,10 @@ macro_rules! gen {
 }
 
 //@ has 'foo/struct.Providers.html'
-//@ has - '//*[@class="rust item-decl"]//code' "pub a: for<'tcx> fn(_: TyCtxt<'tcx>, _: u8) -> i8,"
-//@ has - '//*[@class="rust item-decl"]//code' "pub b: for<'tcx> fn(_: TyCtxt<'tcx>, _: u16) -> i16,"
-//@ has - '//*[@id="structfield.a"]/code' "a: for<'tcx> fn(_: TyCtxt<'tcx>, _: u8) -> i8"
-//@ has - '//*[@id="structfield.b"]/code' "b: for<'tcx> fn(_: TyCtxt<'tcx>, _: u16) -> i16"
+//@ has - '//*[@class="rust item-decl"]//code' "pub a: for<'tcx> fn(TyCtxt<'tcx>, u8) -> i8,"
+//@ has - '//*[@class="rust item-decl"]//code' "pub b: for<'tcx> fn(TyCtxt<'tcx>, u16) -> i16,"
+//@ has - '//*[@id="structfield.a"]/code' "a: for<'tcx> fn(TyCtxt<'tcx>, u8) -> i8"
+//@ has - '//*[@id="structfield.b"]/code' "b: for<'tcx> fn(TyCtxt<'tcx>, u16) -> i16"
 gen! {
     (a, 'tcx, [u8], [i8])
     (b, 'tcx, [u16], [i16])


### PR DESCRIPTION
This matches the style used for the vast majority of function pointer types in real-world code, in my experience. Prefixing `_: ` to every argument does not improve clarity.

**Before:**

<img src="https://github.com/user-attachments/assets/f07efa8b-d57e-4897-aa97-40db7d207862">

**After:**

<img src="https://github.com/user-attachments/assets/8405e08b-d6d2-4904-bcc3-a3eb866cecf0">