### PR TITLE
Use the right binder for rebinding `PolyTraitRef`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -47,11 +47,11 @@ pub fn expand_trait_aliases<'tcx>(
                     queue.extend(
                         tcx.explicit_super_predicates_of(trait_pred.def_id())
                             .iter_identity_copied()
-                            .map(|(clause, span)| {
+                            .map(|(super_clause, span)| {
                                 let mut spans = spans.clone();
                                 spans.push(span);
                                 (
-                                    clause.instantiate_supertrait(
+                                    super_clause.instantiate_supertrait(
                                         tcx,
                                         clause.kind().rebind(trait_pred.trait_ref),
                                     ),

--- a/tests/ui/traits/alias/expand-higher-ranked-alias.rs
+++ b/tests/ui/traits/alias/expand-higher-ranked-alias.rs
@@ -1,0 +1,18 @@
+// Make sure we are using the right binder vars when expanding
+// `for<'a> Foo<'a>` to `for<'a> Bar<'a>`.
+
+//@ check-pass
+
+#![feature(trait_alias)]
+
+trait Bar<'a> {}
+
+trait Foo<'a> = Bar<'a>;
+
+fn test2(_: &(impl for<'a> Foo<'a> + ?Sized)) {}
+
+fn test(x: &dyn for<'a> Foo<'a>) {
+    test2(x);
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #136940

I committed a slightly different test which still demonstrates the issue.