### PR TITLE
Rename to `{u,i}*::reinterpret_{signed,unsigned}` from `cast`

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -197,13 +197,13 @@ macro_rules! int_impl {
         ///
         #[doc = concat!("let n = -1", stringify!($SelfT), ";")]
         ///
-        #[doc = concat!("assert_eq!(n.cast_unsigned(), ", stringify!($UnsignedT), "::MAX);")]
+        #[doc = concat!("assert_eq!(n.reinterpret_unsigned(), ", stringify!($UnsignedT), "::MAX);")]
         /// ```
         #[unstable(feature = "integer_sign_cast", issue = "125882")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
-        pub const fn cast_unsigned(self) -> $UnsignedT {
+        pub const fn reinterpret_unsigned(self) -> $UnsignedT {
             self as $UnsignedT
         }
 

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -227,13 +227,13 @@ macro_rules! uint_impl {
         ///
         #[doc = concat!("let n = ", stringify!($SelfT), "::MAX;")]
         ///
-        #[doc = concat!("assert_eq!(n.cast_signed(), -1", stringify!($SignedT), ");")]
+        #[doc = concat!("assert_eq!(n.reinterpret_signed(), -1", stringify!($SignedT), ");")]
         /// ```
         #[unstable(feature = "integer_sign_cast", issue = "125882")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
-        pub const fn cast_signed(self) -> $SignedT {
+        pub const fn reinterpret_signed(self) -> $SignedT {
             self as $SignedT
         }
 


### PR DESCRIPTION
The previous names did not communicate what happens to values of unsigned integers that do not fit into the target integer values.

We're reinterpreting the bits as an unsigned integer, but "cast" does not say that. E.g. casting from integer to float does not reinterpret the bits, casting from `i8` to `i32` does not solely reinterpret the bits either, it sign-extends them. So "cast" doesn't tell me what happens.

CC https://github.com/rust-lang/rust/issues/125882#issuecomment-2631090130