### PR TITLE
Rewrite UTF-8 validation in shift-based DFA for 70%~135% performance increase on non-ASCII strings

### DIFF
--- a/library/core/src/str/lossy.rs
+++ b/library/core/src/str/lossy.rs
@@ -1,5 +1,4 @@
 use super::from_utf8_unchecked;
-use super::validations::utf8_char_width;
 use crate::fmt;
 use crate::fmt::{Formatter, Write};
 use crate::iter::FusedIterator;
@@ -197,93 +196,27 @@ impl<'a> Iterator for Utf8Chunks<'a> {
             return None;
         }
 
-        const TAG_CONT_U8: u8 = 128;
-        fn safe_get(xs: &[u8], i: usize) -> u8 {
-            *xs.get(i).unwrap_or(&0)
-        }
-
-        let mut i = 0;
-        let mut valid_up_to = 0;
-        while i < self.source.len() {
-            // SAFETY: `i < self.source.len()` per previous line.
-            // For some reason the following are both significantly slower:
-            // while let Some(&byte) = self.source.get(i) {
-            // while let Some(byte) = self.source.get(i).copied() {
-            let byte = unsafe { *self.source.get_unchecked(i) };
-            i += 1;
-
-            if byte < 128 {
-                // This could be a `1 => ...` case in the match below, but for
-                // the common case of all-ASCII inputs, we bypass loading the
-                // sizeable UTF8_CHAR_WIDTH table into cache.
-            } else {
-                let w = utf8_char_width(byte);
-
-                match w {
-                    2 => {
-                        if safe_get(self.source, i) & 192 != TAG_CONT_U8 {
-                            break;
-                        }
-                        i += 1;
-                    }
-                    3 => {
-                        match (byte, safe_get(self.source, i)) {
-                            (0xE0, 0xA0..=0xBF) => (),
-                            (0xE1..=0xEC, 0x80..=0xBF) => (),
-                            (0xED, 0x80..=0x9F) => (),
-                            (0xEE..=0xEF, 0x80..=0xBF) => (),
-                            _ => break,
-                        }
-                        i += 1;
-                        if safe_get(self.source, i) & 192 != TAG_CONT_U8 {
-                            break;
-                        }
-                        i += 1;
-                    }
-                    4 => {
-                        match (byte, safe_get(self.source, i)) {
-                            (0xF0, 0x90..=0xBF) => (),
-                            (0xF1..=0xF3, 0x80..=0xBF) => (),
-                            (0xF4, 0x80..=0x8F) => (),
-                            _ => break,
-                        }
-                        i += 1;
-                        if safe_get(self.source, i) & 192 != TAG_CONT_U8 {
-                            break;
-                        }
-                        i += 1;
-                        if safe_get(self.source, i) & 192 != TAG_CONT_U8 {
-                            break;
-                        }
-                        i += 1;
-                    }
-                    _ => break,
-                }
+        match super::from_utf8(self.source) {
+            Ok(valid) => {
+                // Truncate the slice, no need to touch the pointer.
+                self.source = &self.source[..0];
+                Some(Utf8Chunk { valid, invalid: &[] })
             }
-
-            valid_up_to = i;
+            Err(err) => {
+                let valid_up_to = err.valid_up_to();
+                let error_len = err.error_len().unwrap_or(self.source.len() - valid_up_to);
+                // SAFETY: `valid_up_to` is the valid UTF-8 string length, so is in bound.
+                let (valid, remaining) = unsafe { self.source.split_at_unchecked(valid_up_to) };
+                // SAFETY: `error_len` is the errornous byte sequence length, so is in bound.
+                let (invalid, after_invalid) = unsafe { remaining.split_at_unchecked(error_len) };
+                self.source = after_invalid;
+                Some(Utf8Chunk {
+                    // SAFETY: All bytes up to `valid_up_to` are valid UTF-8.
+                    valid: unsafe { from_utf8_unchecked(valid) },
+                    invalid,
+                })
+            }
         }
-
-        // SAFETY: `i <= self.source.len()` because it is only ever incremented
-        // via `i += 1` and in between every single one of those increments, `i`
-        // is compared against `self.source.len()`. That happens either
-        // literally by `i < self.source.len()` in the while-loop's condition,
-        // or indirectly by `safe_get(self.source, i) & 192 != TAG_CONT_U8`. The
-        // loop is terminated as soon as the latest `i += 1` has made `i` no
-        // longer less than `self.source.len()`, which means it'll be at most
-        // equal to `self.source.len()`.
-        let (inspected, remaining) = unsafe { self.source.split_at_unchecked(i) };
-        self.source = remaining;
-
-        // SAFETY: `valid_up_to <= i` because it is only ever assigned via
-        // `valid_up_to = i` and `i` only increases.
-        let (valid, invalid) = unsafe { inspected.split_at_unchecked(valid_up_to) };
-
-        Some(Utf8Chunk {
-            // SAFETY: All bytes up to `valid_up_to` are valid UTF-8.
-            valid: unsafe { from_utf8_unchecked(valid) },
-            invalid,
-        })
     }
 }
 

