### PR TITLE
Pick the max DWARF version when LTO'ing modules with different versions 

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -97,7 +97,11 @@ impl<'ll, 'tcx> CodegenUnitDebugContext<'ll, 'tcx> {
                 // Android has the same issue (#22398)
                 llvm::add_module_flag_u32(
                     self.llmod,
-                    llvm::ModuleFlagMergeBehavior::Warning,
+                    // In the case where multiple CGUs with different dwarf version
+                    // values are being merged together, such as with cross-crate
+                    // LTO, then we want to use the highest version of dwarf
+                    // we can. This matches Clang's behavior as well.
+                    llvm::ModuleFlagMergeBehavior::Max,
                     "Dwarf Version",
                     sess.dwarf_version(),
                 );

--- a/tests/assembly/auxiliary/dwarf-mixed-versions-lto-aux.rs
+++ b/tests/assembly/auxiliary/dwarf-mixed-versions-lto-aux.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -g --crate-type=rlib -Zdwarf-version=4
+
+pub fn check_is_even(number: &u64) -> bool {
+    number % 2 == 0
+}

--- a/tests/assembly/dwarf-mixed-versions-lto.rs
+++ b/tests/assembly/dwarf-mixed-versions-lto.rs
@@ -1,0 +1,19 @@
+// This test ensures that if LTO occurs between crates with different DWARF versions, we
+// will choose the highest DWARF version for the final binary. This matches Clang's behavior.
+
+//@ only-linux
+//@ aux-build:dwarf-mixed-versions-lto-aux.rs
+//@ compile-flags: -C lto -g -Zdwarf-version=5
+//@ assembly-output: emit-asm
+//@ no-prefer-dynamic
+
+extern crate dwarf_mixed_versions_lto_aux;
+
+fn main() {
+    dwarf_mixed_versions_lto_aux::check_is_even(&0);
+}
+
+// CHECK: .section .debug_info
+// CHECK-NOT: {{\.(short|hword)}} 2
+// CHECK-NOT: {{\.(short|hword)}} 4
+// CHECK: {{\.(short|hword)}} 5

--- a/tests/ui/lto/auxiliary/dwarf-mixed-versions-lto-aux.rs
+++ b/tests/ui/lto/auxiliary/dwarf-mixed-versions-lto-aux.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -g --crate-type=rlib -Zdwarf-version=4
+
+pub fn say_hi() {
+    println!("hello there")
+}

--- a/tests/ui/lto/dwarf-mixed-versions-lto.rs
+++ b/tests/ui/lto/dwarf-mixed-versions-lto.rs
@@ -1,0 +1,15 @@
+// This test verifies that we do not produce a warning when performing LTO on a
+// crate graph that contains a mix of different DWARF version settings. This
+// matches Clang's behavior.
+
+//@ ignore-msvc Platform must use DWARF
+//@ aux-build:dwarf-mixed-versions-lto-aux.rs
+//@ compile-flags: -C lto -g -Zdwarf-version=5
+//@ no-prefer-dynamic
+//@ build-pass
+
+extern crate dwarf_mixed_versions_lto_aux;
+
+fn main() {
+    dwarf_mixed_versions_lto_aux::say_hi();
+}

--- a/tests/ui/lto/dwarf-mixed-versions-lto.stderr
+++ b/tests/ui/lto/dwarf-mixed-versions-lto.stderr
@@ -1,0 +1,4 @@
+warning: linking module flags 'Dwarf Version': IDs have conflicting values ('i32 4' from  with 'i32 5' from dwarf_mixed_versions_lto.7f4a44b55cf2f174-cgu.0)
+
+warning: 1 warning emitted
+

--- a/tests/ui/lto/dwarf-mixed-versions-lto.stderr
+++ b/tests/ui/lto/dwarf-mixed-versions-lto.stderr
@@ -1,4 +1,0 @@
-warning: linking module flags 'Dwarf Version': IDs have conflicting values ('i32 4' from  with 'i32 5' from dwarf_mixed_versions_lto.7f4a44b55cf2f174-cgu.0)
-
-warning: 1 warning emitted
-


### PR DESCRIPTION
Currently, when rustc compiles code with `-Clto` enabled that was built
with different choices for `-Zdwarf-version`, a warning will be
reported. It's very easy to observe this by compiling most anything (eg,
"hello world") and specifying `-Clto -Zdwarf-version=5` since the
standard library is distributed with `-Zdwarf-version=4`.

This behavior isn't actually useful for a few reasons:
- From observation, LLVM chooses to pick the highest DWARF version
  anyway after issuing the warning.
- Clang specifies that in this case, the max version should be picked
  without a warning and as a general principle, we want to support
  x-lang LTO with Clang which implies using the same module flag merge
  behaviors.
- Debuggers need to be able to handle a variety of versions within the
  same debugging session as you can easily have some parts of a binary
  (or some dynamic libraries within an application) all compiled with
  different DWARF versions.

This commit changes the module flag merge behavior to match Clang and
use the highest version of DWARF. It also adds a test to ensure this
behavior is respected in the case of two crates being LTO'd together and
adds a test to ensure no warning is printed.

Fixes #130041 which fails due to these warnings being printed

cc #103057 