### PR TITLE
Introduce a `#[diagnostic::on_unknown_item]` attribute

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -1193,7 +1193,7 @@ pub static BUILTIN_ATTRIBUTE_MAP: LazyLock<FxHashMap<Symbol, &BuiltinAttribute>>
 
 pub fn is_stable_diagnostic_attribute(sym: Symbol, _features: &Features) -> bool {
     match sym {
-        sym::on_unimplemented | sym::do_not_recommend => true,
+        sym::on_unimplemented | sym::do_not_recommend | sym::on_unknown_item => true,
         _ => false,
     }
 }

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -152,6 +152,9 @@ passes_deprecated_attribute =
 passes_diagnostic_diagnostic_on_unimplemented_only_for_traits =
     `#[diagnostic::on_unimplemented]` can only be applied to trait definitions
 
+passes_diagnostic_diagnostic_on_unknown_item_only_for_imports =
+    `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+
 passes_diagnostic_item_first_defined =
     the diagnostic item is first defined here
 
@@ -356,6 +359,11 @@ passes_ignored_derived_impls =
      *[other] traits {$trait_list}, but these are
     } intentionally ignored during dead code analysis
 
+passes_ignored_diagnostic_option = `{$option_name}` is ignored due to previous definition of `{$option_name}`
+    .other_label = `{$option_name}` is first declared here
+    .label = `{$option_name}` is already declared here
+    .help = consider removing the second `{$option_name}` as it is ignored anyway
+
 passes_implied_feature_not_exist =
     feature `{$implied_by}` implying `{$feature}` does not exist
 
@@ -473,6 +481,11 @@ passes_macro_export_on_decl_macro =
 
 passes_macro_use =
     `#[{$name}]` only has an effect on `extern crate` and modules
+
+passes_malformed_on_unknown_item_attr =
+    malformed `#[diagnostic::on_unknown_item]` attribute
+    .label = the `#[diagnostic::on_unknown_item]` attribute expects at least one option
+    .help = at least one of the following options is required: `message`, `label` or `note`
 
 passes_may_dangle =
     `#[may_dangle]` must be applied to a lifetime or type generic parameter in `Drop` impl
@@ -751,6 +764,11 @@ passes_unknown_feature =
 passes_unknown_lang_item =
     definition of an unknown lang item: `{$name}`
     .label = definition of unknown lang item `{$name}`
