### PR TITLE
Replace mem::zeroed with mem::MaybeUninit::uninit for large struct in Unix

### DIFF
--- a/library/std/src/sys/pal/unix/stack_overflow.rs
+++ b/library/std/src/sys/pal/unix/stack_overflow.rs
@@ -319,26 +319,29 @@ mod imp {
     ))]
     unsafe fn get_stack_start() -> Option<*mut libc::c_void> {
         let mut ret = None;
-        let attr: mem::MaybeUninit<libc::pthread_attr_t> = if cfg!(target_os = "freebsd") {
+        let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = if cfg!(target_os = "freebsd") {
             let mut attr = mem::MaybeUninit::uninit();
             assert_eq!(libc::pthread_attr_init((&raw mut attr) as *mut _), 0);
             attr
         } else {
             mem::MaybeUninit::zeroed()
         };
-        let mut attr = unsafe { attr.assume_init() };
+
         #[cfg(target_os = "freebsd")]
-        let e = libc::pthread_attr_get_np(libc::pthread_self(), &mut attr);
+        let e = libc::pthread_attr_get_np(libc::pthread_self(), attr.as_mut_ptr());
         #[cfg(not(target_os = "freebsd"))]
-        let e = libc::pthread_getattr_np(libc::pthread_self(), &mut attr);
+        let e = libc::pthread_getattr_np(libc::pthread_self(), attr.as_mut_ptr());
         if e == 0 {
             let mut stackaddr = crate::ptr::null_mut();
             let mut stacksize = 0;
-            assert_eq!(libc::pthread_attr_getstack(&attr, &mut stackaddr, &mut stacksize), 0);
+            assert_eq!(
+                libc::pthread_attr_getstack(attr.as_ptr(), &mut stackaddr, &mut stacksize),
+                0
+            );
             ret = Some(stackaddr);
         }
         if e == 0 || cfg!(target_os = "freebsd") {
-            assert_eq!(libc::pthread_attr_destroy(&mut attr), 0);
+            assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0);
         }
         ret
     }

