### PR TITLE
Move `llvm.ccache` to `build.ccache`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -87,10 +87,6 @@
 # Whether to build LLVM with support for it's gpu offload runtime.
 #offload = false
 
-# Indicates whether ccache is used when building LLVM. Set to `true` to use the first `ccache` in
-# PATH, or set an absolute path to use a specific version.
-#ccache = false
-
 # When true, link libstdc++ statically into the rustc_llvm.
 # This is useful if you don't want to use the dynamic version of that
 # library provided by LLVM.

--- a/config.example.toml
+++ b/config.example.toml
@@ -424,6 +424,11 @@
 # What custom diff tool to use for displaying compiletest tests.
 #compiletest-diff-tool = <none>
 
+# Indicates whether ccache is used when building certain artifacts (e.g. LLVM).
+# Set to `true` to use the first `ccache` in PATH, or set an absolute path to use
+# a specific version.
+#ccache = false
+
 # =============================================================================
 # General install configuration options
 # =============================================================================

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -44,10 +44,14 @@ o("optimize-tests", "rust.optimize-tests", "build tests with optimizations")
 o("verbose-tests", "rust.verbose-tests", "enable verbose output when running tests")
 o(
     "ccache",
-    "llvm.ccache",
-    "invoke gcc/clang via ccache to reuse object files between builds",
+    "build.ccache",
+    "invoke gcc/clang/rustc via ccache to reuse object files between builds",
 )
-o("sccache", None, "invoke gcc/clang via sccache to reuse object files between builds")
+o(
+    "sccache",
+    None,
+    "invoke gcc/clang/rustc via sccache to reuse object files between builds",
+)
 o("local-rust", None, "use an installed rustc rather than downloading a snapshot")
 v("local-rust-root", None, "set prefix for local rust binary")
 o(
@@ -510,7 +514,7 @@ def apply_args(known_args, option_checking, config):
         build_triple = build(known_args)
 
         if option.name == "sccache":
-            set("llvm.ccache", "sccache", config)
+            set("build.ccache", "sccache", config)
         elif option.name == "local-rust":
             for path in os.environ["PATH"].split(os.pathsep):
                 if os.path.exists(path + "/rustc"):

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -962,6 +962,7 @@ define_config! {
         tests: Option<bool> = "tests",
         enzyme: Option<bool> = "enzyme",
         plugins: Option<bool> = "plugins",
+        // FIXME: Remove this field at Q2 2025, it has been replaced by build.ccache
         ccache: Option<StringOrBool> = "ccache",
         static_libstdcpp: Option<bool> = "static-libstdcpp",
         libzstd: Option<bool> = "libzstd",
@@ -2031,6 +2032,10 @@ impl Config {
                 download_ci_llvm,
                 build_config,
             } = llvm;
+            if llvm_ccache.is_some() {
+                eprintln!("Warning: llvm.ccache is deprecated. Use build.ccache instead.");
+            }
+
             ccache = ccache.or(llvm_ccache);
             set(&mut config.ninja_in_file, ninja);
             llvm_tests = tests;

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -345,4 +345,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "Rustdoc now respects the value of rust.lto.",
     },
+    ChangeInfo {
+        change_id: 136941,
+        severity: ChangeSeverity::Info,
+        summary: "The llvm.ccache option has moved to build.ccache. llvm.ccache is now deprecated.",
+    },
 ];


### PR DESCRIPTION
(S)ccache can be useful for more things that just LLVM. For example, we will soon want to use it also for GCC, and theoretically also for building stage0 Rust tools (https://github.com/rust-lang/rust/pull/136921, https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Using.20sccache.20for.20Rust).

r? @onur-ozkan