### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "minifier"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd559bbf5d350ac7f2c1cf92ed71a869b847a92bce0c1318b47932a5b5f65cdd"
+checksum = "1cf47565b1430f5fe6c81d3afcb4b835271348d7eb35294a4d592e38dd09ea22"
 
 [[package]]
 name = "minimal-lexical"

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -543,7 +543,11 @@ impl<'tcx> LateLintPass<'tcx> for TypeLimits {
         lit: &'tcx hir::Lit,
         negated: bool,
     ) {
-        lint_literal(cx, self, hir_id, lit.span, lit, negated)
+        if negated {
+            self.negated_expr_id = Some(hir_id);
+            self.negated_expr_span = Some(lit.span);
+        }
+        lint_literal(cx, self, hir_id, lit.span, lit, negated);
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx hir::Expr<'tcx>) {

--- a/compiler/rustc_lint/src/types/literal.rs
+++ b/compiler/rustc_lint/src/types/literal.rs
@@ -245,12 +245,11 @@ fn lint_int_literal<'tcx>(
     lit: &hir::Lit,
     t: ty::IntTy,
     v: u128,
-    negated: bool,
 ) {
     let int_type = t.normalize(cx.sess().target.pointer_width);
     let (min, max) = int_ty_range(int_type);
     let max = max as u128;
-    let negative = negated ^ (type_limits.negated_expr_id == Some(hir_id));
+    let negative = type_limits.negated_expr_id == Some(hir_id);
 
     // Detect literal value out of range [min, max] inclusive
     // avoiding use of -min to prevent overflow/panic
@@ -366,7 +365,7 @@ pub(crate) fn lint_literal<'tcx>(
         ty::Int(t) => {
             match lit.node {
                 ast::LitKind::Int(v, ast::LitIntType::Signed(_) | ast::LitIntType::Unsuffixed) => {
-                    lint_int_literal(cx, type_limits, hir_id, span, lit, t, v.get(), negated)
+                    lint_int_literal(cx, type_limits, hir_id, span, lit, t, v.get())
                 }
                 _ => bug!(),
             };

--- a/compiler/rustc_target/src/spec/base/cygwin.rs
+++ b/compiler/rustc_target/src/spec/base/cygwin.rs
@@ -4,14 +4,10 @@ use crate::spec::{Cc, DebuginfoKind, LinkerFlavor, Lld, SplitDebuginfo, TargetOp
 
 pub(crate) fn opts() -> TargetOptions {
     let mut pre_link_args = TargetOptions::link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), &[
-        // FIXME: Disable ASLR for now to fix relocation error
         "--disable-dynamicbase",
         "--enable-auto-image-base",
     ]);
     crate::spec::add_link_args(&mut pre_link_args, LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
-        // Tell GCC to avoid linker plugins, because we are not bundling
-        // them with Windows installer, and Rust does its own LTO anyways.
-        "-fno-use-linker-plugin",
         "-Wl,--disable-dynamicbase",
         "-Wl,--enable-auto-image-base",
     ]);
@@ -42,9 +38,7 @@ pub(crate) fn opts() -> TargetOptions {
         emit_debug_gdb_scripts: false,
         requires_uwtable: true,
         eh_frame_header: false,
-        // FIXME(davidtwco): Support Split DWARF on Cygwin - may require LLVM changes to
-        // output DWO, despite using DWARF, doesn't use ELF..
-        debuginfo_kind: DebuginfoKind::Pdb,
+        debuginfo_kind: DebuginfoKind::Dwarf,
         supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
         ..Default::default()
     }

--- a/compiler/rustc_target/src/spec/base/cygwin.rs
+++ b/compiler/rustc_target/src/spec/base/cygwin.rs
@@ -1,0 +1,51 @@
+use std::borrow::Cow;
+
+use crate::spec::{Cc, DebuginfoKind, LinkerFlavor, Lld, SplitDebuginfo, TargetOptions, cvs};
+
+pub(crate) fn opts() -> TargetOptions {
+    let mut pre_link_args = TargetOptions::link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), &[
+        // FIXME: Disable ASLR for now to fix relocation error
+        "--disable-dynamicbase",
+        "--enable-auto-image-base",
+    ]);
+    crate::spec::add_link_args(&mut pre_link_args, LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
+        // Tell GCC to avoid linker plugins, because we are not bundling
+        // them with Windows installer, and Rust does its own LTO anyways.
+        "-fno-use-linker-plugin",
+        "-Wl,--disable-dynamicbase",
+        "-Wl,--enable-auto-image-base",
+    ]);
+    let cygwin_libs = &["-lcygwin", "-lgcc", "-lcygwin", "-luser32", "-lkernel32", "-lgcc_s"];
+    let mut late_link_args =
+        TargetOptions::link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), cygwin_libs);
+    crate::spec::add_link_args(
+        &mut late_link_args,
+        LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+        cygwin_libs,
+    );
+    TargetOptions {
+        os: "cygwin".into(),
+        vendor: "pc".into(),
+        // FIXME(#13846) this should be enabled for cygwin
+        function_sections: false,
+        linker: Some("gcc".into()),
+        dynamic_linking: true,
+        dll_prefix: "".into(),
+        dll_suffix: ".dll".into(),
+        exe_suffix: ".exe".into(),
+        families: cvs!["unix"],
+        is_like_windows: true,
+        allows_weak_linkage: false,
+        pre_link_args,
+        late_link_args,
+        abi_return_struct_as_int: true,
+        emit_debug_gdb_scripts: false,
+        requires_uwtable: true,
+        eh_frame_header: false,
+        // FIXME(davidtwco): Support Split DWARF on Cygwin - may require LLVM changes to
+        // output DWO, despite using DWARF, doesn't use ELF..
+        debuginfo_kind: DebuginfoKind::Pdb,
+        supported_split_debuginfo: Cow::Borrowed(&[SplitDebuginfo::Off]),
+        ..Default::default()
+    }
+}

