### PR TITLE
Shorten error message for callable with wrong return type

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1518,7 +1518,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         with_forced_trimmed_paths! {
             if self.tcx.is_lang_item(projection_term.def_id, LangItem::FnOnceOutput) {
-                let fn_kind = self_ty.prefix_string(self.tcx);
                 let (span, closure_span) = if let ty::Closure(def_id, _) = self_ty.kind() {
                     let def_span = self.tcx.def_span(def_id);
                     if let Some(local_def_id) = def_id.as_local()
@@ -1555,8 +1554,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     _ => self_ty.to_string(),
                 };
                 Some((format!(
-                    "expected `{item}` to be a {fn_kind} that returns `{expected_ty}`, but it \
-                     returns `{normalized_ty}`",
+                    "expected `{item}` to return `{expected_ty}`, but it returns `{normalized_ty}`",
                 ), span, closure_span))
             } else if self.tcx.is_lang_item(trait_def_id, LangItem::Future) {
                 Some((format!(

--- a/tests/ui/async-await/async-closures/is-not-fn.current.stderr
+++ b/tests/ui/async-await/async-closures/is-not-fn.current.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `{async closure@is-not-fn.rs:8:14}` to be a closure that returns `()`, but it returns `{async closure body@$DIR/is-not-fn.rs:8:23: 8:25}`
+error[E0271]: expected `{async closure@is-not-fn.rs:8:14}` to return `()`, but it returns `{async closure body@$DIR/is-not-fn.rs:8:23: 8:25}`
   --> $DIR/is-not-fn.rs:8:14
    |
 LL |     needs_fn(async || {});

--- a/tests/ui/async-await/async-closures/is-not-fn.next.stderr
+++ b/tests/ui/async-await/async-closures/is-not-fn.next.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `{async closure@is-not-fn.rs:8:14}` to be a closure that returns `()`, but it returns `{async closure body@$DIR/is-not-fn.rs:8:23: 8:25}`
+error[E0271]: expected `{async closure@is-not-fn.rs:8:14}` to return `()`, but it returns `{async closure body@$DIR/is-not-fn.rs:8:23: 8:25}`
   --> $DIR/is-not-fn.rs:8:14
    |
 LL |     needs_fn(async || {});

--- a/tests/ui/async-await/async-closures/is-not-fn.rs
+++ b/tests/ui/async-await/async-closures/is-not-fn.rs
@@ -6,5 +6,5 @@
 fn main() {
     fn needs_fn(x: impl FnOnce()) {}
     needs_fn(async || {});
-    //~^ ERROR expected `{async closure@is-not-fn.rs:8:14}` to be a closure that returns `()`
+    //~^ ERROR expected `{async closure@is-not-fn.rs:8:14}` to return `()`
 }

--- a/tests/ui/async-await/dont-ice-for-type-mismatch-in-closure-in-async.stderr
+++ b/tests/ui/async-await/dont-ice-for-type-mismatch-in-closure-in-async.stderr
@@ -20,7 +20,7 @@ LL |         true
    = note: expected enum `Option<()>`
               found type `bool`
 
-error[E0271]: expected `{closure@dont-ice-for-type-mismatch-in-closure-in-async.rs:6:10}` to be a closure that returns `bool`, but it returns `Option<()>`
+error[E0271]: expected `{closure@dont-ice-for-type-mismatch-in-closure-in-async.rs:6:10}` to return `bool`, but it returns `Option<()>`
   --> $DIR/dont-ice-for-type-mismatch-in-closure-in-async.rs:6:16
    |
 LL |     call(|| -> Option<()> {

--- a/tests/ui/async-await/issue-98634.rs
+++ b/tests/ui/async-await/issue-98634.rs
@@ -43,8 +43,8 @@ impl Runtime {
 fn main() {
     Runtime.block_on(async {
         StructAsync { callback }.await;
-        //~^ ERROR expected `callback` to be a fn item that returns `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
-        //~| ERROR expected `callback` to be a fn item that returns `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
-        //~| ERROR expected `callback` to be a fn item that returns `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
+        //~^ ERROR expected `callback` to return `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
+        //~| ERROR expected `callback` to return `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
+        //~| ERROR expected `callback` to return `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
     });
 }

--- a/tests/ui/async-await/issue-98634.stderr
+++ b/tests/ui/async-await/issue-98634.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `callback` to be a fn item that returns `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
+error[E0271]: expected `callback` to return `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
   --> $DIR/issue-98634.rs:45:23
    |
 LL |         StructAsync { callback }.await;
@@ -10,7 +10,7 @@ note: required by a bound in `StructAsync`
 LL | pub struct StructAsync<F: Fn() -> Pin<Box<dyn Future<Output = ()>>>> {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StructAsync`
 
-error[E0271]: expected `callback` to be a fn item that returns `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
+error[E0271]: expected `callback` to return `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
   --> $DIR/issue-98634.rs:45:9
    |
 LL |         StructAsync { callback }.await;
@@ -22,7 +22,7 @@ note: required by a bound in `StructAsync`
 LL | pub struct StructAsync<F: Fn() -> Pin<Box<dyn Future<Output = ()>>>> {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StructAsync`
 
-error[E0271]: expected `callback` to be a fn item that returns `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
+error[E0271]: expected `callback` to return `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
   --> $DIR/issue-98634.rs:45:34
    |
 LL |         StructAsync { callback }.await;

--- a/tests/ui/closures/return-type-doesnt-match-bound.rs
+++ b/tests/ui/closures/return-type-doesnt-match-bound.rs
@@ -5,7 +5,7 @@ fn foo<F>(f: F) -> ()
 where
     F: FnOnce() -> Result<(), Box<dyn Error>>,
 {
-    f().or_else(|e| -> ! { //~ ERROR to be a closure that returns
+    f().or_else(|e| -> ! { //~ ERROR to return
         eprintln!("{:?}", e);
         exit(1)
     });
@@ -15,7 +15,7 @@ fn bar<F>(f: F) -> ()
 where
     F: FnOnce() -> Result<(), Box<dyn Error>>,
 {
-    let c = |e| -> ! { //~ ERROR to be a closure that returns
+    let c = |e| -> ! { //~ ERROR to return
         eprintln!("{:?}", e);
         exit(1)
     };

--- a/tests/ui/closures/return-type-doesnt-match-bound.stderr
+++ b/tests/ui/closures/return-type-doesnt-match-bound.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `{closure@return-type-doesnt-match-bound.rs:8:17}` to be a closure that returns `Result<(), _>`, but it returns `!`
+error[E0271]: expected `{closure@return-type-doesnt-match-bound.rs:8:17}` to return `Result<(), _>`, but it returns `!`
   --> $DIR/return-type-doesnt-match-bound.rs:8:24
    |
 LL |     f().or_else(|e| -> ! {
@@ -13,7 +13,7 @@ LL |     f().or_else(|e| -> ! {
 note: required by a bound in `Result::<T, E>::or_else`
   --> $SRC_DIR/core/src/result.rs:LL:COL
 
-error[E0271]: expected `{closure@return-type-doesnt-match-bound.rs:18:13}` to be a closure that returns `Result<(), _>`, but it returns `!`
+error[E0271]: expected `{closure@return-type-doesnt-match-bound.rs:18:13}` to return `Result<(), _>`, but it returns `!`
   --> $DIR/return-type-doesnt-match-bound.rs:18:20
    |
 LL |     let c = |e| -> ! {

--- a/tests/ui/higher-ranked/trait-bounds/issue-62203-hrtb-ice.rs
+++ b/tests/ui/higher-ranked/trait-bounds/issue-62203-hrtb-ice.rs
@@ -39,7 +39,7 @@ fn main() {
         L { //~ ERROR type mismatch
             f: |x| {
                 drop(x);
-                Unit4 //~ ERROR to be a closure that returns `Unit3`, but it returns `Unit4`
+                Unit4 //~ ERROR to return `Unit3`, but it returns `Unit4`
             },
         },
     );

--- a/tests/ui/higher-ranked/trait-bounds/issue-62203-hrtb-ice.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-62203-hrtb-ice.stderr
@@ -29,7 +29,7 @@ LL |     where
 LL |         F: for<'r> T0<'r, (<Self as Ty<'r>>::V,), O = <B as Ty<'r>>::V>,
    |                                                   ^^^^^^^^^^^^^^^^^^^^ required by this bound in `T1::m`
 
-error[E0271]: expected `{closure@issue-62203-hrtb-ice.rs:40:16}` to be a closure that returns `Unit3`, but it returns `Unit4`
+error[E0271]: expected `{closure@issue-62203-hrtb-ice.rs:40:16}` to return `Unit3`, but it returns `Unit4`
   --> $DIR/issue-62203-hrtb-ice.rs:42:17
    |
 LL |     let v = Unit2.m(

--- a/tests/ui/intrinsics/const-eval-select-bad.rs
+++ b/tests/ui/intrinsics/const-eval-select-bad.rs
@@ -30,7 +30,7 @@ fn baz(n: bool) -> i32 {
 
 const fn return_ty_mismatch() {
     const_eval_select((1,), foo, bar);
-    //~^ ERROR expected `bar` to be a fn item that returns `i32`, but it returns `bool`
+    //~^ ERROR expected `bar` to return `i32`, but it returns `bool`
 }
 
 const fn args_ty_mismatch() {

--- a/tests/ui/intrinsics/const-eval-select-bad.stderr
+++ b/tests/ui/intrinsics/const-eval-select-bad.stderr
@@ -60,7 +60,7 @@ LL |     const_eval_select((), 42, 0xDEADBEEF);
    = note: expected a function item, found {integer}
    = help: consult the documentation on `const_eval_select` for more information
 
-error[E0271]: expected `bar` to be a fn item that returns `i32`, but it returns `bool`
+error[E0271]: expected `bar` to return `i32`, but it returns `bool`
   --> $DIR/const-eval-select-bad.rs:32:34
    |
 LL |     const_eval_select((1,), foo, bar);

--- a/tests/ui/lint/issue-106991.rs
+++ b/tests/ui/lint/issue-106991.rs
@@ -3,7 +3,7 @@ fn foo(items: &mut Vec<u8>) {
 }
 
 fn bar() -> impl Iterator<Item = i32> {
-    //~^ ERROR expected `foo` to be a fn item that returns `i32`, but it returns `()` [E0271]
+    //~^ ERROR expected `foo` to return `i32`, but it returns `()` [E0271]
     let mut x: Vec<Vec<u8>> = vec![vec![0, 2, 1], vec![5, 4, 3]];
     x.iter_mut().map(foo)
 }

--- a/tests/ui/lint/issue-106991.stderr
+++ b/tests/ui/lint/issue-106991.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `foo` to be a fn item that returns `i32`, but it returns `()`
+error[E0271]: expected `foo` to return `i32`, but it returns `()`
   --> $DIR/issue-106991.rs:5:13
    |
 LL | fn bar() -> impl Iterator<Item = i32> {

--- a/tests/ui/never_type/fallback-closure-wrap.fallback.stderr
+++ b/tests/ui/never_type/fallback-closure-wrap.fallback.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `{closure@fallback-closure-wrap.rs:18:40}` to be a closure that returns `()`, but it returns `!`
+error[E0271]: expected `{closure@fallback-closure-wrap.rs:18:40}` to return `()`, but it returns `!`
   --> $DIR/fallback-closure-wrap.rs:19:9
    |
 LL |     let error = Closure::wrap(Box::new(move || {

--- a/tests/ui/never_type/fallback-closure-wrap.rs
+++ b/tests/ui/never_type/fallback-closure-wrap.rs
@@ -17,7 +17,7 @@ use std::marker::PhantomData;
 fn main() {
     let error = Closure::wrap(Box::new(move || {
         panic!("Can't connect to server.");
-        //[fallback]~^ to be a closure that returns `()`, but it returns `!`
+        //[fallback]~^ to return `()`, but it returns `!`
     }) as Box<dyn FnMut()>);
 }
 

--- a/tests/ui/suggestions/dont-suggest-boxing-async-closure-body.rs
+++ b/tests/ui/suggestions/dont-suggest-boxing-async-closure-body.rs
@@ -7,6 +7,6 @@ fn bar<X>(x: Box<dyn FnOnce() -> X>) {}
 
 fn main() {
     foo(async move || {});
-    //~^ ERROR expected `{async closure@dont-suggest-boxing-async-closure-body.rs:9:9}` to be a closure that returns `Box<_>`
+    //~^ ERROR expected `{async closure@dont-suggest-boxing-async-closure-body.rs:9:9}` to return `Box<_>`
     bar(async move || {}); //~ ERROR mismatched types
 }

--- a/tests/ui/suggestions/dont-suggest-boxing-async-closure-body.stderr
+++ b/tests/ui/suggestions/dont-suggest-boxing-async-closure-body.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `{async closure@dont-suggest-boxing-async-closure-body.rs:9:9}` to be a closure that returns `Box<_>`, but it returns `{async closure body@$DIR/dont-suggest-boxing-async-closure-body.rs:9:23: 9:25}`
+error[E0271]: expected `{async closure@dont-suggest-boxing-async-closure-body.rs:9:9}` to return `Box<_>`, but it returns `{async closure body@$DIR/dont-suggest-boxing-async-closure-body.rs:9:23: 9:25}`
   --> $DIR/dont-suggest-boxing-async-closure-body.rs:9:9
    |
 LL |     foo(async move || {});

--- a/tests/ui/type-alias-impl-trait/issue-98604.rs
+++ b/tests/ui/type-alias-impl-trait/issue-98604.rs
@@ -7,5 +7,5 @@ async fn test() {}
 #[allow(unused_must_use)]
 fn main() {
     Box::new(test) as AsyncFnPtr;
-    //~^ ERROR expected `test` to be a fn item that returns `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>
+    //~^ ERROR expected `test` to return `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>
 }

--- a/tests/ui/type-alias-impl-trait/issue-98604.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-98604.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `test` to be a fn item that returns `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
+error[E0271]: expected `test` to return `Pin<Box<dyn Future<Output = ()>>>`, but it returns `impl Future<Output = ()>`
   --> $DIR/issue-98604.rs:9:5
    |
 LL |     Box::new(test) as AsyncFnPtr;

--- a/tests/ui/type-alias-impl-trait/issue-98608.rs
+++ b/tests/ui/type-alias-impl-trait/issue-98608.rs
@@ -4,7 +4,7 @@ fn hi() -> impl Sized {
 
 fn main() {
     let b: Box<dyn Fn() -> Box<u8>> = Box::new(hi);
-    //~^ ERROR expected `hi` to be a fn item that returns `Box<u8>`, but it returns `impl Sized`
+    //~^ ERROR expected `hi` to return `Box<u8>`, but it returns `impl Sized`
     let boxed = b();
     let null = *boxed;
     println!("{null:?}");

--- a/tests/ui/type-alias-impl-trait/issue-98608.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-98608.stderr
@@ -1,4 +1,4 @@
-error[E0271]: expected `hi` to be a fn item that returns `Box<u8>`, but it returns `impl Sized`
+error[E0271]: expected `hi` to return `Box<u8>`, but it returns `impl Sized`
   --> $DIR/issue-98608.rs:6:39
    |
 LL | fn hi() -> impl Sized {


### PR DESCRIPTION
```
error: expected `{closure@...}` to return `Ret`, but it returns `Other`
```
instead of
```
error: expected `{closure@...}` to be a closure that returns `Ret`, but it returns `Other`
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