--- a/library/std/src/sys/pal/unix/stack_overflow.rs
+++ b/library/std/src/sys/pal/unix/stack_overflow.rs
@@ -319,9 +319,14 @@ mod imp {
     ))]
     unsafe fn get_stack_start() -> Option<*mut libc::c_void> {
         let mut ret = None;
-        let mut attr: libc::pthread_attr_t = crate::mem::zeroed();
-        #[cfg(target_os = "freebsd")]
-        assert_eq!(libc::pthread_attr_init(&mut attr), 0);
+        let attr: mem::MaybeUninit<libc::pthread_attr_t> = if cfg!(target_os = "freebsd") {
+            let mut attr = mem::MaybeUninit::uninit();
+            assert_eq!(libc::pthread_attr_init((&raw mut attr) as *mut _), 0);
+            attr
+        } else {
+            mem::MaybeUninit::zeroed()
+        };
+        let mut attr = unsafe { attr.assume_init() };
         #[cfg(target_os = "freebsd")]
         let e = libc::pthread_attr_get_np(libc::pthread_self(), &mut attr);
         #[cfg(not(target_os = "freebsd"))]
@@ -509,9 +514,15 @@ mod imp {
     // FIXME: I am probably not unsafe.
     unsafe fn current_guard() -> Option<Range<usize>> {
         let mut ret = None;
-        let mut attr: libc::pthread_attr_t = crate::mem::zeroed();
-        #[cfg(target_os = "freebsd")]
-        assert_eq!(libc::pthread_attr_init(&mut attr), 0);
+        let attr: mem::MaybeUninit<libc::pthread_attr_t> = if cfg!(target_os = "freebsd") {
+            let mut attr = mem::MaybeUninit::uninit();
+            assert_eq!(libc::pthread_attr_init((&raw mut attr) as *mut _), 0);
+            attr
+        } else {
+            mem::MaybeUninit::zeroed()
+        };
+
+        let mut attr = unsafe { attr.assume_init() };
         #[cfg(target_os = "freebsd")]
         let e = libc::pthread_attr_get_np(libc::pthread_self(), &mut attr);
         #[cfg(not(target_os = "freebsd"))]

--- a/library/std/src/sys/pal/unix/stack_overflow.rs
+++ b/library/std/src/sys/pal/unix/stack_overflow.rs
@@ -319,14 +319,12 @@ mod imp {
     ))]
     unsafe fn get_stack_start() -> Option<*mut libc::c_void> {
         let mut ret = None;
-        let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = if cfg!(target_os = "freebsd") {
-            let mut attr = mem::MaybeUninit::uninit();
-            assert_eq!(libc::pthread_attr_init((&raw mut attr) as *mut _), 0);
-            attr
-        } else {
-            mem::MaybeUninit::zeroed()
-        };
-
+        let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
+        if !cfg!(target_os = "freebsd") {
+            attr = mem::MaybeUninit::zeroed();
+        }
+        #[cfg(target_os = "freebsd")]
+        assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
         #[cfg(target_os = "freebsd")]
         let e = libc::pthread_attr_get_np(libc::pthread_self(), attr.as_mut_ptr());
         #[cfg(not(target_os = "freebsd"))]
@@ -517,22 +515,20 @@ mod imp {
     // FIXME: I am probably not unsafe.
     unsafe fn current_guard() -> Option<Range<usize>> {
         let mut ret = None;
-        let attr: mem::MaybeUninit<libc::pthread_attr_t> = if cfg!(target_os = "freebsd") {
-            let mut attr = mem::MaybeUninit::uninit();
-            assert_eq!(libc::pthread_attr_init((&raw mut attr) as *mut _), 0);
-            attr
-        } else {
-            mem::MaybeUninit::zeroed()
-        };
 
-        let mut attr = unsafe { attr.assume_init() };
+        let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
+        if !cfg!(target_os = "freebsd") {
+            attr = mem::MaybeUninit::zeroed();
+        }
         #[cfg(target_os = "freebsd")]
-        let e = libc::pthread_attr_get_np(libc::pthread_self(), &mut attr);
+        assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
+        #[cfg(target_os = "freebsd")]
+        let e = libc::pthread_attr_get_np(libc::pthread_self(), attr.as_mut_ptr());
         #[cfg(not(target_os = "freebsd"))]
-        let e = libc::pthread_getattr_np(libc::pthread_self(), &mut attr);
+        let e = libc::pthread_getattr_np(libc::pthread_self(), attr.as_mut_ptr());
         if e == 0 {
             let mut guardsize = 0;
-            assert_eq!(libc::pthread_attr_getguardsize(&attr, &mut guardsize), 0);
+            assert_eq!(libc::pthread_attr_getguardsize(attr.as_ptr(), &mut guardsize), 0);
             if guardsize == 0 {
                 if cfg!(all(target_os = "linux", target_env = "musl")) {
                     // musl versions before 1.1.19 always reported guard
@@ -545,7 +541,7 @@ mod imp {
             }
             let mut stackptr = crate::ptr::null_mut::<libc::c_void>();
             let mut size = 0;
-            assert_eq!(libc::pthread_attr_getstack(&attr, &mut stackptr, &mut size), 0);
+            assert_eq!(libc::pthread_attr_getstack(attr.as_ptr(), &mut stackptr, &mut size), 0);
 
             let stackaddr = stackptr.addr();
             ret = if cfg!(any(target_os = "freebsd", target_os = "netbsd", target_os = "hurd")) {
@@ -566,7 +562,7 @@ mod imp {
             };
         }
         if e == 0 || cfg!(target_os = "freebsd") {
-            assert_eq!(libc::pthread_attr_destroy(&mut attr), 0);
+            assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0);
         }
         ret
     }

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -51,7 +51,6 @@ impl Thread {
         let mut native: libc::pthread_t = mem::zeroed();
         let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
         assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
-        //let mut attr: libc::pthread_attr_t = unsafe { attr.assume_init() };
 
         #[cfg(target_os = "espidf")]
         if stack > 0 {

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -50,24 +50,27 @@ impl Thread {
         let p = Box::into_raw(Box::new(p));
         let mut native: libc::pthread_t = mem::zeroed();
         let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
-        assert_eq!(libc::pthread_attr_init((&raw mut attr) as *mut _), 0);
-        let mut attr: libc::pthread_attr_t = unsafe { attr.assume_init() };
+        assert_eq!(libc::pthread_attr_init(attr.as_mut_ptr()), 0);
+        //let mut attr: libc::pthread_attr_t = unsafe { attr.assume_init() };
 
         #[cfg(target_os = "espidf")]
         if stack > 0 {
             // Only set the stack if a non-zero value is passed
             // 0 is used as an indication that the default stack size configured in the ESP-IDF menuconfig system should be used
             assert_eq!(
-                libc::pthread_attr_setstacksize(&mut attr, cmp::max(stack, min_stack_size(&attr))),
+                libc::pthread_attr_setstacksize(
+                    attr.as_mut_ptr(),
+                    cmp::max(stack, min_stack_size(&attr))
+                ),
                 0
             );
         }
 
         #[cfg(not(target_os = "espidf"))]
         {
-            let stack_size = cmp::max(stack, min_stack_size(&attr));
+            let stack_size = cmp::max(stack, min_stack_size(attr.as_ptr()));
 
-            match libc::pthread_attr_setstacksize(&mut attr, stack_size) {
+            match libc::pthread_attr_setstacksize(attr.as_mut_ptr(), stack_size) {
                 0 => {}
                 n => {
                     assert_eq!(n, libc::EINVAL);
@@ -78,16 +81,16 @@ impl Thread {
                     let page_size = os::page_size();
                     let stack_size =
                         (stack_size + page_size - 1) & (-(page_size as isize - 1) as usize - 1);
-                    assert_eq!(libc::pthread_attr_setstacksize(&mut attr, stack_size), 0);
+                    assert_eq!(libc::pthread_attr_setstacksize(attr.as_mut_ptr(), stack_size), 0);
                 }
             };
         }
 
-        let ret = libc::pthread_create(&mut native, &attr, thread_start, p as *mut _);
+        let ret = libc::pthread_create(&mut native, attr.as_ptr(), thread_start, p as *mut _);
         // Note: if the thread creation fails and this assert fails, then p will
         // be leaked. However, an alternative design could cause double-free
         // which is clearly worse.
-        assert_eq!(libc::pthread_attr_destroy(&mut attr), 0);
+        assert_eq!(libc::pthread_attr_destroy(attr.as_mut_ptr()), 0);
 
         return if ret != 0 {
             // The thread failed to start and as a result p was not consumed. Therefore, it is

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -49,8 +49,9 @@ impl Thread {
     pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
         let p = Box::into_raw(Box::new(p));
         let mut native: libc::pthread_t = mem::zeroed();
-        let mut attr: libc::pthread_attr_t = mem::zeroed();
-        assert_eq!(libc::pthread_attr_init(&mut attr), 0);
+        let mut attr: mem::MaybeUninit<libc::pthread_attr_t> = mem::MaybeUninit::uninit();
+        assert_eq!(libc::pthread_attr_init((&raw mut attr) as *mut _), 0);
+        let mut attr: libc::pthread_attr_t = unsafe { attr.assume_init() };
 
         #[cfg(target_os = "espidf")]
         if stack > 0 {


### PR DESCRIPTION
As discussion in #136737.

- Replace `mem::zeroed()` with `MaybeUninit::uninit()` for `sockaddr_storage` in `accept()` and `recvfrom()` since these functions fill in the address structure
- Replace `mem::zeroed()` with `MaybeUninit::uninit()` for `pthread_attr_t` in thread-related functions since `pthread_attr_init()` initializes the structure
- Add references to man pages to document this behavior

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
