### PR TITLE
Rename `slice::take...` methods to `split_off...`

### DIFF
--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -182,10 +182,10 @@ pub use self::function::{Fn, FnMut, FnOnce};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::index::{Index, IndexMut};
 pub(crate) use self::index_range::IndexRange;
-#[unstable(feature = "one_sided_range", issue = "69780")]
-pub use self::range::OneSidedRange;
 #[stable(feature = "inclusive_range", since = "1.26.0")]
 pub use self::range::{Bound, RangeBounds, RangeInclusive, RangeToInclusive};
+#[unstable(feature = "one_sided_range", issue = "69780")]
+pub use self::range::{OneSidedRange, OneSidedRangeBound};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::range::{Range, RangeFrom, RangeFull, RangeTo};
 #[unstable(feature = "try_trait_v2_residual", issue = "91285")]

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -979,6 +979,19 @@ impl<T> RangeBounds<T> for RangeToInclusive<&T> {
     }
 }
 
+/// An internal helper for `split_off` functions indicating
+/// which end a `OneSidedRange` is bounded on.
+#[unstable(feature = "one_sided_range", issue = "69780")]
+#[allow(missing_debug_implementations)]
+pub enum OneSidedRangeBound {
+    /// The range is bounded inclusively from below and is unbounded above.
+    StartInclusive,
+    /// The range is bounded exclusively from above and is unbounded below.
+    End,
+    /// The range is bounded inclusively from above and is unbounded below.
+    EndInclusive,
+}
+
 /// `OneSidedRange` is implemented for built-in range types that are unbounded
 /// on one side. For example, `a..`, `..b` and `..=c` implement `OneSidedRange`,
 /// but `..`, `d..e`, and `f..=g` do not.
