### PR TITLE
ci: stop mysql before removing it

### DIFF
--- a/src/ci/scripts/free-disk-space.sh
+++ b/src/ci/scripts/free-disk-space.sh
@@ -110,6 +110,9 @@ execAndMeasureSpaceChange() {
 # Remove large packages
 # REF: https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
 cleanPackages() {
+    # Stop services to avoid issues when removing their packages.
+    sudo systemctl stop mysql
+
     local packages=(
         '^aspnetcore-.*'
         '^dotnet-.*'


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
Disable mysql before removing it from the runner.

This error happened in https://github.com/rust-lang/rust/pull/136454#issuecomment-2629588194
<!-- homu-ignore:end -->
try-job: aarch64-gnu