### PR TITLE
Tweak output of const panic diagnostic

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -109,6 +109,8 @@ const_eval_frame_note_inner = inside {$where_ ->
     *[other] {""}
 }
 
+const_eval_frame_note_last = the failure occurred here
+
 const_eval_in_bounds_test = out-of-bounds pointer use
 const_eval_incompatible_calling_conventions =
     calling a function with calling convention {$callee_conv} using calling convention {$caller_conv}
@@ -300,8 +302,7 @@ const_eval_overflow_arith =
 const_eval_overflow_shift =
     overflowing shift by {$shift_amount} in `{$intrinsic}`
 
-const_eval_panic =
-    the evaluated program panicked at '{$msg}', {$file}:{$line}:{$col}
+const_eval_panic = evaluation panicked: {$msg}
 
 const_eval_panic_non_str = argument to `panic!()` in a const context must have type `&str`
 

--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -48,11 +48,8 @@ impl MachineStopType for ConstEvalErrKind {
             | ModifiedGlobal
             | WriteThroughImmutablePointer => {}
             AssertFailure(kind) => kind.add_args(adder),
-            Panic { msg, line, col, file } => {
+            Panic { msg, .. } => {
                 adder("msg".into(), msg.into_diag_arg(&mut None));
-                adder("file".into(), file.into_diag_arg(&mut None));
-                adder("line".into(), line.into_diag_arg(&mut None));
-                adder("col".into(), col.into_diag_arg(&mut None));
             }
         }
     }
@@ -72,7 +69,7 @@ pub fn get_span_and_frames<'tcx>(
     let mut stacktrace = Frame::generate_stacktrace_from_stack(stack);
     // Filter out `requires_caller_location` frames.
     stacktrace.retain(|frame| !frame.instance.def.requires_caller_location(*tcx));
-    let span = stacktrace.first().map(|f| f.span).unwrap_or(tcx.span);
+    let span = stacktrace.last().map(|f| f.span).unwrap_or(tcx.span);
 
     let mut frames = Vec::new();
 
@@ -113,6 +110,20 @@ pub fn get_span_and_frames<'tcx>(
         if let Some(frame) = last_frame {
             add_frame(frame);
         }
+    }
+
+    // In `rustc`, we present const-eval errors from the outer-most place first to the inner-most.
+    // So we reverse the frames here. The first frame will be the same as the span from the current
+    // `TyCtxtAt<'_>`, so we remove it as it would be redundant.
+    frames.reverse();
+    if frames.len() > 0 {
+        frames.remove(0);
+    }
+    if let Some(last) = frames.last_mut()
+        // If the span is not going to be printed, we don't want the span label for `is_last`.
+        && tcx.sess.source_map().span_to_snippet(last.span.source_callsite()).is_ok()
+    {
+        last.has_label = true;
     }
 
     (span, frames)

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -231,13 +231,19 @@ impl<'tcx> FrameInfo<'tcx> {
     pub fn as_note(&self, tcx: TyCtxt<'tcx>) -> errors::FrameNote {
         let span = self.span;
         if tcx.def_key(self.instance.def_id()).disambiguated_data.data == DefPathData::Closure {
-            errors::FrameNote { where_: "closure", span, instance: String::new(), times: 0 }
+            errors::FrameNote {
+                where_: "closure",
+                span,
+                instance: String::new(),
+                times: 0,
+                has_label: false,
+            }
         } else {
             let instance = format!("{}", self.instance);
             // Note: this triggers a `must_produce_diag` state, which means that if we ever get
             // here we must emit a diagnostic. We should never display a `FrameInfo` unless we
             // actually want to emit a warning or error to the user.
-            errors::FrameNote { where_: "instance", span, instance, times: 0 }
+            errors::FrameNote { where_: "instance", span, instance, times: 0, has_label: false }
         }
     }
 }

--- a/src/tools/miri/tests/fail/erroneous_const.stderr
+++ b/src/tools/miri/tests/fail/erroneous_const.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `PrintName::<i32>::VOID` failed
   --> tests/fail/erroneous_const.rs:LL:CC
    |
 LL |     const VOID: ! = panic!();
-   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', tests/fail/erroneous_const.rs:LL:CC
+   |                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/borrowck/issue-81899.rs
+++ b/tests/ui/borrowck/issue-81899.rs
@@ -1,15 +1,14 @@
 // Regression test for #81899.
 // The `panic!()` below is important to trigger the fixed ICE.
 
-const _CONST: &[u8] = &f(&[], |_| {});
+const _CONST: &[u8] = &f(&[], |_| {}); //~ ERROR evaluation of constant value failed
 //~^ constant
 
 const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
-    //~^ panic
+    panic!() //~ inside `f
 }
 
 fn main() {}

--- a/tests/ui/borrowck/issue-81899.stderr
+++ b/tests/ui/borrowck/issue-81899.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-81899.rs:11:5
+  --> $DIR/issue-81899.rs:4:24
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-81899.rs:11:5
+LL | const _CONST: &[u8] = &f(&[], |_| {});
+   |                        ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
 note: inside `f::<{closure@$DIR/issue-81899.rs:4:31: 4:34}>`
   --> $DIR/issue-81899.rs:11:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_CONST`
-  --> $DIR/issue-81899.rs:4:24
-   |
-LL | const _CONST: &[u8] = &f(&[], |_| {});
-   |                        ^^^^^^^^^^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered

--- a/tests/ui/borrowck/issue-88434-minimal-example.rs
+++ b/tests/ui/borrowck/issue-88434-minimal-example.rs
@@ -1,14 +1,13 @@
 // Regression test related to issue 88434
 
-const _CONST: &() = &f(&|_| {});
+const _CONST: &() = &f(&|_| {}); //~ ERROR evaluation of constant value failed
 //~^ constant
 
 const fn f<F>(_: &F)
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
-    //~^ panic
+    panic!() //~ inside `f
 }
 
 fn main() { }

--- a/tests/ui/borrowck/issue-88434-minimal-example.stderr
+++ b/tests/ui/borrowck/issue-88434-minimal-example.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-88434-minimal-example.rs:10:5
+  --> $DIR/issue-88434-minimal-example.rs:3:22
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-88434-minimal-example.rs:10:5
+LL | const _CONST: &() = &f(&|_| {});
+   |                      ^^^^^^^^^^ evaluation panicked: explicit panic
    |
 note: inside `f::<{closure@$DIR/issue-88434-minimal-example.rs:3:25: 3:28}>`
   --> $DIR/issue-88434-minimal-example.rs:10:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_CONST`
-  --> $DIR/issue-88434-minimal-example.rs:3:22
-   |
-LL | const _CONST: &() = &f(&|_| {});
-   |                      ^^^^^^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.rs
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.rs
@@ -1,14 +1,13 @@
 // Regression test for issue 88434
 
-const _CONST: &[u8] = &f(&[], |_| {});
+const _CONST: &[u8] = &f(&[], |_| {}); //~ ERROR evaluation of constant value failed
 //~^ constant
 
 const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
-    //~^ panic
+    panic!() //~ inside `f
 }
 
 fn main() { }

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
+  --> $DIR/issue-88434-removal-index-should-be-less.rs:3:24
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-88434-removal-index-should-be-less.rs:10:5
+LL | const _CONST: &[u8] = &f(&[], |_| {});
+   |                        ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
 note: inside `f::<{closure@$DIR/issue-88434-removal-index-should-be-less.rs:3:31: 3:34}>`
   --> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_CONST`
-  --> $DIR/issue-88434-removal-index-should-be-less.rs:3:24
-   |
-LL | const _CONST: &[u8] = &f(&[], |_| {});
-   |                        ^^^^^^^^^^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered

--- a/tests/ui/coherence/const-errs-dont-conflict-103369.rs
+++ b/tests/ui/coherence/const-errs-dont-conflict-103369.rs
@@ -2,13 +2,12 @@
 
 pub trait ConstGenericTrait<const N: u32> {}
 
-impl ConstGenericTrait<{my_fn(1)}> for () {}
+impl ConstGenericTrait<{my_fn(1)}> for () {} //~ ERROR E0080
 
-impl ConstGenericTrait<{my_fn(2)}> for () {}
+impl ConstGenericTrait<{my_fn(2)}> for () {} //~ ERROR E0080
 
 const fn my_fn(v: u32) -> u32 {
-    panic!("Some error occurred"); //~ ERROR E0080
-    //~| ERROR E0080
+    panic!("Some error occurred");
 }
 
 fn main() {}

--- a/tests/ui/coherence/const-errs-dont-conflict-103369.stderr
+++ b/tests/ui/coherence/const-errs-dont-conflict-103369.stderr
@@ -1,37 +1,27 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Some error occurred', $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-note: inside `my_fn`
-  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `<() as ConstGenericTrait<{my_fn(1)}>>::{constant#0}`
   --> $DIR/const-errs-dont-conflict-103369.rs:5:25
    |
 LL | impl ConstGenericTrait<{my_fn(1)}> for () {}
-   |                         ^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Some error occurred', $DIR/const-errs-dont-conflict-103369.rs:10:5
+   |                         ^^^^^^^^ evaluation panicked: Some error occurred
    |
 note: inside `my_fn`
   --> $DIR/const-errs-dont-conflict-103369.rs:10:5
    |
 LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `<() as ConstGenericTrait<{my_fn(2)}>>::{constant#0}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/const-errs-dont-conflict-103369.rs:7:25
    |
 LL | impl ConstGenericTrait<{my_fn(2)}> for () {}
-   |                         ^^^^^^^^
+   |                         ^^^^^^^^ evaluation panicked: Some error occurred
+   |
+note: inside `my_fn`
+  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
+   |
+LL |     panic!("Some error occurred");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/issues/issue-100313.rs
+++ b/tests/ui/const-generics/issues/issue-100313.rs
@@ -6,15 +6,14 @@ struct T<const B: &'static bool>;
 impl<const B: &'static bool> T<B> {
     const fn set_false(&self) {
         unsafe {
-            *(B as *const bool as *mut bool) = false;
-            //~^ ERROR evaluation of constant value failed [E0080]
+            *(B as *const bool as *mut bool) = false; //~ inside `T
         }
     }
 }
 
 const _: () = {
     let x = T::<{ &true }>;
-    x.set_false();
+    x.set_false(); //~ ERROR evaluation of constant value failed [E0080]
 };
 
 fn main() {}

