### PR TITLE
Use ccache for stage0 tool builds

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1278,6 +1278,17 @@ pub fn rustc_cargo(
         ));
     }
 
+    // The stage0 compiler changes infrequently and does not directly depend on code
+    // in the current working directory. Therefore, caching it with sccache should be
+    // useful.
+    // This is only performed for non-incremental builds, as ccache cannot deal with these.
+    if let Some(ref ccache) = builder.config.ccache
+        && compiler.stage == 0
+        && !builder.config.incremental
+    {
+        cargo.env("RUSTC_WRAPPER", ccache);
+    }
+
     rustc_cargo_env(builder, cargo, target, compiler.stage);
 }
 


### PR DESCRIPTION
Now after the stage0 redesign, we can actually start ccaching the build of the compiler itself. We can also cache the bootstrap tools, since these are also built with the stage0 compiler.

Stage0 compiler builds are now being cached: https://github.com/rust-lang/rust/actions/runs/15397246267#summary-43321151192 (`..bootstrap::core::build_steps::compile::Rustc	483.10s	40.41s	-91.6%`). It's not a gigantic win everywhere, but it should help. It seems to make the Linux jobs ~10 minute faster. It should be especially useful on PR builds after https://github.com/rust-lang/rust/pull/141948.

r? @jieyouxu

try-job: `x86_64-gnu-llvm-19*`
try-job: `x86_64-msvc*`
try-job: `x86_64-apple*`
try-job: `dist-x86_64-linux`