### PR TITLE
Do install msys2 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
       - if: contains(matrix.os, 'windows')
         uses: msys2/setup-msys2@v2.22.0
         with:
+          # FIXME(#136795): this mingw installation seems to be needed for
+          # `i686-pc-windows-gnu`, otherwise we somehow incorrectly ship the
+          # 64-bit `libwinpthread-1.dll` and then `rustc` explodes.
+          #
           # i686 jobs use mingw32. x86_64 and cross-compile jobs use mingw64.
           msystem: ${{ contains(matrix.name, 'i686') && 'mingw32' || 'mingw64' }}
           # don't try to download updates for already installed packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
     name: ${{ matrix.full_name }}
     needs: [ calculate_matrix ]
     runs-on: "${{ matrix.os }}"
+    defaults:
+      run:
+        shell: ${{ contains(matrix.os, 'windows') && 'msys2 {0}' || 'bash' }}
     timeout-minutes: 360
     env:
       CI_JOB_NAME: ${{ matrix.name }}
@@ -77,6 +80,22 @@ jobs:
         # Check the `calculate_matrix` job to see how is the matrix defined.
         include: ${{ fromJSON(needs.calculate_matrix.outputs.jobs) }}
     steps:
+      - if: contains(matrix.os, 'windows')
+        uses: msys2/setup-msys2@v2.22.0
+        with:
+          # i686 jobs use mingw32. x86_64 and cross-compile jobs use mingw64.
+          msystem: ${{ contains(matrix.name, 'i686') && 'mingw32' || 'mingw64' }}
+          # don't try to download updates for already installed packages
+          update: false
+          # don't try to use the msys that comes built-in to the github runner,
+          # so we can control what is installed (i.e. not python)
+          release: true
+          # Inherit the full path from the Windows environment, with MSYS2's */bin/
+          # dirs placed in front. This lets us run Windows-native Python etc.
+          path-type: inherit
+          install: >
+            make
+
       - name: disable git crlf conversion
         run: git config --global core.autocrlf false
 


### PR DESCRIPTION
Reverts #136588.
Only papers over #136795, but the root cause would still need to be investigated (likely a bug in how `i686-pc-windows-gnu` is built?).

Seems like for whatever reason the msys2 installation here is needed for the 32-bit `i686-pc-windows-gnu` target, otherwise we seem to be shipping the wrong DLL. This revert is mostly just to buy time to investigate without having to debug why the build logic for the 32-bit windows-gnu target is wrong.

This reverts commit e0607238c95df66e3d25a6c17aebe18c6726fc74, reversing changes made to a9e7b30487235621751cc628f170c0f15fb215c4.

r? infra
cc @ChrisDenton @Kobzol @mati865 

try-job: dist-x86_64-msvc
try-job: dist-i686-msvc
try-job: dist-aarch64-msvc
try-job: dist-i686-mingw
try-job: dist-x86_64-mingw
try-job: dist-x86_64-msvc-alt