### PR TITLE
Document minimum supported host tooling on macOS

### DIFF
--- a/src/doc/rustc/src/platform-support/apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/apple-darwin.md
@@ -30,6 +30,18 @@ The current default deployment target for `rustc` can be retrieved with
 [deployment target]: https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html
 [rustc-print]: ../command-line-arguments.md#option-print
 
+### Host tooling
+
+The minimum supported OS versions for the host tooling (`rustc`, `cargo`,
+etc.) are currently the same as for applications, namely 10.12 on x86 and 11.0
+on ARM64.
+The minimum supported Xcode version is 9.2.
+
+Building from source likely requires that you can build LLVM from source too,
+which [currently][llvm-os] requires Xcode 10.0 and macOS 10.13 (for LLVM 19).
+
+[llvm-os]: https://releases.llvm.org/19.1.0/docs/GettingStarted.html#host-c-toolchain-both-compiler-and-standard-library
+
 ### Binary format
 
 The default binary format is Mach-O, the executable format used on Apple's


### PR DESCRIPTION
In particular we support macOS 10.12 (same as for binaries produced by `rustc`) and Xcode 9.2 (the highest Xcode version that runs on macOS 10.12.6). I have this installed on a MacBook Pro from 2013 that sits below my desk, and am occasionally testing it.

I am documenting this now because it was unclear in https://github.com/rust-lang/rust/issues/136523.

(I'm not inherently against bumping these one day, but that's a separate discussion, let's at least document what we support right now).

@rustbot label O-macos
