### PR TITLE
Enforce short type string in more errors

### DIFF
--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -470,7 +470,7 @@ pub(crate) struct IntToWide<'tcx> {
     pub span: Span,
     pub metadata: &'tcx str,
     pub expr_ty: String,
-    pub cast_ty: Ty<'tcx>,
+    pub cast_ty: String,
     #[label(hir_typeck_int_to_fat_label_nightly)]
     pub expr_if_nightly: Option<Span>,
     pub known_wide: bool,
@@ -822,10 +822,10 @@ pub(crate) struct ReplaceWithName {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_cast_thin_pointer_to_wide_pointer, code = E0607)]
-pub(crate) struct CastThinPointerToWidePointer<'tcx> {
+pub(crate) struct CastThinPointerToWidePointer {
     #[primary_span]
     pub span: Span,
-    pub expr_ty: Ty<'tcx>,
+    pub expr_ty: String,
     pub cast_ty: String,
     #[note(hir_typeck_teach_help)]
     pub(crate) teach: bool,

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -606,13 +606,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     if let Some(ty) = self.lookup_derefing(expr, oprnd, oprnd_t) {
                         oprnd_t = ty;
                     } else {
+                        let mut path = None;
+                        let ty = self.tcx.short_string(oprnd_t, &mut path);
                         let mut err = type_error_struct!(
                             self.dcx(),
                             expr.span,
                             oprnd_t,
                             E0614,
-                            "type `{oprnd_t}` cannot be dereferenced",
+                            "type `{ty}` cannot be dereferenced",
                         );
+                        *err.long_ty_path() = path;
                         let sp = tcx.sess.source_map().start_point(expr.span).with_parent(None);
                         if let Some(sp) =
                             tcx.sess.psess.ambiguous_block_expr_parse.borrow().get(&sp)
@@ -3286,13 +3289,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let span = field.span;
         debug!("no_such_field_err(span: {:?}, field: {:?}, expr_t: {:?})", span, field, expr_t);
 
+        let mut path = None;
+        let ty = self.tcx.short_string(expr_t, &mut path);
         let mut err = type_error_struct!(
             self.dcx(),
             span,
             expr_t,
             E0609,
-            "no field `{field}` on type `{expr_t}`",
+            "no field `{field}` on type `{ty}`",
         );
+        *err.long_ty_path() = path;
 
         // try to add a suggestion in case the field is a nested field of a field of the Adt
         let mod_id = self.tcx.parent_module(id).to_def_id();

--- a/compiler/rustc_hir_typeck/src/gather_locals.rs
+++ b/compiler/rustc_hir_typeck/src/gather_locals.rs
@@ -114,7 +114,7 @@ impl<'a, 'tcx> GatherLocalsVisitor<'a, 'tcx> {
         debug!(
             "local variable {:?} is assigned type {}",
             decl.pat,
-            self.fcx.ty_to_string(*self.fcx.locals.borrow().get(&decl.hir_id).unwrap())
+            *self.fcx.locals.borrow().get(&decl.hir_id).unwrap()
         );
     }
 }
@@ -174,7 +174,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
             debug!(
                 "pattern binding {} is assigned to {} with type {:?}",
                 ident,
-                self.fcx.ty_to_string(*self.fcx.locals.borrow().get(&p.hir_id).unwrap()),
+                *self.fcx.locals.borrow().get(&p.hir_id).unwrap(),
                 var_ty
             );
         }

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1555,7 +1555,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         pick_diag_hints: &mut PickDiagHints<'_, 'tcx>,
         pick_constraints: Option<&PickConstraintsForShadowed>,
     ) -> Option<PickResult<'tcx>> {
-        debug!("pick_method(self_ty={})", self.ty_to_string(self_ty));
+        debug!("pick_method(self_ty={})", self_ty);
 
         for (kind, candidates) in
             [("inherent", &self.inherent_candidates), ("extension", &self.extension_candidates)]

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -3246,7 +3246,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     fn ty_to_value_string(&self, ty: Ty<'tcx>) -> String {
         match ty.kind() {
             ty::Adt(def, args) => self.tcx.def_path_str_with_args(def.did(), args),
-            _ => self.ty_to_string(ty),
+            _ => self.resolve_vars_if_possible(ty).to_string(),
         }
     }
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -983,10 +983,6 @@ impl<'tcx> InferCtxt<'tcx> {
         }
     }
 
