### PR TITLE
Nuke `Buffer` abstraction from `librustdoc` 💣

### DIFF
--- a/src/librustdoc/html/highlight/tests.rs
+++ b/src/librustdoc/html/highlight/tests.rs
@@ -3,7 +3,6 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_span::create_default_session_globals_then;
 
 use super::{DecorationInfo, write_code};
-use crate::html::format::Buffer;
 
 const STYLE: &str = r#"
 <style>
@@ -21,11 +20,7 @@ const STYLE: &str = r#"
 fn test_html_highlighting() {
     create_default_session_globals_then(|| {
         let src = include_str!("fixtures/sample.rs");
-        let html = {
-            let mut out = Buffer::new();
-            write_code(&mut out, src, None, None);
-            format!("{STYLE}<pre><code>{}</code></pre>\n", out.into_inner())
-        };
+        let html = format!("{STYLE}<pre><code>{}</code></pre>\n", write_code(src, None, None));
         expect_file!["fixtures/sample.html"].assert_eq(&html);
     });
 }
@@ -36,9 +31,7 @@ fn test_dos_backline() {
         let src = "pub fn foo() {\r\n\
     println!(\"foo\");\r\n\
 }\r\n";
-        let mut html = Buffer::new();
-        write_code(&mut html, src, None, None);
-        expect_file!["fixtures/dos_line.html"].assert_eq(&html.into_inner());
+        expect_file!["fixtures/dos_line.html"].assert_eq(&write_code(src, None, None).to_string());
     });
 }
 
@@ -50,9 +43,7 @@ use self::whatever;
 let x = super::b::foo;
 let y = Self::whatever;";
 
-        let mut html = Buffer::new();
-        write_code(&mut html, src, None, None);
-        expect_file!["fixtures/highlight.html"].assert_eq(&html.into_inner());
+        expect_file!["fixtures/highlight.html"].assert_eq(&write_code(src, None, None).to_string());
     });
 }
 
@@ -60,9 +51,7 @@ let y = Self::whatever;";
 fn test_union_highlighting() {
     create_default_session_globals_then(|| {
         let src = include_str!("fixtures/union.rs");
-        let mut html = Buffer::new();
-        write_code(&mut html, src, None, None);
-        expect_file!["fixtures/union.html"].assert_eq(&html.into_inner());
+        expect_file!["fixtures/union.html"].assert_eq(&write_code(src, None, None).to_string());
     });
 }
 
@@ -77,8 +66,7 @@ let a = 4;";
         decorations.insert("example", vec![(0, 10), (11, 21)]);
         decorations.insert("example2", vec![(22, 32)]);
 
-        let mut html = Buffer::new();
-        write_code(&mut html, src, None, Some(&DecorationInfo(decorations)));
-        expect_file!["fixtures/decorations.html"].assert_eq(&html.into_inner());
+        expect_file!["fixtures/decorations.html"]
+            .assert_eq(&write_code(src, None, Some(&DecorationInfo(decorations))).to_string());
     });
 }

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::path::PathBuf;
 
 use rinja::Template;
@@ -5,7 +6,6 @@ use rustc_data_structures::fx::FxIndexMap;
 
 use super::static_files::{STATIC_FILES, StaticFiles};
 use crate::externalfiles::ExternalHtml;
-use crate::html::format::{Buffer, Print};
 use crate::html::render::{StylePath, ensure_trailing_slash};
 
 #[derive(Clone)]
@@ -71,7 +71,7 @@ struct PageLayout<'a> {
 
 pub(crate) use crate::html::render::sidebar::filters;
 
