### PR TITLE
require trait impls to have matching const stabilities as the traits

### DIFF
--- a/compiler/rustc_const_eval/src/check_consts/mod.rs
+++ b/compiler/rustc_const_eval/src/check_consts/mod.rs
@@ -94,6 +94,11 @@ pub fn rustc_allow_const_fn_unstable(
 /// world into two functions: those that are safe to expose on stable (and hence may not use
 /// unstable features, not even recursively), and those that are not.
 pub fn is_fn_or_trait_safe_to_expose_on_stable(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
+    // A default body in a `#[const_trait]` is const-stable when the trait is const-stable.
+    if tcx.is_const_default_method(def_id) {
+        return is_fn_or_trait_safe_to_expose_on_stable(tcx, tcx.parent(def_id));
+    }
+
     match tcx.lookup_const_stability(def_id) {
         None => {
             // In a `staged_api` crate, we do enforce recursive const stability for all unmarked

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -725,6 +725,12 @@ passes_target_feature_on_statement =
     .warn = {-passes_previously_accepted}
     .label = {passes_should_be_applied_to_fn.label}
 
+passes_trait_impl_const_stability_mismatch = const stability on the impl does not match the const stability on the trait
+passes_trait_impl_const_stability_mismatch_impl_stable = this impl is (implicitly) stable...
+passes_trait_impl_const_stability_mismatch_impl_unstable = this impl is unstable...
+passes_trait_impl_const_stability_mismatch_trait_stable = ...but the trait is stable
+passes_trait_impl_const_stability_mismatch_trait_unstable = ...but the trait is unstable
+
 passes_trait_impl_const_stable =
     trait implementations cannot be const stable yet
     .note = see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1553,6 +1553,45 @@ pub(crate) struct TraitImplConstStable {
 }
 
 #[derive(Diagnostic)]
+#[diag(passes_trait_impl_const_stability_mismatch)]
+pub(crate) struct TraitImplConstStabilityMismatch {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub impl_stability: ImplConstStability,
+    #[subdiagnostic]
+    pub trait_stability: TraitConstStability,
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum TraitConstStability {
+    #[note(passes_trait_impl_const_stability_mismatch_trait_stable)]
+    Stable {
+        #[primary_span]
+        span: Span,
+    },
+    #[note(passes_trait_impl_const_stability_mismatch_trait_unstable)]
+    Unstable {
+        #[primary_span]
+        span: Span,
+    },
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum ImplConstStability {
+    #[note(passes_trait_impl_const_stability_mismatch_impl_stable)]
+    Stable {
+        #[primary_span]
+        span: Span,
+    },
+    #[note(passes_trait_impl_const_stability_mismatch_impl_unstable)]
+    Unstable {
+        #[primary_span]
+        span: Span,
+    },
+}
+
+#[derive(Diagnostic)]
 #[diag(passes_unknown_feature, code = E0635)]
 pub(crate) struct UnknownFeature {
     #[primary_span]

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -96,6 +96,7 @@ pub trait Add<Rhs = Self> {
 macro_rules! add_impl {
     ($($t:ty)*) => ($(
         #[stable(feature = "rust1", since = "1.0.0")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const Add for $t {
             type Output = $t;
 

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -150,6 +150,7 @@ pub trait Deref {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_deref", issue = "88955")]
 impl<T: ?Sized> const Deref for &T {
     type Target = T;
 
@@ -163,6 +164,7 @@ impl<T: ?Sized> const Deref for &T {
 impl<T: ?Sized> !DerefMut for &T {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_deref", issue = "88955")]
 impl<T: ?Sized> const Deref for &mut T {
     type Target = T;
 
@@ -273,6 +275,7 @@ pub trait DerefMut: ~const Deref {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_deref", issue = "88955")]
 impl<T: ?Sized> const DerefMut for &mut T {
     fn deref_mut(&mut self) -> &mut T {
         *self

--- a/tests/ui/traits/const-traits/staged-api.rs
+++ b/tests/ui/traits/const-traits/staged-api.rs
@@ -85,4 +85,36 @@ const fn implicitly_stable_const_context() {
     //~^ ERROR cannot use `#[feature(const_trait_impl)]`
 }
 
+// check that const stability of impls and traits must match
+#[const_trait]
+#[rustc_const_unstable(feature = "beef", issue = "none")]
+trait U {}
+
+#[const_trait]
+#[rustc_const_stable(since = "0.0.0", feature = "beef2")]
+trait S {}
+
+// implied stable
+impl const U for u8 {}
+//~^ const stability on the impl does not match the const stability on the trait
+
+#[rustc_const_stable(since = "0.0.0", feature = "beef2")]
+impl const U for u16 {}
+//~^ const stability on the impl does not match the const stability on the trait
+//~| trait implementations cannot be const stable yet
+
+#[rustc_const_unstable(feature = "beef", issue = "none")]
+impl const U for u32 {}
+
+// implied stable
+impl const S for u8 {}
+
+#[rustc_const_stable(since = "0.0.0", feature = "beef2")]
+impl const S for u16 {}
+//~^ trait implementations cannot be const stable yet
+
+#[rustc_const_unstable(feature = "beef", issue = "none")]
+impl const S for u32 {}
+//~^ const stability on the impl does not match the const stability on the trait
+
 fn main() {}

--- a/tests/ui/traits/const-traits/staged-api.stderr
+++ b/tests/ui/traits/const-traits/staged-api.stderr
@@ -1,3 +1,70 @@
+error: const stability on the impl does not match the const stability on the trait
+  --> $DIR/staged-api.rs:98:1
+   |
+LL | impl const U for u8 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this impl is (implicitly) stable...
+  --> $DIR/staged-api.rs:98:1
+   |
+LL | impl const U for u8 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+note: ...but the trait is unstable
+  --> $DIR/staged-api.rs:91:7
+   |
+LL | trait U {}
+   |       ^
+
+error: trait implementations cannot be const stable yet
+  --> $DIR/staged-api.rs:102:1
+   |
+LL | impl const U for u16 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
+
+error: const stability on the impl does not match the const stability on the trait
+  --> $DIR/staged-api.rs:102:1
+   |
+LL | impl const U for u16 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this impl is (implicitly) stable...
+  --> $DIR/staged-api.rs:102:1
+   |
+LL | impl const U for u16 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+note: ...but the trait is unstable
+  --> $DIR/staged-api.rs:91:7
+   |
+LL | trait U {}
+   |       ^
+
+error: trait implementations cannot be const stable yet
+  --> $DIR/staged-api.rs:113:1
+   |
+LL | impl const S for u16 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #67792 <https://github.com/rust-lang/rust/issues/67792> for more information
+
+error: const stability on the impl does not match the const stability on the trait
+  --> $DIR/staged-api.rs:117:1
+   |
+LL | impl const S for u32 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: this impl is unstable...
+  --> $DIR/staged-api.rs:117:1
+   |
+LL | impl const S for u32 {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+note: ...but the trait is stable
+  --> $DIR/staged-api.rs:95:7
+   |
+LL | trait S {}
+   |       ^
+
 error: const function that might be (indirectly) exposed to stable cannot use `#[feature(const_trait_impl)]`
   --> $DIR/staged-api.rs:38:5
    |
@@ -323,5 +390,5 @@ LL + #[rustc_allow_const_fn_unstable(const_trait_impl)]
 LL | const fn implicitly_stable_const_context() {
    |
 
-error: aborting due to 19 previous errors
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
This resolves https://github.com/rust-lang/project-const-traits/issues/5 by implementing the suggested solution in the given thread

r? @RalfJung 
cc @rust-lang/project-const-traits 