### PR TITLE
[DO NOT LOOK] a bunch of compiletest-related changes

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -215,15 +215,22 @@ pub struct Config {
     /// `None` then these tests will be ignored.
     pub run_clang_based_tests_with: Option<String>,
 
-    /// The directory containing the tests to run
-    pub src_base: PathBuf,
+    /// Path to directory containing rust-lang/rust sources.
+    pub src_root: PathBuf,
+    /// Path to the directory containg the test suite sources. Expected to be a subdirectory of
+    /// `src_root`.
+    pub src_test_suite_root: PathBuf,
 
-    /// The directory where programs should be built
-    pub build_base: PathBuf,
+    /// Bootstrap build directory.
+    pub build_root: PathBuf,
+    /// Bootstrap test suite build directory. Expected to be a subdirectory of `build_root`.
+    pub build_test_suite_root: PathBuf,
 
-    /// The directory containing the compiler sysroot
-    pub sysroot_base: PathBuf,
+    /// The directory containing the compiler sysroot.
+    pub sysroot: PathBuf,
 
+    /// Stage number.
+    pub stage: u32,
     /// The name of the stage being built (stage1, etc)
     pub stage_id: String,
 
@@ -802,7 +809,7 @@ pub const UI_COVERAGE_MAP: &str = "cov-map";
 ///   /path/to/build/host-tuple/test/ui/relative/
 /// This is created early when tests are collected to avoid race conditions.
 pub fn output_relative_path(config: &Config, relative_dir: &Path) -> PathBuf {
-    config.build_base.join(relative_dir)
+    config.build_test_suite_root.join(relative_dir)
 }
 
 /// Generates a unique name for the test, such as `testname.revision.mode`.

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -158,6 +158,8 @@ impl ConfigBuilder {
             "--android-cross-path=",
             "--stage-id",
             self.stage_id.as_deref().unwrap_or("stage2-x86_64-unknown-linux-gnu"),
+            "--stage",
+            "2",
             "--channel",
             self.channel.as_deref().unwrap_or("nightly"),
             "--host",

--- a/src/tools/compiletest/src/runtest/debuginfo.rs
+++ b/src/tools/compiletest/src/runtest/debuginfo.rs
@@ -257,11 +257,8 @@ impl TestCx<'_> {
                 println!("Adb process is already finished.");
             }
         } else {
-            let rust_src_root =
-                self.config.find_rust_src_root().expect("Could not find Rust source root");
-            let rust_pp_module_rel_path = Path::new("./src/etc");
-            let rust_pp_module_abs_path =
-                rust_src_root.join(rust_pp_module_rel_path).to_str().unwrap().to_owned();
+            let rust_pp_module_abs_path = self.config.src_root.join("src").join("etc");
+            let rust_pp_module_abs_path = rust_pp_module_abs_path.to_str().unwrap();
             // write debugger script
             let mut script_str = String::with_capacity(2048);
             script_str.push_str(&format!("set charset {}\n", Self::charset()));
@@ -279,14 +276,12 @@ impl TestCx<'_> {
                             rust_pp_module_abs_path.replace(r"\", r"\\")
                         ));
 
-                        let output_base_dir = self.output_base_dir().to_str().unwrap().to_owned();
-
                         // Add the directory containing the output binary to
                         // include embedded pretty printers to GDB's script
                         // auto loading safe path
                         script_str.push_str(&format!(
                             "add-auto-load-safe-path {}\n",
-                            output_base_dir.replace(r"\", r"\\")
+                            self.output_base_dir().to_str().unwrap().replace(r"\", r"\\")
                         ));
                     }
                 }
@@ -336,9 +331,9 @@ impl TestCx<'_> {
 
             let mut gdb = Command::new(self.config.gdb.as_ref().unwrap());
             let pythonpath = if let Ok(pp) = std::env::var("PYTHONPATH") {
-                format!("{pp}:{rust_pp_module_abs_path}")
+                format!("{pp}:{}", rust_pp_module_abs_path)
             } else {
-                rust_pp_module_abs_path
+                rust_pp_module_abs_path.to_string()
             };
             gdb.args(debugger_opts).env("PYTHONPATH", pythonpath);
 
@@ -407,15 +402,12 @@ impl TestCx<'_> {
         // Make LLDB emit its version, so we have it documented in the test output
         script_str.push_str("version\n");
 
-        // Switch LLDB into "Rust mode"
-        let rust_src_root =
-            self.config.find_rust_src_root().expect("Could not find Rust source root");
-        let rust_pp_module_rel_path = Path::new("./src/etc");
-        let rust_pp_module_abs_path = rust_src_root.join(rust_pp_module_rel_path);
+        // Switch LLDB into "Rust mode".
+        let rust_pp_module_abs_path = self.config.src_root.join("src").join("etc");
 
         script_str.push_str(&format!(
             "command script import {}/lldb_lookup.py\n",
-            rust_pp_module_abs_path.to_str().unwrap()
+            rust_pp_module_abs_path.display()
         ));
         File::open(rust_pp_module_abs_path.join("lldb_commands"))
             .and_then(|mut file| file.read_to_string(&mut script_str))
@@ -445,7 +437,7 @@ impl TestCx<'_> {
         let debugger_script = self.make_out_name("debugger.script");
 
         // Let LLDB execute the script via lldb_batchmode.py
