### PR TITLE
Split `thir::PatKind::ExpandedConstant` into two distinct kinds

### DIFF
--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -243,7 +243,10 @@ pub fn walk_pat<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         AscribeUserType { subpattern, ascription: _ }
         | Deref { subpattern }
         | DerefPattern { subpattern, .. }
-        | Binding { subpattern: Some(subpattern), .. } => visitor.visit_pat(subpattern),
+        | Binding { subpattern: Some(subpattern), .. }
+        | InlineConstMarker { subpattern, .. }
+        | NamedConstMarker { subpattern, .. } => visitor.visit_pat(subpattern),
+
         Binding { .. } | Wild | Never | Error(_) => {}
         Variant { subpatterns, adt_def: _, args: _, variant_index: _ } | Leaf { subpatterns } => {
             for subpattern in subpatterns {
@@ -251,7 +254,6 @@ pub fn walk_pat<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
             }
         }
         Constant { value: _ } => {}
-        ExpandedConstant { def_id: _, is_inline: _, subpattern } => visitor.visit_pat(subpattern),
         Range(_) => {}
         Slice { prefix, slice, suffix } | Array { prefix, slice, suffix } => {
             for subpattern in prefix.iter() {

--- a/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/builder/custom/parse/instruction.rs
@@ -146,7 +146,7 @@ impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
             let arm = &self.thir[*arm];
             let value = match arm.pattern.kind {
                 PatKind::Constant { value } => value,
-                PatKind::ExpandedConstant { ref subpattern, def_id: _, is_inline: false }
+                PatKind::NamedConstMarker { ref subpattern, def_id: _ }
                     if let PatKind::Constant { value } = subpattern.kind =>
                 {
                     value

--- a/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/match_pair.rs
@@ -162,11 +162,11 @@ impl<'pat, 'tcx> MatchPairTree<'pat, 'tcx> {
                 TestCase::Irrefutable { ascription: None, binding }
             }
 
-            PatKind::ExpandedConstant { subpattern: ref pattern, def_id: _, is_inline: false } => {
+            PatKind::NamedConstMarker { subpattern: ref pattern, def_id: _ } => {
                 subpairs.push(MatchPairTree::for_pattern(place_builder, pattern, cx));
                 default_irrefutable()
             }
-            PatKind::ExpandedConstant { subpattern: ref pattern, def_id, is_inline: true } => {
+            PatKind::InlineConstMarker { subpattern: ref pattern, def_id } => {
                 // Apply a type ascription for the inline constant to the value at `match_pair.place`
                 let ascription = place.map(|source| {
                     let span = pattern.span;
@@ -177,7 +177,10 @@ impl<'pat, 'tcx> MatchPairTree<'pat, 'tcx> {
                     })
                     .args;
                     let user_ty = cx.infcx.canonicalize_user_type_annotation(ty::UserType::new(
-                        ty::UserTypeKind::TypeOf(def_id, ty::UserArgs { args, user_self_ty: None }),
+                        ty::UserTypeKind::TypeOf(def_id.to_def_id(), ty::UserArgs {
+                            args,
+                            user_self_ty: None,
+                        }),
                     ));
                     let annotation = ty::CanonicalUserTypeAnnotation {
                         inferred_ty: pattern.ty,

--- a/compiler/rustc_mir_build/src/builder/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/builder/matches/mod.rs
@@ -925,7 +925,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.visit_primary_bindings(subpattern, subpattern_user_ty, f)
             }
 
-            PatKind::ExpandedConstant { ref subpattern, .. } => {
+            PatKind::InlineConstMarker { ref subpattern, .. }
+            | PatKind::NamedConstMarker { ref subpattern, .. } => {
                 self.visit_primary_bindings(subpattern, pattern_user_ty, f)
             }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -676,10 +676,10 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
         let mut interpreted_as_const = None;
         let mut interpreted_as_const_sugg = None;
 
-        if let PatKind::ExpandedConstant { def_id, is_inline: false, .. }
+        if let PatKind::NamedConstMarker { def_id,  .. }
         | PatKind::AscribeUserType {
             subpattern:
-                box Pat { kind: PatKind::ExpandedConstant { def_id, is_inline: false, .. }, .. },
+                box Pat { kind: PatKind::NamedConstMarker { def_id,  .. }, .. },
             ..
         } = pat.kind
             && let DefKind::Const = self.tcx.def_kind(def_id)
@@ -1309,7 +1309,7 @@ fn report_non_exhaustive_match<'p, 'tcx>(
 
     for &arm in arms {
         let arm = &thir.arms[arm];
-        if let PatKind::ExpandedConstant { def_id, is_inline: false, .. } = arm.pattern.kind
+        if let PatKind::NamedConstMarker { def_id, .. } = arm.pattern.kind
             && let Ok(snippet) = cx.tcx.sess.source_map().span_to_snippet(arm.pattern.span)
             // We filter out paths with multiple path::segments.
             && snippet.chars().all(|c| c.is_alphanumeric() || c == '_')

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -733,10 +733,16 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                 print_indented!(self, format!("value: {:?}", value), depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl + 1);
             }
-            PatKind::ExpandedConstant { def_id, is_inline, subpattern } => {
-                print_indented!(self, "ExpandedConstant {", depth_lvl + 1);
+            PatKind::InlineConstMarker { def_id, subpattern } => {
+                print_indented!(self, "InlineConstMarker {", depth_lvl + 1);
                 print_indented!(self, format!("def_id: {def_id:?}"), depth_lvl + 2);
-                print_indented!(self, format!("is_inline: {is_inline:?}"), depth_lvl + 2);
+                print_indented!(self, "subpattern:", depth_lvl + 2);
+                self.print_pat(subpattern, depth_lvl + 2);
+                print_indented!(self, "}", depth_lvl + 1);
+            }
+            PatKind::NamedConstMarker { def_id, subpattern } => {
+                print_indented!(self, "NamedConstMarker {", depth_lvl + 1);
+                print_indented!(self, format!("def_id: {def_id:?}"), depth_lvl + 2);
                 print_indented!(self, "subpattern:", depth_lvl + 2);
                 self.print_pat(subpattern, depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl + 1);

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -456,8 +456,12 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
         let fields: Vec<_>;
         match &pat.kind {
             PatKind::AscribeUserType { subpattern, .. }
-            | PatKind::ExpandedConstant { subpattern, .. } => return self.lower_pat(subpattern),
-            PatKind::Binding { subpattern: Some(subpat), .. } => return self.lower_pat(subpat),
+            | PatKind::InlineConstMarker { subpattern, .. }
+            | PatKind::NamedConstMarker { subpattern, .. }
+            | PatKind::Binding { subpattern: Some(subpattern), .. } => {
+                return self.lower_pat(subpattern);
+            }
+
             PatKind::Binding { subpattern: None, .. } | PatKind::Wild => {
                 ctor = Wildcard;
                 fields = vec![];


### PR DESCRIPTION
These two kinds of marker node are superficially similar, but are actually very different in practice, and there is no code that actually wants to treat them as the same thing.

---

For historical reference, `PatKind::InlineConst` was introduced in #116482 to fix THIR unsafeck for inline-const blocks in range pattern endpoints.

It was then modified by #132708 (and renamed to `PatKind::ExpandedConstant`) to also mark named constants, for a diagnostic improvement for code that accidentally tries to perform an irrefutable binding to a name that is already used by a constant. The two sub-variants were indicated by a boolean field, which also changed the significance of the `def_id` field.

But tellingly, there was no code that actually wanted to equivocate between the two. Every occurrence was specifically interested in inline-const, or specifically interested in named-const, or was simply trying to traverse/unpeel pattern nodes without regard for their meaning.