### PR TITLE
Remove the common prelude module

### DIFF
--- a/library/core/src/prelude/mod.rs
+++ b/library/core/src/prelude/mod.rs
@@ -9,16 +9,7 @@
 
 #![stable(feature = "core_prelude", since = "1.4.0")]
 
-mod common;
-
-/// The first version of the prelude of The Rust Standard Library.
-///
-/// See the [module-level documentation](self) for more.
-#[stable(feature = "rust1", since = "1.0.0")]
-pub mod v1 {
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::common::*;
-}
+pub mod v1;
 
 /// The 2015 version of the core prelude.
 ///
@@ -64,7 +55,8 @@ pub mod rust_2021 {
 #[stable(feature = "prelude_2024", since = "1.85.0")]
 pub mod rust_2024 {
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::common::*;
+    #[doc(no_inline)]
+    pub use super::v1::*;
 
     #[stable(feature = "prelude_2021", since = "1.55.0")]
     #[doc(no_inline)]

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -1,15 +1,17 @@
-//! Items common to the prelude of all editions.
+//! The first version of the core prelude.
 //!
 //! See the [module-level documentation](super) for more.
+
+#![stable(feature = "core_prelude", since = "1.4.0")]
 
 // No formatting: this file is nothing but re-exports, and their order is worth preserving.
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
 // Re-exported core operators
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::marker::{Send, Sized, Sync, Unpin};
-#[stable(feature = "rust1", since = "1.0.0")]
+pub use crate::marker::{Copy, Send, Sized, Sync, Unpin};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
 #[stable(feature = "async_closure", since = "1.85.0")]
@@ -17,7 +19,7 @@ pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
 pub use crate::ops::{AsyncFn, AsyncFnMut, AsyncFnOnce};
 
 // Re-exported functions
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::mem::drop;
 #[stable(feature = "size_of_prelude", since = "1.80.0")]
@@ -25,30 +27,43 @@ pub use crate::mem::drop;
 pub use crate::mem::{align_of, align_of_val, size_of, size_of_val};
 
 // Re-exported types and traits
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "core_prelude", since = "1.4.0")]
+#[doc(no_inline)]
+pub use crate::clone::Clone;
+#[stable(feature = "core_prelude", since = "1.4.0")]
+#[doc(no_inline)]
+pub use crate::cmp::{Eq, Ord, PartialEq, PartialOrd};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::convert::{AsMut, AsRef, From, Into};
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator};
-#[stable(feature = "rust1", since = "1.0.0")]
+pub use crate::default::Default;
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
-pub use crate::iter::{Extend, IntoIterator, Iterator};
-#[stable(feature = "rust1", since = "1.0.0")]
+pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator, Extend, IntoIterator, Iterator};
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::option::Option::{self, None, Some};
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]
 pub use crate::result::Result::{self, Err, Ok};
 
 // Re-exported built-in macros
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use crate::fmt::macros::Debug;
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use crate::hash::macros::Hash;
+
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow(deprecated)]
 #[doc(no_inline)]
-pub use core::prelude::v1::{
+pub use crate::{
     assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
     format_args_nl, include, include_bytes, include_str, line, log_syntax, module_path, option_env,
-    stringify, trace_macros, Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd,
+    stringify, trace_macros,
 };
 
 #[unstable(
@@ -57,64 +72,42 @@ pub use core::prelude::v1::{
     reason = "`concat_bytes` is not stable enough for use and is subject to change"
 )]
 #[doc(no_inline)]
-pub use core::prelude::v1::concat_bytes;
+pub use crate::concat_bytes;
 
 // Do not `doc(no_inline)` so that they become doc items on their own
 // (no public module for them to be re-exported from).
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-pub use core::prelude::v1::{
+pub use crate::macros::builtin::{
     alloc_error_handler, bench, derive, global_allocator, test, test_case,
 };
 
 #[unstable(feature = "derive_const", issue = "none")]
-pub use core::prelude::v1::derive_const;
+pub use crate::macros::builtin::derive_const;
 
-// Do not `doc(no_inline)` either.
 #[unstable(
     feature = "cfg_accessible",
     issue = "64797",
     reason = "`cfg_accessible` is not fully implemented"
 )]
-pub use core::prelude::v1::cfg_accessible;
+pub use crate::macros::builtin::cfg_accessible;
 
