### PR TITLE
documentation fix: `f16` and `f128` are not double-precision

### DIFF
--- a/library/std/src/f128.rs
+++ b/library/std/src/f128.rs
@@ -1,4 +1,4 @@
-//! Constants for the `f128` double-precision floating point type.
+//! Constants for the `f128` quadruple-precision floating point type.
 //!
 //! *[See also the `f128` primitive type](primitive@f128).*
 //!

--- a/library/std/src/f16.rs
+++ b/library/std/src/f16.rs
@@ -1,4 +1,4 @@
-//! Constants for the `f16` double-precision floating point type.
+//! Constants for the `f16` half-precision floating point type.
 //!
 //! *[See also the `f16` primitive type](primitive@f16).*
 //!


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
