### PR TITLE
std: replace the `FromInner` implementation for addresses with private conversion functions

### DIFF
--- a/library/std/src/net/ip_addr.rs
+++ b/library/std/src/net/ip_addr.rs
@@ -8,32 +8,3 @@ pub use core::net::IpAddr;
 pub use core::net::Ipv6MulticastScope;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::net::{Ipv4Addr, Ipv6Addr};
-
-use crate::sys::net::netc as c;
-use crate::sys_common::{FromInner, IntoInner};
-
-impl IntoInner<c::in_addr> for Ipv4Addr {
-    #[inline]
-    fn into_inner(self) -> c::in_addr {
-        // `s_addr` is stored as BE on all machines and the array is in BE order.
-        // So the native endian conversion method is used so that it's never swapped.
-        c::in_addr { s_addr: u32::from_ne_bytes(self.octets()) }
-    }
-}
-impl FromInner<c::in_addr> for Ipv4Addr {
-    fn from_inner(addr: c::in_addr) -> Ipv4Addr {
-        Ipv4Addr::from(addr.s_addr.to_ne_bytes())
-    }
-}
-
-impl IntoInner<c::in6_addr> for Ipv6Addr {
-    fn into_inner(self) -> c::in6_addr {
-        c::in6_addr { s6_addr: self.octets() }
-    }
-}
-impl FromInner<c::in6_addr> for Ipv6Addr {
-    #[inline]
-    fn from_inner(addr: c::in6_addr) -> Ipv6Addr {
-        Ipv6Addr::from(addr.s6_addr)
-    }
-}

--- a/library/std/src/net/socket_addr.rs
+++ b/library/std/src/net/socket_addr.rs
@@ -6,50 +6,8 @@ mod tests;
 pub use core::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 
 use crate::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use crate::sys::net::{LookupHost, netc as c};
-use crate::sys_common::{FromInner, IntoInner};
-use crate::{io, iter, mem, option, slice, vec};
-
-impl FromInner<c::sockaddr_in> for SocketAddrV4 {
-    fn from_inner(addr: c::sockaddr_in) -> SocketAddrV4 {
-        SocketAddrV4::new(Ipv4Addr::from_inner(addr.sin_addr), u16::from_be(addr.sin_port))
-    }
-}
-
-impl FromInner<c::sockaddr_in6> for SocketAddrV6 {
-    fn from_inner(addr: c::sockaddr_in6) -> SocketAddrV6 {
-        SocketAddrV6::new(
-            Ipv6Addr::from_inner(addr.sin6_addr),
-            u16::from_be(addr.sin6_port),
-            addr.sin6_flowinfo,
-            addr.sin6_scope_id,
-        )
-    }
-}
-
-impl IntoInner<c::sockaddr_in> for SocketAddrV4 {
-    fn into_inner(self) -> c::sockaddr_in {
-        c::sockaddr_in {
-            sin_family: c::AF_INET as c::sa_family_t,
-            sin_port: self.port().to_be(),
-            sin_addr: self.ip().into_inner(),
-            ..unsafe { mem::zeroed() }
-        }
-    }
-}
-
-impl IntoInner<c::sockaddr_in6> for SocketAddrV6 {
-    fn into_inner(self) -> c::sockaddr_in6 {
-        c::sockaddr_in6 {
-            sin6_family: c::AF_INET6 as c::sa_family_t,
-            sin6_port: self.port().to_be(),
-            sin6_addr: self.ip().into_inner(),
-            sin6_flowinfo: self.flowinfo(),
-            sin6_scope_id: self.scope_id(),
-            ..unsafe { mem::zeroed() }
-        }
-    }
-}
+use crate::sys::net::LookupHost;
+use crate::{io, iter, option, slice, vec};
 
 /// A trait for objects which can be converted or resolved to one or more
 /// [`SocketAddr`] values.

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -122,7 +122,7 @@ impl BorrowedFd<'_> {
     /// Creates a new `OwnedFd` instance that shares the same underlying file
     /// description as the existing `BorrowedFd` instance.
     pub fn try_clone_to_owned(&self) -> crate::io::Result<OwnedFd> {
-        let fd = sys::net::cvt(unsafe { sys::net::netc::dup(self.as_raw_fd()) })?;
+        let fd = sys::net::cvt(unsafe { crate::sys::abi::sockets::dup(self.as_raw_fd()) })?;
         Ok(unsafe { OwnedFd::from_raw_fd(fd) })
     }
 }
