### PR TITLE
Lower fn items as ZST valtrees and delay a bug

### DIFF
--- a/tests/ui/const-generics/mgca/unexpected-fn-item-in-array.rs
+++ b/tests/ui/const-generics/mgca/unexpected-fn-item-in-array.rs
@@ -1,0 +1,13 @@
+// Make sure we don't ICE when encountering an fn item during lowering in mGCA.
+
+#![feature(min_generic_const_args)]
+//~^ WARN the feature `min_generic_const_args` is incomplete
+
+trait A<T> {}
+
+impl A<[usize; fn_item]> for () {}
+//~^ ERROR the constant `fn_item` is not of type `usize`
+
+fn fn_item() {}
+
+fn main() {}

--- a/tests/ui/const-generics/mgca/unexpected-fn-item-in-array.stderr
+++ b/tests/ui/const-generics/mgca/unexpected-fn-item-in-array.stderr
@@ -1,0 +1,19 @@
+warning: the feature `min_generic_const_args` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unexpected-fn-item-in-array.rs:3:12
+   |
+LL | #![feature(min_generic_const_args)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: the constant `fn_item` is not of type `usize`
+  --> $DIR/unexpected-fn-item-in-array.rs:8:6
+   |
+LL | impl A<[usize; fn_item]> for () {}
+   |      ^^^^^^^^^^^^^^^^^^^ expected `usize`, found fn item
+   |
+   = note: the length of array `[usize; fn_item]` must be type `usize`
+
+error: aborting due to 1 previous error; 1 warning emitted
+


### PR DESCRIPTION
Lower it as a ZST instead of a const error, which we can handle mostly fine. Delay a bug so we don't accidentally support it tho.

r? BoxyUwU

Fixes #136855
Fixes #136853
Fixes #136854
Fixes #136337

Only added one test bc that's really the crux of the issue (fn item in array length position).