### PR TITLE
Change the issue number for `likely_unlikely` and `cold_path`

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -646,7 +646,7 @@ pub const fn must_use<T>(value: T) -> T {
 /// ```
 ///
 ///
-#[unstable(feature = "likely_unlikely", issue = "26179")]
+#[unstable(feature = "likely_unlikely", issue = "136873")]
 #[inline(always)]
 pub const fn likely(b: bool) -> bool {
     crate::intrinsics::likely(b)
@@ -696,7 +696,7 @@ pub const fn likely(b: bool) -> bool {
 ///     }
 /// }
 /// ```
-#[unstable(feature = "likely_unlikely", issue = "26179")]
+#[unstable(feature = "likely_unlikely", issue = "136873")]
 #[inline(always)]
 pub const fn unlikely(b: bool) -> bool {
     crate::intrinsics::unlikely(b)
@@ -729,7 +729,7 @@ pub const fn unlikely(b: bool) -> bool {
 ///     }
 /// }
 /// ```
-#[unstable(feature = "cold_path", issue = "26179")]
+#[unstable(feature = "cold_path", issue = "136873")]
 #[inline(always)]
 pub const fn cold_path() {
     crate::intrinsics::cold_path()


### PR DESCRIPTION
These currently point to rust-lang/rust#26179, which is nearly a decade old and has a lot of outdated discussion. Move these features to a new tracking issue specifically for the recently added API.

New tracking issue: https://github.com/rust-lang/rust/issues/136873