### PR TITLE
warn on empty precision

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -655,7 +655,15 @@ impl<'input> Parser<'input> {
                 spec.precision = self.count();
             }
             let span = range.start..self.input_vec_index2range(self.input_vec_index).start;
-            if spec.precision == CountImplied {
+            if spec.precision == CountImplied &&
+            // make an exception for "{:.}":
+            // broad exception:
+            // !self.input.contains("{:.}")
+            // narrow exception:
+            // !self.input.starts_with("{:.}")
+            // very narrow exception:
+                self.input != "{:.}" && self.input != "{:.}\n"
+            {
                 self.warnings.push(ParseError {
                     description: "expected numerical precision after precision specifier"
                         .to_string(),

--- a/tests/ui/fmt/warn-on-empty-precision.rs
+++ b/tests/ui/fmt/warn-on-empty-precision.rs
@@ -1,6 +1,8 @@
 //@ run-pass
 fn main() {
     let float = 0.123_456_789;
+    // this special case is exempted from warning
+    println!("{:.}", float);
     println!("Missing precision: {float:.} {float:3.} {float:_^12.}");
     //~^ WARNING invalid format string: expected numerical precision after precision specifier
     //~| WARNING invalid format string: expected numerical precision after precision specifier

--- a/tests/ui/fmt/warn-on-empty-precision.rs
+++ b/tests/ui/fmt/warn-on-empty-precision.rs
@@ -1,0 +1,9 @@
+//@ run-pass
+fn main() {
+    let float = 0.123_456_789;
+    println!("Missing precision: {float:.} {float:3.} {float:_^12.}");
+    //~^ WARNING invalid format string: expected numerical precision after precision specifier
+    //~| WARNING invalid format string: expected numerical precision after precision specifier
+    //~| WARNING invalid format string: expected numerical precision after precision specifier
+    println!("Given precision: {float:.6} {float:3.15} {float:_^12.7}");
+}

--- a/tests/ui/fmt/warn-on-empty-precision.stderr
+++ b/tests/ui/fmt/warn-on-empty-precision.stderr
@@ -1,5 +1,5 @@
 warning: invalid format string: expected numerical precision after precision specifier
-  --> $DIR/warn-on-empty-precision.rs:4:41
+  --> $DIR/warn-on-empty-precision.rs:6:41
    |
 LL |     println!("Missing precision: {float:.} {float:3.} {float:_^12.}");
    |                                         ^ precision specifier without numerical precision in format string
@@ -7,7 +7,7 @@ LL |     println!("Missing precision: {float:.} {float:3.} {float:_^12.}");
    = note: This may become an error in a future release
 
 warning: invalid format string: expected numerical precision after precision specifier
-  --> $DIR/warn-on-empty-precision.rs:4:52
+  --> $DIR/warn-on-empty-precision.rs:6:52
    |
 LL |     println!("Missing precision: {float:.} {float:3.} {float:_^12.}");
    |                                                    ^ precision specifier without numerical precision in format string
@@ -15,7 +15,7 @@ LL |     println!("Missing precision: {float:.} {float:3.} {float:_^12.}");
    = note: This may become an error in a future release
 
 warning: invalid format string: expected numerical precision after precision specifier
-  --> $DIR/warn-on-empty-precision.rs:4:66
+  --> $DIR/warn-on-empty-precision.rs:6:66
    |
 LL |     println!("Missing precision: {float:.} {float:3.} {float:_^12.}");
    |                                                                  ^ precision specifier without numerical precision in format string

--- a/tests/ui/fmt/warn-on-empty-precision.stderr
+++ b/tests/ui/fmt/warn-on-empty-precision.stderr
@@ -1,0 +1,26 @@
+warning: invalid format string: expected numerical precision after precision specifier
+  --> $DIR/warn-on-empty-precision.rs:4:41
+   |
+LL |     println!("Missing precision: {float:.} {float:3.} {float:_^12.}");
+   |                                         ^ precision specifier without numerical precision in format string
+   |
+   = note: This may become an error in a future release
+
+warning: invalid format string: expected numerical precision after precision specifier
+  --> $DIR/warn-on-empty-precision.rs:4:52
+   |
+LL |     println!("Missing precision: {float:.} {float:3.} {float:_^12.}");
+   |                                                    ^ precision specifier without numerical precision in format string
+   |
+   = note: This may become an error in a future release
+
+warning: invalid format string: expected numerical precision after precision specifier
+  --> $DIR/warn-on-empty-precision.rs:4:66
+   |
+LL |     println!("Missing precision: {float:.} {float:3.} {float:_^12.}");
+   |                                                                  ^ precision specifier without numerical precision in format string
+   |
+   = note: This may become an error in a future release
+
+warning: 3 warnings emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/136638)*
<!-- homu-ignore:end -->

Fixes rust-lang/rust#131159 by <del>erroring</del> warning on missing precision. <del>Alternatively we could document current behavior.</del>

EDIT: Warnings for common case of "{:.}" are now disabled, so this should have a clean crater run.