### PR TITLE
[AIX] Update tests/ui/wait-forked-but-failed-child.rs to accomodate exiting and idle processes.

### DIFF
--- a/tests/ui/wait-forked-but-failed-child.rs
+++ b/tests/ui/wait-forked-but-failed-child.rs
@@ -31,8 +31,17 @@ fn find_zombies() {
     // https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ps.html
     let ps_cmd_output = Command::new("ps").args(&["-A", "-o", "pid,ppid,args"]).output().unwrap();
     let ps_output = String::from_utf8_lossy(&ps_cmd_output.stdout);
+    // On AIX, the PPID is not always present, such as when a process is blocked
+    // (marked as <exiting>), or if a process is idle. In these situations,
+    // the PPID column contains a "-" for the respective process.
+    // Filter out any lines that have a "-" as the PPID as the PPID is
+    // expected to be an integer.
+    let filtered_ps: Vec<_> = ps_output
+        .lines()
+        .filter(|line| line.split(' ').filter(|x| 0 < x.len()).nth(1) != Some("-"))
+        .collect();
 
-    for (line_no, line) in ps_output.split('\n').enumerate() {
+    for (line_no, line) in filtered_ps.into_iter().enumerate() {
         if 0 < line_no && 0 < line.len() &&
            my_pid == line.split(' ').filter(|w| 0 < w.len()).nth(1)
                          .expect("1st column should be PPID")

--- a/tests/ui/wait-forked-but-failed-child.rs
+++ b/tests/ui/wait-forked-but-failed-child.rs
@@ -38,7 +38,7 @@ fn find_zombies() {
     // expected to be an integer.
     let filtered_ps: Vec<_> = ps_output
         .lines()
-        .filter(|line| line.split(' ').filter(|x| 0 < x.len()).nth(1) != Some("-"))
+        .filter(|line| line.split_whitespace().nth(1) != Some("-"))
         .collect();
 
     for (line_no, line) in filtered_ps.into_iter().enumerate() {


### PR DESCRIPTION
The `wait-forked-but-failed-child.rs` test expects to see an integer PPID in the
output of the command: `ps -A -o pid,ppid,args`.

However, on AIX, sometimes an integer PPID is not available when a process is
either exiting or idle, as documented in https://www.ibm.com/docs/en/aix/7.3?topic=p-ps-command.
In these situations, a `-` is instead shown in the PPID column of the `ps` output.

This PR updates the test to accommodate this behaviour on AIX by first filtering out the
lines of the `ps` output where a `-` is found in the `PPID` column.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
