### PR TITLE
Fix a couple NLL TLS spans 

### DIFF
--- a/tests/ui/borrowck/borrowck-thread-local-static-borrow-outlives-fn.stderr
+++ b/tests/ui/borrowck/borrowck-thread-local-static-borrow-outlives-fn.stderr
@@ -4,7 +4,7 @@ error[E0712]: thread-local variable borrowed past end of function
 LL |      assert_static(&FOO);
    |                    ^^^^ thread-local variables cannot be borrowed beyond the end of the function
 LL | }
-   |  - end of enclosing function is here
+   | - end of enclosing function is here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-17954.stderr
+++ b/tests/ui/issues/issue-17954.stderr
@@ -5,7 +5,7 @@ LL |     let a = &FOO;
    |             ^^^^ thread-local variables cannot be borrowed beyond the end of the function
 ...
 LL | }
-   |  - end of enclosing function is here
+   | - end of enclosing function is here
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Some NLL TLS tests show incorrect spans for the end of function. It seems that the `TerminatorKind::Return` source info span can sometimes point at the single character after the end of the function. 

Completely changing the span where the terminator is built also changes a bunch of diagnostics: small functions have more code shown unrelated to the errors at hand, wrapping symbols appear and weird-looking arrows point to the end of function, etc. So it seems this is somehow unexpectedly relied upon in making diagnostics look better and their heuristics.

So I just changed it where it matters for these few tests: the diagnostics specialized to conflict errors with thread locals.

r? @matthewjasper 