### PR TITLE
Remove outdated `base_port` calculation in std net test

### DIFF
--- a/library/std/src/net/test.rs
+++ b/library/std/src/net/test.rs
@@ -5,14 +5,15 @@ use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToS
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
 static PORT: AtomicUsize = AtomicUsize::new(0);
+const BASE_PORT: u16 = 19600;
 
 pub fn next_test_ip4() -> SocketAddr {
-    let port = PORT.fetch_add(1, Ordering::Relaxed) as u16 + base_port();
+    let port = PORT.fetch_add(1, Ordering::Relaxed) as u16 + BASE_PORT;
     SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port))
 }
 
 pub fn next_test_ip6() -> SocketAddr {
-    let port = PORT.fetch_add(1, Ordering::Relaxed) as u16 + base_port();
+    let port = PORT.fetch_add(1, Ordering::Relaxed) as u16 + BASE_PORT;
     SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), port, 0, 0))
 }
 
@@ -29,32 +30,4 @@ pub fn tsa<A: ToSocketAddrs>(a: A) -> Result<Vec<SocketAddr>, String> {
         Ok(a) => Ok(a.collect()),
         Err(e) => Err(e.to_string()),
     }
-}
-
-// The bots run multiple builds at the same time, and these builds
-// all want to use ports. This function figures out which workspace
-// it is running in and assigns a port range based on it.
-fn base_port() -> u16 {
-    let cwd = if cfg!(target_env = "sgx") {
-        String::from("sgx")
-    } else {
-        env::current_dir().unwrap().into_os_string().into_string().unwrap()
-    };
-    let dirs = [
-        "32-opt",
-        "32-nopt",
-        "musl-64-opt",
-        "cross-opt",
-        "64-opt",
-        "64-nopt",
-        "64-opt-vg",
-        "64-debug-opt",
-        "all-opt",
-        "snap3",
-        "dist",
-        "sgx",
-    ];
-    dirs.iter().enumerate().find(|&(_, dir)| cwd.contains(dir)).map(|p| p.0).unwrap_or(0) as u16
-        * 1000
-        + 19600
 }


### PR DESCRIPTION
This was never modified since `std::net` was originally introduced in 395709ca6d39ba1e095e404e1d2a169d918b7f0c, when at that time, each CI runner was running multiple jobs concurrently. This seems to have originally caused issues with jobs fighting over the same ports. This is not the case in the current CI infrastructure, so remove this relic in favor of a simple constant base port number.

I double-checked `19600` and nearby port numbers, and this isn't a well-known port number AFAICT[^1].

Closes #136633.

[^1]: At the time of writing.

