### PR TITLE
Redact CoercePointee target type

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -85,11 +85,15 @@ hir_analysis_cmse_output_stack_spill =
     .note1 = functions with the `{$abi}` ABI must pass their result via the available return registers
     .note2 = the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
-hir_analysis_coerce_pointee_cannot_coerce_unsize = `{$ty}` cannot be coerced to an unsized type
+hir_analysis_coerce_pointee_cannot_coerce_unsized = `{$ty}` cannot be coerced to an unsized type
     .note = `derive(CoercePointee)` demands that `{$ty}` can be coerced to an unsized type
     .help = the standard pointers such as `Arc`, `Rc`, `Box`, and other types with `derive(CoercePointee)` can be coerced to their corresponding unsized types
 
-hir_analysis_coerce_pointee_cannot_unsize = `{$ty}` cannot be coerced to any unsized value
+hir_analysis_coerce_pointee_cannot_dispatch_from_dyn = `{$ty}` cannot be coerced to an unsized type, to which `dyn` methods can be dispatched
+    .note = `derive(CoercePointee)` demands that `dyn` methods can be dispatched when `{$ty}` can be coerced to an unsized type
+    .help = `dyn` methods can be dispatched to the standard pointers such as `Arc`, `Rc`, `Box`, and other types with `derive(CoercePointee)`
+
+hir_analysis_coerce_pointee_cannot_unsize = `{$ty}` cannot be coerced to an unsized value
     .note = `derive(CoercePointee)` demands that `{$ty}` can be coerced to an unsized type
     .help = `derive(CoercePointee)` requires exactly one copy of `#[pointee]` type at the end of the `struct` definition, without any further pointer or reference indirection
 

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -85,6 +85,19 @@ hir_analysis_cmse_output_stack_spill =
     .note1 = functions with the `{$abi}` ABI must pass their result via the available return registers
     .note2 = the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
+hir_analysis_coerce_pointee_cannot_coerce_unsize = `{$ty}` cannot be coerced to an unsized type
+    .note = `derive(CoercePointee)` demands that `{$ty}` can be coerced to an unsized type
+    .help = the standard pointers such as `Arc`, `Rc`, `Box`, and other types with `derive(CoercePointee)` can be coerced to their corresponding unsized types
+
+hir_analysis_coerce_pointee_cannot_unsize = `{$ty}` cannot be coerced to any unsized value
+    .note = `derive(CoercePointee)` demands that `{$ty}` can be coerced to an unsized type
+    .help = `derive(CoercePointee)` requires exactly one copy of `#[pointee]` type at the end of the `struct` definition, without any further pointer or reference indirection
+
+hir_analysis_coerce_pointee_multiple_targets = `derive(CoercePointee)` only admits exactly one data field, {$diag_trait ->
+    [DispatchFromDyn] to which `dyn` methods shall be dispatched
+    *[CoerceUnsized] on which unsize coercion shall be performed
+    }
+
 hir_analysis_coerce_pointee_no_field = `CoercePointee` can only be derived on `struct`s with at least one field
 
 hir_analysis_coerce_pointee_no_user_validity_assertion = asserting applicability of `derive(CoercePointee)` on a target data is forbidden