+
+passes_unknown_option_for_on_unknown_item =
+    unknown `{$option_name}` option for `#[diagnostic::on_unknown_item]` attribute
+    .help = only `message`, `note` and `label` are allowed as options
+    .label = invalid option found here
 
 passes_unlabeled_cf_in_while_condition =
     `break` or `continue` with no label in the condition of a `while` loop

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -656,7 +656,8 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             && let [namespace, attribute, ..] = &*path.segments
             && namespace.ident.name == sym::diagnostic
             && !(attribute.ident.name == sym::on_unimplemented
-                || attribute.ident.name == sym::do_not_recommend)
+                || attribute.ident.name == sym::do_not_recommend
+                || attribute.ident.name == sym::on_unknown_item)
         {
             let distance =
                 edit_distance(attribute.ident.name.as_str(), sym::on_unimplemented.as_str(), 5);

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1431,6 +1431,7 @@ symbols! {
         omit_gdb_pretty_printer_section,
         on,
         on_unimplemented,
+        on_unknown_item,
         opaque,
         opaque_module_name_placeholder: "<opaque>",
         open_options_new,

--- a/tests/ui/diagnostic_namespace/on_unknown_item/incorrect-locations.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown_item/incorrect-locations.rs
@@ -1,0 +1,46 @@
+//@check-pass
+
+#[diagnostic::on_unknown_item(message = "foo")]
+//~^WARN `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+const CONST: () = ();
+
+#[diagnostic::on_unknown_item(message = "foo")]
+//~^WARN `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+static STATIC: () = ();
+
+#[diagnostic::on_unknown_item(message = "foo")]
+//~^WARN `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+type Type = ();
+
+#[diagnostic::on_unknown_item(message = "foo")]
+//~^WARN `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+enum Enum {}
+
+#[diagnostic::on_unknown_item(message = "foo")]
+//~^WARN `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+impl Enum {}
+
+#[diagnostic::on_unknown_item(message = "foo")]
+//~^WARN `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+extern "C" {}
+
+#[diagnostic::on_unknown_item(message = "foo")]
+//~^WARN `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+fn fun() {}
+
+#[diagnostic::on_unknown_item(message = "foo")]
+//~^WARN `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+struct Struct {}
+
+#[diagnostic::on_unknown_item(message = "foo")]
+//~^WARN `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+trait Trait {}
+
+#[diagnostic::on_unknown_item(message = "foo")]
+//~^WARN `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+impl Trait for i32 {}
+
+#[diagnostic::on_unknown_item(message = "foo")]
+use std::str::FromStr;
+
+fn main() {}

--- a/tests/ui/diagnostic_namespace/on_unknown_item/incorrect-locations.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown_item/incorrect-locations.stderr
@@ -1,0 +1,64 @@
+warning: `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+  --> $DIR/incorrect-locations.rs:3:1
+   |
+LL | #[diagnostic::on_unknown_item(message = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unknown_or_malformed_diagnostic_attributes)]` on by default
+
+warning: `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+  --> $DIR/incorrect-locations.rs:7:1
+   |
+LL | #[diagnostic::on_unknown_item(message = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+  --> $DIR/incorrect-locations.rs:11:1
+   |
+LL | #[diagnostic::on_unknown_item(message = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+  --> $DIR/incorrect-locations.rs:15:1
+   |
+LL | #[diagnostic::on_unknown_item(message = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+  --> $DIR/incorrect-locations.rs:19:1
+   |
+LL | #[diagnostic::on_unknown_item(message = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+  --> $DIR/incorrect-locations.rs:23:1
+   |
+LL | #[diagnostic::on_unknown_item(message = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+  --> $DIR/incorrect-locations.rs:27:1
+   |
+LL | #[diagnostic::on_unknown_item(message = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+  --> $DIR/incorrect-locations.rs:31:1
+   |
+LL | #[diagnostic::on_unknown_item(message = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+  --> $DIR/incorrect-locations.rs:35:1
+   |
+LL | #[diagnostic::on_unknown_item(message = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `#[diagnostic::on_unknown_item]` can only be applied to `use` statements
+  --> $DIR/incorrect-locations.rs:39:1
+   |
+LL | #[diagnostic::on_unknown_item(message = "foo")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 10 warnings emitted
+

--- a/tests/ui/diagnostic_namespace/on_unknown_item/malformed_attribute.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown_item/malformed_attribute.rs
@@ -1,0 +1,18 @@
+#[diagnostic::on_unknown_item]
+//~^WARN malformed `#[diagnostic::on_unknown_item]`
+use std::str::FromStr;
+
+#[diagnostic::on_unknown_item(foo = "bar", message = "foo")]
+//~^WARN unknown `foo` option for `#[diagnostic::on_unknown_item]` attribute
+use std::str::Bytes;
+
+#[diagnostic::on_unknown_item(label = "foo", label = "bar")]
+//~^WARN `label` is ignored due to previous definition of `label`
+use std::str::Chars;
+
+#[diagnostic::on_unknown_item(message = "Foo", message = "Bar")]
+//~^WARN `message` is ignored due to previous definition of `message`
+use std::str::NotExisting;
+//~^ERROR Foo
+
+fn main() {}

--- a/tests/ui/diagnostic_namespace/on_unknown_item/malformed_attribute.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown_item/malformed_attribute.stderr
@@ -1,0 +1,46 @@
+error[E0432]: Foo
+  --> $DIR/malformed_attribute.rs:15:5
+   |
+LL | use std::str::NotExisting;
+   |     ^^^^^^^^^^^^^^^^^^^^^ no `NotExisting` in `str`
+
+warning: malformed `#[diagnostic::on_unknown_item]` attribute
+  --> $DIR/malformed_attribute.rs:1:1
+   |
+LL | #[diagnostic::on_unknown_item]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `#[diagnostic::on_unknown_item]` attribute expects at least one option
+   |
+   = help: at least one of the following options is required: `message`, `label` or `note`
+   = note: `#[warn(unknown_or_malformed_diagnostic_attributes)]` on by default
+
+warning: unknown `foo` option for `#[diagnostic::on_unknown_item]` attribute
+  --> $DIR/malformed_attribute.rs:5:31
+   |
+LL | #[diagnostic::on_unknown_item(foo = "bar", message = "foo")]
+   |                               ^^^^^^^^^^^ invalid option found here
+   |
+   = help: only `message`, `note` and `label` are allowed as options
+
+warning: `label` is ignored due to previous definition of `label`
+  --> $DIR/malformed_attribute.rs:9:46
+   |
+LL | #[diagnostic::on_unknown_item(label = "foo", label = "bar")]
+   |                               -------------  ^^^^^^^^^^^^^ `label` is already declared here
+   |                               |
+   |                               `label` is first declared here
+   |
+   = help: consider removing the second `label` as it is ignored anyway
+
+warning: `message` is ignored due to previous definition of `message`
+  --> $DIR/malformed_attribute.rs:13:48
+   |
+LL | #[diagnostic::on_unknown_item(message = "Foo", message = "Bar")]
+   |                               ---------------  ^^^^^^^^^^^^^^^ `message` is already declared here
+   |                               |
+   |                               `message` is first declared here
+   |
+   = help: consider removing the second `message` as it is ignored anyway
+
+error: aborting due to 1 previous error; 4 warnings emitted
+
+For more information about this error, try `rustc --explain E0432`.

--- a/tests/ui/diagnostic_namespace/on_unknown_item/unknown_import.rs
+++ b/tests/ui/diagnostic_namespace/on_unknown_item/unknown_import.rs
@@ -1,0 +1,16 @@
+pub mod foo {
+    pub struct Bar;
+}
+
+#[diagnostic::on_unknown_item(
+    message = "first message",
+    label = "first label",
+    note = "custom note",
+    note = "custom note 2"
+)]
+use foo::Foo;
+//~^ERROR first message
+
+use foo::Bar;
+
+fn main() {}

