### PR TITLE
Prevent generic pattern types from being used in libstd

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -507,6 +507,8 @@ declare_features! (
     (incomplete, generic_const_exprs, "1.56.0", Some(76560)),
     /// Allows generic parameters and where-clauses on free & associated const items.
     (incomplete, generic_const_items, "1.73.0", Some(113521)),
+    /// Allows any generic constants being used as pattern type range ends
+    (incomplete, generic_pattern_types, "CURRENT_RUSTC_VERSION", Some(136574)),
     /// Allows registering static items globally, possibly across crates, to iterate over at runtime.
     (unstable, global_registration, "1.80.0", Some(125119)),
     /// Allows using guards in patterns.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1013,6 +1013,7 @@ symbols! {
         generic_const_exprs,
         generic_const_items,
         generic_param_attrs,
+        generic_pattern_types,
         get_context,
         global_alloc_ty,
         global_allocator,

--- a/tests/ui/type/pattern_types/assoc_const.default.stderr
+++ b/tests/ui/type/pattern_types/assoc_const.default.stderr
@@ -1,3 +1,24 @@
+error[E0658]: wraparound pattern type ranges cause monomorphization time errors
+  --> $DIR/assoc_const.rs:17:19
+   |
+LL | fn foo<T: Foo>(_: pattern_type!(u32 is <T as Foo>::START..=<T as Foo>::END)) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #136574 <https://github.com/rust-lang/rust/issues/136574> for more information
+   = help: add `#![feature(generic_pattern_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: wraparound pattern type ranges cause monomorphization time errors
+  --> $DIR/assoc_const.rs:17:19
+   |
+LL | fn foo<T: Foo>(_: pattern_type!(u32 is <T as Foo>::START..=<T as Foo>::END)) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #136574 <https://github.com/rust-lang/rust/issues/136574> for more information
+   = help: add `#![feature(generic_pattern_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: constant expression depends on a generic parameter
   --> $DIR/assoc_const.rs:17:19
    |
@@ -15,8 +36,29 @@ LL | fn foo<T: Foo>(_: pattern_type!(u32 is <T as Foo>::START..=<T as Foo>::END)
    = note: this may fail depending on what value the parameter takes
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
+error[E0658]: wraparound pattern type ranges cause monomorphization time errors
+  --> $DIR/assoc_const.rs:22:19
+   |
+LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #136574 <https://github.com/rust-lang/rust/issues/136574> for more information
+   = help: add `#![feature(generic_pattern_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: wraparound pattern type ranges cause monomorphization time errors
+  --> $DIR/assoc_const.rs:22:19
+   |
+LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #136574 <https://github.com/rust-lang/rust/issues/136574> for more information
+   = help: add `#![feature(generic_pattern_types)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: constant expression depends on a generic parameter
-  --> $DIR/assoc_const.rs:20:19
+  --> $DIR/assoc_const.rs:22:19
    |
 LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +66,7 @@ LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
    = note: this may fail depending on what value the parameter takes
 
 error: constant expression depends on a generic parameter
-  --> $DIR/assoc_const.rs:20:19
+  --> $DIR/assoc_const.rs:22:19
    |
 LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -32,5 +74,6 @@ LL | fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
    = note: this may fail depending on what value the parameter takes
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 4 previous errors
+error: aborting due to 8 previous errors
 
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/type/pattern_types/assoc_const.rs
+++ b/tests/ui/type/pattern_types/assoc_const.rs
@@ -1,8 +1,8 @@
 #![feature(pattern_types)]
 #![feature(pattern_type_macro)]
-#![cfg_attr(const_arg, feature(generic_const_exprs))]
+#![cfg_attr(const_arg, feature(generic_const_exprs, generic_pattern_types))]
 #![expect(incomplete_features)]
-
+// gate-test-generic_pattern_types line to the test file.
 //@ revisions: default const_arg
 
 //@[const_arg] check-pass
@@ -17,8 +17,12 @@ trait Foo {
 fn foo<T: Foo>(_: pattern_type!(u32 is <T as Foo>::START..=<T as Foo>::END)) {}
 //[default]~^ ERROR: constant expression depends on a generic parameter
 //[default]~| ERROR: constant expression depends on a generic parameter
+//[default]~| ERROR: wraparound pattern type ranges cause monomorphization time errors
+//[default]~| ERROR: wraparound pattern type ranges cause monomorphization time errors
 fn bar<T: Foo>(_: pattern_type!(u32 is T::START..=T::END)) {}
 //[default]~^ ERROR: constant expression depends on a generic parameter
 //[default]~| ERROR: constant expression depends on a generic parameter
+//[default]~| ERROR: wraparound pattern type ranges cause monomorphization time errors
+//[default]~| ERROR: wraparound pattern type ranges cause monomorphization time errors
 
 fn main() {}

--- a/tests/ui/type/pattern_types/const_generics.rs
+++ b/tests/ui/type/pattern_types/const_generics.rs
@@ -1,7 +1,7 @@
 //@ check-pass
 
-#![feature(pattern_types)]
-#![feature(pattern_type_macro)]
+#![feature(pattern_types, generic_pattern_types, pattern_type_macro)]
+#![expect(incomplete_features)]
 
 use std::pat::pattern_type;
 

--- a/tests/ui/type/pattern_types/transmute.rs
+++ b/tests/ui/type/pattern_types/transmute.rs
@@ -1,5 +1,5 @@
-#![feature(pattern_types)]
-#![feature(pattern_type_macro)]
+#![feature(pattern_types, pattern_type_macro, generic_pattern_types)]
+#![expect(incomplete_features)]
 
 use std::pat::pattern_type;
 


### PR DESCRIPTION
Pattern types should follow the same rules that patterns follow. So a pattern type range must not wrap and not be empty. While we reject such invalid ranges at layout computation time, that only happens during monomorphization in the case of const generics. This is the exact same issue as other const generic math has, and since there's no solution there yet, I put these pattern types behind a separate incomplete feature.

These are not necessary for the pattern types MVP (replacing the layout range attributes in libcore and rustc).

cc #136574 (new tracking issue for the `generic_pattern_types` feature gate)

r? @lcnr

cc @scottmcm @joshtriplett 