### PR TITLE
Try to recover from path sep error in type parsing

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -743,9 +743,6 @@ parse_single_colon_import_path = expected `::`, found `:`
     .suggestion = use double colon
     .note = import paths are delimited using `::`
 
-parse_single_colon_struct_type = found single colon in a struct field type path
-    .suggestion = write a path separator here
-
 parse_static_with_generics = static items may not have generic parameters
 
 parse_struct_literal_body_without_path =

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -3072,14 +3072,6 @@ pub(crate) struct BadItemKind {
 }
 
 #[derive(Diagnostic)]
-#[diag(parse_single_colon_struct_type)]
-pub(crate) struct SingleColonStructType {
-    #[primary_span]
-    #[suggestion(code = "::", applicability = "maybe-incorrect", style = "verbose")]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
 #[diag(parse_macro_rules_missing_bang)]
 pub(crate) struct MacroRulesMissingBang {
     #[primary_span]

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2043,9 +2043,6 @@ impl<'a> Parser<'a> {
         }
         self.expect_field_ty_separator()?;
         let ty = self.parse_ty()?;
-        if self.token == token::Colon && self.look_ahead(1, |t| *t != token::Colon) {
-            self.dcx().emit_err(errors::SingleColonStructType { span: self.token.span });
-        }
         let default = if self.token == token::Eq {
             self.bump();
             let const_expr = self.parse_expr_anon_const()?;

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -246,8 +246,19 @@ impl<'a> Parser<'a> {
             segments.push(segment);
 
             if self.is_import_coupler() || !self.eat_path_sep() {
-                if style == PathStyle::Expr
-                    && self.may_recover()
+                let ok_for_recovery = self.may_recover()
+                    && match style {
+                        PathStyle::Expr => true,
+                        PathStyle::Type if let Some((ident, _)) = self.prev_token.ident() => {
+                            self.token == token::Colon
+                                && ident.as_str().chars().all(|c| c.is_lowercase())
+                                && self.token.span.lo() == self.prev_token.span.hi()
+                                && self
+                                    .look_ahead(1, |token| self.token.span.hi() == token.span.lo())
+                        }
+                        _ => false,
+                    };
+                if ok_for_recovery
                     && self.token == token::Colon
                     && self.look_ahead(1, |token| token.is_ident() && !token.is_reserved_ident())
                 {

--- a/tests/ui/suggestions/argument-list-from-path-sep-error-129273.fixed
+++ b/tests/ui/suggestions/argument-list-from-path-sep-error-129273.fixed
@@ -1,0 +1,15 @@
+//@ run-rustfix
+
+use std::fmt;
+
+struct Hello;
+
+impl fmt::Display for Hello {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { //~ ERROR path separator must be a double colon
+        write!(f, "hello")
+    }
+}
+
+fn main() {
+    let _ = Hello;
+}

--- a/tests/ui/suggestions/argument-list-from-path-sep-error-129273.rs
+++ b/tests/ui/suggestions/argument-list-from-path-sep-error-129273.rs
@@ -1,0 +1,15 @@
+//@ run-rustfix
+
+use std::fmt;
+
+struct Hello;
+
+impl fmt::Display for Hello {
+    fn fmt(&self, f: &mut fmt:Formatter) -> fmt::Result { //~ ERROR path separator must be a double colon
+        write!(f, "hello")
+    }
+}
+
+fn main() {
+    let _ = Hello;
+}

--- a/tests/ui/suggestions/argument-list-from-path-sep-error-129273.stderr
+++ b/tests/ui/suggestions/argument-list-from-path-sep-error-129273.stderr
@@ -1,14 +1,14 @@
 error: path separator must be a double colon
-  --> $DIR/single-colon-path-not-const-generics.rs:8:18
+  --> $DIR/argument-list-from-path-sep-error-129273.rs:8:30
    |
-LL |   a: Vec<foo::bar:A>,
-   |                  ^
+LL |     fn fmt(&self, f: &mut fmt:Formatter) -> fmt::Result {
+   |                              ^
    |
    = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
-LL |   a: Vec<foo::bar::A>,
-   |                   +
+LL |     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+   |                               +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.rs
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.rs
@@ -7,14 +7,14 @@ mod foo {
 
 struct Foo {
     a: foo:A,
-    //~^ ERROR found single colon in a struct field type path
-    //~| expected `,`, or `}`, found `:`
+    //~^ ERROR path separator must be a double colon
+    //~| ERROR struct `A` is private
 }
 
 struct Bar {
     b: foo::bar:B,
-    //~^ ERROR found single colon in a struct field type path
-    //~| expected `,`, or `}`, found `:`
+    //~^ ERROR path separator must be a double colon
+    //~| ERROR module `bar` is private
 }
 
 fn main() {}

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
@@ -1,40 +1,53 @@
-error: found single colon in a struct field type path
+error: path separator must be a double colon
   --> $DIR/struct-field-type-including-single-colon.rs:9:11
    |
 LL |     a: foo:A,
    |           ^
    |
-help: write a path separator here
+   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a double colon instead
    |
 LL |     a: foo::A,
    |            +
 
-error: expected `,`, or `}`, found `:`
-  --> $DIR/struct-field-type-including-single-colon.rs:9:11
-   |
-LL | struct Foo {
-   |        --- while parsing this struct
-LL |     a: foo:A,
-   |           ^
-
-error: found single colon in a struct field type path
+error: path separator must be a double colon
   --> $DIR/struct-field-type-including-single-colon.rs:15:16
    |
 LL |     b: foo::bar:B,
    |                ^
    |
-help: write a path separator here
+   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
+help: use a double colon instead
    |
 LL |     b: foo::bar::B,
    |                 +
 
-error: expected `,`, or `}`, found `:`
-  --> $DIR/struct-field-type-including-single-colon.rs:15:16
+error[E0603]: struct `A` is private
+  --> $DIR/struct-field-type-including-single-colon.rs:9:12
    |
-LL | struct Bar {
-   |        --- while parsing this struct
+LL |     a: foo:A,
+   |            ^ private struct
+   |
+note: the struct `A` is defined here
+  --> $DIR/struct-field-type-including-single-colon.rs:2:5
+   |
+LL |     struct A;
+   |     ^^^^^^^^^
+
+error[E0603]: module `bar` is private
+  --> $DIR/struct-field-type-including-single-colon.rs:15:13
+   |
 LL |     b: foo::bar:B,
-   |                ^
+   |             ^^^ - struct `B` is not publicly re-exported
+   |             |
+   |             private module
+   |
+note: the module `bar` is defined here
+  --> $DIR/struct-field-type-including-single-colon.rs:3:5
+   |
+LL |     mod bar {
+   |     ^^^^^^^
 
 error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0603`.


### PR DESCRIPTION
Fixes #129273

Error using `:` in the argument list may mess up the parser.

case `tests/ui/suggestions/struct-field-type-including-single-colon` also changed, seems it's  the same meaning, should be OK.

r? @estebank 

