### PR TITLE
Nuke `Buffer` abstraction from `librustdoc`, take 2 💣

### DIFF
--- a/src/librustdoc/html/highlight/tests.rs
+++ b/src/librustdoc/html/highlight/tests.rs
@@ -3,7 +3,6 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_span::create_default_session_globals_then;
 
 use super::{DecorationInfo, write_code};
-use crate::html::format::Buffer;
 
 const STYLE: &str = r#"
 <style>
@@ -22,9 +21,9 @@ fn test_html_highlighting() {
     create_default_session_globals_then(|| {
         let src = include_str!("fixtures/sample.rs");
         let html = {
-            let mut out = Buffer::new();
+            let mut out = String::new();
             write_code(&mut out, src, None, None, None);
-            format!("{STYLE}<pre><code>{}</code></pre>\n", out.into_inner())
+            format!("{STYLE}<pre><code>{out}</code></pre>\n")
         };
         expect_file!["fixtures/sample.html"].assert_eq(&html);
     });
@@ -36,9 +35,9 @@ fn test_dos_backline() {
         let src = "pub fn foo() {\r\n\
     println!(\"foo\");\r\n\
 }\r\n";
-        let mut html = Buffer::new();
+        let mut html = String::new();
         write_code(&mut html, src, None, None, None);
-        expect_file!["fixtures/dos_line.html"].assert_eq(&html.into_inner());
+        expect_file!["fixtures/dos_line.html"].assert_eq(&html);
     });
 }
 
@@ -50,9 +49,9 @@ use self::whatever;
 let x = super::b::foo;
 let y = Self::whatever;";
 
-        let mut html = Buffer::new();
+        let mut html = String::new();
         write_code(&mut html, src, None, None, None);
-        expect_file!["fixtures/highlight.html"].assert_eq(&html.into_inner());
+        expect_file!["fixtures/highlight.html"].assert_eq(&html);
     });
 }
 
@@ -60,9 +59,9 @@ let y = Self::whatever;";
 fn test_union_highlighting() {
     create_default_session_globals_then(|| {
         let src = include_str!("fixtures/union.rs");
-        let mut html = Buffer::new();
+        let mut html = String::new();
         write_code(&mut html, src, None, None, None);
-        expect_file!["fixtures/union.html"].assert_eq(&html.into_inner());
+        expect_file!["fixtures/union.html"].assert_eq(&html);
     });
 }
 
@@ -77,8 +76,8 @@ let a = 4;";
         decorations.insert("example", vec![(0, 10), (11, 21)]);
         decorations.insert("example2", vec![(22, 32)]);
 
-        let mut html = Buffer::new();
+        let mut html = String::new();
         write_code(&mut html, src, None, Some(&DecorationInfo(decorations)), None);
-        expect_file!["fixtures/decorations.html"].assert_eq(&html.into_inner());
+        expect_file!["fixtures/decorations.html"].assert_eq(&html);
     });
 }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -52,7 +52,6 @@ use crate::clean::RenderedLink;
 use crate::doctest;
 use crate::doctest::GlobalTestOptions;
 use crate::html::escape::{Escape, EscapeBodyText};
-use crate::html::format::Buffer;
 use crate::html::highlight;
 use crate::html::length_limit::HtmlWithLimit;
 use crate::html::render::small_url_encode;
@@ -329,7 +328,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
 
         // insert newline to clearly separate it from the
         // previous block so we can shorten the html output
-        let mut s = Buffer::new();
+        let mut s = String::new();
         s.push('\n');
 
         highlight::render_example_with_highlighting(
@@ -339,7 +338,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
             playground_button.as_deref(),
             &added_classes,
         );
-        Some(Event::Html(s.into_inner().into()))
+        Some(Event::Html(s.into()))
     }
 }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -1,8 +1,8 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
-use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, channel};
+use std::{fmt, io};
 
 use rinja::Template;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
@@ -26,11 +26,12 @@ use crate::formats::FormatRenderer;
 use crate::formats::cache::Cache;
 use crate::formats::item_type::ItemType;
 use crate::html::escape::Escape;
-use crate::html::format::{Buffer, join_with_double_colon};
+use crate::html::format::join_with_double_colon;
+use crate::html::layout::{self, BufDisplay};
 use crate::html::markdown::{self, ErrorCodes, IdMap, plain_text_summary};
 use crate::html::render::write_shared::write_shared;
 use crate::html::url_parts_builder::UrlPartsBuilder;
