### PR TITLE
Implement `write_all_vectored` for `VecDeque`

### DIFF
--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -565,6 +565,11 @@ impl<A: Allocator> Write for VecDeque<u8, A> {
         Ok(len)
     }
 
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.write_vectored(bufs)?;
+        Ok(())
+    }
+
     #[inline]
     fn is_write_vectored(&self) -> bool {
         true


### PR DESCRIPTION
cc #136756