-// Do not `doc(no_inline)` either.
 #[unstable(
     feature = "cfg_eval",
     issue = "82679",
     reason = "`cfg_eval` is a recently implemented feature"
 )]
-pub use core::prelude::v1::cfg_eval;
+pub use crate::macros::builtin::cfg_eval;
 
-// Do not `doc(no_inline)` either.
 #[unstable(
     feature = "type_ascription",
     issue = "23416",
     reason = "placeholder syntax for type ascription"
 )]
-pub use core::prelude::v1::type_ascribe;
+pub use crate::macros::builtin::type_ascribe;
 
-// Do not `doc(no_inline)` either.
 #[unstable(
     feature = "deref_patterns",
     issue = "87121",
     reason = "placeholder syntax for deref patterns"
 )]
-pub use core::prelude::v1::deref;
-
-// The file so far is equivalent to core/src/prelude/v1.rs. It is duplicated
-// rather than glob imported because we want docs to show these re-exports as
-// pointing to within `std`.
-// Below are the items from the alloc crate.
-
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)]
-pub use crate::borrow::ToOwned;
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)]
-pub use crate::boxed::Box;
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)]
-pub use crate::string::{String, ToString};
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)]
-pub use crate::vec::Vec;
+pub use crate::macros::builtin::deref;

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -111,16 +111,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-mod common;
-
-/// The first version of the prelude of The Rust Standard Library.
-///
-/// See the [module-level documentation](self) for more.
-#[stable(feature = "rust1", since = "1.0.0")]
-pub mod v1 {
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::common::*;
-}
+pub mod v1;
 
 /// The 2015 version of the prelude of The Rust Standard Library.
 ///
@@ -162,7 +153,8 @@ pub mod rust_2021 {
 #[stable(feature = "prelude_2024", since = "1.85.0")]
 pub mod rust_2024 {
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub use super::common::*;
+    #[doc(no_inline)]
+    pub use super::v1::*;
 
     #[stable(feature = "prelude_2024", since = "1.85.0")]
     #[doc(no_inline)]

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -1,15 +1,17 @@
-//! Items common to the prelude of all editions.
+//! The first version of the prelude of The Rust Standard Library.
 //!
 //! See the [module-level documentation](super) for more.
+
+#![stable(feature = "rust1", since = "1.0.0")]
 
 // No formatting: this file is nothing but re-exports, and their order is worth preserving.
 #![cfg_attr(rustfmt, rustfmt::skip)]
 
 // Re-exported core operators
-#[stable(feature = "core_prelude", since = "1.4.0")]
+#[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
-pub use crate::marker::{Copy, Send, Sized, Sync, Unpin};
-#[stable(feature = "core_prelude", since = "1.4.0")]
+pub use crate::marker::{Send, Sized, Sync, Unpin};
+#[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
 pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
 #[stable(feature = "async_closure", since = "1.85.0")]
@@ -17,7 +19,7 @@ pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
 pub use crate::ops::{AsyncFn, AsyncFnMut, AsyncFnOnce};
 
 // Re-exported functions
-#[stable(feature = "core_prelude", since = "1.4.0")]
+#[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
 pub use crate::mem::drop;
 #[stable(feature = "size_of_prelude", since = "1.80.0")]
@@ -25,43 +27,30 @@ pub use crate::mem::drop;
 pub use crate::mem::{align_of, align_of_val, size_of, size_of_val};
 
 // Re-exported types and traits
-#[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use crate::clone::Clone;
-#[stable(feature = "core_prelude", since = "1.4.0")]
-#[doc(no_inline)]
-pub use crate::cmp::{Eq, Ord, PartialEq, PartialOrd};
-#[stable(feature = "core_prelude", since = "1.4.0")]
+#[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
 pub use crate::convert::{AsMut, AsRef, From, Into};
-#[stable(feature = "core_prelude", since = "1.4.0")]
+#[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
-pub use crate::default::Default;
-#[stable(feature = "core_prelude", since = "1.4.0")]
+pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator};
+#[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
-pub use crate::iter::{DoubleEndedIterator, ExactSizeIterator, Extend, IntoIterator, Iterator};
-#[stable(feature = "core_prelude", since = "1.4.0")]
+pub use crate::iter::{Extend, IntoIterator, Iterator};
+#[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
 pub use crate::option::Option::{self, None, Some};
-#[stable(feature = "core_prelude", since = "1.4.0")]
+#[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
 pub use crate::result::Result::{self, Err, Ok};
 
 // Re-exported built-in macros
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[doc(no_inline)]
-pub use crate::fmt::macros::Debug;
-#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[doc(no_inline)]
-pub use crate::hash::macros::Hash;
-
-#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow(deprecated)]
 #[doc(no_inline)]
-pub use crate::{
+pub use core::prelude::v1::{
     assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
     format_args_nl, include, include_bytes, include_str, line, log_syntax, module_path, option_env,
-    stringify, trace_macros,
+    stringify, trace_macros, Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd,
 };
 
 #[unstable(
@@ -70,42 +59,64 @@ pub use crate::{
     reason = "`concat_bytes` is not stable enough for use and is subject to change"
 )]
 #[doc(no_inline)]
-pub use crate::concat_bytes;
+pub use core::prelude::v1::concat_bytes;
 
 // Do not `doc(no_inline)` so that they become doc items on their own
 // (no public module for them to be re-exported from).
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-pub use crate::macros::builtin::{
+pub use core::prelude::v1::{
     alloc_error_handler, bench, derive, global_allocator, test, test_case,
 };
 
 #[unstable(feature = "derive_const", issue = "none")]
-pub use crate::macros::builtin::derive_const;
+pub use core::prelude::v1::derive_const;
 
+// Do not `doc(no_inline)` either.
 #[unstable(
     feature = "cfg_accessible",
     issue = "64797",
     reason = "`cfg_accessible` is not fully implemented"
 )]