--- a/tests/ui/const-generics/issues/issue-100313.stderr
+++ b/tests/ui/const-generics/issues/issue-100313.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-100313.rs:9:13
+  --> $DIR/issue-100313.rs:16:5
    |
-LL |             *(B as *const bool as *mut bool) = false;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ writing to ALLOC0 which is read-only
+LL |     x.set_false();
+   |     ^^^^^^^^^^^^^ writing to ALLOC0 which is read-only
    |
 note: inside `T::<&true>::set_false`
   --> $DIR/issue-100313.rs:9:13
    |
 LL |             *(B as *const bool as *mut bool) = false;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `_`
-  --> $DIR/issue-100313.rs:17:5
-   |
-LL |     x.set_false();
-   |     ^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-ptr/forbidden_slices.rs
+++ b/tests/ui/const-ptr/forbidden_slices.rs
@@ -48,9 +48,11 @@ pub static S8: &[u64] = unsafe {
 pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
 //~^ ERROR it is undefined behavior to use this value
 pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }; // errors inside libcore
+//~^ ERROR could not evaluate static initializer
 pub static R2: &[u32] = unsafe {
     let ptr = &D0 as *const u32;
     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
+    //~^ ERROR could not evaluate static initializer
 };
 pub static R4: &[u8] = unsafe {
     //~^ ERROR: it is undefined behavior to use this value
@@ -74,13 +76,16 @@ pub static R7: &[u16] = unsafe {
 };
 pub static R8: &[u64] = unsafe {
     let ptr = (&D4 as *const [u32; 2] as *const u32).byte_add(1).cast::<u64>();
-    from_ptr_range(ptr..ptr.add(1)) //~ inside `R8`
+    from_ptr_range(ptr..ptr.add(1))
+    //~^ ERROR could not evaluate static initializer
 };
 
 // This is sneaky: &D0 and &D0 point to different objects
 // (even if at runtime they have the same address)
 pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
+//~^ ERROR could not evaluate static initializer
 pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
+//~^ ERROR could not evaluate static initializer
 
 const D0: u32 = 0x11111111; // Constant chosen for endianness-independent behavior.
 const D1: MaybeUninit<&u32> = MaybeUninit::uninit();

--- a/tests/ui/const-ptr/forbidden_slices.stderr
+++ b/tests/ui/const-ptr/forbidden_slices.stderr
@@ -100,36 +100,28 @@ LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }
            }
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'assertion failed: 0 < pointee_size && pointee_size <= isize::MAX as usize', $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-note: inside `std::ptr::const_ptr::<impl *const ()>::offset_from_unsigned`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `from_ptr_range::<'_, ()>`
-  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
-note: inside `R1`
   --> $DIR/forbidden_slices.rs:50:33
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }; // errors inside libcore
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: 0 < pointee_size && pointee_size <= isize::MAX as usize
+   |
+note: inside `from_ptr_range::<'_, ()>`
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+note: inside `std::ptr::const_ptr::<impl *const ()>::offset_from_unsigned`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+  --> $DIR/forbidden_slices.rs:54:25
    |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC10 which is only 4 bytes from the end of the allocation
+LL |     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
+   |                         ^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC10 which is only 4 bytes from the end of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u32>::add`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `R2`
-  --> $DIR/forbidden_slices.rs:53:25
-   |
-LL |     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
-   |                         ^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:55:1
+  --> $DIR/forbidden_slices.rs:57:1
    |
 LL | pub static R4: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
@@ -140,7 +132,7 @@ LL | pub static R4: &[u8] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:60:1
+  --> $DIR/forbidden_slices.rs:62:1
    |
 LL | pub static R5: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
@@ -153,7 +145,7 @@ LL | pub static R5: &[u8] = unsafe {
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:65:1
+  --> $DIR/forbidden_slices.rs:67:1
    |
 LL | pub static R6: &[bool] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
@@ -164,7 +156,7 @@ LL | pub static R6: &[bool] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:70:1
+  --> $DIR/forbidden_slices.rs:72:1
    |
 LL | pub static R7: &[u16] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
@@ -175,47 +167,35 @@ LL | pub static R7: &[u16] = unsafe {
            }
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+  --> $DIR/forbidden_slices.rs:79:25
    |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC11+0x1 which is only 7 bytes from the end of the allocation
+LL |     from_ptr_range(ptr..ptr.add(1))
+   |                         ^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC11+0x1 which is only 7 bytes from the end of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u64>::add`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `R8`
-  --> $DIR/forbidden_slices.rs:77:25
-   |
-LL |     from_ptr_range(ptr..ptr.add(1))
-   |                         ^^^^^^^^^^
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `from_ptr_range::<'_, u32>`
-  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
-note: inside `R9`
-  --> $DIR/forbidden_slices.rs:82:34
+  --> $DIR/forbidden_slices.rs:85:34
    |
 LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
    |
-   = note: `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `from_ptr_range::<'_, u32>`
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
-note: inside `R10`
-  --> $DIR/forbidden_slices.rs:83:35
+note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+
+error[E0080]: could not evaluate static initializer
+  --> $DIR/forbidden_slices.rs:87:35
    |
 LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
+   |
+note: inside `from_ptr_range::<'_, u32>`
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/const-ptr/out_of_bounds_read.stderr
+++ b/tests/ui/const-ptr/out_of_bounds_read.stderr
@@ -1,45 +1,33 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
-   |
-note: inside `std::ptr::read::<u32>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `_READ`
   --> $DIR/out_of_bounds_read.rs:10:33
    |
 LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
    |
 note: inside `std::ptr::read::<u32>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u32>::read`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `_CONST_READ`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/out_of_bounds_read.rs:11:39
    |
 LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
-   |                                       ^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |                                       ^^^^^^^^^^^^^^^^^^^ memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
    |
-   = note: memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
-   |
+note: inside `std::ptr::const_ptr::<impl *const u32>::read`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `std::ptr::read::<u32>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::mut_ptr::<impl *mut u32>::read`
-  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-note: inside `_MUT_READ`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/out_of_bounds_read.rs:12:37
    |
 LL |     const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
+   |
+note: inside `std::ptr::mut_ptr::<impl *mut u32>::read`
+  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+note: inside `std::ptr::read::<u32>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/assert-type-intrinsics.stderr
+++ b/tests/ui/consts/assert-type-intrinsics.stderr
@@ -2,19 +2,19 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/assert-type-intrinsics.rs:11:9
    |
 LL |         MaybeUninit::<!>::uninit().assume_init();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'aborted execution: attempted to instantiate uninhabited type `!`', $DIR/assert-type-intrinsics.rs:11:36
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: aborted execution: attempted to instantiate uninhabited type `!`
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/assert-type-intrinsics.rs:15:9
    |
 LL |         intrinsics::assert_mem_uninitialized_valid::<&'static i32>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'aborted execution: attempted to leave type `&i32` uninitialized, which is invalid', $DIR/assert-type-intrinsics.rs:15:9
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: aborted execution: attempted to leave type `&i32` uninitialized, which is invalid
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/assert-type-intrinsics.rs:19:9
    |
 LL |         intrinsics::assert_zero_valid::<&'static i32>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'aborted execution: attempted to zero-initialize type `&i32`, which is invalid', $DIR/assert-type-intrinsics.rs:19:9
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: aborted execution: attempted to zero-initialize type `&i32`, which is invalid
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail2.rs
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail2.rs
@@ -7,12 +7,18 @@ const X: fn(usize) -> usize = double;
 
 const fn bar(x: fn(usize) -> usize, y: usize) -> usize {
     x(y)
-    //~^ ERROR evaluation of constant value failed
-    //~| ERROR evaluation of constant value failed
+    //~^ NOTE inside `bar`
+    //~| NOTE the failure occurred here
+    //~| NOTE inside `bar`
+    //~| NOTE the failure occurred here
 }
 
 const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday
+//~^ ERROR evaluation of constant value failed
+//~| NOTE calling non-const function `double`
 const Z: usize = bar(double, 2); // FIXME: should fail to typeck someday
