### PR TITLE
fix ensure_monomorphic_enough

### DIFF
--- a/tests/mir-opt/gvn_type_id_polymorphic.cursed_is_i32.GVN.diff
+++ b/tests/mir-opt/gvn_type_id_polymorphic.cursed_is_i32.GVN.diff
@@ -1,0 +1,13 @@
+- // MIR for `cursed_is_i32` before GVN
++ // MIR for `cursed_is_i32` after GVN
+  
+  fn cursed_is_i32() -> bool {
+      let mut _0: bool;
+  
+      bb0: {
+-         _0 = Eq(const cursed_is_i32::<T>::{constant#0}, const cursed_is_i32::<T>::{constant#1});
++         _0 = const false;
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/gvn_type_id_polymorphic.cursed_is_i32.GVN.diff
+++ b/tests/mir-opt/gvn_type_id_polymorphic.cursed_is_i32.GVN.diff
@@ -5,8 +5,7 @@
       let mut _0: bool;
   
       bb0: {
--         _0 = Eq(const cursed_is_i32::<T>::{constant#0}, const cursed_is_i32::<T>::{constant#1});
-+         _0 = const false;
+          _0 = Eq(const cursed_is_i32::<T>::{constant#0}, const cursed_is_i32::<T>::{constant#1});
           return;
       }
   }

--- a/tests/mir-opt/gvn_type_id_polymorphic.rs
+++ b/tests/mir-opt/gvn_type_id_polymorphic.rs
@@ -12,7 +12,7 @@ const fn type_id_of_val<T: 'static>(_: &T) -> u128 {
 // EMIT_MIR gvn_type_id_polymorphic.cursed_is_i32.GVN.diff
 fn cursed_is_i32<T: 'static>() -> bool {
     // CHECK-LABEL: fn cursed_is_i32(
-    // CHECK: _0 = const false;
+    // CHECK: _0 = Eq(const cursed_is_i32::<T>::{constant#0}, const cursed_is_i32::<T>::{constant#1});
     // CHECK-NEXT: return;
     (const { type_id_of_val(&generic::<T>) } == const { type_id_of_val(&generic::<i32>) })
 }

--- a/tests/mir-opt/gvn_type_id_polymorphic.rs
+++ b/tests/mir-opt/gvn_type_id_polymorphic.rs
@@ -1,0 +1,22 @@
+//@ test-mir-pass: GVN
+//@ compile-flags: -C opt-level=2
+
+#![feature(core_intrinsics)]
+
+fn generic<T>() {}
+
+const fn type_id_of_val<T: 'static>(_: &T) -> u128 {
+    std::intrinsics::type_id::<T>()
+}
+
+// EMIT_MIR gvn_type_id_polymorphic.cursed_is_i32.GVN.diff
+fn cursed_is_i32<T: 'static>() -> bool {
+    // CHECK-LABEL: fn cursed_is_i32(
+    // CHECK: _0 = const false;
+    // CHECK-NEXT: return;
+    (const { type_id_of_val(&generic::<T>) } == const { type_id_of_val(&generic::<i32>) })
+}
+
+fn main() {
+    dbg!(cursed_is_i32::<i32>());
+}


### PR DESCRIPTION
When polymorphization was still a thing, the visitor was used to only recurse into *used generic parameters* of function/closure/coroutine types and allow unused parameters (i.e. the polymorphized parameters) to remain generic.

When polymorphization got removed, this got changed to always treat all parameters as polymorphic and never recurse into them: https://github.com/rust-lang/rust/pull/133883/files#diff-210c59e321070d0ca4625c04e9fb064bf43ddc34082e7e33a7ee8a6c577e95afL44-L62

This is clearly wrong and can cause MIR opts to misbehave, for example this currently prints "false" in release mode:

```rust
#![feature(core_intrinsics)]

fn generic<T>() {}

const fn type_id_of_val<T: 'static>(_: &T) -> u128 {
    std::intrinsics::type_id::<T>()
}

fn cursed_is_i32<T: 'static>() -> bool {
    (const { type_id_of_val(&generic::<T>) } == const { type_id_of_val(&generic::<i32>) })
}

fn main() {
    dbg!(cursed_is_i32::<i32>());
}
```

This PR reverts to the old behavior of always treating all types that contain type parameters as too generic, like we used to do without `-Zpolymorphize` before.

~~I'm not including the above as a test case here, because I think there is little value in testing code paths that have been removed and this seems unlikely to regress in a way that would be caught by a regression test, but let me know if you disagree and want me to add a test anyway.~~