--- a/compiler/rustc_hir_analysis/src/coherence/builtin/diagnostics.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin/diagnostics.rs
@@ -1,0 +1,136 @@
+use rustc_hir::LangItem;
+use rustc_hir::def_id::DefId;
+use rustc_middle::ty::fast_reject::SimplifiedType;
+use rustc_middle::ty::{
+    self, GenericParamDefKind, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitor,
+};
+use rustc_span::{Span, sym};
+use rustc_trait_selection::traits::FulfillmentError;
+use tracing::instrument;
+
+use crate::errors;
+
+#[instrument(level = "debug", skip(tcx), ret)]
+pub(super) fn extract_coerce_pointee_data<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    adt_did: DefId,
+) -> Option<(usize, DefId)> {
+    // It is decided that a query to cache these results is not necessary
+    // for error reporting.
+    // We can afford to recompute it on-demand.
+    if let Some(impls) = tcx.lang_items().get(LangItem::CoercePointeeValidated).and_then(|did| {
+        tcx.trait_impls_of(did).non_blanket_impls().get(&SimplifiedType::Adt(adt_did))
+    }) && let [impl_did, ..] = impls[..]
+    {
+        // Search for the `#[pointee]`
+        let mut first_type = None;
+        for (idx, param) in tcx.generics_of(adt_did).own_params.iter().enumerate() {
+            if let GenericParamDefKind::Type { .. } = param.kind {
+                first_type = if first_type.is_some() { None } else { Some(idx) };
+            }
+            if tcx.has_attr(param.def_id, sym::pointee) {
+                return Some((idx, impl_did));
+            }
+        }
+        if let Some(idx) = first_type {
+            return Some((idx, impl_did));
+        }
+    }
+    None
+}
+
+fn contains_coerce_pointee_target_pointee<'tcx>(ty: Ty<'tcx>, target_pointee_ty: Ty<'tcx>) -> bool {
+    struct Search<'tcx> {
+        pointee: Ty<'tcx>,
+        found: bool,
+    }
+    impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for Search<'tcx> {
+        fn visit_binder<T: ty::TypeVisitable<TyCtxt<'tcx>>>(
+            &mut self,
+            t: &rustc_type_ir::Binder<TyCtxt<'tcx>, T>,
+        ) {
+            if self.found {
+                return;
+            }
+            t.super_visit_with(self)
+        }
+
+        fn visit_ty(&mut self, t: Ty<'tcx>) {
+            if self.found {
+                return;
+            }
+            if t == self.pointee {
+                self.found = true;
+            } else {
+                t.super_visit_with(self)
+            }
+        }
+
+        fn visit_region(&mut self, r: <TyCtxt<'tcx> as ty::Interner>::Region) {
+            if self.found {
+                return;
+            }
+            if let rustc_type_ir::ReError(guar) = r.kind() {
+                self.visit_error(guar)
+            }
+        }
+
+        fn visit_const(&mut self, c: <TyCtxt<'tcx> as ty::Interner>::Const) {
+            if self.found {
+                return;
+            }
+            c.super_visit_with(self)
+        }
+
+        fn visit_predicate(&mut self, p: <TyCtxt<'tcx> as ty::Interner>::Predicate) {
+            if self.found {
+                return;
+            }
+            p.super_visit_with(self)
+        }
+
+        fn visit_clauses(&mut self, p: <TyCtxt<'tcx> as ty::Interner>::Clauses) {
+            if self.found {
+                return;
+            }
+            p.super_visit_with(self)
+        }
+    }
+    let mut search = Search { pointee: target_pointee_ty, found: false };
+    ty.visit_with(&mut search);
+    search.found
+}
+
+#[instrument(level = "debug", skip(tcx))]
+pub(super) fn redact_fulfillment_err_for_coerce_pointee<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    err: FulfillmentError<'tcx>,
+    target_pointee_ty: Ty<'tcx>,
+    span: Span,
+) -> Option<FulfillmentError<'tcx>> {
+    if let ty::PredicateKind::Clause(ty::ClauseKind::Trait(pred)) =
+        err.obligation.predicate.kind().skip_binder()
+    {
+        let mentions_pointee = || {
+            contains_coerce_pointee_target_pointee(
+                pred.trait_ref.args.type_at(1),
+                target_pointee_ty,
+            )
+        };
+        let source = pred.trait_ref.self_ty();
+        if tcx.is_lang_item(pred.def_id(), LangItem::Unsize) {
+            if mentions_pointee() {
+                // We should redact it
+                tcx.dcx()
+                    .emit_err(errors::CoercePointeeCannotUnsize { ty: source.to_string(), span });
+                return None;
+            }
+        } else if tcx.is_lang_item(pred.def_id(), LangItem::CoerceUnsized) && mentions_pointee() {
+            // We should redact it
+            tcx.dcx()
+                .emit_err(errors::CoercePointeeCannotCoerceUnsize { ty: source.to_string(), span });
+            return None;
+        }
+    }
+    Some(err)
+}

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1229,6 +1229,8 @@ pub(crate) struct CoercePointeeMultipleTargets {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_coerce_pointee_cannot_unsize, code = E0802)]
+#[note]
+#[help]
 pub(crate) struct CoercePointeeCannotUnsize {
     #[primary_span]
     pub span: Span,
@@ -1236,8 +1238,20 @@ pub(crate) struct CoercePointeeCannotUnsize {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis_coerce_pointee_cannot_coerce_unsize, code = E0802)]
+#[diag(hir_analysis_coerce_pointee_cannot_coerce_unsized, code = E0802)]
+#[note]
+#[help]
 pub(crate) struct CoercePointeeCannotCoerceUnsize {
+    #[primary_span]
+    pub span: Span,
+    pub ty: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_coerce_pointee_cannot_dispatch_from_dyn, code = E0802)]
+#[note]
+#[help]
+pub(crate) struct CoercePointeeCannotDispatchFromDyn {
     #[primary_span]
     pub span: Span,
     pub ty: String,

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1220,6 +1220,30 @@ pub(crate) struct CoercePointeeNoField {
 }
 
 #[derive(Diagnostic)]
+#[diag(hir_analysis_coerce_pointee_multiple_targets, code = E0802)]
+pub(crate) struct CoercePointeeMultipleTargets {
+    #[primary_span]
+    pub spans: Vec<Span>,
+    pub diag_trait: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_coerce_pointee_cannot_unsize, code = E0802)]
+pub(crate) struct CoercePointeeCannotUnsize {
+    #[primary_span]
+    pub span: Span,
+    pub ty: String,
+}
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_coerce_pointee_cannot_coerce_unsize, code = E0802)]
+pub(crate) struct CoercePointeeCannotCoerceUnsize {
+    #[primary_span]
+    pub span: Span,
+    pub ty: String,
+}
+
+#[derive(Diagnostic)]
 #[diag(hir_analysis_inherent_ty_outside_relevant, code = E0390)]
 #[help]
 pub(crate) struct InherentTyOutsideRelevant {

--- a/tests/ui/deriving/deriving-coerce-pointee-neg.rs
+++ b/tests/ui/deriving/deriving-coerce-pointee-neg.rs
@@ -8,31 +8,38 @@ use std::marker::CoercePointee;
 
 #[derive(CoercePointee)]
 //~^ ERROR: `CoercePointee` can only be derived on `struct`s with `#[repr(transparent)]`
+//~| NOTE: in this expansion of #[derive(CoercePointee)]
 enum NotStruct<'a, T: ?Sized> {
     Variant(&'a T),
 }
 
 #[derive(CoercePointee)]
 //~^ ERROR: `CoercePointee` can only be derived on `struct`s with at least one field
+//~| NOTE: in this expansion of #[derive(CoercePointee)]
 #[repr(transparent)]
-struct NoField<'a, #[pointee] T: ?Sized> {}
-//~^ ERROR: lifetime parameter `'a` is never used
-//~| ERROR: type parameter `T` is never used
+struct NoField<#[pointee] T: ?Sized> {}
+//~^ ERROR: type parameter `T` is never used
+//~| NOTE: unused type parameter
+//~| HELP: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
 #[derive(CoercePointee)]
 //~^ ERROR: `CoercePointee` can only be derived on `struct`s with at least one field
+//~| NOTE: in this expansion of #[derive(CoercePointee)]
 #[repr(transparent)]
-struct NoFieldUnit<'a, #[pointee] T: ?Sized>();
-//~^ ERROR: lifetime parameter `'a` is never used
-//~| ERROR: type parameter `T` is never used
+struct NoFieldUnit<#[pointee] T: ?Sized>();
+//~^ ERROR: type parameter `T` is never used
+//~| NOTE: unused type parameter
+//~| HELP: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
 #[derive(CoercePointee)]
 //~^ ERROR: `CoercePointee` can only be derived on `struct`s that are generic over at least one type
+//~| NOTE: in this expansion of #[derive(CoercePointee)]
 #[repr(transparent)]
 struct NoGeneric<'a>(&'a u8);
 
 #[derive(CoercePointee)]
 //~^ ERROR: exactly one generic type parameter must be marked as `#[pointee]` to derive `CoercePointee` traits
