### PR TITLE
Only highlight unmatchable parameters at the definition site

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -1,4 +1,4 @@
-use std::{iter, mem};
+use std::{fmt, iter, mem};
 
 use itertools::Itertools;
 use rustc_data_structures::fx::FxIndexSet;
@@ -13,7 +13,7 @@ use rustc_hir::{ExprKind, HirId, Node, QPath};
 use rustc_hir_analysis::check::intrinsicck::InlineAsmCtxt;
 use rustc_hir_analysis::check::potentially_plural_count;
 use rustc_hir_analysis::hir_ty_lowering::HirTyLowerer;
-use rustc_index::{Idx, IndexVec};
+use rustc_index::IndexVec;
 use rustc_infer::infer::{DefineOpaqueTypes, InferOk, TypeTrace};
 use rustc_middle::ty::adjustment::AllowTwoPhase;
 use rustc_middle::ty::error::TypeError;
@@ -25,6 +25,7 @@ use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
 use rustc_trait_selection::error_reporting::infer::{FailureCode, ObligationCauseExt};
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::traits::{self, ObligationCauseCode, ObligationCtxt, SelectionContext};
+use smallvec::SmallVec;
 use tracing::debug;
 use {rustc_ast as ast, rustc_hir as hir};
 
@@ -43,6 +44,12 @@ use crate::{
     BreakableCtxt, Diverges, Expectation, FnCtxt, LoweredTy, Needs, TupleArgumentsFlag, errors,
     struct_span_code_err,
 };
