### PR TITLE
fix: overflowing bin hex

### DIFF
--- a/compiler/rustc_lint/src/types/literal.rs
+++ b/compiler/rustc_lint/src/types/literal.rs
@@ -186,7 +186,7 @@ fn report_bin_hex_error(
                 lit_no_suffix,
                 negative_val: actually.clone(),
                 int_ty: int_ty.name_str(),
-                uint_ty: int_ty.to_unsigned().name_str(),
+                uint_ty: Integer::fit_unsigned(val).uint_ty_str(),
             })
         })
         .flatten();

--- a/tests/ui/lint/type-overflow.rs
+++ b/tests/ui/lint/type-overflow.rs
@@ -41,8 +41,12 @@ fn main() {
 
     let fail = 0x8FFF_FFFF_FFFF_FFFE; //~WARNING literal out of range for `i32`
     //~| HELP consider using the type `u64` instead
-    //~| HELP
+    //~| HELP consider using the type `u64` for the literal and cast it to `i32`
 
     let fail = -0b1111_1111i8; //~WARNING literal out of range for `i8`
     //~| HELP consider using the type `i16` instead
+
+    let fail = 0x8000_0000_0000_0000_0000_0000_FFFF_FFFE; //~WARNING literal out of range for `i32`
+    //~| HELP consider using the type `u128` instead
+    //~| HELP consider using the type `u128` for the literal and cast it to `i32`
 }

--- a/tests/ui/lint/type-overflow.stderr
+++ b/tests/ui/lint/type-overflow.stderr
@@ -112,9 +112,9 @@ LL |     let fail = 0x8FFF_FFFF_FFFF_FFFE;
    |
    = note: the literal `0x8FFF_FFFF_FFFF_FFFE` (decimal `10376293541461622782`) does not fit into the type `i32` and will become `-2i32`
    = help: consider using the type `u64` instead
-help: to use as a negative number (decimal `-2`), consider using the type `u32` for the literal and cast it to `i32`
+help: to use as a negative number (decimal `-2`), consider using the type `u64` for the literal and cast it to `i32`
    |
-LL |     let fail = 0x8FFF_FFFF_FFFF_FFFEu32 as i32;
+LL |     let fail = 0x8FFF_FFFF_FFFF_FFFEu64 as i32;
    |                                     ++++++++++
 
 warning: literal out of range for `i8`
@@ -126,5 +126,18 @@ LL |     let fail = -0b1111_1111i8;
    = note: the literal `0b1111_1111i8` (decimal `255`) does not fit into the type `i8`
    = note: and the value `-0b1111_1111i8` will become `1i8`
 
-warning: 11 warnings emitted
+warning: literal out of range for `i32`
+  --> $DIR/type-overflow.rs:49:16
+   |
+LL |     let fail = 0x8000_0000_0000_0000_0000_0000_FFFF_FFFE;
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the literal `0x8000_0000_0000_0000_0000_0000_FFFF_FFFE` (decimal `170141183460469231731687303720179073022`) does not fit into the type `i32` and will become `-2i32`
+   = help: consider using the type `u128` instead
+help: to use as a negative number (decimal `-2`), consider using the type `u128` for the literal and cast it to `i32`
+   |
+LL |     let fail = 0x8000_0000_0000_0000_0000_0000_FFFF_FFFEu128 as i32;
+   |                                                         +++++++++++
+
+warning: 12 warnings emitted
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

**Overview:**
- This PR fixes #135404.

**Testing**
- Tested the updated functionality.
- previously emitted diagnostics:
```bash
error: literal out of range for `i32`
 --> src/main.rs:2:9
  |
2 |     _ = 0x8FFF_FFFF_FFFF_FFFE;
  |         ^^^^^^^^^^^^^^^^^^^^^
  |
  = note: the literal `0x8FFF_FFFF_FFFF_FFFE` (decimal `10376293541461622782`) does not fit into the type `i32` and will become `-2i32`
  = help: consider using the type `i128` instead
  = note: `#[deny(overflowing_literals)]` on by default
help: to use as a negative number (decimal `-2`), consider using the type `u32` for the literal and cast it to `i32`
  |
2 |     _ = 0x8FFF_FFFF_FFFF_FFFEu32 as i32;
  |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ```
- current diagnostics:
```bash
error: literal out of range for `i32`
 --> ../temp.rs:2:13
  |
2 |     let x = 0x8FFF_FFFF_FFFF_FFFE;
  |             ^^^^^^^^^^^^^^^^^^^^^
  |
  = note: the literal `0x8FFF_FFFF_FFFF_FFFE` (decimal `10376293541461622782`) does not fit into the type `i32` and will become `-2i32`
  = help: consider using the type `u64` instead
  = note: `#[deny(overflowing_literals)]` on by default
help: to use as a negative number (decimal `-2`), consider using the type `u64` for the literal and cast it to `i32`
  |
2 |     let x = 0x8FFF_FFFF_FFFF_FFFEu64 as i32;
  |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
