### PR TITLE
Resolve named regions when reporting type test failures in NLL

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -316,13 +316,16 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     let type_test_span = type_test.span;
 
                     if let Some(lower_bound_region) = lower_bound_region {
-                        let generic_ty = type_test.generic_kind.to_ty(self.infcx.tcx);
+                        let generic_ty = self.regioncx.name_regions(
+                            self.infcx.tcx,
+                            type_test.generic_kind.to_ty(self.infcx.tcx),
+                        );
                         let origin = RelateParamBound(type_test_span, generic_ty, None);
                         self.buffer_error(self.infcx.err_ctxt().construct_generic_bound_failure(
                             self.body.source.def_id().expect_local(),
                             type_test_span,
                             Some(origin),
-                            type_test.generic_kind,
+                            self.regioncx.name_regions(self.infcx.tcx, type_test.generic_kind),
                             lower_bound_region,
                         ));
                     } else {

--- a/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -23,16 +23,20 @@ LL | |     T: Anything<'b, 'c>,
    |
    = note: defining type: no_relationships_late::<'?1, '?2, T>
 
-error[E0309]: the associated type `<T as Anything<'?5, '?6>>::AssocType` may not live long enough
+error[E0309]: the associated type `<T as Anything<'b/#0, 'c/#1>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:38:39
    |
 LL | fn no_relationships_late<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
-   |                          -- the associated type `<T as Anything<'?5, '?6>>::AssocType` must be valid for the lifetime `'a` as defined here...
+   |                          -- the associated type `<T as Anything<'b/#0, 'c/#1>>::AssocType` must be valid for the lifetime `'a` as defined here...
 ...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                                       ^^^^^^^^^^^^^^^^ ...so that the type `<T as Anything<'?5, '?6>>::AssocType` will meet its required lifetime bounds
+   |                                       ^^^^^^^^^^^^^^^^ ...so that the type `<T as Anything<'b/#0, 'c/#1>>::AssocType` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as Anything<'?5, '?6>>::AssocType: 'a`...
+help: consider adding an explicit lifetime bound
+   |
+LL -     T: Anything<'b, 'c>,
+LL +     T: Anything<'b, 'c>, <T as Anything<'b/#0, 'c/#1>>::AssocType: 'a
+   |
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
@@ -59,16 +63,20 @@ LL | |     'a: 'a,
    |
    = note: defining type: no_relationships_early::<'?1, '?2, '?3, T>
 
-error[E0309]: the associated type `<T as Anything<'?6, '?7>>::AssocType` may not live long enough
+error[E0309]: the associated type `<T as Anything<'b/#1, 'c/#2>>::AssocType` may not live long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:39
    |
 LL | fn no_relationships_early<'a, 'b, 'c, T>(cell: Cell<&'a ()>, t: T)
-   |                           -- the associated type `<T as Anything<'?6, '?7>>::AssocType` must be valid for the lifetime `'a` as defined here...
+   |                           -- the associated type `<T as Anything<'b/#1, 'c/#2>>::AssocType` must be valid for the lifetime `'a` as defined here...
 ...
 LL |     with_signature(cell, t, |cell, t| require(cell, t));
-   |                                       ^^^^^^^^^^^^^^^^ ...so that the type `<T as Anything<'?6, '?7>>::AssocType` will meet its required lifetime bounds
+   |                                       ^^^^^^^^^^^^^^^^ ...so that the type `<T as Anything<'b/#1, 'c/#2>>::AssocType` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as Anything<'?6, '?7>>::AssocType: 'a`...
+help: consider adding an explicit lifetime bound
+   |
+LL -     'a: 'a,
+LL +     'a: 'a, <T as Anything<'b/#1, 'c/#2>>::AssocType: 'a
+   |
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:61:29

--- a/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-bound.stderr
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-bound.stderr
@@ -1,13 +1,17 @@
-error[E0309]: the associated type `<T as MyTrait<'_>>::Output` may not live long enough
+error[E0309]: the associated type `<T as MyTrait<'a>>::Output` may not live long enough
   --> $DIR/projection-where-clause-env-wrong-bound.rs:15:5
    |
 LL | fn foo1<'a, 'b, T>() -> &'a ()
-   |         -- the associated type `<T as MyTrait<'_>>::Output` must be valid for the lifetime `'a` as defined here...
+   |         -- the associated type `<T as MyTrait<'a>>::Output` must be valid for the lifetime `'a` as defined here...
 ...
 LL |     bar::<T::Output>()
-   |     ^^^^^^^^^^^^^^^^ ...so that the type `<T as MyTrait<'_>>::Output` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^^^ ...so that the type `<T as MyTrait<'a>>::Output` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as MyTrait<'_>>::Output: 'a`...
+help: consider adding an explicit lifetime bound
+   |
+LL -     <T as MyTrait<'a>>::Output: 'b,
+LL +     <T as MyTrait<'a>>::Output: 'b, <T as MyTrait<'a>>::Output: 'a
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-lifetime.rs
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-lifetime.rs
@@ -12,7 +12,7 @@ where
     <T as MyTrait<'b>>::Output: 'a,
 {
     bar::<<T as MyTrait<'a>>::Output>()
-    //~^ ERROR the associated type `<T as MyTrait<'_>>::Output` may not live long enough
+    //~^ ERROR the associated type `<T as MyTrait<'a>>::Output` may not live long enough
 }
 
 fn bar<'a, T>() -> &'a ()

--- a/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-lifetime.stderr
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-lifetime.stderr
@@ -1,13 +1,17 @@
-error[E0309]: the associated type `<T as MyTrait<'_>>::Output` may not live long enough
+error[E0309]: the associated type `<T as MyTrait<'a>>::Output` may not live long enough
   --> $DIR/projection-where-clause-env-wrong-lifetime.rs:14:5
    |
 LL | fn foo1<'a, 'b, T>() -> &'a ()
-   |         -- the associated type `<T as MyTrait<'_>>::Output` must be valid for the lifetime `'a` as defined here...
+   |         -- the associated type `<T as MyTrait<'a>>::Output` must be valid for the lifetime `'a` as defined here...
 ...
 LL |     bar::<<T as MyTrait<'a>>::Output>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `<T as MyTrait<'_>>::Output` will meet its required lifetime bounds
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `<T as MyTrait<'a>>::Output` will meet its required lifetime bounds
    |
-   = help: consider adding an explicit lifetime bound `<T as MyTrait<'_>>::Output: 'a`...
+help: consider adding an explicit lifetime bound
+   |
+LL -     <T as MyTrait<'b>>::Output: 'a,
+LL +     <T as MyTrait<'b>>::Output: 'a, <T as MyTrait<'a>>::Output: 'a
+   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Just a improvement tweak to an error message that I broke out of a bigger PR that I had to close lol