### PR TITLE
Change two std process tests to not output to std{out,err}, and fix test suite stat reset in bootstrap CI test rendering

### DIFF
--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -418,8 +418,13 @@ fn test_creation_flags() {
     const EXIT_PROCESS_DEBUG_EVENT: u32 = 5;
     const DBG_EXCEPTION_NOT_HANDLED: u32 = 0x80010001;
 
-    let mut child =
-        Command::new("cmd").creation_flags(DEBUG_PROCESS).stdin(Stdio::piped()).spawn().unwrap();
+    let mut child = Command::new("cmd")
+        .creation_flags(DEBUG_PROCESS)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
     child.stdin.take().unwrap().write_all(b"exit\r\n").unwrap();
     let mut events = 0;
     let mut event = DEBUG_EVENT { event_code: 0, process_id: 0, thread_id: 0, _junk: [0; 164] };
@@ -486,9 +491,13 @@ fn test_proc_thread_attributes() {
         }
     }
 
-    let parent = ProcessDropGuard(Command::new("cmd").spawn().unwrap());
+    let mut parent = Command::new("cmd");
+    parent.stdout(Stdio::null()).stderr(Stdio::null());
+
+    let parent = ProcessDropGuard(parent.spawn().unwrap());
 
     let mut child_cmd = Command::new("cmd");
+    child_cmd.stdout(Stdio::null()).stderr(Stdio::null());
 
     let parent_process_handle = parent.0.as_raw_handle();
 

--- a/src/bootstrap/src/utils/render_tests.rs
+++ b/src/bootstrap/src/utils/render_tests.rs
@@ -310,6 +310,9 @@ impl<'a> Renderer<'a> {
         match message {
             Message::Suite(SuiteMessage::Started { test_count }) => {
                 println!("\nrunning {test_count} tests");
+                self.benches = vec![];
+                self.failures = vec![];
+                self.ignored_tests = 0;
                 self.executed_tests = 0;
                 self.terse_tests_in_line = 0;
                 self.tests_count = Some(test_count);


### PR DESCRIPTION
I don't really know how to test if this unbreaks CI (since #136607 reported that this breaks the CI test rendering *sometimes*).

Fixes #136607.

r? @ChrisDenton (two Windows process tests, but feel free to reroll)