### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "minifier"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd559bbf5d350ac7f2c1cf92ed71a869b847a92bce0c1318b47932a5b5f65cdd"
+checksum = "1cf47565b1430f5fe6c81d3afcb4b835271348d7eb35294a4d592e38dd09ea22"
 
 [[package]]
 name = "minimal-lexical"

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -543,7 +543,11 @@ impl<'tcx> LateLintPass<'tcx> for TypeLimits {
         lit: &'tcx hir::Lit,
         negated: bool,
     ) {
-        lint_literal(cx, self, hir_id, lit.span, lit, negated)
+        if negated {
+            self.negated_expr_id = Some(hir_id);
+            self.negated_expr_span = Some(lit.span);
+        }
+        lint_literal(cx, self, hir_id, lit.span, lit, negated);
     }
 
     fn check_expr(&mut self, cx: &LateContext<'tcx>, e: &'tcx hir::Expr<'tcx>) {

--- a/compiler/rustc_lint/src/types/literal.rs
+++ b/compiler/rustc_lint/src/types/literal.rs
@@ -245,12 +245,11 @@ fn lint_int_literal<'tcx>(
     lit: &hir::Lit,
     t: ty::IntTy,
     v: u128,
-    negated: bool,
 ) {
     let int_type = t.normalize(cx.sess().target.pointer_width);
     let (min, max) = int_ty_range(int_type);
     let max = max as u128;
-    let negative = negated ^ (type_limits.negated_expr_id == Some(hir_id));
+    let negative = type_limits.negated_expr_id == Some(hir_id);
 
     // Detect literal value out of range [min, max] inclusive
     // avoiding use of -min to prevent overflow/panic
@@ -366,7 +365,7 @@ pub(crate) fn lint_literal<'tcx>(
         ty::Int(t) => {
             match lit.node {
                 ast::LitKind::Int(v, ast::LitIntType::Signed(_) | ast::LitIntType::Unsuffixed) => {
-                    lint_int_literal(cx, type_limits, hir_id, span, lit, t, v.get(), negated)
+                    lint_int_literal(cx, type_limits, hir_id, span, lit, t, v.get())
                 }
                 _ => bug!(),
             };

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -527,8 +527,9 @@ macro_rules! make_mir_visitor {
                         target: _,
                         unwind: _,
                         call_source: _,
-                        fn_span: _
+                        fn_span,
                     } => {
+                        self.visit_span($(& $mutability)? *fn_span);
                         self.visit_operand(func, location);
                         for arg in args {
                             self.visit_operand(&$($mutability)? arg.node, location);
@@ -543,8 +544,9 @@ macro_rules! make_mir_visitor {
                     TerminatorKind::TailCall {
                         func,
                         args,
-                        fn_span: _,
+                        fn_span,
                     } => {
+                        self.visit_span($(& $mutability)? *fn_span);
                         self.visit_operand(func, location);
                         for arg in args {
                             self.visit_operand(&$($mutability)? arg.node, location);

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -853,6 +853,8 @@ macro_rules! make_mir_visitor {
                     local_info: _,
                 } = local_decl;
 
+                self.visit_source_info(source_info);
+
                 self.visit_ty($(& $mutability)? *ty, TyContext::LocalDecl {
                     local,
                     source_info: *source_info,
@@ -862,7 +864,6 @@ macro_rules! make_mir_visitor {
                         self.visit_user_type_projection(user_ty);
                     }
                 }
-                self.visit_source_info(source_info);
             }
 
             fn super_var_debug_info(

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -1254,6 +1254,8 @@ impl<'tcx> MutVisitor<'tcx> for Integrator<'_, 'tcx> {
         // replaced down below anyways).
         if !matches!(terminator.kind, TerminatorKind::Return) {
             self.super_terminator(terminator, loc);
+        } else {
+            self.visit_source_info(&mut terminator.source_info);
         }
 
         match terminator.kind {

--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -133,7 +133,8 @@ session_unstable_virtual_function_elimination = `-Zvirtual-function-elimination`
 session_unsupported_crate_type_for_target =
     dropping unsupported crate type `{$crate_type}` for target `{$target_triple}`
 
-session_unsupported_dwarf_version = requested DWARF version {$dwarf_version} is greater than 5
+session_unsupported_dwarf_version = requested DWARF version {$dwarf_version} is not supported
+session_unsupported_dwarf_version_help = supported DWARF versions are 2, 3, 4 and 5
 
 session_unsupported_reg_struct_return_arch = `-Zreg-struct-return` is only supported on x86
 session_unsupported_regparm = `-Zregparm={$regparm}` is unsupported (valid values 0-3)

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -161,6 +161,7 @@ pub(crate) struct UnstableVirtualFunctionElimination;
 
 #[derive(Diagnostic)]
 #[diag(session_unsupported_dwarf_version)]
+#[help(session_unsupported_dwarf_version_help)]
 pub(crate) struct UnsupportedDwarfVersion {
     pub(crate) dwarf_version: u32,
 }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1251,7 +1251,8 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     }
 
     if let Some(dwarf_version) = sess.opts.unstable_opts.dwarf_version {
-        if dwarf_version > 5 {
+        // DWARF 1 is not supported by LLVM and DWARF 6 is not yet finalized.
+        if dwarf_version < 2 || dwarf_version > 5 {
             sess.dcx().emit_err(errors::UnsupportedDwarfVersion { dwarf_version });
         }
     }

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -155,7 +155,6 @@
 #![feature(unicode_internals)]
 #![feature(unsize)]
 #![feature(unwrap_infallible)]
-#![feature(vec_pop_if)]
 // tidy-alphabetical-end
 //
 // Language features:

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2518,8 +2518,6 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(vec_pop_if)]
-    ///
     /// let mut vec = vec![1, 2, 3, 4];
     /// let pred = |x: &mut i32| *x % 2 == 0;
     ///
@@ -2527,7 +2525,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(vec, [1, 2, 3]);
     /// assert_eq!(vec.pop_if(pred), None);
     /// ```
-    #[unstable(feature = "vec_pop_if", issue = "122741")]
+    #[stable(feature = "vec_pop_if", since = "CURRENT_RUSTC_VERSION")]
     pub fn pop_if(&mut self, predicate: impl FnOnce(&mut T) -> bool) -> Option<T> {
         let last = self.last_mut()?;
         if predicate(last) { self.pop() } else { None }

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -37,7 +37,6 @@
 #![feature(local_waker)]
 #![feature(str_as_str)]
 #![feature(strict_provenance_lints)]
-#![feature(vec_pop_if)]
 #![feature(vec_deque_pop_if)]
 #![feature(unique_rc_arc)]
 #![feature(macro_metavar_expr_concat)]

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -101,7 +101,7 @@ target | notes
 [`riscv64gc-unknown-linux-gnu`](platform-support/riscv64gc-unknown-linux-gnu.md) | RISC-V Linux (kernel 4.20, glibc 2.29)
 [`riscv64gc-unknown-linux-musl`](platform-support/riscv64gc-unknown-linux-musl.md) | RISC-V Linux (kernel 4.20, musl 1.2.3)
 [`s390x-unknown-linux-gnu`](platform-support/s390x-unknown-linux-gnu.md) | S390x Linux (kernel 3.2, glibc 2.17)
-[`x86_64-unknown-freebsd`](platform-support/freebsd.md) | 64-bit amd64 FreeBSD
+[`x86_64-unknown-freebsd`](platform-support/freebsd.md) | 64-bit x86 FreeBSD
 [`x86_64-unknown-illumos`](platform-support/illumos.md) | illumos
 `x86_64-unknown-linux-musl` | 64-bit Linux with musl 1.2.3
 [`x86_64-unknown-netbsd`](platform-support/netbsd.md) | NetBSD/amd64

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -13,7 +13,7 @@ rinja = { version = "0.3", default-features = false, features = ["config"] }
 base64 = "0.21.7"
 itertools = "0.12"
 indexmap = "2"
-minifier = { version = "0.3.2", default-features = false }
+minifier = { version = "0.3.4", default-features = false }
 pulldown-cmark-old = { version = "0.9.6", package = "pulldown-cmark", default-features = false }
 regex = "1"
 rustdoc-json-types = { path = "../rustdoc-json-types" }

--- a/tests/crashes/135470.rs
+++ b/tests/crashes/135470.rs
@@ -1,0 +1,40 @@
+//@ known-bug: #135470
+//@ compile-flags: --edition=2021 -Copt-level=0
+
+use std::future::Future;
+trait Access {
+    type Lister;
+
+    fn list() -> impl Future<Output = Self::Lister> {
+        async { todo!() }
+    }
+}
+
+trait Foo {}
+impl Access for dyn Foo {
+    type Lister = ();
+}
+
+fn main() {
+    let svc = async {
+        async { <dyn Foo>::list() }.await;
+    };
+    &svc as &dyn Service;
+}
+
+trait UnaryService {
+    fn call2() {}
+}
+trait Unimplemented {}
+impl<T: Unimplemented> UnaryService for T {}
+struct Wrap<T>(T);
+impl<T: Send> UnaryService for Wrap<T> {}
+
+trait Service {
+    fn call(&self);
+}
+impl<T: Send> Service for T {
+    fn call(&self) {
+        Wrap::<T>::call2();
+    }
+}

--- a/tests/crashes/135528.rs
+++ b/tests/crashes/135528.rs
@@ -1,0 +1,18 @@
+//@ known-bug: #135528
+//@ compile-flags: -Zvalidate-mir -Zinline-mir=yes
+#![feature(type_alias_impl_trait)]
+type Tait = impl Copy;
+
+fn set(x: &isize) -> isize {
+    *x
+}
+
+fn d(x: Tait) {
+    set(x);
+}
+
+fn other_define() -> Tait {
+    ()
+}
+
+fn main() {}

--- a/tests/crashes/135570.rs
+++ b/tests/crashes/135570.rs
@@ -1,0 +1,12 @@
+//@ known-bug: #135570
+//@compile-flags: -Zvalidate-mir -Zmir-enable-passes=+Inline -Copt-level=0 -Zmir-enable-passes=+GVN
+//@ only-x86_64
+
+fn function_with_bytes<const BYTES: &'static [u8; 0xc7b889180b67b07d_bc1a3c88783d35b5_u128]>(
+) -> &'static [u8] {
+    BYTES
+}
+
+fn main() {
+    function_with_bytes::<b"aa">() == &[];
+}

--- a/tests/crashes/135617.rs
+++ b/tests/crashes/135617.rs
@@ -1,0 +1,13 @@
+//@ known-bug: #135617
+trait Project {
+    const ASSOC: usize;
+}
+
+fn foo()
+where
+    for<'a> (): Project,
+{
+    [(); <() as Project>::ASSOC];
+}
+
+pub fn main() {}

--- a/tests/crashes/135646.rs
+++ b/tests/crashes/135646.rs
@@ -1,0 +1,5 @@
+//@ known-bug: #135646
+//@ compile-flags: --edition=2024 -Zpolonius=next
+fn main() {
+    &{ [1, 2, 3][4] };
+}

--- a/tests/crashes/135668.rs
+++ b/tests/crashes/135668.rs
@@ -1,0 +1,38 @@
+//@ known-bug: #135668
+//@ compile-flags: --edition=2021
+use std::future::Future;
+
+pub async fn foo() {
+    let _ = create_task().await;
+}
+
+async fn create_task() -> impl Sized {
+    bind(documentation)
+}
+
+async fn documentation() {
+    include_str!("nonexistent");
+}
+
+fn bind<F>(_filter: F) -> impl Sized
+where
+    F: FilterBase,
+{
+    || -> <F as FilterBase>::Assoc { panic!() }
+}
+
+trait FilterBase {
+    type Assoc;
+}
+
+impl<F, R> FilterBase for F
+where
+    F: Fn() -> R,
+    // Removing the below line makes it correctly error on both stable and beta
+    R: Future,
+    // Removing the below line makes it ICE on both stable and beta
+    R: Send,
+    // Removing the above two bounds makes it ICE on stable but correctly error on beta
+{
+    type Assoc = F;
+}

--- a/tests/crashes/135718.rs
+++ b/tests/crashes/135718.rs
@@ -1,0 +1,50 @@
+//@ known-bug: #135718
+
+struct Equal;
+
+struct Bar;
+
+trait TwiceNested {}
+impl<M> TwiceNested for Bar where Bar: NestMakeEqual<NestEq = M> {}
+
+struct Sum;
+
+trait Not {
+    fn not();
+}
+
+impl<P> Not for Sum
+where
+    Bar: NestMakeEqual<NestEq = P>,
+    Self: Problem<P>,
+{
+    fn not() {}
+}
+
+trait NestMakeEqual {
+    type NestEq;
+}
+
+trait MakeEqual {
+    type Eq;
+}
+
+struct Foo;
+impl MakeEqual for Foo {
+    type Eq = Equal;
+}
+
+impl<O> NestMakeEqual for Bar
+where
+    Foo: MakeEqual<Eq = O>,
+{
+    type NestEq = O;
+}
+
+trait Problem<M> {}
+impl Problem<()> for Sum where Bar: TwiceNested {}
+impl Problem<Equal> for Sum where Bar: TwiceNested {}
+
+fn main() {
+    Sum::not();
+}

--- a/tests/crashes/135720.rs
+++ b/tests/crashes/135720.rs
@@ -1,0 +1,4 @@
+//@ known-bug: #135720
+#![feature(generic_const_exprs)]
+type S<'l> = [i32; A];
+fn lint_me(x: S<()>) {}

--- a/tests/crashes/135845.rs
+++ b/tests/crashes/135845.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #135845
+struct S<'a, T: ?Sized>(&'a T);
+
+fn b<'a>() -> S<'static, _> {
+    S::<'a>(&0)
+}

--- a/tests/crashes/135863.rs
+++ b/tests/crashes/135863.rs
@@ -1,0 +1,10 @@
+//@ known-bug: #135863
+struct A;
+
+impl A {
+    fn len(self: &&B) {}
+}
+
+fn main() {
+    A.len()
+}

--- a/tests/crashes/136063.rs
+++ b/tests/crashes/136063.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #136063
+#![feature(generic_const_exprs)]
+trait A<const B: u8 = X> {}
+impl A<1> for bool {}
+fn bar(arg : &dyn A<x>) { bar(true) }
+pub fn main() {}

--- a/tests/ui/debuginfo/dwarf-versions.one.stderr
+++ b/tests/ui/debuginfo/dwarf-versions.one.stderr
@@ -1,0 +1,6 @@
+error: requested DWARF version 1 is not supported
+   |
+   = help: supported DWARF versions are 2, 3, 4 and 5
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/dwarf-versions.rs
+++ b/tests/ui/debuginfo/dwarf-versions.rs
@@ -1,0 +1,38 @@
+// This test verifies the expected behavior of various options passed to
+// `-Zdwarf-version`: 2 - 5 (valid) with all other options being invalid.
+
+//@ revisions: zero one two three four five six
+
+//@[zero] compile-flags: -Zdwarf-version=0
+//@[zero] error-pattern: requested DWARF version 0 is not supported
+
+//@[one] compile-flags: -Zdwarf-version=1
+//@[one] error-pattern: requested DWARF version 1 is not supported
+
+//@[two] compile-flags: -Zdwarf-version=2
+//@[two] check-pass
+
+//@[three] compile-flags: -Zdwarf-version=3
+//@[three] check-pass
+
+//@[four] compile-flags: -Zdwarf-version=4
+//@[four] check-pass
+
+//@[five] compile-flags: -Zdwarf-version=5
+//@[five] check-pass
+
+//@[six] compile-flags: -Zdwarf-version=6
+//@[six] error-pattern: requested DWARF version 6 is not supported
+
+//@ compile-flags: -g --target x86_64-unknown-linux-gnu --crate-type cdylib
+//@ needs-llvm-components: x86
+
+#![feature(no_core, lang_items)]
+
+#![no_core]
+#![no_std]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+pub fn foo() {}

--- a/tests/ui/debuginfo/dwarf-versions.six.stderr
+++ b/tests/ui/debuginfo/dwarf-versions.six.stderr
@@ -1,0 +1,6 @@
+error: requested DWARF version 6 is not supported
+   |
+   = help: supported DWARF versions are 2, 3, 4 and 5
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/debuginfo/dwarf-versions.zero.stderr
+++ b/tests/ui/debuginfo/dwarf-versions.zero.stderr
@@ -1,0 +1,6 @@
+error: requested DWARF version 0 is not supported
+   |
+   = help: supported DWARF versions are 2, 3, 4 and 5
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/lint-overflowing-int-136675.rs
+++ b/tests/ui/lint/lint-overflowing-int-136675.rs
@@ -1,0 +1,4 @@
+fn main() {
+    if let -129 = 0i8 {} //~ ERROR literal out of range for `i8`
+    let x: i8 = -129; //~ ERROR literal out of range for `i8`
+}

--- a/tests/ui/lint/lint-overflowing-int-136675.stderr
+++ b/tests/ui/lint/lint-overflowing-int-136675.stderr
@@ -1,0 +1,21 @@
+error: literal out of range for `i8`
+  --> $DIR/lint-overflowing-int-136675.rs:2:12
+   |
+LL |     if let -129 = 0i8 {}
+   |            ^^^^
+   |
+   = note: the literal `-129` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using the type `i16` instead
+   = note: `#[deny(overflowing_literals)]` on by default
+
+error: literal out of range for `i8`
+  --> $DIR/lint-overflowing-int-136675.rs:3:17
+   |
+LL |     let x: i8 = -129;
+   |                 ^^^^
+   |
+   = note: the literal `-129` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using the type `i16` instead
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #135488 (Stabilize `vec_pop_if`)
 - #136068 (crashes: more tests)
 - #136694 (Update minifier version to `0.3.4`)
 - #136722 (Visit all debug info in MIR Visitor)
 - #136746 (Emit an error if `-Zdwarf-version=1` is requested)
 - #136760 (Fix unwrap error in overflowing int literal)
 - #136782 (Fix mistake in x86_64-unknown-freebsd platform description)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135488,136068,136694,136722,136746,136760,136782)
<!-- homu-ignore:end -->