### PR TITLE
Implement `Random` for array

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -430,12 +430,7 @@ impl<T: Clone, const N: usize> Clone for [T; N] {
 #[unstable(feature = "random", issue = "130703")]
 impl<T: Random, const N: usize> Random for [T; N] {
     fn random(source: &mut (impl RandomSource + ?Sized)) -> Self {
-        let mut buf = [const { MaybeUninit::uninit() }; N];
-        for elem in &mut buf {
-            elem.write(T::random(source));
-        }
-        // SAFETY: all elements of the array were initialized.
-        unsafe { mem::transmute_copy(&buf) }
+        from_fn(|_| T::random(source))
     }
 }
 

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -18,7 +18,7 @@ use crate::ops::{
 };
 use crate::ptr::{null, null_mut};
 use crate::random::{Random, RandomSource};
-use crate::slice::{self, Iter, IterMut};
+use crate::slice::{Iter, IterMut};
 
 mod ascii;
 mod drain;
@@ -455,12 +455,9 @@ macro_rules! impl_random_for_integer_array {
                 // SAFETY: all elements in the buffer were initialized with
                 // random bytes.
                 unsafe {
-                    let bytes = slice::from_raw_parts_mut(
-                        &raw mut buf as *mut u8,
-                        N * (<$t>::BITS as usize / 8),
-                    );
+                    let bytes = buf.as_bytes_mut().assume_init_mut();
                     source.fill_bytes(bytes);
-                    mem::transmute_copy(&buf)
+                    MaybeUninit::array_assume_init(buf)
                 }
             }
         }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/136732)*
<!-- homu-ignore:end -->

Implement `Random` for `[T; N]`, where `Random` is implemented for `T`.

<https://github.com/rust-lang/libs-team/issues/393#issue-2345931645> states:

> The trait `Random` will initially be implemented for all iN and uN integer types, `isize`/`usize`, and `bool`, as well as **arrays**** and tuples of such values.

This PR is also based on <https://github.com/rust-lang/rust/issues/130703#issuecomment-2639855152>.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: rust-lang/rust#130703