### PR TITLE
LTA: Actually check where-clauses for well-formedness at the def site

### DIFF
--- a/tests/ui/lazy-type-alias/def-site-param-defaults-wf.rs
+++ b/tests/ui/lazy-type-alias/def-site-param-defaults-wf.rs
@@ -1,0 +1,9 @@
+//! Ensure that we check generic parameter defaults for well-formedness at the definition site.
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+type Alias<T = Vec<str>, const N: usize = {0 - 1}> = T;
+//~^ ERROR evaluation of constant value failed
+//~| ERROR the size for values of type `str` cannot be known at compilation time
+
+fn main() {}

--- a/tests/ui/lazy-type-alias/def-site-param-defaults-wf.stderr
+++ b/tests/ui/lazy-type-alias/def-site-param-defaults-wf.stderr
@@ -1,0 +1,20 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/def-site-param-defaults-wf.rs:5:44
+   |
+LL | type Alias<T = Vec<str>, const N: usize = {0 - 1}> = T;
+   |                                            ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/def-site-param-defaults-wf.rs:5:16
+   |
+LL | type Alias<T = Vec<str>, const N: usize = {0 - 1}> = T;
+   |                ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by an implicit `Sized` bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0080, E0277.
+For more information about an error, try `rustc --explain E0080`.

--- a/tests/ui/lazy-type-alias/def-site-predicates-wf.rs
+++ b/tests/ui/lazy-type-alias/def-site-predicates-wf.rs
@@ -1,0 +1,13 @@
+//! Ensure that we check the predicates at the definition site for well-formedness.
+#![feature(lazy_type_alias)]
+#![allow(incomplete_features)]
+
+type Alias0 = ()
+where
+    Vec<str>:; //~ ERROR the size for values of type `str` cannot be known at compilation time
+
+type Alias1 = ()
+where
+    Vec<str>: Sized; //~ ERROR the size for values of type `str` cannot be known at compilation time
+
+fn main() {}

--- a/tests/ui/lazy-type-alias/def-site-predicates-wf.stderr
+++ b/tests/ui/lazy-type-alias/def-site-predicates-wf.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/def-site-predicates-wf.rs:7:5
+   |
+LL |     Vec<str>:;
+   |     ^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by an implicit `Sized` bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/def-site-predicates-wf.rs:11:15
+   |
+LL |     Vec<str>: Sized;
+   |               ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+note: required by an implicit `Sized` bound in `Vec`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
All of the added tests used to wrongfully pass.

r? oli-obk or types/compiler or reassign