+//~| NOTE: in this expansion of #[derive(CoercePointee)]
 #[repr(transparent)]
 struct AmbiguousPointee<'a, T1: ?Sized, T2: ?Sized> {
     a: (&'a T1, &'a T2),
@@ -42,6 +49,7 @@ struct AmbiguousPointee<'a, T1: ?Sized, T2: ?Sized> {
 #[repr(transparent)]
 struct TooManyPointees<'a, #[pointee] A: ?Sized, #[pointee] B: ?Sized>((&'a A, &'a B));
 //~^ ERROR: only one type parameter can be marked as `#[pointee]` when deriving `CoercePointee` traits
+//~| NOTE: here another type parameter is marked as `#[pointee]`
 
 #[derive(CoercePointee)]
 struct NotTransparent<'a, #[pointee] T: ?Sized> {
@@ -144,20 +152,41 @@ struct TryToWipeRepr<'a, #[pointee] T: ?Sized> {
 
 #[repr(transparent)]
 #[derive(CoercePointee)]
-//~^ ERROR: `Box<T>` cannot be coerced to any unsized value [E0802]
-//~| ERROR: `Box<T>` cannot be coerced to any unsized value [E0802]
 struct RcWithId<T: ?Sized> {
     inner: std::rc::Rc<(i32, Box<T>)>,
+    //~^ ERROR: `Box<T>` cannot be coerced to an unsized value [E0802]
+    //~| NOTE: `derive(CoercePointee)` demands that `Box<T>` can be coerced to an unsized type
+    //~| HELP: `derive(CoercePointee)` requires exactly one copy of `#[pointee]` type at the end of the `struct` definition, without any further pointer or reference indirection
+    //~| ERROR: `Box<T>` cannot be coerced to an unsized value [E0802]
+    //~| NOTE: `derive(CoercePointee)` demands that `Box<T>` can be coerced to an unsized type
+    //~| HELP: `derive(CoercePointee)` requires exactly one copy of `#[pointee]` type at the end of the `struct` definition, without any further pointer or reference indirection
+    //~| NOTE: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 }
 
 #[repr(transparent)]
 #[derive(CoercePointee)]
 struct MoreThanOneField<T: ?Sized> {
     //~^ ERROR: transparent struct needs at most one field with non-trivial size or alignment, but has 2 [E0690]
+    //~| NOTE: needs at most one field with non-trivial size or alignment, but has 2
     inner1: Box<T>,
     //~^ ERROR: `derive(CoercePointee)` only admits exactly one data field, to which `dyn` methods shall be dispatched [E0802]
     //~| ERROR: `derive(CoercePointee)` only admits exactly one data field, on which unsize coercion shall be performed [E0802]
+    //~| NOTE: this field has non-zero size or requires alignment
     inner2: Box<T>,
+    //~^ NOTE: this field has non-zero size or requires alignment
 }
+
+struct NotCoercePointeeData<T: ?Sized>(T);
+
+#[repr(transparent)]
+#[derive(CoercePointee)]
+struct UsingNonCoercePointeeData<T: ?Sized>(NotCoercePointeeData<T>);
+//~^ ERROR: `NotCoercePointeeData<T>` cannot be coerced to an unsized type [E0802]
+//~| NOTE: `derive(CoercePointee)` demands that `NotCoercePointeeData<T>` can be coerced to an unsized type
+//~| HELP: the standard pointers such as `Arc`, `Rc`, `Box`, and other types with `derive(CoercePointee)` can be coerced to their corresponding unsized types
+//~| ERROR: `NotCoercePointeeData<T>` cannot be coerced to an unsized type, to which `dyn` methods can be dispatched [E0802]
+//~| NOTE: `derive(CoercePointee)` demands that `dyn` methods can be dispatched when `NotCoercePointeeData<T>` can be coerced to an unsized type
+//~| HELP: `dyn` methods can be dispatched to the standard pointers such as `Arc`, `Rc`, `Box`, and other types with `derive(CoercePointee)`
+
 
 fn main() {}

--- a/tests/ui/deriving/deriving-coerce-pointee-neg.rs
+++ b/tests/ui/deriving/deriving-coerce-pointee-neg.rs
@@ -142,4 +142,22 @@ struct TryToWipeRepr<'a, #[pointee] T: ?Sized> {
     ptr: &'a T,
 }
 