--- a/tests/ui/diagnostic_namespace/on_unknown_item/unknown_import.stderr
+++ b/tests/ui/diagnostic_namespace/on_unknown_item/unknown_import.stderr
@@ -1,0 +1,12 @@
+error[E0432]: first message
+  --> $DIR/unknown_import.rs:11:5
+   |
+LL | use foo::Foo;
+   |     ^^^^^^^^ first label
+   |
+   = note: custom note
+   = note: custom note 2
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
This PR introduces a `#[diagnostic::on_unknown_item]` attribute that allows crate authors to customize the error messages emitted by unresolved imports. The main usecase for this is using this attribute as part of a proc macro that expects a certain external module structure to exist or certain dependencies to be there.

For me personally the motivating use-case are several derives in diesel, that expect to refer to a `tabe` module. That is done either implicitly (via the name of the type with the derive) or explicitly by the user. This attribute would allow us to improve the error message in both cases:

* For the implicit case we could explicity call out our assumptions (turning the name into lower case, adding an `s` in the end)
+ point to the explicit variant as alternative
* For the explicit variant we would add additional notes to tell the user why this is happening and what they should look for to fix the problem (be more explicit about certain diesel specific assumptions of the module structure)

I assume that similar use-cases exist for other proc-macros as well, therefore I decided to put in the work implementing this new attribute. I would also assume that this is likely not useful for std-lib internal usage.

cc @estebank as someone that was previously involved in the design of such attributes

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
