### PR TITLE
Sync Fuchsia target spec with clang Fuchsia driver

### DIFF
--- a/compiler/rustc_target/src/spec/base/fuchsia.rs
+++ b/compiler/rustc_target/src/spec/base/fuchsia.rs
@@ -7,7 +7,7 @@ pub(crate) fn opts() -> TargetOptions {
     // now. When using clang as the linker it will supply these options for us,
     // so we only list them for ld/lld.
     //
-    // https://github.com/llvm/llvm-project/blob/db9322b2066c55254e7691efeab863f43bfcc084/clang/lib/Driver/ToolChains/Fuchsia.cpp#L31
+    // https://github.com/llvm/llvm-project/blob/0419db6b95e246fe9dc90b5795beb77c393eb2ce/clang/lib/Driver/ToolChains/Fuchsia.cpp#L32
     let pre_link_args = TargetOptions::link_args(
         LinkerFlavor::Gnu(Cc::No, Lld::No),
         &[
@@ -18,9 +18,13 @@ pub(crate) fn opts() -> TargetOptions {
             "-z",
             "now",
             "-z",
+            "start-stop-visibility=hidden",
+            "-z",
             "rodynamic",
             "-z",
             "separate-loadable-segments",
+            "-z",
+            "rel",
             "--pack-dyn-relocs=relr",
         ],
     );

--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_fuchsia.rs
@@ -1,6 +1,28 @@
-use crate::spec::{SanitizerSet, StackProbeType, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{
+    Cc, LinkerFlavor, Lld, SanitizerSet, StackProbeType, Target, TargetMetadata, base,
+};
 
 pub(crate) fn target() -> Target {
+    let mut base = base::fuchsia::opts();
+    base.cpu = "generic".into();
+    base.features = "+v8a,+crc,+aes,+sha2,+neon".into();
+    base.max_atomic_width = Some(128);
+    base.stack_probes = StackProbeType::Inline;
+    base.supported_sanitizers = SanitizerSet::ADDRESS
+        | SanitizerSet::CFI
+        | SanitizerSet::LEAK
+        | SanitizerSet::SHADOWCALLSTACK;
+    base.supports_xray = true;
+
+    base.add_pre_link_args(
+        LinkerFlavor::Gnu(Cc::No, Lld::No),
+        &[
+            "--execute-only",
+            // Enable the Cortex-A53 errata 843419 mitigation by default
+            "--fix-cortex-a53-843419",
+        ],
+    );
+
     Target {
         llvm_target: "aarch64-unknown-fuchsia".into(),
         metadata: TargetMetadata {
@@ -12,14 +34,6 @@ pub(crate) fn target() -> Target {
         pointer_width: 64,
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32".into(),
         arch: "aarch64".into(),
-        options: TargetOptions {
-            features: "+v8a".into(),
-            max_atomic_width: Some(128),
-            stack_probes: StackProbeType::Inline,
-            supported_sanitizers: SanitizerSet::ADDRESS
-                | SanitizerSet::CFI
-                | SanitizerSet::SHADOWCALLSTACK,
-            ..base::fuchsia::opts()
-        },
+        options: base,
     }
 }

--- a/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64gc_unknown_fuchsia.rs
@@ -1,6 +1,16 @@
-use crate::spec::{CodeModel, SanitizerSet, Target, TargetMetadata, TargetOptions, base};
+use crate::spec::{CodeModel, SanitizerSet, StackProbeType, Target, TargetMetadata, base};
 
 pub(crate) fn target() -> Target {
+    let mut base = base::fuchsia::opts();
+    base.code_model = Some(CodeModel::Medium);
+    base.cpu = "generic-rv64".into();
+    base.features = "+m,+a,+f,+d,+c".into();
+    base.llvm_abiname = "lp64d".into();
+    base.max_atomic_width = Some(64);
+    base.stack_probes = StackProbeType::Inline;
+    base.supported_sanitizers = SanitizerSet::SHADOWCALLSTACK;
+    base.supports_xray = true;
+
     Target {
         llvm_target: "riscv64-unknown-fuchsia".into(),
         metadata: TargetMetadata {
@@ -12,14 +22,6 @@ pub(crate) fn target() -> Target {
         pointer_width: 64,
         data_layout: "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128".into(),
         arch: "riscv64".into(),
-        options: TargetOptions {
-            code_model: Some(CodeModel::Medium),
-            cpu: "generic-rv64".into(),
-            features: "+m,+a,+f,+d,+c".into(),
-            llvm_abiname: "lp64d".into(),
-            max_atomic_width: Some(64),
-            supported_sanitizers: SanitizerSet::SHADOWCALLSTACK,
-            ..base::fuchsia::opts()
-        },
+        options: base,
     }
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_fuchsia.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_fuchsia.rs
@@ -4,7 +4,10 @@ pub(crate) fn target() -> Target {
     let mut base = base::fuchsia::opts();
     base.cpu = "x86-64".into();
     base.plt_by_default = false;
-    base.max_atomic_width = Some(64);
+    // See https://fuchsia.dev/fuchsia-src/contribute/governance/rfcs/0073_x86_64_platform_requirement,
+    // which corresponds to x86-64-v2.
+    base.features = "+cx16,+sahf,+popcnt,+sse3,+sse4.1,+sse4.2,+ssse3".into();
+    base.max_atomic_width = Some(128);
     base.stack_probes = StackProbeType::Inline;
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::LEAK;
     base.supports_xray = true;


### PR DESCRIPTION
This updates the Fuchsia target spec with the [Clang Fuchsia driver], which picks up a few changes:

* Adds `-z start-stop-visibility=hidden` and `-z rel` to the pre link arguments.
* Adds `--execute-only` and `--fix-cortex-a53-843419` for `aarch64-unknown-fuchsia`.
* Enables the equivalent cpu features for `x86-64-v2` for `x86_64-unknown-fuchsia`, which is our minimum supported x86_64 platform according to [RFC-0073].

try-job: x86_64-fuchsia

[Clang Fuchsia driver]: https://github.com/llvm/llvm-project/blob/8374d421861cd3d47e21ae7889ba0b4c498e8d85/clang/lib/Driver/ToolChains/Fuchsia.cpp
[RFC-0073]: https://fuchsia.dev/fuchsia-src/contribute/governance/rfcs/0073_x86_64_platform_requirement