### PR TITLE
tests: `-Copt-level=3` instead of `-O` in assembly tests

### DIFF
--- a/tests/assembly/asm/aarch64-modifiers.rs
+++ b/tests/assembly/asm/aarch64-modifiers.rs
@@ -1,6 +1,6 @@
 //@ add-core-stubs
 //@ assembly-output: emit-asm
-//@ compile-flags: -O -C panic=abort
+//@ compile-flags: -Copt-level=3 -C panic=abort
 //@ compile-flags: --target aarch64-unknown-linux-gnu
 //@ compile-flags: -Zmerge-functions=disabled
 //@ needs-llvm-components: aarch64
@@ -15,7 +15,7 @@ use minicore::*;
 
 macro_rules! check {
     ($func:ident $reg:ident $code:literal) => {
-        // -O and extern "C" guarantee that the selected register is always r0/s0/d0/q0
+        // -Copt-level=3 and extern "C" guarantee that the selected register is always r0/s0/d0/q0
         #[no_mangle]
         pub unsafe extern "C" fn $func() -> i32 {
             let y;

--- a/tests/assembly/asm/aarch64-outline-atomics.rs
+++ b/tests/assembly/asm/aarch64-outline-atomics.rs
@@ -1,5 +1,5 @@
 //@ assembly-output: emit-asm
-//@ compile-flags: -O
+//@ compile-flags: -Copt-level=3
 //@ compile-flags: --target aarch64-unknown-linux-gnu
 //@ needs-llvm-components: aarch64
 //@ only-aarch64

--- a/tests/assembly/asm/arm-modifiers.rs
+++ b/tests/assembly/asm/arm-modifiers.rs
@@ -1,6 +1,6 @@
 //@ add-core-stubs
 //@ assembly-output: emit-asm
-//@ compile-flags: -O -C panic=abort
+//@ compile-flags: -Copt-level=3 -C panic=abort
 //@ compile-flags: --target armv7-unknown-linux-gnueabihf
 //@ compile-flags: -C target-feature=+neon
 //@ compile-flags: -Zmerge-functions=disabled
@@ -21,7 +21,7 @@ impl Copy for f32x4 {}
 
 macro_rules! check {
     ($func:ident $modifier:literal $reg:ident $ty:ident $mov:literal) => {
-        // -O and extern "C" guarantee that the selected register is always r0/s0/d0/q0
+        // -Copt-level=3 and extern "C" guarantee that the selected register is always r0/s0/d0/q0
         #[no_mangle]
         pub unsafe extern "C" fn $func() -> $ty {
             let y;

--- a/tests/assembly/asm/x86-modifiers.rs
+++ b/tests/assembly/asm/x86-modifiers.rs
@@ -1,7 +1,7 @@
 //@ add-core-stubs
 //@ revisions: x86_64 i686
 //@ assembly-output: emit-asm
-//@ compile-flags: -O -C panic=abort
+//@ compile-flags: -Copt-level=3 -C panic=abort
 //@[x86_64] compile-flags: --target x86_64-unknown-linux-gnu
 //@[x86_64] needs-llvm-components: x86
 //@[i686] compile-flags: --target i686-unknown-linux-gnu
@@ -20,7 +20,7 @@ use minicore::*;
 
 macro_rules! check {
     ($func:ident $modifier:literal $reg:ident $mov:literal) => {
-        // -O and extern "C" guarantee that the selected register is always ax/xmm0
+        // -Copt-level=3 and extern "C" guarantee that the selected register is always ax/xmm0
         #[no_mangle]
         pub unsafe extern "C" fn $func() -> i32 {
             let y;

--- a/tests/assembly/libs/issue-115339-zip-arrays.rs
+++ b/tests/assembly/libs/issue-115339-zip-arrays.rs
@@ -1,6 +1,6 @@
 //@ assembly-output: emit-asm
 // # zen3 previously exhibited odd vectorization
-//@ compile-flags: --crate-type=lib -Ctarget-cpu=znver3 -O
+//@ compile-flags: --crate-type=lib -Ctarget-cpu=znver3 -Copt-level=3
 //@ only-x86_64
 //@ ignore-sgx
 

--- a/tests/assembly/manual-eq-efficient.rs
+++ b/tests/assembly/manual-eq-efficient.rs
@@ -1,6 +1,6 @@
 // Regression test for #106269
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C llvm-args=-x86-asm-syntax=intel
 //@ only-x86_64
 //@ ignore-sgx
 

--- a/tests/assembly/panic-no-unwind-no-uwtable.rs
+++ b/tests/assembly/panic-no-unwind-no-uwtable.rs
@@ -1,6 +1,6 @@
 //@ assembly-output: emit-asm
 //@ only-x86_64-unknown-linux-gnu
-//@ compile-flags: -C panic=unwind -C force-unwind-tables=n -O
+//@ compile-flags: -C panic=unwind -C force-unwind-tables=n -Copt-level=3
 
 #![crate_type = "lib"]
 

--- a/tests/assembly/powerpc64-struct-abi.rs
+++ b/tests/assembly/powerpc64-struct-abi.rs
@@ -1,6 +1,6 @@
 //@ revisions: elfv1-be elfv2-be elfv2-le aix
 //@ assembly-output: emit-asm
-//@ compile-flags: -O
+//@ compile-flags: -Copt-level=3
 //@[elfv1-be] compile-flags: --target powerpc64-unknown-linux-gnu
 //@[elfv1-be] needs-llvm-components: powerpc
 //@[elfv2-be] compile-flags: --target powerpc64-unknown-linux-musl

--- a/tests/assembly/s390x-backchain-toggle.rs
+++ b/tests/assembly/s390x-backchain-toggle.rs
@@ -1,6 +1,6 @@
 //@ revisions: enable-backchain disable-backchain
 //@ assembly-output: emit-asm
-//@ compile-flags: -O --crate-type=lib --target=s390x-unknown-linux-gnu
+//@ compile-flags: -Copt-level=3 --crate-type=lib --target=s390x-unknown-linux-gnu
 //@ needs-llvm-components: systemz
 //@[enable-backchain] compile-flags: -Ctarget-feature=+backchain
 //@[disable-backchain] compile-flags: -Ctarget-feature=-backchain

--- a/tests/assembly/s390x-vector-abi.rs
+++ b/tests/assembly/s390x-vector-abi.rs
@@ -1,7 +1,7 @@
 //@ revisions: z10 z10_vector z13 z13_no_vector
 // ignore-tidy-linelength
 //@ assembly-output: emit-asm
-//@ compile-flags: -O -Z merge-functions=disabled
+//@ compile-flags: -Copt-level=3 -Z merge-functions=disabled
 //@[z10] compile-flags: --target s390x-unknown-linux-gnu --cfg no_vector
 //@[z10] needs-llvm-components: systemz
 //@[z10_vector] compile-flags: --target s390x-unknown-linux-gnu -C target-feature=+vector

--- a/tests/assembly/simd-bitmask.rs
+++ b/tests/assembly/simd-bitmask.rs
@@ -10,7 +10,7 @@
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu
 //@ [aarch64] needs-llvm-components: aarch64
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C panic=abort
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 
 #![feature(no_core, lang_items, repr_simd, intrinsics)]
 #![no_core]

--- a/tests/assembly/simd-intrinsic-gather.rs
+++ b/tests/assembly/simd-intrinsic-gather.rs
@@ -3,7 +3,7 @@
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
 //@ [x86-avx512] needs-llvm-components: x86
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C panic=abort
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 
 #![feature(no_core, lang_items, repr_simd, intrinsics)]
 #![no_core]

--- a/tests/assembly/simd-intrinsic-mask-load.rs
+++ b/tests/assembly/simd-intrinsic-mask-load.rs
@@ -6,7 +6,7 @@
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
 //@ [x86-avx512] needs-llvm-components: x86
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C panic=abort
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 
 #![feature(no_core, lang_items, repr_simd, intrinsics)]
 #![no_core]

--- a/tests/assembly/simd-intrinsic-mask-reduce.rs
+++ b/tests/assembly/simd-intrinsic-mask-reduce.rs
@@ -7,7 +7,7 @@
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu
 //@ [aarch64] needs-llvm-components: aarch64
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C panic=abort
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 
 #![feature(no_core, lang_items, repr_simd, intrinsics)]
 #![no_core]

--- a/tests/assembly/simd-intrinsic-mask-store.rs
+++ b/tests/assembly/simd-intrinsic-mask-store.rs
@@ -6,7 +6,7 @@
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
 //@ [x86-avx512] needs-llvm-components: x86
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C panic=abort
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 
 #![feature(no_core, lang_items, repr_simd, intrinsics)]
 #![no_core]

--- a/tests/assembly/simd-intrinsic-scatter.rs
+++ b/tests/assembly/simd-intrinsic-scatter.rs
@@ -3,7 +3,7 @@
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
 //@ [x86-avx512] needs-llvm-components: x86
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C panic=abort
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 
 #![feature(no_core, lang_items, repr_simd, intrinsics)]
 #![no_core]

--- a/tests/assembly/simd-intrinsic-select.rs
+++ b/tests/assembly/simd-intrinsic-select.rs
@@ -8,7 +8,7 @@
 //@ [aarch64] compile-flags: --target=aarch64-unknown-linux-gnu
 //@ [aarch64] needs-llvm-components: aarch64
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C panic=abort
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C panic=abort
 
 #![feature(no_core, lang_items, repr_simd, intrinsics)]
 #![no_core]

--- a/tests/assembly/simd/reduce-fadd-unordered.rs
+++ b/tests/assembly/simd/reduce-fadd-unordered.rs
@@ -1,6 +1,7 @@
 //@ revisions: x86_64 aarch64
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O
+//@ compile-flags: --crate-type=lib -Copt-level=3
+
 //@[aarch64] only-aarch64
 //@[x86_64] only-x86_64
 //@[x86_64] compile-flags: -Ctarget-feature=+sse3

--- a/tests/assembly/slice-is_ascii.rs
+++ b/tests/assembly/slice-is_ascii.rs
@@ -2,7 +2,7 @@
 //@ [WIN] only-windows
 //@ [LIN] only-linux
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C llvm-args=-x86-asm-syntax=intel
 //@ only-x86_64
 //@ ignore-sgx
 

--- a/tests/assembly/x86-return-float.rs
+++ b/tests/assembly/x86-return-float.rs
@@ -6,7 +6,7 @@
 // Use the same target CPU as `i686` so that LLVM orders the instructions in the same order.
 //@ compile-flags: -Ctarget-feature=+sse2 -Ctarget-cpu=pentium4
 // Force frame pointers to make ASM more consistent between targets
-//@ compile-flags: -O -C force-frame-pointers
+//@ compile-flags: -Copt-level=3 -C force-frame-pointers
 //@ filecheck-flags: --implicit-check-not fld --implicit-check-not fst
 //@ revisions: normal win
 //@[normal] ignore-windows

--- a/tests/assembly/x86-return-float.rs
+++ b/tests/assembly/x86-return-float.rs
@@ -1,19 +1,28 @@
 //@ assembly-output: emit-asm
-//@ only-x86
 // FIXME(#114479): LLVM miscompiles loading and storing `f32` and `f64` when SSE is disabled.
 // There's no compiletest directive to ignore a test on i586 only, so just always explicitly enable
 // SSE2.
 // Use the same target CPU as `i686` so that LLVM orders the instructions in the same order.
 //@ compile-flags: -Ctarget-feature=+sse2 -Ctarget-cpu=pentium4
 // Force frame pointers to make ASM more consistent between targets
-//@ compile-flags: -Copt-level=3 -C force-frame-pointers
+//@ compile-flags: -C force-frame-pointers
+// At opt-level=3, LLVM can merge two movss into one movsd, and we aren't testing for that.
+//@ compile-flags: -Copt-level=2
 //@ filecheck-flags: --implicit-check-not fld --implicit-check-not fst
-//@ revisions: normal win
-//@[normal] ignore-windows
-//@[win] only-windows
+//@ revisions: linux win
+//@ add-core-stubs
+//@[linux] needs-llvm-components: x86
+//@[win] needs-llvm-components: x86
+//@[linux] compile-flags: --target i686-unknown-linux-gnu
+//@[win] compile-flags: --target i686-pc-windows-msvc
 
 #![crate_type = "lib"]
 #![feature(f16, f128)]
+#![feature(no_core)]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 // Tests that returning `f32` and `f64` with the "Rust" ABI on 32-bit x86 doesn't use the x87
 // floating point stack, as loading and storing `f32`s and `f64`s to and from the x87 stack quietens
@@ -190,8 +199,8 @@ pub unsafe fn call_f64_f64(x: &mut (f64, f64)) {
     }
     // CHECK: movl {{.*}}(%ebp), %[[PTR:.*]]
     // CHECK: calll {{()|_}}get_f64_f64
-    // normal: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
-    // normal-NEXT: movsd [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
+    // linux: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
+    // linux-NEXT: movsd [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
     // win: movsd (%esp), %[[VAL1:.*]]
     // win-NEXT: movsd 8(%esp), %[[VAL2:.*]]
     // CHECK-NEXT: movsd %[[VAL1]], (%[[PTR]])
@@ -207,12 +216,12 @@ pub unsafe fn call_f32_f64(x: &mut (f32, f64)) {
     }
     // CHECK: movl {{.*}}(%ebp), %[[PTR:.*]]
     // CHECK: calll {{()|_}}get_f32_f64
-    // normal: movss [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
-    // normal-NEXT: movsd [[#%d,OFFSET+4]](%ebp), %[[VAL2:.*]]
+    // linux: movss [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
+    // linux-NEXT: movsd [[#%d,OFFSET+4]](%ebp), %[[VAL2:.*]]
     // win: movss (%esp), %[[VAL1:.*]]
     // win-NEXT: movsd 8(%esp), %[[VAL2:.*]]
     // CHECK-NEXT: movss %[[VAL1]], (%[[PTR]])
-    // normal-NEXT: movsd %[[VAL2]], 4(%[[PTR]])
+    // linux-NEXT: movsd %[[VAL2]], 4(%[[PTR]])
     // win-NEXT: movsd %[[VAL2]], 8(%[[PTR]])
     *x = get_f32_f64();
 }
@@ -225,8 +234,8 @@ pub unsafe fn call_f64_f32(x: &mut (f64, f32)) {
     }
     // CHECK: movl {{.*}}(%ebp), %[[PTR:.*]]
     // CHECK: calll {{()|_}}get_f64_f32
-    // normal: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
-    // normal-NEXT: movss [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
+    // linux: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
+    // linux-NEXT: movss [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
     // win: movsd (%esp), %[[VAL1:.*]]
     // win-NEXT: movss 8(%esp), %[[VAL2:.*]]
     // CHECK-NEXT: movsd %[[VAL1]], (%[[PTR]])
@@ -257,8 +266,8 @@ pub unsafe fn call_f64_other(x: &mut (f64, usize)) {
     }
     // CHECK: movl {{.*}}(%ebp), %[[PTR:.*]]
     // CHECK: calll {{()|_}}get_f64_other
-    // normal: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
-    // normal-NEXT: movl [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
+    // linux: movsd [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
+    // linux-NEXT: movl [[#%d,OFFSET+8]](%ebp), %[[VAL2:.*]]
     // win: movsd (%esp), %[[VAL1:.*]]
     // win-NEXT: movl 8(%esp), %[[VAL2:.*]]
     // CHECK-NEXT: movsd %[[VAL1]], (%[[PTR]])
@@ -289,12 +298,12 @@ pub unsafe fn call_other_f64(x: &mut (usize, f64)) {
     }
     // CHECK: movl {{.*}}(%ebp), %[[PTR:.*]]
     // CHECK: calll {{()|_}}get_other_f64
-    // normal: movl [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
-    // normal-NEXT: movsd [[#%d,OFFSET+4]](%ebp), %[[VAL2:.*]]
+    // linux: movl [[#%d,OFFSET:]](%ebp), %[[VAL1:.*]]
+    // linux-NEXT: movsd [[#%d,OFFSET+4]](%ebp), %[[VAL2:.*]]
     // win: movl (%esp), %[[VAL1:.*]]
     // win-NEXT: movsd 8(%esp), %[[VAL2:.*]]
     // CHECK-NEXT: movl %[[VAL1]], (%[[PTR]])
-    // normal-NEXT: movsd %[[VAL2]], 4(%[[PTR]])
+    // linux-NEXT: movsd %[[VAL2]], 4(%[[PTR]])
     // win-NEXT: movsd %[[VAL2]], 8(%[[PTR]])
     *x = get_other_f64();
 }

--- a/tests/assembly/x86_64-array-pair-load-store-merge.rs
+++ b/tests/assembly/x86_64-array-pair-load-store-merge.rs
@@ -1,5 +1,5 @@
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C llvm-args=-x86-asm-syntax=intel
 //@ only-x86_64
 //@ ignore-sgx
 //@ ignore-apple (manipulates rsp too)

--- a/tests/assembly/x86_64-bigint-helpers.rs
+++ b/tests/assembly/x86_64-bigint-helpers.rs
@@ -1,6 +1,6 @@
 //@ only-x86_64
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O -C target-cpu=x86-64-v4
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C target-cpu=x86-64-v4
 //@ compile-flags: -C llvm-args=-x86-asm-syntax=intel
 //@ revisions: llvm-pre-20 llvm-20
 //@ [llvm-20] min-llvm-version: 20

--- a/tests/assembly/x86_64-floating-point-clamp.rs
+++ b/tests/assembly/x86_64-floating-point-clamp.rs
@@ -3,7 +3,7 @@
 
 //@ assembly-output: emit-asm
 // Set the base cpu explicitly, in case the default has been changed.
-//@ compile-flags: --crate-type=lib -O -C llvm-args=-x86-asm-syntax=intel -C target-cpu=x86-64
+//@ compile-flags: --crate-type=lib -Copt-level=3 -C llvm-args=-x86-asm-syntax=intel -C target-cpu=x86-64
 //@ only-x86_64
 //@ ignore-sgx
 

--- a/tests/assembly/x86_64-function-return.rs
+++ b/tests/assembly/x86_64-function-return.rs
@@ -3,7 +3,7 @@
 
 //@ revisions: unset keep thunk-extern keep-thunk-extern thunk-extern-keep
 //@ assembly-output: emit-asm
-//@ compile-flags: -O
+//@ compile-flags: -Copt-level=3
 //@ [keep] compile-flags: -Zfunction-return=keep
 //@ [thunk-extern] compile-flags: -Zfunction-return=thunk-extern
 //@ [keep-thunk-extern] compile-flags: -Zfunction-return=keep -Zfunction-return=thunk-extern

--- a/tests/assembly/x86_64-no-jump-tables.rs
+++ b/tests/assembly/x86_64-no-jump-tables.rs
@@ -3,7 +3,7 @@
 
 //@ revisions: unset set
 //@ assembly-output: emit-asm
-//@ compile-flags: -O
+//@ compile-flags: -Copt-level=3
 //@ [set] compile-flags: -Zno-jump-tables
 //@ only-x86_64
 //@ ignore-sgx

--- a/tests/assembly/x86_64-typed-swap.rs
+++ b/tests/assembly/x86_64-typed-swap.rs
@@ -3,7 +3,7 @@
 //@ [LIN] only-linux
 //@ only-x86_64
 //@ assembly-output: emit-asm
-//@ compile-flags: --crate-type=lib -O
+//@ compile-flags: --crate-type=lib -Copt-level=3
 
 use std::arch::x86_64::__m128;
 use std::mem::swap;
@@ -12,42 +12,42 @@ use std::mem::swap;
 #[no_mangle]
 pub fn swap_i32(x: &mut i32, y: &mut i32) {
     // CHECK: movl (%[[ARG1:.+]]), %[[T1:.+]]
-    // CHECK: movl (%[[ARG2:.+]]), %[[T2:.+]]
-    // CHECK: movl %[[T2]], (%[[ARG1]])
-    // CHECK: movl %[[T1]], (%[[ARG2]])
-    // CHECK: retq
+    // CHECK-NEXT: movl (%[[ARG2:.+]]), %[[T2:.+]]
+    // CHECK-DAG: movl %[[T2]], (%[[ARG1]])
+    // CHECK-DAG: movl %[[T1]], (%[[ARG2]])
+    // CHECK-NEXT: retq
     swap(x, y)
 }
 
 // CHECK-LABEL: swap_pair:
 #[no_mangle]
 pub fn swap_pair(x: &mut (i32, u32), y: &mut (i32, u32)) {
-    // CHECK: movq (%[[ARG1]]), %[[T1:.+]]
-    // CHECK: movq (%[[ARG2]]), %[[T2:.+]]
-    // CHECK: movq %[[T2]], (%[[ARG1]])
-    // CHECK: movq %[[T1]], (%[[ARG2]])
-    // CHECK: retq
+    // CHECK: movq (%[[ARG1:r..?]]), %[[T1:.+]]
+    // CHECK-NEXT: movq (%[[ARG2:r..?]]), %[[T2:.+]]
+    // CHECK-DAG: movq %[[T2]], (%[[ARG1]])
+    // CHECK-DAG: movq %[[T1]], (%[[ARG2]])
+    // CHECK-NEXT: retq
     swap(x, y)
 }
 
 // CHECK-LABEL: swap_str:
 #[no_mangle]
 pub fn swap_str<'a>(x: &mut &'a str, y: &mut &'a str) {
-    // CHECK: movups (%[[ARG1]]), %[[T1:xmm.]]
-    // CHECK: movups (%[[ARG2]]), %[[T2:xmm.]]
-    // CHECK: movups %[[T2]], (%[[ARG1]])
-    // CHECK: movups %[[T1]], (%[[ARG2]])
-    // CHECK: retq
+    // CHECK: movups (%[[ARG1:r..?]]), %[[T1:xmm.]]
+    // CHECK-NEXT: movups (%[[ARG2:r..?]]), %[[T2:xmm.]]
+    // CHECK-DAG: movups %[[T2]], (%[[ARG1]])
+    // CHECK-DAG: movups %[[T1]], (%[[ARG2]])
+    // CHECK-NEXT: retq
     swap(x, y)
 }
 
 // CHECK-LABEL: swap_simd:
 #[no_mangle]
 pub fn swap_simd(x: &mut __m128, y: &mut __m128) {
-    // CHECK: movaps (%[[ARG1]]), %[[T1:xmm.]]
-    // CHECK: movaps (%[[ARG2]]), %[[T2:xmm.]]
-    // CHECK: movaps %[[T2]], (%[[ARG1]])
-    // CHECK: movaps %[[T1]], (%[[ARG2]])
-    // CHECK: retq
+    // CHECK: movaps (%[[ARG1:r..?]]), %[[T1:xmm.]]
+    // CHECK-NEXT: movaps (%[[ARG2:r..?]]), %[[T2:xmm.]]
+    // CHECK-DAG: movaps %[[T2]], (%[[ARG1]])
+    // CHECK-DAG: movaps %[[T1]], (%[[ARG2]])
+    // CHECK-NEXT: retq
     swap(x, y)
 }

--- a/tests/assembly/x86_64-windows-float-abi.rs
+++ b/tests/assembly/x86_64-windows-float-abi.rs
@@ -1,10 +1,16 @@
 //@ assembly-output: emit-asm
-//@ compile-flags: -O
-//@ only-windows
-//@ only-x86_64
+//@ compile-flags: -Copt-level=3
+//@ compile-flags: --target x86_64-pc-windows-msvc
+//@ needs-llvm-components: x86
+//@ add-core-stubs
 
 #![feature(f16, f128)]
+#![feature(no_core)]
+#![no_core]
 #![crate_type = "lib"]
+
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: second_f16
 // CHECK: movaps %xmm1, %xmm0


### PR DESCRIPTION
An effective blocker for redefining the meaning of `-O` is to stop reusing this somewhat ambiguous alias in our own assembly test suite. The choice between `-Copt-level=2` and `-Copt-level=3` is arbitrary for most of our tests. In most cases it makes no difference, so I set most of them to `-Copt-level=3`, as it will lead to slightly more "normalized" assembly.