-pub(crate) fn render<T: Print, S: Print>(
+pub(crate) fn render<T: Display, S: Display>(
     layout: &Layout,
     page: &Page<'_>,
     sidebar: S,
@@ -98,8 +98,8 @@ pub(crate) fn render<T: Print, S: Print>(
     let mut themes: Vec<String> = style_files.iter().map(|s| s.basename().unwrap()).collect();
     themes.sort();
 
-    let content = Buffer::html().to_display(t); // Note: This must happen before making the sidebar.
-    let sidebar = Buffer::html().to_display(sidebar);
+    let content = t.to_string(); // Note: This must happen before making the sidebar.
+    let sidebar = sidebar.to_string();
     PageLayout {
         static_root_path,
         page,

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -52,7 +52,6 @@ use crate::clean::RenderedLink;
 use crate::doctest;
 use crate::doctest::GlobalTestOptions;
 use crate::html::escape::{Escape, EscapeBodyText};
-use crate::html::format::Buffer;
 use crate::html::highlight;
 use crate::html::length_limit::HtmlWithLimit;
 use crate::html::render::small_url_encode;
@@ -329,17 +328,16 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
 
         // insert newline to clearly separate it from the
         // previous block so we can shorten the html output
-        let mut s = Buffer::new();
-        s.push('\n');
-
-        highlight::render_example_with_highlighting(
-            &text,
-            &mut s,
-            tooltip,
-            playground_button.as_deref(),
-            &added_classes,
+        let s = format!(
+            "\n{}",
+            highlight::render_example_with_highlighting(
+                &text,
+                tooltip,
+                playground_button.as_deref(),
+                &added_classes,
+            )
         );
-        Some(Event::Html(s.into_inner().into()))
+        Some(Event::Html(s.into()))
     }
 }
 

--- a/src/librustdoc/html/render/tests.rs
+++ b/src/librustdoc/html/render/tests.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
+use super::AllTypes;
 use super::print_item::compare_names;
-use super::{AllTypes, Buffer};
 
 #[test]
 fn test_compare_names() {
@@ -47,8 +47,7 @@ fn test_all_types_prints_header_once() {
     // Regression test for #82477
     let all_types = AllTypes::new();
 
-    let mut buffer = Buffer::new();
-    all_types.print(&mut buffer);
+    let buffer = all_types.print().to_string();
 
-    assert_eq!(1, buffer.into_inner().matches("List of all items").count());
+    assert_eq!(1, buffer.matches("List of all items").count());
 }

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -44,7 +44,6 @@ use crate::docfs::PathError;
 use crate::error::Error;
 use crate::formats::Impl;
 use crate::formats::item_type::ItemType;
-use crate::html::format::Buffer;
 use crate::html::layout;
 use crate::html::render::ordered_json::{EscapedJson, OrderedJson};
 use crate::html::render::search_index::{SerializedSearchIndex, build_index};
@@ -622,7 +621,6 @@ impl TypeAliasPart {
                     // to make that functionality work here, it needs to be called with
                     // each type alias, and if it gives a different result, split the impl
                     for &(type_alias_fqp, type_alias_item) in type_aliases {
-                        let mut buf = Buffer::html();
                         cx.id_map.borrow_mut().clear();
                         cx.deref_id_map.borrow_mut().clear();
                         let target_did = impl_
@@ -638,8 +636,7 @@ impl TypeAliasPart {
                         } else {
                             AssocItemLink::Anchor(None)
                         };
-                        super::render_impl(
-                            &mut buf,
+                        let text = super::render_impl(
                             cx,
                             impl_,
                             type_alias_item,
@@ -653,8 +650,8 @@ impl TypeAliasPart {
                                 show_non_assoc_items: true,
                                 toggle_open_by_default: true,
                             },
-                        );
-                        let text = buf.into_inner();
+                        )
+                        .to_string();
                         let type_alias_fqp = (*type_alias_fqp).iter().join("::");
                         if Some(&text) == ret.last().map(|s: &AliasSerializableImpl| &s.text) {
                             ret.last_mut()


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

In #136656  I found out that the `for_html` field in the `Buffer` struct was never read, and pondered if `Buffer` had any utility at all. @GuillaumeGomez  said he agrees that it can be just removed. So this PR is me removing it. So, r? @GuillaumeGomez 

But...
this got *a lot* bigger than I had planned.
A lot of functions had a `&mut Buffer` arg, but instead of replacing it with a `buf: impl fmt::Write` arg, I decided to change those functions to return an opaque `impl fmt::Display` instead.

If this PR turns out to be contentious I can try to make a PR that just removes the `Buffer` struct and tries to make less invasive changes, but personally I do like some of the cleanups that this PR allows. Let's see what others think! I think it'll be better to review this without whitespace (If this gets positive reactions, I'll need to rebase and maybe try to separate this into logical commits, but not sure if that's very practical)

While most of the PR is "cosmetic", I did make some small changes, mostly trying to make some of the formatting lazier, and do less allocations. So a perf run will be nice :)

### Pros and cons of returning `impl fmt::Display` instead of taking a `impl fmt::Write`

#### Cons:
- Named lifetimes: function signatures got a lot more verbose because the RPIT opaque type needs to be explicitly bound by the lifetimes of the refs in the arguments
- Having to use `fmt::from_fn` causes another level of indentation
- Immutable closures, can't move out of non-`Copy` items (wasn't much of a problem in practice)

#### Pros:
- Less arguments, no un-Rusty "out" argument
- Nicer composability, allows the returned type to be directly used in format strings

### Interchangeability

A function receiving a `impl fmt::Write` can be turned into a function returning a `impl fmt::Display` by using `fmt::from_fn`.