### PR TITLE
Fix unwrap error in overflowing int literal

### DIFF
--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -543,7 +543,11 @@ impl<'tcx> LateLintPass<'tcx> for TypeLimits {
         lit: &'tcx hir::Lit,
         negated: bool,
     ) {
-        lint_literal(cx, self, hir_id, lit.span, lit, negated)
+        if negated {
+            self.negated_expr_id = Some(hir_id);
+            self.negated_expr_span = Some(lit.span);
+        }
+        lint_literal(cx, self, hir_id, lit.span, lit, negated);
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx hir::Expr<'tcx>) {

--- a/compiler/rustc_lint/src/types/literal.rs
+++ b/compiler/rustc_lint/src/types/literal.rs
@@ -245,12 +245,11 @@ fn lint_int_literal<'tcx>(
     lit: &hir::Lit,
     t: ty::IntTy,
     v: u128,
-    negated: bool,
 ) {
     let int_type = t.normalize(cx.sess().target.pointer_width);
     let (min, max) = int_ty_range(int_type);
     let max = max as u128;
-    let negative = negated ^ (type_limits.negated_expr_id == Some(hir_id));
+    let negative = type_limits.negated_expr_id == Some(hir_id);
 
     // Detect literal value out of range [min, max] inclusive
     // avoiding use of -min to prevent overflow/panic
@@ -366,7 +365,7 @@ pub(crate) fn lint_literal<'tcx>(
         ty::Int(t) => {
             match lit.node {
                 ast::LitKind::Int(v, ast::LitIntType::Signed(_) | ast::LitIntType::Unsuffixed) => {
-                    lint_int_literal(cx, type_limits, hir_id, span, lit, t, v.get(), negated)
+                    lint_int_literal(cx, type_limits, hir_id, span, lit, t, v.get())
                 }
                 _ => bug!(),
             };

--- a/tests/ui/lint/lint-overflowing-int-136675.rs
+++ b/tests/ui/lint/lint-overflowing-int-136675.rs
@@ -1,0 +1,4 @@
+fn main() {
+    if let -129 = 0i8 {} //~ ERROR literal out of range for `i8`
+    let x: i8 = -129; //~ ERROR literal out of range for `i8`
+}

--- a/tests/ui/lint/lint-overflowing-int-136675.stderr
+++ b/tests/ui/lint/lint-overflowing-int-136675.stderr
@@ -1,0 +1,21 @@
+error: literal out of range for `i8`
+  --> $DIR/lint-overflowing-int-136675.rs:2:12
+   |
+LL |     if let -129 = 0i8 {}
+   |            ^^^^
+   |
+   = note: the literal `-129` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using the type `i16` instead
+   = note: `#[deny(overflowing_literals)]` on by default
+
+error: literal out of range for `i8`
+  --> $DIR/lint-overflowing-int-136675.rs:3:17
+   |
+LL |     let x: i8 = -129;
+   |                 ^^^^
+   |
+   = note: the literal `-129` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using the type `i16` instead
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes #136675

it's maybe `negative` only from [check_lit](https://github.com/chenyukang/rust/blob/526e3288feb68eac55013746e03fb54d6a0b9a1e/compiler/rustc_lint/src/types.rs#L546), in this scenario the fields in `TypeLimits` is none.

r? @oli-obk