--- a/compiler/rustc_target/src/spec/base/mod.rs
+++ b/compiler/rustc_target/src/spec/base/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod android;
 pub(crate) mod apple;
 pub(crate) mod avr_gnu;
 pub(crate) mod bpf;
+pub(crate) mod cygwin;
 pub(crate) mod dragonfly;
 pub(crate) mod freebsd;
 pub(crate) mod fuchsia;

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2019,6 +2019,7 @@ supported_targets! {
     ("riscv64imac-unknown-nuttx-elf", riscv64imac_unknown_nuttx_elf),
     ("riscv64gc-unknown-nuttx-elf", riscv64gc_unknown_nuttx_elf),
 
+    ("x86_64-pc-cygwin", x86_64_pc_cygwin),
 }
 
 /// Cow-Vec-Str: Cow<'static, [Cow<'static, str>]>
@@ -3004,8 +3005,8 @@ impl Target {
         );
         check_eq!(
             self.is_like_windows,
-            self.os == "windows" || self.os == "uefi",
-            "`is_like_windows` must be set if and only if `os` is `windows` or `uefi`"
+            self.os == "windows" || self.os == "uefi" || self.os == "cygwin",
+            "`is_like_windows` must be set if and only if `os` is `windows`, `uefi` or `cygwin`"
         );
         check_eq!(
             self.is_like_wasm,

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_cygwin.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_cygwin.rs
@@ -1,0 +1,32 @@
+use crate::spec::{Cc, LinkerFlavor, Lld, Target, base};
+
+pub(crate) fn target() -> Target {
+    let mut base = base::cygwin::opts();
+    base.cpu = "x86-64".into();
+    // FIXME: Disable ASLR for now to fix relocation error
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), &[
+        "-m",
+        "i386pep",
+        "--disable-high-entropy-va",
+    ]);
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
+        "-m64",
+        "-Wl,--disable-high-entropy-va",
+    ]);
+    base.max_atomic_width = Some(64);
+    base.linker = Some("x86_64-pc-cygwin-gcc".into());
+    Target {
+        llvm_target: "x86_64-pc-cygwin".into(),
+        pointer_width: 64,
+        data_layout:
+            "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128".into(),
+        arch: "x86_64".into(),
+        options: base,
+        metadata: crate::spec::TargetMetadata {
+            description: Some("64-bit x86 Cygwin".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(true),
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_cygwin.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_cygwin.rs
@@ -3,16 +3,8 @@ use crate::spec::{Cc, LinkerFlavor, Lld, Target, base};
 pub(crate) fn target() -> Target {
     let mut base = base::cygwin::opts();
     base.cpu = "x86-64".into();
-    // FIXME: Disable ASLR for now to fix relocation error
-    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), &[
-        "-m",
-        "i386pep",
-        "--disable-high-entropy-va",
-    ]);
-    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[
-        "-m64",
-        "-Wl,--disable-high-entropy-va",
-    ]);
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::No, Lld::No), &["-m", "i386pep"]);
+    base.add_pre_link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &["-m64"]);
     base.max_atomic_width = Some(64);
     base.linker = Some("x86_64-pc-cygwin-gcc".into());
     Target {
@@ -26,7 +18,7 @@ pub(crate) fn target() -> Target {
             description: Some("64-bit x86 Cygwin".into()),
             tier: Some(3),
             host_tools: Some(false),
-            std: Some(true),
+            std: None,
         },
     }
 }

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -155,7 +155,6 @@
 #![feature(unicode_internals)]
 #![feature(unsize)]
 #![feature(unwrap_infallible)]