@@ -986,13 +999,38 @@ impl<T> RangeBounds<T> for RangeToInclusive<&T> {
 /// Types that implement `OneSidedRange<T>` must return `Bound::Unbounded`
 /// from one of `RangeBounds::start_bound` or `RangeBounds::end_bound`.
 #[unstable(feature = "one_sided_range", issue = "69780")]
-pub trait OneSidedRange<T: ?Sized>: RangeBounds<T> {}
+pub trait OneSidedRange<T: ?Sized>: RangeBounds<T> {
+    /// An internal-only helper function for `split_off` and
+    /// `split_off_mut` that returns the bound of the one-sided range.
+    fn bound(self) -> (OneSidedRangeBound, T);
+}
 
 #[unstable(feature = "one_sided_range", issue = "69780")]
-impl<T> OneSidedRange<T> for RangeTo<T> where Self: RangeBounds<T> {}
+impl<T> OneSidedRange<T> for RangeTo<T>
+where
+    Self: RangeBounds<T>,
+{
+    fn bound(self) -> (OneSidedRangeBound, T) {
+        (OneSidedRangeBound::End, self.end)
+    }
+}
 
 #[unstable(feature = "one_sided_range", issue = "69780")]
-impl<T> OneSidedRange<T> for RangeFrom<T> where Self: RangeBounds<T> {}
+impl<T> OneSidedRange<T> for RangeFrom<T>
+where
+    Self: RangeBounds<T>,
+{
+    fn bound(self) -> (OneSidedRangeBound, T) {
+        (OneSidedRangeBound::StartInclusive, self.start)
+    }
+}
 
 #[unstable(feature = "one_sided_range", issue = "69780")]
-impl<T> OneSidedRange<T> for RangeToInclusive<T> where Self: RangeBounds<T> {}
+impl<T> OneSidedRange<T> for RangeToInclusive<T>
+where
+    Self: RangeBounds<T>,
+{
+    fn bound(self) -> (OneSidedRangeBound, T) {
+        (OneSidedRangeBound::EndInclusive, self.end)
+    }
+}

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -10,7 +10,7 @@ use crate::cmp::Ordering::{self, Equal, Greater, Less};
 use crate::intrinsics::{exact_div, unchecked_sub};
 use crate::mem::{self, SizedTypeProperties};
 use crate::num::NonZero;
-use crate::ops::{Bound, OneSidedRange, Range, RangeBounds, RangeInclusive};
+use crate::ops::{OneSidedRange, OneSidedRangeBound, Range, RangeBounds, RangeInclusive};
 use crate::panic::const_panic;
 use crate::simd::{self, Simd};
 use crate::ub_checks::assert_unsafe_precondition;
@@ -83,14 +83,12 @@ pub use raw::{from_raw_parts, from_raw_parts_mut};
 /// which to split. Returns `None` if the split index would overflow.
 #[inline]
 fn split_point_of(range: impl OneSidedRange<usize>) -> Option<(Direction, usize)> {
-    use Bound::*;
+    use OneSidedRangeBound::{End, EndInclusive, StartInclusive};
 
-    Some(match (range.start_bound(), range.end_bound()) {
-        (Unbounded, Excluded(i)) => (Direction::Front, *i),
-        (Unbounded, Included(i)) => (Direction::Front, i.checked_add(1)?),
-        (Excluded(i), Unbounded) => (Direction::Back, i.checked_add(1)?),
-        (Included(i), Unbounded) => (Direction::Back, *i),
-        _ => unreachable!(),
+    Some(match range.bound() {
+        (StartInclusive, i) => (Direction::Back, i),
+        (End, i) => (Direction::Front, i),
+        (EndInclusive, i) => (Direction::Front, i.checked_add(1)?),
     })
 }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -4294,25 +4294,25 @@ impl<T> [T] {
     ///
     /// # Examples
     ///
-    /// Taking the first three elements of a slice:
+    /// Splitting off the first three elements of a slice:
     ///
     /// ```
     /// #![feature(slice_take)]
     ///
     /// let mut slice: &[_] = &['a', 'b', 'c', 'd'];
-    /// let mut first_three = slice.take(..3).unwrap();
+    /// let mut first_three = slice.split_off(..3).unwrap();
     ///
     /// assert_eq!(slice, &['d']);
     /// assert_eq!(first_three, &['a', 'b', 'c']);
     /// ```
     ///
-    /// Taking the last two elements of a slice:
+    /// Splitting off the last two elements of a slice:
     ///
     /// ```
     /// #![feature(slice_take)]
     ///
     /// let mut slice: &[_] = &['a', 'b', 'c', 'd'];
-    /// let mut tail = slice.take(2..).unwrap();
+    /// let mut tail = slice.split_off(2..).unwrap();
     ///
     /// assert_eq!(slice, &['a', 'b']);
     /// assert_eq!(tail, &['c', 'd']);
@@ -4325,16 +4325,19 @@ impl<T> [T] {
     ///
     /// let mut slice: &[_] = &['a', 'b', 'c', 'd'];
     ///
-    /// assert_eq!(None, slice.take(5..));
-    /// assert_eq!(None, slice.take(..5));
-    /// assert_eq!(None, slice.take(..=4));
+    /// assert_eq!(None, slice.split_off(5..));
+    /// assert_eq!(None, slice.split_off(..5));
+    /// assert_eq!(None, slice.split_off(..=4));
     /// let expected: &[char] = &['a', 'b', 'c', 'd'];
-    /// assert_eq!(Some(expected), slice.take(..4));
+    /// assert_eq!(Some(expected), slice.split_off(..4));
     /// ```
     #[inline]
     #[must_use = "method does not modify the slice if the range is out of bounds"]
     #[unstable(feature = "slice_take", issue = "62280")]
-    pub fn take<'a, R: OneSidedRange<usize>>(self: &mut &'a Self, range: R) -> Option<&'a Self> {
+    pub fn split_off<'a, R: OneSidedRange<usize>>(
+        self: &mut &'a Self,
+        range: R,
+    ) -> Option<&'a Self> {
         let (direction, split_index) = split_point_of(range)?;
         if split_index > self.len() {
             return None;
@@ -4363,13 +4366,13 @@ impl<T> [T] {
     ///
     /// # Examples
     ///
-    /// Taking the first three elements of a slice:
+    /// Splitting off the first three elements of a slice:
     ///
     /// ```
     /// #![feature(slice_take)]
     ///
     /// let mut slice: &mut [_] = &mut ['a', 'b', 'c', 'd'];
-    /// let mut first_three = slice.take_mut(..3).unwrap();
+    /// let mut first_three = slice.split_off_mut(..3).unwrap();
     ///
     /// assert_eq!(slice, &mut ['d']);
     /// assert_eq!(first_three, &mut ['a', 'b', 'c']);
@@ -4381,7 +4384,7 @@ impl<T> [T] {
     /// #![feature(slice_take)]
     ///
     /// let mut slice: &mut [_] = &mut ['a', 'b', 'c', 'd'];
-    /// let mut tail = slice.take_mut(2..).unwrap();
+    /// let mut tail = slice.split_off_mut(2..).unwrap();
     ///
     /// assert_eq!(slice, &mut ['a', 'b']);
     /// assert_eq!(tail, &mut ['c', 'd']);
@@ -4394,16 +4397,16 @@ impl<T> [T] {
     ///
     /// let mut slice: &mut [_] = &mut ['a', 'b', 'c', 'd'];
     ///
-    /// assert_eq!(None, slice.take_mut(5..));
-    /// assert_eq!(None, slice.take_mut(..5));
-    /// assert_eq!(None, slice.take_mut(..=4));
+    /// assert_eq!(None, slice.split_off_mut(5..));
+    /// assert_eq!(None, slice.split_off_mut(..5));
+    /// assert_eq!(None, slice.split_off_mut(..=4));
     /// let expected: &mut [_] = &mut ['a', 'b', 'c', 'd'];
-    /// assert_eq!(Some(expected), slice.take_mut(..4));
+    /// assert_eq!(Some(expected), slice.split_off_mut(..4));
     /// ```
     #[inline]
     #[must_use = "method does not modify the slice if the range is out of bounds"]
     #[unstable(feature = "slice_take", issue = "62280")]
-    pub fn take_mut<'a, R: OneSidedRange<usize>>(
+    pub fn split_off_mut<'a, R: OneSidedRange<usize>>(
         self: &mut &'a mut Self,
         range: R,
     ) -> Option<&'a mut Self> {
@@ -4435,14 +4438,14 @@ impl<T> [T] {
     /// #![feature(slice_take)]
     ///
     /// let mut slice: &[_] = &['a', 'b', 'c'];
-    /// let first = slice.take_first().unwrap();
+    /// let first = slice.split_off_first().unwrap();
     ///
     /// assert_eq!(slice, &['b', 'c']);
     /// assert_eq!(first, &'a');
     /// ```
     #[inline]
     #[unstable(feature = "slice_take", issue = "62280")]
-    pub fn take_first<'a>(self: &mut &'a Self) -> Option<&'a T> {
+    pub fn split_off_first<'a>(self: &mut &'a Self) -> Option<&'a T> {
         let (first, rem) = self.split_first()?;
         *self = rem;
         Some(first)
@@ -4459,7 +4462,7 @@ impl<T> [T] {
     /// #![feature(slice_take)]
     ///
     /// let mut slice: &mut [_] = &mut ['a', 'b', 'c'];
-    /// let first = slice.take_first_mut().unwrap();
+    /// let first = slice.split_off_first_mut().unwrap();
     /// *first = 'd';
     ///
     /// assert_eq!(slice, &['b', 'c']);
@@ -4467,7 +4470,7 @@ impl<T> [T] {
     /// ```
     #[inline]
     #[unstable(feature = "slice_take", issue = "62280")]
-    pub fn take_first_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
+    pub fn split_off_first_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
         let (first, rem) = mem::take(self).split_first_mut()?;
         *self = rem;
         Some(first)
@@ -4484,14 +4487,14 @@ impl<T> [T] {
     /// #![feature(slice_take)]
     ///
     /// let mut slice: &[_] = &['a', 'b', 'c'];
-    /// let last = slice.take_last().unwrap();
+    /// let last = slice.split_off_last().unwrap();
     ///
     /// assert_eq!(slice, &['a', 'b']);
     /// assert_eq!(last, &'c');
     /// ```
     #[inline]
     #[unstable(feature = "slice_take", issue = "62280")]
-    pub fn take_last<'a>(self: &mut &'a Self) -> Option<&'a T> {
+    pub fn split_off_last<'a>(self: &mut &'a Self) -> Option<&'a T> {
         let (last, rem) = self.split_last()?;
         *self = rem;
         Some(last)
@@ -4508,7 +4511,7 @@ impl<T> [T] {
     /// #![feature(slice_take)]
     ///
     /// let mut slice: &mut [_] = &mut ['a', 'b', 'c'];
-    /// let last = slice.take_last_mut().unwrap();
+    /// let last = slice.split_off_last_mut().unwrap();
     /// *last = 'd';
     ///
     /// assert_eq!(slice, &['a', 'b']);
@@ -4516,7 +4519,7 @@ impl<T> [T] {
     /// ```
     #[inline]
     #[unstable(feature = "slice_take", issue = "62280")]
-    pub fn take_last_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
+    pub fn split_off_last_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
         let (last, rem) = mem::take(self).split_last_mut()?;
         *self = rem;
         Some(last)

--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -2399,18 +2399,18 @@ fn slice_rsplit_once() {
     assert_eq!(v.rsplit_once(|&x| x == 0), None);
 }
 
-macro_rules! take_tests {
+macro_rules! split_off_tests {
     (slice: &[], $($tts:tt)*) => {
-        take_tests!(ty: &[()], slice: &[], $($tts)*);
+        split_off_tests!(ty: &[()], slice: &[], $($tts)*);
     };
     (slice: &mut [], $($tts:tt)*) => {
-        take_tests!(ty: &mut [()], slice: &mut [], $($tts)*);
+        split_off_tests!(ty: &mut [()], slice: &mut [], $($tts)*);
     };
     (slice: &$slice:expr, $($tts:tt)*) => {
-        take_tests!(ty: &[_], slice: &$slice, $($tts)*);
+        split_off_tests!(ty: &[_], slice: &$slice, $($tts)*);
     };
     (slice: &mut $slice:expr, $($tts:tt)*) => {
-        take_tests!(ty: &mut [_], slice: &mut $slice, $($tts)*);
+        split_off_tests!(ty: &mut [_], slice: &mut $slice, $($tts)*);
     };
     (ty: $ty:ty, slice: $slice:expr, method: $method:ident, $(($test_name:ident, ($($args:expr),*), $output:expr, $remaining:expr),)*) => {
         $(
@@ -2425,64 +2425,64 @@ macro_rules! take_tests {
     };
 }
 
-take_tests! {
-    slice: &[0, 1, 2, 3], method: take,
-    (take_in_bounds_range_to, (..1), Some(&[0] as _), &[1, 2, 3]),
-    (take_in_bounds_range_to_inclusive, (..=0), Some(&[0] as _), &[1, 2, 3]),
-    (take_in_bounds_range_from, (2..), Some(&[2, 3] as _), &[0, 1]),
-    (take_oob_range_to, (..5), None, &[0, 1, 2, 3]),
-    (take_oob_range_to_inclusive, (..=4), None, &[0, 1, 2, 3]),
-    (take_oob_range_from, (5..), None, &[0, 1, 2, 3]),
+split_off_tests! {
+    slice: &[0, 1, 2, 3], method: split_off,
+    (split_off_in_bounds_range_to, (..1), Some(&[0] as _), &[1, 2, 3]),
+    (split_off_in_bounds_range_to_inclusive, (..=0), Some(&[0] as _), &[1, 2, 3]),
+    (split_off_in_bounds_range_from, (2..), Some(&[2, 3] as _), &[0, 1]),
+    (split_off_oob_range_to, (..5), None, &[0, 1, 2, 3]),
+    (split_off_oob_range_to_inclusive, (..=4), None, &[0, 1, 2, 3]),
+    (split_off_oob_range_from, (5..), None, &[0, 1, 2, 3]),
 }
 
-take_tests! {
-    slice: &mut [0, 1, 2, 3], method: take_mut,
-    (take_mut_in_bounds_range_to, (..1), Some(&mut [0] as _), &mut [1, 2, 3]),
-    (take_mut_in_bounds_range_to_inclusive, (..=0), Some(&mut [0] as _), &mut [1, 2, 3]),
-    (take_mut_in_bounds_range_from, (2..), Some(&mut [2, 3] as _), &mut [0, 1]),
-    (take_mut_oob_range_to, (..5), None, &mut [0, 1, 2, 3]),
-    (take_mut_oob_range_to_inclusive, (..=4), None, &mut [0, 1, 2, 3]),
-    (take_mut_oob_range_from, (5..), None, &mut [0, 1, 2, 3]),
+split_off_tests! {
+    slice: &mut [0, 1, 2, 3], method: split_off_mut,
+    (split_off_mut_in_bounds_range_to, (..1), Some(&mut [0] as _), &mut [1, 2, 3]),
+    (split_off_mut_in_bounds_range_to_inclusive, (..=0), Some(&mut [0] as _), &mut [1, 2, 3]),
+    (split_off_mut_in_bounds_range_from, (2..), Some(&mut [2, 3] as _), &mut [0, 1]),
+    (split_off_mut_oob_range_to, (..5), None, &mut [0, 1, 2, 3]),
+    (split_off_mut_oob_range_to_inclusive, (..=4), None, &mut [0, 1, 2, 3]),
+    (split_off_mut_oob_range_from, (5..), None, &mut [0, 1, 2, 3]),
 }
 
-take_tests! {
-    slice: &[1, 2], method: take_first,
-    (take_first_nonempty, (), Some(&1), &[2]),
+split_off_tests! {
+    slice: &[1, 2], method: split_off_first,
+    (split_off_first_nonempty, (), Some(&1), &[2]),
 }
 
-take_tests! {
-    slice: &mut [1, 2], method: take_first_mut,
-    (take_first_mut_nonempty, (), Some(&mut 1), &mut [2]),
+split_off_tests! {
+    slice: &mut [1, 2], method: split_off_first_mut,
+    (split_off_first_mut_nonempty, (), Some(&mut 1), &mut [2]),
 }
 
-take_tests! {
-    slice: &[1, 2], method: take_last,
-    (take_last_nonempty, (), Some(&2), &[1]),
+split_off_tests! {
+    slice: &[1, 2], method: split_off_last,
+    (split_off_last_nonempty, (), Some(&2), &[1]),
 }
 
-take_tests! {
-    slice: &mut [1, 2], method: take_last_mut,
-    (take_last_mut_nonempty, (), Some(&mut 2), &mut [1]),
+split_off_tests! {
+    slice: &mut [1, 2], method: split_off_last_mut,
+    (split_off_last_mut_nonempty, (), Some(&mut 2), &mut [1]),
 }
 
-take_tests! {
-    slice: &[], method: take_first,
-    (take_first_empty, (), None, &[]),
+split_off_tests! {
+    slice: &[], method: split_off_first,
+    (split_off_first_empty, (), None, &[]),
 }
 
-take_tests! {
-    slice: &mut [], method: take_first_mut,
-    (take_first_mut_empty, (), None, &mut []),
+split_off_tests! {
+    slice: &mut [], method: split_off_first_mut,
+    (split_off_first_mut_empty, (), None, &mut []),
 }
 
-take_tests! {
-    slice: &[], method: take_last,
-    (take_last_empty, (), None, &[]),
+split_off_tests! {
+    slice: &[], method: split_off_last,
+    (split_off_last_empty, (), None, &[]),
 }
 
-take_tests! {
-    slice: &mut [], method: take_last_mut,
-    (take_last_mut_empty, (), None, &mut []),
+split_off_tests! {
+    slice: &mut [], method: split_off_last_mut,
+    (split_off_last_mut_empty, (), None, &mut []),
 }
 
 #[cfg(not(miri))] // unused in Miri
@@ -2497,19 +2497,19 @@ macro_rules! empty_max_mut {
 }
 
 #[cfg(not(miri))] // Comparing usize::MAX many elements takes forever in Miri (and in rustc without optimizations)
-take_tests! {
-    slice: &[(); usize::MAX], method: take,
-    (take_in_bounds_max_range_to, (..usize::MAX), Some(EMPTY_MAX), &[(); 0]),
-    (take_oob_max_range_to_inclusive, (..=usize::MAX), None, EMPTY_MAX),
-    (take_in_bounds_max_range_from, (usize::MAX..), Some(&[] as _), EMPTY_MAX),
+split_off_tests! {
+    slice: &[(); usize::MAX], method: split_off,
+    (split_off_in_bounds_max_range_to, (..usize::MAX), Some(EMPTY_MAX), &[(); 0]),
+    (split_off_oob_max_range_to_inclusive, (..=usize::MAX), None, EMPTY_MAX),
+    (split_off_in_bounds_max_range_from, (usize::MAX..), Some(&[] as _), EMPTY_MAX),
 }
 
 #[cfg(not(miri))] // Comparing usize::MAX many elements takes forever in Miri (and in rustc without optimizations)
-take_tests! {
-    slice: &mut [(); usize::MAX], method: take_mut,
-    (take_mut_in_bounds_max_range_to, (..usize::MAX), Some(empty_max_mut!()), &mut [(); 0]),
-    (take_mut_oob_max_range_to_inclusive, (..=usize::MAX), None, empty_max_mut!()),
-    (take_mut_in_bounds_max_range_from, (usize::MAX..), Some(&mut [] as _), empty_max_mut!()),
+split_off_tests! {
+    slice: &mut [(); usize::MAX], method: split_off_mut,
+    (split_off_mut_in_bounds_max_range_to, (..usize::MAX), Some(empty_max_mut!()), &mut [(); 0]),
+    (split_off_mut_oob_max_range_to_inclusive, (..=usize::MAX), None, empty_max_mut!()),
+    (split_off_mut_in_bounds_max_range_from, (usize::MAX..), Some(&mut [] as _), empty_max_mut!()),
 }
 
 #[test]


### PR DESCRIPTION
This rename was discussed and recommended in a recent t-libs meeting.

cc https://github.com/rust-lang/rust/issues/62280

There's an additional commit here which modifies internals of unstable `OneSidedRange` APIs in order to implement `split_off` methods in a panic-free way (remove `unreachable!()`) as recommended in https://github.com/rust-lang/rust/pull/88502/files#r760177240. I can split this out into a separate PR if needed.