### PR TITLE
Do not allow attributes on struct field rest patterns

### DIFF
--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -1472,17 +1472,6 @@ impl<'a> Parser<'a> {
         let mut last_non_comma_dotdot_span = None;
 
         while self.token != token::CloseDelim(Delimiter::Brace) {
-            let attrs = match self.parse_outer_attributes() {
-                Ok(attrs) => attrs,
-                Err(err) => {
-                    if let Some(delayed) = delayed_err {
-                        delayed.emit();
-                    }
-                    return Err(err);
-                }
-            };
-            let lo = self.token.span;
-
             // check that a comma comes after every field
             if !ate_comma {
                 let err = if self.token == token::At {
@@ -1584,6 +1573,17 @@ impl<'a> Parser<'a> {
                     return Err(err);
                 }
             }
+
+            let attrs = match self.parse_outer_attributes() {
+                Ok(attrs) => attrs,
+                Err(err) => {
+                    if let Some(delayed) = delayed_err {
+                        delayed.emit();
+                    }
+                    return Err(err);
+                }
+            };
+            let lo = self.token.span;
 
             let field = self.collect_tokens(None, attrs, ForceCollect::No, |this, attrs| {
                 let field = match this.parse_pat_field(lo, attrs) {

--- a/tests/ui/parser/attribute/attr-pat-struct-rest.rs
+++ b/tests/ui/parser/attribute/attr-pat-struct-rest.rs
@@ -1,0 +1,8 @@
+// #81282: Attributes are not allowed on struct field rest patterns (the ..).
+
+struct S {}
+
+fn main() {
+    let S { #[cfg(any())] .. } = S {};
+    //~^ ERROR expected identifier, found `..`
+}

--- a/tests/ui/parser/attribute/attr-pat-struct-rest.stderr
+++ b/tests/ui/parser/attribute/attr-pat-struct-rest.stderr
@@ -1,0 +1,10 @@
+error: expected identifier, found `..`
+  --> $DIR/attr-pat-struct-rest.rs:6:27
+   |
+LL |     let S { #[cfg(any())] .. } = S {};
+   |         -                 ^^ expected identifier
+   |         |
+   |         while parsing the fields for this pattern
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #81282.

This removes support for attributes on struct field rest patterns (the `..` bit) from the parser. Previously any attributes were being parsed but dropped from the AST, so didn't work and were deleted by rustfmt.

This needs an equivalent change to the reference but I wanted to see how this PR is received first.
The error message it produces isn't great, however it does match the error you get if you try to add attributes to .. in struct expressions atm, although I can understand wanting to do better given this was previously accepted. I think I could move attribute parsing back up to where it was and then emit a specific new error for this case, however I might need some guidance as this is the first time I've messed around inside the compiler.

While this is technically breaking I don't think it's much of an issue: attributes in this position don't currently do anything and rustfmt outright deletes them, meaning it's incredibly unlikely to affect anyone. I have already made the equivalent change to *add* support for attributes (mostly) but the conversation in the linked issue suggested it would be more reasonable to just remove them (and pointed out it's much easier to add support later if we realise we need them).