### PR TITLE
StripDebugInfo can be disabled by #[optimize(none)]

### DIFF
--- a/compiler/rustc_mir_transform/src/strip_debuginfo.rs
+++ b/compiler/rustc_mir_transform/src/strip_debuginfo.rs
@@ -33,6 +33,6 @@ impl<'tcx> crate::MirPass<'tcx> for StripDebugInfo {
     }
 
     fn is_required(&self) -> bool {
-        true
+        false
     }
 }

--- a/tests/codegen/optimize-attr-1.rs
+++ b/tests/codegen/optimize-attr-1.rs
@@ -1,5 +1,6 @@
-//@ revisions: NO-OPT SIZE-OPT SPEED-OPT
+//@ revisions: NO-OPT DEBUGINFO SIZE-OPT SPEED-OPT
 //@[NO-OPT] compile-flags: -Copt-level=0 -Ccodegen-units=1
+//@[DEBUGINFO] compile-flags: -Copt-level=1 -Ccodegen-units=1 -Cdebuginfo=full -Zmir_strip_debuginfo=all-locals
 //@[SIZE-OPT] compile-flags: -Copt-level=s -Ccodegen-units=1
 //@[SPEED-OPT] compile-flags: -Copt-level=3 -Ccodegen-units=1
 
@@ -27,6 +28,7 @@ pub fn size() -> i32 {
 
 // CHECK-LABEL: define{{.*}}i32 @speed
 // NO-OPT-SAME: [[NOTHING_ATTRS]]
+// DEBUGINFO-SAME: [[NOTHING_ATTRS]]
 // SPEED-OPT-SAME: [[NOTHING_ATTRS]]
 // SIZE-OPT-SAME: [[SPEED_ATTRS:#[0-9]+]]
 // SIZE-OPT: ret i32 8
@@ -41,14 +43,16 @@ pub fn speed() -> i32 {
 // CHECK-SAME: [[NONE_ATTRS:#[0-9]+]]
 // SIZE-OPT: alloca
 // SPEED-OPT: alloca
+// DEBUGINFO-DAG: !DILocalVariable(name: "some_local_variable"
 #[no_mangle]
 #[optimize(none)]
 pub fn none() -> i32 {
-    let arr = [0, 1, 2, 3, 4];
-    arr[4]
+    let some_local_variable = [0, 1, 2, 3, 4];
+    some_local_variable[4]
 }
 
 // NO-OPT-DAG: attributes [[SIZE_ATTRS]] = {{.*}}minsize{{.*}}optsize{{.*}}
+// DEBUGINFO-DAG: attributes [[SIZE_ATTRS]] = {{.*}}minsize{{.*}}optsize{{.*}}
 // SPEED-OPT-DAG: attributes [[SIZE_ATTRS]] = {{.*}}minsize{{.*}}optsize{{.*}}
 // SIZE-OPT-DAG: attributes [[NOTHING_ATTRS]] = {{.*}}optsize{{.*}}
 // SIZE-OPT-DAG: attributes [[SIZE_ATTRS]] = {{.*}}minsize{{.*}}optsize{{.*}}


### PR DESCRIPTION
7a9661d768f5 unnecessarily made this pass required. `var_debug_info` is only for debug info, and doesn't affect soundness.

Extra debug info for local variables can be kept when using `#[optimize(none)]`. The equivalent [clang attribute](https://clang.llvm.org/docs/AttributeReference.html#optnone) is meant to improve debugging experience:

> This is particularly useful when you need to debug a particular function

Note that it's only info about local variables, and that debug info won't be _added_ by `#[optimize(none)]`, only preserved when `-Cdebuginfo=full` is also enabled.
