### PR TITLE
mir_build: Rename `thir::cx::Cx` to `ThirBuildCx` and remove `UserAnnotatedTyHelpers`

### DIFF
--- a/compiler/rustc_mir_build/src/thir/cx/block.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/block.rs
@@ -6,9 +6,9 @@ use rustc_middle::ty;
 use rustc_middle::ty::CanonicalUserTypeAnnotation;
 use tracing::debug;
 
-use crate::thir::cx::Cx;
+use crate::thir::cx::ThirBuildCx;
 
-impl<'tcx> Cx<'tcx> {
+impl<'tcx> ThirBuildCx<'tcx> {
     pub(crate) fn mirror_block(&mut self, block: &'tcx hir::Block<'tcx>) -> BlockId {
         // We have to eagerly lower the "spine" of the statements
         // in order to get the lexical scoping correctly.

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -22,7 +22,6 @@ use rustc_span::{Span, sym};
 use tracing::{debug, info, instrument, trace};
 
 use crate::thir::cx::Cx;
-use crate::thir::util::UserAnnotatedTyHelpers;
 
 impl<'tcx> Cx<'tcx> {
     /// Create a THIR expression for the given HIR expression. This expands all
@@ -142,9 +141,9 @@ impl<'tcx> Cx<'tcx> {
             Adjust::Deref(Some(deref)) => {
                 // We don't need to do call adjust_span here since
                 // deref coercions always start with a built-in deref.
-                let call_def_id = deref.method_call(self.tcx());
+                let call_def_id = deref.method_call(self.tcx);
                 let overloaded_callee =
-                    Ty::new_fn_def(self.tcx(), call_def_id, self.tcx().mk_args(&[expr.ty.into()]));
+                    Ty::new_fn_def(self.tcx, call_def_id, self.tcx.mk_args(&[expr.ty.into()]));
 
                 expr = Expr {
                     temp_lifetime,
@@ -253,10 +252,10 @@ impl<'tcx> Cx<'tcx> {
 
         // Check to see if this cast is a "coercion cast", where the cast is actually done
         // using a coercion (or is a no-op).
-        if self.typeck_results().is_coercion_cast(source.hir_id) {
+        if self.typeck_results.is_coercion_cast(source.hir_id) {
             // Convert the lexpr to a vexpr.
             ExprKind::Use { source: self.mirror_expr(source) }
-        } else if self.typeck_results().expr_ty(source).is_ref() {
+        } else if self.typeck_results.expr_ty(source).is_ref() {
             // Special cased so that we can type check that the element
             // type of the source matches the pointed to type of the
             // destination.
@@ -266,8 +265,8 @@ impl<'tcx> Cx<'tcx> {
                 is_from_as_cast: true,
             }
         } else if let hir::ExprKind::Path(ref qpath) = source.kind
-            && let res = self.typeck_results().qpath_res(qpath, source.hir_id)
-            && let ty = self.typeck_results().node_type(source.hir_id)
+            && let res = self.typeck_results.qpath_res(qpath, source.hir_id)
+            && let ty = self.typeck_results.node_type(source.hir_id)
             && let ty::Adt(adt_def, args) = ty.kind()
             && let Res::Def(DefKind::Ctor(CtorOf::Variant, CtorKind::Const), variant_ctor_id) = res
         {
@@ -330,7 +329,7 @@ impl<'tcx> Cx<'tcx> {
     #[instrument(level = "debug", skip(self), ret)]
     fn make_mirror_unadjusted(&mut self, expr: &'tcx hir::Expr<'tcx>) -> Expr<'tcx> {
         let tcx = self.tcx;
-        let expr_ty = self.typeck_results().expr_ty(expr);
+        let expr_ty = self.typeck_results.expr_ty(expr);
         let (temp_lifetime, backwards_incompatible) =
             self.rvalue_scopes.temporary_scope(self.region_scope_tree, expr.hir_id.local_id);
 
@@ -354,7 +353,7 @@ impl<'tcx> Cx<'tcx> {
             }
 
             hir::ExprKind::Call(fun, ref args) => {
-                if self.typeck_results().is_method_call(expr) {
+                if self.typeck_results.is_method_call(expr) {
                     // The callee is something implementing Fn, FnMut, or FnOnce.
                     // Find the actual method implementation being called and
                     // build the appropriate UFCS call expression with the
@@ -364,7 +363,7 @@ impl<'tcx> Cx<'tcx> {
 
                     let method = self.method_callee(expr, fun.span, None);
 
-                    let arg_tys = args.iter().map(|e| self.typeck_results().expr_ty_adjusted(e));
+                    let arg_tys = args.iter().map(|e| self.typeck_results.expr_ty_adjusted(e));
                     let tupled_args = Expr {
                         ty: Ty::new_tup_from_iter(tcx, arg_tys),
                         temp_lifetime: TempLifetime { temp_lifetime, backwards_incompatible },
@@ -380,7 +379,7 @@ impl<'tcx> Cx<'tcx> {
                         from_hir_call: true,
                         fn_span: expr.span,
                     }
-                } else if let ty::FnDef(def_id, _) = self.typeck_results().expr_ty(fun).kind()
+                } else if let ty::FnDef(def_id, _) = self.typeck_results.expr_ty(fun).kind()
                     && let Some(intrinsic) = self.tcx.intrinsic(def_id)
                     && intrinsic.name == sym::box_new
                 {
@@ -413,7 +412,7 @@ impl<'tcx> Cx<'tcx> {
                             },
                             hir::QPath::TypeRelative(_ty, _) => {
                                 if let Some((DefKind::Ctor(_, CtorKind::Fn), ctor_id)) =
-                                    self.typeck_results().type_dependent_def(fun.hir_id)
+                                    self.typeck_results.type_dependent_def(fun.hir_id)
                                 {
                                     Some((adt_def, adt_def.variant_index_with_ctor_id(ctor_id)))
                                 } else {
@@ -426,8 +425,8 @@ impl<'tcx> Cx<'tcx> {
                         None
                     };
                     if let Some((adt_def, index)) = adt_data {
-                        let node_args = self.typeck_results().node_args(fun.hir_id);
-                        let user_provided_types = self.typeck_results().user_provided_types();
+                        let node_args = self.typeck_results.node_args(fun.hir_id);
+                        let user_provided_types = self.typeck_results.user_provided_types();
                         let user_ty =
                             user_provided_types.get(fun.hir_id).copied().map(|mut u_ty| {
                                 if let ty::UserTypeKind::TypeOf(ref mut did, _) =
@@ -457,7 +456,7 @@ impl<'tcx> Cx<'tcx> {
                         }))
                     } else {
                         ExprKind::Call {
-                            ty: self.typeck_results().node_type(fun.hir_id),
+                            ty: self.typeck_results.node_type(fun.hir_id),
                             fun: self.mirror_expr(fun),
                             args: self.mirror_exprs(args),
                             from_hir_call: true,
@@ -482,7 +481,7 @@ impl<'tcx> Cx<'tcx> {
             }
 
             hir::ExprKind::AssignOp(op, lhs, rhs) => {
-                if self.typeck_results().is_method_call(expr) {
+                if self.typeck_results.is_method_call(expr) {
                     let lhs = self.mirror_expr(lhs);
                     let rhs = self.mirror_expr(rhs);
                     self.overloaded_operator(expr, Box::new([lhs, rhs]))
@@ -498,7 +497,7 @@ impl<'tcx> Cx<'tcx> {
             hir::ExprKind::Lit(lit) => ExprKind::Literal { lit, neg: false },
 
             hir::ExprKind::Binary(op, lhs, rhs) => {
-                if self.typeck_results().is_method_call(expr) {
+                if self.typeck_results.is_method_call(expr) {
                     let lhs = self.mirror_expr(lhs);
                     let rhs = self.mirror_expr(rhs);
                     self.overloaded_operator(expr, Box::new([lhs, rhs]))
@@ -527,7 +526,7 @@ impl<'tcx> Cx<'tcx> {
             }
 
             hir::ExprKind::Index(lhs, index, brackets_span) => {
-                if self.typeck_results().is_method_call(expr) {
+                if self.typeck_results.is_method_call(expr) {
                     let lhs = self.mirror_expr(lhs);
                     let index = self.mirror_expr(index);
                     self.overloaded_place(
@@ -543,7 +542,7 @@ impl<'tcx> Cx<'tcx> {
             }
 
             hir::ExprKind::Unary(hir::UnOp::Deref, arg) => {
-                if self.typeck_results().is_method_call(expr) {
+                if self.typeck_results.is_method_call(expr) {
                     let arg = self.mirror_expr(arg);
                     self.overloaded_place(expr, expr_ty, None, Box::new([arg]), expr.span)
                 } else {
@@ -552,7 +551,7 @@ impl<'tcx> Cx<'tcx> {
             }
 
             hir::ExprKind::Unary(hir::UnOp::Not, arg) => {
-                if self.typeck_results().is_method_call(expr) {
+                if self.typeck_results.is_method_call(expr) {
                     let arg = self.mirror_expr(arg);
                     self.overloaded_operator(expr, Box::new([arg]))
                 } else {
@@ -561,7 +560,7 @@ impl<'tcx> Cx<'tcx> {
             }
 
             hir::ExprKind::Unary(hir::UnOp::Neg, arg) => {
-                if self.typeck_results().is_method_call(expr) {
+                if self.typeck_results.is_method_call(expr) {
                     let arg = self.mirror_expr(arg);
                     self.overloaded_operator(expr, Box::new([arg]))
                 } else if let hir::ExprKind::Lit(lit) = arg.kind {
@@ -574,7 +573,7 @@ impl<'tcx> Cx<'tcx> {
             hir::ExprKind::Struct(qpath, fields, ref base) => match expr_ty.kind() {
                 ty::Adt(adt, args) => match adt.adt_kind() {
                     AdtKind::Struct | AdtKind::Union => {
-                        let user_provided_types = self.typeck_results().user_provided_types();
+                        let user_provided_types = self.typeck_results.user_provided_types();
                         let user_ty = user_provided_types.get(expr.hir_id).copied().map(Box::new);
                         debug!("make_mirror_unadjusted: (struct/union) user_ty={:?}", user_ty);
                         ExprKind::Adt(Box::new(AdtExpr {
@@ -586,15 +585,14 @@ impl<'tcx> Cx<'tcx> {
                             base: match base {
                                 hir::StructTailExpr::Base(base) => AdtExprBase::Base(FruInfo {
                                     base: self.mirror_expr(base),
-                                    field_types: self.typeck_results().fru_field_types()
-                                        [expr.hir_id]
+                                    field_types: self.typeck_results.fru_field_types()[expr.hir_id]
                                         .iter()
                                         .copied()
                                         .collect(),
                                 }),
                                 hir::StructTailExpr::DefaultFields(_) => {
                                     AdtExprBase::DefaultFields(
-                                        self.typeck_results().fru_field_types()[expr.hir_id]
+                                        self.typeck_results.fru_field_types()[expr.hir_id]
                                             .iter()
                                             .copied()
                                             .collect(),
@@ -605,7 +603,7 @@ impl<'tcx> Cx<'tcx> {
                         }))
                     }
                     AdtKind::Enum => {
-                        let res = self.typeck_results().qpath_res(qpath, expr.hir_id);
+                        let res = self.typeck_results.qpath_res(qpath, expr.hir_id);
                         match res {
                             Res::Def(DefKind::Variant, variant_id) => {
                                 assert!(matches!(
@@ -615,8 +613,7 @@ impl<'tcx> Cx<'tcx> {
                                 ));
 
                                 let index = adt.variant_index_with_id(variant_id);
-                                let user_provided_types =
-                                    self.typeck_results().user_provided_types();
+                                let user_provided_types = self.typeck_results.user_provided_types();
                                 let user_ty =
                                     user_provided_types.get(expr.hir_id).copied().map(Box::new);
                                 debug!("make_mirror_unadjusted: (variant) user_ty={:?}", user_ty);
@@ -629,8 +626,7 @@ impl<'tcx> Cx<'tcx> {
                                     base: match base {
                                         hir::StructTailExpr::DefaultFields(_) => {
                                             AdtExprBase::DefaultFields(
-                                                self.typeck_results().fru_field_types()
-                                                    [expr.hir_id]
+                                                self.typeck_results.fru_field_types()[expr.hir_id]
                                                     .iter()
                                                     .copied()
                                                     .collect(),
@@ -655,7 +651,7 @@ impl<'tcx> Cx<'tcx> {
             },
 
             hir::ExprKind::Closure { .. } => {
-                let closure_ty = self.typeck_results().expr_ty(expr);
+                let closure_ty = self.typeck_results.expr_ty(expr);
                 let (def_id, args, movability) = match *closure_ty.kind() {
                     ty::Closure(def_id, args) => (def_id, UpvarArgs::Closure(args), None),
                     ty::Coroutine(def_id, args) => {
@@ -703,7 +699,7 @@ impl<'tcx> Cx<'tcx> {
             }
 
             hir::ExprKind::Path(ref qpath) => {
-                let res = self.typeck_results().qpath_res(qpath, expr.hir_id);
+                let res = self.typeck_results.qpath_res(qpath, expr.hir_id);
                 self.convert_path_expr(expr, res)
             }
 
@@ -772,7 +768,7 @@ impl<'tcx> Cx<'tcx> {
             }
 
             hir::ExprKind::ConstBlock(ref anon_const) => {
-                let ty = self.typeck_results().node_type(anon_const.hir_id);
+                let ty = self.typeck_results.node_type(anon_const.hir_id);
                 let did = anon_const.def_id.to_def_id();
                 let typeck_root_def_id = tcx.typeck_root_def_id(did);
                 let parent_args =
@@ -783,7 +779,7 @@ impl<'tcx> Cx<'tcx> {
             }
             // Now comes the rote stuff:
             hir::ExprKind::Repeat(v, _) => {
-                let ty = self.typeck_results().expr_ty(expr);
+                let ty = self.typeck_results.expr_ty(expr);
                 let ty::Array(_, count) = ty.kind() else {
                     span_bug!(expr.span, "unexpected repeat expr ty: {:?}", ty);
                 };
@@ -837,7 +833,7 @@ impl<'tcx> Cx<'tcx> {
                 match_source,
             },
             hir::ExprKind::Loop(body, ..) => {
-                let block_ty = self.typeck_results().node_type(body.hir_id);
+                let block_ty = self.typeck_results.node_type(body.hir_id);
                 let (temp_lifetime, backwards_incompatible) = self
                     .rvalue_scopes
                     .temporary_scope(self.region_scope_tree, body.hir_id.local_id);
@@ -957,7 +953,7 @@ impl<'tcx> Cx<'tcx> {
             | Res::Def(DefKind::Ctor(_, CtorKind::Fn), _)
             | Res::Def(DefKind::Const, _)
             | Res::Def(DefKind::AssocConst, _) => {
-                self.typeck_results().user_provided_types().get(hir_id).copied().map(Box::new)
+                self.typeck_results.user_provided_types().get(hir_id).copied().map(Box::new)
             }
 
             // A unit struct/variant which is used as a value (e.g.,
@@ -989,17 +985,13 @@ impl<'tcx> Cx<'tcx> {
             Some(fn_def) => (fn_def, None),
             None => {
                 let (kind, def_id) =
-                    self.typeck_results().type_dependent_def(expr.hir_id).unwrap_or_else(|| {
+                    self.typeck_results.type_dependent_def(expr.hir_id).unwrap_or_else(|| {
                         span_bug!(expr.span, "no type-dependent def for method callee")
                     });
                 let user_ty = self.user_args_applied_to_res(expr.hir_id, Res::Def(kind, def_id));
                 debug!("method_callee: user_ty={:?}", user_ty);
                 (
-                    Ty::new_fn_def(
-                        self.tcx(),
-                        def_id,
-                        self.typeck_results().node_args(expr.hir_id),
-                    ),
+                    Ty::new_fn_def(self.tcx, def_id, self.typeck_results.node_args(expr.hir_id)),
                     user_ty,
                 )
             }
@@ -1025,7 +1017,7 @@ impl<'tcx> Cx<'tcx> {
     }
 
     fn convert_path_expr(&mut self, expr: &'tcx hir::Expr<'tcx>, res: Res) -> ExprKind<'tcx> {
-        let args = self.typeck_results().node_args(expr.hir_id);
+        let args = self.typeck_results.node_args(expr.hir_id);
         match res {
             // A regular function, constructor function or a constant.
             Res::Def(DefKind::Fn, _)
@@ -1060,7 +1052,7 @@ impl<'tcx> Cx<'tcx> {
                 let user_provided_types = self.typeck_results.user_provided_types();
                 let user_ty = user_provided_types.get(expr.hir_id).copied().map(Box::new);
                 debug!("convert_path_expr: user_ty={:?}", user_ty);
-                let ty = self.typeck_results().node_type(expr.hir_id);
+                let ty = self.typeck_results.node_type(expr.hir_id);
                 match ty.kind() {
                     // A unit struct/variant which is used as a value.
                     // We return a completely different ExprKind here to account for this special case.

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -21,9 +21,9 @@ use rustc_middle::{bug, span_bug};
 use rustc_span::{Span, sym};
 use tracing::{debug, info, instrument, trace};
 
-use crate::thir::cx::Cx;
+use crate::thir::cx::ThirBuildCx;
 
-impl<'tcx> Cx<'tcx> {
+impl<'tcx> ThirBuildCx<'tcx> {
     /// Create a THIR expression for the given HIR expression. This expands all
     /// adjustments and directly adds the type information from the
     /// `typeck_results`. See the [dev-guide] for more details.

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -16,7 +16,6 @@ use rustc_middle::ty::{self, RvalueScopes, TyCtxt};
 use tracing::instrument;
 
 use crate::thir::pattern::pat_from_hir;
-use crate::thir::util::UserAnnotatedTyHelpers;
 
 pub(crate) fn thir_body(
     tcx: TyCtxt<'_>,
@@ -113,7 +112,7 @@ impl<'tcx> Cx<'tcx> {
 
     #[instrument(level = "debug", skip(self))]
     fn pattern_from_hir(&mut self, p: &'tcx hir::Pat<'tcx>) -> Box<Pat<'tcx>> {
-        pat_from_hir(self.tcx, self.typing_env, self.typeck_results(), p)
+        pat_from_hir(self.tcx, self.typing_env, self.typeck_results, p)
     }
 
     fn closure_env_param(&self, owner_def: LocalDefId, expr_id: HirId) -> Option<Param<'tcx>> {
@@ -197,15 +196,12 @@ impl<'tcx> Cx<'tcx> {
             Param { pat: Some(pat), ty, ty_span, self_kind, hir_id: Some(param.hir_id) }
         })
     }
-}
 
-impl<'tcx> UserAnnotatedTyHelpers<'tcx> for Cx<'tcx> {
-    fn tcx(&self) -> TyCtxt<'tcx> {
-        self.tcx
-    }
-
-    fn typeck_results(&self) -> &ty::TypeckResults<'tcx> {
-        self.typeck_results
+    fn user_args_applied_to_ty_of_hir_id(
+        &self,
+        hir_id: HirId,
+    ) -> Option<ty::CanonicalUserType<'tcx>> {
+        crate::thir::util::user_args_applied_to_ty_of_hir_id(self.typeck_results, hir_id)
     }
 }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -27,7 +27,6 @@ use tracing::{debug, instrument};
 pub(crate) use self::check_match::check_match;
 use crate::errors::*;
 use crate::fluent_generated as fluent;
-use crate::thir::util::UserAnnotatedTyHelpers;
 
 struct PatCtxt<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
@@ -537,16 +536,12 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
             _ => {
                 let e = match res {
                     Res::Def(DefKind::ConstParam, def_id) => {
-                        self.tcx.dcx().emit_err(ConstParamInPattern {
-                            span,
-                            const_span: self.tcx().def_span(def_id),
-                        })
+                        let const_span = self.tcx.def_span(def_id);
+                        self.tcx.dcx().emit_err(ConstParamInPattern { span, const_span })
                     }
                     Res::Def(DefKind::Static { .. }, def_id) => {
-                        self.tcx.dcx().emit_err(StaticInPattern {
-                            span,
-                            static_span: self.tcx().def_span(def_id),
-                        })
+                        let static_span = self.tcx.def_span(def_id);
+                        self.tcx.dcx().emit_err(StaticInPattern { span, static_span })
                     }
                     _ => self.tcx.dcx().emit_err(NonConstPath { span }),
                 };
@@ -568,6 +563,13 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         }
 
         kind
+    }
+
+    fn user_args_applied_to_ty_of_hir_id(
+        &self,
+        hir_id: hir::HirId,
+    ) -> Option<ty::CanonicalUserType<'tcx>> {
+        crate::thir::util::user_args_applied_to_ty_of_hir_id(self.typeck_results, hir_id)
     }
 
     /// Takes a HIR Path. If the path is a constant, evaluates it and feeds
@@ -600,12 +602,12 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
             return pattern;
         }
 
-        let user_provided_types = self.typeck_results().user_provided_types();
+        let user_provided_types = self.typeck_results.user_provided_types();
         if let Some(&user_ty) = user_provided_types.get(id) {
             let annotation = CanonicalUserTypeAnnotation {
                 user_ty: Box::new(user_ty),
                 span,
-                inferred_ty: self.typeck_results().node_type(id),
+                inferred_ty: self.typeck_results.node_type(id),
             };
             Box::new(Pat {
                 span,
@@ -667,15 +669,5 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         let lit_input = LitToConstInput { lit: &lit.node, ty: ct_ty, neg };
         let constant = self.tcx.at(expr.span).lit_to_const(lit_input);
         self.const_to_pat(constant, ct_ty, expr.hir_id, lit.span).kind
-    }
-}
-
-impl<'tcx> UserAnnotatedTyHelpers<'tcx> for PatCtxt<'_, 'tcx> {
-    fn tcx(&self) -> TyCtxt<'tcx> {
-        self.tcx
-    }
-
-    fn typeck_results(&self) -> &ty::TypeckResults<'tcx> {
-        self.typeck_results
     }
 }

--- a/compiler/rustc_mir_build/src/thir/util.rs
+++ b/compiler/rustc_mir_build/src/thir/util.rs
@@ -1,33 +1,27 @@
 use rustc_hir as hir;
 use rustc_middle::bug;
-use rustc_middle::ty::{self, CanonicalUserType, TyCtxt};
+use rustc_middle::ty::{self, CanonicalUserType};
 use tracing::debug;
 
-pub(crate) trait UserAnnotatedTyHelpers<'tcx> {
-    fn tcx(&self) -> TyCtxt<'tcx>;
-
-    fn typeck_results(&self) -> &ty::TypeckResults<'tcx>;
-
-    /// Looks up the type associated with this hir-id and applies the
-    /// user-given generic parameters; the hir-id must map to a suitable
-    /// type.
-    fn user_args_applied_to_ty_of_hir_id(
-        &self,
-        hir_id: hir::HirId,
-    ) -> Option<CanonicalUserType<'tcx>> {
-        let user_provided_types = self.typeck_results().user_provided_types();
-        let mut user_ty = *user_provided_types.get(hir_id)?;
-        debug!("user_subts_applied_to_ty_of_hir_id: user_ty={:?}", user_ty);
-        let ty = self.typeck_results().node_type(hir_id);
-        match ty.kind() {
-            ty::Adt(adt_def, ..) => {
-                if let ty::UserTypeKind::TypeOf(ref mut did, _) = &mut user_ty.value.kind {
-                    *did = adt_def.did();
-                }
-                Some(user_ty)
+/// Looks up the type associated with this hir-id and applies the
+/// user-given generic parameters; the hir-id must map to a suitable
+/// type.
+pub(crate) fn user_args_applied_to_ty_of_hir_id<'tcx>(
+    typeck_results: &ty::TypeckResults<'tcx>,
+    hir_id: hir::HirId,
+) -> Option<CanonicalUserType<'tcx>> {
+    let user_provided_types = typeck_results.user_provided_types();
+    let mut user_ty = *user_provided_types.get(hir_id)?;
+    debug!("user_subts_applied_to_ty_of_hir_id: user_ty={:?}", user_ty);
+    let ty = typeck_results.node_type(hir_id);
+    match ty.kind() {
+        ty::Adt(adt_def, ..) => {
+            if let ty::UserTypeKind::TypeOf(ref mut did, _) = &mut user_ty.value.kind {
+                *did = adt_def.did();
             }
-            ty::FnDef(..) => Some(user_ty),
-            _ => bug!("ty: {:?} should not have user provided type {:?} recorded ", ty, user_ty),
+            Some(user_ty)
         }
+        ty::FnDef(..) => Some(user_ty),
+        _ => bug!("ty: {:?} should not have user provided type {:?} recorded ", ty, user_ty),
     }
 }


### PR DESCRIPTION
A combination of two loosely-related tweaks that would otherwise conflict with each other:

- `Cx` is a pretty unhelpful type name, especially when jumping between THIR-building and MIR-building while trying to make changes to THIR data structures.

- The `UserAnnotatedTyHelpers` trait doesn't appear to provide any benefit over a simple helper function, and its `tcx()` method is currently completely unnecessary.

No functional change.