-    pub fn ty_to_string(&self, t: Ty<'tcx>) -> String {
-        self.resolve_vars_if_possible(t).to_string()
-    }
-
     /// If `TyVar(vid)` resolves to a type, return that type. Else, return the
     /// universe index of `TyVar(vid)`.
     pub fn probe_ty_var(&self, vid: TyVid) -> Result<Ty<'tcx>, ty::UniverseIndex> {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2961,7 +2961,7 @@ impl<'tcx> ty::Binder<'tcx, ty::TraitRef<'tcx>> {
     }
 }
 
-#[derive(Copy, Clone, TypeFoldable, TypeVisitable, Lift)]
+#[derive(Copy, Clone, TypeFoldable, TypeVisitable, Lift, Hash)]
 pub struct TraitPredPrintModifiersAndPath<'tcx>(ty::TraitPredicate<'tcx>);
 
 impl<'tcx> fmt::Debug for TraitPredPrintModifiersAndPath<'tcx> {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -137,7 +137,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let actual_ty = self.resolve_vars_if_possible(actual_ty);
         debug!("type_error_struct_with_diag({:?}, {:?})", sp, actual_ty);
 
-        let mut err = mk_diag(self.ty_to_string(actual_ty));
+        let mut path = None;
+        let ty = self.tcx.short_string(actual_ty, &mut path);
+        let mut err = mk_diag(ty);
+        *err.long_ty_path() = path;
 
         // Don't report an error if actual type is `Error`.
         if actual_ty.references_error() {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -233,19 +233,21 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     .add_to_diag(err);
             }
             infer::ReferenceOutlivesReferent(ty, span) => {
+                let name = self.tcx.short_string(ty, err.long_ty_path());
                 RegionOriginNote::WithName {
                     span,
                     msg: fluent::trait_selection_reference_outlives_referent,
-                    name: &self.ty_to_string(ty),
+                    name: &name,
                     continues: false,
                 }
                 .add_to_diag(err);
             }
             infer::RelateParamBound(span, ty, opt_span) => {
+                let name = self.tcx.short_string(ty, err.long_ty_path());
                 RegionOriginNote::WithName {
                     span,
                     msg: fluent::trait_selection_relate_param_bound,
-                    name: &self.ty_to_string(ty),
+                    name: &name,
                     continues: opt_span.is_some(),
                 }
                 .add_to_diag(err);

--- a/tests/ui/contracts/contract-captures-via-closure-noncopy.stderr
+++ b/tests/ui/contracts/contract-captures-via-closure-noncopy.stderr
@@ -14,7 +14,7 @@ LL | #[core::contracts::ensures({let old = x; move |ret:&Baz| ret.baz == old.baz
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------------------------------------^^^^
    | |                                        |
    | |                                        within this `{closure@$DIR/contract-captures-via-closure-noncopy.rs:12:42: 12:57}`
-   | |                                        this tail expression is of type `{closure@contract-captures-via-closure-noncopy.rs:12:42}`
+   | |                                        this tail expression is of type `{closure@$DIR/contract-captures-via-closure-noncopy.rs:12:42: 12:57}`
    | unsatisfied trait bound
    |
    = help: within `{closure@$DIR/contract-captures-via-closure-noncopy.rs:12:42: 12:57}`, the trait `std::marker::Copy` is not implemented for `Baz`

--- a/tests/ui/diagnostic-width/long-E0529.rs
+++ b/tests/ui/diagnostic-width/long-E0529.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: --diagnostic-width=60 -Zwrite-long-types-to-disk=yes
+// The regex below normalizes the long type file name to make it suitable for compare-modes.
+//@ normalize-stderr: "'\$TEST_BUILD_DIR/.*\.long-type-\d+.txt'" -> "'$$TEST_BUILD_DIR/$$FILE.long-type-hash.txt'"
+type A = (i32, i32, i32, i32);
+type B = (A, A, A, A);
+type C = (B, B, B, B);
+type D = (C, C, C, C);
+
+fn foo(x: D) {
+    let [] = x; //~ ERROR expected an array or slice, found `(...
+    //~^ pattern cannot match with input type `(...
+}
+
+fn main() {}

--- a/tests/ui/diagnostic-width/long-E0529.stderr
+++ b/tests/ui/diagnostic-width/long-E0529.stderr
@@ -1,0 +1,12 @@
+error[E0529]: expected an array or slice, found `(..., ..., ..., ...)`
+  --> $DIR/long-E0529.rs:10:9
+   |
+LL |     let [] = x;
+   |         ^^ pattern cannot match with input type `(..., ..., ..., ...)`
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0529`.

--- a/tests/ui/diagnostic-width/long-E0609.rs
+++ b/tests/ui/diagnostic-width/long-E0609.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: --diagnostic-width=60 -Zwrite-long-types-to-disk=yes
+// The regex below normalizes the long type file name to make it suitable for compare-modes.
+//@ normalize-stderr: "'\$TEST_BUILD_DIR/.*\.long-type-\d+.txt'" -> "'$$TEST_BUILD_DIR/$$FILE.long-type-hash.txt'"
+type A = (i32, i32, i32, i32);
+type B = (A, A, A, A);
+type C = (B, B, B, B);
+type D = (C, C, C, C);
+
+fn foo(x: D) {
+    x.field; //~ ERROR no field `field` on type `(...
+}
+
+fn main() {}

--- a/tests/ui/diagnostic-width/long-E0609.stderr
+++ b/tests/ui/diagnostic-width/long-E0609.stderr
@@ -1,0 +1,12 @@
+error[E0609]: no field `field` on type `(..., ..., ..., ...)`
+  --> $DIR/long-E0609.rs:10:7
+   |
+LL |     x.field;
+   |       ^^^^^ unknown field
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0609`.

--- a/tests/ui/diagnostic-width/long-E0614.rs
+++ b/tests/ui/diagnostic-width/long-E0614.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: --diagnostic-width=60 -Zwrite-long-types-to-disk=yes
+// The regex below normalizes the long type file name to make it suitable for compare-modes.
+//@ normalize-stderr: "'\$TEST_BUILD_DIR/.*\.long-type-\d+.txt'" -> "'$$TEST_BUILD_DIR/$$FILE.long-type-hash.txt'"
+type A = (i32, i32, i32, i32);
+type B = (A, A, A, A);
+type C = (B, B, B, B);
+type D = (C, C, C, C);
+
+fn foo(x: D) {
+    *x; //~ ERROR type `(...
+}
+
+fn main() {}

--- a/tests/ui/diagnostic-width/long-E0614.stderr
+++ b/tests/ui/diagnostic-width/long-E0614.stderr
@@ -1,0 +1,12 @@
+error[E0614]: type `(..., ..., ..., ...)` cannot be dereferenced
+  --> $DIR/long-E0614.rs:10:5
+   |
+LL |     *x;
+   |     ^^
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0614`.

--- a/tests/ui/diagnostic-width/long-E0618.rs
+++ b/tests/ui/diagnostic-width/long-E0618.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: --diagnostic-width=60 -Zwrite-long-types-to-disk=yes
+// The regex below normalizes the long type file name to make it suitable for compare-modes.
+//@ normalize-stderr: "'\$TEST_BUILD_DIR/.*\.long-type-\d+.txt'" -> "'$$TEST_BUILD_DIR/$$FILE.long-type-hash.txt'"
+type A = (i32, i32, i32, i32);
+type B = (A, A, A, A);
+type C = (B, B, B, B);
+type D = (C, C, C, C);
+
+fn foo(x: D) { //~ `x` has type `(...
+    x(); //~ ERROR expected function, found `(...
+}
+
+fn main() {}

--- a/tests/ui/diagnostic-width/long-E0618.stderr
+++ b/tests/ui/diagnostic-width/long-E0618.stderr
@@ -1,0 +1,16 @@
+error[E0618]: expected function, found `(..., ..., ..., ...)`
+  --> $DIR/long-E0618.rs:10:5
+   |
+LL | fn foo(x: D) {
+   |        - `x` has type `(..., ..., ..., ...)`
+LL |     x();
+   |     ^--
+   |     |
+   |     call expression requires function
+   |
+   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0618`.

--- a/tests/ui/error-codes/E0604.stderr
+++ b/tests/ui/error-codes/E0604.stderr
@@ -2,10 +2,13 @@ error[E0604]: only `u8` can be cast as `char`, not `u32`
   --> $DIR/E0604.rs:2:5
    |
 LL |     1u32 as char;
-   |     ^^^^^^^^^^^^
-   |     |
-   |     invalid cast
-   |     help: try `char::from_u32` instead: `char::from_u32(1u32)`
+   |     ^^^^^^^^^^^^ invalid cast
+   |
+help: try `char::from_u32` instead
+   |
+LL -     1u32 as char;
+LL +     char::from_u32(1u32);
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-festival.stderr
+++ b/tests/ui/error-festival.stderr
@@ -58,10 +58,13 @@ error[E0604]: only `u8` can be cast as `char`, not `u32`
   --> $DIR/error-festival.rs:25:5
    |
 LL |     0u32 as char;
-   |     ^^^^^^^^^^^^
-   |     |
-   |     invalid cast
-   |     help: try `char::from_u32` instead: `char::from_u32(0u32)`
+   |     ^^^^^^^^^^^^ invalid cast
+   |
+help: try `char::from_u32` instead
+   |
+LL -     0u32 as char;
+LL +     char::from_u32(0u32);
+   |
 
 error[E0605]: non-primitive cast: `u8` as `Vec<u8>`
   --> $DIR/error-festival.rs:29:5

--- a/tests/ui/mismatched_types/cast-rfc0401.stderr
+++ b/tests/ui/mismatched_types/cast-rfc0401.stderr
@@ -104,10 +104,13 @@ error[E0604]: only `u8` can be cast as `char`, not `u32`
   --> $DIR/cast-rfc0401.rs:41:13
    |
 LL |     let _ = 0x61u32 as char;
-   |             ^^^^^^^^^^^^^^^
-   |             |
-   |             invalid cast
-   |             help: try `char::from_u32` instead: `char::from_u32(0x61u32)`
+   |             ^^^^^^^^^^^^^^^ invalid cast
+   |
+help: try `char::from_u32` instead
+   |
+LL -     let _ = 0x61u32 as char;
+LL +     let _ = char::from_u32(0x61u32);
+   |
 
 error[E0606]: casting `bool` as `f32` is invalid
   --> $DIR/cast-rfc0401.rs:43:13


### PR DESCRIPTION
```
error[E0529]: expected an array or slice, found `(..., ..., ..., ...)`
  --> $DIR/long-E0529.rs:10:9
   |
LL |     let [] = x;
   |         ^^ pattern cannot match with input type `(..., ..., ..., ...)`
   |
   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
   = note: consider using `--verbose` to print the full type name to the console
```
```
error[E0609]: no field `field` on type `(..., ..., ..., ...)`
  --> $DIR/long-E0609.rs:10:7
   |
LL |     x.field;
   |       ^^^^^ unknown field
   |
   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
   = note: consider using `--verbose` to print the full type name to the console
```
```
error[E0614]: type `(..., ..., ..., ...)` cannot be dereferenced
  --> $DIR/long-E0614.rs:10:5
   |
LL |     *x;
   |     ^^
   |
   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
   = note: consider using `--verbose` to print the full type name to the console
```
```
error[E0618]: expected function, found `(..., ..., ..., ...)`
  --> $DIR/long-E0618.rs:10:5
   |
LL | fn foo(x: D) {
   |        - `x` has type `(..., ..., ..., ...)`
LL |     x();
   |     ^--
   |     |
   |     call expression requires function
   |
   = note: the full name for the type has been written to '$TEST_BUILD_DIR/$FILE.long-type-hash.txt'
   = note: consider using `--verbose` to print the full type name to the console
```

Use multipart suggestion for cast -> into:

```
error[E0604]: only `u8` can be cast as `char`, not `u32`
  --> $DIR/E0604.rs:2:5
   |
LL |     1u32 as char;
   |     ^^^^^^^^^^^^ invalid cast
   |
help: try `char::from_u32` instead
   |
LL -     1u32 as char;
LL +     char::from_u32(1u32);
   |
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

CC #135919.