### PR TITLE
ci: install node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,10 @@ jobs:
         with:
           fetch-depth: 2
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       # Free up disk space on Linux by removing preinstalled components that
       # we do not need. We do this to enable some of the less resource
       # intensive jobs to run on free runners, which however also have


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
We saw segmentation faults when running npm on ARM. See [zulip](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Upload.20to.20datadog.20CI.20script.2E.2E.2E.20segfaulted.3F).
GitHub runners have node version 20. With this PR we install node version 22, which is the latest LTS. Hopefully they fixed this issue in the latest version.
<!-- homu-ignore:end -->
try-job: aarch64-gnu
try-job: aarch64-gnu-debug