### PR TITLE
transmutability: fix ICE when passing wrong ADT to ASSUME

### DIFF
--- a/tests/ui/transmutability/malformed-program-gracefulness/wrong-adt-assume.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/wrong-adt-assume.rs
@@ -1,0 +1,20 @@
+//! Test that we don't ICE when passing the wrong ADT to ASSUME.
+
+#![feature(adt_const_params)]
+#![feature(transmutability)]
+
+use std::marker::ConstParamTy;
+use std::mem::TransmuteFrom;
+
+#[derive(ConstParamTy, PartialEq, Eq)]
+struct NotAssume;
+
+fn foo<const ASSUME: NotAssume>()
+where
+    u8: TransmuteFrom<u8, ASSUME>, //~ ERROR the constant `ASSUME` is not of type `Assume`
+{
+}
+
+fn main() {
+    foo::<{ NotAssume }>();
+}

--- a/tests/ui/transmutability/malformed-program-gracefulness/wrong-adt-assume.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/wrong-adt-assume.stderr
@@ -1,0 +1,11 @@
+error: the constant `ASSUME` is not of type `Assume`
+  --> $DIR/wrong-adt-assume.rs:14:9
+   |
+LL |     u8: TransmuteFrom<u8, ASSUME>,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Assume`, found `NotAssume`
+   |
+note: required by a const generic parameter in `TransmuteFrom`
+  --> $SRC_DIR/core/src/mem/transmutability.rs:LL:COL
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
- Remove an incorrect assert that the `ASSUME` parameter has the type `Assume` and delay a bug instead.
- Since we checked the type of `ASSUME` is `Assume` (an ADT), its valtree must be a branch, so we can just unwrap it.

r? @jswrenn