@@ -168,7 +168,7 @@ impl FromRawFd for OwnedFd {
 impl Drop for OwnedFd {
     #[inline]
     fn drop(&mut self) {
-        unsafe { sys::net::netc::close(self.fd.as_inner()) };
+        unsafe { crate::sys::abi::sockets::close(self.fd.as_inner()) };
     }
 }
 

--- a/library/std/src/sys/net/connection/sgx.rs
+++ b/library/std/src/sys/net/connection/sgx.rs
@@ -499,38 +499,3 @@ impl<'a> TryFrom<(&'a str, u16)> for LookupHost {
         LookupHost::new(format!("{host}:{port}"))
     }
 }
-
-#[allow(bad_style)]
-pub mod netc {
-    pub const AF_INET: u8 = 0;
-    pub const AF_INET6: u8 = 1;
-    pub type sa_family_t = u8;
-
-    #[derive(Copy, Clone)]
-    pub struct in_addr {
-        pub s_addr: u32,
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in {
-        #[allow(dead_code)]
-        pub sin_family: sa_family_t,
-        pub sin_port: u16,
-        pub sin_addr: in_addr,
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct in6_addr {
-        pub s6_addr: [u8; 16],
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in6 {
-        #[allow(dead_code)]
-        pub sin6_family: sa_family_t,
-        pub sin6_port: u16,
-        pub sin6_addr: in6_addr,
-        pub sin6_flowinfo: u32,
-        pub sin6_scope_id: u32,
-    }
-}

--- a/library/std/src/sys/net/connection/socket/hermit.rs
+++ b/library/std/src/sys/net/connection/socket/hermit.rs
@@ -2,13 +2,13 @@
 
 use core::ffi::c_int;
 
-pub(crate) use hermit_abi as netc;
+pub(super) use hermit_abi as netc;
 
+use super::{getsockopt, setsockopt, socket_addr_from_c, socket_addr_to_c};
 use crate::io::{self, BorrowedBuf, BorrowedCursor, IoSlice, IoSliceMut};
 use crate::net::{Shutdown, SocketAddr};
 use crate::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, RawFd};
 use crate::sys::fd::FileDesc;
-use crate::sys::net::{getsockopt, setsockopt, sockaddr_to_addr};
 use crate::sys::time::Instant;
 pub use crate::sys::{cvt, cvt_r};
 use crate::sys_common::{AsInner, FromInner, IntoInner};
@@ -55,7 +55,7 @@ impl Socket {
     }
 
     pub fn connect(&self, addr: &SocketAddr) -> io::Result<()> {
-        let (addr, len) = addr.into_inner();
+        let (addr, len) = socket_addr_to_c(addr);
         cvt_r(|| unsafe { netc::connect(self.as_raw_fd(), addr.as_ptr(), len) })?;
         Ok(())
     }
@@ -63,7 +63,7 @@ impl Socket {
     pub fn connect_timeout(&self, addr: &SocketAddr, timeout: Duration) -> io::Result<()> {
         self.set_nonblocking(true)?;
         let r = unsafe {
-            let (addr, len) = addr.into_inner();
+            let (addr, len) = socket_addr_to_c(addr);
             cvt(netc::connect(self.as_raw_fd(), addr.as_ptr(), len))
         };
         self.set_nonblocking(false)?;
@@ -195,7 +195,7 @@ impl Socket {
                 &mut addrlen,
             )
         })?;
-        Ok((n as usize, sockaddr_to_addr(&storage, addrlen as usize)?))
+        Ok((n as usize, unsafe { socket_addr_from_c(&storage, addrlen as usize)? }))
     }
 
     pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {

--- a/library/std/src/sys/net/connection/socket/solid.rs
+++ b/library/std/src/sys/net/connection/socket/solid.rs
@@ -1,17 +1,17 @@
 use libc::{c_int, c_void, size_t};
 
 use self::netc::{MSG_PEEK, sockaddr, socklen_t};
+use super::{getsockopt, setsockopt, socket_addr_from_c, socket_addr_to_c};
 use crate::ffi::CStr;
 use crate::io::{self, BorrowedBuf, BorrowedCursor, ErrorKind, IoSlice, IoSliceMut};
 use crate::net::{Shutdown, SocketAddr};
 use crate::os::solid::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd};
 use crate::sys::abi;
-use crate::sys::net::{getsockopt, setsockopt, sockaddr_to_addr};
 use crate::sys_common::{FromInner, IntoInner};
 use crate::time::Duration;
 use crate::{cmp, mem, ptr, str};
 
-pub mod netc {
+pub(super) mod netc {
     pub use crate::sys::abi::sockets::*;
 }
 
@@ -131,7 +131,7 @@ impl Socket {
     }
 
     pub fn connect(&self, addr: &SocketAddr) -> io::Result<()> {
-        let (addr, len) = addr.into_inner();
+        let (addr, len) = socket_addr_to_c(addr);
         cvt(unsafe { netc::connect(self.as_raw_fd(), addr.as_ptr(), len) })?;
         Ok(())
     }
@@ -256,7 +256,7 @@ impl Socket {
                 &mut addrlen,
             )
         })?;
