### PR TITLE
Implement `Random` for `num::{Saturating,Wrapping}`

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -6,7 +6,6 @@ use crate::hash::{Hash, Hasher};
 use crate::marker::{Freeze, StructuralPartialEq};
 use crate::ops::{BitOr, BitOrAssign, Div, DivAssign, Neg, Rem, RemAssign};
 use crate::panic::{RefUnwindSafe, UnwindSafe};
-use crate::random::{Random, RandomSource};
 use crate::str::FromStr;
 use crate::{fmt, intrinsics, ptr, ub_checks};
 
@@ -358,17 +357,6 @@ where
     #[inline]
     fn bitor_assign(&mut self, rhs: T) {
         *self = *self | rhs;
-    }
-}
-
-#[unstable(feature = "random", issue = "130703")]
-impl<T: ZeroablePrimitive + Random> Random for NonZero<T> {
-    fn random(source: &mut (impl RandomSource + ?Sized)) -> Self {
-        loop {
-            if let Some(n) = Self::new(T::random(source)) {
-                break n;
-            }
-        }
     }
 }
 

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -6,6 +6,7 @@ use crate::hash::{Hash, Hasher};
 use crate::marker::{Freeze, StructuralPartialEq};
 use crate::ops::{BitOr, BitOrAssign, Div, DivAssign, Neg, Rem, RemAssign};
 use crate::panic::{RefUnwindSafe, UnwindSafe};
+use crate::random::{Random, RandomSource};
 use crate::str::FromStr;
 use crate::{fmt, intrinsics, ptr, ub_checks};
 
@@ -357,6 +358,17 @@ where
     #[inline]
     fn bitor_assign(&mut self, rhs: T) {
         *self = *self | rhs;
+    }
+}
+
+#[unstable(feature = "random", issue = "130703")]
+impl<T: ZeroablePrimitive + Random> Random for NonZero<T> {
+    fn random(source: &mut (impl RandomSource + ?Sized)) -> Self {
+        loop {
+            if let Some(n) = Self::new(T::random(source)) {
+                break n;
+            }
+        }
     }
 }
 

--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -5,6 +5,7 @@ use crate::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Sub, SubAssign,
 };
+use crate::random::{Random, RandomSource};
 
 /// Provides intentionally-saturating arithmetic on `T`.
 ///
@@ -76,6 +77,13 @@ impl<T: fmt::LowerHex> fmt::LowerHex for Saturating<T> {
 impl<T: fmt::UpperHex> fmt::UpperHex for Saturating<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+#[unstable(feature = "random", issue = "130703")]
+impl<T: Random> Random for Saturating<T> {
+    fn random(source: &mut (impl RandomSource + ?Sized)) -> Self {
+        Self(T::random(source))
     }
 }
 

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -5,6 +5,7 @@ use crate::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
 };
+use crate::random::{Random, RandomSource};
 
 /// Provides intentionally-wrapped arithmetic on `T`.
 ///
@@ -81,6 +82,13 @@ impl<T: fmt::LowerHex> fmt::LowerHex for Wrapping<T> {
 impl<T: fmt::UpperHex> fmt::UpperHex for Wrapping<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+#[unstable(feature = "random", issue = "130703")]
+impl<T: Random> Random for Wrapping<T> {
+    fn random(source: &mut (impl RandomSource + ?Sized)) -> Self {
+        Self(T::random(source))
     }
 }
 


### PR DESCRIPTION
<https://github.com/rust-lang/libs-team/issues/393#issue-2345931645> states:

> We can implement `Random` for many more types, such as `NonZero<T>` and `Wrapping<T>`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: #130703