+#[repr(transparent)]
+#[derive(CoercePointee)]
+//~^ ERROR: `Box<T>` cannot be coerced to any unsized value [E0802]
+//~| ERROR: `Box<T>` cannot be coerced to any unsized value [E0802]
+struct RcWithId<T: ?Sized> {
+    inner: std::rc::Rc<(i32, Box<T>)>,
+}
+
+#[repr(transparent)]
+#[derive(CoercePointee)]
+struct MoreThanOneField<T: ?Sized> {
+    //~^ ERROR: transparent struct needs at most one field with non-trivial size or alignment, but has 2 [E0690]
+    inner1: Box<T>,
+    //~^ ERROR: `derive(CoercePointee)` only admits exactly one data field, to which `dyn` methods shall be dispatched [E0802]
+    //~| ERROR: `derive(CoercePointee)` only admits exactly one data field, on which unsize coercion shall be performed [E0802]
+    inner2: Box<T>,
+}
+
 fn main() {}

--- a/tests/ui/deriving/deriving-coerce-pointee-neg.stderr
+++ b/tests/ui/deriving/deriving-coerce-pointee-neg.stderr
@@ -118,7 +118,54 @@ error[E0802]: `derive(CoercePointee)` is only applicable to `struct` with `repr(
 LL | struct TryToWipeRepr<'a, #[pointee] T: ?Sized> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 17 previous errors
+error[E0802]: `Box<T>` cannot be coerced to any unsized value
+  --> $DIR/deriving-coerce-pointee-neg.rs:146:10
+   |
+LL | #[derive(CoercePointee)]
+   |          ^^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-Some errors have detailed explanations: E0392, E0802.
+error[E0802]: `derive(CoercePointee)` only admits exactly one data field, to which `dyn` methods shall be dispatched
+  --> $DIR/deriving-coerce-pointee-neg.rs:157:5
+   |
+LL |     inner1: Box<T>,
+   |     ^^^^^^^^^^^^^^
+...
+LL |     inner2: Box<T>,
+   |     ^^^^^^^^^^^^^^
+
+error[E0802]: `Box<T>` cannot be coerced to any unsized value
+  --> $DIR/deriving-coerce-pointee-neg.rs:146:10
+   |
+LL | #[derive(CoercePointee)]
+   |          ^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0802]: `derive(CoercePointee)` only admits exactly one data field, on which unsize coercion shall be performed
+  --> $DIR/deriving-coerce-pointee-neg.rs:157:5
+   |
+LL |     inner1: Box<T>,
+   |     ^^^^^^^^^^^^^^
+...
+LL |     inner2: Box<T>,
+   |     ^^^^^^^^^^^^^^
+
+error[E0690]: transparent struct needs at most one field with non-trivial size or alignment, but has 2
+  --> $DIR/deriving-coerce-pointee-neg.rs:155:1
+   |
+LL | struct MoreThanOneField<T: ?Sized> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ needs at most one field with non-trivial size or alignment, but has 2
+LL |
+LL |     inner1: Box<T>,
+   |     -------------- this field has non-zero size or requires alignment
+...
+LL |     inner2: Box<T>,
+   |     -------------- this field has non-zero size or requires alignment
+
+error: aborting due to 22 previous errors
+
+Some errors have detailed explanations: E0392, E0690, E0802.
 For more information about an error, try `rustc --explain E0392`.

--- a/tests/ui/deriving/deriving-coerce-pointee-neg.stderr
+++ b/tests/ui/deriving/deriving-coerce-pointee-neg.stderr
@@ -7,7 +7,7 @@ LL | #[derive(CoercePointee)]
    = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0802]: `CoercePointee` can only be derived on `struct`s with at least one field
-  --> $DIR/deriving-coerce-pointee-neg.rs:15:10
+  --> $DIR/deriving-coerce-pointee-neg.rs:16:10
    |
 LL | #[derive(CoercePointee)]
    |          ^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL | #[derive(CoercePointee)]
    = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0802]: `CoercePointee` can only be derived on `struct`s with at least one field
-  --> $DIR/deriving-coerce-pointee-neg.rs:22:10
+  --> $DIR/deriving-coerce-pointee-neg.rs:25:10
    |
 LL | #[derive(CoercePointee)]
    |          ^^^^^^^^^^^^^
@@ -23,14 +23,6 @@ LL | #[derive(CoercePointee)]
    = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0802]: `CoercePointee` can only be derived on `struct`s that are generic over at least one type
-  --> $DIR/deriving-coerce-pointee-neg.rs:29:10
-   |
-LL | #[derive(CoercePointee)]
-   |          ^^^^^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0802]: exactly one generic type parameter must be marked as `#[pointee]` to derive `CoercePointee` traits
   --> $DIR/deriving-coerce-pointee-neg.rs:34:10
    |
 LL | #[derive(CoercePointee)]
