### PR TITLE
rustc_target: Add TargetOption.check_environment

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -271,7 +271,7 @@ pub fn run_compiler(at_args: &[String], callbacks: &mut (dyn Callbacks + Send)) 
 
     let registered_lints = config.register_lints.is_some();
 
-    interface::run_compiler(config, |compiler| {
+    if let Err(error_msg) = interface::run_compiler(config, |compiler| {
         let sess = &compiler.sess;
         let codegen_backend = &*compiler.codegen_backend;
 
@@ -379,7 +379,9 @@ pub fn run_compiler(at_args: &[String], callbacks: &mut (dyn Callbacks + Send)) 
         if let Some(linker) = linker {
             linker.link(sess, codegen_backend);
         }
-    })
+    }) {
+        eprintln!("Error: {error_msg}");
+    }
 }
 
 fn dump_feature_usage_metrics(tcxt: TyCtxt<'_>, metrics_dir: &Path) {

--- a/compiler/rustc_target/src/spec/json.rs
+++ b/compiler/rustc_target/src/spec/json.rs
@@ -248,6 +248,15 @@ impl Target {
                     Some(Ok(()))
                 })).unwrap_or(Ok(()))
             } );
+            ($key_name:ident, CheckEnvironment) => ( {
+                obj.remove("check-environment").and_then(|o| o.as_str().and_then(|s| {
+                    match s.parse::<super::CheckEnvironment>() {
+                        Ok(support) => base.check_environment = support,
+                        _ => return Some(Err(format!("'{s}' is not a valid value for check-environment."))),
+                    }
+                    Some(Ok(()))
+                })).unwrap_or(Ok(()))
+            } );
             ($key_name:ident, list) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 if let Some(j) = obj.remove(&name) {
@@ -641,6 +650,7 @@ impl Target {
         key!(entry_name);
         key!(entry_abi, Conv)?;
         key!(supports_xray, bool);
+        key!(check_environment, CheckEnvironment)?;
 
         base.update_from_cli();
         base.check_consistency(TargetKind::Json)?;
@@ -819,6 +829,7 @@ impl ToJson for Target {
         target_option_val!(entry_name);
         target_option_val!(entry_abi);
         target_option_val!(supports_xray);
+        target_option_val!(check_environment);
 
         // Serializing `-Clink-self-contained` needs a dynamic key to support the
         // backwards-compatible variants.

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -248,7 +248,8 @@ pub(crate) fn run(dcx: DiagCtxtHandle<'_>, input: Input, options: RustdocOptions
         compiler.sess.dcx().abort_if_errors();
 
         collector
-    });
+    })
+    .unwrap();
 
     let CreateRunnableDocTests {
         standalone_tests,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -833,7 +833,8 @@ fn main_args(early_dcx: &mut EarlyDiagCtxt, at_args: &[String]) {
                 dcx,
                 interface::run_compiler(config, |_compiler| {
                     markdown::render_and_write(&md_input, render_options, edition)
-                }),
+                })
+                .unwrap(),
             );
         }
         (false, None) => {}
@@ -907,4 +908,5 @@ fn main_args(early_dcx: &mut EarlyDiagCtxt, at_args: &[String]) {
             }
         })
     })
+    .unwrap()
 }


### PR DESCRIPTION
This function gets called after a Target is created, and can be used to verify that the environment is suitable for building for a given target. E.g. it's a place to check for environment variables, executables in the path, libraries required for linking, and so on.

If the check fails, the user gets a simple error message instead of a backtrace culminating in a message to file a bug against the Rust team.

I use this in my LynxOS-178 support code to give a user a friendly error message if the linker and libraries aren't found.

It would be cleaner to change the target() function for each target to return a Result, but the change would be considerably larger.