-        Ok((n as usize, sockaddr_to_addr(&storage, addrlen as usize)?))
+        Ok((n as usize, unsafe { socket_addr_from_c(&storage, addrlen as usize)? }))
     }
 
     pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {

--- a/library/std/src/sys/net/connection/socket/unix.rs
+++ b/library/std/src/sys/net/connection/socket/unix.rs
@@ -5,7 +5,7 @@ use crate::io::{self, BorrowedBuf, BorrowedCursor, IoSlice, IoSliceMut};
 use crate::net::{Shutdown, SocketAddr};
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 use crate::sys::fd::FileDesc;
-use crate::sys::net::{getsockopt, setsockopt, sockaddr_to_addr};
+use crate::sys::net::{getsockopt, setsockopt};
 use crate::sys::pal::IsMinusOne;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 use crate::time::{Duration, Instant};
@@ -19,8 +19,9 @@ cfg_if::cfg_if! {
     }
 }
 
-pub(crate) use libc as netc;
+pub(super) use libc as netc;
 
+use super::{socket_addr_from_c, socket_addr_to_c};
 pub use crate::sys::{cvt, cvt_r};
 
 #[expect(non_camel_case_types)]
@@ -150,7 +151,7 @@ impl Socket {
     }
 
     pub fn connect(&self, addr: &SocketAddr) -> io::Result<()> {
-        let (addr, len) = addr.into_inner();
+        let (addr, len) = socket_addr_to_c(addr);
         loop {
             let result = unsafe { libc::connect(self.as_raw_fd(), addr.as_ptr(), len) };
             if result.is_minus_one() {
@@ -168,7 +169,7 @@ impl Socket {
     pub fn connect_timeout(&self, addr: &SocketAddr, timeout: Duration) -> io::Result<()> {
         self.set_nonblocking(true)?;
         let r = unsafe {
-            let (addr, len) = addr.into_inner();
+            let (addr, len) = socket_addr_to_c(addr);
             cvt(libc::connect(self.as_raw_fd(), addr.as_ptr(), len))
         };
         self.set_nonblocking(false)?;
@@ -334,7 +335,7 @@ impl Socket {
                 &mut addrlen,
             )
         })?;
-        Ok((n as usize, sockaddr_to_addr(&storage, addrlen as usize)?))
+        Ok((n as usize, unsafe { socket_addr_from_c(&storage, addrlen as usize)? }))
     }
 
     pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {

--- a/library/std/src/sys/net/connection/socket/windows.rs
+++ b/library/std/src/sys/net/connection/socket/windows.rs
@@ -2,6 +2,7 @@
 
 use core::ffi::{c_int, c_long, c_ulong, c_ushort};
 
+use super::{getsockopt, setsockopt, socket_addr_from_c, socket_addr_to_c};
 use crate::io::{self, BorrowedBuf, BorrowedCursor, IoSlice, IoSliceMut, Read};
 use crate::net::{Shutdown, SocketAddr};
 use crate::os::windows::io::{
@@ -16,7 +17,7 @@ use crate::{cmp, mem, ptr, sys};
 #[allow(non_camel_case_types)]
 pub type wrlen_t = i32;
 
-pub mod netc {
+pub(super) mod netc {
     //! BSD socket compatibility shim
     //!
     //! Some Windows API types are not quite what's expected by our cross-platform
@@ -225,7 +226,7 @@ impl Socket {
     }
 
     pub fn connect(&self, addr: &SocketAddr) -> io::Result<()> {
-        let (addr, len) = addr.into_inner();
+        let (addr, len) = socket_addr_to_c(addr);
         let result = unsafe { c::connect(self.as_raw(), addr.as_ptr(), len) };
         cvt(result).map(drop)
     }
@@ -401,12 +402,12 @@ impl Socket {
                 let error = unsafe { c::WSAGetLastError() };
 
                 if error == c::WSAESHUTDOWN {
-                    Ok((0, super::sockaddr_to_addr(&storage, addrlen as usize)?))
+                    Ok((0, unsafe { socket_addr_from_c(&storage, addrlen as usize)? }))
                 } else {
                     Err(io::Error::from_raw_os_error(error))
                 }
             }
-            _ => Ok((result as usize, super::sockaddr_to_addr(&storage, addrlen as usize)?)),
+            _ => Ok((result as usize, unsafe { socket_addr_from_c(&storage, addrlen as usize)? })),
         }
     }
 
@@ -451,11 +452,11 @@ impl Socket {
             }
             None => 0,
         };
-        super::setsockopt(self, c::SOL_SOCKET, kind, timeout)
+        setsockopt(self, c::SOL_SOCKET, kind, timeout)
     }
 
     pub fn timeout(&self, kind: c_int) -> io::Result<Option<Duration>> {
-        let raw: u32 = super::getsockopt(self, c::SOL_SOCKET, kind)?;
+        let raw: u32 = getsockopt(self, c::SOL_SOCKET, kind)?;
         if raw == 0 {
             Ok(None)
         } else {
@@ -488,26 +489,26 @@ impl Socket {
             l_linger: linger.unwrap_or_default().as_secs() as c_ushort,
         };
 
-        super::setsockopt(self, c::SOL_SOCKET, c::SO_LINGER, linger)
+        setsockopt(self, c::SOL_SOCKET, c::SO_LINGER, linger)
     }
 
     pub fn linger(&self) -> io::Result<Option<Duration>> {
-        let val: c::LINGER = super::getsockopt(self, c::SOL_SOCKET, c::SO_LINGER)?;
+        let val: c::LINGER = getsockopt(self, c::SOL_SOCKET, c::SO_LINGER)?;
 
         Ok((val.l_onoff != 0).then(|| Duration::from_secs(val.l_linger as u64)))
     }
 
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
-        super::setsockopt(self, c::IPPROTO_TCP, c::TCP_NODELAY, nodelay as c::BOOL)
+        setsockopt(self, c::IPPROTO_TCP, c::TCP_NODELAY, nodelay as c::BOOL)
     }
 
     pub fn nodelay(&self) -> io::Result<bool> {
-        let raw: c::BOOL = super::getsockopt(self, c::IPPROTO_TCP, c::TCP_NODELAY)?;
+        let raw: c::BOOL = getsockopt(self, c::IPPROTO_TCP, c::TCP_NODELAY)?;
         Ok(raw != 0)
     }
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
-        let raw: c_int = super::getsockopt(self, c::SOL_SOCKET, c::SO_ERROR)?;
+        let raw: c_int = getsockopt(self, c::SOL_SOCKET, c::SO_ERROR)?;
         if raw == 0 { Ok(None) } else { Ok(Some(io::Error::from_raw_os_error(raw as i32))) }
     }
 

--- a/library/std/src/sys/net/connection/uefi/mod.rs
+++ b/library/std/src/sys/net/connection/uefi/mod.rs
@@ -332,38 +332,3 @@ impl<'a> TryFrom<(&'a str, u16)> for LookupHost {
         unsupported()
     }
 }
