### PR TITLE
Add a missing `//@ needs-symlink` to `tests/run-make/libs-through-symlinks`

### DIFF
--- a/tests/run-make/libs-through-symlinks/rmake.rs
+++ b/tests/run-make/libs-through-symlinks/rmake.rs
@@ -21,6 +21,7 @@
 //! <https://github.com/rust-lang/rust/pull/13903>.
 
 //@ ignore-cross-compile
+//@ needs-symlink
 
 use run_make_support::{bare_rustc, cwd, path, rfs, rust_lib_name};
 


### PR DESCRIPTION
r? @wesleywiser (since you [found it](https://rust-lang.zulipchat.com/#narrow/channel/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202025-02-06/near/498173394) :P or reroll)

