### PR TITLE
Check whole `Unsize` predicate for escaping bound vars

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -920,11 +920,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         //     T: Trait
         // so it seems ok if we (conservatively) fail to accept that `Unsize`
         // obligation above. Should be possible to extend this in the future.
-        let Some(source) = obligation.self_ty().no_bound_vars() else {
+        let Some(trait_pred) = obligation.predicate.no_bound_vars() else {
             // Don't add any candidates if there are bound regions.
             return;
         };
-        let target = obligation.predicate.skip_binder().trait_ref.args.type_at(1);
+        let source = trait_pred.self_ty();
+        let target = trait_pred.trait_ref.args.type_at(1);
 
         debug!(?source, ?target, "assemble_candidates_for_unsizing");
 

--- a/tests/ui/traits/unsize-goal-escaping-bounds.current.stderr
+++ b/tests/ui/traits/unsize-goal-escaping-bounds.current.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `for<'a> (): Unsize<(dyn Trait + 'a)>` is not satisfied
+  --> $DIR/unsize-goal-escaping-bounds.rs:20:5
+   |
+LL |     foo();
+   |     ^^^^^ the trait `for<'a> Unsize<(dyn Trait + 'a)>` is not implemented for `()`
+   |
+   = note: all implementations of `Unsize` are provided automatically by the compiler, see <https://doc.rust-lang.org/stable/std/marker/trait.Unsize.html> for more information
+note: required by a bound in `foo`
+  --> $DIR/unsize-goal-escaping-bounds.rs:15:17
+   |
+LL | fn foo()
+   |    --- required by a bound in this function
+LL | where
+LL |     for<'a> (): Unsize<dyn Trait + 'a>,
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `foo`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/unsize-goal-escaping-bounds.rs
+++ b/tests/ui/traits/unsize-goal-escaping-bounds.rs
@@ -1,0 +1,22 @@
+//@ revisions: current next
+//@[next] compile-flags: -Znext-solver
+//@[next] check-pass
+//@ ignore-compare-mode-next-solver (explicit revisions)
+
+#![feature(unsize)]
+
+use std::marker::Unsize;
+
+trait Trait {}
+impl Trait for () {}
+
+fn foo()
+where
+    for<'a> (): Unsize<dyn Trait + 'a>,
+{
+}
+
+fn main() {
+    foo();
+    //[current]~^ ERROR the trait bound `for<'a> (): Unsize<(dyn Trait + 'a)>` is not satisfied
+}


### PR DESCRIPTION
Fixes #136799