-
-#[allow(nonstandard_style)]
-pub mod netc {
-    pub const AF_INET: u8 = 0;
-    pub const AF_INET6: u8 = 1;
-    pub type sa_family_t = u8;
-
-    #[derive(Copy, Clone)]
-    pub struct in_addr {
-        pub s_addr: u32,
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in {
-        #[allow(dead_code)]
-        pub sin_family: sa_family_t,
-        pub sin_port: u16,
-        pub sin_addr: in_addr,
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct in6_addr {
-        pub s6_addr: [u8; 16],
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in6 {
-        #[allow(dead_code)]
-        pub sin6_family: sa_family_t,
-        pub sin6_port: u16,
-        pub sin6_addr: in6_addr,
-        pub sin6_flowinfo: u32,
-        pub sin6_scope_id: u32,
-    }
-}

--- a/library/std/src/sys/net/connection/unsupported.rs
+++ b/library/std/src/sys/net/connection/unsupported.rs
@@ -332,38 +332,3 @@ impl<'a> TryFrom<(&'a str, u16)> for LookupHost {
         unsupported()
     }
 }
-
-#[allow(nonstandard_style)]
-pub mod netc {
-    pub const AF_INET: u8 = 0;
-    pub const AF_INET6: u8 = 1;
-    pub type sa_family_t = u8;
-
-    #[derive(Copy, Clone)]
-    pub struct in_addr {
-        pub s_addr: u32,
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in {
-        #[allow(dead_code)]
-        pub sin_family: sa_family_t,
-        pub sin_port: u16,
-        pub sin_addr: in_addr,
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct in6_addr {
-        pub s6_addr: [u8; 16],
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in6 {
-        #[allow(dead_code)]
-        pub sin6_family: sa_family_t,
-        pub sin6_port: u16,
-        pub sin6_addr: in6_addr,
-        pub sin6_flowinfo: u32,
-        pub sin6_scope_id: u32,
-    }
-}

--- a/library/std/src/sys/net/connection/wasip1.rs
+++ b/library/std/src/sys/net/connection/wasip1.rs
@@ -505,38 +505,3 @@ impl<'a> TryFrom<(&'a str, u16)> for LookupHost {
         unsupported()
     }
 }
-
-#[allow(nonstandard_style)]
-pub mod netc {
-    pub const AF_INET: u8 = 0;
-    pub const AF_INET6: u8 = 1;
-    pub type sa_family_t = u8;
-
-    #[derive(Copy, Clone)]
-    pub struct in_addr {
-        pub s_addr: u32,
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in {
-        #[allow(dead_code)]
-        pub sin_family: sa_family_t,
-        pub sin_port: u16,
-        pub sin_addr: in_addr,
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct in6_addr {
-        pub s6_addr: [u8; 16],
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in6 {
-        #[allow(dead_code)]
-        pub sin6_family: sa_family_t,
-        pub sin6_port: u16,
-        pub sin6_addr: in6_addr,
-        pub sin6_flowinfo: u32,
-        pub sin6_scope_id: u32,
-    }
-}

--- a/library/std/src/sys/net/connection/xous/mod.rs
+++ b/library/std/src/sys/net/connection/xous/mod.rs
@@ -46,38 +46,3 @@ pub struct GetAddress {
 }
 
 pub use dns::LookupHost;
-
-#[allow(nonstandard_style)]
-pub mod netc {
-    pub const AF_INET: u8 = 0;
-    pub const AF_INET6: u8 = 1;
-    pub type sa_family_t = u8;
-
-    #[derive(Copy, Clone)]
-    pub struct in_addr {
-        pub s_addr: u32,
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in {
-        #[allow(dead_code)]
-        pub sin_family: sa_family_t,
-        pub sin_port: u16,
-        pub sin_addr: in_addr,
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct in6_addr {
-        pub s6_addr: [u8; 16],
-    }
-
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in6 {
-        #[allow(dead_code)]
-        pub sin6_family: sa_family_t,
-        pub sin6_port: u16,
-        pub sin6_addr: in6_addr,
-        pub sin6_flowinfo: u32,
-        pub sin6_scope_id: u32,
-    }
-}


### PR DESCRIPTION
Having these implementation available crate-wide means that platforms not using sockets for their networking code have to stub out the libc definitions required to support them. This PR moves the conversions to private helper functions that are only available where actually needed.

I also fixed the signature of the function converting from a C socket address to a Rust one: taking a reference to a `sockaddr_storage` resulted in unsound usage inside  `LookupHost::next`, which could create a reference to a structure smaller than `sockaddr_storage`. Thus I've replaced the argument type with a pointer and made the function `unsafe`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