+//~^ ERROR evaluation of constant value failed
+//~| NOTE calling non-const function `double`
 
 fn main() {
     assert_eq!(Y, 4);

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail2.stderr
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail2.stderr
@@ -1,36 +1,26 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_fn_ptr_fail2.rs:9:5
-   |
-LL |     x(y)
-   |     ^^^^ calling non-const function `double`
-   |
-note: inside `bar`
-  --> $DIR/const_fn_ptr_fail2.rs:9:5
-   |
-LL |     x(y)
-   |     ^^^^
-note: inside `Y`
-  --> $DIR/const_fn_ptr_fail2.rs:14:18
+  --> $DIR/const_fn_ptr_fail2.rs:16:18
    |
 LL | const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday
-   |                  ^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const_fn_ptr_fail2.rs:9:5
-   |
-LL |     x(y)
-   |     ^^^^ calling non-const function `double`
+   |                  ^^^^^^^^^ calling non-const function `double`
    |
 note: inside `bar`
   --> $DIR/const_fn_ptr_fail2.rs:9:5
    |
 LL |     x(y)
-   |     ^^^^
-note: inside `Z`
-  --> $DIR/const_fn_ptr_fail2.rs:15:18
+   |     ^^^^ the failure occurred here
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const_fn_ptr_fail2.rs:19:18
    |
 LL | const Z: usize = bar(double, 2); // FIXME: should fail to typeck someday
-   |                  ^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^^^ calling non-const function `double`
+   |
+note: inside `bar`
+  --> $DIR/const_fn_ptr_fail2.rs:9:5
+   |
+LL |     x(y)
+   |     ^^^^ the failure occurred here
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
+++ b/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic-normalize-tabs-115498.rs:3:17
    |
 LL | struct Bug([u8; panic!{"\t"}]);
-   |                 ^^^^^^^^^^^^ the evaluated program panicked at '    ', $DIR/const_panic-normalize-tabs-115498.rs:3:17
+   |                 ^^^^^^^^^^^^ evaluation panicked:     
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic.stderr
+++ b/tests/ui/consts/const-eval/const_panic.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:6:15
    |
 LL | const Z: () = std::panic!("cheese");
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic.rs:6:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: cheese
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:9:16
    |
 LL | const Z2: () = std::panic!();
-   |                ^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:9:16
+   |                ^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:12:15
    |
 LL | const Y: () = std::unreachable!();
-   |               ^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:12:15
+   |               ^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `std::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:15:15
    |
 LL | const X: () = std::unimplemented!();
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:15:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `std::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +34,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:18:15
    |
 LL | const W: () = std::panic!(MSG);
-   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:18:15
+   |               ^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -42,7 +42,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:21:16
    |
 LL | const W2: () = std::panic!("{}", MSG);
-   |                ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:21:16
+   |                ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:24:20
    |
 LL | const Z_CORE: () = core::panic!("cheese");
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic.rs:24:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: cheese
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -58,7 +58,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:27:21
    |
 LL | const Z2_CORE: () = core::panic!();
-   |                     ^^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:27:21
+   |                     ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -66,7 +66,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:30:20
    |
 LL | const Y_CORE: () = core::unreachable!();
-   |                    ^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:30:20
+   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `core::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -74,7 +74,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:33:20
    |
 LL | const X_CORE: () = core::unimplemented!();
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:33:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `core::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -82,7 +82,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:36:20
    |
 LL | const W_CORE: () = core::panic!(MSG);
-   |                    ^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:36:20
+   |                    ^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -90,7 +90,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:39:21
    |
 LL | const W2_CORE: () = core::panic!("{}", MSG);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:39:21
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic_2021.stderr
+++ b/tests/ui/consts/const-eval/const_panic_2021.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:6:15
    |
 LL | const A: () = std::panic!("blåhaj");
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'blåhaj', $DIR/const_panic_2021.rs:6:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: blåhaj
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:9:15
    |
 LL | const B: () = std::panic!();
-   |               ^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic_2021.rs:9:15
+   |               ^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:12:15
    |
 LL | const C: () = std::unreachable!();
-   |               ^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_2021.rs:12:15
+   |               ^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `std::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:15:15
    |
 LL | const D: () = std::unimplemented!();
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic_2021.rs:15:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `std::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +34,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:18:15
    |
 LL | const E: () = std::panic!("{}", MSG);
-   |               ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic_2021.rs:18:15
+   |               ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -42,7 +42,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:21:20
    |
 LL | const A_CORE: () = core::panic!("shark");
-   |                    ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'shark', $DIR/const_panic_2021.rs:21:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: shark
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:24:20
    |
 LL | const B_CORE: () = core::panic!();
-   |                    ^^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic_2021.rs:24:20
+   |                    ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -58,7 +58,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:27:20
    |
 LL | const C_CORE: () = core::unreachable!();
-   |                    ^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_2021.rs:27:20
+   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `core::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -66,7 +66,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:30:20
    |
 LL | const D_CORE: () = core::unimplemented!();
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic_2021.rs:30:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `core::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -74,7 +74,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:33:20
    |
 LL | const E_CORE: () = core::panic!("{}", MSG);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic_2021.rs:33:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:8:15
    |
 LL | const Z: () = panic!("cheese");
-   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic_libcore_bin.rs:8:15
+   |               ^^^^^^^^^^^^^^^^ evaluation panicked: cheese
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:11:15
    |
 LL | const Y: () = unreachable!();
-   |               ^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_bin.rs:11:15
+   |               ^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:14:15
    |
 LL | const X: () = unimplemented!();
-   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic_libcore_bin.rs:14:15
+   |               ^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic_track_caller.rs
+++ b/tests/ui/consts/const-eval/const_panic_track_caller.rs
@@ -12,11 +12,10 @@ const fn b() -> u32 {
 }
 
 const fn c() -> u32 {
-    b()
-    //~^ ERROR evaluation of constant value failed
-    //~| NOTE the evaluated program panicked
-    //~| NOTE inside
+    b() //~ NOTE inside `c`
+    //~^ NOTE the failure occurred here
 }
 
 const X: u32 = c();
-//~^ NOTE inside
+//~^ ERROR evaluation of constant value failed
+//~| NOTE hey

--- a/tests/ui/consts/const-eval/const_panic_track_caller.stderr
+++ b/tests/ui/consts/const-eval/const_panic_track_caller.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_panic_track_caller.rs:15:5
+  --> $DIR/const_panic_track_caller.rs:19:16
    |
-LL |     b()
-   |     ^^^ the evaluated program panicked at 'hey', $DIR/const_panic_track_caller.rs:15:5
+LL | const X: u32 = c();
+   |                ^^^ evaluation panicked: hey
    |
 note: inside `c`
   --> $DIR/const_panic_track_caller.rs:15:5
    |
 LL |     b()
-   |     ^^^
-note: inside `X`
-  --> $DIR/const_panic_track_caller.rs:21:16
-   |
-LL | const X: u32 = c();
-   |                ^^^
+   |     ^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
@@ -2,11 +2,10 @@
 #![feature(const_heap)]
 use std::intrinsics;
 
-const FOO: i32 = foo();
+const FOO: i32 = foo(); //~ error: evaluation of constant value failed
 const fn foo() -> i32 {
     unsafe {
-        let _ = intrinsics::const_allocate(4, 3) as *mut i32;
-        //~^ error: evaluation of constant value failed
+        let _ = intrinsics::const_allocate(4, 3) as *mut i32; //~ inside `foo`
     }
     1
 }

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/alloc_intrinsic_errors.rs:8:17
+  --> $DIR/alloc_intrinsic_errors.rs:5:18
    |
-LL |         let _ = intrinsics::const_allocate(4, 3) as *mut i32;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid align passed to `const_allocate`: 3 is not a power of 2
+LL | const FOO: i32 = foo();
+   |                  ^^^^^ invalid align passed to `const_allocate`: 3 is not a power of 2
    |
 note: inside `foo`
   --> $DIR/alloc_intrinsic_errors.rs:8:17
    |
 LL |         let _ = intrinsics::const_allocate(4, 3) as *mut i32;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/alloc_intrinsic_errors.rs:5:18
-   |
-LL | const FOO: i32 = foo();
-   |                  ^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/panic-assoc-never-type.rs:9:21
    |
 LL |     const VOID: ! = panic!();
-   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:9:21
+   |                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/panic-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-never-type.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/panic-never-type.rs:4:17
    |
 LL | const VOID: ! = panic!();
-   |                 ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:4:17
+   |                 ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/parse_ints.rs
+++ b/tests/ui/consts/const-eval/parse_ints.rs
@@ -2,7 +2,7 @@ const _OK: () = match i32::from_str_radix("-1234", 10) {
     Ok(x) => assert!(x == -1234),
     Err(_) => panic!(),
 };
-const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); };
-const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); };
+const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); }; //~ ERROR evaluation of constant value failed
+const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); }; //~ ERROR evaluation of constant value failed
 
 fn main () {}

--- a/tests/ui/consts/const-eval/parse_ints.stderr
+++ b/tests/ui/consts/const-eval/parse_ints.stderr
@@ -1,33 +1,25 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'from_ascii_radix: radix must lie in the range `[2, 36]`', $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-note: inside `core::num::<impl u64>::from_ascii_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `core::num::<impl u64>::from_str_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `_TOO_LOW`
   --> $DIR/parse_ints.rs:5:24
    |
 LL | const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
+   |
+note: inside `core::num::<impl u64>::from_str_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+note: inside `core::num::<impl u64>::from_ascii_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
    = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'from_ascii_radix: radix must lie in the range `[2, 36]`', $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-note: inside `core::num::<impl u64>::from_ascii_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `core::num::<impl u64>::from_str_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `_TOO_HIGH`
   --> $DIR/parse_ints.rs:6:25
    |
 LL | const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
+   |
+note: inside `core::num::<impl u64>::from_str_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+note: inside `core::num::<impl u64>::from_ascii_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
    = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/consts/const-eval/raw-pointer-ub.rs
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.rs
@@ -17,7 +17,10 @@ const MISALIGNED_COPY: () = unsafe {
     let y = x.as_ptr().cast::<u32>();
     let mut z = 123;
     y.copy_to_nonoverlapping(&mut z, 1);
-    //~^NOTE
+    //~^ ERROR evaluation of constant value failed
+    //~| NOTE inside `std::ptr::const_ptr
+    //~| NOTE inside `copy_nonoverlapping::<u32>`
+    //~| NOTE accessing memory with alignment 1, but alignment 4 is required
     // The actual error points into the implementation of `copy_to_nonoverlapping`.
 };
 