-#![feature(vec_pop_if)]
 // tidy-alphabetical-end
 //
 // Language features:

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2518,8 +2518,6 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(vec_pop_if)]
-    ///
     /// let mut vec = vec![1, 2, 3, 4];
     /// let pred = |x: &mut i32| *x % 2 == 0;
     ///
@@ -2527,7 +2525,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(vec, [1, 2, 3]);
     /// assert_eq!(vec.pop_if(pred), None);
     /// ```
-    #[unstable(feature = "vec_pop_if", issue = "122741")]
+    #[stable(feature = "vec_pop_if", since = "CURRENT_RUSTC_VERSION")]
     pub fn pop_if(&mut self, predicate: impl FnOnce(&mut T) -> bool) -> Option<T> {
         let last = self.last_mut()?;
         if predicate(last) { self.pop() } else { None }

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -37,7 +37,6 @@
 #![feature(local_waker)]
 #![feature(str_as_str)]
 #![feature(strict_provenance_lints)]
-#![feature(vec_pop_if)]
 #![feature(vec_deque_pop_if)]
 #![feature(unique_rc_arc)]
 #![feature(macro_metavar_expr_concat)]

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -245,7 +245,11 @@ impl Cargo {
                 // flesh out rpath support more fully in the future.
                 self.rustflags.arg("-Zosx-rpath-install-name");
                 Some(format!("-Wl,-rpath,@loader_path/../{libdir}"))
-            } else if !target.is_windows() && !target.contains("aix") && !target.contains("xous") {
+            } else if !target.is_windows()
+                && !target.contains("cygwin")
+                && !target.contains("aix")
+                && !target.contains("xous")
+            {
                 self.rustflags.arg("-Clink-args=-Wl,-z,origin");
                 Some(format!("-Wl,-rpath,$ORIGIN/../{libdir}"))
             } else {

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -101,6 +101,7 @@
     - [\*-win7-windows-gnu](platform-support/win7-windows-gnu.md)
     - [\*-win7-windows-msvc](platform-support/win7-windows-msvc.md)
     - [x86_64-fortanix-unknown-sgx](platform-support/x86_64-fortanix-unknown-sgx.md)
+    - [x86_64-pc-cygwin](platform-support/x86_64-pc-cygwin.md)
     - [x86_64-pc-solaris](platform-support/solaris.md)
     - [x86_64-unknown-linux-none.md](platform-support/x86_64-unknown-linux-none.md)
     - [x86_64-unknown-none](platform-support/x86_64-unknown-none.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -406,6 +406,7 @@ target | std | host | notes
 [`wasm64-unknown-unknown`](platform-support/wasm64-unknown-unknown.md) | ? |  | WebAssembly
 [`x86_64-apple-tvos`](platform-support/apple-tvos.md) | ✓ |  | x86 64-bit tvOS
 [`x86_64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ |  | x86 64-bit Apple WatchOS simulator
+[`x86_64-pc-cygwin`](platform-support/x86_64-pc-cygwin.md) | ? |  | 64-bit x86 Cygwin |
 [`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with default network stack (io-pkt) |
 [`x86_64-pc-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with new network stack (io-sock) |
 [`x86_64-pc-nto-qnx800`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 8.0 RTOS |

--- a/src/doc/rustc/src/platform-support/x86_64-pc-cygwin.md
+++ b/src/doc/rustc/src/platform-support/x86_64-pc-cygwin.md
@@ -1,0 +1,39 @@
+# `x86_64-pc-cygwin`
+
+**Tier: 3**
+
+Windows targets supporting Cygwin.
+The `*-cygwin` targets are **not** intended as native target for applications,
+a developer writing Windows applications should use the `*-pc-windows-*` targets instead, which are *native* Windows.
+
+Cygwin is only intended as an emulation layer for Unix-only programs which do not support the native Windows targets.
+
+## Target maintainers
+
+- [Berrysoft](https://github.com/Berrysoft)
+
+## Requirements
+
+This target is cross compiled. It needs `x86_64-pc-cygwin-gcc` as linker.
+
+The `target_os` of the target is `cygwin`, and it is `unix`.
+
+## Building the target
+
+For cross-compilation you want LLVM with [llvm/llvm-project#121439 (merged)](https://github.com/llvm/llvm-project/pull/121439) applied to fix the LLVM codegen on importing external global variables from DLLs.
+No native builds on Cygwin now. It should be possible theoretically though, but might need a lot of patches.
+
+## Building Rust programs
+
+Rust does not yet ship pre-compiled artifacts for this target. To compile for
+this target, you will either need to build Rust with the target enabled (see
+"Building the target" above), or build your own copy of `core` by using
+`build-std` or similar.
+
+## Testing
+
+Created binaries work fine on Windows with Cygwin.
+
+## Cross-compilation toolchains and C code
+
+Compatible C code can be built with GCC shipped with Cygwin. Clang is untested.

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -13,7 +13,7 @@ rinja = { version = "0.3", default-features = false, features = ["config"] }
 base64 = "0.21.7"
 itertools = "0.12"
 indexmap = "2"
-minifier = { version = "0.3.2", default-features = false }
+minifier = { version = "0.3.4", default-features = false }
 pulldown-cmark-old = { version = "0.9.6", package = "pulldown-cmark", default-features = false }
 regex = "1"
 rustdoc-json-types = { path = "../rustdoc-json-types" }

--- a/tests/assembly/targets/targets-pe.rs
+++ b/tests/assembly/targets/targets-pe.rs
@@ -84,6 +84,9 @@
 //@ revisions: x86_64_win7_windows_msvc
 //@ [x86_64_win7_windows_msvc] compile-flags: --target x86_64-win7-windows-msvc
 //@ [x86_64_win7_windows_msvc] needs-llvm-components: x86
+//@ revisions: x86_64_pc_cygwin
+//@ [x86_64_pc_cygwin] compile-flags: --target x86_64-pc-cygwin
+//@ [x86_64_pc_cygwin] needs-llvm-components: x86
 
 // Sanity-check that each target can produce assembly code.
 

--- a/tests/crashes/135470.rs
+++ b/tests/crashes/135470.rs
@@ -1,0 +1,40 @@
+//@ known-bug: #135470
+//@ compile-flags: --edition=2021 -Copt-level=0
+
+use std::future::Future;
+trait Access {
+    type Lister;
+
+    fn list() -> impl Future<Output = Self::Lister> {
+        async { todo!() }
+    }
+}
+
+trait Foo {}
+impl Access for dyn Foo {
+    type Lister = ();
+}
+
+fn main() {
+    let svc = async {
+        async { <dyn Foo>::list() }.await;
+    };
+    &svc as &dyn Service;
+}
+
+trait UnaryService {
+    fn call2() {}
+}
+trait Unimplemented {}
+impl<T: Unimplemented> UnaryService for T {}
+struct Wrap<T>(T);
+impl<T: Send> UnaryService for Wrap<T> {}
+
+trait Service {
+    fn call(&self);
+}
+impl<T: Send> Service for T {
+    fn call(&self) {
+        Wrap::<T>::call2();
+    }
+}

--- a/tests/crashes/135528.rs
+++ b/tests/crashes/135528.rs
@@ -1,0 +1,18 @@
+//@ known-bug: #135528
+//@ compile-flags: -Zvalidate-mir -Zinline-mir=yes
+#![feature(type_alias_impl_trait)]
+type Tait = impl Copy;
+
+fn set(x: &isize) -> isize {
+    *x
+}
+
+fn d(x: Tait) {
+    set(x);
+}
+
+fn other_define() -> Tait {
+    ()
+}
+
+fn main() {}

--- a/tests/crashes/135570.rs
+++ b/tests/crashes/135570.rs
@@ -1,0 +1,12 @@
+//@ known-bug: #135570
+//@compile-flags: -Zvalidate-mir -Zmir-enable-passes=+Inline -Copt-level=0 -Zmir-enable-passes=+GVN
+//@ only-x86_64
+
+fn function_with_bytes<const BYTES: &'static [u8; 0xc7b889180b67b07d_bc1a3c88783d35b5_u128]>(
+) -> &'static [u8] {
+    BYTES
+}
+
+fn main() {
+    function_with_bytes::<b"aa">() == &[];
+}

--- a/tests/crashes/135617.rs
+++ b/tests/crashes/135617.rs
@@ -1,0 +1,13 @@
+//@ known-bug: #135617
+trait Project {
+    const ASSOC: usize;
+}
+
+fn foo()
+where
+    for<'a> (): Project,
+{
+    [(); <() as Project>::ASSOC];
+}
+
+pub fn main() {}

--- a/tests/crashes/135646.rs
+++ b/tests/crashes/135646.rs
@@ -1,0 +1,5 @@
+//@ known-bug: #135646
+//@ compile-flags: --edition=2024 -Zpolonius=next
+fn main() {
+    &{ [1, 2, 3][4] };
+}

--- a/tests/crashes/135668.rs
+++ b/tests/crashes/135668.rs
@@ -1,0 +1,38 @@
+//@ known-bug: #135668
+//@ compile-flags: --edition=2021
+use std::future::Future;
+
+pub async fn foo() {
+    let _ = create_task().await;
+}
+
+async fn create_task() -> impl Sized {
+    bind(documentation)
+}
+
+async fn documentation() {
+    include_str!("nonexistent");
+}
+
+fn bind<F>(_filter: F) -> impl Sized
+where
+    F: FilterBase,
+{
+    || -> <F as FilterBase>::Assoc { panic!() }
+}
+
+trait FilterBase {
+    type Assoc;
+}
+
+impl<F, R> FilterBase for F
+where
+    F: Fn() -> R,
+    // Removing the below line makes it correctly error on both stable and beta
+    R: Future,
+    // Removing the below line makes it ICE on both stable and beta
+    R: Send,
+    // Removing the above two bounds makes it ICE on stable but correctly error on beta
+{
+    type Assoc = F;
+}

--- a/tests/crashes/135718.rs
+++ b/tests/crashes/135718.rs
@@ -1,0 +1,50 @@
+//@ known-bug: #135718
+
+struct Equal;
+
+struct Bar;
+
+trait TwiceNested {}
+impl<M> TwiceNested for Bar where Bar: NestMakeEqual<NestEq = M> {}
+
+struct Sum;
+
+trait Not {
+    fn not();
+}
+
+impl<P> Not for Sum
+where
+    Bar: NestMakeEqual<NestEq = P>,
+    Self: Problem<P>,
+{
+    fn not() {}
+}
+
+trait NestMakeEqual {
+    type NestEq;
+}
+
+trait MakeEqual {
+    type Eq;
+}
+
+struct Foo;
+impl MakeEqual for Foo {
+    type Eq = Equal;
+}
+
+impl<O> NestMakeEqual for Bar
+where
+    Foo: MakeEqual<Eq = O>,
+{
+    type NestEq = O;
+}
+
+trait Problem<M> {}
+impl Problem<()> for Sum where Bar: TwiceNested {}
+impl Problem<Equal> for Sum where Bar: TwiceNested {}
+
+fn main() {
+    Sum::not();
+}

--- a/tests/crashes/135720.rs
+++ b/tests/crashes/135720.rs
@@ -1,0 +1,4 @@
+//@ known-bug: #135720
+#![feature(generic_const_exprs)]
+type S<'l> = [i32; A];
+fn lint_me(x: S<()>) {}

--- a/tests/crashes/135845.rs
+++ b/tests/crashes/135845.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #135845
+struct S<'a, T: ?Sized>(&'a T);
+
+fn b<'a>() -> S<'static, _> {
+    S::<'a>(&0)
+}

--- a/tests/crashes/135863.rs
+++ b/tests/crashes/135863.rs
@@ -1,0 +1,10 @@
+//@ known-bug: #135863
+struct A;
+
+impl A {
+    fn len(self: &&B) {}
+}
+
+fn main() {
+    A.len()
+}

--- a/tests/crashes/136063.rs
+++ b/tests/crashes/136063.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #136063
+#![feature(generic_const_exprs)]
+trait A<const B: u8 = X> {}
+impl A<1> for bool {}
+fn bar(arg : &dyn A<x>) { bar(true) }
+pub fn main() {}

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -201,7 +201,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_os = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `redox`, `rtems`, `solaris`, `solid_asp3`, `teeos`, `trusty`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`, and `zkvm`
+   = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `cygwin`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `redox`, `rtems`, `solaris`, `solid_asp3`, `teeos`, `trusty`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`, and `zkvm`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
@@ -274,7 +274,7 @@ LL | #[cfg(target_os = "linuz")] // testing that we suggest `linux`
    |                   |
    |                   help: there is a expected value with a similar name: `"linux"`
    |
-   = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `redox`, `rtems`, `solaris`, `solid_asp3`, `teeos`, `trusty`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`, and `zkvm`
+   = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `cygwin`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `redox`, `rtems`, `solaris`, `solid_asp3`, `teeos`, `trusty`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`, and `zkvm`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: 28 warnings emitted

--- a/tests/ui/lint/lint-overflowing-int-136675.rs
+++ b/tests/ui/lint/lint-overflowing-int-136675.rs
@@ -1,0 +1,4 @@
+fn main() {
+    if let -129 = 0i8 {} //~ ERROR literal out of range for `i8`
+    let x: i8 = -129; //~ ERROR literal out of range for `i8`
+}

--- a/tests/ui/lint/lint-overflowing-int-136675.stderr
+++ b/tests/ui/lint/lint-overflowing-int-136675.stderr
@@ -1,0 +1,21 @@
+error: literal out of range for `i8`
+  --> $DIR/lint-overflowing-int-136675.rs:2:12
+   |
+LL |     if let -129 = 0i8 {}
+   |            ^^^^
+   |
+   = note: the literal `-129` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using the type `i16` instead
+   = note: `#[deny(overflowing_literals)]` on by default
+
+error: literal out of range for `i8`
+  --> $DIR/lint-overflowing-int-136675.rs:3:17
+   |
+LL |     let x: i8 = -129;
+   |                 ^^^^
+   |
+   = note: the literal `-129` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using the type `i16` instead
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #134999 (Add cygwin target.)
 - #135488 (Stabilize `vec_pop_if`)
 - #136068 (crashes: more tests)
 - #136694 (Update minifier version to `0.3.4`)
 - #136760 (Fix unwrap error in overflowing int literal)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134999,135488,136068,136694,136760)
<!-- homu-ignore:end -->