### PR TITLE
ci: Use largedisk for loongarch

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -167,10 +167,10 @@ auto:
     <<: *job-linux-4c
 
   - name: dist-loongarch64-linux
-    <<: *job-linux-4c
+    <<: *job-linux-4c-largedisk
 
   - name: dist-loongarch64-musl
-    <<: *job-linux-4c
+    <<: *job-linux-4c-largedisk
 
   - name: dist-ohos
     <<: *job-linux-4c


### PR DESCRIPTION
`dist-loongarch64-linux` and `dist-loongarch64-musl` seem to run out of disk space when adding the amdgpu LLVM backend. There are changes underway to free more disk space, but that may take a while, so it was suggested to switch the affected jobs to a largedisk runner until that is ready.
`dist-powerpc64-linux` is another job that ran out of disk space one time, but it succeeded the other times, so I did not include it here.

amdgpu target PR with more references to the failures: #134740

r? @marcoieni

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