--- a/tests/ui/consts/const-eval/raw-pointer-ub.stderr
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.stderr
@@ -11,28 +11,24 @@ LL |     *ptr = 0;
    |     ^^^^^^^^ accessing memory based on pointer with alignment 1, but alignment 4 is required
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
-   |
-   = note: accessing memory with alignment 1, but alignment 4 is required
-   |
-note: inside `copy_nonoverlapping::<u32>`
-  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u32>::copy_to_nonoverlapping`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `MISALIGNED_COPY`
   --> $DIR/raw-pointer-ub.rs:19:5
    |
 LL |     y.copy_to_nonoverlapping(&mut z, 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment 1, but alignment 4 is required
+   |
+note: inside `std::ptr::const_ptr::<impl *const u32>::copy_to_nonoverlapping`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `copy_nonoverlapping::<u32>`
+  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/raw-pointer-ub.rs:31:16
+  --> $DIR/raw-pointer-ub.rs:34:16
    |
 LL |     let _val = (*ptr).0;
    |                ^^^^^^^^ accessing memory based on pointer with alignment 4, but alignment 16 is required
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/raw-pointer-ub.rs:38:16
+  --> $DIR/raw-pointer-ub.rs:41:16
    |
 LL |     let _val = *ptr;
    |                ^^^^ memory access failed: expected a pointer to 8 bytes of memory, but got ALLOC0 which is only 4 bytes from the end of the allocation

--- a/tests/ui/consts/const-eval/transmute-size-mismatch.rs
+++ b/tests/ui/consts/const-eval/transmute-size-mismatch.rs
@@ -10,15 +10,19 @@ const unsafe fn mir_transmute<T, U>(x: T) -> U {
     mir!{
         {
             RET = CastTransmute(x);
-            //~^ ERROR evaluation of constant value failed
-            //~| ERROR evaluation of constant value failed
+            //~^ NOTE inside `mir_transmute
+            //~| NOTE inside `mir_transmute
+            //~| NOTE the failure occurred here
+            //~| NOTE the failure occurred here
             Return()
         }
     }
 }
 
-const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) };
+const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) }; //~ ERROR evaluation of constant value failed
+//~^ NOTE transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
 
-const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) };
+const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) }; //~ ERROR evaluation of constant value failed
+//~^ NOTE transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
 
 fn main() {}

--- a/tests/ui/consts/const-eval/transmute-size-mismatch.stderr
+++ b/tests/ui/consts/const-eval/transmute-size-mismatch.stderr
@@ -1,36 +1,26 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/transmute-size-mismatch.rs:12:13
+  --> $DIR/transmute-size-mismatch.rs:22:35
    |
-LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
+LL | const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) };
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
    |
 note: inside `mir_transmute::<i32, u16>`
   --> $DIR/transmute-size-mismatch.rs:12:13
    |
 LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FROM_BIGGER`
-  --> $DIR/transmute-size-mismatch.rs:20:35
-   |
-LL | const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/transmute-size-mismatch.rs:12:13
+  --> $DIR/transmute-size-mismatch.rs:25:36
    |
-LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
+LL | const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) };
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
    |
 note: inside `mir_transmute::<i16, u32>`
   --> $DIR/transmute-size-mismatch.rs:12:13
    |
 LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FROM_SMALLER`
