### PR TITLE
ci: use ubuntu 22 for free arm runners

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -50,7 +50,7 @@ runners:
   - &job-aarch64-linux
     # Free some disk space to avoid running out of space during the build.
     free_disk: true
-    os: ubuntu-24.04-arm
+    os: ubuntu-22.04-arm
 
   - &job-aarch64-linux-8c
     os: ubuntu-22.04-arm64-8core-32gb


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
ubuntu 24 on arm has issues.
So imo we should run ubuntu 24 only on x86 runners.
Discussed in [zulip](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Upload.20to.20datadog.20CI.20script.2E.2E.2E.20segfaulted.3F/near/498169107).
<!-- homu-ignore:end -->
try-job: aarch64-gnu
try-job: aarch64-gnu-debug