### PR TITLE
Mark `FnPtr` as `#[fundamental]`

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1082,6 +1082,7 @@ marker_impls! {
     issue = "none",
     reason = "internal trait for implementing various traits for all function pointers"
 )]
+#[fundamental]
 #[lang = "fn_ptr_trait"]
 #[rustc_deny_explicit_impl]
 #[rustc_do_not_implement_via_object]


### PR DESCRIPTION
Allows code like this to compile:

```rust
#![feature(fundamental)]

#[fundamental]
#[derive(Debug)]
pub struct Wrap<T>(T);
```

Current error:
```console
error[E0119]: conflicting implementations of trait `Debug` for type `Wrap<_>`
 --> src/lib.rs:4:10
  |
4 | #[derive(Debug)]
  |          ^^^^^
  |
  = note: conflicting implementation in crate `core`:
          - impl<F> Debug for F
            where F: FnPtr;
  = note: downstream crates may implement trait `std::clone::Clone` for type `Wrap<_>`
  = note: downstream crates may implement trait `std::marker::Copy` for type `Wrap<_>`
  = note: downstream crates may implement trait `std::marker::FnPtr` for type `Wrap<_>`
  = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0119`.
```

Current workaround:
```rust
#![feature(fundamental)]
#![feature(negative_impls, with_negative_coherence)]

#[fundamental]
#[derive(Debug)]
pub struct Wrap<T>(T);

impl<T> !Copy for Wrap<T> {}
impl<T> !Clone for Wrap<T> {}
```

Deriving `Copy` and `Clone` is insufficient because of
> note: downstream crates may implement trait `std::marker::FnPtr` for type `Wrap<_>`

An `impl<T> !FnPtr for Wrap<T> {}` is not allowed due to `#[rustc_deny_explicit_impl]` which errors on negative impls.

This issue does not arise with the `Tuple` trait (and others) because there are no blanket impls for all `T: Tuple`.