### PR TITLE
Fix `unreachable_pub` lint for hermit target

### DIFF
--- a/library/panic_unwind/src/hermit.rs
+++ b/library/panic_unwind/src/hermit.rs
@@ -7,14 +7,14 @@ use core::any::Any;
 
 pub(crate) unsafe fn cleanup(_ptr: *mut u8) -> Box<dyn Any + Send> {
     extern "C" {
-        pub fn __rust_abort() -> !;
+        fn __rust_abort() -> !;
     }
     __rust_abort();
 }
 
 pub(crate) unsafe fn panic(_data: Box<dyn Any + Send>) -> u32 {
     extern "C" {
-        pub fn __rust_abort() -> !;
+        fn __rust_abort() -> !;
     }
     __rust_abort();
 }


### PR DESCRIPTION
The build for the hermit target (`#[cfg(target_os = "hermit")]`) fails on master as of [8df89d1cb07](https://github.com/rust-lang/rust/commit/8df89d1cb077cd76013d3f9f5a4e92c5b5a9280c) (2025-02-05), due to introducing `#[warn(unreachable_pub)]` at the root in https://github.com/rust-lang/rust/pull/134286 (Enable unreachable_pub lint in core, merged 2025-01-20).

Make the relevant visibility modifiers more specific to resolve the warning.

```
$ ./x build --target x86_64-unknown-hermit
Building bootstrap
    Finished `dev` profile [unoptimized] target(s) in 0.34s
Building stage0 library artifacts (x86_64-apple-darwin)
    Finished `release` profile [optimized] target(s) in 0.15s
Building compiler artifacts (stage0 -> stage1, x86_64-apple-darwin)
    Finished `release` profile [optimized] target(s) in 1.67s
Creating a sysroot for stage1 compiler (use `rustup toolchain link 'name' build/host/stage1`)
Building stage1 library artifacts {alloc, core, panic_abort, panic_unwind, proc_macro, std, sysroot, test, unwind} (x86_64-apple-darwin -> x86_64-unknown-hermit)
   Compiling panic_unwind v0.0.0 (library/panic_unwind)
error: unreachable `pub` item
  --> library/panic_unwind/src/hermit.rs:10:9
   |
10 |         pub fn __rust_abort() -> !;
   |         ---^^^^^^^^^^^^^^^^^^^^^^^^
   |         |
   |         help: consider restricting its visibility: `pub(crate)`
   |
   = help: or consider exporting it for use by other crates
   = note: `-D unreachable-pub` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unreachable_pub)]`

error: unreachable `pub` item
  --> library/panic_unwind/src/hermit.rs:17:9
   |
17 |         pub fn __rust_abort() -> !;
   |         ---^^^^^^^^^^^^^^^^^^^^^^^^
   |         |
   |         help: consider restricting its visibility: `pub(crate)`
   |
   = help: or consider exporting it for use by other crates

error: could not compile `panic_unwind` (lib) due to 2 previous errors
Build completed unsuccessfully in 0:00:39
```