### PR TITLE
librustdoc: remove unused `for_html` field from `Buffer` 🦄

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -62,9 +62,8 @@ impl Print for &'_ str {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct Buffer {
-    for_html: bool,
     buffer: String,
 }
 
@@ -86,16 +85,8 @@ impl core::fmt::Write for Buffer {
 }
 
 impl Buffer {
-    pub(crate) fn empty_from(v: &Buffer) -> Buffer {
-        Buffer { for_html: v.for_html, buffer: String::new() }
-    }
-
-    pub(crate) fn html() -> Buffer {
-        Buffer { for_html: true, buffer: String::new() }
-    }
-
     pub(crate) fn new() -> Buffer {
-        Buffer { for_html: false, buffer: String::new() }
+        Self::default()
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -98,8 +98,8 @@ pub(crate) fn render<T: Print, S: Print>(
     let mut themes: Vec<String> = style_files.iter().map(|s| s.basename().unwrap()).collect();
     themes.sort();
 
-    let content = Buffer::html().to_display(t); // Note: This must happen before making the sidebar.
-    let sidebar = Buffer::html().to_display(sidebar);
+    let content = Buffer::new().to_display(t); // Note: This must happen before making the sidebar.
+    let sidebar = Buffer::new().to_display(sidebar);
     PageLayout {
         static_root_path,
         page,

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -235,7 +235,7 @@ impl<'tcx> Context<'tcx> {
         };
 
         if !render_redirect_pages {
-            let mut page_buffer = Buffer::html();
+            let mut page_buffer = Buffer::new();
             print_item(self, it, &mut page_buffer);
             let page = layout::Page {
                 css_class: tyname_s,
@@ -627,7 +627,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             rust_logo: has_doc_flag(self.tcx(), LOCAL_CRATE.as_def_id(), sym::rust_logo),
         };
         let all = shared.all.replace(AllTypes::new());
-        let mut sidebar = Buffer::html();
+        let mut sidebar = Buffer::new();
 
         // all.html is not customizable, so a blank id map is fine
         let blocks = sidebar_module_like(all.item_sections(), &mut IdMap::new(), ModuleLike::Crate);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1222,7 +1222,7 @@ pub(crate) fn render_all_impls(
     synthetic: &[&Impl],
     blanket_impl: &[&Impl],
 ) {
-    let mut impls = Buffer::html();
+    let mut impls = Buffer::new();
     render_impls(cx, &mut impls, concrete, containing_item, true);
     let impls = impls.into_inner();
     if !impls.is_empty() {
@@ -1277,7 +1277,7 @@ fn render_assoc_items_inner(
     let (non_trait, traits): (Vec<_>, _) = v.iter().partition(|i| i.inner_impl().trait_.is_none());
     if !non_trait.is_empty() {
         let mut close_tags = <Vec<&str>>::with_capacity(1);
-        let mut tmp_buf = Buffer::html();
+        let mut tmp_buf = Buffer::new();
         let (render_mode, id, class_html) = match what {
             AssocItemRender::All => {
                 write_impl_section_heading(&mut tmp_buf, "Implementations", "implementations");
@@ -1305,7 +1305,7 @@ fn render_assoc_items_inner(
                 (RenderMode::ForDeref { mut_: deref_mut_ }, derived_id, r#" class="impl-items""#)
             }
         };
-        let mut impls_buf = Buffer::html();
+        let mut impls_buf = Buffer::new();
         for i in &non_trait {
             render_impl(
                 &mut impls_buf,
@@ -1485,7 +1485,7 @@ pub(crate) fn notable_traits_button(ty: &clean::Type, cx: &Context<'_>) -> Optio
 }
 
 fn notable_traits_decl(ty: &clean::Type, cx: &Context<'_>) -> (String, String) {
-    let mut out = Buffer::html();
+    let mut out = Buffer::new();
 
     let did = ty.def_id(cx.cache()).expect("notable_traits_button already checked this");
 
@@ -1622,8 +1622,8 @@ fn render_impl(
 
         let in_trait_class = if trait_.is_some() { " trait-impl" } else { "" };
 
-        let mut doc_buffer = Buffer::empty_from(boring);
-        let mut info_buffer = Buffer::empty_from(boring);
+        let mut doc_buffer = Buffer::new();
+        let mut info_buffer = Buffer::new();
         let mut short_documented = true;
 
         if render_method_item {
@@ -1819,8 +1819,8 @@ fn render_impl(
         }
     }
 
-    let mut impl_items = Buffer::empty_from(w);
-    let mut default_impl_items = Buffer::empty_from(w);
+    let mut impl_items = Buffer::new();
+    let mut default_impl_items = Buffer::new();
     let impl_ = i.inner_impl();
 
     // Impl items are grouped by kinds:

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -787,7 +787,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         let item_type = m.type_();
         let id = cx.derive_id(format!("{item_type}.{name}"));
 
-        let mut content = Buffer::empty_from(w);
+        let mut content = Buffer::new();
         write!(content, "{}", document_full(m, cx, HeadingOffset::H5));
 
         let toggled = !content.is_empty();
@@ -2152,7 +2152,7 @@ fn render_union<'a, 'cx: 'a>(
 
         let where_displayed = g
             .map(|g| {
-                let mut buf = Buffer::html();
+                let mut buf = Buffer::new();
                 write!(buf, "{}", g.print(cx));
                 let where_displayed = print_where_clause_and_check(&mut buf, g, cx);
                 write!(f, "{buf}", buf = buf.into_inner()).unwrap();

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -622,7 +622,7 @@ impl TypeAliasPart {
                     // to make that functionality work here, it needs to be called with
                     // each type alias, and if it gives a different result, split the impl
                     for &(type_alias_fqp, type_alias_item) in type_aliases {
-                        let mut buf = Buffer::html();
+                        let mut buf = Buffer::new();
                         cx.id_map.borrow_mut().clear();
                         cx.deref_id_map.borrow_mut().clear();
                         let target_did = impl_


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
So while, err... in the throes of trying to [put myself out (😁)](https://github.com/rust-lang/rust/pull/136599#issuecomment-2637868462), I realized that the `for_html` is never actually read, just initialized.

I'm not sure there's much purpose to `Buffer` without it, might be worth completely yanking it out? It's quite a bit of boilerplate for, basically, allowing us to avoid a few useless `.unwrap()`s.

r? @GuillaumeGomez (again, feel free to re-assign)
and also cc @Mark-Simulacrum because git blame shows you originally added the `Buffer` abstraction, maybe you know what `for_html` was originally used for?