### PR TITLE
Emit an error if `-Zdwarf-version=1` is requested

### DIFF
--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -133,7 +133,8 @@ session_unstable_virtual_function_elimination = `-Zvirtual-function-elimination`
 session_unsupported_crate_type_for_target =
     dropping unsupported crate type `{$crate_type}` for target `{$target_triple}`
 
-session_unsupported_dwarf_version = requested DWARF version {$dwarf_version} is greater than 5
+session_unsupported_dwarf_version = requested DWARF version {$dwarf_version} is not supported
+session_unsupported_dwarf_version_help = supported DWARF versions are 2, 3, 4 and 5
 
 session_unsupported_reg_struct_return_arch = `-Zreg-struct-return` is only supported on x86
 session_unsupported_regparm = `-Zregparm={$regparm}` is unsupported (valid values 0-3)

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -161,6 +161,7 @@ pub(crate) struct UnstableVirtualFunctionElimination;
 
 #[derive(Diagnostic)]
 #[diag(session_unsupported_dwarf_version)]
+#[help(session_unsupported_dwarf_version_help)]
 pub(crate) struct UnsupportedDwarfVersion {
     pub(crate) dwarf_version: u32,
 }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1251,7 +1251,8 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     }
 
     if let Some(dwarf_version) = sess.opts.unstable_opts.dwarf_version {
-        if dwarf_version > 5 {
+        // DWARF 1 is not supported by LLVM and DWARF 6 is not yet finalized.
+        if dwarf_version < 2 || dwarf_version > 5 {
             sess.dcx().emit_err(errors::UnsupportedDwarfVersion { dwarf_version });
         }
     }

--- a/tests/ui/debuginfo/dwarf-versions.one.stderr
+++ b/tests/ui/debuginfo/dwarf-versions.one.stderr
@@ -1,0 +1,6 @@
+error: requested DWARF version 1 is not supported
+   |
+   = help: supported DWARF versions are 2, 3, 4 and 5
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/dwarf-versions.rs
+++ b/tests/ui/debuginfo/dwarf-versions.rs
@@ -1,0 +1,38 @@
+// This test verifies the expected behavior of various options passed to
+// `-Zdwarf-version`: 2 - 5 (valid) with all other options being invalid.
+
+//@ revisions: zero one two three four five six
+
+//@[zero] compile-flags: -Zdwarf-version=0
+//@[zero] error-pattern: requested DWARF version 0 is not supported
+
+//@[one] compile-flags: -Zdwarf-version=1
+//@[one] error-pattern: requested DWARF version 1 is not supported
+
+//@[two] compile-flags: -Zdwarf-version=2
+//@[two] check-pass
+
+//@[three] compile-flags: -Zdwarf-version=3
+//@[three] check-pass
+
+//@[four] compile-flags: -Zdwarf-version=4
+//@[four] check-pass
+
+//@[five] compile-flags: -Zdwarf-version=5
+//@[five] check-pass
+
+//@[six] compile-flags: -Zdwarf-version=6
+//@[six] error-pattern: requested DWARF version 6 is not supported
+
+//@ compile-flags: -g --target x86_64-unknown-linux-gnu --crate-type cdylib
+//@ needs-llvm-components: x86
+
+#![feature(no_core, lang_items)]
+
+#![no_core]
+#![no_std]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub fn foo() {}

--- a/tests/ui/debuginfo/dwarf-versions.six.stderr
+++ b/tests/ui/debuginfo/dwarf-versions.six.stderr
@@ -1,0 +1,6 @@
+error: requested DWARF version 6 is not supported
+   |
+   = help: supported DWARF versions are 2, 3, 4 and 5
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/dwarf-versions.zero.stderr
+++ b/tests/ui/debuginfo/dwarf-versions.zero.stderr
@@ -1,0 +1,6 @@
+error: requested DWARF version 0 is not supported
+   |
+   = help: supported DWARF versions are 2, 3, 4 and 5
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
DWARF 1 is very different than DWARF 2+[^1] and LLVM does not really seem to support DWARF 1 as Clang does not offer a `-gdwarf-1` flag[^2] and `llc` will just generate DWARF 2 with the version set to 1[^3].

Since this isn't actually supported (and it's not clear it would be useful anyway), report that DWARF 1 is not supported if it is requested.

Also add a help message to the error saying which versions are supported.

cc #103057 

[^1]: https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html#index-gdwarf
[^2]: https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-gdwarf
[^3]: https://godbolt.org/z/s85d87n3a