### PR TITLE
ci: use ubuntu 24 for free arm runner

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -50,7 +50,7 @@ runners:
   - &job-aarch64-linux
     # Free some disk space to avoid running out of space during the build.
     free_disk: true
-    os: ubuntu-22.04-arm
+    os: ubuntu-24.04-arm
 
   - &job-aarch64-linux-8c
     os: ubuntu-22.04-arm64-8core-32gb


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
GitHub told us they rolled back the faulty machines causing issues like [this](https://github.com/rust-lang/rust/issues/135867) and [this](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Upload.20to.20datadog.20CI.20script.2E.2E.2E.20segfaulted.3F), so it should be safe to use ubuntu 24 on ARM now.

This PR reverts https://github.com/rust-lang/rust/pull/136647

r? @jdno 
<!-- homu-ignore:end -->
try-job: aarch64-gnu
try-job: aarch64-gnu-debug