### PR TITLE
ignore win_delete_self test in Miri

### DIFF
--- a/library/std/tests/win_delete_self.rs
+++ b/library/std/tests/win_delete_self.rs
@@ -2,6 +2,7 @@
 
 /// Attempting to delete a running binary should return an error on Windows.
 #[test]
+#[cfg_attr(miri, ignore)] // `remove_file` does not work in Miri on Windows
 fn win_delete_self() {
     let path = std::env::current_exe().unwrap();
     assert!(std::fs::remove_file(path).is_err());


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/134679, fixes miri-test-libstd on Windows

Cc @ChrisDenton @Mark-Simulacrum 