### PR TITLE
rustc_middle: parallel: TyCtxt: remove "unsafe impl DynSend/DynSync"

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1290,9 +1290,6 @@ pub struct TyCtxt<'tcx> {
     gcx: &'tcx GlobalCtxt<'tcx>,
 }
 
-// Explicitly implement `DynSync` and `DynSend` for `TyCtxt` to short circuit trait resolution.
-unsafe impl DynSend for TyCtxt<'_> {}
-unsafe impl DynSync for TyCtxt<'_> {}
 fn _assert_tcx_fields() {
     sync::assert_dyn_sync::<&'_ GlobalCtxt<'_>>();
     sync::assert_dyn_send::<&'_ GlobalCtxt<'_>>();


### PR DESCRIPTION
rustc_middle: parallel: TyCtxt: remove "unsafe impl DynSend/DynSync"

We don't need to "short circuit trait resolution", because DynSend and DynSync are auto traits and thus coinductive

cc "Parallel Rustc Front-end" https://github.com/rust-lang/rust/issues/113349

r? SparrowLii

@rustbot label: +WG-compiler-parallel

(rustbot sometimes ignores me and doesn't attach labels on my behalf. rustbot banned me?)