@@ -38,96 +30,89 @@ LL | #[derive(CoercePointee)]
    |
    = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0802]: exactly one generic type parameter must be marked as `#[pointee]` to derive `CoercePointee` traits
+  --> $DIR/deriving-coerce-pointee-neg.rs:40:10
+   |
+LL | #[derive(CoercePointee)]
+   |          ^^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0802]: only one type parameter can be marked as `#[pointee]` when deriving `CoercePointee` traits
-  --> $DIR/deriving-coerce-pointee-neg.rs:43:39
+  --> $DIR/deriving-coerce-pointee-neg.rs:50:39
    |
 LL | struct TooManyPointees<'a, #[pointee] A: ?Sized, #[pointee] B: ?Sized>((&'a A, &'a B));
    |                                       ^                     - here another type parameter is marked as `#[pointee]`
 
 error[E0802]: `derive(CoercePointee)` requires `T` to be marked `?Sized`
-  --> $DIR/deriving-coerce-pointee-neg.rs:54:36
+  --> $DIR/deriving-coerce-pointee-neg.rs:62:36
    |
 LL | struct NoMaybeSized<'a, #[pointee] T> {
    |                                    ^
 
 error: the `#[pointee]` attribute may only be used on generic parameters
-  --> $DIR/deriving-coerce-pointee-neg.rs:62:5
+  --> $DIR/deriving-coerce-pointee-neg.rs:70:5
    |
 LL |     #[pointee]
    |     ^^^^^^^^^^
 
 error: the `#[pointee]` attribute may only be used on generic parameters
