### PR TITLE
Make ub_check message clear that it's not an assert

### DIFF
--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -65,9 +65,9 @@ macro_rules! assert_unsafe_precondition {
             #[rustc_nounwind]
             const fn precondition_check($($name:$ty),*) {
                 if !$e {
-                    ::core::panicking::panic_nounwind(
-                        concat!("unsafe precondition(s) violated: ", $message)
-                    );
+                    ::core::panicking::panic_nounwind(concat!("unsafe precondition(s) violated: ", $message,
+                        "\n\nThis indicates a bug in the program. \
+                        This Undefined Behavior check is optional, and cannot be relied on for safety."));
                 }
             }
 

--- a/src/tools/miri/tests/fail/ptr_swap_nonoverlapping.stderr
+++ b/src/tools/miri/tests/fail/ptr_swap_nonoverlapping.stderr
@@ -1,6 +1,8 @@
 
 thread 'main' panicked at RUSTLIB/core/src/panicking.rs:LL:CC:
 unsafe precondition(s) violated: ptr::swap_nonoverlapping requires that both pointer arguments are aligned and non-null and the specified memory ranges do not overlap
+
+This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 note: in Miri, you may have to set `MIRIFLAGS=-Zmiri-env-forward=RUST_BACKTRACE` for the environment variable to have an effect
 thread caused non-unwinding panic. aborting.


### PR DESCRIPTION
I've seen a user assume that their unsound code was *safe*, because ub_check prevented the program from performing the unsafe operation. 

This PR makes the panic message clearer that ub_check is a bug detector, not run-time safety protection.