--- a/library/core/src/str/lossy.rs
+++ b/library/core/src/str/lossy.rs
@@ -1,4 +1,5 @@
 use super::from_utf8_unchecked;
+use super::validations::run_utf8_validation;
 use crate::fmt;
 use crate::fmt::{Formatter, Write};
 use crate::iter::FusedIterator;
@@ -196,8 +197,10 @@ impl<'a> Iterator for Utf8Chunks<'a> {
             return None;
         }
 
-        match super::from_utf8(self.source) {
-            Ok(valid) => {
+        match run_utf8_validation(self.source) {
+            Ok(()) => {
+                // SAFETY: The whole `source` is valid in UTF-8.
+                let valid = unsafe { from_utf8_unchecked(&self.source) };
                 // Truncate the slice, no need to touch the pointer.
                 self.source = &self.source[..0];
                 Some(Utf8Chunk { valid, invalid: &[] })

--- a/library/core/src/str/solve_dfa.py
+++ b/library/core/src/str/solve_dfa.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Use z3 to solve UTF-8 validation DFA for offset and transition table,
+# in order to encode transition table into u32.
+# We minimize the output variables in the solution to make it deterministic.
+# Ref: <https://gist.github.com/dougallj/166e326de6ad4cf2c94be97a204c025f>
+# See more detail explanation in `./validations.rs`.
+#
+# It is expected to find a solution in <30s on a modern machine, and the
+# solution is appended to the end of this file.
+from z3 import *
+
+STATE_CNT = 9
+
+# The transition table.
+# A value X on column Y means state Y should transition to state X on some
+# input bytes. We assign state 0 as ERROR and state 1 as ACCEPT (initial).
+# Eg. first line: for input byte 00..=7F, transition S1 -> S1, others -> S0.
+TRANSITIONS = [
+    # 0  1  2  3  4  5  6  7  8
+    # First bytes
+    ((0, 1, 0, 0, 0, 0, 0, 0, 0), "00-7F"),
+    ((0, 2, 0, 0, 0, 0, 0, 0, 0), "C2-DF"),
+    ((0, 3, 0, 0, 0, 0, 0, 0, 0), "E0"),
+    ((0, 4, 0, 0, 0, 0, 0, 0, 0), "E1-EC, EE-EF"),
+    ((0, 5, 0, 0, 0, 0, 0, 0, 0), "ED"),
+    ((0, 6, 0, 0, 0, 0, 0, 0, 0), "F0"),
+    ((0, 7, 0, 0, 0, 0, 0, 0, 0), "F1-F3"),
+    ((0, 8, 0, 0, 0, 0, 0, 0, 0), "F4"),
+    # Continuation bytes
+    ((0, 0, 1, 0, 2, 2, 0, 4, 4), "80-8F"),
+    ((0, 0, 1, 0, 2, 2, 4, 4, 0), "90-9F"),
+    ((0, 0, 1, 2, 2, 0, 4, 4, 0), "A0-BF"),
+    # Illegal
+    ((0, 0, 0, 0, 0, 0, 0, 0, 0), "C0-C1, F5-FF"),
+]
+
+o = Optimize()
+offsets = [BitVec(f"o{i}", 32) for i in range(STATE_CNT)]
+trans_table = [BitVec(f"t{i}", 32) for i in range(len(TRANSITIONS))]
+
+# Add some guiding constraints to make solving faster.
+o.add(offsets[0] == 0)
+o.add(trans_table[-1] == 0)
+
+for i in range(len(offsets)):
+    # Do not over-shift. It's not necessary but makes solving faster.
+    o.add(offsets[i] < 32 - 5)
+    for j in range(i):
+        o.add(offsets[i] != offsets[j])
+for trans, (targets, _) in zip(trans_table, TRANSITIONS):
+    for src, tgt in enumerate(targets):
+        o.add((LShR(trans, offsets[src]) & 31) == offsets[tgt])
+
+# Minimize ordered outputs to get a unique solution.
+goal = Concat(*offsets, *trans_table)
+o.minimize(goal)
+print(o.check())
+print("Offset[]= ", [o.model()[i].as_long() for i in offsets])
+print("Transitions:")
+for (_, label), v in zip(TRANSITIONS, [o.model()[i].as_long() for i in trans_table]):
+    print(f"{label:14} => {v:#10x}, // {v:032b}")
+
+# Output should be deterministic:
+# sat
+# Offset[]=  [0, 6, 16, 19, 1, 25, 11, 18, 24]
+# Transitions:
+# 00-7F          =>      0x180, // 00000000000000000000000110000000
+# C2-DF          =>      0x400, // 00000000000000000000010000000000
+# E0             =>      0x4c0, // 00000000000000000000010011000000
+# E1-EC, EE-EF   =>       0x40, // 00000000000000000000000001000000
+# ED             =>      0x640, // 00000000000000000000011001000000
+# F0             =>      0x2c0, // 00000000000000000000001011000000
+# F1-F3          =>      0x480, // 00000000000000000000010010000000
+# F4             =>      0x600, // 00000000000000000000011000000000
+# 80-8F          => 0x21060020, // 00100001000001100000000000100000
+# 90-9F          => 0x20060820, // 00100000000001100000100000100000
+# A0-BF          =>   0x860820, // 00000000100001100000100000100000
+# C0-C1, F5-FF   =>        0x0, // 00000000000000000000000000000000

--- a/library/core/src/str/validations.rs
+++ b/library/core/src/str/validations.rs
@@ -166,7 +166,11 @@ const ST_ACCEPT: u32 = OFFSETS[1];
 // See the end of `./solve_dfa.py`.
 const OFFSETS: [u32; STATE_CNT] = [0, 6, 16, 19, 1, 25, 11, 18, 24];
 
-static TRANS_TABLE: [u32; 256] = {
+// Keep the whole table in a single page.
+#[repr(align(1024))]
+struct TransitionTable([u32; 256]);
+
+static TRANS_TABLE: TransitionTable = {
     let mut table = [0u32; 256];
     let mut b = 0;
     while b < 256 {
@@ -187,12 +191,12 @@ static TRANS_TABLE: [u32; 256] = {
         };
         b += 1;
     }
-    table
+    TransitionTable(table)
 };
 
 #[inline(always)]
 const fn next_state(st: u32, byte: u8) -> u32 {
-    TRANS_TABLE[byte as usize].wrapping_shr(st)
+    TRANS_TABLE.0[byte as usize].wrapping_shr(st)
 }
 
 /// Check if `byte` is a valid UTF-8 first byte, assuming it must be a valid first or

--- a/library/core/src/str/validations.rs
+++ b/library/core/src/str/validations.rs
@@ -303,7 +303,7 @@ fn run_utf8_validation_rt(bytes: &[u8]) -> Result<(), Utf8Error> {
         // We also did a quick inspection on the first byte to avoid getting into this path at all
         // when handling strings with almost no ASCII, eg. Chinese scripts.
         // SAFETY: `i` is in bound.
-        if st == ST_ACCEPT && unsafe { bytes.get_unchecked(i).is_ascii() } {
+        if st & STATE_MASK == ST_ACCEPT && unsafe { bytes.get_unchecked(i).is_ascii() } {
             // SAFETY: `i` is in bound.
             let rest = unsafe { bytes.get_unchecked(i..) };
             let mut ascii_chunks = rest.array_chunks::<ASCII_CHUNK_SIZE>();

--- a/library/core/src/str/validations.rs
+++ b/library/core/src/str/validations.rs
@@ -263,10 +263,14 @@ const unsafe fn run_with_error_handling(
 
 /// Walks through `v` checking that it's a valid UTF-8 sequence,
 /// returning `Ok(())` in that case, or, if it is invalid, `Err(err)`.
-#[inline]
+#[cfg_attr(not(feature = "optimize_for_size"), inline)]
 #[rustc_allow_const_fn_unstable(const_eval_select)] // fallback impl has same behavior
 pub(super) const fn run_utf8_validation(bytes: &[u8]) -> Result<(), Utf8Error> {
-    const_eval_select((bytes,), run_utf8_validation_const, run_utf8_validation_rt)
+    if cfg!(feature = "optimize_for_size") {
+        run_utf8_validation_const(bytes)
+    } else {
+        const_eval_select((bytes,), run_utf8_validation_const, run_utf8_validation_rt)
+    }
 }
 
 #[inline]

--- a/library/core/src/str/validations.rs
+++ b/library/core/src/str/validations.rs
@@ -1,7 +1,7 @@
 //! Operations related to UTF-8 validation.
 
 use super::Utf8Error;
-use crate::intrinsics::const_eval_select;
+use crate::intrinsics::{const_eval_select, unlikely};
 
 /// Returns the initial codepoint accumulator for the first byte.
 /// The first byte is special, only want bottom 5 bits for width 2, 4 bits
@@ -111,140 +111,228 @@ where
     Some(ch)
 }
 
-const NONASCII_MASK: usize = usize::repeat_u8(0x80);
+// The shift-based DFA algorithm for UTF-8 validation.
+// Ref: <https://gist.github.com/pervognsen/218ea17743e1442e59bb60d29b1aa725>
+//
+// In short, we encode DFA transitions in an array `TRANS_TABLE` such that:
+// ```
+// TRANS_TABLE[next_byte] =
+//     OFFSET[target_state1] << OFFSET[source_state1] |
+//     OFFSET[target_state2] << OFFSET[source_state2] |
+//     ...
+// ```
+// Where `OFFSET[]` is a compile-time map from each state to a distinct 0..32 value.
+//
+// To execute the DFA:
+// ```
+// let state = OFFSET[initial_state];
+// for byte in .. {
+//     state = TRANS_TABLE[byte] >> (state & ((1 << BITS_PER_STATE) - 1));
+// }
+// ```
+// By choosing `BITS_PER_STATE = 5` and `state: u32`, we can replace the masking by `wrapping_shr`
+// and it becomes free on modern ISAs, including x86, x86_64 and ARM.
+//
+// ```
+// // shrx state, qword ptr [table_addr + 8 * byte], state   # On x86-64-v3
+// state = TRANS_TABLE[byte].wrapping_shr(state);
+// ```
+//
+// The DFA is directly derived from UTF-8 syntax from the RFC3629:
+// <https://datatracker.ietf.org/doc/html/rfc3629#section-4>.
+// We assign S0 as ERROR and S1 as ACCEPT. DFA starts at S1.
+// Syntax are annotated with DFA states in angle bracket as following:
+//
+// UTF8-char   = <S1> (UTF8-1 / UTF8-2 / UTF8-3 / UTF8-4)
+// UTF8-1      = <S1> %x00-7F
+// UTF8-2      = <S1> %xC2-DF                <S2> UTF8-tail
+// UTF8-3      = <S1> %xE0                   <S3> %xA0-BF <S2> UTF8-tail /
+//               <S1> (%xE1-EC / %xEE-EF)    <S4> 2( UTF8-tail ) /
+//               <S1> %xED                   <S5> %x80-9F <S2> UTF8-tail
+// UTF8-4      = <S1> %xF0    <S6> %x90-BF   <S4> 2( UTF8-tail ) /
+//               <S1> %xF1-F3 <S7> UTF8-tail <S4> 2( UTF8-tail ) /
+//               <S1> %xF4    <S8> %x80-8F   <S4> 2( UTF8-tail )
+// UTF8-tail   = %x80-BF   # Inlined into above usages.
+//
+// You may notice that encoding 9 states with 5bits per state into 32bit seems impossible,
+// but we exploit overlapping bits to find a possible `OFFSET[]` and `TRANS_TABLE[]` solution.
+// The SAT solver to find such (minimal) solution is in `./solve_dfa.py`.
+// The solution is also appended to the end of that file and is verifiable.
+const BITS_PER_STATE: u32 = 5;
+const STATE_MASK: u32 = (1 << BITS_PER_STATE) - 1;
+const STATE_CNT: usize = 9;
+const ST_ERROR: u32 = OFFSETS[0];
+const ST_ACCEPT: u32 = OFFSETS[1];
+// See the end of `./solve_dfa.py`.
+const OFFSETS: [u32; STATE_CNT] = [0, 6, 16, 19, 1, 25, 11, 18, 24];
 
-/// Returns `true` if any byte in the word `x` is nonascii (>= 128).
+static TRANS_TABLE: [u32; 256] = {
+    let mut table = [0u32; 256];
+    let mut b = 0;
+    while b < 256 {
+        // See the end of `./solve_dfa.py`.
+        table[b] = match b as u8 {
+            0x00..=0x7F => 0x180,
+            0xC2..=0xDF => 0x400,
+            0xE0 => 0x4C0,
+            0xE1..=0xEC | 0xEE..=0xEF => 0x40,
+            0xED => 0x640,
+            0xF0 => 0x2C0,
+            0xF1..=0xF3 => 0x480,
+            0xF4 => 0x600,
+            0x80..=0x8F => 0x21060020,
+            0x90..=0x9F => 0x20060820,
+            0xA0..=0xBF => 0x860820,
+            0xC0..=0xC1 | 0xF5..=0xFF => 0x0,
+        };
+        b += 1;
+    }
+    table
+};
+
+#[inline(always)]
+const fn next_state(st: u32, byte: u8) -> u32 {
+    TRANS_TABLE[byte as usize].wrapping_shr(st)
+}
+
+/// Check if `byte` is a valid UTF-8 first byte, assuming it must be a valid first or
+/// continuation byte.
+#[inline(always)]
+const fn is_utf8_first_byte(byte: u8) -> bool {
+    byte as i8 >= 0b1100_0000u8 as i8
+}
+
+/// # Safety
+/// The caller must ensure `bytes[..i]` is a valid UTF-8 prefix and `st` is the DFA state after
+/// executing on `bytes[..i]`.
 #[inline]
-const fn contains_nonascii(x: usize) -> bool {
-    (x & NONASCII_MASK) != 0
+const unsafe fn resolve_error_location(st: u32, bytes: &[u8], i: usize) -> (usize, u8) {
+    // There are two cases:
+    // 1. [valid UTF-8..] | *here
+    //    The previous state must be ACCEPT for the case 1, and `valid_up_to = i`.
+    // 2. [valid UTF-8..] | valid first byte, [valid continuation byte...], *here
+    //    `valid_up_to` is at the latest non-continuation byte, which must exist and
+    //    be in range `(i-3)..i`.
+    if st & STATE_MASK == ST_ACCEPT {
+        (i, 1)
+    // SAFETY: UTF-8 first byte must exist if we are in an intermediate state.
+    // We use pointer here because `get_unchecked` is not const fn.
+    } else if is_utf8_first_byte(unsafe { bytes.as_ptr().add(i - 1).read() }) {
+        (i - 1, 1)
+    // SAFETY: Same as above.
+    } else if is_utf8_first_byte(unsafe { bytes.as_ptr().add(i - 2).read() }) {
+        (i - 2, 2)
+    } else {
+        (i - 3, 3)
+    }
+}
+
+// The simpler but slower algorithm to run DFA with error handling.
+//
+// # Safety
+// The caller must ensure `bytes[..i]` is a valid UTF-8 prefix and `st` is the DFA state after
+// executing on `bytes[..i]`.
+const unsafe fn run_with_error_handling(
+    st: &mut u32,
+    bytes: &[u8],
+    mut i: usize,
+) -> Result<(), Utf8Error> {
+    while i < bytes.len() {
+        let new_st = next_state(*st, bytes[i]);
+        if unlikely(new_st & STATE_MASK == ST_ERROR) {
+            // SAFETY: Guaranteed by the caller.
+            let (valid_up_to, error_len) = unsafe { resolve_error_location(*st, bytes, i) };
+            return Err(Utf8Error { valid_up_to, error_len: Some(error_len) });
+        }
+        *st = new_st;
+        i += 1;
+    }
+    Ok(())
 }
 
 /// Walks through `v` checking that it's a valid UTF-8 sequence,
 /// returning `Ok(())` in that case, or, if it is invalid, `Err(err)`.
 #[inline(always)]
 #[rustc_allow_const_fn_unstable(const_eval_select)] // fallback impl has same behavior
-pub(super) const fn run_utf8_validation(v: &[u8]) -> Result<(), Utf8Error> {
-    let mut index = 0;
-    let len = v.len();
+pub(super) const fn run_utf8_validation(bytes: &[u8]) -> Result<(), Utf8Error> {
+    const_eval_select((bytes,), run_utf8_validation_const, run_utf8_validation_rt)
+}
 
-    const USIZE_BYTES: usize = size_of::<usize>();
-
-    let ascii_block_size = 2 * USIZE_BYTES;
-    let blocks_end = if len >= ascii_block_size { len - ascii_block_size + 1 } else { 0 };
-    // Below, we safely fall back to a slower codepath if the offset is `usize::MAX`,
-    // so the end-to-end behavior is the same at compiletime and runtime.
-    let align = const_eval_select!(
-        @capture { v: &[u8] } -> usize:
-        if const {
-            usize::MAX
-        } else {
-            v.as_ptr().align_offset(USIZE_BYTES)
-        }
-    );
-
-    while index < len {
-        let old_offset = index;
-        macro_rules! err {
-            ($error_len: expr) => {
-                return Err(Utf8Error { valid_up_to: old_offset, error_len: $error_len })
-            };
-        }
-
-        macro_rules! next {
-            () => {{
-                index += 1;
-                // we needed data, but there was none: error!
-                if index >= len {
-                    err!(None)
-                }
-                v[index]
-            }};
-        }
-
-        let first = v[index];
-        if first >= 128 {
-            let w = utf8_char_width(first);
-            // 2-byte encoding is for codepoints  \u{0080} to  \u{07ff}
-            //        first  C2 80        last DF BF
-            // 3-byte encoding is for codepoints  \u{0800} to  \u{ffff}
-            //        first  E0 A0 80     last EF BF BF
-            //   excluding surrogates codepoints  \u{d800} to  \u{dfff}
-            //               ED A0 80 to       ED BF BF
-            // 4-byte encoding is for codepoints \u{10000} to \u{10ffff}
-            //        first  F0 90 80 80  last F4 8F BF BF
-            //
-            // Use the UTF-8 syntax from the RFC
-            //
-            // https://tools.ietf.org/html/rfc3629
-            // UTF8-1      = %x00-7F
-            // UTF8-2      = %xC2-DF UTF8-tail
-            // UTF8-3      = %xE0 %xA0-BF UTF8-tail / %xE1-EC 2( UTF8-tail ) /
-            //               %xED %x80-9F UTF8-tail / %xEE-EF 2( UTF8-tail )
-            // UTF8-4      = %xF0 %x90-BF 2( UTF8-tail ) / %xF1-F3 3( UTF8-tail ) /
-            //               %xF4 %x80-8F 2( UTF8-tail )
-            match w {
-                2 => {
-                    if next!() as i8 >= -64 {
-                        err!(Some(1))
-                    }
-                }
-                3 => {
-                    match (first, next!()) {
-                        (0xE0, 0xA0..=0xBF)
-                        | (0xE1..=0xEC, 0x80..=0xBF)
-                        | (0xED, 0x80..=0x9F)
-                        | (0xEE..=0xEF, 0x80..=0xBF) => {}
-                        _ => err!(Some(1)),
-                    }
-                    if next!() as i8 >= -64 {
-                        err!(Some(2))
-                    }
-                }
-                4 => {
-                    match (first, next!()) {
-                        (0xF0, 0x90..=0xBF) | (0xF1..=0xF3, 0x80..=0xBF) | (0xF4, 0x80..=0x8F) => {}
-                        _ => err!(Some(1)),
-                    }
-                    if next!() as i8 >= -64 {
-                        err!(Some(2))
-                    }
-                    if next!() as i8 >= -64 {
-                        err!(Some(3))
-                    }
-                }
-                _ => err!(Some(1)),
-            }
-            index += 1;
-        } else {
-            // Ascii case, try to skip forward quickly.
-            // When the pointer is aligned, read 2 words of data per iteration
-            // until we find a word containing a non-ascii byte.
-            if align != usize::MAX && align.wrapping_sub(index) % USIZE_BYTES == 0 {
-                let ptr = v.as_ptr();
-                while index < blocks_end {
-                    // SAFETY: since `align - index` and `ascii_block_size` are
-                    // multiples of `USIZE_BYTES`, `block = ptr.add(index)` is
-                    // always aligned with a `usize` so it's safe to dereference
-                    // both `block` and `block.add(1)`.
-                    unsafe {
-                        let block = ptr.add(index) as *const usize;
-                        // break if there is a nonascii byte
-                        let zu = contains_nonascii(*block);
-                        let zv = contains_nonascii(*block.add(1));
-                        if zu || zv {
-                            break;
-                        }
-                    }
-                    index += ascii_block_size;
-                }
-                // step from the point where the wordwise loop stopped
-                while index < len && v[index] < 128 {
-                    index += 1;
-                }
+#[inline]
+const fn run_utf8_validation_const(bytes: &[u8]) -> Result<(), Utf8Error> {
+    let mut st = ST_ACCEPT;
+    // SAFETY: Start at empty string with valid state ACCEPT.
+    match unsafe { run_with_error_handling(&mut st, bytes, 0) } {
+        Err(err) => Err(err),
+        Ok(()) => {
+            if st & STATE_MASK == ST_ACCEPT {
+                Ok(())
             } else {
-                index += 1;
+                // SAFETY: `st` is the last state after execution without encountering any error.
+                let (valid_up_to, _) = unsafe { resolve_error_location(st, bytes, bytes.len()) };
+                Err(Utf8Error { valid_up_to, error_len: None })
             }
         }
+    }
+}
+
+#[inline]
+fn run_utf8_validation_rt(bytes: &[u8]) -> Result<(), Utf8Error> {
+    const MAIN_CHUNK_SIZE: usize = 16;
+    const ASCII_CHUNK_SIZE: usize = 16;
+    const { assert!(ASCII_CHUNK_SIZE % MAIN_CHUNK_SIZE == 0) };
+
+    let mut st = ST_ACCEPT;
+    let mut i = 0usize;
+
+    while i + MAIN_CHUNK_SIZE <= bytes.len() {
+        // Fast path: if the current state is ACCEPT, we can skip to the next non-ASCII chunk.
+        // We also did a quick inspection on the first byte to avoid getting into this path at all
+        // when handling strings with almost no ASCII, eg. Chinese scripts.
+        // SAFETY: `i` is in bound.
+        if st == ST_ACCEPT && unsafe { *bytes.get_unchecked(i) } < 0x80 {
+            // SAFETY: `i` is in bound.
+            let rest = unsafe { bytes.get_unchecked(i..) };
+            let mut ascii_chunks = rest.array_chunks::<ASCII_CHUNK_SIZE>();
+            let ascii_rest_chunk_cnt = ascii_chunks.len();
+            let pos = ascii_chunks
+                .position(|chunk| {
+                    // NB. Always traverse the whole chunk to enable vectorization, instead of `.any()`.
+                    // LLVM will be fear of memory traps and fallback if loop has short-circuit.
+                    #[expect(clippy::unnecessary_fold)]
+                    let has_non_ascii = chunk.iter().fold(false, |acc, &b| acc || (b >= 0x80));
+                    has_non_ascii
+                })
+                .unwrap_or(ascii_rest_chunk_cnt);
+            i += pos * ASCII_CHUNK_SIZE;
+            if i + MAIN_CHUNK_SIZE > bytes.len() {
+                break;
+            }
+        }
+
+        // SAFETY: `i` and `i + MAIN_CHUNK_SIZE` are in bound by loop invariant.
+        let chunk = unsafe { &*bytes.as_ptr().add(i).cast::<[u8; MAIN_CHUNK_SIZE]>() };
+        let mut new_st = st;
+        for &b in chunk {
+            new_st = next_state(new_st, b);
+        }
+        if unlikely(new_st & STATE_MASK == ST_ERROR) {
+            // Discard the current chunk erronous result, and reuse the trailing chunk handling to
+            // report the error location.
+            break;
+        }
+
+        st = new_st;
+        i += MAIN_CHUNK_SIZE;
+    }
+
+    // SAFETY: `st` is the last state after executing `bytes[..i]` without encountering any error.
+    unsafe { run_with_error_handling(&mut st, bytes, i)? };
+
+    if unlikely(st & STATE_MASK != ST_ACCEPT) {
+        // SAFETY: Same as above.
+        let (valid_up_to, _) = unsafe { resolve_error_location(st, bytes, bytes.len()) };
+        return Err(Utf8Error { valid_up_to, error_len: None });
     }
 
     Ok(())

--- a/library/coretests/benches/str.rs
+++ b/library/coretests/benches/str.rs
@@ -11,3 +11,8 @@ mod iter;
 fn str_validate_emoji(b: &mut Bencher) {
     b.iter(|| str::from_utf8(black_box(corpora::emoji::LARGE.as_bytes())));
 }
+
+#[bench]
+fn str_validate_ascii(b: &mut Bencher) {
+    b.iter(|| str::from_utf8(black_box(corpora::en::LARGE.as_bytes())));
+}

--- a/library/coretests/tests/str_lossy.rs
+++ b/library/coretests/tests/str_lossy.rs
@@ -58,6 +58,9 @@ fn chunks() {
         ("foo\u{10000}bar", b""),
     );
 
+    // incomplete
+    assert_chunks!(b"bar\xF1\x80\x80", ("bar", b"\xF1\x80\x80"));
+
     // surrogates
     assert_chunks!(
         b"\xED\xA0\x80foo\xED\xBF\xBFbar",


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/136693)*
<!-- homu-ignore:end -->

Take 2 of rust-lang/rust#107760 (cc @thomcc)

### Background

About the technique: https://gist.github.com/pervognsen/218ea17743e1442e59bb60d29b1aa725

As stated in rust-lang/rust#107760,
> For prior art: shift-DFAs are now used for UTF-8 validation in [PostgreSQL](https://github.com/postgres/postgres/blob/aa6954104644334c53838f181053b9f7aa13f58c/src/common/wchar.c#L1753), and seems to be in progress or under consideration for use in https://github.com/JuliaLang/julia/pull/47880 and perhaps https://github.com/golang/go/issues/47120. Of these, PG's impl is the most similar to this one, at least at a high level[1](https://github.com/rust-lang/rust/pull/107760#user-content-fn-pg-a9b64c301fa792150e615ee4b94efb93).

### Rationales

1. Performance: This algorithm gives plenty of performance increase on validating strings with many non-ASCII codepoints, which is the normal case for almost every non-English content.

2. Generality: It does not use SIMD instructions and does not rely on the branch predictor to get a good performance, thus is good as a general, default, architecture-agnostic implementation. There is still a bypass for ASCII-only strings to benefit from auto-vectorization, if the target supports.

### Implementation details

I use the ordinary UTF-8 language definition from [RFC3692](https://datatracker.ietf.org/doc/html/rfc3629#section-4) and directly translate it into a 9-state DFA. ~~So the compressed state is 64-bit, resulting in a table of `[u64; 256]`, or 2KiB rodata.~~ Now the table is compressed into 1KiB `[u32; 256]`, see `library/core/src/str/solve_dfa.py` for details.

The main algorithm consists of following parts:
1. Main loop: taking a chunk of `MAIN_CHUNK_SIZE = 16` bytes on each iteration, execute the DFA on the chunk, and check if the state is in ERROR once per chunk.
2. ASCII bypass: in each chunk iteration, if the current state is ACCEPT, we know we are not in the middle of an encoded sequence, so we can skip a large block of trivial ASCIIs and stop at the first chunk containing any non-ASCII bytes. I choose `ASCII_CHUNK_SIZE = 16` to align with the current implementation: taking 16 bytes each to check non-ASCIIs, to encourage LLVM auto-vectorize it.
3. Trailing chunk and error reporting: execute the DFA step by step, stop on error as soon as possible, and calculate the error/valid location. To be simple, if any error are encountered in the main loop, it will discard the errornous chunk and `break` into this path to find the precise error location. That is, the erronous chunk, if exists, will be traversed twice, in exchange for a tighter and more efficient hot loop.

There are also some small tricks being used:
1. Since we have i686-linux in Tier 1 support, and its 64-bit shift (SHRD) is quite slow in our latency-intensive hot loop, I arrange the state storage so that the state transition can be done in 32-bit shift and conditional move. It shows a 200%+ speed up comparing to 64-bit-shift version.
2. We still need to get UTF-8 encoded length from the first byte in `utf8_char_width`. ~~I merge the previous lookup table into the unused high bits of the DFA transition table. So we don't need two tables. It did introduce an extra 32-bit shift. I believe it's almost free but have not benchmarked yet.~~ I kept `UTF8_CHAR_WIDTH` table unchanged.

### Benchmarks

I made an [out-of-tree implementation repository](https://github.com/oxalica/shift-dfa-utf8) for easier testing and benching. It also tested various `MAIN_CHUNK_SIZE` (m) and `ASCII_CHUNK_SIZE` (a) configurations. Bench data are taken from the first 4KiB (from the first paragraph, plain text not HTML, cut at char boundary) of Wikipedia [William Shakespeare in en](https://en.wikipedia.org/wiki/William_Shakespeare), [es](https://es.wikipedia.org/wiki/William_Shakespeare) and [zh](https://zh.wikipedia.org/wiki/%E5%A8%81%E5%BB%89%C2%B7%E8%8E%8E%E5%A3%AB%E6%AF%94%E4%BA%9A) language.

In short: with m=16, a=16, shift-DFA performance gives -45% on en, +69% on es, +135% on zh; with m=8, a=32, it gives +5% on en, +22% on es, +136% on zh. It's quite expected, as the larger ASCII bypass chunk is, it performs better on ASCII, but worse on mixed content like "es" because of the taken branch is flipping around.
To me, the difference in "en" is minimal in absolute time because the throughput is already high enough, comparing to not-as-fast "es". So I currently picking m=16, a=16 to lean towards "es" in the PR.

<details>
<summary>x86_64-linux results</summary>

On: Ryzen 7 5700G @3.775GHz (disabled turbo, with cpuset, with [stack layout randomizer](https://github.com/bheisler/criterion.rs/pull/744)):

Note: zh input consists of solely non-ASCII codepoints and runs fully on DFA path, it's the same performance as purely emoji inputs.

| Algorithm         | Input language | Throughput / (GiB/s)  |
|-------------------|----------------|-----------------------|
| std               | en             | 48.791 +-0.128        |
| shift-dfa-m16-a16 | en             | 26.815 +-0.006        | 
| shift-dfa-m8-a32  | en             | 51.314 +-0.018        |
| std               | es             |  5.925 +-0.069        |
| shift-dfa-m16-a16 | es             | 10.033 +-0.007        |
| shift-dfa-m8-a32  | es             |  7.254 +-0.035        |
| std               | zh             |  1.450 +-0.008        |
| shift-dfa-m16-a16 | zh             |  3.414 +-0.002        |
| shift-dfa-m8-a32  | zh             |  3.421 +-0.002        |


Before (486b0d11bd7d08f7a8f02f933b6447933f93009a):
```
    test string::from_utf8_lossy_100_ascii                   ... bench:          40.96 ns/iter (+/- 6.47)
    test string::from_utf8_lossy_100_invalid                 ... bench:       1,738.28 ns/iter (+/- 10.53)
    test string::from_utf8_lossy_100_multibyte               ... bench:          61.22 ns/iter (+/- 0.38)
    test string::from_utf8_lossy_invalid                     ... bench:         125.26 ns/iter (+/- 1.85)

    test str::str_validate_emoji                             ... bench:       3,279.32 ns/iter (+/- 54.01)
```
After with m16 a16 (ceb82dd971b7aef47493298255bab732bdc67b5e):
```
    test string::from_utf8_lossy_100_ascii                   ... bench:          23.92 ns/iter (+/- 0.10)
    test string::from_utf8_lossy_100_invalid                 ... bench:       1,962.22 ns/iter (+/- 42.19)
    test string::from_utf8_lossy_100_multibyte               ... bench:          41.19 ns/iter (+/- 0.75)
    test string::from_utf8_lossy_invalid                     ... bench:         155.69 ns/iter (+/- 3.46)

    test str::str_validate_emoji                             ... bench:       1,909.92 ns/iter (+/- 94.34)
```
After with m8 a32 (ceb82dd971b7aef47493298255bab732bdc67b5e):
```
    test string::from_utf8_lossy_100_ascii                   ... bench:          20.14 ns/iter (+/- 0.03)
    test string::from_utf8_lossy_100_invalid                 ... bench:       2,017.46 ns/iter (+/- 9.39)
    test string::from_utf8_lossy_100_multibyte               ... bench:          54.19 ns/iter (+/- 0.07)
    test string::from_utf8_lossy_invalid                     ... bench:         152.43 ns/iter (+/- 2.46)

    test str::str_validate_emoji                             ... bench:       2,715.99 ns/iter (+/- 164.68)
```
</details>


### Unresolved

- [x] Benchmark on aarch64-darwin, another tier 1 target.
  See [this comment](https://github.com/rust-lang/rust/pull/136693#issuecomment-2646355751).

- [ ] Decide the chunk size parameters. I'm currently picking m=16, a=16.

- [x] Should we also replace the implementation of [lossy conversion](https://github.com/oxalica/rust/blob/c0639b8cad126d886ddd88964f729dd33fb90e67/library/core/src/str/lossy.rs#L194) by calling the new validation function? It has a very similar code doing almost the same thing.

  It now also uses the new validation algorithm. Benchmarks of lossy conversions are included above.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