-  --> $DIR/transmute-size-mismatch.rs:22:36
-   |
-LL | const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) };
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/ub-enum.rs
+++ b/tests/ui/consts/const-eval/ub-enum.rs
@@ -101,7 +101,7 @@ const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe { mem:
 const TEST_ICE_89765: () = {
     // This is a regression test for https://github.com/rust-lang/rust/issues/89765.
     unsafe { std::mem::discriminant(&*(&() as *const () as *const Never)); };
-    //~^ inside `TEST_ICE_89765`
+    //~^ ERROR evaluation of constant value failed
 };
 
 fn main() {

--- a/tests/ui/consts/const-eval/ub-enum.stderr
+++ b/tests/ui/consts/const-eval/ub-enum.stderr
@@ -117,17 +117,13 @@ LL | const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe {
    |                                                                             ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: read discriminant of an uninhabited enum variant
-   |
-note: inside `discriminant::<Never>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `TEST_ICE_89765`
   --> $DIR/ub-enum.rs:103:14
    |
 LL |     unsafe { std::mem::discriminant(&*(&() as *const () as *const Never)); };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ read discriminant of an uninhabited enum variant
+   |
+note: inside `discriminant::<Never>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/consts/const-eval/ub-invalid-values.rs
+++ b/tests/ui/consts/const-eval/ub-invalid-values.rs
@@ -1,11 +1,12 @@
 const fn bool_cast(ptr: *const bool) { unsafe {
-    let _val = *ptr as u32; //~ERROR: evaluation of constant value failed
-    //~^ interpreting an invalid 8-bit value as a bool
+    let _val = *ptr as u32; //~ NOTE inside `bool_cast`
+    //~^ NOTE the failure occurred here
 }}
 
 const _: () = {
     let v = 3_u8;
-    bool_cast(&v as *const u8 as *const bool);
+    bool_cast(&v as *const u8 as *const bool); //~ ERROR: evaluation of constant value failed
+    //~^ NOTE interpreting an invalid 8-bit value as a bool
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-invalid-values.stderr
+++ b/tests/ui/consts/const-eval/ub-invalid-values.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-invalid-values.rs:2:16
+  --> $DIR/ub-invalid-values.rs:8:5
    |
-LL |     let _val = *ptr as u32;
-   |                ^^^^^^^^^^^ interpreting an invalid 8-bit value as a bool: 0x03
+LL |     bool_cast(&v as *const u8 as *const bool);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ interpreting an invalid 8-bit value as a bool: 0x03
    |
 note: inside `bool_cast`
   --> $DIR/ub-invalid-values.rs:2:16
    |
 LL |     let _val = *ptr as u32;
-   |                ^^^^^^^^^^^
-note: inside `_`
-  --> $DIR/ub-invalid-values.rs:8:5
-   |
-LL |     bool_cast(&v as *const u8 as *const bool);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -63,7 +63,7 @@ const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
 const UNALIGNED_READ: () = unsafe {
     let x = &[0u8; 4];
     let ptr = x.as_ptr().cast::<u32>();
-    ptr.read(); //~ inside `UNALIGNED_READ`
+    ptr.read(); //~ ERROR evaluation of constant value failed
 };
 
 

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -149,19 +149,15 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: accessing memory based on pointer with alignment 1, but alignment 4 is required
-   |
-note: inside `std::ptr::read::<u32>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u32>::read`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNALIGNED_READ`
   --> $DIR/ub-ref-ptr.rs:66:5
    |
 LL |     ptr.read();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ accessing memory based on pointer with alignment 1, but alignment 4 is required
+   |
+note: inside `std::ptr::const_ptr::<impl *const u32>::read`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `std::ptr::read::<u32>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/consts/const-eval/unwind-abort.rs
+++ b/tests/ui/consts/const-eval/unwind-abort.rs
@@ -1,8 +1,8 @@
 const extern "C" fn foo() {
-    panic!() //~ ERROR evaluation of constant value failed
+    panic!() //~ inside `foo`
 }
 
-const _: () = foo();
+const _: () = foo(); //~ ERROR evaluation of constant value failed
 // Ensure that the CTFE engine handles calls to `extern "C"` aborting gracefully
 
 fn main() {

--- a/tests/ui/consts/const-eval/unwind-abort.stderr
+++ b/tests/ui/consts/const-eval/unwind-abort.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/unwind-abort.rs:2:5
+  --> $DIR/unwind-abort.rs:5:15
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/unwind-abort.rs:2:5
+LL | const _: () = foo();
+   |               ^^^^^ evaluation panicked: explicit panic
    |
 note: inside `foo`
   --> $DIR/unwind-abort.rs:2:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_`
-  --> $DIR/unwind-abort.rs:5:15
-   |
-LL | const _: () = foo();
-   |               ^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -1,6 +1,5 @@
 const fn foo() -> ! {
-    unsafe { std::mem::transmute(()) }
-    //~^ ERROR evaluation of constant value failed
+    unsafe { std::mem::transmute(()) } //~ inside `foo`
 }
 
 // Type defined in a submodule, so that it is not "visibly"
@@ -14,6 +13,7 @@ pub mod empty {
 }
 
 const FOO: [empty::Empty; 3] = [foo(); 3];
+//~^ ERROR evaluation of constant value failed
 
 const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
 //~^ ERROR evaluation of constant value failed

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/validate_uninhabited_zsts.rs:2:14
+  --> $DIR/validate_uninhabited_zsts.rs:15:33
    |
-LL |     unsafe { std::mem::transmute(()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a value of the never type `!`
+LL | const FOO: [empty::Empty; 3] = [foo(); 3];
+   |                                 ^^^^^ constructing invalid value: encountered a value of the never type `!`
    |
 note: inside `foo`
   --> $DIR/validate_uninhabited_zsts.rs:2:14
    |
 LL |     unsafe { std::mem::transmute(()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/validate_uninhabited_zsts.rs:16:33
-   |
-LL | const FOO: [empty::Empty; 3] = [foo(); 3];
-   |                                 ^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/validate_uninhabited_zsts.rs:18:42

--- a/tests/ui/consts/const-ptr-is-null.rs
+++ b/tests/ui/consts/const-ptr-is-null.rs
@@ -19,7 +19,7 @@ const MAYBE_NULL: () = {
     assert!(!ptr.wrapping_byte_sub(1).is_null());
     // ... but once we shift outside the allocation, with an offset divisible by 4,
     // we might become null.
-    assert!(!ptr.wrapping_sub(512).is_null()); //~inside `MAYBE_NULL`
+    assert!(!ptr.wrapping_sub(512).is_null()); //~ ERROR evaluation of constant value failed
 };
 
 fn main() {}

--- a/tests/ui/consts/const-ptr-is-null.stderr
+++ b/tests/ui/consts/const-ptr-is-null.stderr
@@ -1,18 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'null-ness of this pointer cannot be determined in const context', $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-note: inside `std::ptr::const_ptr::<impl *const T>::is_null::compiletime`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const i32>::is_null`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `MAYBE_NULL`
   --> $DIR/const-ptr-is-null.rs:22:14
    |
 LL |     assert!(!ptr.wrapping_sub(512).is_null());
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: null-ness of this pointer cannot be determined in const context
+   |
+note: inside `std::ptr::const_ptr::<impl *const i32>::is_null`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `std::ptr::const_ptr::<impl *const T>::is_null::compiletime`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-unwrap.rs
+++ b/tests/ui/consts/const-unwrap.rs
@@ -5,7 +5,7 @@ const FOO: i32 = Some(42i32).unwrap();
 
 const BAR: i32 = Option::<i32>::None.unwrap();
 //~^ ERROR: evaluation of constant value failed
-//~| NOTE: the evaluated program panicked
+//~| NOTE: called `Option::unwrap()` on a `None` value
 
 const BAZ: i32 = Option::<i32>::None.expect("absolutely not!");
 //~^ ERROR: evaluation of constant value failed

--- a/tests/ui/consts/const-unwrap.stderr
+++ b/tests/ui/consts/const-unwrap.stderr
@@ -2,13 +2,13 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const-unwrap.rs:6:18
    |
 LL | const BAR: i32 = Option::<i32>::None.unwrap();
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'called `Option::unwrap()` on a `None` value', $DIR/const-unwrap.rs:6:38
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: called `Option::unwrap()` on a `None` value
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-unwrap.rs:10:18
    |
 LL | const BAZ: i32 = Option::<i32>::None.expect("absolutely not!");
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'absolutely not!', $DIR/const-unwrap.rs:10:38
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: absolutely not!
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const_unsafe_unreachable_ub.rs
+++ b/tests/ui/consts/const_unsafe_unreachable_ub.rs
@@ -1,13 +1,14 @@
-//@ error-pattern: evaluation of constant value failed
-
 const unsafe fn foo(x: bool) -> bool {
     match x {
         true => true,
-        false => std::hint::unreachable_unchecked(),
+        false => std::hint::unreachable_unchecked(), //~ NOTE inside `foo`
     }
 }
 
 const BAR: bool = unsafe { foo(false) };
+//~^ ERROR evaluation of constant value failed
+//~| NOTE entering unreachable code
+//~| NOTE inside `unreachable_unchecked`
 
 fn main() {
     assert_eq!(BAR, true);

--- a/tests/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/tests/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -1,20 +1,16 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
+  --> $DIR/const_unsafe_unreachable_ub.rs:8:28
    |
-   = note: entering unreachable code
+LL | const BAR: bool = unsafe { foo(false) };
+   |                            ^^^^^^^^^^ entering unreachable code
    |
-note: inside `unreachable_unchecked`
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
 note: inside `foo`
-  --> $DIR/const_unsafe_unreachable_ub.rs:6:18
+  --> $DIR/const_unsafe_unreachable_ub.rs:4:18
    |
 LL |         false => std::hint::unreachable_unchecked(),
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `BAR`
-  --> $DIR/const_unsafe_unreachable_ub.rs:10:28
-   |
-LL | const BAR: bool = unsafe { foo(false) };
-   |                            ^^^^^^^^^^
+note: inside `unreachable_unchecked`
+  --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/control-flow/assert.stderr
+++ b/tests/ui/consts/control-flow/assert.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/assert.rs:5:15
    |
 LL | const _: () = assert!(false);
-   |               ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/assert.rs:5:15
+   |               ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-32829.stderr
+++ b/tests/ui/consts/issue-32829.stderr
@@ -2,7 +2,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/issue-32829.rs:1:22
    |
 LL | static S : u64 = { { panic!("foo"); 0 } };
-   |                      ^^^^^^^^^^^^^ the evaluated program panicked at 'foo', $DIR/issue-32829.rs:1:22
+   |                      ^^^^^^^^^^^^^ evaluation panicked: foo
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-66693-panic-in-array-len.stderr
+++ b/tests/ui/consts/issue-66693-panic-in-array-len.stderr
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-66693-panic-in-array-len.rs:10:21
    |
 LL |     let _ = [false; panic!()];
-   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-66693-panic-in-array-len.rs:10:21
+   |                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-66693.stderr
+++ b/tests/ui/consts/issue-66693.stderr
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-66693.rs:16:15
    |
 LL | const _: () = panic!();
-   |               ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-66693.rs:16:15
+   |               ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/issue-66693.rs:18:19
    |
 LL | static _BAR: () = panic!("panic in static");
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'panic in static', $DIR/issue-66693.rs:18:19
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: panic in static
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-76064.stderr
+++ b/tests/ui/consts/issue-76064.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-76064.rs:1:17
    |
 LL | struct Bug([u8; panic!("panic")]);
-   |                 ^^^^^^^^^^^^^^^ the evaluated program panicked at 'panic', $DIR/issue-76064.rs:1:17
+   |                 ^^^^^^^^^^^^^^^ evaluation panicked: panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-miri-1910.rs
+++ b/tests/ui/consts/issue-miri-1910.rs
@@ -5,6 +5,7 @@ const C: () = unsafe {
     let foo = Some(&42 as *const i32);
     let one_and_a_half_pointers = std::mem::size_of::<*const i32>()/2*3;
     (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
+    //~^ ERROR evaluation of constant value failed
 };
 
 fn main() {

--- a/tests/ui/consts/issue-miri-1910.stderr
+++ b/tests/ui/consts/issue-miri-1910.stderr
@@ -1,17 +1,13 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: unable to turn pointer into integer
-   |
-note: inside `std::ptr::read::<u8>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u8>::read`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `C`
   --> $DIR/issue-miri-1910.rs:7:5
    |
 LL |     (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::read`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `std::ptr::read::<u8>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 

--- a/tests/ui/consts/miri_unleashed/abi-mismatch.rs
+++ b/tests/ui/consts/miri_unleashed/abi-mismatch.rs
@@ -4,13 +4,12 @@
 const extern "C" fn c_fn() {}
 
 const fn call_rust_fn(my_fn: extern "Rust" fn()) {
-    my_fn();
-    //~^ ERROR could not evaluate static initializer
-    //~| NOTE calling a function with calling convention C using calling convention Rust
-    //~| NOTE inside `call_rust_fn`
+    my_fn(); //~ NOTE inside `call_rust_fn`
+    //~^ NOTE the failure occurred here
 }
 
 static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-//~^ NOTE inside `VAL`
+//~^ ERROR could not evaluate static initializer
+//~| NOTE calling a function with calling convention C using calling convention Rust
 
 fn main() {}

--- a/tests/ui/consts/miri_unleashed/abi-mismatch.stderr
+++ b/tests/ui/consts/miri_unleashed/abi-mismatch.stderr
@@ -1,19 +1,14 @@
 error[E0080]: could not evaluate static initializer
-  --> $DIR/abi-mismatch.rs:7:5
+  --> $DIR/abi-mismatch.rs:11:18
    |
-LL |     my_fn();
-   |     ^^^^^^^ calling a function with calling convention C using calling convention Rust
+LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calling a function with calling convention C using calling convention Rust
    |
 note: inside `call_rust_fn`
   --> $DIR/abi-mismatch.rs:7:5
    |
 LL |     my_fn();
-   |     ^^^^^^^
-note: inside `VAL`
-  --> $DIR/abi-mismatch.rs:13:18
-   |
-LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^ the failure occurred here
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/miri_unleashed/assoc_const.rs
+++ b/tests/ui/consts/miri_unleashed/assoc_const.rs
@@ -9,7 +9,7 @@ trait Foo<T> {
 }
 
 trait Bar<T, U: Foo<T>> {
-    const F: u32 = (U::X, 42).1;
+    const F: u32 = (U::X, 42).1; //~ ERROR
 }
 
 impl Foo<u32> for () {
@@ -26,5 +26,5 @@ fn main() {
     // this is fine, but would have been forbidden by the static checks on `F`
     let x = <() as Bar<u32, ()>>::F;
     // this test only causes errors due to the line below, so post-monomorphization
-    let y = <String as Bar<Vec<u32>, String>>::F; //~ constant
+    let y = <String as Bar<Vec<u32>, String>>::F;
 }

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -1,17 +1,13 @@
-error[E0080]: evaluation of `<String as Bar<Vec<u32>, String>>::F` failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<u32> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `<String as Bar<Vec<u32>, String>>::F`
+error[E0080]: evaluation of `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))` failed
   --> $DIR/assoc_const.rs:12:31
    |
 LL |     const F: u32 = (U::X, 42).1;
-   |                               ^
+   |                               ^ calling non-const function `<Vec<u32> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 note: erroneous constant encountered
   --> $DIR/assoc_const.rs:29:13

--- a/tests/ui/consts/miri_unleashed/drop.stderr
+++ b/tests/ui/consts/miri_unleashed/drop.stderr
@@ -1,15 +1,11 @@
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<i32> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `TEST_BAD`
   --> $DIR/drop.rs:17:1
    |
 LL | };
-   | ^
+   | ^ calling non-const function `<Vec<i32> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -13,7 +13,7 @@ const X: () = {
 
     // Swap them, bytewise.
     unsafe {
-        ptr::swap_nonoverlapping(
+        ptr::swap_nonoverlapping( //~ ERROR evaluation of constant value failed
             &mut ptr1 as *mut _ as *mut MaybeUninit<u8>,
             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
             mem::size_of::<&i32>(),

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -1,17 +1,4 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: unable to copy parts of a pointer from memory at ALLOC0
-   |
-note: inside `std::ptr::read::<MaybeUninit<MaybeUninit<u8>>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::swap_nonoverlapping_simple_untyped::<MaybeUninit<u8>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `swap_nonoverlapping::compiletime::<MaybeUninit<u8>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `swap_nonoverlapping::<MaybeUninit<u8>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `X`
   --> $DIR/missing_span_in_backtrace.rs:16:9
    |
 16 | /         ptr::swap_nonoverlapping(
@@ -19,7 +6,16 @@ note: inside `X`
 18 | |             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
 19 | |             mem::size_of::<&i32>(),
 20 | |         );
-   | |_________^
+   | |_________^ unable to copy parts of a pointer from memory at ALLOC0
+   |
+note: inside `swap_nonoverlapping::<MaybeUninit<u8>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `swap_nonoverlapping::compiletime::<MaybeUninit<u8>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::swap_nonoverlapping_simple_untyped::<MaybeUninit<u8>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::read::<MaybeUninit<MaybeUninit<u8>>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/consts/offset_from_ub.rs
+++ b/tests/ui/consts/offset_from_ub.rs
@@ -21,7 +21,7 @@ pub const DIFFERENT_ALLOC: usize = {
 };
 
 pub const NOT_PTR: usize = {
-    unsafe { (42 as *const u8).offset_from(&5u8) as usize }
+    unsafe { (42 as *const u8).offset_from(&5u8) as usize } //~ ERROR evaluation of constant value failed
 };
 
 pub const NOT_MULTIPLE_OF_SIZE: isize = {
@@ -107,13 +107,13 @@ pub const OFFSET_VERY_FAR1: isize = {
     let ptr1 = ptr::null::<u8>();
     let ptr2 = ptr1.wrapping_offset(isize::MAX);
     unsafe { ptr2.offset_from(ptr1) }
-    //~^ inside
+    //~^ ERROR evaluation of constant value failed
 };
 pub const OFFSET_VERY_FAR2: isize = {
     let ptr1 = ptr::null::<u8>();
     let ptr2 = ptr1.wrapping_offset(isize::MAX);
     unsafe { ptr1.offset_from(ptr2.wrapping_offset(1)) }
-    //~^ inside
+    //~^ ERROR evaluation of constant value failed
 };
 
 // If the pointers are the same, OOB/null/UAF is fine.

--- a/tests/ui/consts/offset_from_ub.stderr
+++ b/tests/ui/consts/offset_from_ub.stderr
@@ -5,17 +5,13 @@ LL |     let offset = unsafe { ptr_offset_from(field_ptr, base_ptr) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `NOT_PTR`
   --> $DIR/offset_from_ub.rs:24:14
    |
 LL |     unsafe { (42 as *const u8).offset_from(&5u8) as usize }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/offset_from_ub.rs:31:14
@@ -78,30 +74,22 @@ LL |     unsafe { ptr_offset_from_unsigned(ptr2, ptr1) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called when first pointer is too far ahead of second
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OFFSET_VERY_FAR1`
   --> $DIR/offset_from_ub.rs:109:14
    |
 LL |     unsafe { ptr2.offset_from(ptr1) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from` called when first pointer is too far before second
+   |              ^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OFFSET_VERY_FAR2`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_from_ub.rs:115:14
    |
 LL |     unsafe { ptr1.offset_from(ptr2.wrapping_offset(1)) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called when first pointer is too far before second
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/consts/offset_ub.rs
+++ b/tests/ui/consts/offset_ub.rs
@@ -5,21 +5,21 @@ use std::ptr;
 //@ normalize-stderr: "\d+ bytes" -> "$$BYTES bytes"
 
 
-pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) }; //~NOTE
-pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) }; //~NOTE
-pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) }; //~NOTE
+pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) }; //~ ERROR
+pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) }; //~ ERROR
+pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) }; //~ ERROR
 
-pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) }; //~NOTE
-pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) }; //~NOTE
-pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) }; //~NOTE
-pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) }; //~NOTE
-pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) }; //~NOTE
+pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) }; //~ ERROR
+pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) }; //~ ERROR
+pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) }; //~ ERROR
+pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) }; //~ ERROR
+pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) }; //~ ERROR
 
-pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) }; //~NOTE
-pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) }; //~NOTE
+pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) }; //~ ERROR
+pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) }; //~ ERROR
 
 // Make sure that we don't panic when computing abs(offset*size_of::<T>())
-pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) }; //~NOTE
+pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) }; //~ ERROR
 
 // Offset-by-zero is allowed.
 pub const NULL_OFFSET_ZERO: *const u8 = unsafe { ptr::null::<u8>().offset(0) };

--- a/tests/ui/consts/offset_ub.stderr
+++ b/tests/ui/consts/offset_ub.stderr
@@ -1,145 +1,101 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of 1 byte of memory, but got ALLOC0 which is at the beginning of the allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `BEFORE_START`
   --> $DIR/offset_ub.rs:8:46
    |
 LL | pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) };
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC1 which is only 1 byte from the end of the allocation
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of 1 byte of memory, but got ALLOC0 which is at the beginning of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `AFTER_END`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:9:43
    |
 LL | pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC2 which is only $BYTES bytes from the end of the allocation
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC1 which is only 1 byte from the end of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `AFTER_ARRAY`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:10:45
    |
 LL | pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC2 which is only $BYTES bytes from the end of the allocation
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
-   |
-note: inside `std::ptr::const_ptr::<impl *const u16>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OVERFLOW`
   --> $DIR/offset_ub.rs:12:43
    |
 LL | pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
    |
 note: inside `std::ptr::const_ptr::<impl *const u16>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNDERFLOW`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:13:44
    |
 LL | pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) };
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
+   |
+note: inside `std::ptr::const_ptr::<impl *const u16>::offset`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OVERFLOW_ADDRESS_SPACE`
   --> $DIR/offset_ub.rs:14:56
    |
 LL | pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) };
-   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNDERFLOW_ADDRESS_SPACE`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:15:57
    |
 LL | pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) };
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got ALLOC3-0x2 which points to before the beginning of the allocation
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `NEGATIVE_OFFSET`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:16:49
    |
 LL | pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) };
-   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to 1 byte of memory, but got ALLOC4 which is at or beyond the end of the allocation of size $BYTES bytes
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got ALLOC3-0x2 which points to before the beginning of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `ZERO_SIZED_ALLOC`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:18:50
    |
 LL | pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) };
-   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
-   |
-note: inside `std::ptr::mut_ptr::<impl *mut u8>::offset`
-  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-note: inside `DANGLING`
-  --> $DIR/offset_ub.rs:19:42
-   |
-LL | pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to 1 byte of memory, but got ALLOC4 which is at or beyond the end of the allocation of size $BYTES bytes
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNDERFLOW_ABS`
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/offset_ub.rs:19:42
+   |
+LL | pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
+   |
+note: inside `std::ptr::mut_ptr::<impl *mut u8>::offset`
+  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:22:47
    |
 LL | pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) };
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/consts/qualif-indirect-mutation-fail.rs
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.rs
@@ -15,7 +15,7 @@ pub const A1: () = {
     let b = &mut y;
     std::mem::swap(a, b);
     std::mem::forget(y);
-};
+}; //~ ERROR evaluation of constant value failed
 
 // Mutable borrow of a type with drop impl.
 pub const A2: () = {
@@ -26,7 +26,7 @@ pub const A2: () = {
     std::mem::swap(a, b);
     std::mem::forget(y);
     let _z = x; //~ ERROR destructor of
-};
+}; //~ ERROR evaluation of constant value failed
 
 // Shared borrow of a type that might be !Freeze and Drop.
 pub const fn g1<T>() {

--- a/tests/ui/consts/qualif-indirect-mutation-fail.stderr
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.stderr
@@ -8,21 +8,17 @@ LL | };
    | - value is dropped here
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<u8> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `A1`
   --> $DIR/qualif-indirect-mutation-fail.rs:18:1
    |
 LL | };
-   | ^
+   | ^ calling non-const function `<Vec<u8> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:28:9
@@ -33,21 +29,17 @@ LL | };
    | - value is dropped here
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<u8> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `A2`
   --> $DIR/qualif-indirect-mutation-fail.rs:29:1
    |
 LL | };
-   | ^
+   | ^ calling non-const function `<Vec<u8> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `(u32, Option<String>)` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:6:9

--- a/tests/ui/consts/recursive.rs
+++ b/tests/ui/consts/recursive.rs
@@ -2,9 +2,8 @@
 
 const fn f<T>(x: T) { //~ WARN function cannot return without recursing
     f(x);
-    //~^ ERROR evaluation of constant value failed
 }
 
-const X: () = f(1);
+const X: () = f(1); //~ ERROR evaluation of constant value failed
 
 fn main() {}

--- a/tests/ui/consts/recursive.stderr
+++ b/tests/ui/consts/recursive.stderr
@@ -10,26 +10,21 @@ LL |     f(x);
    = note: `#[warn(unconditional_recursion)]` on by default
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/recursive.rs:4:5
+  --> $DIR/recursive.rs:7:15
    |
-LL |     f(x);
-   |     ^^^^ reached the configured maximum number of stack frames
+LL | const X: () = f(1);
+   |               ^^^^ reached the configured maximum number of stack frames
    |
-note: inside `f::<i32>`
-  --> $DIR/recursive.rs:4:5
-   |
-LL |     f(x);
-   |     ^^^^
 note: [... 126 additional calls inside `f::<i32>` ...]
   --> $DIR/recursive.rs:4:5
    |
 LL |     f(x);
    |     ^^^^
