### PR TITLE
Stabilize `core::str::from_utf8_mut` as `const`

### DIFF
--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -29,7 +29,6 @@
 #![feature(string_remove_matches)]
 #![feature(const_btree_len)]
 #![feature(const_trait_impl)]
-#![feature(const_str_from_utf8)]
 #![feature(panic_update_hook)]
 #![feature(pointer_is_aligned_to)]
 #![feature(test)]

--- a/library/core/src/str/converts.rs
+++ b/library/core/src/str/converts.rs
@@ -126,7 +126,7 @@ pub const fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
 /// See the docs for [`Utf8Error`] for more details on the kinds of
 /// errors that can be returned.
 #[stable(feature = "str_mut_extras", since = "1.20.0")]
-#[rustc_const_unstable(feature = "const_str_from_utf8", issue = "91006")]
+#[rustc_const_stable(feature = "const_str_from_utf8", since = "CURRENT_RUSTC_VERSION")]
 #[rustc_diagnostic_item = "str_from_utf8_mut"]
 pub const fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
     // FIXME(const-hack): This should use `?` again, once it's `const`

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -265,7 +265,7 @@ impl str {
     /// See the docs for [`Utf8Error`] for more details on the kinds of
     /// errors that can be returned.
     #[stable(feature = "inherent_str_constructors", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_unstable(feature = "const_str_from_utf8", issue = "91006")]
+    #[rustc_const_stable(feature = "const_str_from_utf8", since = "CURRENT_RUSTC_VERSION")]
     #[rustc_diagnostic_item = "str_inherent_from_utf8_mut"]
     pub const fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
         converts::from_utf8_mut(v)


### PR DESCRIPTION
cc #91006 (tracking issue)

r? libs-api