-        let debugger_run_result = self.run_lldb(&exe_file, &debugger_script, &rust_src_root);
+        let debugger_run_result = self.run_lldb(&exe_file, &debugger_script);
 
         if !debugger_run_result.status.success() {
             self.fatal_proc_rec("Error while running LLDB", &debugger_run_result);
@@ -456,18 +448,14 @@ impl TestCx<'_> {
         }
     }
 
-    fn run_lldb(
-        &self,
-        test_executable: &Path,
-        debugger_script: &Path,
-        rust_src_root: &Path,
-    ) -> ProcRes {
+    fn run_lldb(&self, test_executable: &Path, debugger_script: &Path) -> ProcRes {
         // Prepare the lldb_batchmode which executes the debugger script
-        let lldb_script_path = rust_src_root.join("src/etc/lldb_batchmode.py");
+        let lldb_script_path =
+            self.config.src_root.join("src").join("etc").join("lldb_batchmode.py");
         let pythonpath = if let Ok(pp) = std::env::var("PYTHONPATH") {
             format!("{pp}:{}", self.config.lldb_python_dir.as_ref().unwrap())
         } else {
-            self.config.lldb_python_dir.as_ref().unwrap().to_string()
+            self.config.lldb_python_dir.clone().unwrap()
         };
         self.run_command_to_procres(
             Command::new(&self.config.python)

--- a/src/tools/compiletest/src/runtest/js_doc.rs
+++ b/src/tools/compiletest/src/runtest/js_doc.rs
@@ -8,13 +8,18 @@ impl TestCx<'_> {
             let out_dir = self.output_base_dir();
 
             self.document(&out_dir, &self.testpaths);
-
-            let root = self.config.find_rust_src_root().unwrap();
             let file_stem =
                 self.testpaths.file.file_stem().and_then(|f| f.to_str()).expect("no file stem");
             let res = self.run_command_to_procres(
                 Command::new(&nodejs)
-                    .arg(root.join("src/tools/rustdoc-js/tester.js"))
+                    .arg(
+                        self.config
+                            .src_root
+                            .join("src")
+                            .join("tools")
+                            .join("rustdoc-js")
+                            .join("tester.js"),
+                    )
                     .arg("--doc-folder")
                     .arg(out_dir)
                     .arg("--crate-name")

--- a/src/tools/compiletest/src/runtest/rustdoc.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc.rs
@@ -17,9 +17,10 @@ impl TestCx<'_> {
         if self.props.check_test_line_numbers_match {
             self.check_rustdoc_test_option(proc_res);
         } else {
-            let root = self.config.find_rust_src_root().unwrap();
             let mut cmd = Command::new(&self.config.python);
-            cmd.arg(root.join("src/etc/htmldocck.py")).arg(&out_dir).arg(&self.testpaths.file);
+            cmd.arg(self.config.src_root.join("src").join("etc").join("htmldocck.py"))
+                .arg(&out_dir)
+                .arg(&self.testpaths.file);
             if self.config.bless {
                 cmd.arg("--bless");
             }

--- a/src/tools/compiletest/src/runtest/rustdoc_json.rs
+++ b/src/tools/compiletest/src/runtest/rustdoc_json.rs
@@ -16,13 +16,12 @@ impl TestCx<'_> {
             self.fatal_proc_rec("rustdoc failed!", &proc_res);
         }
 
-        let root = self.config.find_rust_src_root().unwrap();
         let mut json_out = out_dir.join(self.testpaths.file.file_stem().unwrap());
         json_out.set_extension("json");
         let res = self.run_command_to_procres(
             Command::new(self.config.jsondocck_path.as_ref().unwrap())
                 .arg("--doc-dir")
-                .arg(root.join(&out_dir))
+                .arg(&out_dir)
                 .arg("--template")
                 .arg(&self.testpaths.file),
         );

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -66,7 +66,7 @@ impl TestCx<'_> {
                 && !self.props.run_rustfix
                 && !self.props.rustfix_only_machine_applicable
             {
-                let mut coverage_file_path = self.config.build_base.clone();
+                let mut coverage_file_path = self.config.build_test_suite_root.clone();
                 coverage_file_path.push("rustfix_missing_coverage.txt");
                 debug!("coverage_file_path: {}", coverage_file_path.display());
 

--- a/tests/codegen/debug-compile-unit-path.rs
+++ b/tests/codegen/debug-compile-unit-path.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -g --remap-path-prefix={{cwd}}=/cwd/ --remap-path-prefix={{src-base}}=/base/
+//@ compile-flags: -g --remap-path-prefix={{cwd}}=/cwd/ --remap-path-prefix={{test-suite-src-base}}=/base/
 //
 //
 // Ensure that we remap the compile unit directory and that we set it to the compilers current

--- a/tests/codegen/remap_path_prefix/auxiliary/remap_path_prefix_aux.rs
+++ b/tests/codegen/remap_path_prefix/auxiliary/remap_path_prefix_aux.rs
@@ -1,6 +1,6 @@
 //
 
-//@ compile-flags: -g  --remap-path-prefix={{cwd}}=/the/aux-cwd --remap-path-prefix={{src-base}}/remap_path_prefix/auxiliary=/the/aux-src
+//@ compile-flags: -g  --remap-path-prefix={{cwd}}=/the/aux-cwd --remap-path-prefix={{test-suite-src-base}}/remap_path_prefix/auxiliary=/the/aux-src
 
 #[inline]
 pub fn some_aux_function() -> i32 {

--- a/tests/codegen/remap_path_prefix/auxiliary/xcrate-generic.rs
+++ b/tests/codegen/remap_path_prefix/auxiliary/xcrate-generic.rs
@@ -1,5 +1,5 @@
 //
-//@ compile-flags: -g  --remap-path-prefix={{cwd}}=/the/aux-cwd --remap-path-prefix={{src-base}}/remap_path_prefix/auxiliary=/the/aux-src
+//@ compile-flags: -g  --remap-path-prefix={{cwd}}=/the/aux-cwd --remap-path-prefix={{test-suite-src-base}}/remap_path_prefix/auxiliary=/the/aux-src
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/remap_path_prefix/main.rs
+++ b/tests/codegen/remap_path_prefix/main.rs
@@ -1,7 +1,7 @@
 //@ ignore-windows
 //
 
-//@ compile-flags: -g  -C no-prepopulate-passes --remap-path-prefix={{cwd}}=/the/cwd --remap-path-prefix={{src-base}}=/the/src -Zinline-mir=no
+//@ compile-flags: -g  -C no-prepopulate-passes --remap-path-prefix={{cwd}}=/the/cwd --remap-path-prefix={{test-suite-src-base}}=/the/src -Zinline-mir=no
 //@ aux-build:remap_path_prefix_aux.rs
 
 extern crate remap_path_prefix_aux;

--- a/tests/incremental/auxiliary/circular-dependencies-aux.rs
+++ b/tests/incremental/auxiliary/circular-dependencies-aux.rs
@@ -1,5 +1,5 @@
 //@ edition: 2021
-//@ compile-flags: --crate-type lib --extern circular_dependencies={{build-base}}/circular-dependencies/libcircular_dependencies.rmeta --emit dep-info,metadata
+//@ compile-flags: --crate-type lib --extern circular_dependencies={{test-suite-build-base}}/circular-dependencies/libcircular_dependencies.rmeta --emit dep-info,metadata
 
 use circular_dependencies::Foo;
 

--- a/tests/incremental/circular-dependencies.rs
+++ b/tests/incremental/circular-dependencies.rs
@@ -3,7 +3,7 @@
 //@ edition: 2021
 //@ [cpass1] compile-flags: --crate-type lib --emit dep-info,metadata
 //@ [cfail2] aux-build: circular-dependencies-aux.rs
-//@ [cfail2] compile-flags: --test --extern aux={{build-base}}/circular-dependencies/auxiliary/libcircular_dependencies_aux.rmeta -L dependency={{build-base}}/circular-dependencies
+//@ [cfail2] compile-flags: --test --extern aux={{test-suite-build-base}}/circular-dependencies/auxiliary/libcircular_dependencies_aux.rmeta -L dependency={{test-suite-build-base}}/circular-dependencies
 
 pub struct Foo;
 //[cfail2]~^ NOTE the crate `circular_dependencies` is compiled multiple times, possibly with different configurations

--- a/tests/incremental/remapped_paths_cc/auxiliary/extern_crate.rs
+++ b/tests/incremental/remapped_paths_cc/auxiliary/extern_crate.rs
@@ -1,6 +1,6 @@
 //@[rpass1] compile-flags: -g
 //@[rpass2] compile-flags: -g
-//@[rpass3] compile-flags: -g --remap-path-prefix={{src-base}}=/the/src
+//@[rpass3] compile-flags: -g --remap-path-prefix={{test-suite-src-base}}=/the/src
 
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]

--- a/tests/pretty/expanded-and-path-remap-80832.pp
+++ b/tests/pretty/expanded-and-path-remap-80832.pp
@@ -8,6 +8,6 @@ extern crate std;
 //
 //@ pretty-mode:expanded
 //@ pp-exact:expanded-and-path-remap-80832.pp
-//@ compile-flags: --remap-path-prefix {{src-base}}=the/src
+//@ compile-flags: --remap-path-prefix {{test-suite-src-base}}=the/src
 
 fn main() {}

--- a/tests/pretty/expanded-and-path-remap-80832.rs
+++ b/tests/pretty/expanded-and-path-remap-80832.rs
@@ -2,6 +2,6 @@
 //
 //@ pretty-mode:expanded
 //@ pp-exact:expanded-and-path-remap-80832.pp
-//@ compile-flags: --remap-path-prefix {{src-base}}=the/src
+//@ compile-flags: --remap-path-prefix {{test-suite-src-base}}=the/src
 
 fn main() {}

--- a/tests/pretty/tests-are-sorted.pp
+++ b/tests/pretty/tests-are-sorted.pp
@@ -4,7 +4,7 @@
 use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
-//@ compile-flags: --crate-type=lib --test --remap-path-prefix={{src-base}}/=/the/src/ --remap-path-prefix={{src-base}}\=/the/src/
+//@ compile-flags: --crate-type=lib --test --remap-path-prefix={{test-suite-src-base}}/=/the/src/ --remap-path-prefix={{test-suite-src-base}}\=/the/src/
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:tests-are-sorted.pp

--- a/tests/pretty/tests-are-sorted.rs
+++ b/tests/pretty/tests-are-sorted.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --crate-type=lib --test --remap-path-prefix={{src-base}}/=/the/src/ --remap-path-prefix={{src-base}}\=/the/src/
+//@ compile-flags: --crate-type=lib --test --remap-path-prefix={{test-suite-src-base}}/=/the/src/ --remap-path-prefix={{test-suite-src-base}}\=/the/src/
 //@ pretty-compare-only
 //@ pretty-mode:expanded
 //@ pp-exact:tests-are-sorted.pp

--- a/tests/rustdoc-ui/argfile/commandline-argfile-badutf8-windows.rs
+++ b/tests/rustdoc-ui/argfile/commandline-argfile-badutf8-windows.rs
@@ -5,7 +5,7 @@
 // line arguments and is only run on windows.
 //
 //@ only-windows
-//@ compile-flags: --cfg cmdline_set @{{src-base}}\argfile\commandline-argfile-badutf8.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}\argfile\commandline-argfile-badutf8.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/rustdoc-ui/argfile/commandline-argfile-badutf8.rs
+++ b/tests/rustdoc-ui/argfile/commandline-argfile-badutf8.rs
@@ -6,7 +6,7 @@
 // windows.
 //
 //@ ignore-windows
-//@ compile-flags: --cfg cmdline_set @{{src-base}}/argfile/commandline-argfile-badutf8.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}/argfile/commandline-argfile-badutf8.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/rustdoc-ui/argfile/commandline-argfile-missing-windows.rs
+++ b/tests/rustdoc-ui/argfile/commandline-argfile-missing-windows.rs
@@ -7,7 +7,7 @@
 //@ only-windows
 //@ normalize-stderr: "os error \d+" -> "os error $$ERR"
 //@ normalize-stderr: "commandline-argfile-missing.args:[^(]*" -> "commandline-argfile-missing.args: $$FILE_MISSING "
-//@ compile-flags: --cfg cmdline_set @{{src-base}}\argfile\commandline-argfile-missing.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}\argfile\commandline-argfile-missing.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/rustdoc-ui/argfile/commandline-argfile-missing.rs
+++ b/tests/rustdoc-ui/argfile/commandline-argfile-missing.rs
@@ -8,7 +8,7 @@
 //@ ignore-windows
 //@ normalize-stderr: "os error \d+" -> "os error $$ERR"
 //@ normalize-stderr: "commandline-argfile-missing.args:[^(]*" -> "commandline-argfile-missing.args: $$FILE_MISSING "
-//@ compile-flags: --cfg cmdline_set @{{src-base}}/argfile/commandline-argfile-missing.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}/argfile/commandline-argfile-missing.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/rustdoc-ui/argfile/commandline-argfile-multiple-windows.rs
+++ b/tests/rustdoc-ui/argfile/commandline-argfile-multiple-windows.rs
@@ -8,7 +8,7 @@
 //@ normalize-stderr: "os error \d+" -> "os error $$ERR"
 //@ normalize-stderr: "commandline-argfile-missing.args:[^(]*" -> "commandline-argfile-missing.args: $$FILE_MISSING "
 //@ normalize-stderr: "commandline-argfile-missing2.args:[^(]*" -> "commandline-argfile-missing2.args: $$FILE_MISSING "
-//@ compile-flags: --cfg cmdline_set @{{src-base}}\argfile\commandline-argfile-missing.args @{{src-base}}\argfile\commandline-argfile-badutf8.args @{{src-base}}\argfile\commandline-argfile-missing2.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}\argfile\commandline-argfile-missing.args @{{test-suite-src-base}}\argfile\commandline-argfile-badutf8.args @{{test-suite-src-base}}\argfile\commandline-argfile-missing2.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/rustdoc-ui/argfile/commandline-argfile-multiple.rs
+++ b/tests/rustdoc-ui/argfile/commandline-argfile-multiple.rs
@@ -9,7 +9,7 @@
 //@ normalize-stderr: "os error \d+" -> "os error $$ERR"
 //@ normalize-stderr: "commandline-argfile-missing.args:[^(]*" -> "commandline-argfile-missing.args: $$FILE_MISSING "
 //@ normalize-stderr: "commandline-argfile-missing2.args:[^(]*" -> "commandline-argfile-missing2.args: $$FILE_MISSING "
-//@ compile-flags: --cfg cmdline_set @{{src-base}}/argfile/commandline-argfile-missing.args @{{src-base}}/argfile/commandline-argfile-badutf8.args @{{src-base}}/argfile/commandline-argfile-missing2.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}/argfile/commandline-argfile-missing.args @{{test-suite-src-base}}/argfile/commandline-argfile-badutf8.args @{{test-suite-src-base}}/argfile/commandline-argfile-missing2.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/rustdoc-ui/argfile/commandline-argfile.rs
+++ b/tests/rustdoc-ui/argfile/commandline-argfile.rs
@@ -2,7 +2,7 @@
 //
 //@ check-pass
 //@ compile-flags: --cfg cmdline_set --check-cfg=cfg(cmdline_set,unbroken)
-//@ compile-flags: @{{src-base}}/argfile/commandline-argfile.args
+//@ compile-flags: @{{test-suite-src-base}}/argfile/commandline-argfile.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/rustdoc-ui/doctest/run-directory.rs
+++ b/tests/rustdoc-ui/doctest/run-directory.rs
@@ -2,8 +2,8 @@
 
 //@ revisions: correct incorrect
 //@ check-pass
-//@ [correct]compile-flags:--test --test-run-directory={{src-base}}
-//@ [incorrect]compile-flags:--test --test-run-directory={{src-base}}/coverage
+//@ [correct]compile-flags:--test --test-run-directory={{test-suite-src-base}}
+//@ [incorrect]compile-flags:--test --test-run-directory={{test-suite-src-base}}/coverage
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 

--- a/tests/rustdoc-ui/invalid-theme-name.rs
+++ b/tests/rustdoc-ui/invalid-theme-name.rs
@@ -1,3 +1,3 @@
-//@ compile-flags:--theme {{src-base}}/invalid-theme-name.rs
+//@ compile-flags:--theme {{test-suite-src-base}}/invalid-theme-name.rs
 //@ error-pattern: invalid argument
 //@ error-pattern: must have a .css extension

--- a/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-failed-doctest-output.rs
@@ -2,7 +2,7 @@
 // adapted to use that, and that normalize line can go away
 
 //@ failure-status: 101
-//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
+//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{test-suite-src-base}}=remapped_path --test-args --test-threads=1
 //@ rustc-env:RUST_BACKTRACE=0
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ normalize-stdout: "exit (status|code): 101" -> "exit status: 101"

--- a/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-invalid-doctest.rs
@@ -2,7 +2,7 @@
 // adapted to use that, and that normalize line can go away
 
 //@ failure-status: 101
-//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
+//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{test-suite-src-base}}=remapped_path --test-args --test-threads=1
 //@ rustc-env:RUST_BACKTRACE=0
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 

--- a/tests/rustdoc-ui/remap-path-prefix-lint.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-lint.rs
@@ -1,7 +1,7 @@
 // Regression test for remapped paths in rustdoc errors
 // <https://github.com/rust-lang/rust/issues/69264>.
 
-//@ compile-flags:-Z unstable-options --remap-path-prefix={{src-base}}=remapped_path
+//@ compile-flags:-Z unstable-options --remap-path-prefix={{test-suite-src-base}}=remapped_path
 //@ rustc-env:RUST_BACKTRACE=0
 
 #![deny(rustdoc::invalid_html_tags)]

--- a/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-passed-doctest-output.rs
@@ -4,7 +4,7 @@
 // FIXME: if/when the output of the test harness can be tested on its own, this test should be
 // adapted to use that, and that normalize line can go away
 
-//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{src-base}}=remapped_path --test-args --test-threads=1
+//@ compile-flags:--test -Z unstable-options --remap-path-prefix={{test-suite-src-base}}=remapped_path --test-args --test-threads=1
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // doctest passes at runtime

--- a/tests/rustdoc-ui/scrape-examples/scrape-examples-fail-if-type-error.rs
+++ b/tests/rustdoc-ui/scrape-examples/scrape-examples-fail-if-type-error.rs
@@ -1,5 +1,5 @@
 //@ check-fail
-//@ compile-flags: -Z unstable-options --scrape-examples-output-path {{build-base}}/t.calls --scrape-examples-target-crate foobar
+//@ compile-flags: -Z unstable-options --scrape-examples-output-path {{test-suite-build-base}}/t.calls --scrape-examples-target-crate foobar
 
 pub fn foo() {
   INVALID_FUNC();

--- a/tests/rustdoc-ui/scrape-examples/scrape-examples-ice.rs
+++ b/tests/rustdoc-ui/scrape-examples/scrape-examples-ice.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z unstable-options --scrape-examples-output-path {{build-base}}/t.calls --scrape-examples-target-crate foobar
+//@ compile-flags: -Z unstable-options --scrape-examples-output-path {{test-suite-build-base}}/t.calls --scrape-examples-target-crate foobar
 //@ check-pass
 #![no_std]
 use core as _;

--- a/tests/rustdoc/auxiliary/external-macro-src.rs
+++ b/tests/rustdoc/auxiliary/external-macro-src.rs
@@ -1,4 +1,4 @@
-//@ compile-flags:--remap-path-prefix={{src-base}}=/does-not-exist
+//@ compile-flags:--remap-path-prefix={{test-suite-src-base}}=/does-not-exist
 
 #![doc(html_root_url = "https://example.com/")]
 

--- a/tests/ui-fulldeps/obtain-borrowck.rs
+++ b/tests/ui-fulldeps/obtain-borrowck.rs
@@ -1,7 +1,7 @@
 //@ edition: 2021
 //@ run-pass
 //@ check-run-results
-//@ run-flags: --sysroot {{sysroot-base}} --edition=2021 {{src-base}}/auxiliary/obtain-borrowck-input.rs
+//@ run-flags: --sysroot {{sysroot-base}} --edition=2021 {{test-suite-src-base}}/auxiliary/obtain-borrowck-input.rs
 //@ ignore-stage1 (requires matching sysroot built with in-tree compiler)
 // ignore-tidy-linelength
 

--- a/tests/ui/argfile/commandline-argfile-badutf8-windows.rs
+++ b/tests/ui/argfile/commandline-argfile-badutf8-windows.rs
@@ -5,7 +5,7 @@
 // line arguments and is only run on windows.
 //
 //@ only-windows
-//@ compile-flags: --cfg cmdline_set @{{src-base}}\argfile\commandline-argfile-badutf8.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}\argfile\commandline-argfile-badutf8.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/ui/argfile/commandline-argfile-badutf8.rs
+++ b/tests/ui/argfile/commandline-argfile-badutf8.rs
@@ -6,7 +6,7 @@
 // windows.
 //
 //@ ignore-windows
-//@ compile-flags: --cfg cmdline_set @{{src-base}}/argfile/commandline-argfile-badutf8.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}/argfile/commandline-argfile-badutf8.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/ui/argfile/commandline-argfile-missing-windows.rs
+++ b/tests/ui/argfile/commandline-argfile-missing-windows.rs
@@ -7,7 +7,7 @@
 //@ only-windows
 //@ normalize-stderr: "os error \d+" -> "os error $$ERR"
 //@ normalize-stderr: "commandline-argfile-missing.args:[^(]*" -> "commandline-argfile-missing.args: $$FILE_MISSING "
-//@ compile-flags: --cfg cmdline_set @{{src-base}}\argfile\commandline-argfile-missing.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}\argfile\commandline-argfile-missing.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/ui/argfile/commandline-argfile-missing.rs
+++ b/tests/ui/argfile/commandline-argfile-missing.rs
@@ -8,7 +8,7 @@
 //@ ignore-windows
 //@ normalize-stderr: "os error \d+" -> "os error $$ERR"
 //@ normalize-stderr: "commandline-argfile-missing.args:[^(]*" -> "commandline-argfile-missing.args: $$FILE_MISSING "
-//@ compile-flags: --cfg cmdline_set @{{src-base}}/argfile/commandline-argfile-missing.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}/argfile/commandline-argfile-missing.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/ui/argfile/commandline-argfile-multiple-windows.rs
+++ b/tests/ui/argfile/commandline-argfile-multiple-windows.rs
@@ -8,7 +8,7 @@
 //@ normalize-stderr: "os error \d+" -> "os error $$ERR"
 //@ normalize-stderr: "commandline-argfile-missing.args:[^(]*" -> "commandline-argfile-missing.args: $$FILE_MISSING "
 //@ normalize-stderr: "commandline-argfile-missing2.args:[^(]*" -> "commandline-argfile-missing2.args: $$FILE_MISSING "
-//@ compile-flags: --cfg cmdline_set @{{src-base}}\argfile\commandline-argfile-missing.args @{{src-base}}\argfile\commandline-argfile-badutf8.args @{{src-base}}\argfile\commandline-argfile-missing2.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}\argfile\commandline-argfile-missing.args @{{test-suite-src-base}}\argfile\commandline-argfile-badutf8.args @{{test-suite-src-base}}\argfile\commandline-argfile-missing2.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/ui/argfile/commandline-argfile-multiple.rs
+++ b/tests/ui/argfile/commandline-argfile-multiple.rs
@@ -9,7 +9,7 @@
 //@ normalize-stderr: "os error \d+" -> "os error $$ERR"
 //@ normalize-stderr: "commandline-argfile-missing.args:[^(]*" -> "commandline-argfile-missing.args: $$FILE_MISSING "
 //@ normalize-stderr: "commandline-argfile-missing2.args:[^(]*" -> "commandline-argfile-missing2.args: $$FILE_MISSING "
-//@ compile-flags: --cfg cmdline_set @{{src-base}}/argfile/commandline-argfile-missing.args @{{src-base}}/argfile/commandline-argfile-badutf8.args @{{src-base}}/argfile/commandline-argfile-missing2.args
+//@ compile-flags: --cfg cmdline_set @{{test-suite-src-base}}/argfile/commandline-argfile-missing.args @{{test-suite-src-base}}/argfile/commandline-argfile-badutf8.args @{{test-suite-src-base}}/argfile/commandline-argfile-missing2.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/ui/argfile/commandline-argfile.rs
+++ b/tests/ui/argfile/commandline-argfile.rs
@@ -2,7 +2,7 @@
 //
 //@ build-pass
 //@ compile-flags: --cfg cmdline_set --check-cfg=cfg(cmdline_set,unbroken)
-//@ compile-flags: @{{src-base}}/argfile/commandline-argfile.args
+//@ compile-flags: @{{test-suite-src-base}}/argfile/commandline-argfile.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");

--- a/tests/ui/check-cfg/values-target-json.rs
+++ b/tests/ui/check-cfg/values-target-json.rs
@@ -3,7 +3,7 @@
 //@ check-pass
 //@ no-auto-check-cfg
 //@ needs-llvm-components: x86
-//@ compile-flags: --crate-type=lib --check-cfg=cfg() --target={{src-base}}/check-cfg/my-awesome-platform.json
+//@ compile-flags: --crate-type=lib --check-cfg=cfg() --target={{test-suite-src-base}}/check-cfg/my-awesome-platform.json
 
 #![feature(lang_items, no_core, auto_traits)]
 #![no_core]

--- a/tests/ui/codegen/mismatched-data-layouts.rs
+++ b/tests/ui/codegen/mismatched-data-layouts.rs
@@ -2,7 +2,7 @@
 //
 //@ build-fail
 //@ needs-llvm-components: x86
-//@ compile-flags: --crate-type=lib --target={{src-base}}/codegen/mismatched-data-layout.json -Z unstable-options
+//@ compile-flags: --crate-type=lib --target={{test-suite-src-base}}/codegen/mismatched-data-layout.json -Z unstable-options
 //@ error-pattern: differs from LLVM target's
 //@ normalize-stderr: "`, `[A-Za-z0-9-:]*`" -> "`, `normalized data layout`"
 //@ normalize-stderr: "layout, `[A-Za-z0-9-:]*`" -> "layout, `normalized data layout`"

--- a/tests/ui/crate-loading/invalid-rlib.rs
+++ b/tests/ui/crate-loading/invalid-rlib.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --crate-type lib --extern foo={{src-base}}/crate-loading/auxiliary/libfoo.rlib
+//@ compile-flags: --crate-type lib --extern foo={{test-suite-src-base}}/crate-loading/auxiliary/libfoo.rlib
 //@ normalize-stderr: "failed to mmap file '.*auxiliary/libfoo.rlib':.*" -> "failed to mmap file 'auxiliary/libfoo.rlib'"
 // don't emit warn logging, it's basically the same as the errors and it's annoying to normalize
 //@ rustc-env:RUSTC_LOG=error

--- a/tests/ui/errors/auxiliary/remapped_dep.rs
+++ b/tests/ui/errors/auxiliary/remapped_dep.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --remap-path-prefix={{src-base}}/errors/auxiliary=remapped-aux
+//@ compile-flags: --remap-path-prefix={{test-suite-src-base}}/errors/auxiliary=remapped-aux
 // no-remap-src-base: Manually remap, so the remapped path remains in .stderr file.
 
 pub struct SomeStruct {} // This line should be show as part of the error.

--- a/tests/ui/errors/issue-104621-extern-bad-file.rs
+++ b/tests/ui/errors/issue-104621-extern-bad-file.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --extern foo={{src-base}}/errors/issue-104621-extern-bad-file.rs
+//@ compile-flags: --extern foo={{test-suite-src-base}}/errors/issue-104621-extern-bad-file.rs
 //@ only-linux
 
 extern crate foo;

--- a/tests/ui/errors/remap-path-prefix-macro.rs
+++ b/tests/ui/errors/remap-path-prefix-macro.rs
@@ -2,7 +2,7 @@
 //@ check-run-results
 
 //@ revisions: normal with-macro-scope without-macro-scope
-//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: --remap-path-prefix={{test-suite-src-base}}=remapped
 //@ [with-macro-scope]compile-flags: -Zremap-path-scope=macro,diagnostics
 //@ [without-macro-scope]compile-flags: -Zremap-path-scope=diagnostics
 // no-remap-src-base: Manually remap, so the remapped path remains in .stderr file.

--- a/tests/ui/errors/remap-path-prefix-reverse.rs
+++ b/tests/ui/errors/remap-path-prefix-reverse.rs
@@ -1,8 +1,8 @@
 //@ aux-build:remapped_dep.rs
-//@ compile-flags: --remap-path-prefix={{src-base}}/errors/auxiliary=remapped-aux
+//@ compile-flags: --remap-path-prefix={{test-suite-src-base}}/errors/auxiliary=remapped-aux
 
 //@ revisions: local-self remapped-self
-// [local-self] no-remap-src-base: The hack should work regardless of remapping.
+// The hack should work regardless of remapping.
 //@ [remapped-self] remap-src-base
 
 // Verify that the expected source code is shown.

--- a/tests/ui/errors/remap-path-prefix-sysroot.rs
+++ b/tests/ui/errors/remap-path-prefix-sysroot.rs
@@ -1,7 +1,7 @@
 //@ revisions: with-remap without-remap
 //@ compile-flags: -g -Ztranslate-remapped-path-to-local-path=yes
-//@ [with-remap]compile-flags: --remap-path-prefix={{rust-src-base}}=remapped
-//@ [with-remap]compile-flags: --remap-path-prefix={{src-base}}=remapped-tests-ui
+//@ [with-remap]compile-flags: --remap-path-prefix={{sysroot-rust-src-base}}=remapped
+//@ [with-remap]compile-flags: --remap-path-prefix={{test-suite-src-base}}=remapped-tests-ui
 //@ [without-remap]compile-flags:
 //@ error-pattern: E0507
 

--- a/tests/ui/errors/remap-path-prefix.rs
+++ b/tests/ui/errors/remap-path-prefix.rs
@@ -1,5 +1,5 @@
 //@ revisions: normal with-diagnostic-scope without-diagnostic-scope
-//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: --remap-path-prefix={{test-suite-src-base}}=remapped
 //@ [with-diagnostic-scope]compile-flags: -Zremap-path-scope=diagnostics
 //@ [without-diagnostic-scope]compile-flags: -Zremap-path-scope=object
 // no-remap-src-base: Manually remap, so the remapped path remains in .stderr file.

--- a/tests/ui/meta/revision-bad.rs
+++ b/tests/ui/meta/revision-bad.rs
@@ -5,7 +5,7 @@
 //@ revisions: foo bar
 //@ should-fail
 //@ needs-run-enabled
-//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: --remap-path-prefix={{test-suite-src-base}}=remapped
 //@[foo] error-pattern:bar
 //@[bar] error-pattern:foo
 

--- a/tests/ui/sanitizer/dataflow.rs
+++ b/tests/ui/sanitizer/dataflow.rs
@@ -4,7 +4,7 @@
 //@ needs-sanitizer-support
 //@ needs-sanitizer-dataflow
 //@ run-pass
-//@ compile-flags: -Zsanitizer=dataflow -Zsanitizer-dataflow-abilist={{src-base}}/sanitizer/dataflow-abilist.txt
+//@ compile-flags: -Zsanitizer=dataflow -Zsanitizer-dataflow-abilist={{test-suite-src-base}}/sanitizer/dataflow-abilist.txt
 
 use std::mem::size_of;
 use std::os::raw::{c_int, c_long, c_void};

--- a/tests/ui/shell-argfiles/shell-argfiles-badquotes-windows.rs
+++ b/tests/ui/shell-argfiles/shell-argfiles-badquotes-windows.rs
@@ -5,7 +5,7 @@
 // line arguments and is only run on windows.
 //
 //@ only-windows
-//@ compile-flags: --cfg cmdline_set -Z shell-argfiles @shell:{{src-base}}\shell-argfiles\shell-argfiles-badquotes.args
+//@ compile-flags: --cfg cmdline_set -Z shell-argfiles @shell:{{test-suite-src-base}}\shell-argfiles\shell-argfiles-badquotes.args
 
 fn main() {
 }

--- a/tests/ui/shell-argfiles/shell-argfiles-badquotes.rs
+++ b/tests/ui/shell-argfiles/shell-argfiles-badquotes.rs
@@ -6,7 +6,7 @@
 // windows.
 //
 //@ ignore-windows
-//@ compile-flags: --cfg cmdline_set -Z shell-argfiles @shell:{{src-base}}/shell-argfiles/shell-argfiles-badquotes.args
+//@ compile-flags: --cfg cmdline_set -Z shell-argfiles @shell:{{test-suite-src-base}}/shell-argfiles/shell-argfiles-badquotes.args
 
 fn main() {
 }

--- a/tests/ui/shell-argfiles/shell-argfiles-via-argfile.rs
+++ b/tests/ui/shell-argfiles/shell-argfiles-via-argfile.rs
@@ -2,7 +2,7 @@
 //
 //@ build-pass
 //@ no-auto-check-cfg
-//@ compile-flags: @{{src-base}}/shell-argfiles/shell-argfiles-via-argfile.args @shell:{{src-base}}/shell-argfiles/shell-argfiles-via-argfile-shell.args
+//@ compile-flags: @{{test-suite-src-base}}/shell-argfiles/shell-argfiles-via-argfile.args @shell:{{test-suite-src-base}}/shell-argfiles/shell-argfiles-via-argfile-shell.args
 
 #[cfg(not(shell_args_set))]
 compile_error!("shell_args_set not set");

--- a/tests/ui/shell-argfiles/shell-argfiles.rs
+++ b/tests/ui/shell-argfiles/shell-argfiles.rs
@@ -1,7 +1,7 @@
 // Check to see if we can get parameters from an @argsfile file
 //
 //@ build-pass
-//@ compile-flags: --cfg cmdline_set -Z shell-argfiles @shell:{{src-base}}/shell-argfiles/shell-argfiles.args
+//@ compile-flags: --cfg cmdline_set -Z shell-argfiles @shell:{{test-suite-src-base}}/shell-argfiles/shell-argfiles.args
 
 #[cfg(not(cmdline_set))]
 compile_error!("cmdline_set not set");


### PR DESCRIPTION
Some exploratory changes while trying to figure out why cg_clif's tests were failing.

Not intended for review, this PR needs to be broken up into reviewable PRs with logical commits. Only posted for reference purposes.

```diff
-        cmd.arg("--src-base").arg(builder.src.join("tests").join(suite));
-        cmd.arg("--build-base").arg(testdir(builder, compiler.host).join(suite));
+        cmd.arg("--src-root").arg(&builder.src);
+        cmd.arg("--src-test-suite-root").arg(builder.src.join("tests").join(suite));
+        cmd.arg("--build-root").arg(&builder.out);
+        cmd.arg("--build-test-suite-root").arg(testdir(builder, compiler.host).join(suite));
```

```bash
$ find tests -type f -exec sed -i 's/{{src-base}}/{{test-suite-src-base}}/g' {} \;
$ find tests -type f -exec sed -i 's/{{rust-src-base}}/{{sysroot-rust-src-base}}/g' {} \;
$ find tests -type f -exec sed -i 's/{{build-base}}/{{test-suite-build-base}}/g' {} \;
```

### Planned PR series

1. Cleanup `is_rustdoc` matching logic and remove a useless `rustdoc-json` `Path::join`. https://github.com/rust-lang/rust/pull/136441
1. Pass `--stage` as a compiletest flag to not have to do `stage-id` gymnastics in run-make runtest logic. https://github.com/rust-lang/rust/pull/136472
1. Rectify `src_base` handling: split `--src-base` into two flags, `--src-root` and `--src-test-suite-root`, and tidy up logic that exercises `src_base` previously. Remove `find_rust_src_root`. https://github.com/rust-lang/rust/pull/136474
1. Rectify `build_base` handling: split `--build-base` into two flags, `--build-root` and `--build-test-suite-root`, and tidy up logic that exercises `build_base` previously. https://github.com/rust-lang/rust/pull/136542
1. Rename `{{src-base}}` -> `{{test-suite-src-base}}`. Rebless tests. Update rustc-dev-guide.
1. Rename `{{rust-src-base}}` -> `{{sysroot-rust-src-base}}`. Rebless tests. Update rustc-dev-guide.
1. Rename `{{build-base}}` -> `{{test-suite-build-base}}`. Rebless tests. Update rustc-dev-guide.