### PR TITLE
Fix `rustc_hidden_type_of_opaques` for RPITITs with no default body

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/dump.rs
+++ b/compiler/rustc_hir_analysis/src/collect/dump.rs
@@ -11,6 +11,15 @@ pub(crate) fn opaque_hidden_types(tcx: TyCtxt<'_>) {
     }
 
     for id in tcx.hir_crate_items(()).opaques() {
+        if let hir::OpaqueTyOrigin::FnReturn { parent: fn_def_id, .. }
+        | hir::OpaqueTyOrigin::AsyncFn { parent: fn_def_id, .. } =
+            tcx.hir().expect_opaque_ty(id).origin
+            && let hir::Node::TraitItem(trait_item) = tcx.hir_node_by_def_id(fn_def_id)
+            && let (_, hir::TraitFn::Required(..)) = trait_item.expect_fn()
+        {
+            continue;
+        }
+
         let ty = tcx.type_of(id).instantiate_identity();
         let span = tcx.def_span(id);
         tcx.dcx().emit_err(crate::errors::TypeOf { span, ty });

--- a/tests/ui/impl-trait/in-trait/dump.rs
+++ b/tests/ui/impl-trait/in-trait/dump.rs
@@ -1,0 +1,15 @@
+//@ compile-flags: -Zverbose-internals
+
+#![feature(precise_capturing_in_traits, rustc_attrs)]
+#![rustc_hidden_type_of_opaques]
+
+trait Foo {
+    fn hello(&self) -> impl Sized;
+}
+
+fn hello<'s, T: Foo>(x: &'s T) -> impl Sized + use<'s, T> {
+//~^ ERROR <T as Foo>::{synthetic#0}<'s/#1>
+    x.hello()
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/dump.stderr
+++ b/tests/ui/impl-trait/in-trait/dump.stderr
@@ -1,0 +1,8 @@
+error: <T as Foo>::{synthetic#0}<'s/#1>
+  --> $DIR/dump.rs:10:35
+   |
+LL | fn hello<'s, T: Foo>(x: &'s T) -> impl Sized + use<'s, T> {
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Needed this when debugging something