### PR TITLE
[rustdoc]  Improve display of prev/next scraped examples buttons

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1697,6 +1697,10 @@ instead, we check that it's not a "finger" cursor.
 .example-wrap .button-holder > *:not(:first-child) {
 	margin-left: var(--button-left-margin);
 }
+.example-wrap .button-holder .prev,
+.example-wrap .button-holder .next {
+	font-size: 1.3em;
+}
 .example-wrap .button-holder .copy-button {
 	padding: 2px 0 0 4px;
 }

--- a/src/librustdoc/html/static/js/scrape-examples.js
+++ b/src/librustdoc/html/static/js/scrape-examples.js
@@ -60,8 +60,8 @@
 
         const locs = example.locs;
         if (locs.length > 1) {
-            const next = createScrapeButton(buttonHolder, "next", "≻");
-            const prev = createScrapeButton(buttonHolder, "prev", "≺");
+            const next = createScrapeButton(buttonHolder, "next", ">");
+            const prev = createScrapeButton(buttonHolder, "prev", "<");
 
             // Toggle through list of examples in a given file
             const onChangeLoc = changeIndex => {

--- a/tests/rustdoc-gui/scrape-examples-button-focus.goml
+++ b/tests/rustdoc-gui/scrape-examples-button-focus.goml
@@ -11,6 +11,8 @@ assert-property: (".scraped-example-list > .scraped-example .rust", {
     "scrollTop": |initialScrollTop|,
 })
 focus: ".scraped-example-list > .scraped-example .next"
+assert-text: (".scraped-example-list > .scraped-example .next", ">")
+assert-css: (".scraped-example-list > .scraped-example .next", { "font-size": "20.8px" })
 press-key: "Enter"
 assert-property-false: (".scraped-example-list > .scraped-example .src-line-numbers", {
     "scrollTop": |initialScrollTop|
@@ -19,6 +21,8 @@ assert-property-false: (".scraped-example-list > .scraped-example .rust", {
     "scrollTop": |initialScrollTop|
 }, NEAR)
 focus: ".scraped-example-list > .scraped-example .prev"
+assert-css: (".scraped-example-list > .scraped-example .next", { "font-size": "20.8px" })
+assert-text: (".scraped-example-list > .scraped-example .prev", "<")
 press-key: "Enter"
 assert-property: (".scraped-example-list > .scraped-example .src-line-numbers", {
     "scrollTop": |initialScrollTop|


### PR DESCRIPTION
Currently it looks like this:

![Screenshot From 2025-02-11 15-20-22](https://github.com/user-attachments/assets/4257e313-614d-4a30-a4c9-994d4e3bff72)

Which is... not great. With this PR, it now looks like this:

![image](https://github.com/user-attachments/assets/8f2369ab-d884-419d-9642-bbb5fbebbcdc)

It switched to the plain `<` and `>` characters and made them a bit bigger so they match other buttons size.

r? @notriddle 