-use crate::html::{layout, sources, static_files};
+use crate::html::{sources, static_files};
 use crate::scrape_examples::AllCallLocations;
 use crate::{DOC_RUST_LANG_ORG_VERSION, try_err};
 
@@ -235,7 +236,7 @@ impl<'tcx> Context<'tcx> {
         };
 
         if !render_redirect_pages {
-            let mut page_buffer = Buffer::html();
+            let mut page_buffer = String::new();
             print_item(self, it, &mut page_buffer);
             let page = layout::Page {
                 css_class: tyname_s,
@@ -249,8 +250,10 @@ impl<'tcx> Context<'tcx> {
             layout::render(
                 &self.shared.layout,
                 &page,
-                |buf: &mut _| print_sidebar(self, it, buf),
-                move |buf: &mut Buffer| buf.push_buffer(page_buffer),
+                BufDisplay(|buf: &mut String| {
+                    print_sidebar(self, it, buf);
+                }),
+                page_buffer,
                 &self.shared.style_files,
             )
         } else {
@@ -627,7 +630,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             rust_logo: has_doc_flag(self.tcx(), LOCAL_CRATE.as_def_id(), sym::rust_logo),
         };
         let all = shared.all.replace(AllTypes::new());
-        let mut sidebar = Buffer::html();
+        let mut sidebar = String::new();
 
         // all.html is not customizable, so a blank id map is fine
         let blocks = sidebar_module_like(all.item_sections(), &mut IdMap::new(), ModuleLike::Crate);
@@ -646,8 +649,10 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         let v = layout::render(
             &shared.layout,
             &page,
-            sidebar.into_inner(),
-            |buf: &mut Buffer| all.print(buf),
+            sidebar,
+            BufDisplay(|buf: &mut String| {
+                all.print(buf);
+            }),
             &shared.style_files,
         );
         shared.fs.write(final_file, v)?;
@@ -665,7 +670,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                 &shared.layout,
                 &page,
                 sidebar,
-                |buf: &mut Buffer| {
+                fmt::from_fn(|buf| {
                     write!(
                         buf,
                         "<div class=\"main-heading\">\
@@ -684,7 +689,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                          <script defer src=\"{static_root_path}{settings_js}\"></script>",
                         static_root_path = page.get_static_root_path(),
                         settings_js = static_files::STATIC_FILES.settings_js,
-                    );
+                    )?;
                     // Pre-load all theme CSS files, so that switching feels seamless.
                     //
                     // When loading settings.html as a popover, the equivalent HTML is
@@ -697,10 +702,11 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                                     as=\"style\">",
                                 root_path = page.static_root_path.unwrap_or(""),
                                 suffix = page.resource_suffix,
-                            );
+                            )?;
                         }
                     }
-                },
+                    Ok(())
+                }),
                 &shared.style_files,
             );
             shared.fs.write(settings_file, v)?;
@@ -716,25 +722,22 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                 &shared.layout,
                 &page,
                 sidebar,
-                |buf: &mut Buffer| {
-                    write!(
-                        buf,
-                        "<div class=\"main-heading\">\
-                         <h1>Rustdoc help</h1>\
-                         <span class=\"out-of-band\">\
-                             <a id=\"back\" href=\"javascript:void(0)\" onclick=\"history.back();\">\
-                                Back\
-                            </a>\
-                         </span>\
-                         </div>\
-                         <noscript>\
-                            <section>\
-                                <p>You need to enable JavaScript to use keyboard commands or search.</p>\
-                                <p>For more information, browse the <a href=\"{DOC_RUST_LANG_ORG_VERSION}/rustdoc/\">rustdoc handbook</a>.</p>\
-                            </section>\
-                         </noscript>",
-                    )
-                },
+                format_args!(
+                    "<div class=\"main-heading\">\
+                        <h1>Rustdoc help</h1>\
+                        <span class=\"out-of-band\">\
+                            <a id=\"back\" href=\"javascript:void(0)\" onclick=\"history.back();\">\
+                            Back\
+                        </a>\
+                        </span>\
+                        </div>\
+                        <noscript>\
+                        <section>\
+                            <p>You need to enable JavaScript to use keyboard commands or search.</p>\
+                            <p>For more information, browse the <a href=\"{DOC_RUST_LANG_ORG_VERSION}/rustdoc/\">rustdoc handbook</a>.</p>\
+                        </section>\
+                        </noscript>",
+                ),
                 &shared.style_files,
             );
             shared.fs.write(help_file, v)?;

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -11,7 +11,6 @@ use super::{Context, ItemSection, item_ty_to_section};
 use crate::clean;
 use crate::formats::Impl;
 use crate::formats::item_type::ItemType;
