### PR TITLE
ci: move x86_64-msvc-ext jobs to windows 2025

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -488,7 +488,7 @@ auto:
     env:
       SCRIPT: python x.py --stage 2 test src/tools/cargotest src/tools/cargo
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
-    <<: *job-windows
+    <<: *job-windows-25
 
   # Temporary builder to workaround CI issues
   # See <https://github.com/rust-lang/rust/issues/127883>
@@ -502,7 +502,7 @@ auto:
         python x.py miri --stage 2 library/alloc --test-args notest &&
         python x.py miri --stage 2 library/std --test-args notest
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
-    <<: *job-windows
+    <<: *job-windows-25
 
   # Run `checktools.sh` and upload the toolstate file.
   - name: x86_64-msvc-ext3
@@ -511,7 +511,7 @@ auto:
       HOST_TARGET: x86_64-pc-windows-msvc
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld --save-toolstates=/tmp/toolstate/toolstates.json
       DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
-    <<: *job-windows
+    <<: *job-windows-25
 
   # 32/64-bit MinGW builds.
   #


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
These jobs are a bit flaky. See [this](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Spurious.20CI.20errors.20on.20x86_64-msvc-ext) zulip thread and [this](https://github.com/rust-lang/rust/issues/127883) GitHub issue.
Windows 2025 is working well for `x86_64-msvc` jobs since we moved them in https://github.com/rust-lang/rust/pull/135632 

## Analysis
- The jobs x86_64-msvc-ext2 and x86_64-msvc-ext3 never failed in the last month
- The job x86_64-msvc-ext1 failed 6 times:
![image](https://github.com/user-attachments/assets/80a93434-8bf8-424d-8c79-29013e648b5c)

<!-- homu-ignore:end -->
try-job: x86_64-msvc-ext1
try-job: x86_64-msvc-ext2
try-job: x86_64-msvc-ext3