### PR TITLE
ci: use ubuntu 24 for x86 large runners

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -12,15 +12,15 @@ runners:
 
   # Large runner used mainly for its bigger disk capacity
   - &job-linux-4c-largedisk
-    os: ubuntu-22.04-4core-16gb
+    os: ubuntu-24.04-4core-16gb
     <<: *base-job
 
   - &job-linux-8c
-    os: ubuntu-22.04-8core-32gb
+    os: ubuntu-24.04-8core-32gb
     <<: *base-job
 
   - &job-linux-16c
-    os: ubuntu-22.04-16core-64gb
+    os: ubuntu-24.04-16core-64gb
     <<: *base-job
 
   - &job-macos-xl


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
In https://github.com/rust-lang/rust/pull/136136 we moved free runners to ubuntu 24.
In this PR we move x86 large runners, too.
ARM runners will be moved in a separate PRs because they are a bit flaky and ubuntu 24 might have issues. This is based both on the failed try job of this PR and [this](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Upload.20to.20datadog.20CI.20script.2E.2E.2E.20segfaulted.3F) zulip discussion.
<!-- homu-ignore:end -->
try-job: dist-powerpc64le-linux
try-job: x86_64-gnu-debug
try-job: dist-arm-linux
try-job: x86_64-fuchsia
try-job: x86_64-gnu-distcheck
try-job: dist-x86_64-linux
try-job: dist-x86_64-linux-alt
