### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_codegen_gcc/src/base.rs
+++ b/compiler/rustc_codegen_gcc/src/base.rs
@@ -51,7 +51,6 @@ pub fn global_linkage_to_gcc(linkage: Linkage) -> GlobalKind {
         Linkage::WeakODR => unimplemented!(),
         Linkage::Appending => unimplemented!(),
         Linkage::Internal => GlobalKind::Internal,
-        Linkage::Private => GlobalKind::Internal,
         Linkage::ExternalWeak => GlobalKind::Imported, // TODO(antoyo): should be weak linkage.
         Linkage::Common => unimplemented!(),
     }
@@ -68,7 +67,6 @@ pub fn linkage_to_gcc(linkage: Linkage) -> FunctionType {
         Linkage::WeakODR => unimplemented!(),
         Linkage::Appending => unimplemented!(),
         Linkage::Internal => FunctionType::Internal,
-        Linkage::Private => FunctionType::Internal,
         Linkage::ExternalWeak => unimplemented!(),
         Linkage::Common => unimplemented!(),
     }

--- a/compiler/rustc_codegen_gcc/src/base.rs
+++ b/compiler/rustc_codegen_gcc/src/base.rs
@@ -49,7 +49,6 @@ pub fn global_linkage_to_gcc(linkage: Linkage) -> GlobalKind {
         Linkage::LinkOnceODR => unimplemented!(),
         Linkage::WeakAny => unimplemented!(),
         Linkage::WeakODR => unimplemented!(),
-        Linkage::Appending => unimplemented!(),
         Linkage::Internal => GlobalKind::Internal,
         Linkage::ExternalWeak => GlobalKind::Imported, // TODO(antoyo): should be weak linkage.
         Linkage::Common => unimplemented!(),
@@ -65,7 +64,6 @@ pub fn linkage_to_gcc(linkage: Linkage) -> FunctionType {
         Linkage::LinkOnceODR => unimplemented!(),
         Linkage::WeakAny => FunctionType::Exported, // FIXME(antoyo): should be similar to linkonce.
         Linkage::WeakODR => unimplemented!(),
-        Linkage::Appending => unimplemented!(),
         Linkage::Internal => FunctionType::Internal,
         Linkage::ExternalWeak => unimplemented!(),
         Linkage::Common => unimplemented!(),

--- a/compiler/rustc_codegen_gcc/src/mono_item.rs
+++ b/compiler/rustc_codegen_gcc/src/mono_item.rs
@@ -61,10 +61,7 @@ impl<'gcc, 'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
         // compiler-rt, then we want to implicitly compile everything with hidden
         // visibility as we're going to link this object all over the place but
         // don't want the symbols to get exported.
-        if linkage != Linkage::Internal
-            && linkage != Linkage::Private
-            && self.tcx.is_compiler_builtins(LOCAL_CRATE)
-        {
+        if linkage != Linkage::Internal && self.tcx.is_compiler_builtins(LOCAL_CRATE) {
             #[cfg(feature = "master")]
             decl.add_attribute(FnAttribute::Visibility(gccjit::Visibility::Hidden));
         } else {

--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -157,7 +157,6 @@ pub(crate) fn linkage_to_llvm(linkage: Linkage) -> llvm::Linkage {
         Linkage::LinkOnceODR => llvm::Linkage::LinkOnceODRLinkage,
         Linkage::WeakAny => llvm::Linkage::WeakAnyLinkage,
         Linkage::WeakODR => llvm::Linkage::WeakODRLinkage,
-        Linkage::Appending => llvm::Linkage::AppendingLinkage,
         Linkage::Internal => llvm::Linkage::InternalLinkage,
         Linkage::ExternalWeak => llvm::Linkage::ExternalWeakLinkage,
         Linkage::Common => llvm::Linkage::CommonLinkage,

--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -159,7 +159,6 @@ pub(crate) fn linkage_to_llvm(linkage: Linkage) -> llvm::Linkage {
         Linkage::WeakODR => llvm::Linkage::WeakODRLinkage,
         Linkage::Appending => llvm::Linkage::AppendingLinkage,
         Linkage::Internal => llvm::Linkage::InternalLinkage,
-        Linkage::Private => llvm::Linkage::PrivateLinkage,
         Linkage::ExternalWeak => llvm::Linkage::ExternalWeakLinkage,
         Linkage::Common => llvm::Linkage::CommonLinkage,
     }

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -319,19 +319,16 @@ fn build_subroutine_type_di_node<'ll, 'tcx>(
     // This is actually a function pointer, so wrap it in pointer DI.
     let name = compute_debuginfo_type_name(cx.tcx, fn_ty, false);
     let (size, align) = match fn_ty.kind() {
-        ty::FnDef(..) => (0, 1),
-        ty::FnPtr(..) => (
-            cx.tcx.data_layout.pointer_size.bits(),
-            cx.tcx.data_layout.pointer_align.abi.bits() as u32,
-        ),
+        ty::FnDef(..) => (Size::ZERO, Align::ONE),
+        ty::FnPtr(..) => (cx.tcx.data_layout.pointer_size, cx.tcx.data_layout.pointer_align.abi),
         _ => unreachable!(),
     };
     let di_node = unsafe {
         llvm::LLVMRustDIBuilderCreatePointerType(
             DIB(cx),
             fn_di_node,
-            size,
-            align,
+            size.bits(),
+            align.bits() as u32,
             0, // Ignore DWARF address space.
             name.as_c_char_ptr(),
             name.len(),

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -633,7 +633,7 @@ impl<'ll, 'tcx> DebugInfoCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                 true,
                 DIFlags::FlagZero,
                 argument_index,
-                align.bytes() as u32,
+                align.bits() as u32,
             )
         }
     }

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -97,7 +97,11 @@ impl<'ll, 'tcx> CodegenUnitDebugContext<'ll, 'tcx> {
                 // Android has the same issue (#22398)
                 llvm::add_module_flag_u32(
                     self.llmod,
-                    llvm::ModuleFlagMergeBehavior::Warning,
+                    // In the case where multiple CGUs with different dwarf version
+                    // values are being merged together, such as with cross-crate
+                    // LTO, then we want to use the highest version of dwarf
+                    // we can. This matches Clang's behavior as well.
+                    llvm::ModuleFlagMergeBehavior::Max,
                     "Dwarf Version",
                     sess.dwarf_version(),
                 );

--- a/compiler/rustc_codegen_llvm/src/mono_item.rs
+++ b/compiler/rustc_codegen_llvm/src/mono_item.rs
@@ -71,10 +71,7 @@ impl<'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'_, 'tcx> {
         // compiler-rt, then we want to implicitly compile everything with hidden
         // visibility as we're going to link this object all over the place but
         // don't want the symbols to get exported.
-        if linkage != Linkage::Internal
-            && linkage != Linkage::Private
-            && self.tcx.is_compiler_builtins(LOCAL_CRATE)
-        {
+        if linkage != Linkage::Internal && self.tcx.is_compiler_builtins(LOCAL_CRATE) {
             llvm::set_visibility(lldecl, llvm::Visibility::Hidden);
         } else {
             llvm::set_visibility(lldecl, base::visibility_to_llvm(visibility));

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -41,7 +41,6 @@ fn linkage_by_name(tcx: TyCtxt<'_>, def_id: LocalDefId, name: &str) -> Linkage {
     // ghost, dllimport, dllexport and linkonce_odr_autohide are not supported
     // and don't have to be, LLVM treats them as no-ops.
     match name {
-        "appending" => Appending,
         "available_externally" => AvailableExternally,
         "common" => Common,
         "extern_weak" => ExternalWeak,

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -49,7 +49,6 @@ fn linkage_by_name(tcx: TyCtxt<'_>, def_id: LocalDefId, name: &str) -> Linkage {
         "internal" => Internal,
         "linkonce" => LinkOnceAny,
         "linkonce_odr" => LinkOnceODR,
-        "private" => Private,
         "weak" => WeakAny,
         "weak_odr" => WeakODR,
         _ => tcx.dcx().span_fatal(tcx.def_span(def_id), "invalid linkage specified"),

--- a/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
@@ -187,7 +187,7 @@ fn prefix_and_suffix<'tcx>(
                     }
                 }
             }
-            Linkage::Internal | Linkage::Private => {
+            Linkage::Internal => {
                 // write nothing
             }
             Linkage::Appending => emit_fatal("Only global variables can have appending linkage!"),

--- a/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
@@ -190,7 +190,6 @@ fn prefix_and_suffix<'tcx>(
             Linkage::Internal => {
                 // write nothing
             }
-            Linkage::Appending => emit_fatal("Only global variables can have appending linkage!"),
             Linkage::Common => emit_fatal("Functions may not have common linkage"),
             Linkage::AvailableExternally => {
                 // this would make the function equal an extern definition

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -178,7 +178,7 @@ impl CodegenFnAttrs {
             || match self.linkage {
                 // These are private, so make sure we don't try to consider
                 // them external.
-                None | Some(Linkage::Internal | Linkage::Private) => false,
+                None | Some(Linkage::Internal) => false,
                 Some(_) => true,
             }
     }

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -329,7 +329,6 @@ pub enum Linkage {
     WeakODR,
     Appending,
     Internal,
-    Private,
     ExternalWeak,
     Common,
 }

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -327,7 +327,6 @@ pub enum Linkage {
     LinkOnceODR,
     WeakAny,
     WeakODR,
-    Appending,
     Internal,
     ExternalWeak,
     Common,

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -1238,7 +1238,6 @@ fn collect_and_partition_mono_items(tcx: TyCtxt<'_>, (): ()) -> MonoItemPartitio
                         Linkage::LinkOnceODR => "OnceODR",
                         Linkage::WeakAny => "WeakAny",
                         Linkage::WeakODR => "WeakODR",
-                        Linkage::Appending => "Appending",
                         Linkage::Internal => "Internal",
                         Linkage::ExternalWeak => "ExternalWeak",
                         Linkage::Common => "Common",

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -1240,7 +1240,6 @@ fn collect_and_partition_mono_items(tcx: TyCtxt<'_>, (): ()) -> MonoItemPartitio
                         Linkage::WeakODR => "WeakODR",
                         Linkage::Appending => "Appending",
                         Linkage::Internal => "Internal",
-                        Linkage::Private => "Private",
                         Linkage::ExternalWeak => "ExternalWeak",
                         Linkage::Common => "Common",
                     };

--- a/compiler/rustc_target/src/spec/targets/i686_unknown_hurd_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_unknown_hurd_gnu.rs
@@ -2,7 +2,7 @@ use crate::spec::{Cc, LinkerFlavor, Lld, StackProbeType, Target, base};
 
 pub(crate) fn target() -> Target {
     let mut base = base::hurd_gnu::opts();
-    base.cpu = "pentiumpro".into();
+    base.cpu = "pentium4".into();
     base.max_atomic_width = Some(64);
     base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m32"]);
     base.stack_probes = StackProbeType::Inline;

--- a/src/bootstrap/src/utils/exec.rs
+++ b/src/bootstrap/src/utils/exec.rs
@@ -1,3 +1,8 @@
+//! Command Execution Module
+//!
+//! This module provides a structured way to execute and manage commands efficiently,
+//! ensuring controlled failure handling and output management.
+
 use std::ffi::OsStr;
 use std::fmt::{Debug, Formatter};
 use std::path::Path;

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -312,7 +312,7 @@ target | std | host | notes
 [`i586-unknown-netbsd`](platform-support/netbsd.md) | ✓ |  | 32-bit x86 (original Pentium) [^x86_32-floats-x87]
 [`i686-apple-darwin`](platform-support/apple-darwin.md) | ✓ | ✓ | 32-bit macOS (10.12+, Sierra+, Penryn) [^x86_32-floats-return-ABI]
 `i686-unknown-haiku` | ✓ | ✓ | 32-bit Haiku (Pentium 4) [^x86_32-floats-return-ABI]
-[`i686-unknown-hurd-gnu`](platform-support/hurd.md) | ✓ | ✓ | 32-bit GNU/Hurd (PentiumPro) [^x86_32-floats-x87]
+[`i686-unknown-hurd-gnu`](platform-support/hurd.md) | ✓ | ✓ | 32-bit GNU/Hurd (Pentium 4) [^x86_32-floats-x87]
 [`i686-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | NetBSD/i386 (Pentium 4) [^x86_32-floats-return-ABI]
 [`i686-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | 32-bit OpenBSD (Pentium 4) [^x86_32-floats-return-ABI]
 [`i686-unknown-redox`](platform-support/redox.md) | ✓ |  | i686 Redox OS (PentiumPro) [^x86_32-floats-x87]

--- a/tests/assembly/auxiliary/dwarf-mixed-versions-lto-aux.rs
+++ b/tests/assembly/auxiliary/dwarf-mixed-versions-lto-aux.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -g --crate-type=rlib -Zdwarf-version=4
+
+pub fn check_is_even(number: &u64) -> bool {
+    number % 2 == 0
+}

--- a/tests/assembly/dwarf-mixed-versions-lto.rs
+++ b/tests/assembly/dwarf-mixed-versions-lto.rs
@@ -1,0 +1,19 @@
+// This test ensures that if LTO occurs between crates with different DWARF versions, we
+// will choose the highest DWARF version for the final binary. This matches Clang's behavior.
+
+//@ only-linux
+//@ aux-build:dwarf-mixed-versions-lto-aux.rs
+//@ compile-flags: -C lto -g -Zdwarf-version=5
+//@ assembly-output: emit-asm
+//@ no-prefer-dynamic
+
+extern crate dwarf_mixed_versions_lto_aux;
+
+fn main() {
+    dwarf_mixed_versions_lto_aux::check_is_even(&0);
+}
+
+// CHECK: .section .debug_info
+// CHECK-NOT: .short 2
+// CHECK-NOT: .short 4
+// CHECK: .short 5

--- a/tests/codegen/debug-fndef-size.rs
+++ b/tests/codegen/debug-fndef-size.rs
@@ -1,4 +1,6 @@
-// Verify that `i32::cmp` FnDef type is declared with size 0 and align 1 in LLVM debuginfo.
+// Verify that `i32::cmp` FnDef type is declared with a size of 0 and an
+// alignment of 8 bits (1 byte) in LLVM debuginfo.
+
 //@ compile-flags: -O -g -Cno-prepopulate-passes
 //@ ignore-msvc the types are mangled differently
 
@@ -14,5 +16,5 @@ pub fn main() {
 
 // CHECK: %compare.dbg.spill = alloca [0 x i8], align 1
 // CHECK: dbg{{.}}declare({{(metadata )?}}ptr %compare.dbg.spill, {{(metadata )?}}![[VAR:.*]], {{(metadata )?}}!DIExpression()
-// CHECK: ![[TYPE:.*]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "fn(&i32, &i32) -> core::cmp::Ordering", baseType: !{{.*}}, align: 1, dwarfAddressSpace: {{.*}})
-// CHECK: ![[VAR]] = !DILocalVariable(name: "compare", scope: !{{.*}}, file: !{{.*}}, line: {{.*}}, type: ![[TYPE]], align: 1)
+// CHECK: ![[TYPE:.*]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "fn(&i32, &i32) -> core::cmp::Ordering", baseType: !{{.*}}, align: 8, dwarfAddressSpace: {{.*}})
+// CHECK: ![[VAR]] = !DILocalVariable(name: "compare", scope: !{{.*}}, file: !{{.*}}, line: {{.*}}, type: ![[TYPE]], align: 8)

--- a/tests/run-make/libs-through-symlinks/rmake.rs
+++ b/tests/run-make/libs-through-symlinks/rmake.rs
@@ -21,6 +21,7 @@
 //! <https://github.com/rust-lang/rust/pull/13903>.
 
 //@ ignore-cross-compile
+//@ needs-symlink
 
 use run_make_support::{bare_rustc, cwd, path, rfs, rust_lib_name};
 

--- a/tests/ui/argument-suggestions/extern-fn-arg-names.stderr
+++ b/tests/ui/argument-suggestions/extern-fn-arg-names.stderr
@@ -14,7 +14,7 @@ note: function defined here
   --> $DIR/extern-fn-arg-names.rs:2:8
    |
 LL |     fn dstfn(src: i32, dst: err);
-   |        ^^^^^
+   |        ^^^^^           ---
 help: provide the argument
    |
 LL |     dstfn(1, /* dst */);

--- a/tests/ui/c-variadic/variadic-ffi-1.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-1.stderr
@@ -14,7 +14,7 @@ note: function defined here
   --> $DIR/variadic-ffi-1.rs:15:8
    |
 LL |     fn foo(f: isize, x: u8, ...);
-   |        ^^^
+   |        ^^^ -         -
 help: provide the arguments
    |
 LL |         foo(/* isize */, /* u8 */);
@@ -30,7 +30,7 @@ note: function defined here
   --> $DIR/variadic-ffi-1.rs:15:8
    |
 LL |     fn foo(f: isize, x: u8, ...);
-   |        ^^^
+   |        ^^^           -
 help: provide the argument
    |
 LL |         foo(1, /* u8 */);

--- a/tests/ui/error-codes/E0060.stderr
+++ b/tests/ui/error-codes/E0060.stderr
@@ -8,7 +8,7 @@ note: function defined here
   --> $DIR/E0060.rs:2:8
    |
 LL |     fn printf(_: *const u8, ...) -> u32;
-   |        ^^^^^^
+   |        ^^^^^^ -
 help: provide the argument
    |
 LL |     unsafe { printf(/* *const u8 */); }

--- a/tests/ui/fn/param-mismatch-foreign.rs
+++ b/tests/ui/fn/param-mismatch-foreign.rs
@@ -1,0 +1,11 @@
+extern "C" {
+    fn foo(x: i32, y: u32, z: i32);
+    //~^ NOTE function defined here
+}
+
+fn main() {
+    foo(1i32, 2i32);
+    //~^ ERROR this function takes 3 arguments but 2 arguments were supplied
+    //~| NOTE argument #2 of type `u32` is missing
+    //~| HELP provide the argument
+}

--- a/tests/ui/fn/param-mismatch-foreign.stderr
+++ b/tests/ui/fn/param-mismatch-foreign.stderr
@@ -1,0 +1,19 @@
+error[E0061]: this function takes 3 arguments but 2 arguments were supplied
+  --> $DIR/param-mismatch-foreign.rs:7:5
+   |
+LL |     foo(1i32, 2i32);
+   |     ^^^       ---- argument #2 of type `u32` is missing
+   |
+note: function defined here
+  --> $DIR/param-mismatch-foreign.rs:2:8
+   |
+LL |     fn foo(x: i32, y: u32, z: i32);
+   |        ^^^         -
+help: provide the argument
+   |
+LL |     foo(1i32, /* u32 */, 2i32);
+   |        ~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0061`.

--- a/tests/ui/linkage-attr/linkage-attr-does-not-panic-llvm-issue-33992.rs
+++ b/tests/ui/linkage-attr/linkage-attr-does-not-panic-llvm-issue-33992.rs
@@ -18,9 +18,6 @@ pub static TEST4: bool = true;
 #[linkage = "linkonce_odr"]
 pub static TEST5: bool = true;
 
-#[linkage = "private"]
-pub static TEST6: bool = true;
-
 #[linkage = "weak"]
 pub static TEST7: bool = true;
 

--- a/tests/ui/lto/auxiliary/dwarf-mixed-versions-lto-aux.rs
+++ b/tests/ui/lto/auxiliary/dwarf-mixed-versions-lto-aux.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -g --crate-type=rlib -Zdwarf-version=4
+
+pub fn say_hi() {
+    println!("hello there")
+}

--- a/tests/ui/lto/dwarf-mixed-versions-lto.rs
+++ b/tests/ui/lto/dwarf-mixed-versions-lto.rs
@@ -1,0 +1,15 @@
+// This test verifies that we do not produce a warning when performing LTO on a
+// crate graph that contains a mix of different DWARF version settings. This
+// matches Clang's behavior.
+
+//@ ignore-msvc Platform must use DWARF
+//@ aux-build:dwarf-mixed-versions-lto-aux.rs
+//@ compile-flags: -C lto -g -Zdwarf-version=5
+//@ no-prefer-dynamic
+//@ build-pass
+
+extern crate dwarf_mixed_versions_lto_aux;
+
+fn main() {
+    dwarf_mixed_versions_lto_aux::say_hi();
+}

--- a/tests/ui/lto/dwarf-mixed-versions-lto.stderr
+++ b/tests/ui/lto/dwarf-mixed-versions-lto.stderr
@@ -1,0 +1,4 @@
+warning: linking module flags 'Dwarf Version': IDs have conflicting values ('i32 4' from  with 'i32 5' from dwarf_mixed_versions_lto.7f4a44b55cf2f174-cgu.0)
+
+warning: 1 warning emitted
+

--- a/tests/ui/lto/dwarf-mixed-versions-lto.stderr
+++ b/tests/ui/lto/dwarf-mixed-versions-lto.stderr
@@ -1,4 +1,0 @@
-warning: linking module flags 'Dwarf Version': IDs have conflicting values ('i32 4' from  with 'i32 5' from dwarf_mixed_versions_lto.7f4a44b55cf2f174-cgu.0)
-
-warning: 1 warning emitted
-

--- a/tests/ui/mismatched_types/issue-26480.stderr
+++ b/tests/ui/mismatched_types/issue-26480.stderr
@@ -13,7 +13,7 @@ note: function defined here
   --> $DIR/issue-26480.rs:2:8
    |
 LL |     fn write(fildes: i32, buf: *const i8, nbyte: u64) -> i64;
-   |        ^^^^^
+   |        ^^^^^                              -----
    = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
    |

--- a/tests/ui/suggestions/suggest-null-ptr.stderr
+++ b/tests/ui/suggestions/suggest-null-ptr.stderr
@@ -12,7 +12,7 @@ note: function defined here
   --> $DIR/suggest-null-ptr.rs:7:8
    |
 LL |     fn foo(ptr: *const u8);
-   |        ^^^
+   |        ^^^ ---
 help: if you meant to create a null pointer, use `std::ptr::null()`
    |
 LL |         foo(std::ptr::null());
@@ -32,7 +32,7 @@ note: function defined here
   --> $DIR/suggest-null-ptr.rs:9:8
    |
 LL |     fn foo_mut(ptr: *mut u8);
-   |        ^^^^^^^
+   |        ^^^^^^^ ---
 help: if you meant to create a null pointer, use `std::ptr::null_mut()`
    |
 LL |         foo_mut(std::ptr::null_mut());
@@ -52,7 +52,7 @@ note: function defined here
   --> $DIR/suggest-null-ptr.rs:11:8
    |
 LL |     fn usize(ptr: *const usize);
-   |        ^^^^^
+   |        ^^^^^ ---
 help: if you meant to create a null pointer, use `std::ptr::null()`
    |
 LL |         usize(std::ptr::null());
@@ -72,7 +72,7 @@ note: function defined here
   --> $DIR/suggest-null-ptr.rs:13:8
    |
 LL |     fn usize_mut(ptr: *mut usize);
-   |        ^^^^^^^^^
+   |        ^^^^^^^^^ ---
 help: if you meant to create a null pointer, use `std::ptr::null_mut()`
    |
 LL |         usize_mut(std::ptr::null_mut());


### PR DESCRIPTION
Successful merges:

 - #136640 (Debuginfo for function ZSTs should have alignment of 8 bits, not 1 bit)
 - #136648 (Add a missing `//@ needs-symlink` to `tests/run-make/libs-through-symlinks`)
 - #136651 (Label mismatched parameters at the def site for foreign functions)
 - #136659 (Pick the max DWARF version when LTO'ing modules with different versions )
 - #136691 (Remove Linkage::Private and Linkage::Appending)
 - #136692 (add module level doc for bootstrap:utils:exec)
 - #136700 (i686-unknown-hurd-gnu: bump baseline CPU to Pentium 4)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=136640,136648,136651,136659,136691,136692,136700)
<!-- homu-ignore:end -->