### PR TITLE
Fix last compare-mode false negatives in tests

### DIFF
--- a/tests/ui/crate-loading/crateresolve1.rs
+++ b/tests/ui/crate-loading/crateresolve1.rs
@@ -2,11 +2,11 @@
 //@ aux-build:crateresolve1-2.rs
 //@ aux-build:crateresolve1-3.rs
 
-//@ normalize-stderr: "\.nll/" -> "/"
+//@ normalize-stderr: "crateresolve1\..+/auxiliary/" -> "crateresolve1/auxiliary/"
 //@ normalize-stderr: "\\\?\\" -> ""
 //@ normalize-stderr: "(lib)?crateresolve1-([123])\.[a-z]+" -> "libcrateresolve1-$2.somelib"
 
-// NOTE: This test is duplicated at `tests/ui/error-codes/E0464.rs`.
+// NOTE: This test is duplicated at `tests/ui/error-codes/E0464.rs` and `E0523.rs`.
 
 extern crate crateresolve1;
 //~^ ERROR multiple candidates for `rlib` dependency `crateresolve1` found

--- a/tests/ui/crate-loading/crateresolve2.rs
+++ b/tests/ui/crate-loading/crateresolve2.rs
@@ -4,7 +4,7 @@
 //@ aux-build:crateresolve2-2.rs
 //@ aux-build:crateresolve2-3.rs
 
-//@ normalize-stderr: "\.nll/" -> "/"
+//@ normalize-stderr: "crateresolve2\..+/auxiliary/" -> "crateresolve2/auxiliary/"
 //@ normalize-stderr: "\\\?\\" -> ""
 
 extern crate crateresolve2;

--- a/tests/ui/diagnostic-width/E0271.ascii.stderr
+++ b/tests/ui/diagnostic-width/E0271.ascii.stderr
@@ -15,7 +15,7 @@ note: expected this to be `Foo`
 LL |     type Error = E;
    |                  ^
    = note: required for the cast from `Box<Result<..., ()>>` to `Box<...>`
-   = note: the full name for the type has been written to '$TEST_BUILD_DIR/diagnostic-width/E0271.ascii/E0271.long-type-hash.txt'
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
    = note: consider using `--verbose` to print the full type name to the console
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic-width/E0271.rs
+++ b/tests/ui/diagnostic-width/E0271.rs
@@ -1,7 +1,7 @@
 //@ revisions: ascii unicode
 //@[ascii] compile-flags: --diagnostic-width=40 -Zwrite-long-types-to-disk=yes
 //@[unicode] compile-flags: -Zunstable-options --error-format=human-unicode --diagnostic-width=40 -Zwrite-long-types-to-disk=yes
-//@ normalize-stderr: "long-type-\d+" -> "long-type-hash"
+//@ normalize-stderr: "'\$TEST_BUILD_DIR/.*\.long-type-\d+.txt'" -> "'$$TEST_BUILD_DIR/$$FILE.long-type-hash.txt'"
 trait Future {
     type Error;
 }

--- a/tests/ui/diagnostic-width/E0271.unicode.stderr
+++ b/tests/ui/diagnostic-width/E0271.unicode.stderr
@@ -15,7 +15,7 @@ note: expected this to be `Foo`
 LL │     type Error = E;
    │                  ━
    ├ note: required for the cast from `Box<Result<..., ()>>` to `Box<...>`
-   ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/diagnostic-width/E0271.unicode/E0271.long-type-hash.txt'
+   ├ note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
    ╰ note: consider using `--verbose` to print the full type name to the console
 
 error: aborting due to 1 previous error

--- a/tests/ui/error-codes/E0462.rs
+++ b/tests/ui/error-codes/E0462.rs
@@ -1,6 +1,6 @@
 //@ aux-build:found-staticlib.rs
 
-//@ normalize-stderr: "\.nll/" -> "/"
+//@ normalize-stderr: "E0462\..+/auxiliary/" -> "E0462/auxiliary/"
 //@ normalize-stderr: "\\\?\\" -> ""
 //@ normalize-stderr: "(lib)?found_staticlib\.[a-z]+" -> "libfound_staticlib.somelib"
 

--- a/tests/ui/error-codes/E0464.rs
+++ b/tests/ui/error-codes/E0464.rs
@@ -2,7 +2,7 @@
 //@ aux-build:crateresolve1-2.rs
 //@ aux-build:crateresolve1-3.rs
 
-//@ normalize-stderr: "\.nll/" -> "/"
+//@ normalize-stderr: "E0464\..+/auxiliary/" -> "E0464/auxiliary/"
 //@ normalize-stderr: "\\\?\\" -> ""
 //@ normalize-stderr: "(lib)?crateresolve1-([123])\.[a-z]+" -> "libcrateresolve1-$2.somelib"
 

--- a/tests/ui/error-codes/E0523.rs
+++ b/tests/ui/error-codes/E0523.rs
@@ -2,7 +2,7 @@
 //@ aux-build:crateresolve1-2.rs
 //@ aux-build:crateresolve1-3.rs
 
-//@ normalize-stderr: "\.nll/" -> "/"
+//@ normalize-stderr: "E0523\..+/auxiliary/" -> "E0523/auxiliary/"
 //@ normalize-stderr: "\\\?\\" -> ""
 //@ normalize-stderr: "(lib)?crateresolve1-([123])\.[a-z]+" -> "libcrateresolve1-$2.somelib"
 

--- a/tests/ui/json/json-multiple.rs
+++ b/tests/ui/json/json-multiple.rs
@@ -1,5 +1,6 @@
 //@ build-pass
 //@ ignore-pass (different metadata emitted in different modes)
 //@ compile-flags: --json=diagnostic-short --json artifacts --error-format=json
+//@ normalize-stderr: "json-multiple\..+/libjson_multiple.rlib" -> "json-multiple/libjson_multiple.rlib"
 
 #![crate_type = "lib"]

--- a/tests/ui/json/json-options.rs
+++ b/tests/ui/json/json-options.rs
@@ -1,5 +1,6 @@
 //@ build-pass
 //@ ignore-pass (different metadata emitted in different modes)
 //@ compile-flags: --json=diagnostic-short,artifacts --error-format=json
+//@ normalize-stderr: "json-options\..+/libjson_options.rlib" -> "json-options/libjson_options.rlib"
 
 #![crate_type = "lib"]


### PR DESCRIPTION
This PR is a continuation of #136310 and fixes the last remaining cases of false negatives when running tests under a compare-mode. 

With these normalizations, all the compare-mode failures in `next-solver` (and `polonius`) should now be real, actual differences in diagnostics.