-note: inside `X`
-  --> $DIR/recursive.rs:8:15
+note: inside `f::<i32>`
+  --> $DIR/recursive.rs:4:5
    |
-LL | const X: () = f(1);
-   |               ^^^^
+LL |     f(x);
+   |     ^^^^ the failure occurred here
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/consts/required-consts/collect-in-called-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-called-fn.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-called-fn.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-called-fn.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-called-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-called-fn.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-called-fn.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-called-fn.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-closure.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-closure.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-closure.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-closure.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-closure.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-closure.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-closure.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-closure.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-drop.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-drop.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-drop.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-drop.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-drop.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-drop.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-drop.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-drop.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-generic.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-generic.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-generic.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-generic.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `m::Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
    |
 LL |         const C: () = panic!();
-   |                       ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
+   |                       ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `m::Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
    |
 LL |         const C: () = panic!();
-   |                       ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
+   |                       ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Late::<i32>::FAIL` failed
   --> $DIR/collect-in-dead-fnptr-in-const.rs:9:22
    |
 LL |     const FAIL: () = panic!();
-   |                      ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr-in-const.rs:9:22
+   |                      ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Late::<i32>::FAIL` failed
   --> $DIR/collect-in-dead-fnptr-in-const.rs:9:22
    |
 LL |     const FAIL: () = panic!();
-   |                      ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr-in-const.rs:9:22
+   |                      ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fnptr.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fnptr.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-move.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-move.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-move.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-move.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-move.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-move.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-move.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-move.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-vtable.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-vtable.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-vtable.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-vtable.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-vtable.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-vtable.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-vtable.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-vtable.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-promoted-const.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-promoted-const.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<T>::C` failed
   --> $DIR/collect-in-promoted-const.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-promoted-const.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-promoted-const.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-promoted-const.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-const-called-fn.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-const-called-fn.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-const-called-fn.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-const-called-fn.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-promoted.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.noopt.stderr
@@ -1,20 +1,16 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
+  --> $DIR/interpret-in-promoted.rs:13:28
    |
-   = note: entering unreachable code
+LL |     let _x: &'static () = &ub();
+   |                            ^^^^ entering unreachable code
    |
-note: inside `unreachable_unchecked`
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
 note: inside `ub`
   --> $DIR/interpret-in-promoted.rs:7:5
    |
 LL |     std::hint::unreachable_unchecked();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/interpret-in-promoted.rs:13:28
-   |
-LL |     let _x: &'static () = &ub();
-   |                            ^^^^
+note: inside `unreachable_unchecked`
+  --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 note: erroneous constant encountered
   --> $DIR/interpret-in-promoted.rs:13:27

--- a/tests/ui/consts/required-consts/interpret-in-promoted.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.opt.stderr
@@ -1,20 +1,16 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
+  --> $DIR/interpret-in-promoted.rs:13:28
    |
-   = note: entering unreachable code
+LL |     let _x: &'static () = &ub();
+   |                            ^^^^ entering unreachable code
    |
-note: inside `unreachable_unchecked`
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
 note: inside `ub`
   --> $DIR/interpret-in-promoted.rs:7:5
    |
 LL |     std::hint::unreachable_unchecked();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/interpret-in-promoted.rs:13:28
-   |
-LL |     let _x: &'static () = &ub();
-   |                            ^^^^
+note: inside `unreachable_unchecked`
+  --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 note: erroneous constant encountered
   --> $DIR/interpret-in-promoted.rs:13:27

--- a/tests/ui/consts/required-consts/interpret-in-promoted.rs
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.rs
@@ -4,13 +4,13 @@
 //! Make sure we evaluate const fn calls even if they get promoted and their result ignored.
 
 const unsafe fn ub() {
-    std::hint::unreachable_unchecked();
+    std::hint::unreachable_unchecked(); //~ inside `ub`
 }
 
 pub const FOO: () = unsafe {
     // Make sure that this gets promoted and then fails to evaluate, and we deal with that
     // correctly.
-    let _x: &'static () = &ub(); //~ erroneous constant
+    let _x: &'static () = &ub(); //~ ERROR evaluation of constant value failed
 };
 
 fn main() {}

--- a/tests/ui/consts/required-consts/interpret-in-static.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-static.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-static.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-static.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-static.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-static.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-static.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-static.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/uninhabited-const-issue-61744.rs
+++ b/tests/ui/consts/uninhabited-const-issue-61744.rs
@@ -1,7 +1,7 @@
 //@ build-fail
 
 pub const unsafe fn fake_type<T>() -> T {
-    hint_unreachable() //~ ERROR evaluation of `<i32 as Const>::CONSTANT` failed
+    hint_unreachable() //~ inside
 }
 
 pub const unsafe fn hint_unreachable() -> ! {
@@ -9,7 +9,7 @@ pub const unsafe fn hint_unreachable() -> ! {
 }
 
 trait Const {
-    const CONSTANT: i32 = unsafe { fake_type() }; //~ inside
+    const CONSTANT: i32 = unsafe { fake_type() }; //~ ERROR evaluation of `fake_type::<!>` failed
 }
 
 impl<T> Const for T {}

--- a/tests/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/tests/ui/consts/uninhabited-const-issue-61744.stderr
@@ -1,649 +1,644 @@
-error[E0080]: evaluation of `<i32 as Const>::CONSTANT` failed
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+error[E0080]: evaluation of `fake_type::<!>` failed
+  --> $DIR/uninhabited-const-issue-61744.rs:12:36
    |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^ reached the configured maximum number of stack frames
+LL |     const CONSTANT: i32 = unsafe { fake_type() };
+   |                                    ^^^^^^^^^^^ reached the configured maximum number of stack frames
    |
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
 note: inside `fake_type::<i32>`
   --> $DIR/uninhabited-const-issue-61744.rs:4:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
-note: inside `<i32 as Const>::CONSTANT`
-  --> $DIR/uninhabited-const-issue-61744.rs:12:36
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
    |
-LL |     const CONSTANT: i32 = unsafe { fake_type() };
-   |                                    ^^^^^^^^^^^
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/explicit-tail-calls/ctfe-id-unlimited.return.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-id-unlimited.return.stderr
@@ -1,29 +1,24 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ctfe-id-unlimited.rs:17:42
+  --> $DIR/ctfe-id-unlimited.rs:28:20
    |
-LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
-   |                                          ^^^^^^^^^^^^^^^^^^^^^ reached the configured maximum number of stack frames
+LL | const ID_ED: u32 = rec_id(ORIGINAL);
+   |                    ^^^^^^^^^^^^^^^^ reached the configured maximum number of stack frames
    |
-note: inside `inner`
-  --> $DIR/ctfe-id-unlimited.rs:17:42
+note: inside `rec_id`
+  --> $DIR/ctfe-id-unlimited.rs:21:5
    |
-LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
-   |                                          ^^^^^^^^^^^^^^^^^^^^^
+LL |     inner(0, n)
+   |     ^^^^^^^^^^^
 note: [... 125 additional calls inside `inner` ...]
   --> $DIR/ctfe-id-unlimited.rs:17:42
    |
 LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
    |                                          ^^^^^^^^^^^^^^^^^^^^^
-note: inside `rec_id`
-  --> $DIR/ctfe-id-unlimited.rs:22:5
+note: inside `inner`
+  --> $DIR/ctfe-id-unlimited.rs:17:42
    |
-LL |     inner(0, n)
-   |     ^^^^^^^^^^^
-note: inside `ID_ED`
-  --> $DIR/ctfe-id-unlimited.rs:29:20
-   |
-LL | const ID_ED: u32 = rec_id(ORIGINAL);
-   |                    ^^^^^^^^^^^^^^^^
+LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
+   |                                          ^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/explicit-tail-calls/ctfe-id-unlimited.rs
+++ b/tests/ui/explicit-tail-calls/ctfe-id-unlimited.rs
@@ -15,7 +15,6 @@ const fn rec_id(n: u32) -> u32 {
             0 => acc,
             #[cfg(r#become)] _ => become inner(acc + 1, n - 1),
             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
-            //[return]~^ error: evaluation of constant value failed
         }
     }
 
@@ -26,7 +25,7 @@ const fn rec_id(n: u32) -> u32 {
 const ORIGINAL: u32 = 12345;
 // Original number, but with identity function applied
 // (this is the same, but requires execution of the recursion)
-const ID_ED: u32 = rec_id(ORIGINAL);
+const ID_ED: u32 = rec_id(ORIGINAL); //[return]~ error: evaluation of constant value failed
 // Assert to make absolutely sure the computation actually happens
 const ASSERT: () = assert!(ORIGINAL == ID_ED);
 

--- a/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.rs
+++ b/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.rs
@@ -6,14 +6,11 @@ pub const fn f() {
 }
 
 const fn g() {
-    panic!()
-    //~^ error: evaluation of constant value failed
-    //~| note: in this expansion of panic!
-    //~| note: inside `g`
-    //~| note: in this expansion of panic!
+    panic!() //~ NOTE inside `g`
+    //~^ NOTE in this expansion of panic!
 }
 
-const _: () = f();
-//~^ note: inside `_`
+const _: () = f(); //~ ERROR evaluation of constant value failed
+//~^ NOTE explicit panic
 
 fn main() {}

--- a/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ctfe-tail-call-panic.rs:9:5
+  --> $DIR/ctfe-tail-call-panic.rs:13:15
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/ctfe-tail-call-panic.rs:9:5
+LL | const _: () = f();
+   |               ^^^ evaluation panicked: explicit panic
    |
 note: inside `g`
   --> $DIR/ctfe-tail-call-panic.rs:9:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_`
