### PR TITLE
compiler: replace `ExternAbi::name` calls with formatters

### DIFF
--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -367,9 +367,7 @@ fn push_debuginfo_type_name<'tcx>(
                 output.push_str(sig.safety.prefix_str());
 
                 if sig.abi != rustc_abi::ExternAbi::Rust {
-                    output.push_str("extern \"");
-                    output.push_str(sig.abi.name());
-                    output.push_str("\" ");
+                    let _ = write!(output, "extern {} ", sig.abi);
                 }
 
                 output.push_str("fn(");

--- a/compiler/rustc_errors/src/diagnostic_impls.rs
+++ b/compiler/rustc_errors/src/diagnostic_impls.rs
@@ -93,6 +93,7 @@ into_diag_arg_using_display!(
     SplitDebuginfo,
     ExitStatus,
     ErrCode,
+    rustc_abi::ExternAbi,
 );
 
 impl<I: rustc_type_ir::Interner> IntoDiagArg for rustc_type_ir::TraitRef<I> {

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -72,17 +72,17 @@ hir_analysis_cmse_entry_generic =
     functions with the `"C-cmse-nonsecure-entry"` ABI cannot contain generics in their type
 
 hir_analysis_cmse_inputs_stack_spill =
-    arguments for `"{$abi_name}"` function too large to pass via registers
+    arguments for `{$abi}` function too large to pass via registers
     .label = {$plural ->
         [false] this argument doesn't
         *[true] these arguments don't
     } fit in the available registers
-    .note = functions with the `"{$abi_name}"` ABI must pass all their arguments via the 4 32-bit available argument registers
+    .note = functions with the `{$abi}` ABI must pass all their arguments via the 4 32-bit available argument registers
 
 hir_analysis_cmse_output_stack_spill =
-    return value of `"{$abi_name}"` function too large to pass via registers
+    return value of `{$abi}` function too large to pass via registers
     .label = this type doesn't fit in the available registers
-    .note1 = functions with the `"{$abi_name}"` ABI must pass their result via the available return registers
+    .note1 = functions with the `{$abi}` ABI must pass their result via the available return registers
     .note2 = the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 hir_analysis_coerce_pointee_no_field = `CoercePointee` can only be derived on `struct`s with at least one field

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1,5 +1,6 @@
 //! Errors emitted by `rustc_hir_analysis`.
 
+use rustc_abi::ExternAbi;
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level, MultiSpan,
@@ -1689,7 +1690,7 @@ pub(crate) struct CmseInputsStackSpill {
     #[label]
     pub span: Span,
     pub plural: bool,
-    pub abi_name: &'static str,
+    pub abi: ExternAbi,
 }
 
 #[derive(Diagnostic)]
@@ -1700,7 +1701,7 @@ pub(crate) struct CmseOutputStackSpill {
     #[primary_span]
     #[label]
     pub span: Span,
-    pub abi_name: &'static str,
+    pub abi: ExternAbi,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/cmse.rs
@@ -17,8 +17,6 @@ pub(crate) fn validate_cmse_abi<'tcx>(
     abi: ExternAbi,
     fn_sig: ty::PolyFnSig<'tcx>,
 ) {
-    let abi_name = abi.name();
-
     match abi {
         ExternAbi::CCmseNonSecureCall => {
             let hir_node = tcx.hir_node(hir_id);
@@ -56,7 +54,7 @@ pub(crate) fn validate_cmse_abi<'tcx>(
                         .to(bare_fn_ty.decl.inputs[index].span)
                         .to(bare_fn_ty.decl.inputs.last().unwrap().span);
                     let plural = bare_fn_ty.param_names.len() - index != 1;
-                    dcx.emit_err(errors::CmseInputsStackSpill { span, plural, abi_name });
+                    dcx.emit_err(errors::CmseInputsStackSpill { span, plural, abi });
                 }
                 Err(layout_err) => {
                     if should_emit_generic_error(abi, layout_err) {
@@ -69,7 +67,7 @@ pub(crate) fn validate_cmse_abi<'tcx>(
                 Ok(true) => {}
                 Ok(false) => {
                     let span = bare_fn_ty.decl.output.span();
-                    dcx.emit_err(errors::CmseOutputStackSpill { span, abi_name });
+                    dcx.emit_err(errors::CmseOutputStackSpill { span, abi });
                 }
                 Err(layout_err) => {
                     if should_emit_generic_error(abi, layout_err) {
@@ -92,7 +90,7 @@ pub(crate) fn validate_cmse_abi<'tcx>(
                     //                                      ^^^^^^
                     let span = decl.inputs[index].span.to(decl.inputs.last().unwrap().span);
                     let plural = decl.inputs.len() - index != 1;
-                    dcx.emit_err(errors::CmseInputsStackSpill { span, plural, abi_name });
+                    dcx.emit_err(errors::CmseInputsStackSpill { span, plural, abi });
                 }
                 Err(layout_err) => {
                     if should_emit_generic_error(abi, layout_err) {
@@ -105,7 +103,7 @@ pub(crate) fn validate_cmse_abi<'tcx>(
                 Ok(true) => {}
                 Ok(false) => {
                     let span = decl.output.span();
-                    dcx.emit_err(errors::CmseOutputStackSpill { span, abi_name });
+                    dcx.emit_err(errors::CmseOutputStackSpill { span, abi });
                 }
                 Err(layout_err) => {
                     if should_emit_generic_error(abi, layout_err) {

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -160,8 +160,7 @@ pub(super) fn decorate_lint(
             .decorate_lint(diag);
         }
         BuiltinLintDiag::MissingAbi(label_span, default_abi) => {
-            lints::MissingAbi { span: label_span, default_abi: default_abi.name() }
-                .decorate_lint(diag);
+            lints::MissingAbi { span: label_span, default_abi }.decorate_lint(diag);
         }
         BuiltinLintDiag::LegacyDeriveHelpers(label_span) => {
             lints::LegacyDeriveHelpers { span: label_span }.decorate_lint(diag);

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2,6 +2,7 @@
 #![allow(rustc::untranslatable_diagnostic)]
 use std::num::NonZero;
 
+use rustc_abi::ExternAbi;
 use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagArgValue, DiagMessage, DiagStyledString, ElidedLifetimeInPathSubdiag,
@@ -2833,9 +2834,9 @@ pub(crate) struct PatternsInFnsWithoutBodySub {
 #[derive(LintDiagnostic)]
 #[diag(lint_extern_without_abi)]
 pub(crate) struct MissingAbi {
-    #[suggestion(code = "extern \"{default_abi}\"", applicability = "machine-applicable")]
+    #[suggestion(code = "extern {default_abi}", applicability = "machine-applicable")]
     pub span: Span,
-    pub default_abi: &'static str,
+    pub default_abi: ExternAbi,
 }
 
 #[derive(LintDiagnostic)]

--- a/compiler/rustc_mir_transform/src/function_item_references.rs
+++ b/compiler/rustc_mir_transform/src/function_item_references.rs
@@ -161,12 +161,7 @@ impl<'tcx> FunctionItemRefChecker<'_, 'tcx> {
         let unsafety = fn_sig.safety().prefix_str();
         let abi = match fn_sig.abi() {
             ExternAbi::Rust => String::from(""),
-            other_abi => {
-                let mut s = String::from("extern \"");
-                s.push_str(other_abi.name());
-                s.push_str("\" ");
-                s
-            }
+            other_abi => format!("extern {other_abi} "),
         };
         let ident = self.tcx.item_ident(fn_id);
         let ty_params = fn_args.types().map(|ty| format!("{ty}"));

--- a/tests/ui/link-native-libs/suggest-libname-only-1.stderr
+++ b/tests/ui/link-native-libs/suggest-libname-only-1.stderr
@@ -2,7 +2,7 @@ warning: extern declarations without an explicit ABI are deprecated
   --> $DIR/suggest-libname-only-1.rs:7:1
    |
 LL | extern { }
-   | ^^^^^^ help: explicitly specify the C ABI: `extern "C"`
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
    |
    = note: `#[warn(missing_abi)]` on by default
 

--- a/tests/ui/link-native-libs/suggest-libname-only-2.stderr
+++ b/tests/ui/link-native-libs/suggest-libname-only-2.stderr
@@ -2,7 +2,7 @@ warning: extern declarations without an explicit ABI are deprecated
   --> $DIR/suggest-libname-only-2.rs:7:1
    |
 LL | extern { }
-   | ^^^^^^ help: explicitly specify the C ABI: `extern "C"`
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
    |
    = note: `#[warn(missing_abi)]` on by default
 

--- a/tests/ui/lint/cli-lint-override.forbid_warn.stderr
+++ b/tests/ui/lint/cli-lint-override.forbid_warn.stderr
@@ -2,7 +2,7 @@ error: extern declarations without an explicit ABI are deprecated
   --> $DIR/cli-lint-override.rs:12:1
    |
 LL | extern fn foo() {}
-   | ^^^^^^ help: explicitly specify the C ABI: `extern "C"`
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
    |
    = note: requested on the command line with `-F missing-abi`
 

--- a/tests/ui/lint/cli-lint-override.force_warn_deny.stderr
+++ b/tests/ui/lint/cli-lint-override.force_warn_deny.stderr
@@ -2,7 +2,7 @@ warning: extern declarations without an explicit ABI are deprecated
   --> $DIR/cli-lint-override.rs:12:1
    |
 LL | extern fn foo() {}
-   | ^^^^^^ help: explicitly specify the C ABI: `extern "C"`
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
    |
    = note: requested on the command line with `--force-warn missing-abi`
 

--- a/tests/ui/lint/cli-lint-override.warn_deny.stderr
+++ b/tests/ui/lint/cli-lint-override.warn_deny.stderr
@@ -2,7 +2,7 @@ error: extern declarations without an explicit ABI are deprecated
   --> $DIR/cli-lint-override.rs:12:1
    |
 LL | extern fn foo() {}
-   | ^^^^^^ help: explicitly specify the C ABI: `extern "C"`
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
    |
    = note: requested on the command line with `-D missing-abi`
 

--- a/tests/ui/parser/bad-lit-suffixes.stderr
+++ b/tests/ui/parser/bad-lit-suffixes.stderr
@@ -55,7 +55,7 @@ warning: extern declarations without an explicit ABI are deprecated
   --> $DIR/bad-lit-suffixes.rs:3:1
    |
 LL | extern
-   | ^^^^^^ help: explicitly specify the C ABI: `extern "C"`
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
    |
    = note: `#[warn(missing_abi)]` on by default
 
@@ -63,7 +63,7 @@ warning: extern declarations without an explicit ABI are deprecated
   --> $DIR/bad-lit-suffixes.rs:7:1
    |
 LL | extern
-   | ^^^^^^ help: explicitly specify the C ABI: `extern "C"`
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
 
 error: suffixes on string literals are invalid
   --> $DIR/bad-lit-suffixes.rs:12:5

--- a/tests/ui/parser/lit-err-in-macro.stderr
+++ b/tests/ui/parser/lit-err-in-macro.stderr
@@ -8,7 +8,7 @@ warning: extern declarations without an explicit ABI are deprecated
   --> $DIR/lit-err-in-macro.rs:3:9
    |
 LL |         extern $abi fn f() {}
-   |         ^^^^^^ help: explicitly specify the C ABI: `extern "C"`
+   |         ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
 ...
 LL | f!("Foo"__);
    | ----------- in this macro invocation

--- a/tests/ui/proc-macro/inner-attrs.stderr
+++ b/tests/ui/proc-macro/inner-attrs.stderr
@@ -26,7 +26,7 @@ warning: extern declarations without an explicit ABI are deprecated
   --> $DIR/inner-attrs.rs:82:1
    |
 LL | extern {
-   | ^^^^^^ help: explicitly specify the C ABI: `extern "C"`
+   | ^^^^^^ help: explicitly specify the "C" ABI: `extern "C"`
    |
    = note: `#[warn(missing_abi)]` on by default
 


### PR DESCRIPTION
Most of these just format the ABI string, so... just format ExternAbi? This makes it more consistent and less jank when we can do it.

<!-- homu-ignore:start -->
<!-- homu-ignore:end -->