### PR TITLE
[AIX] expect `EINVAL` for `pthread_mutex_destroy`

### DIFF
--- a/library/std/src/sys/pal/unix/sync/mutex.rs
+++ b/library/std/src/sys/pal/unix/sync/mutex.rs
@@ -111,9 +111,9 @@ impl Drop for Mutex {
         // `PTHREAD_MUTEX_INITIALIZER`, which is valid at all locations. Thus,
         // this call always destroys a valid mutex.
         let r = unsafe { libc::pthread_mutex_destroy(self.raw()) };
-        if cfg!(target_os = "dragonfly") {
-            // On DragonFly pthread_mutex_destroy() returns EINVAL if called on a
-            // mutex that was just initialized with libc::PTHREAD_MUTEX_INITIALIZER.
+        if cfg!(any(target_os = "aix", target_os = "dragonfly")) {
+            // On AIX and DragonFly pthread_mutex_destroy() returns EINVAL if called
+            // on a mutex that was just initialized with libc::PTHREAD_MUTEX_INITIALIZER.
             // Once it is used (locked/unlocked) or pthread_mutex_init() is called,
             // this behaviour no longer occurs.
             debug_assert!(r == 0 || r == libc::EINVAL);


### PR DESCRIPTION
Calling `pthread_mutex_destory` on a mutex initalized with the static initializer macro `PTHREAD_MUTEX_INITIALIZER` will result in `EINVAL` if the mutex is not lock/unlocked prior to calling `pthread_mutex_destroy`.