### PR TITLE
Only apply LTO to rustdoc at stage 2

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1064,9 +1064,7 @@ pub fn rustc_cargo(
         cargo.rustflag("-Zdefault-visibility=protected");
     }
 
-    // We currently don't support cross-crate LTO in stage0. This also isn't hugely necessary
-    // and may just be a time sink.
-    if compiler.stage != 0 {
+    if is_lto_stage(compiler) {
         match builder.config.rust_lto {
             RustcLto::Thin | RustcLto::Fat => {
                 // Since using LTO for optimizing dylibs is currently experimental,
@@ -2289,4 +2287,9 @@ pub fn strip_debug(builder: &Builder<'_>, target: TargetSelection, path: &Path) 
     // is greater than the mtime of rustc-main, and will rebuild rustc-main. That will then cause
     // everything else (standard library, future stages...) to be rebuilt.
     t!(file.set_modified(previous_mtime));
+}
+
+/// We only use LTO for stage 2+, to speed up build time of intermediate stages.
+pub fn is_lto_stage(build_compiler: &Compiler) -> bool {
+    build_compiler.stage != 0
 }

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::{env, fs};
 
+use crate::core::build_steps::compile::is_lto_stage;
 use crate::core::build_steps::toolstate::ToolState;
 use crate::core::build_steps::{compile, llvm};
 use crate::core::builder;
@@ -660,14 +661,16 @@ impl Step for Rustdoc {
         );
 
         // rustdoc is performance sensitive, so apply LTO to it.
-        let lto = match builder.config.rust_lto {
-            RustcLto::Off => Some("off"),
-            RustcLto::Thin => Some("thin"),
-            RustcLto::Fat => Some("fat"),
-            RustcLto::ThinLocal => None,
-        };
-        if let Some(lto) = lto {
-            cargo.env(cargo_profile_var("LTO", &builder.config), lto);
+        if is_lto_stage(&build_compiler) {
+            let lto = match builder.config.rust_lto {
+                RustcLto::Off => Some("off"),
+                RustcLto::Thin => Some("thin"),
+                RustcLto::Fat => Some("fat"),
+                RustcLto::ThinLocal => None,
+            };
+            if let Some(lto) = lto {
+                cargo.env(cargo_profile_var("LTO", &builder.config), lto);
+            }
         }
 
         let _guard = builder.msg_tool(


### PR DESCRIPTION
It doesn't make much sense at stage 1, and it was broken anyway. This was implemented in https://github.com/rust-lang/rust/pull/135832. The issue with LTO and stage 1 rustdoc was reported [here](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/x.20test.20with.20lto.20.3D.20.22thin.22.20fails.20to.20build.20rustdoc.3F).

r? @onur-ozkan