+
+rustc_index::newtype_index! {
+    #[orderable]
+    #[debug_format = "GenericIdx({})"]
+    pub(crate) struct GenericIdx {}
+}
 
 #[derive(Clone, Copy, Default)]
 pub(crate) enum DivergingBlockBehavior {
@@ -2288,7 +2295,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // If we're calling a method of a Fn/FnMut/FnOnce trait object implicitly
         // (eg invoking a closure) we want to point at the underlying callable,
         // not the method implicitly invoked (eg call_once).
-        if let Some(assoc_item) = self.tcx.opt_associated_item(def_id)
+        // TupleArguments is set only when this is an implicit call (my_closure(...)) rather than explicit (my_closure.call(...))
+        if tuple_arguments == TupleArguments
+            && let Some(assoc_item) = self.tcx.opt_associated_item(def_id)
             // Since this is an associated item, it might point at either an impl or a trait item.
             // We want it to always point to the trait item.
             // If we're pointing at an inherent function, we don't need to do anything,
@@ -2298,8 +2307,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Just an easy way to check "trait_def_id == Fn/FnMut/FnOnce"
             && let Some(call_kind) = self.tcx.fn_trait_kind_from_def_id(maybe_trait_def_id)
             && let Some(callee_ty) = callee_ty
-            // TupleArguments is set only when this is an implicit call (my_closure(...)) rather than explicit (my_closure.call(...))
-            && tuple_arguments == TupleArguments
         {
             let callee_ty = callee_ty.peel_refs();
             match *callee_ty.kind() {
@@ -2368,174 +2375,136 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             && !def_span.is_dummy()
         {
             let mut spans: MultiSpan = def_span.into();
-
-            if let Some(params_with_generics) = self.get_hir_params_with_generics(def_id, is_method)
+            if let Some((params_with_generics, hir_generics)) =
+                self.get_hir_param_info(def_id, is_method)
             {
+                struct MismatchedParam<'a> {
+                    idx: ExpectedIdx,
+                    generic: GenericIdx,
+                    param: &'a FnParam<'a>,
+                    deps: SmallVec<[ExpectedIdx; 4]>,
+                }
+
                 debug_assert_eq!(params_with_generics.len(), matched_inputs.len());
-
-                let mut generics_with_unmatched_params = Vec::new();
-
-                let check_for_matched_generics = || {
-                    if matched_inputs.iter().any(|x| x.is_some())
-                        && params_with_generics.iter().any(|(x, _)| x.is_some())
-                    {
-                        for (idx, (generic, _)) in params_with_generics.iter_enumerated() {
-                            // Param has to have a generic and be matched to be relevant
-                            if matched_inputs[idx].is_none() {
-                                continue;
-                            }
-
-                            let Some(generic) = generic else {
-                                continue;
-                            };
-
-                            for unmatching_idx in
-                                idx.plus(1)..ExpectedIdx::from_usize(params_with_generics.len())
-                            {
-                                if matched_inputs[unmatching_idx].is_none()
-                                    && let Some(unmatched_idx_param_generic) =
-                                        params_with_generics[unmatching_idx].0
-                                    && unmatched_idx_param_generic.name.ident()
-                                        == generic.name.ident()
-                                {
-                                    // We found a parameter that didn't match that needed to
-                                    return true;
+                // Gather all mismatched parameters with generics.
+                let mut mismatched_params = Vec::<MismatchedParam<'_>>::new();
+                if let Some(expected_idx) = expected_idx {
+                    let expected_idx = ExpectedIdx::from_usize(expected_idx);
+                    let &(expected_generic, ref expected_param) =
+                        &params_with_generics[expected_idx];
+                    if let Some(expected_generic) = expected_generic {
+                        mismatched_params.push(MismatchedParam {
+                            idx: expected_idx,
+                            generic: expected_generic,
+                            param: expected_param,
+                            deps: SmallVec::new(),
+                        });
+                    } else {
+                        // Still mark the mismatched parameter
+                        spans.push_span_label(expected_param.span(), "");
+                    }
+                } else {
+                    mismatched_params.extend(
+                        params_with_generics.iter_enumerated().zip(matched_inputs).filter_map(
+                            |((idx, &(generic, ref param)), matched_idx)| {
+                                if matched_idx.is_some() {
+                                    None
+                                } else if let Some(generic) = generic {
+                                    Some(MismatchedParam {
+                                        idx,
+                                        generic,
+                                        param,
+                                        deps: SmallVec::new(),
+                                    })
+                                } else {
+                                    // Still mark mismatched parameters
+                                    spans.push_span_label(param.span(), "");
+                                    None
                                 }
+                            },
+                        ),
+                    );
+                }
+
+                if !mismatched_params.is_empty() {
+                    // For each mismatched paramter, create a two-way link to each matched parameter
+                    // of the same type.
+                    let mut dependants = IndexVec::<ExpectedIdx, _>::from_fn_n(
+                        |_| SmallVec::<[u32; 4]>::new(),
+                        params_with_generics.len(),
+                    );
+                    let mut generic_uses = IndexVec::<GenericIdx, _>::from_fn_n(
+                        |_| SmallVec::<[ExpectedIdx; 4]>::new(),
+                        hir_generics.params.len(),
+                    );
+                    for (idx, param) in mismatched_params.iter_mut().enumerate() {
+                        for ((other_idx, &(other_generic, _)), &other_matched_idx) in
+                            params_with_generics.iter_enumerated().zip(matched_inputs)
+                        {
+                            if other_generic == Some(param.generic) && other_matched_idx.is_some() {
+                                generic_uses[param.generic].extend([param.idx, other_idx]);
+                                dependants[other_idx].push(idx as u32);
+                                param.deps.push(other_idx);
                             }
                         }
                     }
-                    false
-                };
 
-                let check_for_matched_generics = check_for_matched_generics();
-
-                for (idx, &(generic_param, param)) in
-                    params_with_generics.iter_enumerated().filter(|&(idx, _)| {
-                        check_for_matched_generics
-                            || expected_idx
-                                .is_none_or(|expected_idx| expected_idx == idx.as_usize())
-                    })
-                {
-                    let Some(generic_param) = generic_param else {
-                        spans.push_span_label(param.span(), "");
-                        continue;
-                    };
-
-                    let other_params_matched: Vec<(ExpectedIdx, FnParam<'_>)> =
-                        params_with_generics
-                            .iter_enumerated()
-                            .filter(|&(other_idx, &(other_generic_param, _))| {
-                                if other_idx == idx {
-                                    return false;
-                                }
-                                let Some(other_generic_param) = other_generic_param else {
-                                    return false;
-                                };
-                                if matched_inputs[idx].is_none()
-                                    && matched_inputs[other_idx].is_none()
-                                {
-                                    return false;
-                                }
-                                if matched_inputs[idx].is_some()
-                                    && matched_inputs[other_idx].is_some()
-                                {
-                                    return false;
-                                }
-                                other_generic_param.name.ident() == generic_param.name.ident()
-                            })
-                            .map(|(other_idx, &(_, other_param))| (other_idx, other_param))
-                            .collect();
-
-                    if !other_params_matched.is_empty() {
-                        let other_param_matched_names: Vec<String> = other_params_matched
-                            .iter()
-                            .map(|(idx, other_param)| {
-                                if let Some(name) = other_param.name() {
-                                    format!("`{name}`")
-                                } else {
-                                    format!("parameter #{}", idx.as_u32() + 1)
-                                }
-                            })
-                            .collect();
-
-                        let matched_ty = self
-                            .resolve_vars_if_possible(formal_and_expected_inputs[idx].1)
-                            .sort_string(self.tcx);
-
-                        if matched_inputs[idx].is_some() {
+                    // Highlight each mismatched type along with a note about which other parameters
+                    // the type depends on (if any).
+                    for param in &mismatched_params {
+                        if let Some(deps_list) = listify(&param.deps, |&dep| {
+                            params_with_generics[dep].1.display(dep.as_usize()).to_string()
+                        }) {
                             spans.push_span_label(
-                                param.span(),
+                                param.param.span(),
                                 format!(
-                                    "{} need{} to match the {} type of this parameter",
-                                    listify(&other_param_matched_names, |n| n.to_string())
-                                        .unwrap_or_default(),
-                                    pluralize!(if other_param_matched_names.len() == 1 {
-                                        0
-                                    } else {
-                                        1
-                                    }),
-                                    matched_ty,
+                                    "this parameter needs to match the {} type of {deps_list}",
+                                    self.resolve_vars_if_possible(
+                                        formal_and_expected_inputs[param.deps[0]].1
+                                    )
+                                    .sort_string(self.tcx),
                                 ),
                             );
                         } else {
+                            // Still mark mismatched parameters
+                            spans.push_span_label(param.param.span(), "");
+                        }
+                    }
+                    // Highligh each parameter being depended on for a generic type.
+                    for ((&(_, param), deps), &(_, expected_ty)) in
+                        params_with_generics.iter().zip(&dependants).zip(formal_and_expected_inputs)
+                    {
+                        if let Some(deps_list) = listify(deps, |&dep| {
+                            let param = &mismatched_params[dep as usize];
+                            param.param.display(param.idx.as_usize()).to_string()
+                        }) {
                             spans.push_span_label(
                                 param.span(),
                                 format!(
-                                    "this parameter needs to match the {} type of {}",
-                                    matched_ty,
-                                    listify(&other_param_matched_names, |n| n.to_string())
-                                        .unwrap_or_default(),
+                                    "{deps_list} need{} to match the {} type of this parameter",
+                                    pluralize!((deps.len() != 1) as u32),
+                                    self.resolve_vars_if_possible(expected_ty)
+                                        .sort_string(self.tcx),
                                 ),
                             );
                         }
-                        generics_with_unmatched_params.push(generic_param);
-                    } else {
-                        spans.push_span_label(param.span(), "");
                     }
-                }
-
-                for generic_param in self
-                    .tcx
-                    .hir()
-                    .get_if_local(def_id)
-                    .and_then(|node| node.generics())
-                    .into_iter()
-                    .flat_map(|x| x.params)
-                    .filter(|x| {
-                        generics_with_unmatched_params
-                            .iter()
-                            .any(|y| x.name.ident() == y.name.ident())
-                    })
-                {
-                    let param_idents_matching: Vec<String> = params_with_generics
-                        .iter_enumerated()
-                        .filter(|&(_, &(generic, _))| {
-                            if let Some(generic) = generic {
-                                generic.name.ident() == generic_param.name.ident()
-                            } else {
-                                false
-                            }
-                        })
-                        .map(|(idx, &(_, param))| {
-                            if let Some(name) = param.name() {
-                                format!("`{name}`")
-                            } else {
-                                format!("parameter #{}", idx.as_u32() + 1)
-                            }
-                        })
-                        .collect();
-
-                    if !param_idents_matching.is_empty() {
-                        spans.push_span_label(
-                            generic_param.span,
-                            format!(
-                                "{} {} reference this parameter `{}`",
-                                listify(&param_idents_matching, |n| n.to_string())
-                                    .unwrap_or_default(),
-                                if param_idents_matching.len() == 2 { "both" } else { "all" },
-                                generic_param.name.ident().name,
-                            ),
-                        );
+                    // Highlight each generic parameter in use.
+                    for (param, uses) in hir_generics.params.iter().zip(&mut generic_uses) {
+                        uses.sort();
+                        uses.dedup();
+                        if let Some(param_list) = listify(uses, |&idx| {
+                            params_with_generics[idx].1.display(idx.as_usize()).to_string()
+                        }) {
+                            spans.push_span_label(
+                                param.span,
+                                format!(
+                                    "{param_list} {} reference this parameter `{}`",
+                                    if uses.len() == 2 { "both" } else { "all" },
+                                    param.name.ident().name,
+                                ),
+                            );
+                        }
                     }
                 }
             }
@@ -2611,7 +2580,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         };
 
-        if let Some(params_with_generics) = self.get_hir_params_with_generics(def_id, is_method) {
+        if let Some((params_with_generics, _)) = self.get_hir_param_info(def_id, is_method) {
             debug_assert_eq!(params_with_generics.len(), matched_inputs.len());
             for (idx, (generic_param, _)) in params_with_generics.iter_enumerated() {
                 if matched_inputs[idx].is_none() {
@@ -2639,7 +2608,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         if matched_inputs[other_idx].is_some() {
                             return false;
                         }
-                        other_generic_param.name.ident() == generic_param.name.ident()
+                        other_generic_param == generic_param
                     })
                     .count();
 
@@ -2671,11 +2640,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// Returns the parameters of a function, with their generic parameters if those are the full
     /// type of that parameter. Returns `None` if the function has no generics or the body is
     /// unavailable (eg is an instrinsic).
-    fn get_hir_params_with_generics(
+    fn get_hir_param_info(
         &self,
         def_id: DefId,
         is_method: bool,
-    ) -> Option<IndexVec<ExpectedIdx, (Option<&hir::GenericParam<'_>>, FnParam<'_>)>> {
+    ) -> Option<(IndexVec<ExpectedIdx, (Option<GenericIdx>, FnParam<'_>)>, &hir::Generics<'_>)>
+    {
         let (sig, generics, body_id, param_names) = match self.tcx.hir().get_if_local(def_id)? {
             hir::Node::TraitItem(&hir::TraitItem {
                 generics,
@@ -2705,7 +2675,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 &hir::Path { res: Res::Def(_, res_def_id), .. },
             )) = param.kind
             {
-                generics.params.iter().find(|param| param.def_id.to_def_id() == res_def_id)
+                generics
+                    .params
+                    .iter()
+                    .position(|param| param.def_id.to_def_id() == res_def_id)
+                    .map(GenericIdx::from_usize)
             } else {
                 None
             }
@@ -2717,12 +2691,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let params =
                     params.get(is_method as usize..params.len() - sig.decl.c_variadic as usize)?;
                 debug_assert_eq!(params.len(), fn_inputs.len());
-                Some(fn_inputs.zip(params.iter().map(|param| FnParam::Param(param))).collect())
+                Some((
+                    fn_inputs.zip(params.iter().map(|param| FnParam::Param(param))).collect(),
+                    generics,
+                ))
             }
             (None, Some(params)) => {
                 let params = params.get(is_method as usize..)?;
                 debug_assert_eq!(params.len(), fn_inputs.len());
-                Some(fn_inputs.zip(params.iter().map(|param| FnParam::Name(param))).collect())
+                Some((
+                    fn_inputs.zip(params.iter().map(|param| FnParam::Name(param))).collect(),
+                    generics,
+                ))
             }
         }
     }
@@ -2769,5 +2749,19 @@ impl FnParam<'_> {
             Self::Name(x) if x.name != kw::Empty => Some(x.name),
             _ => None,
         }
+    }
+
+    fn display(&self, idx: usize) -> impl '_ + fmt::Display {
+        struct D<'a>(FnParam<'a>, usize);
+        impl fmt::Display for D<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                if let Some(name) = self.0.name() {
+                    write!(f, "`{name}`")
+                } else {
+                    write!(f, "parameter #{}", self.1 + 1)
+                }
+            }
+        }
+        D(*self, idx)
     }
 }

--- a/tests/ui/argument-suggestions/basic.stderr
+++ b/tests/ui/argument-suggestions/basic.stderr
@@ -57,7 +57,7 @@ note: function defined here
   --> $DIR/basic.rs:16:4
    |
 LL | fn swapped(_i: u32, _s: &str) {}
-   |    ^^^^^^^ -------  --------
+   |    ^^^^^^^
 help: swap these arguments
    |
 LL |     swapped(1, "");
@@ -76,7 +76,7 @@ note: function defined here
   --> $DIR/basic.rs:17:4
    |
 LL | fn permuted(_x: X, _y: Y, _z: Z) {}
-   |    ^^^^^^^^ -----  -----  -----
+   |    ^^^^^^^^
 help: reorder these arguments
    |
 LL |     permuted(X {}, Y {}, Z {});

--- a/tests/ui/argument-suggestions/complex.stderr
+++ b/tests/ui/argument-suggestions/complex.stderr
@@ -8,7 +8,7 @@ note: function defined here
   --> $DIR/complex.rs:11:4
    |
 LL | fn complex(_i: u32, _s: &str, _e: E, _f: F, _g: G, _x: X, _y: Y, _z: Z ) {}
-   |    ^^^^^^^ -------  --------  -----  -----  -----  -----  -----  -----
+   |    ^^^^^^^ -------            -----
 help: did you mean
    |
 LL |   complex(/* u32 */, &"", /* E */, F::X2, G{}, X {}, Y {}, Z {});

--- a/tests/ui/argument-suggestions/extra_arguments.stderr
+++ b/tests/ui/argument-suggestions/extra_arguments.stderr
@@ -44,7 +44,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:2:4
    |
 LL | fn one_arg<T>(_a: T) {}
-   |    ^^^^^^^    -----
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -   one_arg(1, 1);
@@ -61,7 +61,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:2:4
    |
 LL | fn one_arg<T>(_a: T) {}
-   |    ^^^^^^^    -----
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -   one_arg(1, "");
@@ -80,7 +80,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:2:4
    |
 LL | fn one_arg<T>(_a: T) {}
-   |    ^^^^^^^    -----
+   |    ^^^^^^^
 help: remove the extra arguments
    |
 LL -   one_arg(1, "", 1.0);
@@ -97,7 +97,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:3:4
    |
 LL | fn two_arg_same(_a: i32, _b: i32) {}
-   |    ^^^^^^^^^^^^ -------  -------
+   |    ^^^^^^^^^^^^
 help: remove the extra argument
    |
 LL -   two_arg_same(1, 1, 1);
@@ -114,7 +114,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:3:4
    |
 LL | fn two_arg_same(_a: i32, _b: i32) {}
-   |    ^^^^^^^^^^^^ -------  -------
+   |    ^^^^^^^^^^^^
 help: remove the extra argument
    |
 LL -   two_arg_same(1, 1, 1.0);
@@ -131,7 +131,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:4:4
    |
 LL | fn two_arg_diff(_a: i32, _b: &str) {}
-   |    ^^^^^^^^^^^^ -------  --------
+   |    ^^^^^^^^^^^^
 help: remove the extra argument
    |
 LL -   two_arg_diff(1, 1, "");
@@ -148,7 +148,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:4:4
    |
 LL | fn two_arg_diff(_a: i32, _b: &str) {}
-   |    ^^^^^^^^^^^^ -------  --------
+   |    ^^^^^^^^^^^^
 help: remove the extra argument
    |
 LL -   two_arg_diff(1, "", "");
@@ -167,7 +167,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:4:4
    |
 LL | fn two_arg_diff(_a: i32, _b: &str) {}
-   |    ^^^^^^^^^^^^ -------  --------
+   |    ^^^^^^^^^^^^
 help: remove the extra arguments
    |
 LL -   two_arg_diff(1, 1, "", "");
@@ -186,7 +186,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:4:4
    |
 LL | fn two_arg_diff(_a: i32, _b: &str) {}
-   |    ^^^^^^^^^^^^ -------  --------
+   |    ^^^^^^^^^^^^
 help: remove the extra arguments
    |
 LL -   two_arg_diff(1, "", 1, "");
@@ -203,7 +203,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:3:4
    |
 LL | fn two_arg_same(_a: i32, _b: i32) {}
-   |    ^^^^^^^^^^^^ -------  -------
+   |    ^^^^^^^^^^^^
 help: remove the extra argument
    |
 LL -   two_arg_same(1, 1,     "");
@@ -220,7 +220,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:4:4
    |
 LL | fn two_arg_diff(_a: i32, _b: &str) {}
-   |    ^^^^^^^^^^^^ -------  --------
+   |    ^^^^^^^^^^^^
 help: remove the extra argument
    |
 LL -   two_arg_diff(1, 1,     "");
@@ -240,7 +240,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:3:4
    |
 LL | fn two_arg_same(_a: i32, _b: i32) {}
-   |    ^^^^^^^^^^^^ -------  -------
+   |    ^^^^^^^^^^^^
 help: remove the extra argument
    |
 LL -     1,
@@ -261,7 +261,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:4:4
    |
 LL | fn two_arg_diff(_a: i32, _b: &str) {}
-   |    ^^^^^^^^^^^^ -------  --------
+   |    ^^^^^^^^^^^^
 help: remove the extra argument
    |
 LL -     1,
@@ -335,7 +335,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:2:4
    |
 LL | fn one_arg<T>(_a: T) {}
-   |    ^^^^^^^    -----
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -   one_arg(1, panic!());
@@ -352,7 +352,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:2:4
    |
 LL | fn one_arg<T>(_a: T) {}
-   |    ^^^^^^^    -----
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -   one_arg(panic!(), 1);
@@ -369,7 +369,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:2:4
    |
 LL | fn one_arg<T>(_a: T) {}
-   |    ^^^^^^^    -----
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -   one_arg(stringify!($e), 1);
@@ -386,7 +386,7 @@ note: function defined here
   --> $DIR/extra_arguments.rs:2:4
    |
 LL | fn one_arg<T>(_a: T) {}
-   |    ^^^^^^^    -----
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -   one_arg(for _ in 1.. {}, 1);

--- a/tests/ui/argument-suggestions/invalid_arguments.stderr
+++ b/tests/ui/argument-suggestions/invalid_arguments.stderr
@@ -150,7 +150,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:8:4
    |
 LL | fn three_arg_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^ -------  -------
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:29:3
@@ -164,7 +164,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:8:4
    |
 LL | fn three_arg_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^ -------           --------
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:30:3
@@ -178,7 +178,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:8:4
    |
 LL | fn three_arg_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^          -------  --------
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:32:3
@@ -249,7 +249,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:9:4
    |
 LL | fn three_arg_repeat(_a: i32, _b: i32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^^^ -------  -------
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:39:3
@@ -263,7 +263,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:9:4
    |
 LL | fn three_arg_repeat(_a: i32, _b: i32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^^^ -------           --------
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:40:3
@@ -277,7 +277,7 @@ note: function defined here
   --> $DIR/invalid_arguments.rs:9:4
    |
 LL | fn three_arg_repeat(_a: i32, _b: i32, _c: &str) {}
-   |    ^^^^^^^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^^^^^^^          -------  --------
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/invalid_arguments.rs:42:3

--- a/tests/ui/argument-suggestions/issue-100478.stderr
+++ b/tests/ui/argument-suggestions/issue-100478.stderr
@@ -11,7 +11,7 @@ note: function defined here
   --> $DIR/issue-100478.rs:30:4
    |
 LL | fn three_diff(_a: T1, _b: T2, _c: T3) {}
-   |    ^^^^^^^^^^ ------  ------  ------
+   |    ^^^^^^^^^^ ------          ------
 help: provide the arguments
    |
 LL |     three_diff(/* T1 */, T2::new(0), /* T3 */);
@@ -31,7 +31,7 @@ note: function defined here
   --> $DIR/issue-100478.rs:31:4
    |
 LL | fn four_shuffle(_a: T1, _b: T2, _c: T3, _d: T4) {}
-   |    ^^^^^^^^^^^^ ------  ------  ------  ------
+   |    ^^^^^^^^^^^^
 help: did you mean
    |
 LL |     four_shuffle(T1::default(), T2::default(), T3::default(), T4::default());
@@ -50,7 +50,7 @@ note: function defined here
   --> $DIR/issue-100478.rs:31:4
    |
 LL | fn four_shuffle(_a: T1, _b: T2, _c: T3, _d: T4) {}
-   |    ^^^^^^^^^^^^ ------  ------  ------  ------
+   |    ^^^^^^^^^^^^                         ------
 help: swap these arguments
    |
 LL |     four_shuffle(T1::default(), T2::default(), T3::default(), /* T4 */);
@@ -69,7 +69,7 @@ note: function defined here
   --> $DIR/issue-100478.rs:29:4
    |
 LL | fn foo(p1: T1, p2: Arc<T2>, p3: T3, p4: Arc<T4>, p5: T5, p6: T6, p7: T7, p8: Arc<T8>) {}
-   |    ^^^ ------  -----------  ------  -----------  ------  ------  ------  -----------
+   |    ^^^         -----------
 help: provide the argument
    |
 LL |     foo(p1, /* Arc<T2> */, p3, p4, p5, p6, p7, p8);

--- a/tests/ui/argument-suggestions/issue-101097.stderr
+++ b/tests/ui/argument-suggestions/issue-101097.stderr
@@ -13,18 +13,6 @@ note: function defined here
    |
 LL | fn f(
    |    ^
-LL |     a1: A,
-   |     -----
-LL |     a2: A,
-   |     -----
-LL |     b1: B,
-   |     -----
-LL |     b2: B,
-   |     -----
-LL |     c1: C,
-   |     -----
-LL |     c2: C,
-   |     -----
 help: did you mean
    |
 LL |     f(A, A, B, B, C, C);
@@ -41,18 +29,6 @@ note: function defined here
    |
 LL | fn f(
    |    ^
-LL |     a1: A,
-   |     -----
-LL |     a2: A,
-   |     -----
-LL |     b1: B,
-   |     -----
-LL |     b2: B,
-   |     -----
-LL |     c1: C,
-   |     -----
-LL |     c2: C,
-   |     -----
 help: did you mean
    |
 LL |     f(A, A, B, B, C, C);
@@ -72,14 +48,7 @@ note: function defined here
    |
 LL | fn f(
    |    ^
-LL |     a1: A,
-   |     -----
-LL |     a2: A,
-   |     -----
-LL |     b1: B,
-   |     -----
-LL |     b2: B,
-   |     -----
+...
 LL |     c1: C,
    |     -----
 LL |     c2: C,
@@ -104,18 +73,6 @@ note: function defined here
    |
 LL | fn f(
    |    ^
-LL |     a1: A,
-   |     -----
-LL |     a2: A,
-   |     -----
-LL |     b1: B,
-   |     -----
-LL |     b2: B,
-   |     -----
-LL |     c1: C,
-   |     -----
-LL |     c2: C,
-   |     -----
 help: did you mean
    |
 LL |     f(A, A, B, B, C, C);
@@ -137,17 +94,8 @@ note: function defined here
    |
 LL | fn f(
    |    ^
-LL |     a1: A,
-   |     -----
-LL |     a2: A,
-   |     -----
+...
 LL |     b1: B,
-   |     -----
-LL |     b2: B,
-   |     -----
-LL |     c1: C,
-   |     -----
-LL |     c2: C,
    |     -----
 help: did you mean
    |

--- a/tests/ui/argument-suggestions/issue-109425.stderr
+++ b/tests/ui/argument-suggestions/issue-109425.stderr
@@ -29,7 +29,7 @@ note: function defined here
   --> $DIR/issue-109425.rs:4:4
    |
 LL | fn i(_: u32) {}
-   |    ^ ------
+   |    ^
 help: remove the extra arguments
    |
 LL -     i(0, 1, 2,);     // i(0,)
@@ -48,7 +48,7 @@ note: function defined here
   --> $DIR/issue-109425.rs:4:4
    |
 LL | fn i(_: u32) {}
-   |    ^ ------
+   |    ^
 help: remove the extra arguments
    |
 LL -     i(0, 1, 2);      // i(0)
@@ -67,7 +67,7 @@ note: function defined here
   --> $DIR/issue-109425.rs:5:4
    |
 LL | fn is(_: u32, _: &str) {}
-   |    ^^ ------  -------
+   |    ^^
 help: remove the extra arguments
    |
 LL -     is(0, 1, 2, ""); // is(0, "")
@@ -86,7 +86,7 @@ note: function defined here
   --> $DIR/issue-109425.rs:5:4
    |
 LL | fn is(_: u32, _: &str) {}
-   |    ^^ ------  -------
+   |    ^^
 help: remove the extra arguments
    |
 LL -     is((), 1, "", ());
@@ -105,7 +105,7 @@ note: function defined here
   --> $DIR/issue-109425.rs:5:4
    |
 LL | fn is(_: u32, _: &str) {}
-   |    ^^ ------  -------
+   |    ^^
 help: remove the extra arguments
    |
 LL -     is(1, (), "", ());
@@ -124,7 +124,7 @@ note: function defined here
   --> $DIR/issue-109425.rs:6:4
    |
 LL | fn s(_: &str) {}
-   |    ^ -------
+   |    ^
 help: remove the extra arguments
    |
 LL -     s(0, 1, "");     // s("")

--- a/tests/ui/argument-suggestions/issue-109831.stderr
+++ b/tests/ui/argument-suggestions/issue-109831.stderr
@@ -38,7 +38,7 @@ note: function defined here
   --> $DIR/issue-109831.rs:4:4
    |
 LL | fn f(b1: B, b2: B, a2: C) {}
-   |    ^ -----  -----  -----
+   |    ^ -----  -----
 help: remove the extra argument
    |
 LL -     f(A, A, B, C);

--- a/tests/ui/argument-suggestions/issue-96638.stderr
+++ b/tests/ui/argument-suggestions/issue-96638.stderr
@@ -10,7 +10,7 @@ note: function defined here
   --> $DIR/issue-96638.rs:1:4
    |
 LL | fn f(_: usize, _: &usize, _: usize) {}
-   |    ^ --------  ---------  --------
+   |    ^ --------             --------
 help: provide the argument
    |
 LL |     f(/* usize */, &x, /* usize */);

--- a/tests/ui/argument-suggestions/issue-97197.stderr
+++ b/tests/ui/argument-suggestions/issue-97197.stderr
@@ -8,7 +8,7 @@ note: function defined here
   --> $DIR/issue-97197.rs:6:8
    |
 LL | pub fn g(a1: (), a2: bool, a3: bool, a4: bool, a5: bool, a6: ()) -> () {}
-   |        ^ ------  --------  --------  --------  --------  ------
+   |        ^         --------  --------  --------  --------
 help: provide the arguments
    |
 LL |     g((), /* bool */, /* bool */, /* bool */, /* bool */, ());

--- a/tests/ui/argument-suggestions/issue-97484.stderr
+++ b/tests/ui/argument-suggestions/issue-97484.stderr
@@ -12,7 +12,7 @@ note: function defined here
   --> $DIR/issue-97484.rs:9:4
    |
 LL | fn foo(a: &A, d: D, e: &E, g: G) {}
-   |    ^^^ -----  ----  -----  ----
+   |    ^^^              -----
 help: consider borrowing here
    |
 LL |     foo(&&A, B, C, D, &E, F, G);

--- a/tests/ui/argument-suggestions/missing_arguments.stderr
+++ b/tests/ui/argument-suggestions/missing_arguments.stderr
@@ -40,7 +40,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:2:4
    |
 LL | fn two_same(_a: i32, _b: i32) {}
-   |    ^^^^^^^^ -------  -------
+   |    ^^^^^^^^          -------
 help: provide the argument
    |
 LL |   two_same(1, /* i32 */);
@@ -72,7 +72,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:3:4
    |
 LL | fn two_diff(_a: i32, _b: f32) {}
-   |    ^^^^^^^^ -------  -------
+   |    ^^^^^^^^          -------
 help: provide the argument
    |
 LL |   two_diff(1, /* f32 */);
@@ -88,7 +88,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:3:4
    |
 LL | fn two_diff(_a: i32, _b: f32) {}
-   |    ^^^^^^^^ -------  -------
+   |    ^^^^^^^^ -------
 help: provide the argument
    |
 LL |   two_diff(/* i32 */, 1.0);
@@ -120,7 +120,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:4:4
    |
 LL | fn three_same(_a: i32, _b: i32, _c: i32) {}
-   |    ^^^^^^^^^^ -------  -------  -------
+   |    ^^^^^^^^^^          -------  -------
 help: provide the arguments
    |
 LL |   three_same(1, /* i32 */, /* i32 */);
@@ -136,7 +136,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:4:4
    |
 LL | fn three_same(_a: i32, _b: i32, _c: i32) {}
-   |    ^^^^^^^^^^ -------  -------  -------
+   |    ^^^^^^^^^^                   -------
 help: provide the argument
    |
 LL |   three_same(1, 1, /* i32 */);
@@ -152,7 +152,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:5:4
    |
 LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^ -------
 help: provide the argument
    |
 LL |   three_diff(/* i32 */, 1.0, "");
@@ -168,7 +168,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:5:4
    |
 LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^          -------
 help: provide the argument
    |
 LL |   three_diff(1, /* f32 */, "");
@@ -184,7 +184,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:5:4
    |
 LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^                   --------
 help: provide the argument
    |
 LL |   three_diff(1, 1.0, /* &str */);
@@ -200,7 +200,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:5:4
    |
 LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^ -------  -------
 help: provide the arguments
    |
 LL |   three_diff(/* i32 */, /* f32 */, "");
@@ -219,7 +219,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:5:4
    |
 LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^ -------           --------
 help: provide the arguments
    |
 LL |   three_diff(/* i32 */, 1.0, /* &str */);
@@ -235,7 +235,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:5:4
    |
 LL | fn three_diff(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^          -------  --------
 help: provide the arguments
    |
 LL |   three_diff(1, /* f32 */, /* &str */);
@@ -267,7 +267,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:6:4
    |
 LL | fn four_repeated(_a: i32, _b: f32, _c: f32, _d: &str) {}
-   |    ^^^^^^^^^^^^^ -------  -------  -------  --------
+   |    ^^^^^^^^^^^^^          -------  -------
 help: provide the arguments
    |
 LL |   four_repeated(1, /* f32 */, /* f32 */, "");
@@ -299,7 +299,7 @@ note: function defined here
   --> $DIR/missing_arguments.rs:7:4
    |
 LL | fn complex(_a: i32, _b: f32, _c: i32, _d: f32, _e: &str) {}
-   |    ^^^^^^^ -------  -------  -------  -------  --------
+   |    ^^^^^^^          -------  -------  -------
 help: provide the arguments
    |
 LL |   complex(1, /* f32 */, /* i32 */, /* f32 */, "");

--- a/tests/ui/argument-suggestions/mixed_cases.stderr
+++ b/tests/ui/argument-suggestions/mixed_cases.stderr
@@ -10,7 +10,7 @@ note: function defined here
   --> $DIR/mixed_cases.rs:5:4
    |
 LL | fn two_args(_a: i32, _b: f32) {}
-   |    ^^^^^^^^ -------  -------
+   |    ^^^^^^^^          -------
 help: remove the extra argument
    |
 LL -   two_args(1, "", X {});
@@ -30,7 +30,7 @@ note: function defined here
   --> $DIR/mixed_cases.rs:6:4
    |
 LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^          -------
 help: did you mean
    |
 LL |   three_args(1, /* f32 */, "");
@@ -49,7 +49,7 @@ note: function defined here
   --> $DIR/mixed_cases.rs:6:4
    |
 LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^          -------  --------
 help: provide the argument
    |
 LL |   three_args(1, /* f32 */, /* &str */);
@@ -67,7 +67,7 @@ note: function defined here
   --> $DIR/mixed_cases.rs:6:4
    |
 LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^          -------
 help: did you mean
    |
 LL |   three_args(1, /* f32 */, "");
@@ -86,7 +86,7 @@ note: function defined here
   --> $DIR/mixed_cases.rs:6:4
    |
 LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^          -------
 help: swap these arguments
    |
 LL |   three_args(1, /* f32 */, "");
@@ -106,7 +106,7 @@ note: function defined here
   --> $DIR/mixed_cases.rs:6:4
    |
 LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^          -------
 help: did you mean
    |
 LL |   three_args(1, /* f32 */, "");

--- a/tests/ui/argument-suggestions/permuted_arguments.stderr
+++ b/tests/ui/argument-suggestions/permuted_arguments.stderr
@@ -11,7 +11,7 @@ note: function defined here
   --> $DIR/permuted_arguments.rs:5:4
    |
 LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^
 help: reorder these arguments
    |
 LL |   three_args(1, 1.0, "");
@@ -32,7 +32,7 @@ note: function defined here
   --> $DIR/permuted_arguments.rs:6:4
    |
 LL | fn many_args(_a: i32, _b: f32, _c: &str, _d: X, _e: Y) {}
-   |    ^^^^^^^^^ -------  -------  --------  -----  -----
+   |    ^^^^^^^^^
 help: reorder these arguments
    |
 LL |   many_args(1, 1.0, "", X {}, Y {});

--- a/tests/ui/argument-suggestions/suggest-better-removing-issue-126246.stderr
+++ b/tests/ui/argument-suggestions/suggest-better-removing-issue-126246.stderr
@@ -38,7 +38,7 @@ note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:1:4
    |
 LL | fn add_one(x: i32) -> i32 {
-   |    ^^^^^^^ ------
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -     add_one(2, 2);
@@ -55,7 +55,7 @@ note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:1:4
    |
 LL | fn add_one(x: i32) -> i32 {
-   |    ^^^^^^^ ------
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -     add_one(no_such_local, 10);
@@ -72,7 +72,7 @@ note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:1:4
    |
 LL | fn add_one(x: i32) -> i32 {
-   |    ^^^^^^^ ------
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -     add_one(10, no_such_local);
@@ -89,7 +89,7 @@ note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:5:4
    |
 LL | fn add_two(x: i32, y: i32) -> i32 {
-   |    ^^^^^^^ ------  ------
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -     add_two(10, no_such_local, 10);
@@ -106,7 +106,7 @@ note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:5:4
    |
 LL | fn add_two(x: i32, y: i32) -> i32 {
-   |    ^^^^^^^ ------  ------
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -     add_two(no_such_local, 10, 10);
@@ -123,7 +123,7 @@ note: function defined here
   --> $DIR/suggest-better-removing-issue-126246.rs:5:4
    |
 LL | fn add_two(x: i32, y: i32) -> i32 {
-   |    ^^^^^^^ ------  ------
+   |    ^^^^^^^
 help: remove the extra argument
    |
 LL -     add_two(10, 10, no_such_local);

--- a/tests/ui/argument-suggestions/swapped_arguments.stderr
+++ b/tests/ui/argument-suggestions/swapped_arguments.stderr
@@ -10,7 +10,7 @@ note: function defined here
   --> $DIR/swapped_arguments.rs:3:4
    |
 LL | fn two_args(_a: i32, _b: f32) {}
-   |    ^^^^^^^^ -------  -------
+   |    ^^^^^^^^
 help: swap these arguments
    |
 LL |   two_args(1, 1.0);
@@ -28,7 +28,7 @@ note: function defined here
   --> $DIR/swapped_arguments.rs:4:4
    |
 LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^
 help: swap these arguments
    |
 LL |   three_args(1, 1.0, "");
@@ -46,7 +46,7 @@ note: function defined here
   --> $DIR/swapped_arguments.rs:4:4
    |
 LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^
 help: swap these arguments
    |
 LL |   three_args(1, 1.0, "");
@@ -64,7 +64,7 @@ note: function defined here
   --> $DIR/swapped_arguments.rs:4:4
    |
 LL | fn three_args(_a: i32, _b: f32, _c: &str) {}
-   |    ^^^^^^^^^^ -------  -------  --------
+   |    ^^^^^^^^^^
 help: swap these arguments
    |
 LL |   three_args(1, 1.0, "");
@@ -84,7 +84,7 @@ note: function defined here
   --> $DIR/swapped_arguments.rs:5:4
    |
 LL | fn four_args(_a: i32, _b: f32, _c: &str, _d: X) {}
-   |    ^^^^^^^^^ -------  -------  --------  -----
+   |    ^^^^^^^^^
 help: did you mean
    |
 LL |   four_args(1, 1.0, "", X {});

--- a/tests/ui/error-codes/E0061.stderr
+++ b/tests/ui/error-codes/E0061.stderr
@@ -8,7 +8,7 @@ note: function defined here
   --> $DIR/E0061.rs:1:4
    |
 LL | fn f(a: u16, b: &str) {}
-   |    ^ ------  -------
+   |    ^         -------
 help: provide the argument
    |
 LL |     f(0, /* &str */);

--- a/tests/ui/issues/issue-4935.stderr
+++ b/tests/ui/issues/issue-4935.stderr
@@ -8,7 +8,7 @@ note: function defined here
   --> $DIR/issue-4935.rs:3:4
    |
 LL | fn foo(a: usize) {}
-   |    ^^^ --------
+   |    ^^^
 help: remove the extra argument
    |
 LL - fn main() { foo(5, 6) }

--- a/tests/ui/methods/method-call-err-msg.stderr
+++ b/tests/ui/methods/method-call-err-msg.stderr
@@ -41,7 +41,7 @@ note: method defined here
   --> $DIR/method-call-err-msg.rs:7:8
    |
 LL |     fn two(self, _: isize, _: isize) -> Foo { self }
-   |        ^^^       --------  --------
+   |        ^^^                 --------
 help: provide the argument
    |
 LL |      .two(0, /* isize */);

--- a/tests/ui/mismatched_types/generic-mismatch-reporting-issue-116615.stderr
+++ b/tests/ui/mismatched_types/generic-mismatch-reporting-issue-116615.stderr
@@ -31,9 +31,8 @@ note: function defined here
   --> $DIR/generic-mismatch-reporting-issue-116615.rs:2:4
    |
 LL | fn foo_multi_same<T>(a: T, b: T, c: T, d: T, e: T, f: i32) {}
-   |    ^^^^^^^^^^^^^^ -  ----  ----  ----  ----  ----  ------
-   |                   |  |     |     |     |     |
-   |                   |  |     |     |     |     this parameter needs to match the `&str` type of `a` and `b`
+   |    ^^^^^^^^^^^^^^ -  ----  ----  ----  ----  ---- this parameter needs to match the `&str` type of `a` and `b`
+   |                   |  |     |     |     |
    |                   |  |     |     |     this parameter needs to match the `&str` type of `a` and `b`
    |                   |  |     |     this parameter needs to match the `&str` type of `a` and `b`
    |                   |  |     `c`, `d` and `e` need to match the `&str` type of this parameter
@@ -83,9 +82,8 @@ note: function defined here
   --> $DIR/generic-mismatch-reporting-issue-116615.rs:2:4
    |
 LL | fn foo_multi_same<T>(a: T, b: T, c: T, d: T, e: T, f: i32) {}
-   |    ^^^^^^^^^^^^^^ -  ----  ----  ----  ----  ----  ------
-   |                   |  |     |     |     |     |
-   |                   |  |     |     |     |     `b` and `c` need to match the `&str` type of this parameter
+   |    ^^^^^^^^^^^^^^ -  ----  ----  ----  ----  ---- `b` and `c` need to match the `&str` type of this parameter
+   |                   |  |     |     |     |
    |                   |  |     |     |     `b` and `c` need to match the `&str` type of this parameter
    |                   |  |     |     this parameter needs to match the `&str` type of `a`, `d` and `e`
    |                   |  |     this parameter needs to match the `&str` type of `a`, `d` and `e`

--- a/tests/ui/not-enough-arguments.stderr
+++ b/tests/ui/not-enough-arguments.stderr
@@ -8,7 +8,7 @@ note: function defined here
   --> $DIR/not-enough-arguments.rs:5:4
    |
 LL | fn foo(a: isize, b: isize, c: isize, d:isize) {
-   |    ^^^ --------  --------  --------  -------
+   |    ^^^                               -------
 help: provide the argument
    |
 LL |   foo(1, 2, 3, /* isize */);
@@ -25,12 +25,7 @@ note: function defined here
    |
 LL | fn bar(
    |    ^^^
-LL |     a: i32,
-   |     ------
-LL |     b: i32,
-   |     ------
-LL |     c: i32,
-   |     ------
+...
 LL |     d: i32,
    |     ------
 LL |     e: i32,

--- a/tests/ui/span/issue-34264.stderr
+++ b/tests/ui/span/issue-34264.stderr
@@ -60,7 +60,7 @@ note: function defined here
   --> $DIR/issue-34264.rs:1:4
    |
 LL | fn foo(Option<i32>, String) {}
-   |    ^^^ -----------  ------
+   |    ^^^
 help: remove the extra argument
    |
 LL -     foo(Some(42), 2, "");
@@ -91,7 +91,7 @@ note: function defined here
   --> $DIR/issue-34264.rs:3:4
    |
 LL | fn bar(x, y: usize) {}
-   |    ^^^ -  --------
+   |    ^^^
 help: remove the extra argument
    |
 LL -     bar(1, 2, 3);

--- a/tests/ui/span/missing-unit-argument.stderr
+++ b/tests/ui/span/missing-unit-argument.stderr
@@ -37,7 +37,7 @@ note: function defined here
   --> $DIR/missing-unit-argument.rs:1:4
    |
 LL | fn foo(():(), ():()) {}
-   |    ^^^ -----  -----
+   |    ^^^        -----
 help: provide the argument
    |
 LL |     foo((), ());

--- a/tests/ui/traits/next-solver/diagnostics/coerce-in-may-coerce.stderr
+++ b/tests/ui/traits/next-solver/diagnostics/coerce-in-may-coerce.stderr
@@ -10,7 +10,7 @@ note: function defined here
   --> $DIR/coerce-in-may-coerce.rs:12:4
    |
 LL | fn arg_error(x: <fn() as Mirror>::Assoc, y: ()) { todo!() }
-   |    ^^^^^^^^^ --------------------------  -----
+   |    ^^^^^^^^^
 help: swap these arguments
    |
 LL |     arg_error(|| (), ());

--- a/tests/ui/type/type-check/point-at-inference-4.rs
+++ b/tests/ui/type/type-check/point-at-inference-4.rs
@@ -4,7 +4,6 @@ impl<A, B> S<A, B> {
     fn infer(&self, a: A, b: B) {}
     //~^ NOTE method defined here
     //~| NOTE
-    //~| NOTE
 }
 
 fn main() {

--- a/tests/ui/type/type-check/point-at-inference-4.stderr
+++ b/tests/ui/type/type-check/point-at-inference-4.stderr
@@ -1,5 +1,5 @@
 error[E0061]: this method takes 2 arguments but 1 argument was supplied
-  --> $DIR/point-at-inference-4.rs:12:7
+  --> $DIR/point-at-inference-4.rs:11:7
    |
 LL |     s.infer(0i32);
    |       ^^^^^------ argument #2 is missing
@@ -8,14 +8,14 @@ note: method defined here
   --> $DIR/point-at-inference-4.rs:4:8
    |
 LL |     fn infer(&self, a: A, b: B) {}
-   |        ^^^^^        ----  ----
+   |        ^^^^^              ----
 help: provide the argument
    |
 LL |     s.infer(0i32, /* b */);
    |            ~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
-  --> $DIR/point-at-inference-4.rs:19:24
+  --> $DIR/point-at-inference-4.rs:18:24
    |
 LL |     s.infer(0i32);
    |     -       ---- this argument has type `i32`...

--- a/tests/ui/typeck/remove-extra-argument.stderr
+++ b/tests/ui/typeck/remove-extra-argument.stderr
@@ -8,7 +8,7 @@ note: function defined here
   --> $DIR/remove-extra-argument.rs:3:4
    |
 LL | fn l(_a: Vec<u8>) {}
-   |    ^ -----------
+   |    ^
 help: remove the extra argument
    |
 LL -     l(vec![], vec![])


### PR DESCRIPTION
Followup to #136497

This generally results more focused messages in the same vein as #99635 (see `test/ui/argument-suggestions/complex.rs`). There are still some cases (e.g. `test/ui/argument-suggestions/permuted_arguments.rs`) where it might be worth highlighting the arguments. This is mitigated by the fact that a suggestion with a suggested rearrangement is given.

r? @compiler-errors 