-  --> $DIR/ctfe-tail-call-panic.rs:16:15
-   |
-LL | const _: () = f();
-   |               ^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/generic-const-items/def-site-eval.fail.stderr
+++ b/tests/ui/generic-const-items/def-site-eval.fail.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `_::<'_>` failed
   --> $DIR/def-site-eval.rs:14:20
    |
 LL | const _<'_a>: () = panic!();
-   |                    ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/def-site-eval.rs:14:20
+   |                    ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/generics/post_monomorphization_error_backtrace.rs
+++ b/tests/ui/generics/post_monomorphization_error_backtrace.rs
@@ -6,10 +6,10 @@ fn assert_zst<T>() {
         const V: () = assert!(std::mem::size_of::<T>() == 0);
         //~^ ERROR: evaluation of `assert_zst::F::<u32>::V` failed [E0080]
         //~| NOTE: in this expansion of assert!
-        //~| NOTE: the evaluated program panicked
+        //~| NOTE: assertion failed
         //~| ERROR: evaluation of `assert_zst::F::<i32>::V` failed [E0080]
         //~| NOTE: in this expansion of assert!
-        //~| NOTE: the evaluated program panicked
+        //~| NOTE: assertion failed
     }
     F::<T>::V;
     //~^NOTE: erroneous constant

--- a/tests/ui/generics/post_monomorphization_error_backtrace.stderr
+++ b/tests/ui/generics/post_monomorphization_error_backtrace.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `assert_zst::F::<u32>::V` failed
   --> $DIR/post_monomorphization_error_backtrace.rs:6:23
    |
 LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/post_monomorphization_error_backtrace.rs:6:23
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -22,7 +22,7 @@ error[E0080]: evaluation of `assert_zst::F::<i32>::V` failed
   --> $DIR/post_monomorphization_error_backtrace.rs:6:23
    |
 LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/post_monomorphization_error_backtrace.rs:6:23
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/infinite/infinite-recursion-const-fn.rs
+++ b/tests/ui/infinite/infinite-recursion-const-fn.rs
@@ -1,11 +1,11 @@
 //https://github.com/rust-lang/rust/issues/31364
 
 const fn a() -> usize {
-    b() //~ ERROR evaluation of constant value failed [E0080]
+    b()
 }
 const fn b() -> usize {
     a()
 }
-const ARR: [i32; a()] = [5; 6];
+const ARR: [i32; a()] = [5; 6]; //~ ERROR evaluation of constant value failed [E0080]
 
 fn main() {}

--- a/tests/ui/infinite/infinite-recursion-const-fn.stderr
+++ b/tests/ui/infinite/infinite-recursion-const-fn.stderr
@@ -1,649 +1,644 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^ reached the configured maximum number of stack frames
-   |
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `ARR::{constant#0}`
   --> $DIR/infinite-recursion-const-fn.rs:9:18
    |
 LL | const ARR: [i32; a()] = [5; 6];
-   |                  ^^^
+   |                  ^^^ reached the configured maximum number of stack frames
+   |
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inline-const/const-expr-generic-err.stderr
+++ b/tests/ui/inline-const/const-expr-generic-err.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `foo::<i32>::{constant#0}` failed
   --> $DIR/const-expr-generic-err.rs:4:13
    |
 LL |     const { assert!(std::mem::size_of::<T>() == 0); }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/const-expr-generic-err.rs:4:13
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/inline-const/required-const.stderr
+++ b/tests/ui/inline-const/required-const.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `foo::<i32>::{constant#0}` failed
   --> $DIR/required-const.rs:6:17
    |
 LL |         const { panic!() }
-   |                 ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/required-const.rs:6:17
+   |                 ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/issues/issue-76191.stderr
+++ b/tests/ui/issues/issue-76191.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-76191.rs:8:37
    |
 LL | const RANGE2: RangeInclusive<i32> = panic!();
-   |                                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-76191.rs:8:37
+   |                                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/layout/invalid-unsized-in-always-sized-tail.rs
+++ b/tests/ui/layout/invalid-unsized-in-always-sized-tail.rs
@@ -12,6 +12,6 @@ struct P2 {
     //~^ ERROR: the size for values of type `[bool]` cannot be known at compilation time
 }
 
-static CHECK: () = assert!(align_of::<P2>() == 1);
+static CHECK: () = assert!(align_of::<P2>() == 1); //~ ERROR could not evaluate static initializer
 
 fn main() {}

--- a/tests/ui/layout/invalid-unsized-in-always-sized-tail.stderr
+++ b/tests/ui/layout/invalid-unsized-in-always-sized-tail.stderr
@@ -19,17 +19,13 @@ LL | struct MySlice<T>(T);
    |                this could be changed to `T: ?Sized`...
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: the type `MySlice<[bool]>` has an unknown layout
-   |
-note: inside `align_of::<P2>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `CHECK`
   --> $DIR/invalid-unsized-in-always-sized-tail.rs:15:28
    |
 LL | static CHECK: () = assert!(align_of::<P2>() == 1);
-   |                            ^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^ the type `MySlice<[bool]>` has an unknown layout
+   |
+note: inside `align_of::<P2>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/layout/unknown-when-no-type-parameter.stderr
+++ b/tests/ui/layout/unknown-when-no-type-parameter.stderr
@@ -1,15 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: the type `<() as Project>::Assoc` has an unknown layout
-   |
-note: inside `std::mem::size_of::<<() as Project>::Assoc>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `foo::{constant#0}`
   --> $DIR/unknown-when-no-type-parameter.rs:11:10
    |
 LL |     [(); size_of::<<() as Project>::Assoc>()];
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the type `<() as Project>::Assoc` has an unknown layout
+   |
+note: inside `std::mem::size_of::<<() as Project>::Assoc>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/limits/issue-55878.stderr
+++ b/tests/ui/limits/issue-55878.stderr
@@ -1,15 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: values of the type `[u8; usize::MAX]` are too big for the target architecture
-   |
-note: inside `std::mem::size_of::<[u8; usize::MAX]>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `main`
   --> $DIR/issue-55878.rs:5:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ values of the type `[u8; usize::MAX]` are too big for the target architecture
+   |
+note: inside `std::mem::size_of::<[u8; usize::MAX]>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/simd/const-err-trumps-simd-err.stderr
+++ b/tests/ui/simd/const-err-trumps-simd-err.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `get_elem::<4>::{constant#0}` failed
   --> $DIR/const-err-trumps-simd-err.rs:16:13
    |
 LL |     const { assert!(LANE < 4); } // the error should be here...
-   |             ^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: LANE < 4', $DIR/const-err-trumps-simd-err.rs:16:13
+   |             ^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: LANE < 4
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/structs/default-field-values/invalid-const.stderr
+++ b/tests/ui/structs/default-field-values/invalid-const.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/invalid-const.rs:5:19
    |
 LL |     pub bax: u8 = panic!("asdf"),
-   |                   ^^^^^^^^^^^^^^ the evaluated program panicked at 'asdf', $DIR/invalid-const.rs:5:19
+   |                   ^^^^^^^^^^^^^^ evaluation panicked: asdf
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/transmutability/uninhabited.stderr
+++ b/tests/ui/transmutability/uninhabited.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:41:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:41:9
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:63:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:63:9
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:87:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:87:9
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
### Shorten span of panic failures in const context

Previously, we included a redundant prefix on the panic message and a postfix of the location of the panic. The prefix didn't carry any additional information beyond "something failed", and the location of the panic is redundant with the diagnostic's span, which gets printed out even if its code is not shown.

```
error[E0080]: evaluation of constant value failed
--> $DIR/assert-type-intrinsics.rs:11:9
   |
LL |         MaybeUninit::<!>::uninit().assume_init();
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ panic: aborted execution: attempted to instantiate uninhabited type `!`
```

```
error[E0080]: evaluation of `Fail::<i32>::C` failed
--> $DIR/collect-in-dead-closure.rs:9:19
   |
LL |     const C: () = panic!();
   |                   ^^^^^^^^ explicit panic
   |
   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
```
```
error[E0080]: evaluation of constant value failed
--> $DIR/uninhabited.rs:87:9
   |
LL |         assert!(false);
   |         ^^^^^^^^^^^^^^ assertion failed: false
   |
   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
```

### Remove duplicated span from const eval frame list

When the primary span for a const error is the same as the first frame in the const error report, skip it.

```
error[E0080]: evaluation of constant value failed
  --> $DIR/issue-88434-removal-index-should-be-less.rs:3:24
   |
LL | const _CONST: &[u8] = &f(&[], |_| {});
   |                        ^^^^^^^^^^^^^^ explicit panic
   |
note: inside `f::<{closure@$DIR/issue-88434-removal-index-should-be-less.rs:3:31: 3:34}>`
  --> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
   |
LL |     panic!()
   |     ^^^^^^^^ the failure occurred here
   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
```
instead of
```
error[E0080]: evaluation of constant value failed
--> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
   |
LL |     panic!()
   |     ^^^^^^^^ explicit panic
   |
note: inside `f::<{closure@$DIR/issue-88434-removal-index-should-be-less.rs:3:31: 3:34}>`
--> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
   |
LL |     panic!()
   |     ^^^^^^^^
note: inside `_CONST`
--> $DIR/issue-88434-removal-index-should-be-less.rs:3:24
   |
LL | const _CONST: &[u8] = &f(&[], |_| {});
   |                        ^^^^^^^^^^^^^^
   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)

note: erroneous constant encountered
--> $DIR/issue-88434-removal-index-should-be-less.rs:3:23
   |
LL | const _CONST: &[u8] = &f(&[], |_| {});
   |                       ^^^^^^^^^^^^^^^
```

r? @oli-obk