-  --> $DIR/deriving-coerce-pointee-neg.rs:72:33
+  --> $DIR/deriving-coerce-pointee-neg.rs:80:33
    |
 LL |                     struct UhOh<#[pointee] T>(T);
    |                                 ^^^^^^^^^^
 
 error: the `#[pointee]` attribute may only be used on generic parameters
-  --> $DIR/deriving-coerce-pointee-neg.rs:86:21
+  --> $DIR/deriving-coerce-pointee-neg.rs:94:21
    |
 LL |         struct UhOh<#[pointee] T>(T);
    |                     ^^^^^^^^^^
 
 error: the `#[pointee]` attribute may only be used on generic parameters
-  --> $DIR/deriving-coerce-pointee-neg.rs:101:25
+  --> $DIR/deriving-coerce-pointee-neg.rs:109:25
    |
 LL |             struct UhOh<#[pointee] T>(T);
    |                         ^^^^^^^^^^
 
-error[E0392]: lifetime parameter `'a` is never used
-  --> $DIR/deriving-coerce-pointee-neg.rs:18:16
+error[E0392]: type parameter `T` is never used
+  --> $DIR/deriving-coerce-pointee-neg.rs:20:27
    |
-LL | struct NoField<'a, #[pointee] T: ?Sized> {}
-   |                ^^ unused lifetime parameter
+LL | struct NoField<#[pointee] T: ?Sized> {}
+   |                           ^ unused type parameter
    |
-   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
 error[E0392]: type parameter `T` is never used
-  --> $DIR/deriving-coerce-pointee-neg.rs:18:31
+  --> $DIR/deriving-coerce-pointee-neg.rs:29:31
    |
-LL | struct NoField<'a, #[pointee] T: ?Sized> {}
+LL | struct NoFieldUnit<#[pointee] T: ?Sized>();
    |                               ^ unused type parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
-error[E0392]: lifetime parameter `'a` is never used
-  --> $DIR/deriving-coerce-pointee-neg.rs:25:20
-   |
-LL | struct NoFieldUnit<'a, #[pointee] T: ?Sized>();
-   |                    ^^ unused lifetime parameter
-   |
-   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
-
-error[E0392]: type parameter `T` is never used
-  --> $DIR/deriving-coerce-pointee-neg.rs:25:35
-   |
-LL | struct NoFieldUnit<'a, #[pointee] T: ?Sized>();
-   |                                   ^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-
 error[E0802]: `derive(CoercePointee)` is only applicable to `struct` with `repr(transparent)` layout
-  --> $DIR/deriving-coerce-pointee-neg.rs:47:1
+  --> $DIR/deriving-coerce-pointee-neg.rs:55:1
    |
 LL | struct NotTransparent<'a, #[pointee] T: ?Sized> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0802]: `derive(CoercePointee)` is only applicable to `struct` with `repr(transparent)` layout
-  --> $DIR/deriving-coerce-pointee-neg.rs:140:1
+  --> $DIR/deriving-coerce-pointee-neg.rs:148:1
    |
 LL | struct TryToWipeRepr<'a, #[pointee] T: ?Sized> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0802]: `Box<T>` cannot be coerced to any unsized value
