### PR TITLE
Fix import in bench for wasm

### DIFF
--- a/library/std/benches/time.rs
+++ b/library/std/benches/time.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 #[cfg(not(target_arch = "wasm32"))]
 use test::{Bencher, black_box};
 
@@ -10,6 +8,7 @@ macro_rules! bench_instant_threaded {
         fn $bench_name(b: &mut Bencher) -> std::thread::Result<()> {
             use std::sync::Arc;
             use std::sync::atomic::{AtomicBool, Ordering};
+            use std::time::Instant;
 
             let running = Arc::new(AtomicBool::new(true));
 


### PR DESCRIPTION
This import was causing annoying unused import errors when checking the standard library for some wasm targets. The problem is that everything here is disabled if it is wasm32, but this import wasn't cfg'd.