-use crate::html::format::Buffer;
 use crate::html::markdown::{IdMap, MarkdownWithToc};
 
 #[derive(Clone, Copy)]
@@ -114,7 +113,7 @@ pub(crate) mod filters {
     }
 }
 
-pub(super) fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut Buffer) {
+pub(super) fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut String) {
     let mut ids = IdMap::new();
     let mut blocks: Vec<LinkBlock<'_>> = docblock_toc(cx, it, &mut ids).into_iter().collect();
     let deref_id_map = cx.deref_id_map.borrow();

--- a/src/librustdoc/html/render/tests.rs
+++ b/src/librustdoc/html/render/tests.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
+use super::AllTypes;
 use super::print_item::compare_names;
-use super::{AllTypes, Buffer};
 
 #[test]
 fn test_compare_names() {
@@ -47,8 +47,8 @@ fn test_all_types_prints_header_once() {
     // Regression test for #82477
     let all_types = AllTypes::new();
 
-    let mut buffer = Buffer::new();
+    let mut buffer = String::new();
     all_types.print(&mut buffer);
 
-    assert_eq!(1, buffer.into_inner().matches("List of all items").count());
+    assert_eq!(1, buffer.matches("List of all items").count());
 }

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -44,7 +44,6 @@ use crate::docfs::PathError;
 use crate::error::Error;
 use crate::formats::Impl;
 use crate::formats::item_type::ItemType;
-use crate::html::format::Buffer;
 use crate::html::layout;
 use crate::html::render::ordered_json::{EscapedJson, OrderedJson};
 use crate::html::render::search_index::{SerializedSearchIndex, build_index};
@@ -622,7 +621,6 @@ impl TypeAliasPart {
                     // to make that functionality work here, it needs to be called with
                     // each type alias, and if it gives a different result, split the impl
                     for &(type_alias_fqp, type_alias_item) in type_aliases {
-                        let mut buf = Buffer::html();
                         cx.id_map.borrow_mut().clear();
                         cx.deref_id_map.borrow_mut().clear();
                         let target_did = impl_
@@ -638,23 +636,26 @@ impl TypeAliasPart {
                         } else {
                             AssocItemLink::Anchor(None)
                         };
-                        super::render_impl(
-                            &mut buf,
-                            cx,
-                            impl_,
-                            type_alias_item,
-                            assoc_link,
-                            RenderMode::Normal,
-                            None,
-                            &[],
-                            ImplRenderingParameters {
-                                show_def_docs: true,
-                                show_default_items: true,
-                                show_non_assoc_items: true,
-                                toggle_open_by_default: true,
-                            },
-                        );
-                        let text = buf.into_inner();
+                        let text = {
+                            let mut buf = String::new();
+                            super::render_impl(
+                                &mut buf,
+                                cx,
+                                impl_,
+                                type_alias_item,
+                                assoc_link,
+                                RenderMode::Normal,
+                                None,
+                                &[],
+                                ImplRenderingParameters {
+                                    show_def_docs: true,
+                                    show_default_items: true,
+                                    show_non_assoc_items: true,
+                                    toggle_open_by_default: true,
+                                },
+                            );
+                            buf
+                        };
                         let type_alias_fqp = (*type_alias_fqp).iter().join("::");
                         if Some(&text) == ret.last().map(|s: &AliasSerializableImpl| &s.text) {
                             ret.last_mut()

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -7,6 +7,7 @@
 #![feature(box_patterns)]
 #![feature(debug_closure_helpers)]
 #![feature(file_buffered)]
+#![feature(format_args_nl)]
 #![feature(if_let_guard)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(iter_intersperse)]


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/136656 I found out that the for_html field in the Buffer struct was never read, and pondered if Buffer had any utility at all. @GuillaumeGomez said he agrees that it can be just removed. So this PR is me removing it. So, r? @aDotInTheVoid , maybe?

Supersedes #136748 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
