### PR TITLE
Revert vita's c_char back to i8

### DIFF
--- a/library/core/src/ffi/primitives.rs
+++ b/library/core/src/ffi/primitives.rs
@@ -39,7 +39,6 @@ mod c_char_definition {
         // These are the targets on which c_char is unsigned. Usually the
         // signedness is the same for all target_os values on a given architecture
         // but there are some exceptions (see isSignedCharDefault() in clang).
-        //
         // aarch64:
         //   Section 10 "Arm C and C++ language mappings" in Procedure Call Standard for the Arm®
         //   64-bit Architecture (AArch64) says C/C++ char is unsigned byte.
@@ -97,14 +96,19 @@ mod c_char_definition {
         //   are promoted to int as if from type signed char by default, unless the /J compilation
         //   option is used."
         //   https://learn.microsoft.com/en-us/cpp/cpp/fundamental-types-cpp?view=msvc-170#character-types
+        // Vita:
+        //   Chars are signed by default on the Vita, and VITASDK follows that convention.
+        //   https://github.com/vitasdk/buildscripts/blob/09c533b771591ecde88864b6acad28ffb688dbd4/patches/gcc/0001-gcc-10.patch#L33-L34
+        //
         // L4Re:
-        //   The kernel builds with -funsigned-char on all targets (but useserspace follows the
+        //   The kernel builds with -funsigned-char on all targets (but userspace follows the
         //   architecture defaults). As we only have a target for userspace apps so there are no
         //   special cases for L4Re below.
         //   https://github.com/rust-lang/rust/pull/132975#issuecomment-2484645240
         if #[cfg(all(
             not(windows),
             not(target_vendor = "apple"),
+            not(target_os = "vita"),
             any(
                 target_arch = "aarch64",
                 target_arch = "arm",


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

# Description

Hi!

https://github.com/rust-lang/rust/pull/132975 changed the definition of `c_char` from i8 to u8 for most ARM targets. While that would usually be correct, [VITASDK uses signed chars by default](https://github.com/vitasdk/buildscripts/blob/master/patches/gcc/0001-gcc-10.patch#L33-L34). The Clang definitions are incorrect because Clang is not (yet?) supported by the vita commmunity / `VITADSK`, On the Rust side, the pre-compiled libraries the user can link to are all compiled using vita's `gcc` and [we set `TARGET_CC` and `TARGET_CXX`](https://github.com/vita-rust/cargo-vita/blob/d564a132cbd43947118c0d6d0ebfbea7d1dd7fa7/src/commands/build.rs#L230) in `cargo vita` for build scripts using `cc`.

I'm creating it as a draft PR so that we can discuss it and possibly get it approved here, but wait to merge the [libc side](https://github.com/rust-lang/libc/pull/4258) and get a libc version first, as having the definitions out of sync breaks std. As a nightly-only target it can be confusing/frustrating for new users when the latest nightly, which is the default, is broken.