### PR TITLE
Add safe new() to NotAllOnes

### DIFF
--- a/library/core/src/num/niche_types.rs
+++ b/library/core/src/num/niche_types.rs
@@ -32,6 +32,16 @@ macro_rules! define_valid_range_type {
         };
 
         impl $name {
+            #[inline]
+            pub const fn new(val: $int) -> Option<Self> {
+                if (val as $uint) >= ($low as $uint) && (val as $uint) <= ($high as $uint) {
+                    // SAFETY: just checked the inclusive range
+                    Some(unsafe { $name(val) })
+                } else {
+                    None
+                }
+            }
+
             /// Constructs an instance of this type from the underlying integer
             /// primitive without checking whether its zero.
             ///

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -67,13 +67,11 @@ impl BorrowedFd<'_> {
     /// The resource pointed to by `fd` must remain open for the duration of
     /// the returned `BorrowedFd`, and it must not have the value `-1`.
     #[inline]
+    #[track_caller]
     #[rustc_const_stable(feature = "io_safety", since = "1.63.0")]
     #[stable(feature = "io_safety", since = "1.63.0")]
     pub const unsafe fn borrow_raw(fd: RawFd) -> Self {
-        assert!(fd != u32::MAX as RawFd);
-        // SAFETY: we just asserted that the value is in the valid range and isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
-        let fd = unsafe { ValidRawFd::new_unchecked(fd) };
-        Self { fd, _phantom: PhantomData }
+        Self { fd: ValidRawFd::new(fd).expect("fd != -1"), _phantom: PhantomData }
     }
 }
 
@@ -154,11 +152,9 @@ impl FromRawFd for OwnedFd {
     ///
     /// [io-safety]: io#io-safety
     #[inline]
+    #[track_caller]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        assert_ne!(fd, u32::MAX as RawFd);
-        // SAFETY: we just asserted that the value is in the valid range and isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
-        let fd = unsafe { ValidRawFd::new_unchecked(fd) };
-        Self { fd }
+        Self { fd: ValidRawFd::new(fd).expect("fd != -1") }
     }
 }
 

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -101,12 +101,9 @@ impl BorrowedFd<'_> {
     /// the returned `BorrowedFd`, and it must not have the value
     /// `SOLID_NET_INVALID_FD`.
     #[inline]
+    #[track_caller]
     pub const unsafe fn borrow_raw(fd: RawFd) -> Self {
-        assert!(fd != -1 as RawFd);
-        // SAFETY: we just asserted that the value is in the valid range and
-        // isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
-        let fd = unsafe { ValidRawFd::new_unchecked(fd) };
-        Self { fd, _phantom: PhantomData }
+        Self { fd: ValidRawFd::new(fd).expect("fd != -1"), _phantom: PhantomData }
     }
 }
 
@@ -156,12 +153,9 @@ impl FromRawFd for OwnedFd {
     /// The resource pointed to by `fd` must be open and suitable for assuming
     /// ownership. The resource must not require any cleanup other than `close`.
     #[inline]
+    #[track_caller]
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        assert_ne!(fd, -1 as RawFd);
-        // SAFETY: we just asserted that the value is in the valid range and
-        // isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
-        let fd = unsafe { ValidRawFd::new_unchecked(fd) };
-        Self { fd }
+        Self { fd: ValidRawFd::new(fd).expect("fd != -1") }
     }
 }
 

--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -58,12 +58,11 @@ impl BorrowedSocket<'_> {
     /// the returned `BorrowedSocket`, and it must not have the value
     /// `INVALID_SOCKET`.
     #[inline]
+    #[track_caller]
     #[rustc_const_stable(feature = "io_safety", since = "1.63.0")]
     #[stable(feature = "io_safety", since = "1.63.0")]
     pub const unsafe fn borrow_raw(socket: RawSocket) -> Self {
-        assert!(socket != sys::c::INVALID_SOCKET as RawSocket);
-        let socket = unsafe { ValidRawSocket::new_unchecked(socket) };
-        Self { socket, _phantom: PhantomData }
+        Self { socket: ValidRawSocket::new(socket).expect("socket != -1"), _phantom: PhantomData }
     }
 }
 
@@ -185,10 +184,9 @@ impl IntoRawSocket for OwnedSocket {
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl FromRawSocket for OwnedSocket {
     #[inline]
+    #[track_caller]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
-        debug_assert_ne!(socket, sys::c::INVALID_SOCKET as RawSocket);
-        let socket = unsafe { ValidRawSocket::new_unchecked(socket) };
-        Self { socket }
+        Self { socket: ValidRawSocket::new(socket).expect("socket != -1") }
     }
 }
 

--- a/library/std/src/sys/pal/solid/fs.rs
+++ b/library/std/src/sys/pal/solid/fs.rs
@@ -22,12 +22,9 @@ struct FileDesc {
 
 impl FileDesc {
     #[inline]
+    #[track_caller]
     fn new(fd: c_int) -> FileDesc {
-        assert_ne!(fd, -1i32);
-        // Safety: we just asserted that the value is in the valid range and
-        // isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
-        let fd = unsafe { CIntNotMinusOne::new_unchecked(fd) };
-        FileDesc { fd }
+        FileDesc { fd: CIntNotMinusOne::new(fd).expect("fd != -1") }
     }
 
     #[inline]


### PR DESCRIPTION
Replaces duplicated `unsafe` code with a single, easier to verify implementation.
