### PR TITLE
Document why some "type mismatches" exist

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1619,6 +1619,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ast::LitKind::Int(_, ast::LitIntType::Unsuffixed) => {
                 let opt_ty = expected.to_option(self).and_then(|ty| match ty.kind() {
                     ty::Int(_) | ty::Uint(_) => Some(ty),
+                    // These exist to direct casts like `0x61 as char` to use
+                    // the right integer type to cast from, instead of falling back to
+                    // i32 due to no further constraints.
                     ty::Char => Some(tcx.types.u8),
                     ty::RawPtr(..) => Some(tcx.types.usize),
                     ty::FnDef(..) | ty::FnPtr(..) => Some(tcx.types.usize),


### PR DESCRIPTION
Just something I stumbled over and thought to save myself (and maybe others) the research time when encountering it again.
