### PR TITLE
Detect (non-raw) borrows of null ZST pointers in CheckNull

### DIFF
--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -272,7 +272,7 @@ impl<O> AssertKind<O> {
                     "\"misaligned pointer dereference: address must be a multiple of {{}} but is {{}}\", {required:?}, {found:?}"
                 )
             }
-            NullPointerDereference => write!(f, "\"null pointer dereference occured\""),
+            NullPointerDereference => write!(f, "\"null pointer dereference occurred\""),
             ResumedAfterReturn(CoroutineKind::Coroutine(_)) => {
                 write!(f, "\"coroutine resumed after completion\"")
             }

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -1,5 +1,6 @@
 use rustc_index::IndexVec;
 use rustc_middle::mir::interpret::Scalar;
+use rustc_middle::mir::visit::PlaceContext;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_session::Session;
@@ -44,6 +45,7 @@ fn insert_alignment_check<'tcx>(
     tcx: TyCtxt<'tcx>,
     pointer: Place<'tcx>,
     pointee_ty: Ty<'tcx>,
+    _context: PlaceContext,
     local_decls: &mut IndexVec<Local, LocalDecl<'tcx>>,
     stmts: &mut Vec<Statement<'tcx>>,
     source_info: SourceInfo,

--- a/compiler/stable_mir/src/mir/body.rs
+++ b/compiler/stable_mir/src/mir/body.rs
@@ -307,7 +307,7 @@ impl AssertMessage {
             AssertMessage::MisalignedPointerDereference { .. } => {
                 Ok("misaligned pointer dereference")
             }
-            AssertMessage::NullPointerDereference => Ok("null pointer dereference occured"),
+            AssertMessage::NullPointerDereference => Ok("null pointer dereference occurred"),
         }
     }
 }

--- a/compiler/stable_mir/src/mir/pretty.rs
+++ b/compiler/stable_mir/src/mir/pretty.rs
@@ -299,7 +299,7 @@ fn pretty_assert_message<W: Write>(writer: &mut W, msg: &AssertMessage) -> io::R
             )
         }
         AssertMessage::NullPointerDereference => {
-            write!(writer, "\"null pointer dereference occured.\"")
+            write!(writer, "\"null pointer dereference occurred\"")
         }
         AssertMessage::ResumedAfterReturn(_) | AssertMessage::ResumedAfterPanic(_) => {
             write!(writer, "{}", msg.description().unwrap())

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -302,7 +302,7 @@ fn panic_null_pointer_dereference() -> ! {
     }
 
     panic_nounwind_fmt(
-        format_args!("null pointer dereference occured"),
+        format_args!("null pointer dereference occurred"),
         /* force_no_backtrace */ false,
     )
 }

--- a/tests/ui/mir/null/borrowed_mut_null.rs
+++ b/tests/ui/mir/null/borrowed_mut_null.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occured
+//@ error-pattern: null pointer dereference occurred
 
 fn main() {
     let ptr: *mut u32 = std::ptr::null_mut();

--- a/tests/ui/mir/null/borrowed_null.rs
+++ b/tests/ui/mir/null/borrowed_null.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occured
+//@ error-pattern: null pointer dereference occurred
 
 fn main() {
     let ptr: *const u32 = std::ptr::null();

--- a/tests/ui/mir/null/borrowed_null_zst.rs
+++ b/tests/ui/mir/null/borrowed_null_zst.rs
@@ -1,0 +1,8 @@
+//@ run-fail
+//@ compile-flags: -C debug-assertions
+//@ error-pattern: null pointer dereference occured
+
+fn main() {
+    let ptr: *const () = std::ptr::null();
+    let _ptr: &() = unsafe { &*ptr };
+}

--- a/tests/ui/mir/null/borrowed_null_zst.rs
+++ b/tests/ui/mir/null/borrowed_null_zst.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occured
+//@ error-pattern: null pointer dereference occurred
 
 fn main() {
     let ptr: *const () = std::ptr::null();

--- a/tests/ui/mir/null/null_lhs.rs
+++ b/tests/ui/mir/null/null_lhs.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occured
+//@ error-pattern: null pointer dereference occurred
 
 fn main() {
     let ptr: *mut u32 = std::ptr::null_mut();

--- a/tests/ui/mir/null/null_rhs.rs
+++ b/tests/ui/mir/null/null_rhs.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occured
+//@ error-pattern: null pointer dereference occurred
 
 fn main() {
     let ptr: *mut u32 = std::ptr::null_mut();

--- a/tests/ui/mir/null/place_without_read_zst.rs
+++ b/tests/ui/mir/null/place_without_read_zst.rs
@@ -3,7 +3,7 @@
 //@ compile-flags: -C debug-assertions
 
 fn main() {
-    let ptr: *const u16 = std::ptr::null();
+    let ptr: *const () = std::ptr::null();
     unsafe {
         let _ = *ptr;
         let _ = &raw const *ptr;

--- a/tests/ui/mir/null/two_pointers.rs
+++ b/tests/ui/mir/null/two_pointers.rs
@@ -1,6 +1,6 @@
 //@ run-fail
 //@ compile-flags: -C debug-assertions
-//@ error-pattern: null pointer dereference occured
+//@ error-pattern: null pointer dereference occurred
 
 fn main() {
     let ptr = std::ptr::null();


### PR DESCRIPTION
Fixes #136568. Ensures that we check that borrows of derefs are non-null in the `CheckNull` pass **even if** it's a ZST pointee.

I'm actually surprised that this is UB in Miri, but if it's certainly UB, then this PR modifies the null check to be stricter. I couldn't find anywhere in https://doc.rust-lang.org/reference/behavior-considered-undefined.html that discusses this case specifically, but I didn't read it too closely, or perhaps it's just missing a bullet point.

On the contrary, if this is actually erroneous UB in Miri, then I'm happy to close this (and perhaps fix the null check in Miri to exclude ZSTs?)

On the double contrary, if this is still an "open question", I'm also happy to close this and wait for a decision to be made.

r? @saethlin cc @RalfJung (perhaps you feel strongly about this change)