### PR TITLE
Faster fmt::Display of 128-bit integers, without unsafe pointer

### DIFF
--- a/library/coretests/tests/fmt/num.rs
+++ b/library/coretests/tests/fmt/num.rs
@@ -1,5 +1,29 @@
+use std::mem::size_of;
+
 #[test]
-fn test_format_int() {
+fn test_format_int_zero() {
+    assert_eq!(format!("{}", 0), "0");
+    assert_eq!(format!("{:?}", 0), "0");
+    assert_eq!(format!("{:b}", 0), "0");
+    assert_eq!(format!("{:o}", 0), "0");
+    assert_eq!(format!("{:x}", 0), "0");
+    assert_eq!(format!("{:X}", 0), "0");
+    assert_eq!(format!("{:e}", 0), "0e0");
+    assert_eq!(format!("{:E}", 0), "0E0");
+
+    // again, with unsigned
+    assert_eq!(format!("{}", 0u32), "0");
+    assert_eq!(format!("{:?}", 0u32), "0");
+    assert_eq!(format!("{:b}", 0u32), "0");
+    assert_eq!(format!("{:o}", 0u32), "0");
+    assert_eq!(format!("{:x}", 0u32), "0");
+    assert_eq!(format!("{:X}", 0u32), "0");
+    assert_eq!(format!("{:e}", 0u32), "0e0");
+    assert_eq!(format!("{:E}", 0u32), "0E0");
+}
+
+#[test]
+fn test_format_int_one() {
     // Formatting integers should select the right implementation based off
     // the type of the argument. Also, hex/octal/binary should be defined
     // for integers, but they shouldn't emit the negative sign.
@@ -8,87 +32,157 @@ fn test_format_int() {
     assert_eq!(format!("{}", 1i16), "1");
     assert_eq!(format!("{}", 1i32), "1");
     assert_eq!(format!("{}", 1i64), "1");
-    assert_eq!(format!("{}", -1isize), "-1");
-    assert_eq!(format!("{}", -1i8), "-1");
-    assert_eq!(format!("{}", -1i16), "-1");
-    assert_eq!(format!("{}", -1i32), "-1");
-    assert_eq!(format!("{}", -1i64), "-1");
+    assert_eq!(format!("{}", 1i128), "1");
     assert_eq!(format!("{:?}", 1isize), "1");
     assert_eq!(format!("{:?}", 1i8), "1");
     assert_eq!(format!("{:?}", 1i16), "1");
     assert_eq!(format!("{:?}", 1i32), "1");
     assert_eq!(format!("{:?}", 1i64), "1");
+    assert_eq!(format!("{:?}", 1i128), "1");
     assert_eq!(format!("{:b}", 1isize), "1");
     assert_eq!(format!("{:b}", 1i8), "1");
     assert_eq!(format!("{:b}", 1i16), "1");
     assert_eq!(format!("{:b}", 1i32), "1");
     assert_eq!(format!("{:b}", 1i64), "1");
+    assert_eq!(format!("{:b}", 1i128), "1");
     assert_eq!(format!("{:x}", 1isize), "1");
     assert_eq!(format!("{:x}", 1i8), "1");
     assert_eq!(format!("{:x}", 1i16), "1");
     assert_eq!(format!("{:x}", 1i32), "1");
     assert_eq!(format!("{:x}", 1i64), "1");
+    assert_eq!(format!("{:x}", 1i128), "1");
     assert_eq!(format!("{:X}", 1isize), "1");
     assert_eq!(format!("{:X}", 1i8), "1");
     assert_eq!(format!("{:X}", 1i16), "1");
     assert_eq!(format!("{:X}", 1i32), "1");
     assert_eq!(format!("{:X}", 1i64), "1");
+    assert_eq!(format!("{:X}", 1i128), "1");
     assert_eq!(format!("{:o}", 1isize), "1");
     assert_eq!(format!("{:o}", 1i8), "1");
     assert_eq!(format!("{:o}", 1i16), "1");
     assert_eq!(format!("{:o}", 1i32), "1");
     assert_eq!(format!("{:o}", 1i64), "1");
+    assert_eq!(format!("{:o}", 1i128), "1");
     assert_eq!(format!("{:e}", 1isize), "1e0");
     assert_eq!(format!("{:e}", 1i8), "1e0");
     assert_eq!(format!("{:e}", 1i16), "1e0");
     assert_eq!(format!("{:e}", 1i32), "1e0");
     assert_eq!(format!("{:e}", 1i64), "1e0");
+    assert_eq!(format!("{:e}", 1i128), "1e0");
     assert_eq!(format!("{:E}", 1isize), "1E0");
     assert_eq!(format!("{:E}", 1i8), "1E0");
     assert_eq!(format!("{:E}", 1i16), "1E0");
     assert_eq!(format!("{:E}", 1i32), "1E0");
     assert_eq!(format!("{:E}", 1i64), "1E0");
+    assert_eq!(format!("{:E}", 1i128), "1E0");
 
+    // again, with unsigned
     assert_eq!(format!("{}", 1usize), "1");
     assert_eq!(format!("{}", 1u8), "1");
     assert_eq!(format!("{}", 1u16), "1");
     assert_eq!(format!("{}", 1u32), "1");
     assert_eq!(format!("{}", 1u64), "1");
+    assert_eq!(format!("{}", 1u128), "1");
     assert_eq!(format!("{:?}", 1usize), "1");
     assert_eq!(format!("{:?}", 1u8), "1");
     assert_eq!(format!("{:?}", 1u16), "1");
     assert_eq!(format!("{:?}", 1u32), "1");
     assert_eq!(format!("{:?}", 1u64), "1");
+    assert_eq!(format!("{:?}", 1u128), "1");
     assert_eq!(format!("{:b}", 1usize), "1");
     assert_eq!(format!("{:b}", 1u8), "1");
     assert_eq!(format!("{:b}", 1u16), "1");
     assert_eq!(format!("{:b}", 1u32), "1");
     assert_eq!(format!("{:b}", 1u64), "1");
+    assert_eq!(format!("{:b}", 1u128), "1");
     assert_eq!(format!("{:x}", 1usize), "1");
     assert_eq!(format!("{:x}", 1u8), "1");
     assert_eq!(format!("{:x}", 1u16), "1");
     assert_eq!(format!("{:x}", 1u32), "1");
     assert_eq!(format!("{:x}", 1u64), "1");
+    assert_eq!(format!("{:x}", 1u128), "1");
     assert_eq!(format!("{:X}", 1usize), "1");
     assert_eq!(format!("{:X}", 1u8), "1");
     assert_eq!(format!("{:X}", 1u16), "1");
     assert_eq!(format!("{:X}", 1u32), "1");
     assert_eq!(format!("{:X}", 1u64), "1");
+    assert_eq!(format!("{:X}", 1u128), "1");
     assert_eq!(format!("{:o}", 1usize), "1");
     assert_eq!(format!("{:o}", 1u8), "1");
     assert_eq!(format!("{:o}", 1u16), "1");
     assert_eq!(format!("{:o}", 1u32), "1");
     assert_eq!(format!("{:o}", 1u64), "1");
+    assert_eq!(format!("{:o}", 1u128), "1");
     assert_eq!(format!("{:e}", 1u8), "1e0");
     assert_eq!(format!("{:e}", 1u16), "1e0");
     assert_eq!(format!("{:e}", 1u32), "1e0");
     assert_eq!(format!("{:e}", 1u64), "1e0");
+    assert_eq!(format!("{:e}", 1u128), "1e0");
     assert_eq!(format!("{:E}", 1u8), "1E0");
     assert_eq!(format!("{:E}", 1u16), "1E0");
     assert_eq!(format!("{:E}", 1u32), "1E0");
     assert_eq!(format!("{:E}", 1u64), "1E0");
+    assert_eq!(format!("{:E}", 1u128), "1E0");
 
-    // Test a larger number
+    // again, with negative
+    assert_eq!(format!("{}", -1isize), "-1");
+    assert_eq!(format!("{}", -1i8), "-1");
+    assert_eq!(format!("{}", -1i16), "-1");
+    assert_eq!(format!("{}", -1i32), "-1");
+    assert_eq!(format!("{}", -1i64), "-1");
+    assert_eq!(format!("{}", -1i128), "-1");
+    assert_eq!(format!("{:?}", -1isize), "-1");
+    assert_eq!(format!("{:?}", -1i8), "-1");
+    assert_eq!(format!("{:?}", -1i16), "-1");
+    assert_eq!(format!("{:?}", -1i32), "-1");
+    assert_eq!(format!("{:?}", -1i64), "-1");
+    assert_eq!(format!("{:?}", -1i128), "-1");
+    assert_eq!(format!("{:b}", -1isize), "1".repeat(size_of::<isize>() * 8));
+    assert_eq!(format!("{:b}", -1i8), "11111111");
+    assert_eq!(format!("{:b}", -1i16), "1111111111111111");
+    assert_eq!(format!("{:b}", -1i32), "11111111111111111111111111111111");
+    assert_eq!(
+        format!("{:b}", -1i64),
+        "1111111111111111111111111111111111111111111111111111111111111111"
+    );
+    assert_eq!(
+        format!("{:b}", -1i128),
+        "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+    );
+    assert_eq!(format!("{:x}", -1isize), "ff".repeat(size_of::<isize>()));
+    assert_eq!(format!("{:x}", -1i8), "ff");
+    assert_eq!(format!("{:x}", -1i16), "ffff");
+    assert_eq!(format!("{:x}", -1i32), "ffffffff");
+    assert_eq!(format!("{:x}", -1i64), "ffffffffffffffff");
+    assert_eq!(format!("{:x}", -1i128), "ffffffffffffffffffffffffffffffff");
+    assert_eq!(format!("{:X}", -1isize), "FF".repeat(size_of::<isize>()));
+    assert_eq!(format!("{:X}", -1i8), "FF");
+    assert_eq!(format!("{:X}", -1i16), "FFFF");
+    assert_eq!(format!("{:X}", -1i32), "FFFFFFFF");
+    assert_eq!(format!("{:X}", -1i64), "FFFFFFFFFFFFFFFF");
+    assert_eq!(format!("{:X}", -1i128), "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+    // octal test for isize omitted
+    assert_eq!(format!("{:o}", -1i8), "377");
+    assert_eq!(format!("{:o}", -1i16), "177777");
+    assert_eq!(format!("{:o}", -1i32), "37777777777");
+    assert_eq!(format!("{:o}", -1i64), "1777777777777777777777");
+    assert_eq!(format!("{:o}", -1i128), "3777777777777777777777777777777777777777777");
+    assert_eq!(format!("{:e}", -1isize), "-1e0");
+    assert_eq!(format!("{:e}", -1i8), "-1e0");
+    assert_eq!(format!("{:e}", -1i16), "-1e0");
+    assert_eq!(format!("{:e}", -1i32), "-1e0");
+    assert_eq!(format!("{:e}", -1i64), "-1e0");
+    assert_eq!(format!("{:e}", -1i128), "-1e0");
+    assert_eq!(format!("{:E}", -1isize), "-1E0");
+    assert_eq!(format!("{:E}", -1i8), "-1E0");
+    assert_eq!(format!("{:E}", -1i16), "-1E0");
+    assert_eq!(format!("{:E}", -1i32), "-1E0");
+    assert_eq!(format!("{:E}", -1i64), "-1E0");
+    assert_eq!(format!("{:E}", -1i128), "-1E0");
+}
+
+#[test]
+fn test_format_int_misc() {
     assert_eq!(format!("{:b}", 55), "110111");
     assert_eq!(format!("{:o}", 55), "67");
     assert_eq!(format!("{}", 55), "55");
@@ -100,6 +194,26 @@ fn test_format_int() {
     assert_eq!(format!("{:E}", 10000000000u64), "1E10");
     assert_eq!(format!("{:e}", 10000000001u64), "1.0000000001e10");
     assert_eq!(format!("{:E}", 10000000001u64), "1.0000000001E10");
+}
+
+#[test]
+fn test_format_int_limits() {
+    assert_eq!(format!("{}", i8::MIN), "-128");
+    assert_eq!(format!("{}", i8::MAX), "127");
+    assert_eq!(format!("{}", i16::MIN), "-32768");
+    assert_eq!(format!("{}", i16::MAX), "32767");
+    assert_eq!(format!("{}", i32::MIN), "-2147483648");
+    assert_eq!(format!("{}", i32::MAX), "2147483647");
+    assert_eq!(format!("{}", i64::MIN), "-9223372036854775808");
+    assert_eq!(format!("{}", i64::MAX), "9223372036854775807");
+    assert_eq!(format!("{}", i128::MIN), "-170141183460469231731687303715884105728");
+    assert_eq!(format!("{}", i128::MAX), "170141183460469231731687303715884105727");
+
+    assert_eq!(format!("{}", u8::MAX), "255");
+    assert_eq!(format!("{}", u16::MAX), "65535");
+    assert_eq!(format!("{}", u32::MAX), "4294967295");
+    assert_eq!(format!("{}", u64::MAX), "18446744073709551615");
+    assert_eq!(format!("{}", u128::MAX), "340282366920938463463374607431768211455");
 }
 
 #[test]
@@ -168,27 +282,6 @@ fn test_format_int_exp_precision() {
 }
 
 #[test]
-fn test_format_int_zero() {
-    assert_eq!(format!("{}", 0), "0");
-    assert_eq!(format!("{:?}", 0), "0");
-    assert_eq!(format!("{:b}", 0), "0");
-    assert_eq!(format!("{:o}", 0), "0");
-    assert_eq!(format!("{:x}", 0), "0");
-    assert_eq!(format!("{:X}", 0), "0");
-    assert_eq!(format!("{:e}", 0), "0e0");
-    assert_eq!(format!("{:E}", 0), "0E0");
-
-    assert_eq!(format!("{}", 0u32), "0");
-    assert_eq!(format!("{:?}", 0u32), "0");
-    assert_eq!(format!("{:b}", 0u32), "0");
-    assert_eq!(format!("{:o}", 0u32), "0");
-    assert_eq!(format!("{:x}", 0u32), "0");
-    assert_eq!(format!("{:X}", 0u32), "0");
-    assert_eq!(format!("{:e}", 0u32), "0e0");
-    assert_eq!(format!("{:E}", 0u32), "0E0");
-}
-
-#[test]
 fn test_format_int_flags() {
     assert_eq!(format!("{:3}", 1), "  1");
     assert_eq!(format!("{:>3}", 1), "  1");
@@ -223,14 +316,6 @@ fn test_format_int_sign_padding() {
     assert_eq!(format!("{:05}", -1), "-0001");
     assert_eq!(format!("{:+05}", 1), "+0001");
     assert_eq!(format!("{:+05}", -1), "-0001");
-}
-
-#[test]
-fn test_format_int_twos_complement() {
-    assert_eq!(format!("{}", i8::MIN), "-128");
-    assert_eq!(format!("{}", i16::MIN), "-32768");
-    assert_eq!(format!("{}", i32::MIN), "-2147483648");
-    assert_eq!(format!("{}", i64::MIN), "-9223372036854775808");
 }
 
 #[test]


### PR DESCRIPTION
In followup of #135265, hereby the 128-bit part.

* Batches per 16 instead of 19 digits
* Buffer access as array insteaf of unsafe pointer 
* Added test coverage for i128 and u128

r? tgross35 ChrisDenton
