### PR TITLE
Split out the `extern_system_varargs` feature

### DIFF
--- a/compiler/rustc_abi/src/extern_abi.rs
+++ b/compiler/rustc_abi/src/extern_abi.rs
@@ -195,7 +195,6 @@ impl ExternAbi {
         // * C and Cdecl obviously support varargs.
         // * C can be based on Aapcs, SysV64 or Win64, so they must support varargs.
         // * EfiApi is based on Win64 or C, so it also supports it.
-        // * System falls back to C for functions with varargs.
         //
         // * Stdcall does not, because it would be impossible for the callee to clean
         //   up the arguments. (callee doesn't know how many arguments are there)
@@ -204,7 +203,6 @@ impl ExternAbi {
         match self {
             Self::C { .. }
             | Self::Cdecl { .. }
-            | Self::System { .. }
             | Self::Aapcs { .. }
             | Self::Win64 { .. }
             | Self::SysV64 { .. }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -487,9 +487,11 @@ declare_features! (
     (unstable, exhaustive_patterns, "1.13.0", Some(51085)),
     /// Allows explicit tail calls via `become` expression.
     (incomplete, explicit_tail_calls, "1.72.0", Some(112788)),
-    /// Allows using `efiapi`, `sysv64` and `win64` as calling convention
+    /// Allows using `aapcs`, `efiapi`, `sysv64` and `win64` as calling conventions
     /// for functions with varargs.
     (unstable, extended_varargs_abi_support, "1.65.0", Some(100189)),
+    /// Allows using `system` as a calling convention with varargs.
+    (unstable, extern_system_varargs, "CURRENT_RUSTC_VERSION", Some(136946)),
     /// Allows defining `extern type`s.
     (unstable, extern_types, "1.23.0", Some(43467)),
     /// Allow using 128-bit (quad precision) floating point numbers.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -879,6 +879,7 @@ symbols! {
         extern_crate_self,
         extern_in_paths,
         extern_prelude,
+        extern_system_varargs,
         extern_types,
         external,
         external_doc,

--- a/tests/ui/c-variadic/feature-gate-extended_varargs_abi_support.rs
+++ b/tests/ui/c-variadic/feature-gate-extended_varargs_abi_support.rs
@@ -1,18 +1,15 @@
 //@ only-x86_64
 
 fn efiapi(f: extern "efiapi" fn(usize, ...)) {
-    //~^ ERROR: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
-    //~^^ ERROR: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
+    //~^ ERROR: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
     f(22, 44);
 }
 fn sysv(f: extern "sysv64" fn(usize, ...)) {
-    //~^ ERROR: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
-    //~^^ ERROR: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
+    //~^ ERROR: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
     f(22, 44);
 }
 fn win(f: extern "win64" fn(usize, ...)) {
-    //~^ ERROR: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
-    //~^^ ERROR: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
+    //~^ ERROR: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
     f(22, 44);
 }
 

--- a/tests/ui/c-variadic/feature-gate-extended_varargs_abi_support.stderr
+++ b/tests/ui/c-variadic/feature-gate-extended_varargs_abi_support.stderr
@@ -8,14 +8,8 @@ LL | fn efiapi(f: extern "efiapi" fn(usize, ...)) {
    = help: add `#![feature(extended_varargs_abi_support)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:3:14
-   |
-LL | fn efiapi(f: extern "efiapi" fn(usize, ...)) {
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention
-
 error[E0658]: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:8:12
+  --> $DIR/feature-gate-extended_varargs_abi_support.rs:7:12
    |
 LL | fn sysv(f: extern "sysv64" fn(usize, ...)) {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,14 +18,8 @@ LL | fn sysv(f: extern "sysv64" fn(usize, ...)) {
    = help: add `#![feature(extended_varargs_abi_support)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:8:12
-   |
-LL | fn sysv(f: extern "sysv64" fn(usize, ...)) {
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention
-
 error[E0658]: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:13:11
+  --> $DIR/feature-gate-extended_varargs_abi_support.rs:11:11
    |
 LL | fn win(f: extern "win64" fn(usize, ...)) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -40,13 +28,6 @@ LL | fn win(f: extern "win64" fn(usize, ...)) {
    = help: add `#![feature(extended_varargs_abi_support)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:13:11
-   |
-LL | fn win(f: extern "win64" fn(usize, ...)) {
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention
+error: aborting due to 3 previous errors
 
-error: aborting due to 6 previous errors
-
-Some errors have detailed explanations: E0045, E0658.
-For more information about an error, try `rustc --explain E0045`.
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/c-variadic/variadic-ffi-1.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-1.stderr
@@ -1,4 +1,4 @@
-error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
+error[E0045]: C-variadic function must have a compatible calling convention, like `C`, `cdecl`, `system`, `aapcs`, `win64`, `sysv64` or `efiapi`
   --> $DIR/variadic-ffi-1.rs:9:5
    |
 LL |     fn printf(_: *const u8, ...);

--- a/tests/ui/c-variadic/variadic-ffi-2.rs
+++ b/tests/ui/c-variadic/variadic-ffi-2.rs
@@ -8,9 +8,6 @@ fn baz(f: extern "stdcall" fn(usize, ...)) {
     f(22, 44);
 }
 
-fn system(f: extern "system" fn(usize, ...)) {
-    f(22, 44);
-}
 #[cfg(target_arch = "x86_64")]
 fn sysv(f: extern "sysv64" fn(usize, ...)) {
     f(22, 44);

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.rs
@@ -39,4 +39,4 @@ type WithTransparentTraitObject =
 //~^ ERROR return value of `"C-cmse-nonsecure-call"` function too large to pass via registers [E0798]
 
 type WithVarArgs = extern "C-cmse-nonsecure-call" fn(u32, ...);
-//~^ ERROR C-variadic function must have a compatible calling convention, like `C` or `cdecl` [E0045]
+//~^ ERROR C-variadic function must have a compatible calling convention, like `C`

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
@@ -69,7 +69,7 @@ LL |     extern "C-cmse-nonsecure-call" fn(WrapperTransparent) -> WrapperTranspa
    = note: functions with the `"C-cmse-nonsecure-call"` ABI must pass their result via the available return registers
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
-error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
+error[E0045]: C-variadic function must have a compatible calling convention, like `C`, `cdecl`, `system`, `aapcs`, `win64`, `sysv64` or `efiapi`
   --> $DIR/generics.rs:41:20
    |
 LL | type WithVarArgs = extern "C-cmse-nonsecure-call" fn(u32, ...);

--- a/tests/ui/error-codes/E0045.stderr
+++ b/tests/ui/error-codes/E0045.stderr
@@ -1,4 +1,4 @@
-error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
+error[E0045]: C-variadic function must have a compatible calling convention, like `C`, `cdecl`, `system`, `aapcs`, `win64`, `sysv64` or `efiapi`
   --> $DIR/E0045.rs:1:17
    |
 LL | extern "Rust" { fn foo(x: u8, ...); }

--- a/tests/ui/feature-gates/feature-gate-extern_system_varargs.rs
+++ b/tests/ui/feature-gates/feature-gate-extern_system_varargs.rs
@@ -1,0 +1,7 @@
+fn system(f: extern "system" fn(usize, ...)) {
+    //~^  ERROR using calling conventions other than `C` or `cdecl` for varargs functions is unstable
+
+    f(22, 44);
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-extern_system_varargs.stderr
+++ b/tests/ui/feature-gates/feature-gate-extern_system_varargs.stderr
@@ -1,0 +1,13 @@
+error[E0658]: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
+  --> $DIR/feature-gate-extern_system_varargs.rs:1:14
+   |
+LL | fn system(f: extern "system" fn(usize, ...)) {
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #136946 <https://github.com/rust-lang/rust/issues/136946> for more information
+   = help: add `#![feature(extern_system_varargs)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
After the stabilization PR was opened, `extern "system"` functions were added to `extended_varargs_abi_support`. This has a number of questions regarding it that were not discussed and were somewhat surprising. It deserves to be considered as its own feature, separate from `extended_varargs_abi_support`.

Tracking issue:
- https://github.com/rust-lang/rust/issues/136946