### PR TITLE
Pattern Migration 2024: suggest nicer patterns

### DIFF
--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -812,7 +812,7 @@ impl<'tcx> std::fmt::Display for UserTypeKind<'tcx> {
 
 /// Information on a pattern incompatible with Rust 2024, for use by the error/migration diagnostic
 /// emitted during THIR construction.
-#[derive(TyEncodable, TyDecodable, Debug, HashStable)]
+#[derive(TyEncodable, TyDecodable, Debug, Default, HashStable)]
 pub struct Rust2024IncompatiblePatInfo {
     /// Labeled spans for `&`s, `&mut`s, and binding modifiers incompatible with Rust 2024.
     pub primary_labels: Vec<(Span, String)>,
@@ -820,6 +820,4 @@ pub struct Rust2024IncompatiblePatInfo {
     pub bad_modifiers: bool,
     /// Whether any `&` or `&mut` patterns occur under a non-`move` default binding mode.
     pub bad_ref_pats: bool,
-    /// If `true`, we can give a simpler suggestion solely by eliding explicit binding modifiers.
-    pub suggest_eliding_modes: bool,
 }

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -34,7 +34,7 @@ struct PatCtxt<'a, 'tcx> {
     typeck_results: &'a ty::TypeckResults<'tcx>,
 
     /// Used by the Rust 2024 migration lint.
-    rust_2024_migration: Option<PatMigration<'a>>,
+    rust_2024_migration: Option<PatMigration<'a, 'tcx>>,
 }
 
 pub(super) fn pat_from_hir<'a, 'tcx>(
@@ -69,7 +69,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         if let Some(s) = &mut self.rust_2024_migration
             && !adjustments.is_empty()
         {
-            s.visit_implicit_derefs(pat.span, adjustments);
+            s.visit_implicit_derefs(pat, adjustments);
         }
 
         // When implicit dereferences have been inserted in this pattern, the unadjusted lowered

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -306,10 +306,10 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                 let mutability = if mutable { hir::Mutability::Mut } else { hir::Mutability::Not };
                 PatKind::DerefPattern { subpattern: self.lower_pattern(subpattern), mutability }
             }
-            hir::PatKind::Ref(subpattern, _) => {
+            hir::PatKind::Ref(subpattern, mutbl) => {
                 // Track the default binding mode for the Rust 2024 migration suggestion.
                 if let Some(s) = &mut self.rust_2024_migration {
-                    s.visit_explicit_deref(pat.span);
+                    s.visit_explicit_deref(pat.span, mutbl);
                 }
                 let subpattern = self.lower_pattern(subpattern);
                 if let Some(s) = &mut self.rust_2024_migration {

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -344,8 +344,8 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                     .get(pat.hir_id)
                     .expect("missing binding mode");
 
-                if let Some(s) = &mut self.rust_2024_migration {
-                    s.visit_binding(pat.span, mode, explicit_ba, ident);
+                if let Some(m) = &mut self.rust_2024_migration {
+                    m.visit_binding(pat, mode, explicit_ba, ident);
                 }
 
                 // A ref x pattern is the same node used for x, and as such it has

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -309,7 +309,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
             hir::PatKind::Ref(subpattern, mutbl) => {
                 // Track the default binding mode for the Rust 2024 migration suggestion.
                 if let Some(s) = &mut self.rust_2024_migration {
-                    s.visit_explicit_deref(pat.span, mutbl);
+                    s.visit_explicit_deref(pat.span, mutbl, subpattern);
                 }
                 let subpattern = self.lower_pattern(subpattern);
                 if let Some(s) = &mut self.rust_2024_migration {

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/auxiliary/migration_lint_macros.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/auxiliary/migration_lint_macros.rs
@@ -16,3 +16,10 @@ macro_rules! bind_ref {
         ref $foo
     };
 }
+
+#[macro_export]
+macro_rules! match_ref {
+    ($p:pat) => {
+        &$p
+    };
+}

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2024.stderr
@@ -46,10 +46,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [ref x] = &[0];
    |         ^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+help: remove the unnecessary binding modifier
    |
-LL |     let &[ref x] = &[0];
-   |         +
+LL -     let [ref x] = &[0];
+LL +     let [x] = &[0];
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move`
   --> $DIR/ref-binding-on-inh-ref-errors.rs:79:10
@@ -80,10 +81,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [ref mut x] = &mut [0];
    |         ^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+help: remove the unnecessary binding modifier
    |
-LL |     let &mut [ref mut x] = &mut [0];
-   |         ++++
+LL -     let [ref mut x] = &mut [0];
+LL +     let [x] = &mut [0];
+   |
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2024.stderr
@@ -152,10 +152,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [ref x] = &[0];
    |         ^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+help: remove the unnecessary binding modifier
    |
-LL |     let &[ref x] = &[0];
-   |         +
+LL -     let [ref x] = &[0];
+LL +     let [x] = &[0];
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move`
   --> $DIR/ref-binding-on-inh-ref-errors.rs:79:10
@@ -186,10 +187,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [ref mut x] = &mut [0];
    |         ^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+help: remove the unnecessary binding modifier
    |
-LL |     let &mut [ref mut x] = &mut [0];
-   |         ++++
+LL -     let [ref mut x] = &mut [0];
+LL +     let [x] = &mut [0];
+   |
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2024.stderr
@@ -10,10 +10,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [&ref x] = &[&0];
    |         ^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+help: rewrite the pattern
    |
-LL |     let &[&ref x] = &[&0];
-   |         +
+LL -     let [&ref x] = &[&0];
+LL +     let &[x] = &[&0];
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move`
   --> $DIR/ref-binding-on-inh-ref-errors.rs:20:11
@@ -27,10 +28,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [&ref x] = &mut [&0];
    |         ^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+help: rewrite the pattern
    |
-LL |     let &mut [&ref x] = &mut [&0];
-   |         ++++
+LL -     let [&ref x] = &mut [&0];
+LL +     let &mut [x] = &mut [&0];
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move`
   --> $DIR/ref-binding-on-inh-ref-errors.rs:25:15
@@ -61,10 +63,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [&mut ref mut x] = &mut [&mut 0];
    |         ^^^^^^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+help: rewrite the pattern
    |
-LL |     let &mut [&mut ref mut x] = &mut [&mut 0];
-   |         ++++
+LL -     let [&mut ref mut x] = &mut [&mut 0];
+LL +     let &mut [x] = &mut [&mut 0];
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move`
   --> $DIR/ref-binding-on-inh-ref-errors.rs:39:11
@@ -78,10 +81,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [&ref x] = &[&mut 0];
    |         ^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+help: rewrite the pattern
    |
-LL |     let &[&ref x] = &[&mut 0];
-   |         +
+LL -     let [&ref x] = &[&mut 0];
+LL +     let &[x] = &[&mut 0];
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move`
   --> $DIR/ref-binding-on-inh-ref-errors.rs:45:11
@@ -95,10 +99,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [&ref x] = &mut [&mut 0];
    |         ^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference pattern explicit
+help: rewrite the pattern
    |
-LL |     let &mut [&ref x] = &mut [&mut 0];
-   |         ++++
+LL -     let [&ref x] = &mut [&mut 0];
+LL +     let &mut [x] = &mut [&mut 0];
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move`
   --> $DIR/ref-binding-on-inh-ref-errors.rs:54:15

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
@@ -244,4 +244,10 @@ fn main() {
     let &[migration_lint_macros::bind_ref!(a)] = &[0];
     //~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
     assert_type_eq(a, &0u32);
+
+    // Test that we use the correct span when labeling a `&` whose subpattern is from an expansion.
+    let &[&migration_lint_macros::bind_ref!(a)] = &[&0];
+    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~| WARN: this changes meaning in Rust 2024
+    assert_type_eq(a, &0u32);
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
@@ -151,8 +151,6 @@ fn main() {
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
 
-    // NB: Most of the following tests are for possible future improvements to migration suggestions
-
     // Test removing multiple binding modifiers.
     let Struct { a, b, c } = &Struct { a: 0, b: 0, c: 0 };
     //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
@@ -96,7 +96,7 @@ fn main() {
         assert_type_eq(x, 0u8);
     }
 
-    if let &mut Some(&mut Some(&mut Some(ref mut x))) = &mut Some(&mut Some(&mut Some(0u8))) {
+    if let Some(Some(Some(x))) = &mut Some(&mut Some(&mut Some(0u8))) {
         //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         assert_type_eq(x, &mut 0u8);
@@ -121,7 +121,7 @@ fn main() {
     assert_type_eq(b, &&0u32);
     assert_type_eq(c, &&0u32);
 
-    if let &Struct { a: &Some(a), b: &Some(&b), c: &Some(ref c) } =
+    if let &Struct { a: &Some(a), b: &Some(&b), c: Some(c) } =
         //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
         //~| WARN: this changes meaning in Rust 2024
         &(Struct { a: &Some(&0), b: &Some(&0), c: &Some(&0) })
@@ -142,12 +142,12 @@ fn main() {
         _ => {}
     }
 
-    let &mut [&mut &[ref a]] = &mut [&mut &[0]];
+    let [[a]] = &mut [&mut &[0]];
     //~^ ERROR: binding modifiers and reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
 
-    let &[&(_)] = &[&0];
+    let [(_)] = &[&0];
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
 
@@ -167,7 +167,7 @@ fn main() {
     assert_type_eq(c, &mut 0u32);
 
     // Test removing multiple reference patterns of various mutabilities, plus a binding modifier.
-    let &mut &Struct { a: &[ref a], b: &mut [&[ref b]], ref c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
+    let Struct { a: [a], b: [[b]], c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
@@ -181,7 +181,7 @@ fn main() {
     assert_type_eq(a, &0u32);
 
     // Test that we don't change bindings' modes when adding reference paterns (caught early).
-    let &(&a, ref b, &[ref c], &mut [&mut (ref d, &[ref e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
+    let &(&a, ref b, [c], &mut [&mut (ref d, [e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, 0u32);
@@ -199,7 +199,7 @@ fn main() {
     assert_type_eq(c, 0u32);
 
     // Test featuring both additions and removals.
-    let &(&a, &mut (ref b, &[ref c])) = &(&0, &mut (0, &[0]));
+    let &(&a, &mut (ref b, [c])) = &(&0, &mut (0, &[0]));
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, 0u32);
@@ -239,7 +239,7 @@ fn main() {
     assert_type_eq(d, 0u32);
 
     // Test that we use the correct message and suggestion style when pointing inside expansions.
-    let &[migration_lint_macros::bind_ref!(a)] = &[0];
+    let [migration_lint_macros::bind_ref!(a)] = &[0];
     //~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
     assert_type_eq(a, &0u32);
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
@@ -175,7 +175,7 @@ fn main() {
     assert_type_eq(c, &0u32);
 
     // Test that we don't change bindings' types when removing reference patterns.
-    let &Foo(&ref a) = &Foo(&0);
+    let &Foo(a) = &Foo(&0);
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
@@ -221,7 +221,7 @@ fn main() {
     assert_type_eq(b, 0u32);
 
     // Test that we respect bindings' subpatterns' types when rewriting `&ref x` to `x`.
-    let [&Foo(&ref a @ ref b), &Foo(&ref c @ d)] = [&Foo(&0); 2];
+    let [&Foo(a @ b), &Foo(&ref c @ d)] = [&Foo(&0); 2];
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &0u32);
@@ -230,7 +230,7 @@ fn main() {
     assert_type_eq(d, 0u32);
 
     // Test that we respect bindings' subpatterns' modes when rewriting `&ref x` to `x`.
-    let [&Foo(&ref a @ [ref b]), &Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
+    let [&Foo(a @ [b]), &Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
     assert_type_eq(a, &[0u32]);

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
@@ -243,9 +243,19 @@ fn main() {
     //~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
     assert_type_eq(a, &0u32);
 
+    let &[migration_lint_macros::match_ref!(a)] = &[&0];
+    //~^ ERROR: reference patterns may only be written when the default binding mode is `move`
+    assert_type_eq(a, 0u32);
+
     // Test that we use the correct span when labeling a `&` whose subpattern is from an expansion.
+    // Also test that we don't simplify `&ref x` to `x` when the `ref` is from an expansion.
     let &[&migration_lint_macros::bind_ref!(a)] = &[&0];
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
+    assert_type_eq(a, &0u32);
+
+    // Test that we don't simplify `&ref x` to `x` when the `&` is from an expansion.
+    let &[migration_lint_macros::match_ref!(ref a)] = &[&0];
+    //~^ ERROR: reference patterns may only be written when the default binding mode is `move`
     assert_type_eq(a, &0u32);
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.fixed
@@ -239,7 +239,7 @@ fn main() {
     assert_type_eq(d, 0u32);
 
     // Test that we use the correct message and suggestion style when pointing inside expansions.
-    let [migration_lint_macros::bind_ref!(a)] = &[0];
+    let &[migration_lint_macros::bind_ref!(a)] = &[0];
     //~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
     assert_type_eq(a, &0u32);
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.rs
@@ -244,4 +244,10 @@ fn main() {
     let [migration_lint_macros::bind_ref!(a)] = &[0];
     //~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
     assert_type_eq(a, &0u32);
+
+    // Test that we use the correct span when labeling a `&` whose subpattern is from an expansion.
+    let [&migration_lint_macros::bind_ref!(a)] = &[&0];
+    //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+    //~| WARN: this changes meaning in Rust 2024
+    assert_type_eq(a, &0u32);
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.rs
@@ -243,9 +243,19 @@ fn main() {
     //~^ ERROR: binding modifiers may only be written when the default binding mode is `move`
     assert_type_eq(a, &0u32);
 
+    let [migration_lint_macros::match_ref!(a)] = &[&0];
+    //~^ ERROR: reference patterns may only be written when the default binding mode is `move`
+    assert_type_eq(a, 0u32);
+
     // Test that we use the correct span when labeling a `&` whose subpattern is from an expansion.
+    // Also test that we don't simplify `&ref x` to `x` when the `ref` is from an expansion.
     let [&migration_lint_macros::bind_ref!(a)] = &[&0];
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
+    assert_type_eq(a, &0u32);
+
+    // Test that we don't simplify `&ref x` to `x` when the `&` is from an expansion.
+    let [migration_lint_macros::match_ref!(ref a)] = &[&0];
+    //~^ ERROR: reference patterns may only be written when the default binding mode is `move`
     assert_type_eq(a, &0u32);
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.rs
@@ -151,8 +151,6 @@ fn main() {
     //~^ ERROR: reference patterns may only be written when the default binding mode is `move` in Rust 2024
     //~| WARN: this changes meaning in Rust 2024
 
-    // NB: Most of the following tests are for possible future improvements to migration suggestions
-
     // Test removing multiple binding modifiers.
     let Struct { ref a, ref b, c } = &Struct { a: 0, b: 0, c: 0 };
     //~^ ERROR: binding modifiers may only be written when the default binding mode is `move` in Rust 2024

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
@@ -342,7 +342,7 @@ LL |     let &[&(_)] = &[&0];
    |         +
 
 error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:157:18
+  --> $DIR/migration_lint.rs:155:18
    |
 LL |     let Struct { ref a, ref b, c } = &Struct { a: 0, b: 0, c: 0 };
    |                  ^^^    ^^^ binding modifier not allowed under `ref` default binding mode
@@ -352,7 +352,7 @@ LL |     let Struct { ref a, ref b, c } = &Struct { a: 0, b: 0, c: 0 };
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:157:9
+  --> $DIR/migration_lint.rs:155:9
    |
 LL |     let Struct { ref a, ref b, c } = &Struct { a: 0, b: 0, c: 0 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
@@ -363,7 +363,7 @@ LL +     let Struct { a, b, c } = &Struct { a: 0, b: 0, c: 0 };
    |
 
 error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:164:18
+  --> $DIR/migration_lint.rs:162:18
    |
 LL |     let Struct { ref a, ref mut b, c } = &mut Struct { a: 0, b: 0, c: 0 };
    |                  ^^^    ^^^^^^^ binding modifier not allowed under `ref mut` default binding mode
@@ -373,7 +373,7 @@ LL |     let Struct { ref a, ref mut b, c } = &mut Struct { a: 0, b: 0, c: 0 };
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:164:9
+  --> $DIR/migration_lint.rs:162:9
    |
 LL |     let Struct { ref a, ref mut b, c } = &mut Struct { a: 0, b: 0, c: 0 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&mut _`
@@ -383,7 +383,7 @@ LL |     let &mut Struct { ref a, ref mut b, ref mut c } = &mut Struct { a: 0, b
    |         ++++                            +++++++
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:172:21
+  --> $DIR/migration_lint.rs:170:21
    |
 LL |     let Struct { a: &[ref a], b: &mut [[b]], c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
    |                     ^            ^^^^ reference pattern not allowed under `ref` default binding mode
@@ -393,7 +393,7 @@ LL |     let Struct { a: &[ref a], b: &mut [[b]], c } = &mut &Struct { a: &[0], 
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:172:9
+  --> $DIR/migration_lint.rs:170:9
    |
 LL |     let Struct { a: &[ref a], b: &mut [[b]], c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
@@ -403,7 +403,7 @@ LL |     let &mut &Struct { a: &[ref a], b: &mut [&[ref b]], ref c } = &mut &Str
    |         ++++++                               + +++      +++
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:180:13
+  --> $DIR/migration_lint.rs:178:13
    |
 LL |     let Foo(&ref a) = &Foo(&0);
    |             ^ reference pattern not allowed under `ref` default binding mode
@@ -411,7 +411,7 @@ LL |     let Foo(&ref a) = &Foo(&0);
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:180:9
+  --> $DIR/migration_lint.rs:178:9
    |
 LL |     let Foo(&ref a) = &Foo(&0);
    |         ^^^^^^^^^^^ this matches on type `&_`
@@ -421,7 +421,7 @@ LL |     let &Foo(&ref a) = &Foo(&0);
    |         +
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:186:10
+  --> $DIR/migration_lint.rs:184:10
    |
 LL |     let (&a, b, [c], [(d, [e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
    |          ^ reference pattern not allowed under `ref` default binding mode
@@ -429,7 +429,7 @@ LL |     let (&a, b, [c], [(d, [e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:186:9
+  --> $DIR/migration_lint.rs:184:9
    |
 LL |     let (&a, b, [c], [(d, [e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
@@ -439,7 +439,7 @@ LL |     let &(&a, ref b, &[ref c], &mut [&mut (ref d, &[ref e])]) = &(&0, 0, &[
    |         +     +++    + +++     ++++  ++++  +++    + +++
 
 error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:196:19
+  --> $DIR/migration_lint.rs:194:19
    |
 LL |     let (a, [b], [mut c]) = &(0, &mut [0], &[0]);
    |                   ^^^ binding modifier not allowed under `ref` default binding mode
@@ -447,7 +447,7 @@ LL |     let (a, [b], [mut c]) = &(0, &mut [0], &[0]);
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:196:9
+  --> $DIR/migration_lint.rs:194:9
    |
 LL |     let (a, [b], [mut c]) = &(0, &mut [0], &[0]);
    |         ^^^^^^^^^^^^^^^^^ this matches on type `&_`
@@ -457,7 +457,7 @@ LL |     let &(ref a, &mut [ref b], &[mut c]) = &(0, &mut [0], &[0]);
    |         + +++    ++++  +++     +
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:204:10
+  --> $DIR/migration_lint.rs:202:10
    |
 LL |     let (&a, (b, &[ref c])) = &(&0, &mut (0, &[0]));
    |          ^       ^ reference pattern not allowed under `ref` default binding mode
@@ -467,7 +467,7 @@ LL |     let (&a, (b, &[ref c])) = &(&0, &mut (0, &[0]));
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:204:9
+  --> $DIR/migration_lint.rs:202:9
    |
 LL |     let (&a, (b, &[ref c])) = &(&0, &mut (0, &[0]));
    |         ^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
@@ -477,7 +477,7 @@ LL |     let &(&a, &mut (ref b, &[ref c])) = &(&0, &mut (0, &[0]));
    |         +     ++++  +++
 
 error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:212:10
+  --> $DIR/migration_lint.rs:210:10
    |
 LL |     let [mut a @ b] = &[0];
    |          ^^^ binding modifier not allowed under `ref` default binding mode
@@ -485,7 +485,7 @@ LL |     let [mut a @ b] = &[0];
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:212:9
+  --> $DIR/migration_lint.rs:210:9
    |
 LL |     let [mut a @ b] = &[0];
    |         ^^^^^^^^^^^ this matches on type `&_`
@@ -495,7 +495,7 @@ LL |     let &[mut a @ ref b] = &[0];
    |         +         +++
 
 error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:219:14
+  --> $DIR/migration_lint.rs:217:14
    |
 LL |     let [a @ mut b] = &[0];
    |              ^^^ binding modifier not allowed under `ref` default binding mode
@@ -503,7 +503,7 @@ LL |     let [a @ mut b] = &[0];
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:219:9
+  --> $DIR/migration_lint.rs:217:9
    |
 LL |     let [a @ mut b] = &[0];
    |         ^^^^^^^^^^^ this matches on type `&_`
@@ -513,7 +513,7 @@ LL |     let &[ref a @ mut b] = &[0];
    |         + +++
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:226:14
+  --> $DIR/migration_lint.rs:224:14
    |
 LL |     let [Foo(&ref a @ ref b), Foo(&ref c @ d)] = [&Foo(&0); 2];
    |              ^                    ^ reference pattern not allowed under `ref` default binding mode
@@ -523,12 +523,12 @@ LL |     let [Foo(&ref a @ ref b), Foo(&ref c @ d)] = [&Foo(&0); 2];
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:226:31
+  --> $DIR/migration_lint.rs:224:31
    |
 LL |     let [Foo(&ref a @ ref b), Foo(&ref c @ d)] = [&Foo(&0); 2];
    |                               ^^^^^^^^^^^^^^^ this matches on type `&_`
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:226:10
+  --> $DIR/migration_lint.rs:224:10
    |
 LL |     let [Foo(&ref a @ ref b), Foo(&ref c @ d)] = [&Foo(&0); 2];
    |          ^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
@@ -538,7 +538,7 @@ LL |     let [&Foo(&ref a @ ref b), &Foo(&ref c @ d)] = [&Foo(&0); 2];
    |          +                     +
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:235:14
+  --> $DIR/migration_lint.rs:233:14
    |
 LL |     let [Foo(&ref a @ [ref b]), Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
    |              ^                      ^ reference pattern not allowed under `ref` default binding mode
@@ -548,12 +548,12 @@ LL |     let [Foo(&ref a @ [ref b]), Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:235:33
+  --> $DIR/migration_lint.rs:233:33
    |
 LL |     let [Foo(&ref a @ [ref b]), Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
    |                                 ^^^^^^^^^^^^^^^^^ this matches on type `&_`
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:235:10
+  --> $DIR/migration_lint.rs:233:10
    |
 LL |     let [Foo(&ref a @ [ref b]), Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
    |          ^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
@@ -419,10 +419,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let Foo(&ref a) = &Foo(&0);
    |         ^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+help: rewrite the pattern
    |
-LL |     let &Foo(&ref a) = &Foo(&0);
-   |         +
+LL -     let Foo(&ref a) = &Foo(&0);
+LL +     let &Foo(a) = &Foo(&0);
+   |
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
   --> $DIR/migration_lint.rs:184:10
@@ -537,10 +538,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [Foo(&ref a @ ref b), Foo(&ref c @ d)] = [&Foo(&0); 2];
    |          ^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns explicit
+help: rewrite the pattern
    |
-LL |     let [&Foo(&ref a @ ref b), &Foo(&ref c @ d)] = [&Foo(&0); 2];
-   |          +                     +
+LL -     let [Foo(&ref a @ ref b), Foo(&ref c @ d)] = [&Foo(&0); 2];
+LL +     let [&Foo(a @ b), &Foo(&ref c @ d)] = [&Foo(&0); 2];
+   |
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
   --> $DIR/migration_lint.rs:233:14
@@ -562,10 +564,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [Foo(&ref a @ [ref b]), Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
    |          ^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns explicit
+help: rewrite the pattern
    |
-LL |     let [&Foo(&ref a @ [ref b]), &Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
-   |          +                       +
+LL -     let [Foo(&ref a @ [ref b]), Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
+LL +     let [&Foo(a @ [b]), &Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move`
   --> $DIR/migration_lint.rs:242:10

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
@@ -580,5 +580,26 @@ help: make the implied reference pattern explicit
 LL |     let &[migration_lint_macros::bind_ref!(a)] = &[0];
    |         +
 
-error: aborting due to 30 previous errors
+error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
+  --> $DIR/auxiliary/migration_lint_macros.rs:15:22
+   |
+LL |       ($foo:ident) => {
+   |  ______________________^
+LL | |         ref $foo
+   | |________________^ reference pattern not allowed under `ref` default binding mode
+   |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern changes the default binding mode
+  --> $DIR/migration_lint.rs:249:9
+   |
+LL |     let [&migration_lint_macros::bind_ref!(a)] = &[&0];
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
+help: make the implied reference pattern explicit
+  --> $DIR/migration_lint.rs:249:9
+   |
+LL |     let &[&migration_lint_macros::bind_ref!(a)] = &[&0];
+   |         +
+
+error: aborting due to 31 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
@@ -585,8 +585,26 @@ help: make the implied reference pattern explicit
 LL |     let &[migration_lint_macros::bind_ref!(a)] = &[0];
    |         +
 
+error: reference patterns may only be written when the default binding mode is `move`
+  --> $DIR/migration_lint.rs:246:10
+   |
+LL |     let [migration_lint_macros::match_ref!(a)] = &[&0];
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ occurs within macro expansion
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern changes the default binding mode
+  --> $DIR/migration_lint.rs:246:9
+   |
+LL |     let [migration_lint_macros::match_ref!(a)] = &[&0];
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
+   = note: this error originates in the macro `migration_lint_macros::match_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: make the implied reference pattern explicit
+   |
+LL |     let &[migration_lint_macros::match_ref!(a)] = &[&0];
+   |         +
+
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/migration_lint.rs:249:10
+  --> $DIR/migration_lint.rs:252:10
    |
 LL |     let [&migration_lint_macros::bind_ref!(a)] = &[&0];
    |          ^ reference pattern not allowed under `ref` default binding mode
@@ -594,7 +612,7 @@ LL |     let [&migration_lint_macros::bind_ref!(a)] = &[&0];
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:249:9
+  --> $DIR/migration_lint.rs:252:9
    |
 LL |     let [&migration_lint_macros::bind_ref!(a)] = &[&0];
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
@@ -603,5 +621,23 @@ help: make the implied reference pattern explicit
 LL |     let &[&migration_lint_macros::bind_ref!(a)] = &[&0];
    |         +
 
-error: aborting due to 31 previous errors
+error: reference patterns may only be written when the default binding mode is `move`
+  --> $DIR/migration_lint.rs:258:10
+   |
+LL |     let [migration_lint_macros::match_ref!(ref a)] = &[&0];
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ occurs within macro expansion
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
+note: matching on a reference type with a non-reference pattern changes the default binding mode
+  --> $DIR/migration_lint.rs:258:9
+   |
+LL |     let [migration_lint_macros::match_ref!(ref a)] = &[&0];
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
+   = note: this error originates in the macro `migration_lint_macros::match_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: make the implied reference pattern explicit
+   |
+LL |     let &[migration_lint_macros::match_ref!(ref a)] = &[&0];
+   |         +
+
+error: aborting due to 33 previous errors
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
@@ -581,12 +581,10 @@ LL |     let &[migration_lint_macros::bind_ref!(a)] = &[0];
    |         +
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
-  --> $DIR/auxiliary/migration_lint_macros.rs:15:22
+  --> $DIR/migration_lint.rs:249:10
    |
-LL |       ($foo:ident) => {
-   |  ______________________^
-LL | |         ref $foo
-   | |________________^ reference pattern not allowed under `ref` default binding mode
+LL |     let [&migration_lint_macros::bind_ref!(a)] = &[&0];
+   |          ^ reference pattern not allowed under `ref` default binding mode
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
@@ -596,7 +594,6 @@ note: matching on a reference type with a non-reference pattern changes the defa
 LL |     let [&migration_lint_macros::bind_ref!(a)] = &[&0];
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
 help: make the implied reference pattern explicit
-  --> $DIR/migration_lint.rs:249:9
    |
 LL |     let &[&migration_lint_macros::bind_ref!(a)] = &[&0];
    |         +

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
@@ -580,6 +580,10 @@ note: matching on a reference type with a non-reference pattern changes the defa
 LL |     let [migration_lint_macros::bind_ref!(a)] = &[0];
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
    = note: this error originates in the macro `migration_lint_macros::bind_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: make the implied reference pattern explicit
+   |
+LL |     let &[migration_lint_macros::bind_ref!(a)] = &[0];
+   |         +
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
   --> $DIR/migration_lint.rs:249:10

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
@@ -215,10 +215,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     if let Some(&mut Some(Some(x))) = &mut Some(&mut Some(&mut Some(0u8))) {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference patterns and variable binding mode explicit
+help: remove the unnecessary reference pattern
    |
-LL |     if let &mut Some(&mut Some(&mut Some(ref mut x))) = &mut Some(&mut Some(&mut Some(0u8))) {
-   |            ++++                ++++      +++++++
+LL -     if let Some(&mut Some(Some(x))) = &mut Some(&mut Some(&mut Some(0u8))) {
+LL +     if let Some(Some(Some(x))) = &mut Some(&mut Some(&mut Some(0u8))) {
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
   --> $DIR/migration_lint.rs:111:21
@@ -273,10 +274,10 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     if let Struct { a: &Some(a), b: Some(&b), c: Some(c) } =
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns and variable binding mode explicit
+help: make the implied reference patterns explicit
    |
-LL |     if let &Struct { a: &Some(a), b: &Some(&b), c: &Some(ref c) } =
-   |            +                         +             +     +++
+LL |     if let &Struct { a: &Some(a), b: &Some(&b), c: Some(c) } =
+   |            +                         +
 
 error: binding modifiers may only be written when the default binding mode is `move`
   --> $DIR/migration_lint.rs:137:15
@@ -318,10 +319,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [&mut [ref a]] = &mut [&mut &[0]];
    |         ^^^^^^^^^^^^^^ this matches on type `&mut _`
-help: make the implied reference patterns explicit
+help: remove the unnecessary reference pattern and binding modifier
    |
-LL |     let &mut [&mut &[ref a]] = &mut [&mut &[0]];
-   |         ++++       +
+LL -     let [&mut [ref a]] = &mut [&mut &[0]];
+LL +     let [[a]] = &mut [&mut &[0]];
+   |
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
   --> $DIR/migration_lint.rs:150:10
@@ -336,10 +338,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let [&(_)] = &[&0];
    |         ^^^^^^ this matches on type `&_`
-help: make the implied reference pattern explicit
+help: remove the unnecessary reference pattern
    |
-LL |     let &[&(_)] = &[&0];
-   |         +
+LL -     let [&(_)] = &[&0];
+LL +     let [(_)] = &[&0];
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
   --> $DIR/migration_lint.rs:155:18
@@ -397,10 +400,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let Struct { a: &[ref a], b: &mut [[b]], c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns and variable binding modes explicit
+help: remove the unnecessary reference patterns and binding modifier
    |
-LL |     let &mut &Struct { a: &[ref a], b: &mut [&[ref b]], ref c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
-   |         ++++++                               + +++      +++
+LL -     let Struct { a: &[ref a], b: &mut [[b]], c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
+LL +     let Struct { a: [a], b: [[b]], c } = &mut &Struct { a: &[0], b: &mut [&[0]], c: 0 };
+   |
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
   --> $DIR/migration_lint.rs:178:13
@@ -435,8 +439,8 @@ LL |     let (&a, b, [c], [(d, [e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
 help: make the implied reference patterns and variable binding modes explicit
    |
-LL |     let &(&a, ref b, &[ref c], &mut [&mut (ref d, &[ref e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
-   |         +     +++    + +++     ++++  ++++  +++    + +++
+LL |     let &(&a, ref b, [c], &mut [&mut (ref d, [e])]) = &(&0, 0, &[0], &mut [&mut (0, &[0])]);
+   |         +     +++         ++++  ++++  +++
 
 error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
   --> $DIR/migration_lint.rs:194:19
@@ -471,10 +475,11 @@ note: matching on a reference type with a non-reference pattern changes the defa
    |
 LL |     let (&a, (b, &[ref c])) = &(&0, &mut (0, &[0]));
    |         ^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
-help: make the implied reference patterns and variable binding mode explicit
+help: rewrite the pattern
    |
-LL |     let &(&a, &mut (ref b, &[ref c])) = &(&0, &mut (0, &[0]));
-   |         +     ++++  +++
+LL -     let (&a, (b, &[ref c])) = &(&0, &mut (0, &[0]));
+LL +     let &(&a, &mut (ref b, [c])) = &(&0, &mut (0, &[0]));
+   |
 
 error: binding modifiers may only be written when the default binding mode is `move` in Rust 2024
   --> $DIR/migration_lint.rs:210:10
@@ -563,22 +568,18 @@ LL |     let [&Foo(&ref a @ [ref b]), &Foo(&ref c @ [d])] = [&Foo(&[0]); 2];
    |          +                       +
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/migration_lint.rs:244:10
+  --> $DIR/migration_lint.rs:242:10
    |
 LL |     let [migration_lint_macros::bind_ref!(a)] = &[0];
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ occurs within macro expansion
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/migration_lint.rs:244:9
+  --> $DIR/migration_lint.rs:242:9
    |
 LL |     let [migration_lint_macros::bind_ref!(a)] = &[0];
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this matches on type `&_`
    = note: this error originates in the macro `migration_lint_macros::bind_ref` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: make the implied reference pattern explicit
-   |
-LL |     let &[migration_lint_macros::bind_ref!(a)] = &[0];
-   |         +
 
 error: reference patterns may only be written when the default binding mode is `move` in Rust 2024
   --> $DIR/migration_lint.rs:249:10


### PR DESCRIPTION
This is based on #136817. The new commits start with removing a comment on the tests. The goal of the refactors in the following commits is to eventually [produce suggestions which remove reference patterns], fixing #136047 in a more thorough way.

Here's a simplified version of how it works, for reference (it's not actually split into discrete phases, but these are the conceptual steps): 
1. Try removing all reference patterns and binding modifiers; if this doesn't change any bindings, we can suggest the resultant pattern.
2. If a binding would be changed by this, we give it an explicit binding modifier. This requires adding explicit reference patterns for any dereferences above it (which may have previously been inserted implicitly by match ergonomics). This may change other bindings, in which case we'll need to suggest binding modifiers for them, which may require suggesting more reference patterns, etc.. We suggest whatever we end up with once we've fixed all such inconsistencies.
3. Simplify `&ref x` to `x` when it's convenient. This isn't quite complete; full simplification would require potentially rewriting `&ref x @ ...` to `x @ &...`, which would add a bit of complexity, though I can implement that too if desired.

Unfortunately, it ended up being more code than I'd hoped, so I understand if it's unappealing from a maintenance perspective. If nothing else, finalizing match ergonomics 2024 should open up significant simplifications, and I'm happy to help maintain it until then. There's a chance some common bookkeeping could be shared between other diagnostics/suggestions too; I have a couple in mind, but I haven't checked whether it'd be less complexity overall.

Relevant tracking issue: #131414

This doesn't aim to provide viable suggestions under the feature gates `ref_pat_eat_one_layer_2024` or `ref_pat_eat_one_layer_2024_structural`; some of the suggestions in the test output for those features are wrong and/or not as pretty as they could be. I've included FIXME comments providing more detail. Producing suggestions targeting the match ergonomics implemented by those features would actually be significantly simpler than what this PR does, but since it would require different[^1] logic, I'm inclined to save that for later. cc @Nadrieril, do any other feature gates come to mind that might require tweaks to this?

@rustbot label A-diagnostics A-patterns A-edition-2024 

[^1]: It would only require a small tweak to correct the suggestions in the `ref_pat_eat_one_layer_2024` and `ref_pat_eat_one_layer_2024_structural` tests. However, a different approach to the one in this PR would let us use simpler logic to give more local suggestions. I figure if we're adding logic specific to new match ergonomics, we may as well not (slightly) complicate this version of it further when we could be doing something better.