-  --> $DIR/deriving-coerce-pointee-neg.rs:146:10
+error[E0802]: `Box<T>` cannot be coerced to an unsized value
+  --> $DIR/deriving-coerce-pointee-neg.rs:156:5
    |
-LL | #[derive(CoercePointee)]
-   |          ^^^^^^^^^^^^^
+LL |     inner: std::rc::Rc<(i32, Box<T>)>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `derive(CoercePointee)` demands that `Box<T>` can be coerced to an unsized type
+   = help: `derive(CoercePointee)` requires exactly one copy of `#[pointee]` type at the end of the `struct` definition, without any further pointer or reference indirection
 
 error[E0802]: `derive(CoercePointee)` only admits exactly one data field, to which `dyn` methods shall be dispatched
-  --> $DIR/deriving-coerce-pointee-neg.rs:157:5
+  --> $DIR/deriving-coerce-pointee-neg.rs:171:5
    |
 LL |     inner1: Box<T>,
    |     ^^^^^^^^^^^^^^
@@ -135,17 +120,27 @@ LL |     inner1: Box<T>,
 LL |     inner2: Box<T>,
    |     ^^^^^^^^^^^^^^
 
-error[E0802]: `Box<T>` cannot be coerced to any unsized value
-  --> $DIR/deriving-coerce-pointee-neg.rs:146:10
+error[E0802]: `NotCoercePointeeData<T>` cannot be coerced to an unsized type, to which `dyn` methods can be dispatched
+  --> $DIR/deriving-coerce-pointee-neg.rs:183:45
    |
-LL | #[derive(CoercePointee)]
-   |          ^^^^^^^^^^^^^
+LL | struct UsingNonCoercePointeeData<T: ?Sized>(NotCoercePointeeData<T>);
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: `derive(CoercePointee)` demands that `dyn` methods can be dispatched when `NotCoercePointeeData<T>` can be coerced to an unsized type
+   = help: `dyn` methods can be dispatched to the standard pointers such as `Arc`, `Rc`, `Box`, and other types with `derive(CoercePointee)`
+
+error[E0802]: `Box<T>` cannot be coerced to an unsized value
+  --> $DIR/deriving-coerce-pointee-neg.rs:156:5
+   |
+LL |     inner: std::rc::Rc<(i32, Box<T>)>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `derive(CoercePointee)` demands that `Box<T>` can be coerced to an unsized type
+   = help: `derive(CoercePointee)` requires exactly one copy of `#[pointee]` type at the end of the `struct` definition, without any further pointer or reference indirection
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0802]: `derive(CoercePointee)` only admits exactly one data field, on which unsize coercion shall be performed
-  --> $DIR/deriving-coerce-pointee-neg.rs:157:5
+  --> $DIR/deriving-coerce-pointee-neg.rs:171:5
    |
 LL |     inner1: Box<T>,
    |     ^^^^^^^^^^^^^^
@@ -153,12 +148,21 @@ LL |     inner1: Box<T>,
 LL |     inner2: Box<T>,
    |     ^^^^^^^^^^^^^^
 
+error[E0802]: `NotCoercePointeeData<T>` cannot be coerced to an unsized type
+  --> $DIR/deriving-coerce-pointee-neg.rs:183:45
+   |
+LL | struct UsingNonCoercePointeeData<T: ?Sized>(NotCoercePointeeData<T>);
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `derive(CoercePointee)` demands that `NotCoercePointeeData<T>` can be coerced to an unsized type
+   = help: the standard pointers such as `Arc`, `Rc`, `Box`, and other types with `derive(CoercePointee)` can be coerced to their corresponding unsized types
+
 error[E0690]: transparent struct needs at most one field with non-trivial size or alignment, but has 2
-  --> $DIR/deriving-coerce-pointee-neg.rs:155:1
+  --> $DIR/deriving-coerce-pointee-neg.rs:168:1
    |
 LL | struct MoreThanOneField<T: ?Sized> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ needs at most one field with non-trivial size or alignment, but has 2
-LL |
+...
 LL |     inner1: Box<T>,
    |     -------------- this field has non-zero size or requires alignment
 ...


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fix #134846

The issue here is that `__S` is actually an implementation detail of `derive(CoercePointee)`. This should not appear in our diagnostics. A better way to present this message is to designate it as `<pointee generic type> {unsized}` as opposed to the undecipherable `__S` here.


r? @compiler-errors 