-pub use crate::macros::builtin::cfg_accessible;
+pub use core::prelude::v1::cfg_accessible;
 
+// Do not `doc(no_inline)` either.
 #[unstable(
     feature = "cfg_eval",
     issue = "82679",
     reason = "`cfg_eval` is a recently implemented feature"
 )]
-pub use crate::macros::builtin::cfg_eval;
+pub use core::prelude::v1::cfg_eval;
 
+// Do not `doc(no_inline)` either.
 #[unstable(
     feature = "type_ascription",
     issue = "23416",
     reason = "placeholder syntax for type ascription"
 )]
-pub use crate::macros::builtin::type_ascribe;
+pub use core::prelude::v1::type_ascribe;
 
+// Do not `doc(no_inline)` either.
 #[unstable(
     feature = "deref_patterns",
     issue = "87121",
     reason = "placeholder syntax for deref patterns"
 )]
-pub use crate::macros::builtin::deref;
+pub use core::prelude::v1::deref;
+
+// The file so far is equivalent to core/src/prelude/v1.rs. It is duplicated
+// rather than glob imported because we want docs to show these re-exports as
+// pointing to within `std`.
+// Below are the items from the alloc crate.
+
+#[stable(feature = "rust1", since = "1.0.0")]
+#[doc(no_inline)]
+pub use crate::borrow::ToOwned;
+#[stable(feature = "rust1", since = "1.0.0")]
+#[doc(no_inline)]
+pub use crate::boxed::Box;
+#[stable(feature = "rust1", since = "1.0.0")]
+#[doc(no_inline)]
+pub use crate::string::{String, ToString};
+#[stable(feature = "rust1", since = "1.0.0")]
+#[doc(no_inline)]
+pub use crate::vec::Vec;

--- a/tests/rustdoc-js-std/vec-new.js
+++ b/tests/rustdoc-js-std/vec-new.js
@@ -9,7 +9,7 @@ const EXPECTED = [
     {
         'query': 'prelude::vec',
         'others': [
-            { 'path': 'std::prelude::rust_2024', 'name': 'Vec' },
+            { 'path': 'std::prelude::v1', 'name': 'Vec' },
         ],
     },
     {


### PR DESCRIPTION
This fixes the issues described in https://github.com/rust-lang/rust/issues/136102. Primarily, this resolves some issues with how the documentation for the prelude is generated:

- It avoids showing "unstable" for macros in the prelude that are actually stable.
- Avoids duplication of some pages due to the previous lack of `doc(no_inline)`.
- Makes the different edition preludes consistent, and sets a pattern that can be used by future editions.

We may need to rearrange these modules in the future if we decide to remove anything from the prelude again. If we do, I think we should look into a different solution that avoids the documentation problems.

Closes https://github.com/rust-lang/rust/issues/136102