### PR TITLE
Update `String::from_raw_parts` safety requirements

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -966,11 +966,8 @@ impl String {
     /// This is highly unsafe, due to the number of invariants that aren't
     /// checked:
     ///
-    /// * The memory at `buf` needs to have been previously allocated by the
-    ///   same allocator the standard library uses, with a required alignment of exactly 1.
-    /// * `length` needs to be less than or equal to `capacity`.
-    /// * `capacity` needs to be the correct value.
-    /// * The first `length` bytes at `buf` need to be valid UTF-8.
+    /// * all safety requirements for [`Vec::<u8>::from_raw_parts`]
+    /// * all safety requirements for [`String::from_utf8_unchecked`]
     ///
     /// Violating these may cause problems like corrupting the allocator's
     /// internal data structures. For example, it is normally **not** safe to

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -966,8 +966,8 @@ impl String {
     /// This is highly unsafe, due to the number of invariants that aren't
     /// checked:
     ///
-    /// * all safety requirements for [`Vec::<u8>::from_raw_parts`]
-    /// * all safety requirements for [`String::from_utf8_unchecked`]
+    /// * all safety requirements for [`Vec::<u8>::from_raw_parts`].
+    /// * all safety requirements for [`String::from_utf8_unchecked`].
     ///
     /// Violating these may cause problems like corrupting the allocator's
     /// internal data structures. For example, it is normally **not** safe to


### PR DESCRIPTION
These have gotten out of sync with `Vec::from_raw_part`'s safety requirements, and are likely to diverge again. I think it's safest to just point at `Vec`'s requirements.

https://github.com/rust-lang/rust/issues/119206#issuecomment-2180116680