### PR TITLE
ci: move dist-x86_64-msvc to windows 2025

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -558,7 +558,7 @@ auto:
       SCRIPT: python x.py build --set rust.debug=true opt-dist && PGO_HOST=x86_64-pc-windows-msvc ./build/x86_64-pc-windows-msvc/stage0-tools-bin/opt-dist windows-ci -- python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-windows-8c
+    <<: *job-windows-25-8c
 
   - name: dist-i686-msvc
     env:


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
This job is very flaky: it failed 19 times in the last month. 

![image](https://github.com/user-attachments/assets/9a775f6a-19bc-43f1-b037-16aaf3f94f45)

See also [this](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Spurious.20CI.20errors.20on.20x86_64-msvc-ext) zulip thread and [this](https://github.com/rust-lang/rust/issues/127883) GitHub issue.

Windows 2025 is working well for `x86_64-msvc` jobs since we moved them in https://github.com/rust-lang/rust/pull/135632 so we want to move this runner as well to try to reduce the flakiness.
<!-- homu-ignore:end -->
try-job: dist-x86_64-msvc