### PR TITLE
core: use `FormattingOptions` by reference

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2751,7 +2751,7 @@ impl<T: fmt::Display + ?Sized> SpecToString for T {
     default fn spec_to_string(&self) -> String {
         let mut buf = String::new();
         let mut formatter =
-            core::fmt::Formatter::new(&mut buf, core::fmt::FormattingOptions::new());
+            core::fmt::Formatter::new(&mut buf, const { &core::fmt::FormattingOptions::new() });
         // Bypass format_args!() to avoid write_str with zero-length strs
         fmt::Display::fmt(self, &mut formatter)
             .expect("a Display implementation returned an error unexpectedly");

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -637,7 +637,7 @@ pub fn begin_panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
             // Lazily, the first time this gets called, run the actual string formatting.
             self.string.get_or_insert_with(|| {
                 let mut s = String::new();
-                let mut fmt = fmt::Formatter::new(&mut s, fmt::FormattingOptions::new());
+                let mut fmt = fmt::Formatter::new(&mut s, const { &fmt::FormattingOptions::new() });
                 let _err = fmt::Display::fmt(&inner, &mut fmt);
                 s
             })

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-abort.diff
@@ -29,6 +29,7 @@
                   debug precision => _8;
                   let _8: usize;
                   scope 5 (inlined Formatter::<'_>::precision) {
+                      let mut _23: &std::fmt::FormattingOptions;
                   }
               }
           }
@@ -36,17 +37,21 @@
       scope 4 (inlined Formatter::<'_>::sign_plus) {
           let mut _20: u32;
           let mut _21: u32;
+          let mut _22: &std::fmt::FormattingOptions;
       }
   
       bb0: {
           StorageLive(_4);
+          StorageLive(_22);
           StorageLive(_20);
           StorageLive(_21);
-          _21 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
+          _22 = copy ((*_1).1: &std::fmt::FormattingOptions);
+          _21 = copy ((*_22).0: u32);
           _20 = BitAnd(move _21, const 1_u32);
           StorageDead(_21);
           _4 = Ne(move _20, const 0_u32);
           StorageDead(_20);
+          StorageDead(_22);
           StorageLive(_5);
           switchInt(copy _4) -> [0: bb2, otherwise: bb1];
       }
@@ -65,7 +70,10 @@
   
       bb3: {
           StorageLive(_6);
-          _6 = copy (((*_1).0: std::fmt::FormattingOptions).4: std::option::Option<usize>);
+          StorageLive(_23);
+          _23 = copy ((*_1).1: &std::fmt::FormattingOptions);
+          _6 = copy ((*_23).4: std::option::Option<usize>);
+          StorageDead(_23);
           _7 = discriminant(_6);
           switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb9];
       }

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-unwind.diff
@@ -29,6 +29,7 @@
                   debug precision => _8;
                   let _8: usize;
                   scope 5 (inlined Formatter::<'_>::precision) {
+                      let mut _23: &std::fmt::FormattingOptions;
                   }
               }
           }
@@ -36,17 +37,21 @@
       scope 4 (inlined Formatter::<'_>::sign_plus) {
           let mut _20: u32;
           let mut _21: u32;
+          let mut _22: &std::fmt::FormattingOptions;
       }
   
       bb0: {
           StorageLive(_4);
+          StorageLive(_22);
           StorageLive(_20);
           StorageLive(_21);
-          _21 = copy (((*_1).0: std::fmt::FormattingOptions).0: u32);
+          _22 = copy ((*_1).1: &std::fmt::FormattingOptions);
+          _21 = copy ((*_22).0: u32);
           _20 = BitAnd(move _21, const 1_u32);
           StorageDead(_21);
           _4 = Ne(move _20, const 0_u32);
           StorageDead(_20);
+          StorageDead(_22);
           StorageLive(_5);
           switchInt(copy _4) -> [0: bb2, otherwise: bb1];
       }
@@ -65,7 +70,10 @@
   
       bb3: {
           StorageLive(_6);
-          _6 = copy (((*_1).0: std::fmt::FormattingOptions).4: std::option::Option<usize>);
+          StorageLive(_23);
+          _23 = copy ((*_1).1: &std::fmt::FormattingOptions);
+          _6 = copy ((*_23).4: std::option::Option<usize>);
+          StorageDead(_23);
           _7 = discriminant(_6);
           switchInt(move _7) -> [1: bb4, 0: bb6, otherwise: bb9];
       }


### PR DESCRIPTION
Most of the time, the options passed to `Formatter` will be the unmodified default options. The current approach of using the options by-value means that a new `FormattingOptions` structure has to be created every time a formatter is constructed. With this PR, `Formatter` stores the options by-reference, which means that one `FormattingOptions` instance in static memory is enough to create a `Formatter`. In the future (and in particular once #119899 has merged), we might even consider removing `fmt::rt::Placeholder` in favour of `FormattingOptions`, which would – in combination with this change – decrease the option-copying even further.

CC #118117 @EliasHolzmann 
