### PR TITLE
Fix presentation of purely "additive" replacement suggestion parts

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1976,9 +1976,11 @@ impl HumanEmitter {
             Some(Style::HeaderMsg),
         );
 
+        let other_suggestions = suggestions.len().saturating_sub(MAX_SUGGESTIONS);
+
         let mut row_num = 2;
         for (i, (complete, parts, highlights, _)) in
-            suggestions.iter().enumerate().take(MAX_SUGGESTIONS)
+            suggestions.into_iter().enumerate().take(MAX_SUGGESTIONS)
         {
             debug!(?complete, ?parts, ?highlights);
 
@@ -2168,7 +2170,7 @@ impl HumanEmitter {
                 self.draw_code_line(
                     &mut buffer,
                     &mut row_num,
-                    highlight_parts,
+                    &highlight_parts,
                     line_pos + line_start,
                     line,
                     show_code_change,
@@ -2214,7 +2216,12 @@ impl HumanEmitter {
             if let DisplaySuggestion::Diff | DisplaySuggestion::Underline | DisplaySuggestion::Add =
                 show_code_change
             {
-                for part in parts {
+                for mut part in parts {
+                    // If this is a replacement of, e.g. `"a"` into `"ab"`, adjust the
+                    // suggestion and snippet to look as if we just suggested to add
+                    // `"b"`, which is typically much easier for the user to understand.
+                    part.trim_trivial_replacements(sm);
+
                     let snippet = if let Ok(snippet) = sm.span_to_snippet(part.span) {
                         snippet
                     } else {
@@ -2377,9 +2384,12 @@ impl HumanEmitter {
                 row_num = row + 1;
             }
         }
-        if suggestions.len() > MAX_SUGGESTIONS {
-            let others = suggestions.len() - MAX_SUGGESTIONS;
-            let msg = format!("and {} other candidate{}", others, pluralize!(others));
+        if other_suggestions > 0 {
+            let msg = format!(
+                "and {} other candidate{}",
+                other_suggestions,
+                pluralize!(other_suggestions)
+            );
             buffer.puts(row_num, max_line_num_len + 3, &msg, Style::NoStyle);
         }
 

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1982,7 +1982,8 @@ impl HumanEmitter {
         {
             debug!(?complete, ?parts, ?highlights);
 
-            let has_deletion = parts.iter().any(|p| p.is_deletion(sm) || p.is_replacement(sm));
+            let has_deletion =
+                parts.iter().any(|p| p.is_deletion(sm) || p.is_destructive_replacement(sm));
             let is_multiline = complete.lines().count() > 1;
 
             if i == 0 {

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -236,9 +236,10 @@ impl SubstitutionPart {
     /// it with "abx" is, since the "c" character is lost.
     pub fn is_destructive_replacement(&self, sm: &SourceMap) -> bool {
         self.is_replacement(sm)
-            && !sm
-                .span_to_snippet(self.span)
-                .is_ok_and(|snippet| self.snippet.trim_start().starts_with(snippet.trim_start()))
+            && !sm.span_to_snippet(self.span).is_ok_and(|snippet| {
+                self.snippet.trim_start().starts_with(snippet.trim_start())
+                    || self.snippet.trim_end().ends_with(snippet.trim_end())
+            })
     }
 
     fn replaces_meaningful_content(&self, sm: &SourceMap) -> bool {

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -230,6 +230,17 @@ impl SubstitutionPart {
         !self.snippet.is_empty() && self.replaces_meaningful_content(sm)
     }
 
+    /// Whether this is a replacement that overwrites source with a snippet
+    /// in a way that isn't a superset of the original string. For example,
+    /// replacing "abc" with "abcde" is not destructive, but replacing it
+    /// it with "abx" is, since the "c" character is lost.
+    pub fn is_destructive_replacement(&self, sm: &SourceMap) -> bool {
+        self.is_replacement(sm)
+            && !sm
+                .span_to_snippet(self.span)
+                .is_ok_and(|snippet| self.snippet.trim_start().starts_with(snippet.trim_start()))
+    }
+
     fn replaces_meaningful_content(&self, sm: &SourceMap) -> bool {
         sm.span_to_snippet(self.span)
             .map_or(!self.span.is_empty(), |snippet| !snippet.trim().is_empty())

--- a/src/tools/clippy/tests/ui/implicit_return.stderr
+++ b/src/tools/clippy/tests/ui/implicit_return.stderr
@@ -8,8 +8,7 @@ LL |     true
    = help: to override `-D warnings` add `#[allow(clippy::implicit_return)]`
 help: add `return` as shown
    |
-LL -     true
-LL +     return true
+LL |     return true
    |
 
 error: missing `return` statement
@@ -20,9 +19,8 @@ LL |     if true { true } else { false }
    |
 help: add `return` as shown
    |
-LL -     if true { true } else { false }
-LL +     if true { return true } else { false }
-   |
+LL |     if true { return true } else { false }
+   |               ++++++
 
 error: missing `return` statement
   --> tests/ui/implicit_return.rs:19:29
@@ -32,9 +30,8 @@ LL |     if true { true } else { false }
    |
 help: add `return` as shown
    |
-LL -     if true { true } else { false }
-LL +     if true { true } else { return false }
-   |
+LL |     if true { true } else { return false }
+   |                             ++++++
 
 error: missing `return` statement
   --> tests/ui/implicit_return.rs:25:17
@@ -44,9 +41,8 @@ LL |         true => false,
    |
 help: add `return` as shown
    |
-LL -         true => false,
-LL +         true => return false,
-   |
+LL |         true => return false,
+   |                 ++++++
 
 error: missing `return` statement
   --> tests/ui/implicit_return.rs:26:20
@@ -56,9 +52,8 @@ LL |         false => { true },
    |
 help: add `return` as shown
    |
-LL -         false => { true },
-LL +         false => { return true },
-   |
+LL |         false => { return true },
+   |                    ++++++
 
 error: missing `return` statement
   --> tests/ui/implicit_return.rs:39:9
@@ -104,9 +99,8 @@ LL |     let _ = || { true };
    |
 help: add `return` as shown
    |
-LL -     let _ = || { true };
-LL +     let _ = || { return true };
-   |
+LL |     let _ = || { return true };
+   |                  ++++++
 
 error: missing `return` statement
   --> tests/ui/implicit_return.rs:73:16
@@ -116,9 +110,8 @@ LL |     let _ = || true;
    |
 help: add `return` as shown
    |
-LL -     let _ = || true;
-LL +     let _ = || return true;
-   |
+LL |     let _ = || return true;
+   |                ++++++
 
 error: missing `return` statement
   --> tests/ui/implicit_return.rs:81:5
@@ -128,8 +121,7 @@ LL |     format!("test {}", "test")
    |
 help: add `return` as shown
    |
-LL -     format!("test {}", "test")
-LL +     return format!("test {}", "test")
+LL |     return format!("test {}", "test")
    |
 
 error: missing `return` statement
@@ -140,8 +132,7 @@ LL |     m!(true, false)
    |
 help: add `return` as shown
    |
-LL -     m!(true, false)
-LL +     return m!(true, false)
+LL |     return m!(true, false)
    |
 
 error: missing `return` statement
@@ -191,8 +182,7 @@ LL |     true
    |
 help: add `return` as shown
    |
-LL -     true
-LL +     return true
+LL |     return true
    |
 
 error: aborting due to 16 previous errors

--- a/src/tools/clippy/tests/ui/legacy_numeric_constants.stderr
+++ b/src/tools/clippy/tests/ui/legacy_numeric_constants.stderr
@@ -68,9 +68,8 @@ LL |     MAX;
    |
 help: use the associated constant instead
    |
-LL -     MAX;
-LL +     u32::MAX;
-   |
+LL |     u32::MAX;
+   |     +++++
 
 error: usage of a legacy numeric method
   --> tests/ui/legacy_numeric_constants.rs:49:10

--- a/tests/ui/associated-types/defaults-suitability.current.stderr
+++ b/tests/ui/associated-types/defaults-suitability.current.stderr
@@ -135,7 +135,7 @@ LL |     type Baz = T;
 help: consider further restricting type parameter `T` with trait `Clone`
    |
 LL |     Self::Baz: Clone, T: std::clone::Clone
-   |                     ~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/associated-types/defaults-suitability.current.stderr
+++ b/tests/ui/associated-types/defaults-suitability.current.stderr
@@ -134,9 +134,8 @@ LL |     type Baz = T;
    |          --- required by a bound in this associated type
 help: consider further restricting type parameter `T` with trait `Clone`
    |
-LL -     Self::Baz: Clone,
-LL +     Self::Baz: Clone, T: std::clone::Clone
-   |
+LL |     Self::Baz: Clone, T: std::clone::Clone
+   |                     ~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/associated-types/defaults-suitability.next.stderr
+++ b/tests/ui/associated-types/defaults-suitability.next.stderr
@@ -135,7 +135,7 @@ LL |     type Baz = T;
 help: consider further restricting type parameter `T` with trait `Clone`
    |
 LL |     Self::Baz: Clone, T: std::clone::Clone
-   |                     ~~~~~~~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++++++++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/associated-types/defaults-suitability.next.stderr
+++ b/tests/ui/associated-types/defaults-suitability.next.stderr
@@ -134,9 +134,8 @@ LL |     type Baz = T;
    |          --- required by a bound in this associated type
 help: consider further restricting type parameter `T` with trait `Clone`
    |
-LL -     Self::Baz: Clone,
-LL +     Self::Baz: Clone, T: std::clone::Clone
-   |
+LL |     Self::Baz: Clone, T: std::clone::Clone
+   |                     ~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/associated-types/issue-38821.stderr
+++ b/tests/ui/associated-types/issue-38821.stderr
@@ -14,7 +14,7 @@ LL | impl<T: NotNull> IntoNullable for T {
 help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull
-   |                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                                                         +++++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:40:1
@@ -38,7 +38,7 @@ LL | impl<T: NotNull> IntoNullable for T {
 help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull
-   |                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                                                         +++++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:10

--- a/tests/ui/associated-types/issue-38821.stderr
+++ b/tests/ui/associated-types/issue-38821.stderr
@@ -13,9 +13,8 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         unsatisfied trait bound introduced here
 help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
    |
-LL -     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
-LL +     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull
-   |
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull
+   |                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:40:1
@@ -38,9 +37,8 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         unsatisfied trait bound introduced here
 help: consider extending the `where` clause, but there might be an alternative better way to express this requirement
    |
-LL -     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>,
-LL +     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull
-   |
+LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull
+   |                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:10

--- a/tests/ui/associated-types/issue-54108.current.stderr
+++ b/tests/ui/associated-types/issue-54108.current.stderr
@@ -13,7 +13,7 @@ LL |     type Size: Add<Output = Self::Size>;
 help: consider further restricting the associated type
    |
 LL |     T: SubEncoder, <T as SubEncoder>::ActualSize: Add
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/issue-54108.current.stderr
+++ b/tests/ui/associated-types/issue-54108.current.stderr
@@ -12,9 +12,8 @@ LL |     type Size: Add<Output = Self::Size>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Encoder::Size`
 help: consider further restricting the associated type
    |
-LL -     T: SubEncoder,
-LL +     T: SubEncoder, <T as SubEncoder>::ActualSize: Add
-   |
+LL |     T: SubEncoder, <T as SubEncoder>::ActualSize: Add
+   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/issue-54108.next.stderr
+++ b/tests/ui/associated-types/issue-54108.next.stderr
@@ -13,7 +13,7 @@ LL |     type Size: Add<Output = Self::Size>;
 help: consider further restricting the associated type
    |
 LL |     T: SubEncoder, <T as SubEncoder>::ActualSize: Add
-   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                    ++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/issue-54108.next.stderr
+++ b/tests/ui/associated-types/issue-54108.next.stderr
@@ -12,9 +12,8 @@ LL |     type Size: Add<Output = Self::Size>;
    |                    ^^^^^^^^^^^^^^^^^^^ required by this bound in `Encoder::Size`
 help: consider further restricting the associated type
    |
-LL -     T: SubEncoder,
-LL +     T: SubEncoder, <T as SubEncoder>::ActualSize: Add
-   |
+LL |     T: SubEncoder, <T as SubEncoder>::ActualSize: Add
+   |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/rustc_confusables.stderr
+++ b/tests/ui/attributes/rustc_confusables.stderr
@@ -35,9 +35,8 @@ LL |     x.inser();
    |
 help: there is a method `insert` with a similar name
    |
-LL -     x.inser();
-LL +     x.insert();
-   |
+LL |     x.insert();
+   |       ~~~~~~
 
 error[E0599]: no method named `foo` found for struct `rustc_confusables_across_crate::BTreeSet` in the current scope
   --> $DIR/rustc_confusables.rs:15:7

--- a/tests/ui/attributes/rustc_confusables.stderr
+++ b/tests/ui/attributes/rustc_confusables.stderr
@@ -36,7 +36,7 @@ LL |     x.inser();
 help: there is a method `insert` with a similar name
    |
 LL |     x.insert();
-   |       ~~~~~~
+   |            +
 
 error[E0599]: no method named `foo` found for struct `rustc_confusables_across_crate::BTreeSet` in the current scope
   --> $DIR/rustc_confusables.rs:15:7

--- a/tests/ui/attributes/rustc_confusables_std_cases.stderr
+++ b/tests/ui/attributes/rustc_confusables_std_cases.stderr
@@ -39,7 +39,7 @@ LL |     let mut x = VecDeque::new();
 help: you might have meant to use `push_back`
    |
 LL |     x.push_back(1);
-   |       ~~~~~~~~~
+   |           +++++
 
 error[E0599]: no method named `length` found for struct `Vec<{integer}>` in the current scope
   --> $DIR/rustc_confusables_std_cases.rs:15:7
@@ -98,7 +98,7 @@ note: method defined here
 help: you might have meant to use `push_str`
    |
 LL |     String::new().push_str("");
-   |                   ~~~~~~~~
+   |                       ++++
 
 error[E0599]: no method named `append` found for struct `String` in the current scope
   --> $DIR/rustc_confusables_std_cases.rs:24:19

--- a/tests/ui/attributes/rustc_confusables_std_cases.stderr
+++ b/tests/ui/attributes/rustc_confusables_std_cases.stderr
@@ -38,9 +38,8 @@ LL |     let mut x = VecDeque::new();
    |         ----- earlier `x` shadowed here with type `VecDeque`
 help: you might have meant to use `push_back`
    |
-LL -     x.push(1);
-LL +     x.push_back(1);
-   |
+LL |     x.push_back(1);
+   |       ~~~~~~~~~
 
 error[E0599]: no method named `length` found for struct `Vec<{integer}>` in the current scope
   --> $DIR/rustc_confusables_std_cases.rs:15:7
@@ -98,9 +97,8 @@ note: method defined here
   --> $SRC_DIR/alloc/src/string.rs:LL:COL
 help: you might have meant to use `push_str`
    |
-LL -     String::new().push("");
-LL +     String::new().push_str("");
-   |
+LL |     String::new().push_str("");
+   |                   ~~~~~~~~
 
 error[E0599]: no method named `append` found for struct `String` in the current scope
   --> $DIR/rustc_confusables_std_cases.rs:24:19

--- a/tests/ui/borrowck/issue-115259-suggest-iter-mut.stderr
+++ b/tests/ui/borrowck/issue-115259-suggest-iter-mut.stderr
@@ -9,7 +9,7 @@ LL |         self.layers.iter().fold(0, |result, mut layer| result + layer.proce
 help: you may want to use `iter_mut` here
    |
 LL |         self.layers.iter_mut().fold(0, |result, mut layer| result + layer.process())
-   |                     ~~~~~~~~
+   |                         ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-115259-suggest-iter-mut.stderr
+++ b/tests/ui/borrowck/issue-115259-suggest-iter-mut.stderr
@@ -8,9 +8,8 @@ LL |         self.layers.iter().fold(0, |result, mut layer| result + layer.proce
    |
 help: you may want to use `iter_mut` here
    |
-LL -         self.layers.iter().fold(0, |result, mut layer| result + layer.process())
-LL +         self.layers.iter_mut().fold(0, |result, mut layer| result + layer.process())
-   |
+LL |         self.layers.iter_mut().fold(0, |result, mut layer| result + layer.process())
+   |                     ~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-62387-suggest-iter-mut-2.stderr
+++ b/tests/ui/borrowck/issue-62387-suggest-iter-mut-2.stderr
@@ -9,7 +9,7 @@ LL |             vec.iter().flat_map(|container| container.things()).cloned().co
 help: you may want to use `iter_mut` here
    |
 LL |             vec.iter_mut().flat_map(|container| container.things()).cloned().collect::<Vec<PathBuf>>();
-   |                 ~~~~~~~~
+   |                     ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-62387-suggest-iter-mut-2.stderr
+++ b/tests/ui/borrowck/issue-62387-suggest-iter-mut-2.stderr
@@ -8,9 +8,8 @@ LL |             vec.iter().flat_map(|container| container.things()).cloned().co
    |
 help: you may want to use `iter_mut` here
    |
-LL -             vec.iter().flat_map(|container| container.things()).cloned().collect::<Vec<PathBuf>>();
-LL +             vec.iter_mut().flat_map(|container| container.things()).cloned().collect::<Vec<PathBuf>>();
-   |
+LL |             vec.iter_mut().flat_map(|container| container.things()).cloned().collect::<Vec<PathBuf>>();
+   |                 ~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-62387-suggest-iter-mut.stderr
+++ b/tests/ui/borrowck/issue-62387-suggest-iter-mut.stderr
@@ -9,7 +9,7 @@ LL |     v.iter().for_each(|a| a.double());
 help: you may want to use `iter_mut` here
    |
 LL |     v.iter_mut().for_each(|a| a.double());
-   |       ~~~~~~~~
+   |           ++++
 
 error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/issue-62387-suggest-iter-mut.rs:25:39
@@ -22,7 +22,7 @@ LL |     v.iter().rev().rev().for_each(|a| a.double());
 help: you may want to use `iter_mut` here
    |
 LL |     v.iter_mut().rev().rev().for_each(|a| a.double());
-   |       ~~~~~~~~
+   |           ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/issue-62387-suggest-iter-mut.stderr
+++ b/tests/ui/borrowck/issue-62387-suggest-iter-mut.stderr
@@ -8,9 +8,8 @@ LL |     v.iter().for_each(|a| a.double());
    |
 help: you may want to use `iter_mut` here
    |
-LL -     v.iter().for_each(|a| a.double());
-LL +     v.iter_mut().for_each(|a| a.double());
-   |
+LL |     v.iter_mut().for_each(|a| a.double());
+   |       ~~~~~~~~
 
 error[E0596]: cannot borrow `*a` as mutable, as it is behind a `&` reference
   --> $DIR/issue-62387-suggest-iter-mut.rs:25:39
@@ -22,9 +21,8 @@ LL |     v.iter().rev().rev().for_each(|a| a.double());
    |
 help: you may want to use `iter_mut` here
    |
-LL -     v.iter().rev().rev().for_each(|a| a.double());
-LL +     v.iter_mut().rev().rev().for_each(|a| a.double());
-   |
+LL |     v.iter_mut().rev().rev().for_each(|a| a.double());
+   |       ~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/c-variadic/issue-86053-1.stderr
+++ b/tests/ui/c-variadic/issue-86053-1.stderr
@@ -63,9 +63,8 @@ LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize
    |
 help: a trait with a similar name exists
    |
-LL -     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize ) {
-LL +     self , ... ,   self ,   self , ... ) where Fn : FnOnce ( & 'a & 'b usize ) {
-   |
+LL |     self , ... ,   self ,   self , ... ) where Fn : FnOnce ( & 'a & 'b usize ) {
+   |                                                ~~
 help: you might be missing a type parameter
    |
 LL | fn ordering4 < 'a , 'b, F     > ( a :            ,   self , self ,   self ,

--- a/tests/ui/c-variadic/issue-86053-1.stderr
+++ b/tests/ui/c-variadic/issue-86053-1.stderr
@@ -64,7 +64,7 @@ LL |     self , ... ,   self ,   self , ... ) where F : FnOnce ( & 'a & 'b usize
 help: a trait with a similar name exists
    |
 LL |     self , ... ,   self ,   self , ... ) where Fn : FnOnce ( & 'a & 'b usize ) {
-   |                                                ~~
+   |                                                 +
 help: you might be missing a type parameter
    |
 LL | fn ordering4 < 'a , 'b, F     > ( a :            ,   self , self ,   self ,

--- a/tests/ui/cfg/cfg-method-receiver.stderr
+++ b/tests/ui/cfg/cfg-method-receiver.stderr
@@ -17,7 +17,7 @@ LL |     cbor_map! { #[cfg(test)] 4};
 help: you must specify a concrete type for this numeric value, like `i32`
    |
 LL |     cbor_map! { #[cfg(test)] 4_i32};
-   |                              ~~~~~
+   |                               ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/cfg/cfg-method-receiver.stderr
+++ b/tests/ui/cfg/cfg-method-receiver.stderr
@@ -16,9 +16,8 @@ LL |     cbor_map! { #[cfg(test)] 4};
    = note: this error originates in the macro `cbor_map` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you must specify a concrete type for this numeric value, like `i32`
    |
-LL -     cbor_map! { #[cfg(test)] 4};
-LL +     cbor_map! { #[cfg(test)] 4_i32};
-   |
+LL |     cbor_map! { #[cfg(test)] 4_i32};
+   |                              ~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/check-cfg/diagnotics.cargo.stderr
+++ b/tests/ui/check-cfg/diagnotics.cargo.stderr
@@ -17,9 +17,8 @@ LL | #[cfg(featur = "foo")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
 help: there is a config with a similar name and value
    |
-LL - #[cfg(featur = "foo")]
-LL + #[cfg(feature = "foo")]
-   |
+LL | #[cfg(feature = "foo")]
+   |       ~~~~~~~
 
 warning: unexpected `cfg` condition name: `featur`
   --> $DIR/diagnotics.rs:17:7

--- a/tests/ui/check-cfg/diagnotics.cargo.stderr
+++ b/tests/ui/check-cfg/diagnotics.cargo.stderr
@@ -18,7 +18,7 @@ LL | #[cfg(featur = "foo")]
 help: there is a config with a similar name and value
    |
 LL | #[cfg(feature = "foo")]
-   |       ~~~~~~~
+   |             +
 
 warning: unexpected `cfg` condition name: `featur`
   --> $DIR/diagnotics.rs:17:7

--- a/tests/ui/check-cfg/diagnotics.rustc.stderr
+++ b/tests/ui/check-cfg/diagnotics.rustc.stderr
@@ -20,7 +20,7 @@ LL | #[cfg(featur = "foo")]
 help: there is a config with a similar name and value
    |
 LL | #[cfg(feature = "foo")]
-   |       ~~~~~~~
+   |             +
 
 warning: unexpected `cfg` condition name: `featur`
   --> $DIR/diagnotics.rs:17:7

--- a/tests/ui/check-cfg/diagnotics.rustc.stderr
+++ b/tests/ui/check-cfg/diagnotics.rustc.stderr
@@ -19,9 +19,8 @@ LL | #[cfg(featur = "foo")]
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 help: there is a config with a similar name and value
    |
-LL - #[cfg(featur = "foo")]
-LL + #[cfg(feature = "foo")]
-   |
+LL | #[cfg(feature = "foo")]
+   |       ~~~~~~~
 
 warning: unexpected `cfg` condition name: `featur`
   --> $DIR/diagnotics.rs:17:7

--- a/tests/ui/closures/2229_closure_analysis/bad-pattern.stderr
+++ b/tests/ui/closures/2229_closure_analysis/bad-pattern.stderr
@@ -109,7 +109,7 @@ LL |         let PAT = v1;
 help: introduce a variable instead
    |
 LL |         let PAT_var = v1;
-   |             ~~~~~~~
+   |                ++++
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/closures/2229_closure_analysis/bad-pattern.stderr
+++ b/tests/ui/closures/2229_closure_analysis/bad-pattern.stderr
@@ -108,9 +108,8 @@ LL |         let PAT = v1;
    = note: the matched value is of type `u32`
 help: introduce a variable instead
    |
-LL -         let PAT = v1;
-LL +         let PAT_var = v1;
-   |
+LL |         let PAT_var = v1;
+   |             ~~~~~~~
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/closures/2229_closure_analysis/issue-118144.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-118144.stderr
@@ -9,7 +9,7 @@ LL |         V(x) = func_arg;
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |         V(x) = &*func_arg;
-   |                ~~~~~~~~~~
+   |                ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/2229_closure_analysis/issue-118144.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-118144.stderr
@@ -8,9 +8,8 @@ LL |         V(x) = func_arg;
    |
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -         V(x) = func_arg;
-LL +         V(x) = &*func_arg;
-   |
+LL |         V(x) = &*func_arg;
+   |                ~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/issue-78720.stderr
+++ b/tests/ui/closures/issue-78720.stderr
@@ -15,9 +15,8 @@ LL |     _func: F,
    |
 help: a trait with a similar name exists
    |
-LL -     _func: F,
-LL +     _func: Fn,
-   |
+LL |     _func: Fn,
+   |            ~~
 help: you might be missing a type parameter
    |
 LL | struct Map2<Segment2, F> {

--- a/tests/ui/closures/issue-78720.stderr
+++ b/tests/ui/closures/issue-78720.stderr
@@ -16,7 +16,7 @@ LL |     _func: F,
 help: a trait with a similar name exists
    |
 LL |     _func: Fn,
-   |            ~~
+   |             +
 help: you might be missing a type parameter
    |
 LL | struct Map2<Segment2, F> {

--- a/tests/ui/compare-method/bad-self-type.stderr
+++ b/tests/ui/compare-method/bad-self-type.stderr
@@ -9,7 +9,7 @@ LL |     fn poll(self, _: &mut Context<'_>) -> Poll<()> {
 help: change the self-receiver type to match the trait
    |
 LL |     fn poll(self: Pin<&mut MyFuture>, _: &mut Context<'_>) -> Poll<()> {
-   |             ~~~~~~~~~~~~~~~~~~~~~~~~
+   |                 ++++++++++++++++++++
 
 error[E0053]: method `foo` has an incompatible type for trait
   --> $DIR/bad-self-type.rs:22:18

--- a/tests/ui/compare-method/bad-self-type.stderr
+++ b/tests/ui/compare-method/bad-self-type.stderr
@@ -8,9 +8,8 @@ LL |     fn poll(self, _: &mut Context<'_>) -> Poll<()> {
               found signature `fn(MyFuture, &mut Context<'_>) -> Poll<_>`
 help: change the self-receiver type to match the trait
    |
-LL -     fn poll(self, _: &mut Context<'_>) -> Poll<()> {
-LL +     fn poll(self: Pin<&mut MyFuture>, _: &mut Context<'_>) -> Poll<()> {
-   |
+LL |     fn poll(self: Pin<&mut MyFuture>, _: &mut Context<'_>) -> Poll<()> {
+   |             ~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0053]: method `foo` has an incompatible type for trait
   --> $DIR/bad-self-type.rs:22:18

--- a/tests/ui/const-generics/ensure_is_evaluatable.stderr
+++ b/tests/ui/const-generics/ensure_is_evaluatable.stderr
@@ -15,7 +15,7 @@ LL |     [(); N + 1]:,
 help: try adding a `where` bound
    |
 LL |     [(); M + 1]:, [(); N + 1]:
-   |                 ~~~~~~~~~~~~~~
+   |                   ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/ensure_is_evaluatable.stderr
+++ b/tests/ui/const-generics/ensure_is_evaluatable.stderr
@@ -14,9 +14,8 @@ LL |     [(); N + 1]:,
    |          ^^^^^ required by this bound in `bar`
 help: try adding a `where` bound
    |
-LL -     [(); M + 1]:,
-LL +     [(); M + 1]:, [(); N + 1]:
-   |
+LL |     [(); M + 1]:, [(); N + 1]:
+   |                 ~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/fn_with_two_const_inputs.stderr
+++ b/tests/ui/const-generics/fn_with_two_const_inputs.stderr
@@ -15,7 +15,7 @@ LL |     [(); N + 1]:,
 help: try adding a `where` bound
    |
 LL |     [(); both(N + 1, M + 1)]:, [(); N + 1]:
-   |                              ~~~~~~~~~~~~~~
+   |                                ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/fn_with_two_const_inputs.stderr
+++ b/tests/ui/const-generics/fn_with_two_const_inputs.stderr
@@ -14,9 +14,8 @@ LL |     [(); N + 1]:,
    |          ^^^^^ required by this bound in `bar`
 help: try adding a `where` bound
    |
-LL -     [(); both(N + 1, M + 1)]:,
-LL +     [(); both(N + 1, M + 1)]:, [(); N + 1]:
-   |
+LL |     [(); both(N + 1, M + 1)]:, [(); N + 1]:
+   |                              ~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
@@ -17,7 +17,7 @@ LL |     fn assert_impl<T: Trait>() {}
 help: try adding a `where` bound
    |
 LL |     EvaluatableU128<{N as u128}>:, [(); { O as u128 } as usize]: {
-   |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                    +++++++++++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:17:5
@@ -52,7 +52,7 @@ LL |     fn assert_impl<T: Trait>() {}
 help: try adding a `where` bound
    |
 LL |     EvaluatableU128<{N as u128}>:, [(); { O as u128 } as usize]: {
-   |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                    +++++++++++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:20:5
@@ -115,7 +115,7 @@ LL |     fn assert_impl<T: Trait>() {}
 help: try adding a `where` bound
    |
 LL |     EvaluatableU128<{N as _}>:, [(); { O as u128 } as usize]: {
-   |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                 +++++++++++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:35:5
@@ -150,7 +150,7 @@ LL |     fn assert_impl<T: Trait>() {}
 help: try adding a `where` bound
    |
 LL |     EvaluatableU128<{N as _}>:, [(); { O as u128 } as usize]: {
-   |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                 +++++++++++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:38:5

--- a/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
@@ -16,9 +16,8 @@ LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
 help: try adding a `where` bound
    |
-LL -     EvaluatableU128<{N as u128}>:, {
-LL +     EvaluatableU128<{N as u128}>:, [(); { O as u128 } as usize]: {
-   |
+LL |     EvaluatableU128<{N as u128}>:, [(); { O as u128 } as usize]: {
+   |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:17:5
@@ -52,9 +51,8 @@ LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
 help: try adding a `where` bound
    |
-LL -     EvaluatableU128<{N as u128}>:, {
-LL +     EvaluatableU128<{N as u128}>:, [(); { O as u128 } as usize]: {
-   |
+LL |     EvaluatableU128<{N as u128}>:, [(); { O as u128 } as usize]: {
+   |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:20:5
@@ -116,9 +114,8 @@ LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
 help: try adding a `where` bound
    |
-LL -     EvaluatableU128<{N as _}>:, {
-LL +     EvaluatableU128<{N as _}>:, [(); { O as u128 } as usize]: {
-   |
+LL |     EvaluatableU128<{N as _}>:, [(); { O as u128 } as usize]: {
+   |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:35:5
@@ -152,9 +149,8 @@ LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
 help: try adding a `where` bound
    |
-LL -     EvaluatableU128<{N as _}>:, {
-LL +     EvaluatableU128<{N as _}>:, [(); { O as u128 } as usize]: {
-   |
+LL |     EvaluatableU128<{N as _}>:, [(); { O as u128 } as usize]: {
+   |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:38:5

--- a/tests/ui/const-generics/generic_const_exprs/assoc_const_unification/doesnt_unify_evaluatable.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/assoc_const_unification/doesnt_unify_evaluatable.stderr
@@ -7,7 +7,7 @@ LL |     bar::<{ T::ASSOC }>();
 help: try adding a `where` bound
    |
 LL | fn foo<T: Trait, U: Trait>() where [(); U::ASSOC]:, [(); { T::ASSOC }]: {
-   |                                                   ~~~~~~~~~~~~~~~~~~~~~
+   |                                                     +++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/assoc_const_unification/doesnt_unify_evaluatable.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/assoc_const_unification/doesnt_unify_evaluatable.stderr
@@ -6,9 +6,8 @@ LL |     bar::<{ T::ASSOC }>();
    |
 help: try adding a `where` bound
    |
-LL - fn foo<T: Trait, U: Trait>() where [(); U::ASSOC]:, {
-LL + fn foo<T: Trait, U: Trait>() where [(); U::ASSOC]:, [(); { T::ASSOC }]: {
-   |
+LL | fn foo<T: Trait, U: Trait>() where [(); U::ASSOC]:, [(); { T::ASSOC }]: {
+   |                                                   ~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
@@ -27,7 +27,7 @@ LL |     foo::<_, L>([(); L + 1 + L]);
 help: try adding a `where` bound
    |
 LL |     [(); (L - 1) + 1 + L]:, [(); L + 1 + L]:
-   |                           ~~~~~~~~~~~~~~~~~~
+   |                             ++++++++++++++++
 
 error: unconstrained generic constant
   --> $DIR/issue_114151.rs:17:17

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
@@ -26,9 +26,8 @@ LL |     foo::<_, L>([(); L + 1 + L]);
    |
 help: try adding a `where` bound
    |
-LL -     [(); (L - 1) + 1 + L]:,
-LL +     [(); (L - 1) + 1 + L]:, [(); L + 1 + L]:
-   |
+LL |     [(); (L - 1) + 1 + L]:, [(); L + 1 + L]:
+   |                           ~~~~~~~~~~~~~~~~~~
 
 error: unconstrained generic constant
   --> $DIR/issue_114151.rs:17:17

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/wf_obligation.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/wf_obligation.stderr
@@ -16,7 +16,7 @@ LL |     foo::<_, L>([(); L + 1 + L]);
 help: try adding a `where` bound
    |
 LL |     [(); (L - 1) + 1 + L]:, [(); L + 1 + L]:
-   |                           ~~~~~~~~~~~~~~~~~~
+   |                             ++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/wf_obligation.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/wf_obligation.stderr
@@ -15,9 +15,8 @@ LL |     foo::<_, L>([(); L + 1 + L]);
    |
 help: try adding a `where` bound
    |
-LL -     [(); (L - 1) + 1 + L]:,
-LL +     [(); (L - 1) + 1 + L]:, [(); L + 1 + L]:
-   |
+LL |     [(); (L - 1) + 1 + L]:, [(); L + 1 + L]:
+   |                           ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
@@ -9,9 +9,8 @@ LL |          let f: F = async { 1 };
    |
 help: a trait with a similar name exists
    |
-LL -          let f: F = async { 1 };
-LL +          let f: Fn = async { 1 };
-   |
+LL |          let f: Fn = async { 1 };
+   |                 ~~
 help: you might be missing a type parameter
    |
 LL | fn f<T, F>(

--- a/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/expected-type-of-closure-body-to-be-a-closure-or-coroutine-ice-113776.stderr
@@ -10,7 +10,7 @@ LL |          let f: F = async { 1 };
 help: a trait with a similar name exists
    |
 LL |          let f: Fn = async { 1 };
-   |                 ~~
+   |                  +
 help: you might be missing a type parameter
    |
 LL | fn f<T, F>(

--- a/tests/ui/consts/const-pattern-irrefutable.stderr
+++ b/tests/ui/consts/const-pattern-irrefutable.stderr
@@ -12,9 +12,8 @@ LL |     let a = 4;
    = note: the matched value is of type `u8`
 help: introduce a variable instead
    |
-LL -     let a = 4;
-LL +     let a_var = 4;
-   |
+LL |     let a_var = 4;
+   |         ~~~~~
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/const-pattern-irrefutable.rs:28:9
@@ -48,9 +47,8 @@ LL |     let d = (4, 4);
    = note: the matched value is of type `(u8, u8)`
 help: introduce a variable instead
    |
-LL -     let d = (4, 4);
-LL +     let d_var = (4, 4);
-   |
+LL |     let d_var = (4, 4);
+   |         ~~~~~
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/const-pattern-irrefutable.rs:36:9
@@ -71,9 +69,8 @@ LL | struct S {
    = note: the matched value is of type `S`
 help: introduce a variable instead
    |
-LL -     let e = S {
-LL +     let e_var = S {
-   |
+LL |     let e_var = S {
+   |         ~~~~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/const-pattern-irrefutable.stderr
+++ b/tests/ui/consts/const-pattern-irrefutable.stderr
@@ -13,7 +13,7 @@ LL |     let a = 4;
 help: introduce a variable instead
    |
 LL |     let a_var = 4;
-   |         ~~~~~
+   |          ++++
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/const-pattern-irrefutable.rs:28:9
@@ -48,7 +48,7 @@ LL |     let d = (4, 4);
 help: introduce a variable instead
    |
 LL |     let d_var = (4, 4);
-   |         ~~~~~
+   |          ++++
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/const-pattern-irrefutable.rs:36:9
@@ -70,7 +70,7 @@ LL | struct S {
 help: introduce a variable instead
    |
 LL |     let e_var = S {
-   |         ~~~~~
+   |          ++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/did_you_mean/dont-suggest-hygienic-fields.stderr
+++ b/tests/ui/did_you_mean/dont-suggest-hygienic-fields.stderr
@@ -10,9 +10,8 @@ LL |     const CRATE: Crate = Crate { fiel: () };
    = note: this error originates in the macro `environment` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: a field with a similar name exists
    |
-LL -     const CRATE: Crate = Crate { fiel: () };
-LL +     const CRATE: Crate = Crate { field: () };
-   |
+LL |     const CRATE: Crate = Crate { field: () };
+   |                                  ~~~~~
 
 error[E0609]: no field `field` on type `Compound`
   --> $DIR/dont-suggest-hygienic-fields.rs:24:16

--- a/tests/ui/did_you_mean/dont-suggest-hygienic-fields.stderr
+++ b/tests/ui/did_you_mean/dont-suggest-hygienic-fields.stderr
@@ -11,7 +11,7 @@ LL |     const CRATE: Crate = Crate { fiel: () };
 help: a field with a similar name exists
    |
 LL |     const CRATE: Crate = Crate { field: () };
-   |                                  ~~~~~
+   |                                      +
 
 error[E0609]: no field `field` on type `Compound`
   --> $DIR/dont-suggest-hygienic-fields.rs:24:16

--- a/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
+++ b/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
@@ -12,7 +12,7 @@ LL | struct DropMe<T: Copy>(T);
 help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL |     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply `T: Copy`
-   |                 ~~~~~~~~~~~~~~~~~~~~~~
+   |                   ++++++++++++++++++++
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/explicit-drop-bounds.rs:32:18
@@ -28,7 +28,7 @@ LL | struct DropMe<T: Copy>(T);
 help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL |     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply `T: Copy`
-   |                 ~~~~~~~~~~~~~~~~~~~~~~
+   |                   ++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
+++ b/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
@@ -11,9 +11,8 @@ LL | struct DropMe<T: Copy>(T);
    |                  ^^^^ required by this bound in `DropMe`
 help: consider further restricting type parameter `T` with trait `Copy`
    |
-LL -     [T; 1]: Copy, // But `[T; 1]: Copy` does not imply `T: Copy`
-LL +     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply `T: Copy`
-   |
+LL |     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply `T: Copy`
+   |                 ~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/explicit-drop-bounds.rs:32:18
@@ -28,9 +27,8 @@ LL | struct DropMe<T: Copy>(T);
    |                  ^^^^ required by this bound in `DropMe`
 help: consider further restricting type parameter `T` with trait `Copy`
    |
-LL -     [T; 1]: Copy, // But `[T; 1]: Copy` does not imply `T: Copy`
-LL +     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply `T: Copy`
-   |
+LL |     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply `T: Copy`
+   |                 ~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/dst/issue-90528-unsizing-suggestion-3.stderr
+++ b/tests/ui/dst/issue-90528-unsizing-suggestion-3.stderr
@@ -68,7 +68,7 @@ LL | fn wants_write(_: impl Write) {}
 help: consider changing this borrow's mutability
    |
 LL |     wants_write(&mut [0u8][..]);
-   |                 ~~~~
+   |                  +++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/dst/issue-90528-unsizing-suggestion-3.stderr
+++ b/tests/ui/dst/issue-90528-unsizing-suggestion-3.stderr
@@ -67,9 +67,8 @@ LL | fn wants_write(_: impl Write) {}
    |                        ^^^^^ required by this bound in `wants_write`
 help: consider changing this borrow's mutability
    |
-LL -     wants_write(&[0u8][..]);
-LL +     wants_write(&mut [0u8][..]);
-   |
+LL |     wants_write(&mut [0u8][..]);
+   |                 ~~~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/empty/empty-struct-braces-expr.stderr
+++ b/tests/ui/empty/empty-struct-braces-expr.stderr
@@ -125,9 +125,8 @@ LL |     let xe3 = XE::Empty3;
    |
 help: there is a variant with a similar name
    |
-LL -     let xe3 = XE::Empty3;
-LL +     let xe3 = XE::XEmpty3;
-   |
+LL |     let xe3 = XE::XEmpty3;
+   |                   ~~~~~~~
 
 error[E0599]: no variant or associated item named `Empty3` found for enum `empty_struct::XE` in the current scope
   --> $DIR/empty-struct-braces-expr.rs:26:19

--- a/tests/ui/empty/empty-struct-braces-expr.stderr
+++ b/tests/ui/empty/empty-struct-braces-expr.stderr
@@ -15,7 +15,7 @@ LL | pub struct XEmpty2;
 help: use struct literal syntax instead
    |
 LL |     let e1 = Empty1 {};
-   |              ~~~~~~~~~
+   |                     ++
 help: a unit struct with a similar name exists
    |
 LL -     let e1 = Empty1;
@@ -38,7 +38,7 @@ LL | pub struct XEmpty2;
 help: use struct literal syntax instead
    |
 LL |     let xe1 = XEmpty1 {};
-   |               ~~~~~~~~~~
+   |                       ++
 help: a unit struct with a similar name exists
    |
 LL -     let xe1 = XEmpty1;
@@ -126,7 +126,7 @@ LL |     let xe3 = XE::Empty3;
 help: there is a variant with a similar name
    |
 LL |     let xe3 = XE::XEmpty3;
-   |                   ~~~~~~~
+   |                   +
 
 error[E0599]: no variant or associated item named `Empty3` found for enum `empty_struct::XE` in the current scope
   --> $DIR/empty-struct-braces-expr.rs:26:19

--- a/tests/ui/empty/empty-struct-braces-expr.stderr
+++ b/tests/ui/empty/empty-struct-braces-expr.stderr
@@ -14,9 +14,8 @@ LL | pub struct XEmpty2;
    |
 help: use struct literal syntax instead
    |
-LL -     let e1 = Empty1;
-LL +     let e1 = Empty1 {};
-   |
+LL |     let e1 = Empty1 {};
+   |              ~~~~~~~~~
 help: a unit struct with a similar name exists
    |
 LL -     let e1 = Empty1;
@@ -38,9 +37,8 @@ LL | pub struct XEmpty2;
    |
 help: use struct literal syntax instead
    |
-LL -     let xe1 = XEmpty1;
-LL +     let xe1 = XEmpty1 {};
-   |
+LL |     let xe1 = XEmpty1 {};
+   |               ~~~~~~~~~~
 help: a unit struct with a similar name exists
    |
 LL -     let xe1 = XEmpty1;

--- a/tests/ui/empty/empty-struct-tuple-pat.stderr
+++ b/tests/ui/empty/empty-struct-tuple-pat.stderr
@@ -47,7 +47,7 @@ LL |     XEmpty5(),
 help: use the tuple variant pattern syntax instead
    |
 LL |         XE::XEmpty5() => (),
-   |         ~~~~~~~~~~~~~
+   |                    ++
 help: a unit variant with a similar name exists
    |
 LL -         XE::XEmpty5 => (),

--- a/tests/ui/empty/empty-struct-tuple-pat.stderr
+++ b/tests/ui/empty/empty-struct-tuple-pat.stderr
@@ -46,9 +46,8 @@ LL |     XEmpty5(),
    |
 help: use the tuple variant pattern syntax instead
    |
-LL -         XE::XEmpty5 => (),
-LL +         XE::XEmpty5() => (),
-   |
+LL |         XE::XEmpty5() => (),
+   |         ~~~~~~~~~~~~~
 help: a unit variant with a similar name exists
    |
 LL -         XE::XEmpty5 => (),

--- a/tests/ui/env-macro/error-recovery-issue-55897.stderr
+++ b/tests/ui/env-macro/error-recovery-issue-55897.stderr
@@ -30,9 +30,8 @@ LL |     use env;
    |
 help: consider importing this module instead
    |
-LL -     use env;
-LL +     use std::env;
-   |
+LL |     use std::env;
+   |         ~~~~~~~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/env-macro/error-recovery-issue-55897.stderr
+++ b/tests/ui/env-macro/error-recovery-issue-55897.stderr
@@ -31,7 +31,7 @@ LL |     use env;
 help: consider importing this module instead
    |
 LL |     use std::env;
-   |         ~~~~~~~~
+   |         +++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/error-codes/E0027.stderr
+++ b/tests/ui/error-codes/E0027.stderr
@@ -7,15 +7,15 @@ LL |         Dog { age: x } => {}
 help: include the missing field in the pattern
    |
 LL |         Dog { age: x, name } => {}
-   |                     ~~~~~~~~
+   |                     ++++++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |         Dog { age: x, name: _ } => {}
-   |                     ~~~~~~~~~~~
+   |                     +++++++++
 help: or always ignore missing fields here
    |
 LL |         Dog { age: x, .. } => {}
-   |                     ~~~~~~
+   |                     ++++
 
 error[E0027]: pattern does not mention field `age`
   --> $DIR/E0027.rs:15:9

--- a/tests/ui/error-codes/E0027.stderr
+++ b/tests/ui/error-codes/E0027.stderr
@@ -6,19 +6,16 @@ LL |         Dog { age: x } => {}
    |
 help: include the missing field in the pattern
    |
-LL -         Dog { age: x } => {}
-LL +         Dog { age: x, name } => {}
-   |
+LL |         Dog { age: x, name } => {}
+   |                     ~~~~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -         Dog { age: x } => {}
-LL +         Dog { age: x, name: _ } => {}
-   |
+LL |         Dog { age: x, name: _ } => {}
+   |                     ~~~~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -         Dog { age: x } => {}
-LL +         Dog { age: x, .. } => {}
-   |
+LL |         Dog { age: x, .. } => {}
+   |                     ~~~~~~
 
 error[E0027]: pattern does not mention field `age`
   --> $DIR/E0027.rs:15:9

--- a/tests/ui/extern/not-in-block.stderr
+++ b/tests/ui/extern/not-in-block.stderr
@@ -11,9 +11,8 @@ LL + extern fn none_fn(x: bool) -> i32 { <body> }
    |
 help: if you meant to declare an externally defined function, use an `extern` block
    |
-LL - extern fn none_fn(x: bool) -> i32;
-LL + extern { fn none_fn(x: bool) -> i32; }
-   |
+LL | extern { fn none_fn(x: bool) -> i32; }
+   | ~~~~~~~~                             +
 
 error: free function without a body
   --> $DIR/not-in-block.rs:6:1
@@ -28,9 +27,8 @@ LL + extern "C" fn c_fn(x: bool) -> i32 { <body> }
    |
 help: if you meant to declare an externally defined function, use an `extern` block
    |
-LL - extern "C" fn c_fn(x: bool) -> i32;
-LL + extern "C" { fn c_fn(x: bool) -> i32; }
-   |
+LL | extern "C" { fn c_fn(x: bool) -> i32; }
+   | ~~~~~~~~~~~~                          +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/extern/not-in-block.stderr
+++ b/tests/ui/extern/not-in-block.stderr
@@ -12,7 +12,7 @@ LL + extern fn none_fn(x: bool) -> i32 { <body> }
 help: if you meant to declare an externally defined function, use an `extern` block
    |
 LL | extern { fn none_fn(x: bool) -> i32; }
-   | ~~~~~~~~                             +
+   |        +                             +
 
 error: free function without a body
   --> $DIR/not-in-block.rs:6:1
@@ -28,7 +28,7 @@ LL + extern "C" fn c_fn(x: bool) -> i32 { <body> }
 help: if you meant to declare an externally defined function, use an `extern` block
    |
 LL | extern "C" { fn c_fn(x: bool) -> i32; }
-   | ~~~~~~~~~~~~                          +
+   |            +                          +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -95,9 +95,8 @@ LL |     extern "rust-call" fn call(self, args: ()) -> () {}
               found signature `extern "rust-call" fn(Foo, ()) -> ()`
 help: change the self-receiver type to match the trait
    |
-LL -     extern "rust-call" fn call(self, args: ()) -> () {}
-LL +     extern "rust-call" fn call(&self, args: ()) -> () {}
-   |
+LL |     extern "rust-call" fn call(&self, args: ()) -> () {}
+   |                                ~~~~~
 
 error[E0183]: manual implementations of `FnOnce` are experimental
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -96,7 +96,7 @@ LL |     extern "rust-call" fn call(self, args: ()) -> () {}
 help: change the self-receiver type to match the trait
    |
 LL |     extern "rust-call" fn call(&self, args: ()) -> () {}
-   |                                ~~~~~
+   |                                +
 
 error[E0183]: manual implementations of `FnOnce` are experimental
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:18:6

--- a/tests/ui/fmt/no-inline-literals-out-of-range.stderr
+++ b/tests/ui/fmt/no-inline-literals-out-of-range.stderr
@@ -52,7 +52,7 @@ LL |     format_args!("{}", 0xffff_ffff); // treat unsuffixed literals as i32
 help: to use as a negative number (decimal `-1`), consider using the type `u32` for the literal and cast it to `i32`
    |
 LL |     format_args!("{}", 0xffff_ffffu32 as i32); // treat unsuffixed literals as i32
-   |                        ~~~~~~~~~~~~~~~~~~~~~
+   |                                   ++++++++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/fmt/no-inline-literals-out-of-range.stderr
+++ b/tests/ui/fmt/no-inline-literals-out-of-range.stderr
@@ -51,9 +51,8 @@ LL |     format_args!("{}", 0xffff_ffff); // treat unsuffixed literals as i32
    = help: consider using the type `u32` instead
 help: to use as a negative number (decimal `-1`), consider using the type `u32` for the literal and cast it to `i32`
    |
-LL -     format_args!("{}", 0xffff_ffff); // treat unsuffixed literals as i32
-LL +     format_args!("{}", 0xffff_ffffu32 as i32); // treat unsuffixed literals as i32
-   |
+LL |     format_args!("{}", 0xffff_ffffu32 as i32); // treat unsuffixed literals as i32
+   |                        ~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/tests/ui/impl-trait/no-method-suggested-traits.stderr
@@ -18,7 +18,7 @@ LL + use no_method_suggested_traits::qux::PrivPub;
 help: there is a method `method2` with a similar name
    |
 LL |     1u32.method2();
-   |          ~~~~~~~
+   |                +
 
 error[E0599]: no method named `method` found for struct `Rc<&mut Box<&u32>>` in the current scope
   --> $DIR/no-method-suggested-traits.rs:26:44
@@ -40,7 +40,7 @@ LL + use no_method_suggested_traits::qux::PrivPub;
 help: there is a method `method2` with a similar name
    |
 LL |     std::rc::Rc::new(&mut Box::new(&1u32)).method2();
-   |                                            ~~~~~~~
+   |                                                  +
 
 error[E0599]: no method named `method` found for type `char` in the current scope
   --> $DIR/no-method-suggested-traits.rs:30:9
@@ -59,7 +59,7 @@ LL + use foo::Bar;
 help: there is a method `method2` with a similar name
    |
 LL |     'a'.method2();
-   |         ~~~~~~~
+   |               +
 
 error[E0599]: no method named `method` found for struct `Rc<&mut Box<&char>>` in the current scope
   --> $DIR/no-method-suggested-traits.rs:32:43
@@ -75,7 +75,7 @@ LL + use foo::Bar;
 help: there is a method `method2` with a similar name
    |
 LL |     std::rc::Rc::new(&mut Box::new(&'a')).method2();
-   |                                           ~~~~~~~
+   |                                                 +
 
 error[E0599]: no method named `method` found for type `i32` in the current scope
   --> $DIR/no-method-suggested-traits.rs:35:10
@@ -96,7 +96,7 @@ LL + use no_method_suggested_traits::foo::PubPub;
 help: there is a method `method3` with a similar name
    |
 LL |     1i32.method3();
-   |          ~~~~~~~
+   |                +
 
 error[E0599]: no method named `method` found for struct `Rc<&mut Box<&i32>>` in the current scope
   --> $DIR/no-method-suggested-traits.rs:37:44
@@ -112,7 +112,7 @@ LL + use no_method_suggested_traits::foo::PubPub;
 help: there is a method `method3` with a similar name
    |
 LL |     std::rc::Rc::new(&mut Box::new(&1i32)).method3();
-   |                                            ~~~~~~~
+   |                                                  +
 
 error[E0599]: no method named `method` found for struct `Foo` in the current scope
   --> $DIR/no-method-suggested-traits.rs:40:9

--- a/tests/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/tests/ui/impl-trait/no-method-suggested-traits.stderr
@@ -17,9 +17,8 @@ LL + use no_method_suggested_traits::qux::PrivPub;
    |
 help: there is a method `method2` with a similar name
    |
-LL -     1u32.method();
-LL +     1u32.method2();
-   |
+LL |     1u32.method2();
+   |          ~~~~~~~
 
 error[E0599]: no method named `method` found for struct `Rc<&mut Box<&u32>>` in the current scope
   --> $DIR/no-method-suggested-traits.rs:26:44
@@ -40,9 +39,8 @@ LL + use no_method_suggested_traits::qux::PrivPub;
    |
 help: there is a method `method2` with a similar name
    |
-LL -     std::rc::Rc::new(&mut Box::new(&1u32)).method();
-LL +     std::rc::Rc::new(&mut Box::new(&1u32)).method2();
-   |
+LL |     std::rc::Rc::new(&mut Box::new(&1u32)).method2();
+   |                                            ~~~~~~~
 
 error[E0599]: no method named `method` found for type `char` in the current scope
   --> $DIR/no-method-suggested-traits.rs:30:9
@@ -60,9 +58,8 @@ LL + use foo::Bar;
    |
 help: there is a method `method2` with a similar name
    |
-LL -     'a'.method();
-LL +     'a'.method2();
-   |
+LL |     'a'.method2();
+   |         ~~~~~~~
 
 error[E0599]: no method named `method` found for struct `Rc<&mut Box<&char>>` in the current scope
   --> $DIR/no-method-suggested-traits.rs:32:43
@@ -77,9 +74,8 @@ LL + use foo::Bar;
    |
 help: there is a method `method2` with a similar name
    |
-LL -     std::rc::Rc::new(&mut Box::new(&'a')).method();
-LL +     std::rc::Rc::new(&mut Box::new(&'a')).method2();
-   |
+LL |     std::rc::Rc::new(&mut Box::new(&'a')).method2();
+   |                                           ~~~~~~~
 
 error[E0599]: no method named `method` found for type `i32` in the current scope
   --> $DIR/no-method-suggested-traits.rs:35:10
@@ -99,9 +95,8 @@ LL + use no_method_suggested_traits::foo::PubPub;
    |
 help: there is a method `method3` with a similar name
    |
-LL -     1i32.method();
-LL +     1i32.method3();
-   |
+LL |     1i32.method3();
+   |          ~~~~~~~
 
 error[E0599]: no method named `method` found for struct `Rc<&mut Box<&i32>>` in the current scope
   --> $DIR/no-method-suggested-traits.rs:37:44
@@ -116,9 +111,8 @@ LL + use no_method_suggested_traits::foo::PubPub;
    |
 help: there is a method `method3` with a similar name
    |
-LL -     std::rc::Rc::new(&mut Box::new(&1i32)).method();
-LL +     std::rc::Rc::new(&mut Box::new(&1i32)).method3();
-   |
+LL |     std::rc::Rc::new(&mut Box::new(&1i32)).method3();
+   |                                            ~~~~~~~
 
 error[E0599]: no method named `method` found for struct `Foo` in the current scope
   --> $DIR/no-method-suggested-traits.rs:40:9

--- a/tests/ui/imports/glob-resolve1.stderr
+++ b/tests/ui/imports/glob-resolve1.stderr
@@ -38,7 +38,7 @@ LL | |     }
 help: you might have meant to use the following enum variant
    |
 LL |     B::B1;
-   |     ~~~~~
+   |      ++++
 
 error[E0425]: cannot find value `C` in this scope
   --> $DIR/glob-resolve1.rs:29:5

--- a/tests/ui/imports/glob-resolve1.stderr
+++ b/tests/ui/imports/glob-resolve1.stderr
@@ -37,9 +37,8 @@ LL | |     }
    | |_____^
 help: you might have meant to use the following enum variant
    |
-LL -     B;
-LL +     B::B1;
-   |
+LL |     B::B1;
+   |     ~~~~~
 
 error[E0425]: cannot find value `C` in this scope
   --> $DIR/glob-resolve1.rs:29:5

--- a/tests/ui/imports/issue-45829/import-self.stderr
+++ b/tests/ui/imports/issue-45829/import-self.stderr
@@ -33,7 +33,7 @@ LL | use foo::{self};
 help: you can use `as` to change the binding name of the import
    |
 LL | use foo::{self as other_foo};
-   |           ~~~~~~~~~~~~~~~~~
+   |                ++++++++++++
 
 error[E0255]: the name `foo` is defined multiple times
   --> $DIR/import-self.rs:12:5

--- a/tests/ui/imports/issue-45829/import-self.stderr
+++ b/tests/ui/imports/issue-45829/import-self.stderr
@@ -32,9 +32,8 @@ LL | use foo::{self};
    = note: `foo` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - use foo::{self};
-LL + use foo::{self as other_foo};
-   |
+LL | use foo::{self as other_foo};
+   |           ~~~~~~~~~~~~~~~~~
 
 error[E0255]: the name `foo` is defined multiple times
   --> $DIR/import-self.rs:12:5

--- a/tests/ui/imports/suggest-import-issue-120074.edition2015.stderr
+++ b/tests/ui/imports/suggest-import-issue-120074.edition2015.stderr
@@ -7,7 +7,7 @@ LL |     println!("Hello, {}!", crate::bar::do_the_thing);
 help: a similar path exists
    |
 LL |     println!("Hello, {}!", crate::foo::bar::do_the_thing);
-   |                                   ~~~~~~~~
+   |                                   +++++
 help: consider importing this module
    |
 LL + use foo::bar;

--- a/tests/ui/imports/suggest-import-issue-120074.edition2015.stderr
+++ b/tests/ui/imports/suggest-import-issue-120074.edition2015.stderr
@@ -6,9 +6,8 @@ LL |     println!("Hello, {}!", crate::bar::do_the_thing);
    |
 help: a similar path exists
    |
-LL -     println!("Hello, {}!", crate::bar::do_the_thing);
-LL +     println!("Hello, {}!", crate::foo::bar::do_the_thing);
-   |
+LL |     println!("Hello, {}!", crate::foo::bar::do_the_thing);
+   |                                   ~~~~~~~~
 help: consider importing this module
    |
 LL + use foo::bar;

--- a/tests/ui/imports/suggest-import-issue-120074.edition2021.stderr
+++ b/tests/ui/imports/suggest-import-issue-120074.edition2021.stderr
@@ -7,7 +7,7 @@ LL |     println!("Hello, {}!", crate::bar::do_the_thing);
 help: a similar path exists
    |
 LL |     println!("Hello, {}!", crate::foo::bar::do_the_thing);
-   |                                   ~~~~~~~~
+   |                                   +++++
 help: consider importing this module
    |
 LL + use foo::bar;

--- a/tests/ui/imports/suggest-import-issue-120074.edition2021.stderr
+++ b/tests/ui/imports/suggest-import-issue-120074.edition2021.stderr
@@ -6,9 +6,8 @@ LL |     println!("Hello, {}!", crate::bar::do_the_thing);
    |
 help: a similar path exists
    |
-LL -     println!("Hello, {}!", crate::bar::do_the_thing);
-LL +     println!("Hello, {}!", crate::foo::bar::do_the_thing);
-   |
+LL |     println!("Hello, {}!", crate::foo::bar::do_the_thing);
+   |                                   ~~~~~~~~
 help: consider importing this module
    |
 LL + use foo::bar;

--- a/tests/ui/issues/issue-32004.stderr
+++ b/tests/ui/issues/issue-32004.stderr
@@ -11,9 +11,8 @@ LL |         Foo::Bar => {}
    |
 help: use the tuple variant pattern syntax instead
    |
-LL -         Foo::Bar => {}
-LL +         Foo::Bar(_) => {}
-   |
+LL |         Foo::Bar(_) => {}
+   |         ~~~~~~~~~~~
 help: a unit variant with a similar name exists
    |
 LL -         Foo::Bar => {}

--- a/tests/ui/issues/issue-32004.stderr
+++ b/tests/ui/issues/issue-32004.stderr
@@ -12,7 +12,7 @@ LL |         Foo::Bar => {}
 help: use the tuple variant pattern syntax instead
    |
 LL |         Foo::Bar(_) => {}
-   |         ~~~~~~~~~~~
+   |                 +++
 help: a unit variant with a similar name exists
    |
 LL -         Foo::Bar => {}

--- a/tests/ui/issues/issue-41652/issue-41652.stderr
+++ b/tests/ui/issues/issue-41652/issue-41652.stderr
@@ -7,7 +7,7 @@ LL |         3.f()
 help: you must specify a concrete type for this numeric value, like `i32`
    |
 LL |         3_i32.f()
-   |         ~~~~~
+   |          ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-41652/issue-41652.stderr
+++ b/tests/ui/issues/issue-41652/issue-41652.stderr
@@ -6,9 +6,8 @@ LL |         3.f()
    |
 help: you must specify a concrete type for this numeric value, like `i32`
    |
-LL -         3.f()
-LL +         3_i32.f()
-   |
+LL |         3_i32.f()
+   |         ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-51874.stderr
+++ b/tests/ui/issues/issue-51874.stderr
@@ -7,7 +7,7 @@ LL |     let a = (1.0).pow(1.0);
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |     let a = (1.0_f32).pow(1.0);
-   |              ~~~~~~~
+   |                 ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-51874.stderr
+++ b/tests/ui/issues/issue-51874.stderr
@@ -6,9 +6,8 @@ LL |     let a = (1.0).pow(1.0);
    |
 help: you must specify a concrete type for this numeric value, like `f32`
    |
-LL -     let a = (1.0).pow(1.0);
-LL +     let a = (1.0_f32).pow(1.0);
-   |
+LL |     let a = (1.0_f32).pow(1.0);
+   |              ~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-5358-1.stderr
+++ b/tests/ui/issues/issue-5358-1.stderr
@@ -15,7 +15,7 @@ LL |         S(Either::Right(_)) => {}
 help: you might have meant to use field `0` whose type is `Either<usize, usize>`
    |
 LL |     match S(Either::Left(5)).0 {
-   |           ~~~~~~~~~~~~~~~~~~~~
+   |                             ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-5358-1.stderr
+++ b/tests/ui/issues/issue-5358-1.stderr
@@ -14,9 +14,8 @@ LL |         S(Either::Right(_)) => {}
    |         ++                +
 help: you might have meant to use field `0` whose type is `Either<usize, usize>`
    |
-LL -     match S(Either::Left(5)) {
-LL +     match S(Either::Left(5)).0 {
-   |
+LL |     match S(Either::Left(5)).0 {
+   |           ~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-56175.stderr
+++ b/tests/ui/issues/issue-56175.stderr
@@ -17,7 +17,7 @@ LL + use reexported_trait::Trait;
 help: there is a method `trait_method_b` with a similar name
    |
 LL |     reexported_trait::FooStruct.trait_method_b();
-   |                                 ~~~~~~~~~~~~~~
+   |                                             ++
 
 error[E0599]: no method named `trait_method_b` found for struct `FooStruct` in the current scope
   --> $DIR/issue-56175.rs:7:33

--- a/tests/ui/issues/issue-56175.stderr
+++ b/tests/ui/issues/issue-56175.stderr
@@ -16,9 +16,8 @@ LL + use reexported_trait::Trait;
    |
 help: there is a method `trait_method_b` with a similar name
    |
-LL -     reexported_trait::FooStruct.trait_method();
-LL +     reexported_trait::FooStruct.trait_method_b();
-   |
+LL |     reexported_trait::FooStruct.trait_method_b();
+   |                                 ~~~~~~~~~~~~~~
 
 error[E0599]: no method named `trait_method_b` found for struct `FooStruct` in the current scope
   --> $DIR/issue-56175.rs:7:33

--- a/tests/ui/issues/issue-57741-dereference-boxed-value/issue-57741.stderr
+++ b/tests/ui/issues/issue-57741-dereference-boxed-value/issue-57741.stderr
@@ -11,7 +11,7 @@ LL |         T::A(a) | T::B(a) => a,
 help: consider dereferencing the boxed value
    |
 LL |     let y = match *x {
-   |                   ~~
+   |                   +
 
 error[E0308]: mismatched types
   --> $DIR/issue-57741.rs:20:19
@@ -26,7 +26,7 @@ LL |         T::A(a) | T::B(a) => a,
 help: consider dereferencing the boxed value
    |
 LL |     let y = match *x {
-   |                   ~~
+   |                   +
 
 error[E0308]: mismatched types
   --> $DIR/issue-57741.rs:27:9
@@ -41,7 +41,7 @@ LL |         S::A { a } | S::B { b: a } => a,
 help: consider dereferencing the boxed value
    |
 LL |     let y = match *x {
-   |                   ~~
+   |                   +
 
 error[E0308]: mismatched types
   --> $DIR/issue-57741.rs:27:22
@@ -56,7 +56,7 @@ LL |         S::A { a } | S::B { b: a } => a,
 help: consider dereferencing the boxed value
    |
 LL |     let y = match *x {
-   |                   ~~
+   |                   +
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/issues/issue-57741-dereference-boxed-value/issue-57741.stderr
+++ b/tests/ui/issues/issue-57741-dereference-boxed-value/issue-57741.stderr
@@ -10,9 +10,8 @@ LL |         T::A(a) | T::B(a) => a,
                 found enum `T`
 help: consider dereferencing the boxed value
    |
-LL -     let y = match x {
-LL +     let y = match *x {
-   |
+LL |     let y = match *x {
+   |                   ~~
 
 error[E0308]: mismatched types
   --> $DIR/issue-57741.rs:20:19
@@ -26,9 +25,8 @@ LL |         T::A(a) | T::B(a) => a,
                 found enum `T`
 help: consider dereferencing the boxed value
    |
-LL -     let y = match x {
-LL +     let y = match *x {
-   |
+LL |     let y = match *x {
+   |                   ~~
 
 error[E0308]: mismatched types
   --> $DIR/issue-57741.rs:27:9
@@ -42,9 +40,8 @@ LL |         S::A { a } | S::B { b: a } => a,
                 found enum `S`
 help: consider dereferencing the boxed value
    |
-LL -     let y = match x {
-LL +     let y = match *x {
-   |
+LL |     let y = match *x {
+   |                   ~~
 
 error[E0308]: mismatched types
   --> $DIR/issue-57741.rs:27:22
@@ -58,9 +55,8 @@ LL |         S::A { a } | S::B { b: a } => a,
                 found enum `S`
 help: consider dereferencing the boxed value
    |
-LL -     let y = match x {
-LL +     let y = match *x {
-   |
+LL |     let y = match *x {
+   |                   ~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/let-else/let-else-deref-coercion.stderr
+++ b/tests/ui/let-else/let-else-deref-coercion.stderr
@@ -9,7 +9,7 @@ LL |         let Bar::Present(z) = self else {
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |         let Bar::Present(z) = &**self else {
-   |                               ~~~~~~~
+   |                               +++
 
 error[E0308]: mismatched types
   --> $DIR/let-else-deref-coercion.rs:68:13
@@ -22,7 +22,7 @@ LL |         let Bar(z) = x;
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |         let Bar(z) = &**x;
-   |                      ~~~~
+   |                      +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/let-else/let-else-deref-coercion.stderr
+++ b/tests/ui/let-else/let-else-deref-coercion.stderr
@@ -8,9 +8,8 @@ LL |         let Bar::Present(z) = self else {
    |
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -         let Bar::Present(z) = self else {
-LL +         let Bar::Present(z) = &**self else {
-   |
+LL |         let Bar::Present(z) = &**self else {
+   |                               ~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/let-else-deref-coercion.rs:68:13
@@ -22,9 +21,8 @@ LL |         let Bar(z) = x;
    |
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -         let Bar(z) = x;
-LL +         let Bar(z) = &**x;
-   |
+LL |         let Bar(z) = &**x;
+   |                      ~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lexer/lex-bad-char-literals-1.stderr
+++ b/tests/ui/lexer/lex-bad-char-literals-1.stderr
@@ -32,9 +32,8 @@ LL |     "\●"
    = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
    |
-LL -     "\●"
-LL +     r"\●"
-   |
+LL |     r"\●"
+   |     ~~~~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/lexer/lex-bad-char-literals-1.stderr
+++ b/tests/ui/lexer/lex-bad-char-literals-1.stderr
@@ -33,7 +33,7 @@ LL |     "\●"
 help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
    |
 LL |     r"\●"
-   |     ~~~~~
+   |     +
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -13,7 +13,7 @@ LL |     x.use_mut();
 help: consider consuming the `Vec<i32>` when turning it into an `Iterator`
    |
 LL |     let mut x = vec![1].into_iter();
-   |                         ~~~~~~~~~
+   |                         +++++
 help: consider using a `let` binding to create a longer lived value
    |
 LL ~     let binding = vec![1];

--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -12,9 +12,8 @@ LL |     x.use_mut();
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider consuming the `Vec<i32>` when turning it into an `Iterator`
    |
-LL -     let mut x = vec![1].iter();
-LL +     let mut x = vec![1].into_iter();
-   |
+LL |     let mut x = vec![1].into_iter();
+   |                         ~~~~~~~~~
 help: consider using a `let` binding to create a longer lived value
    |
 LL ~     let binding = vec![1];

--- a/tests/ui/lint/let_underscore/issue-119696-err-on-fn.stderr
+++ b/tests/ui/lint/let_underscore/issue-119696-err-on-fn.stderr
@@ -11,9 +11,8 @@ LL | #![deny(let_underscore_drop)]
    |         ^^^^^^^^^^^^^^^^^^^
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
-LL -     let _ = foo();
-LL +     let _unused = foo();
-   |
+LL |     let _unused = foo();
+   |         ~~~~~~~
 help: consider immediately dropping the value
    |
 LL -     let _ = foo();

--- a/tests/ui/lint/let_underscore/issue-119696-err-on-fn.stderr
+++ b/tests/ui/lint/let_underscore/issue-119696-err-on-fn.stderr
@@ -12,7 +12,7 @@ LL | #![deny(let_underscore_drop)]
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
 LL |     let _unused = foo();
-   |         ~~~~~~~
+   |          ++++++
 help: consider immediately dropping the value
    |
 LL -     let _ = foo();

--- a/tests/ui/lint/let_underscore/issue-119697-extra-let.stderr
+++ b/tests/ui/lint/let_underscore/issue-119697-extra-let.stderr
@@ -29,7 +29,7 @@ LL |     let _ = field;
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
 LL |     let _unused = field;
-   |         ~~~~~~~
+   |          ++++++
 help: consider immediately dropping the value
    |
 LL -     let _ = field;

--- a/tests/ui/lint/let_underscore/issue-119697-extra-let.stderr
+++ b/tests/ui/lint/let_underscore/issue-119697-extra-let.stderr
@@ -28,9 +28,8 @@ LL |     let _ = field;
    |
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
-LL -     let _ = field;
-LL +     let _unused = field;
-   |
+LL |     let _unused = field;
+   |         ~~~~~~~
 help: consider immediately dropping the value
    |
 LL -     let _ = field;

--- a/tests/ui/lint/let_underscore/let_underscore_drop.stderr
+++ b/tests/ui/lint/let_underscore/let_underscore_drop.stderr
@@ -11,9 +11,8 @@ LL | #![warn(let_underscore_drop)]
    |         ^^^^^^^^^^^^^^^^^^^
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
-LL -     let _ = NontrivialDrop;
-LL +     let _unused = NontrivialDrop;
-   |
+LL |     let _unused = NontrivialDrop;
+   |         ~~~~~~~
 help: consider immediately dropping the value
    |
 LL -     let _ = NontrivialDrop;

--- a/tests/ui/lint/let_underscore/let_underscore_drop.stderr
+++ b/tests/ui/lint/let_underscore/let_underscore_drop.stderr
@@ -12,7 +12,7 @@ LL | #![warn(let_underscore_drop)]
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
 LL |     let _unused = NontrivialDrop;
-   |         ~~~~~~~
+   |          ++++++
 help: consider immediately dropping the value
    |
 LL -     let _ = NontrivialDrop;

--- a/tests/ui/lint/let_underscore/let_underscore_lock.stderr
+++ b/tests/ui/lint/let_underscore/let_underscore_lock.stderr
@@ -7,9 +7,8 @@ LL |     let _ = data.lock().unwrap();
    = note: `#[deny(let_underscore_lock)]` on by default
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
-LL -     let _ = data.lock().unwrap();
-LL +     let _unused = data.lock().unwrap();
-   |
+LL |     let _unused = data.lock().unwrap();
+   |         ~~~~~~~
 help: consider immediately dropping the value
    |
 LL -     let _ = data.lock().unwrap();
@@ -24,9 +23,8 @@ LL |     let _ = data.lock();
    |
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
-LL -     let _ = data.lock();
-LL +     let _unused = data.lock();
-   |
+LL |     let _unused = data.lock();
+   |         ~~~~~~~
 help: consider immediately dropping the value
    |
 LL -     let _ = data.lock();
@@ -42,9 +40,8 @@ LL |     let (_, _) = (data.lock(), 1);
    = help: consider immediately dropping the value using `drop(..)` after the `let` statement
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
-LL -     let (_, _) = (data.lock(), 1);
-LL +     let (_unused, _) = (data.lock(), 1);
-   |
+LL |     let (_unused, _) = (data.lock(), 1);
+   |          ~~~~~~~
 
 error: non-binding let on a synchronization lock
   --> $DIR/let_underscore_lock.rs:16:26
@@ -55,9 +52,8 @@ LL |     let (_a, Struct { a: _ }) = (0, Struct { a: data.lock() });
    = help: consider immediately dropping the value using `drop(..)` after the `let` statement
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
-LL -     let (_a, Struct { a: _ }) = (0, Struct { a: data.lock() });
-LL +     let (_a, Struct { a: _unused }) = (0, Struct { a: data.lock() });
-   |
+LL |     let (_a, Struct { a: _unused }) = (0, Struct { a: data.lock() });
+   |                          ~~~~~~~
 
 error: non-binding let on a synchronization lock
   --> $DIR/let_underscore_lock.rs:18:6

--- a/tests/ui/lint/let_underscore/let_underscore_lock.stderr
+++ b/tests/ui/lint/let_underscore/let_underscore_lock.stderr
@@ -8,7 +8,7 @@ LL |     let _ = data.lock().unwrap();
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
 LL |     let _unused = data.lock().unwrap();
-   |         ~~~~~~~
+   |          ++++++
 help: consider immediately dropping the value
    |
 LL -     let _ = data.lock().unwrap();
@@ -24,7 +24,7 @@ LL |     let _ = data.lock();
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
 LL |     let _unused = data.lock();
-   |         ~~~~~~~
+   |          ++++++
 help: consider immediately dropping the value
    |
 LL -     let _ = data.lock();
@@ -41,7 +41,7 @@ LL |     let (_, _) = (data.lock(), 1);
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
 LL |     let (_unused, _) = (data.lock(), 1);
-   |          ~~~~~~~
+   |           ++++++
 
 error: non-binding let on a synchronization lock
   --> $DIR/let_underscore_lock.rs:16:26
@@ -53,7 +53,7 @@ LL |     let (_a, Struct { a: _ }) = (0, Struct { a: data.lock() });
 help: consider binding to an unused variable to avoid immediately dropping the value
    |
 LL |     let (_a, Struct { a: _unused }) = (0, Struct { a: data.lock() });
-   |                          ~~~~~~~
+   |                           ++++++
 
 error: non-binding let on a synchronization lock
   --> $DIR/let_underscore_lock.rs:18:6

--- a/tests/ui/lint/lint-strict-provenance-lossy-casts.stderr
+++ b/tests/ui/lint/lint-strict-provenance-lossy-casts.stderr
@@ -26,7 +26,7 @@ LL |     let addr_32bit = &x as *const u8 as u32;
 help: use `.addr()` to obtain the address of a pointer
    |
 LL |     let addr_32bit = (&x as *const u8).addr() as u32;
-   |                      +               ~~~~~~~~~~~~~~~
+   |                      +               ++++++++
 
 error: under strict provenance it is considered bad style to cast pointer `*const u8` to integer `usize`
   --> $DIR/lint-strict-provenance-lossy-casts.rs:14:20

--- a/tests/ui/lint/lint-strict-provenance-lossy-casts.stderr
+++ b/tests/ui/lint/lint-strict-provenance-lossy-casts.stderr
@@ -25,9 +25,8 @@ LL |     let addr_32bit = &x as *const u8 as u32;
    = help: if you can't comply with strict provenance and need to expose the pointer provenance you can use `.expose_provenance()` instead
 help: use `.addr()` to obtain the address of a pointer
    |
-LL -     let addr_32bit = &x as *const u8 as u32;
-LL +     let addr_32bit = (&x as *const u8).addr() as u32;
-   |
+LL |     let addr_32bit = (&x as *const u8).addr() as u32;
+   |                      +               ~~~~~~~~~~~~~~~
 
 error: under strict provenance it is considered bad style to cast pointer `*const u8` to integer `usize`
   --> $DIR/lint-strict-provenance-lossy-casts.rs:14:20

--- a/tests/ui/lint/static-mut-refs.e2021.stderr
+++ b/tests/ui/lint/static-mut-refs.e2021.stderr
@@ -10,7 +10,7 @@ LL |         let _y = &X;
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let _y = &raw const X;
-   |                  ~~~~~~~~~~
+   |                   +++++++++
 
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:42:18
@@ -46,7 +46,7 @@ LL |         let (_b, _c) = (&X, &Y);
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let (_b, _c) = (&raw const X, &Y);
-   |                         ~~~~~~~~~~
+   |                          +++++++++
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:54:29
@@ -59,7 +59,7 @@ LL |         let (_b, _c) = (&X, &Y);
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let (_b, _c) = (&X, &raw const Y);
-   |                             ~~~~~~~~~~
+   |                              +++++++++
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:60:13
@@ -72,7 +72,7 @@ LL |         foo(&X);
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         foo(&raw const X);
-   |             ~~~~~~~~~~
+   |              +++++++++
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:66:17
@@ -103,7 +103,7 @@ LL |         let _v = &A.value;
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let _v = &raw const A.value;
-   |                  ~~~~~~~~~~
+   |                   +++++++++
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:80:18
@@ -116,7 +116,7 @@ LL |         let _s = &A.s.value;
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let _s = &raw const A.s.value;
-   |                  ~~~~~~~~~~
+   |                   +++++++++
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:84:22

--- a/tests/ui/lint/static-mut-refs.e2021.stderr
+++ b/tests/ui/lint/static-mut-refs.e2021.stderr
@@ -9,9 +9,8 @@ LL |         let _y = &X;
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         let _y = &X;
-LL +         let _y = &raw const X;
-   |
+LL |         let _y = &raw const X;
+   |                  ~~~~~~~~~~
 
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:42:18
@@ -46,9 +45,8 @@ LL |         let (_b, _c) = (&X, &Y);
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         let (_b, _c) = (&X, &Y);
-LL +         let (_b, _c) = (&raw const X, &Y);
-   |
+LL |         let (_b, _c) = (&raw const X, &Y);
+   |                         ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:54:29
@@ -60,9 +58,8 @@ LL |         let (_b, _c) = (&X, &Y);
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         let (_b, _c) = (&X, &Y);
-LL +         let (_b, _c) = (&X, &raw const Y);
-   |
+LL |         let (_b, _c) = (&X, &raw const Y);
+   |                             ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:60:13
@@ -74,9 +71,8 @@ LL |         foo(&X);
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         foo(&X);
-LL +         foo(&raw const X);
-   |
+LL |         foo(&raw const X);
+   |             ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:66:17
@@ -106,9 +102,8 @@ LL |         let _v = &A.value;
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         let _v = &A.value;
-LL +         let _v = &raw const A.value;
-   |
+LL |         let _v = &raw const A.value;
+   |                  ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:80:18
@@ -120,9 +115,8 @@ LL |         let _s = &A.s.value;
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         let _s = &A.s.value;
-LL +         let _s = &raw const A.s.value;
-   |
+LL |         let _s = &raw const A.s.value;
+   |                  ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:84:22

--- a/tests/ui/lint/static-mut-refs.e2024.stderr
+++ b/tests/ui/lint/static-mut-refs.e2024.stderr
@@ -9,9 +9,8 @@ LL |         let _y = &X;
    = note: `#[deny(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         let _y = &X;
-LL +         let _y = &raw const X;
-   |
+LL |         let _y = &raw const X;
+   |                  ~~~~~~~~~~
 
 error: creating a mutable reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:42:18
@@ -46,9 +45,8 @@ LL |         let (_b, _c) = (&X, &Y);
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         let (_b, _c) = (&X, &Y);
-LL +         let (_b, _c) = (&raw const X, &Y);
-   |
+LL |         let (_b, _c) = (&raw const X, &Y);
+   |                         ~~~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:54:29
@@ -60,9 +58,8 @@ LL |         let (_b, _c) = (&X, &Y);
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         let (_b, _c) = (&X, &Y);
-LL +         let (_b, _c) = (&X, &raw const Y);
-   |
+LL |         let (_b, _c) = (&X, &raw const Y);
+   |                             ~~~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:60:13
@@ -74,9 +71,8 @@ LL |         foo(&X);
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         foo(&X);
-LL +         foo(&raw const X);
-   |
+LL |         foo(&raw const X);
+   |             ~~~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:66:17
@@ -106,9 +102,8 @@ LL |         let _v = &A.value;
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         let _v = &A.value;
-LL +         let _v = &raw const A.value;
-   |
+LL |         let _v = &raw const A.value;
+   |                  ~~~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:80:18
@@ -120,9 +115,8 @@ LL |         let _s = &A.s.value;
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -         let _s = &A.s.value;
-LL +         let _s = &raw const A.s.value;
-   |
+LL |         let _s = &raw const A.s.value;
+   |                  ~~~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:84:22

--- a/tests/ui/lint/static-mut-refs.e2024.stderr
+++ b/tests/ui/lint/static-mut-refs.e2024.stderr
@@ -10,7 +10,7 @@ LL |         let _y = &X;
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let _y = &raw const X;
-   |                  ~~~~~~~~~~
+   |                   +++++++++
 
 error: creating a mutable reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:42:18
@@ -46,7 +46,7 @@ LL |         let (_b, _c) = (&X, &Y);
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let (_b, _c) = (&raw const X, &Y);
-   |                         ~~~~~~~~~~
+   |                          +++++++++
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:54:29
@@ -59,7 +59,7 @@ LL |         let (_b, _c) = (&X, &Y);
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let (_b, _c) = (&X, &raw const Y);
-   |                             ~~~~~~~~~~
+   |                              +++++++++
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:60:13
@@ -72,7 +72,7 @@ LL |         foo(&X);
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         foo(&raw const X);
-   |             ~~~~~~~~~~
+   |              +++++++++
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:66:17
@@ -103,7 +103,7 @@ LL |         let _v = &A.value;
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let _v = &raw const A.value;
-   |                  ~~~~~~~~~~
+   |                   +++++++++
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:80:18
@@ -116,7 +116,7 @@ LL |         let _s = &A.s.value;
 help: use `&raw const` instead to create a raw pointer
    |
 LL |         let _s = &raw const A.s.value;
-   |                  ~~~~~~~~~~
+   |                   +++++++++
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:84:22

--- a/tests/ui/lint/type-overflow.stderr
+++ b/tests/ui/lint/type-overflow.stderr
@@ -66,9 +66,8 @@ LL |     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
    = help: consider using the type `u128` instead
 help: to use as a negative number (decimal `-170141183460469231731687303715884105728`), consider using the type `u128` for the literal and cast it to `i128`
    |
-LL -     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
-LL +     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000u128 as i128;
-   |
+LL |     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000u128 as i128;
+   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 warning: literal out of range for `i32`
   --> $DIR/type-overflow.rs:27:16
@@ -117,9 +116,8 @@ LL |     let fail = 0x8FFF_FFFF_FFFF_FFFE;
    = help: consider using the type `u64` instead
 help: to use as a negative number (decimal `-2`), consider using the type `u32` for the literal and cast it to `i32`
    |
-LL -     let fail = 0x8FFF_FFFF_FFFF_FFFE;
-LL +     let fail = 0x8FFF_FFFF_FFFF_FFFEu32 as i32;
-   |
+LL |     let fail = 0x8FFF_FFFF_FFFF_FFFEu32 as i32;
+   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 warning: literal out of range for `i8`
   --> $DIR/type-overflow.rs:46:17

--- a/tests/ui/lint/type-overflow.stderr
+++ b/tests/ui/lint/type-overflow.stderr
@@ -67,7 +67,7 @@ LL |     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
 help: to use as a negative number (decimal `-170141183460469231731687303715884105728`), consider using the type `u128` for the literal and cast it to `i128`
    |
 LL |     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000u128 as i128;
-   |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                                               ++++++++++++
 
 warning: literal out of range for `i32`
   --> $DIR/type-overflow.rs:27:16
@@ -117,7 +117,7 @@ LL |     let fail = 0x8FFF_FFFF_FFFF_FFFE;
 help: to use as a negative number (decimal `-2`), consider using the type `u32` for the literal and cast it to `i32`
    |
 LL |     let fail = 0x8FFF_FFFF_FFFF_FFFEu32 as i32;
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                     ++++++++++
 
 warning: literal out of range for `i8`
   --> $DIR/type-overflow.rs:46:17

--- a/tests/ui/lint/unused/issue-67691-unused-field-in-or-pattern.stderr
+++ b/tests/ui/lint/unused/issue-67691-unused-field-in-or-pattern.stderr
@@ -13,7 +13,7 @@ LL | #![deny(unused)]
 help: try ignoring the field
    |
 LL |         A { i, j: _ } | B { i, j: _ } => {
-   |                ~~~~            ~~~~
+   |                 +++             +++
 
 error: unused variable: `j`
   --> $DIR/issue-67691-unused-field-in-or-pattern.rs:30:16
@@ -36,7 +36,7 @@ LL |         Some(A { i, j } | B { i, j }) => {
 help: try ignoring the field
    |
 LL |         Some(A { i, j: _ } | B { i, j: _ }) => {
-   |                     ~~~~            ~~~~
+   |                      +++             +++
 
 error: unused variable: `j`
   --> $DIR/issue-67691-unused-field-in-or-pattern.rs:52:21

--- a/tests/ui/lint/unused/issue-67691-unused-field-in-or-pattern.stderr
+++ b/tests/ui/lint/unused/issue-67691-unused-field-in-or-pattern.stderr
@@ -12,9 +12,8 @@ LL | #![deny(unused)]
    = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
 help: try ignoring the field
    |
-LL -         A { i, j } | B { i, j } => {
-LL +         A { i, j: _ } | B { i, j: _ } => {
-   |
+LL |         A { i, j: _ } | B { i, j: _ } => {
+   |                ~~~~            ~~~~
 
 error: unused variable: `j`
   --> $DIR/issue-67691-unused-field-in-or-pattern.rs:30:16
@@ -36,9 +35,8 @@ LL |         Some(A { i, j } | B { i, j }) => {
    |
 help: try ignoring the field
    |
-LL -         Some(A { i, j } | B { i, j }) => {
-LL +         Some(A { i, j: _ } | B { i, j: _ }) => {
-   |
+LL |         Some(A { i, j: _ } | B { i, j: _ }) => {
+   |                     ~~~~            ~~~~
 
 error: unused variable: `j`
   --> $DIR/issue-67691-unused-field-in-or-pattern.rs:52:21

--- a/tests/ui/lint/wide_pointer_comparisons.stderr
+++ b/tests/ui/lint/wide_pointer_comparisons.stderr
@@ -627,9 +627,8 @@ LL |         cmp!(a, b);
    |
 help: use `std::ptr::addr_eq` or untyped pointers to only compare their addresses
    |
-LL -         cmp!(a, b);
-LL +         cmp!(std::ptr::addr_eq(a, b));
-   |
+LL |         cmp!(std::ptr::addr_eq(a, b));
+   |              ++++++++++++++++++    +
 
 warning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
   --> $DIR/wide_pointer_comparisons.rs:159:39

--- a/tests/ui/macros/expr_2021_cargo_fix_edition.stderr
+++ b/tests/ui/macros/expr_2021_cargo_fix_edition.stderr
@@ -14,7 +14,7 @@ LL | #![warn(edition_2024_expr_fragment_specifier)]
 help: to keep the existing behavior, use the `expr_2021` fragment specifier
    |
 LL |     ($e:expr_2021) => {
-   |         ~~~~~~~~~
+   |             +++++
 
 warning: the `expr` fragment specifier will accept more expressions in the 2024 edition
   --> $DIR/expr_2021_cargo_fix_edition.rs:11:11
@@ -27,7 +27,7 @@ LL |     ($($i:expr)*) => { };
 help: to keep the existing behavior, use the `expr_2021` fragment specifier
    |
 LL |     ($($i:expr_2021)*) => { };
-   |           ~~~~~~~~~
+   |               +++++
 
 warning: 2 warnings emitted
 

--- a/tests/ui/macros/expr_2021_cargo_fix_edition.stderr
+++ b/tests/ui/macros/expr_2021_cargo_fix_edition.stderr
@@ -13,9 +13,8 @@ LL | #![warn(edition_2024_expr_fragment_specifier)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: to keep the existing behavior, use the `expr_2021` fragment specifier
    |
-LL -     ($e:expr) => {
-LL +     ($e:expr_2021) => {
-   |
+LL |     ($e:expr_2021) => {
+   |         ~~~~~~~~~
 
 warning: the `expr` fragment specifier will accept more expressions in the 2024 edition
   --> $DIR/expr_2021_cargo_fix_edition.rs:11:11
@@ -27,9 +26,8 @@ LL |     ($($i:expr)*) => { };
    = note: for more information, see Migration Guide <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/macro-fragment-specifiers.html>
 help: to keep the existing behavior, use the `expr_2021` fragment specifier
    |
-LL -     ($($i:expr)*) => { };
-LL +     ($($i:expr_2021)*) => { };
-   |
+LL |     ($($i:expr_2021)*) => { };
+   |           ~~~~~~~~~
 
 warning: 2 warnings emitted
 

--- a/tests/ui/macros/macro-backtrace-invalid-internals.stderr
+++ b/tests/ui/macros/macro-backtrace-invalid-internals.stderr
@@ -44,7 +44,7 @@ LL |     real_method_stmt!();
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |           2.0_f32.neg()
-   |           ~~~~~~~
+   |              ++++
 
 error[E0599]: no method named `fake` found for type `{integer}` in the current scope
   --> $DIR/macro-backtrace-invalid-internals.rs:23:13
@@ -92,7 +92,7 @@ LL |     let _ = real_method_expr!();
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |           2.0_f32.neg()
-   |           ~~~~~~~
+   |              ++++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/macros/macro-backtrace-invalid-internals.stderr
+++ b/tests/ui/macros/macro-backtrace-invalid-internals.stderr
@@ -43,9 +43,8 @@ LL |     real_method_stmt!();
    = note: this error originates in the macro `real_method_stmt` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you must specify a concrete type for this numeric value, like `f32`
    |
-LL -           2.0.neg()
-LL +           2.0_f32.neg()
-   |
+LL |           2.0_f32.neg()
+   |           ~~~~~~~
 
 error[E0599]: no method named `fake` found for type `{integer}` in the current scope
   --> $DIR/macro-backtrace-invalid-internals.rs:23:13
@@ -92,9 +91,8 @@ LL |     let _ = real_method_expr!();
    = note: this error originates in the macro `real_method_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you must specify a concrete type for this numeric value, like `f32`
    |
-LL -           2.0.neg()
-LL +           2.0_f32.neg()
-   |
+LL |           2.0_f32.neg()
+   |           ~~~~~~~
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/match/issue-56685.stderr
+++ b/tests/ui/match/issue-56685.stderr
@@ -12,7 +12,7 @@ LL | #![deny(unused_variables)]
 help: if this is intentional, prefix it with an underscore
    |
 LL |         E::A(_x) | E::B(_x) => {}
-   |              ~~         ~~
+   |              +          +
 
 error: unused variable: `x`
   --> $DIR/issue-56685.rs:25:14
@@ -23,7 +23,7 @@ LL |         F::A(x, y) | F::B(x, y) => { y },
 help: if this is intentional, prefix it with an underscore
    |
 LL |         F::A(_x, y) | F::B(_x, y) => { y },
-   |              ~~            ~~
+   |              +             +
 
 error: unused variable: `a`
   --> $DIR/issue-56685.rs:27:14
@@ -46,7 +46,7 @@ LL |     let _ = if let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
 help: if this is intentional, prefix it with an underscore
    |
 LL |     let _ = if let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
-   |                         ~~            ~~
+   |                         +             +
 
 error: unused variable: `x`
   --> $DIR/issue-56685.rs:39:20
@@ -57,7 +57,7 @@ LL |     while let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
 help: if this is intentional, prefix it with an underscore
    |
 LL |     while let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
-   |                    ~~            ~~
+   |                    +             +
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/match/issue-56685.stderr
+++ b/tests/ui/match/issue-56685.stderr
@@ -11,9 +11,8 @@ LL | #![deny(unused_variables)]
    |         ^^^^^^^^^^^^^^^^
 help: if this is intentional, prefix it with an underscore
    |
-LL -         E::A(x) | E::B(x) => {}
-LL +         E::A(_x) | E::B(_x) => {}
-   |
+LL |         E::A(_x) | E::B(_x) => {}
+   |              ~~         ~~
 
 error: unused variable: `x`
   --> $DIR/issue-56685.rs:25:14
@@ -23,9 +22,8 @@ LL |         F::A(x, y) | F::B(x, y) => { y },
    |
 help: if this is intentional, prefix it with an underscore
    |
-LL -         F::A(x, y) | F::B(x, y) => { y },
-LL +         F::A(_x, y) | F::B(_x, y) => { y },
-   |
+LL |         F::A(_x, y) | F::B(_x, y) => { y },
+   |              ~~            ~~
 
 error: unused variable: `a`
   --> $DIR/issue-56685.rs:27:14
@@ -47,9 +45,8 @@ LL |     let _ = if let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
    |
 help: if this is intentional, prefix it with an underscore
    |
-LL -     let _ = if let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
-LL +     let _ = if let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
-   |
+LL |     let _ = if let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
+   |                         ~~            ~~
 
 error: unused variable: `x`
   --> $DIR/issue-56685.rs:39:20
@@ -59,9 +56,8 @@ LL |     while let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
    |
 help: if this is intentional, prefix it with an underscore
    |
-LL -     while let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
-LL +     while let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
-   |
+LL |     while let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
+   |                    ~~            ~~
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/methods/issues/issue-90315.stderr
+++ b/tests/ui/methods/issues/issue-90315.stderr
@@ -182,7 +182,7 @@ LL |     let _res: i32 = ..6.take(2).sum();
 help: you must specify a concrete type for this numeric value, like `i32`
    |
 LL |     let _res: i32 = ..6_i32.take(2).sum();
-   |                       ~~~~~
+   |                        ++++
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/methods/issues/issue-90315.stderr
+++ b/tests/ui/methods/issues/issue-90315.stderr
@@ -181,9 +181,8 @@ LL |     let _res: i32 = ..6.take(2).sum();
    |
 help: you must specify a concrete type for this numeric value, like `i32`
    |
-LL -     let _res: i32 = ..6.take(2).sum();
-LL +     let _res: i32 = ..6_i32.take(2).sum();
-   |
+LL |     let _res: i32 = ..6_i32.take(2).sum();
+   |                       ~~~~~
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/methods/method-on-ambiguous-numeric-type.stderr
+++ b/tests/ui/methods/method-on-ambiguous-numeric-type.stderr
@@ -7,7 +7,7 @@ LL |     let x = 2.0.neg();
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |     let x = 2.0_f32.neg();
-   |             ~~~~~~~
+   |                ++++
 
 error[E0689]: can't call method `neg` on ambiguous numeric type `{float}`
   --> $DIR/method-on-ambiguous-numeric-type.rs:17:15

--- a/tests/ui/methods/method-on-ambiguous-numeric-type.stderr
+++ b/tests/ui/methods/method-on-ambiguous-numeric-type.stderr
@@ -6,9 +6,8 @@ LL |     let x = 2.0.neg();
    |
 help: you must specify a concrete type for this numeric value, like `f32`
    |
-LL -     let x = 2.0.neg();
-LL +     let x = 2.0_f32.neg();
-   |
+LL |     let x = 2.0_f32.neg();
+   |             ~~~~~~~
 
 error[E0689]: can't call method `neg` on ambiguous numeric type `{float}`
   --> $DIR/method-on-ambiguous-numeric-type.rs:17:15

--- a/tests/ui/mir/issue-112269.stderr
+++ b/tests/ui/mir/issue-112269.stderr
@@ -12,7 +12,7 @@ LL |     let x: i32 = 3;
 help: introduce a variable instead
    |
 LL |     let x_var: i32 = 3;
-   |         ~~~~~
+   |          ++++
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/issue-112269.rs:7:9
@@ -28,7 +28,7 @@ LL |     let y = 4;
 help: introduce a variable instead
    |
 LL |     let y_var = 4;
-   |         ~~~~~
+   |          ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/mir/issue-112269.stderr
+++ b/tests/ui/mir/issue-112269.stderr
@@ -11,9 +11,8 @@ LL |     let x: i32 = 3;
    = note: the matched value is of type `i32`
 help: introduce a variable instead
    |
-LL -     let x: i32 = 3;
-LL +     let x_var: i32 = 3;
-   |
+LL |     let x_var: i32 = 3;
+   |         ~~~~~
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/issue-112269.rs:7:9
@@ -28,9 +27,8 @@ LL |     let y = 4;
    = note: the matched value is of type `i32`
 help: introduce a variable instead
    |
-LL -     let y = 4;
-LL +     let y_var = 4;
-   |
+LL |     let y_var = 4;
+   |         ~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/mismatched_types/issue-112036.stderr
+++ b/tests/ui/mismatched_types/issue-112036.stderr
@@ -9,7 +9,7 @@ LL |     fn drop(self) {}
 help: change the self-receiver type to match the trait
    |
 LL |     fn drop(&mut self) {}
-   |             ~~~~~~~~~
+   |             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/mismatched_types/issue-112036.stderr
+++ b/tests/ui/mismatched_types/issue-112036.stderr
@@ -8,9 +8,8 @@ LL |     fn drop(self) {}
               found signature `fn(Foo)`
 help: change the self-receiver type to match the trait
    |
-LL -     fn drop(self) {}
-LL +     fn drop(&mut self) {}
-   |
+LL |     fn drop(&mut self) {}
+   |             ~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/moves/use_of_moved_value_copy_suggestions.stderr
+++ b/tests/ui/moves/use_of_moved_value_copy_suggestions.stderr
@@ -196,7 +196,7 @@ LL |     [t, t];
 help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL |     T:, T: Copy
-   |       ~~~~~~~~~
+   |         +++++++
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/moves/use_of_moved_value_copy_suggestions.stderr
+++ b/tests/ui/moves/use_of_moved_value_copy_suggestions.stderr
@@ -195,9 +195,8 @@ LL |     [t, t];
    |      - you could clone this value
 help: consider further restricting type parameter `T` with trait `Copy`
    |
-LL -     T:,
-LL +     T:, T: Copy
-   |
+LL |     T:, T: Copy
+   |       ~~~~~~~~~
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/namespace/namespace-mix.stderr
+++ b/tests/ui/namespace/namespace-mix.stderr
@@ -11,7 +11,7 @@ LL |     check(m1::S);
 help: a tuple struct with a similar name exists
    |
 LL |     check(m1::TS);
-   |               ~~
+   |               +
 help: consider importing one of these constants instead
    |
 LL + use m2::S;
@@ -39,7 +39,7 @@ LL |     pub struct TS();
 help: a tuple struct with a similar name exists
    |
 LL |     check(xm1::TS);
-   |                ~~
+   |                +
 help: consider importing one of these constants instead
    |
 LL + use m2::S;
@@ -65,7 +65,7 @@ LL |     check(m7::V);
 help: a tuple variant with a similar name exists
    |
 LL |     check(m7::TV);
-   |               ~~
+   |               +
 help: consider importing one of these constants instead
    |
 LL + use m8::V;
@@ -93,7 +93,7 @@ LL |         TV(),
 help: a tuple variant with a similar name exists
    |
 LL |     check(xm7::TV);
-   |                ~~
+   |                +
 help: consider importing one of these constants instead
    |
 LL + use m8::V;

--- a/tests/ui/namespace/namespace-mix.stderr
+++ b/tests/ui/namespace/namespace-mix.stderr
@@ -10,9 +10,8 @@ LL |     check(m1::S);
    = note: can't use a type alias as a constructor
 help: a tuple struct with a similar name exists
    |
-LL -     check(m1::S);
-LL +     check(m1::TS);
-   |
+LL |     check(m1::TS);
+   |               ~~
 help: consider importing one of these constants instead
    |
 LL + use m2::S;
@@ -39,9 +38,8 @@ LL |     pub struct TS();
    = note: can't use a type alias as a constructor
 help: a tuple struct with a similar name exists
    |
-LL -     check(xm1::S);
-LL +     check(xm1::TS);
-   |
+LL |     check(xm1::TS);
+   |                ~~
 help: consider importing one of these constants instead
    |
 LL + use m2::S;
@@ -66,9 +64,8 @@ LL |     check(m7::V);
    = note: can't use a type alias as a constructor
 help: a tuple variant with a similar name exists
    |
-LL -     check(m7::V);
-LL +     check(m7::TV);
-   |
+LL |     check(m7::TV);
+   |               ~~
 help: consider importing one of these constants instead
    |
 LL + use m8::V;
@@ -95,9 +92,8 @@ LL |         TV(),
    = note: can't use a type alias as a constructor
 help: a tuple variant with a similar name exists
    |
-LL -     check(xm7::V);
-LL +     check(xm7::TV);
-   |
+LL |     check(xm7::TV);
+   |                ~~
 help: consider importing one of these constants instead
    |
 LL + use m8::V;

--- a/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -34,7 +34,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
 help: consider adding an explicit lifetime bound
    |
 LL |     T: Iterator, <T as Iterator>::Item: 'a
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                  +++++++++++++++++++++++++
 
 note: external requirements
   --> $DIR/projection-no-regions-closure.rs:34:23
@@ -96,7 +96,7 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
 help: consider adding an explicit lifetime bound
    |
 LL |     T: 'b + Iterator, <T as Iterator>::Item: 'a
-   |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       +++++++++++++++++++++++++
 
 note: external requirements
   --> $DIR/projection-no-regions-closure.rs:52:23

--- a/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-closure.stderr
@@ -33,9 +33,8 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    |
 help: consider adding an explicit lifetime bound
    |
-LL -     T: Iterator,
-LL +     T: Iterator, <T as Iterator>::Item: 'a
-   |
+LL |     T: Iterator, <T as Iterator>::Item: 'a
+   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 note: external requirements
   --> $DIR/projection-no-regions-closure.rs:34:23
@@ -96,9 +95,8 @@ LL |     with_signature(x, |mut y| Box::new(y.next()))
    |
 help: consider adding an explicit lifetime bound
    |
-LL -     T: 'b + Iterator,
-LL +     T: 'b + Iterator, <T as Iterator>::Item: 'a
-   |
+LL |     T: 'b + Iterator, <T as Iterator>::Item: 'a
+   |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 note: external requirements
   --> $DIR/projection-no-regions-closure.rs:52:23

--- a/tests/ui/nll/ty-outlives/projection-no-regions-fn.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-fn.stderr
@@ -10,7 +10,7 @@ LL |     Box::new(x.next())
 help: consider adding an explicit lifetime bound
    |
 LL |     T: Iterator, <T as Iterator>::Item: 'a
-   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                  +++++++++++++++++++++++++
 
 error[E0309]: the associated type `<T as Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-fn.rs:28:5
@@ -24,7 +24,7 @@ LL |     Box::new(x.next())
 help: consider adding an explicit lifetime bound
    |
 LL |     T: 'b + Iterator, <T as Iterator>::Item: 'a
-   |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                       +++++++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/ty-outlives/projection-no-regions-fn.stderr
+++ b/tests/ui/nll/ty-outlives/projection-no-regions-fn.stderr
@@ -9,9 +9,8 @@ LL |     Box::new(x.next())
    |
 help: consider adding an explicit lifetime bound
    |
-LL -     T: Iterator,
-LL +     T: Iterator, <T as Iterator>::Item: 'a
-   |
+LL |     T: Iterator, <T as Iterator>::Item: 'a
+   |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0309]: the associated type `<T as Iterator>::Item` may not live long enough
   --> $DIR/projection-no-regions-fn.rs:28:5
@@ -24,9 +23,8 @@ LL |     Box::new(x.next())
    |
 help: consider adding an explicit lifetime bound
    |
-LL -     T: 'b + Iterator,
-LL +     T: 'b + Iterator, <T as Iterator>::Item: 'a
-   |
+LL |     T: 'b + Iterator, <T as Iterator>::Item: 'a
+   |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -34,9 +34,8 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
 help: consider adding an explicit lifetime bound
    |
-LL -     T: Anything<'b, 'c>,
-LL +     T: Anything<'b, 'c>, <T as Anything<'b/#0, 'c/#1>>::AssocType: 'a
-   |
+LL |     T: Anything<'b, 'c>, <T as Anything<'b/#0, 'c/#1>>::AssocType: 'a
+   |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
@@ -74,9 +73,8 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
 help: consider adding an explicit lifetime bound
    |
-LL -     'a: 'a,
-LL +     'a: 'a, <T as Anything<'b/#1, 'c/#2>>::AssocType: 'a
-   |
+LL |     'a: 'a, <T as Anything<'b/#1, 'c/#2>>::AssocType: 'a
+   |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:61:29

--- a/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/tests/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -35,7 +35,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
 help: consider adding an explicit lifetime bound
    |
 LL |     T: Anything<'b, 'c>, <T as Anything<'b/#0, 'c/#1>>::AssocType: 'a
-   |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                          ++++++++++++++++++++++++++++++++++++++++++++
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:48:29
@@ -74,7 +74,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
 help: consider adding an explicit lifetime bound
    |
 LL |     'a: 'a, <T as Anything<'b/#1, 'c/#2>>::AssocType: 'a
-   |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             ++++++++++++++++++++++++++++++++++++++++++++
 
 note: external requirements
   --> $DIR/projection-two-region-trait-bound-closure.rs:61:29

--- a/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-bound.stderr
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-bound.stderr
@@ -10,7 +10,7 @@ LL |     bar::<T::Output>()
 help: consider adding an explicit lifetime bound
    |
 LL |     <T as MyTrait<'a>>::Output: 'b, <T as MyTrait<'a>>::Output: 'a
-   |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                     ++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-bound.stderr
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-bound.stderr
@@ -9,9 +9,8 @@ LL |     bar::<T::Output>()
    |
 help: consider adding an explicit lifetime bound
    |
-LL -     <T as MyTrait<'a>>::Output: 'b,
-LL +     <T as MyTrait<'a>>::Output: 'b, <T as MyTrait<'a>>::Output: 'a
-   |
+LL |     <T as MyTrait<'a>>::Output: 'b, <T as MyTrait<'a>>::Output: 'a
+   |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-lifetime.stderr
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-lifetime.stderr
@@ -10,7 +10,7 @@ LL |     bar::<<T as MyTrait<'a>>::Output>()
 help: consider adding an explicit lifetime bound
    |
 LL |     <T as MyTrait<'b>>::Output: 'a, <T as MyTrait<'a>>::Output: 'a
-   |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                     ++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-lifetime.stderr
+++ b/tests/ui/nll/ty-outlives/projection-where-clause-env-wrong-lifetime.stderr
@@ -9,9 +9,8 @@ LL |     bar::<<T as MyTrait<'a>>::Output>()
    |
 help: consider adding an explicit lifetime bound
    |
-LL -     <T as MyTrait<'b>>::Output: 'a,
-LL +     <T as MyTrait<'b>>::Output: 'a, <T as MyTrait<'a>>::Output: 'a
-   |
+LL |     <T as MyTrait<'b>>::Output: 'a, <T as MyTrait<'a>>::Output: 'a
+   |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/object-pointer-types.stderr
+++ b/tests/ui/object-pointer-types.stderr
@@ -10,7 +10,7 @@ LL |     x.owned();
 help: there is a method `to_owned` with a similar name
    |
 LL |     x.to_owned();
-   |       ~~~~~~~~
+   |       +++
 
 error[E0599]: no method named `owned` found for mutable reference `&mut dyn Foo` in the current scope
   --> $DIR/object-pointer-types.rs:17:7

--- a/tests/ui/object-pointer-types.stderr
+++ b/tests/ui/object-pointer-types.stderr
@@ -9,9 +9,8 @@ LL |     x.owned();
    |
 help: there is a method `to_owned` with a similar name
    |
-LL -     x.owned();
-LL +     x.to_owned();
-   |
+LL |     x.to_owned();
+   |       ~~~~~~~~
 
 error[E0599]: no method named `owned` found for mutable reference `&mut dyn Foo` in the current scope
   --> $DIR/object-pointer-types.rs:17:7

--- a/tests/ui/parser/bad-char-literals.stderr
+++ b/tests/ui/parser/bad-char-literals.stderr
@@ -6,9 +6,8 @@ LL |     ''';
    |
 help: escape the character
    |
-LL -     ''';
-LL +     '\'';
-   |
+LL |     '\'';
+   |      ~~
 
 error: character constant must be escaped: `\n`
   --> $DIR/bad-char-literals.rs:10:6

--- a/tests/ui/parser/bad-char-literals.stderr
+++ b/tests/ui/parser/bad-char-literals.stderr
@@ -7,7 +7,7 @@ LL |     ''';
 help: escape the character
    |
 LL |     '\'';
-   |      ~~
+   |      +
 
 error: character constant must be escaped: `\n`
   --> $DIR/bad-char-literals.rs:10:6

--- a/tests/ui/parser/bad-escape-suggest-raw-string.stderr
+++ b/tests/ui/parser/bad-escape-suggest-raw-string.stderr
@@ -8,7 +8,7 @@ LL |     let bad = "ab\[c";
 help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
    |
 LL |     let bad = r"ab\[c";
-   |               ~~~~~~~~
+   |               +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/bad-escape-suggest-raw-string.stderr
+++ b/tests/ui/parser/bad-escape-suggest-raw-string.stderr
@@ -7,9 +7,8 @@ LL |     let bad = "ab\[c";
    = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
 help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
    |
-LL -     let bad = "ab\[c";
-LL +     let bad = r"ab\[c";
-   |
+LL |     let bad = r"ab\[c";
+   |               ~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/byte-literals.stderr
+++ b/tests/ui/parser/byte-literals.stderr
@@ -40,7 +40,7 @@ LL |     b''';
 help: escape the character
    |
 LL |     b'\'';
-   |       ~~
+   |       +
 
 error: non-ASCII character in byte literal
   --> $DIR/byte-literals.rs:10:7

--- a/tests/ui/parser/byte-literals.stderr
+++ b/tests/ui/parser/byte-literals.stderr
@@ -39,9 +39,8 @@ LL |     b''';
    |
 help: escape the character
    |
-LL -     b''';
-LL +     b'\'';
-   |
+LL |     b'\'';
+   |       ~~
 
 error: non-ASCII character in byte literal
   --> $DIR/byte-literals.rs:10:7

--- a/tests/ui/parser/char/whitespace-character-literal.stderr
+++ b/tests/ui/parser/char/whitespace-character-literal.stderr
@@ -11,9 +11,8 @@ LL |     let _hair_space_around = ' x​';
    |                               ^^
 help: consider removing the non-printing characters
    |
-LL -     let _hair_space_around = ' x​';
-LL +     let _hair_space_around = 'x​';
-   |
+LL |     let _hair_space_around = 'x​';
+   |                               ~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/extern-no-fn.stderr
+++ b/tests/ui/parser/extern-no-fn.stderr
@@ -12,7 +12,7 @@ LL | }
 help: if you meant to call a macro, try
    |
 LL |     f!();
-   |     ~~
+   |      +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/extern-no-fn.stderr
+++ b/tests/ui/parser/extern-no-fn.stderr
@@ -11,9 +11,8 @@ LL | }
    |
 help: if you meant to call a macro, try
    |
-LL -     f();
-LL +     f!();
-   |
+LL |     f!();
+   |     ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-65257-invalid-var-decl-recovery.stderr
+++ b/tests/ui/parser/issues/issue-65257-invalid-var-decl-recovery.stderr
@@ -54,9 +54,8 @@ LL |     mut n = 0;
    |
 help: missing keyword
    |
-LL -     mut n = 0;
-LL +     let mut n = 0;
-   |
+LL |     let mut n = 0;
+   |     ~~~~~~~
 
 error: invalid variable declaration
   --> $DIR/issue-65257-invalid-var-decl-recovery.rs:16:5
@@ -66,9 +65,8 @@ LL |     mut var;
    |
 help: missing keyword
    |
-LL -     mut var;
-LL +     let mut var;
-   |
+LL |     let mut var;
+   |     ~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/issue-65257-invalid-var-decl-recovery.rs:20:33

--- a/tests/ui/parser/issues/issue-65257-invalid-var-decl-recovery.stderr
+++ b/tests/ui/parser/issues/issue-65257-invalid-var-decl-recovery.stderr
@@ -55,7 +55,7 @@ LL |     mut n = 0;
 help: missing keyword
    |
 LL |     let mut n = 0;
-   |     ~~~~~~~
+   |     +++
 
 error: invalid variable declaration
   --> $DIR/issue-65257-invalid-var-decl-recovery.rs:16:5
@@ -66,7 +66,7 @@ LL |     mut var;
 help: missing keyword
    |
 LL |     let mut var;
-   |     ~~~~~~~
+   |     +++
 
 error[E0308]: mismatched types
   --> $DIR/issue-65257-invalid-var-decl-recovery.rs:20:33

--- a/tests/ui/parser/issues/issue-87086-colon-path-sep.stderr
+++ b/tests/ui/parser/issues/issue-87086-colon-path-sep.stderr
@@ -9,7 +9,7 @@ LL |         Foo:Bar => {}
 help: maybe write a path separator here
    |
 LL |         Foo::Bar => {}
-   |            ~~
+   |             +
 
 error: expected one of `!`, `(`, `...`, `..=`, `..`, `::`, `{`, or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:23:17
@@ -22,7 +22,7 @@ LL |         qux::Foo:Bar => {}
 help: maybe write a path separator here
    |
 LL |         qux::Foo::Bar => {}
-   |                 ~~
+   |                  +
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:29:12
@@ -35,7 +35,7 @@ LL |         qux:Foo::Baz => {}
 help: maybe write a path separator here
    |
 LL |         qux::Foo::Baz => {}
-   |            ~~
+   |             +
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:35:12
@@ -61,7 +61,7 @@ LL |     if let Foo:Bar = f() {
 help: maybe write a path separator here
    |
 LL |     if let Foo::Bar = f() {
-   |               ~~
+   |                +
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:49:16
@@ -100,7 +100,7 @@ LL |         Foo:Bar::Baz => {}
 help: maybe write a path separator here
    |
 LL |         Foo::Bar::Baz => {}
-   |            ~~
+   |             +
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:75:12
@@ -113,7 +113,7 @@ LL |         Foo:Bar => {}
 help: maybe write a path separator here
    |
 LL |         Foo::Bar => {}
-   |            ~~
+   |             +
 
 warning: irrefutable `if let` pattern
   --> $DIR/issue-87086-colon-path-sep.rs:40:8

--- a/tests/ui/parser/issues/issue-87086-colon-path-sep.stderr
+++ b/tests/ui/parser/issues/issue-87086-colon-path-sep.stderr
@@ -8,9 +8,8 @@ LL |         Foo:Bar => {}
    |
 help: maybe write a path separator here
    |
-LL -         Foo:Bar => {}
-LL +         Foo::Bar => {}
-   |
+LL |         Foo::Bar => {}
+   |            ~~
 
 error: expected one of `!`, `(`, `...`, `..=`, `..`, `::`, `{`, or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:23:17
@@ -22,9 +21,8 @@ LL |         qux::Foo:Bar => {}
    |
 help: maybe write a path separator here
    |
-LL -         qux::Foo:Bar => {}
-LL +         qux::Foo::Bar => {}
-   |
+LL |         qux::Foo::Bar => {}
+   |                 ~~
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:29:12
@@ -36,9 +34,8 @@ LL |         qux:Foo::Baz => {}
    |
 help: maybe write a path separator here
    |
-LL -         qux:Foo::Baz => {}
-LL +         qux::Foo::Baz => {}
-   |
+LL |         qux::Foo::Baz => {}
+   |            ~~
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:35:12
@@ -64,9 +61,8 @@ LL |     if let Foo:Bar = f() {
    |
 help: maybe write a path separator here
    |
-LL -     if let Foo:Bar = f() {
-LL +     if let Foo::Bar = f() {
-   |
+LL |     if let Foo::Bar = f() {
+   |               ~~
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:49:16
@@ -106,9 +102,8 @@ LL |         Foo:Bar::Baz => {}
    |
 help: maybe write a path separator here
    |
-LL -         Foo:Bar::Baz => {}
-LL +         Foo::Bar::Baz => {}
-   |
+LL |         Foo::Bar::Baz => {}
+   |            ~~
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:75:12
@@ -120,9 +115,8 @@ LL |         Foo:Bar => {}
    |
 help: maybe write a path separator here
    |
-LL -         Foo:Bar => {}
-LL +         Foo::Bar => {}
-   |
+LL |         Foo::Bar => {}
+   |            ~~
 
 warning: irrefutable `if let` pattern
   --> $DIR/issue-87086-colon-path-sep.rs:40:8

--- a/tests/ui/parser/issues/issue-87086-colon-path-sep.stderr
+++ b/tests/ui/parser/issues/issue-87086-colon-path-sep.stderr
@@ -47,9 +47,8 @@ LL |         qux: Foo::Baz if true => {}
    |
 help: maybe write a path separator here
    |
-LL -         qux: Foo::Baz if true => {}
-LL +         qux::Foo::Baz if true => {}
-   |
+LL |         qux::Foo::Baz if true => {}
+   |            ~~
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:40:15
@@ -74,9 +73,8 @@ LL |         ref qux: Foo::Baz => {}
    |
 help: maybe write a path separator here
    |
-LL -         ref qux: Foo::Baz => {}
-LL +         ref qux::Foo::Baz => {}
-   |
+LL |         ref qux::Foo::Baz => {}
+   |                ~~
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:58:16
@@ -88,9 +86,8 @@ LL |         mut qux: Foo::Baz => {}
    |
 help: maybe write a path separator here
    |
-LL -         mut qux: Foo::Baz => {}
-LL +         mut qux::Foo::Baz => {}
-   |
+LL |         mut qux::Foo::Baz => {}
+   |                ~~
 
 error: expected one of `@` or `|`, found `:`
   --> $DIR/issue-87086-colon-path-sep.rs:69:12

--- a/tests/ui/parser/missing-fn-issue-65381-2.stderr
+++ b/tests/ui/parser/missing-fn-issue-65381-2.stderr
@@ -7,7 +7,7 @@ LL | main();
 help: if you meant to call a macro, try
    |
 LL | main!();
-   | ~~~~~
+   |     +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/missing-fn-issue-65381-2.stderr
+++ b/tests/ui/parser/missing-fn-issue-65381-2.stderr
@@ -6,9 +6,8 @@ LL | main();
    |
 help: if you meant to call a macro, try
    |
-LL - main();
-LL + main!();
-   |
+LL | main!();
+   | ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/const.stderr
+++ b/tests/ui/parser/misspelled-keywords/const.stderr
@@ -7,7 +7,7 @@ LL | cons A: u8 = 10;
 help: there is a keyword `const` with a similar name
    |
 LL | const A: u8 = 10;
-   | ~~~~~
+   |     +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/const.stderr
+++ b/tests/ui/parser/misspelled-keywords/const.stderr
@@ -6,9 +6,8 @@ LL | cons A: u8 = 10;
    |
 help: there is a keyword `const` with a similar name
    |
-LL - cons A: u8 = 10;
-LL + const A: u8 = 10;
-   |
+LL | const A: u8 = 10;
+   | ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/recover/turbofish-arg-with-stray-colon.stderr
+++ b/tests/ui/parser/recover/turbofish-arg-with-stray-colon.stderr
@@ -7,9 +7,8 @@ LL |     let x = Tr<A, A:>;
    = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: maybe write a path separator here
    |
-LL -     let x = Tr<A, A:>;
-LL +     let x = Tr<A, A::>;
-   |
+LL |     let x = Tr<A, A::>;
+   |                    ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/recover/turbofish-arg-with-stray-colon.stderr
+++ b/tests/ui/parser/recover/turbofish-arg-with-stray-colon.stderr
@@ -8,7 +8,7 @@ LL |     let x = Tr<A, A:>;
 help: maybe write a path separator here
    |
 LL |     let x = Tr<A, A::>;
-   |                    ~~
+   |                     +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/type-ascription-in-pattern.stderr
+++ b/tests/ui/parser/type-ascription-in-pattern.stderr
@@ -8,9 +8,8 @@ LL |         x: i32 => x,
    |
 help: maybe write a path separator here
    |
-LL -         x: i32 => x,
-LL +         x::i32 => x,
-   |
+LL |         x::i32 => x,
+   |          ~~
 
 error: expected one of `...`, `..=`, `..`, or `|`, found `:`
   --> $DIR/type-ascription-in-pattern.rs:12:11
@@ -38,9 +37,8 @@ LL |         x: i32 => (),
    |
 help: maybe write a path separator here
    |
-LL -         x: i32 => (),
-LL +         x::i32 => (),
-   |
+LL |         x::i32 => (),
+   |          ~~
 
 error[E0308]: mismatched types
   --> $DIR/type-ascription-in-pattern.rs:3:19

--- a/tests/ui/parser/use-colon-as-mod-sep.stderr
+++ b/tests/ui/parser/use-colon-as-mod-sep.stderr
@@ -8,7 +8,7 @@ LL | use std::process:Command;
 help: use double colon
    |
 LL | use std::process::Command;
-   |                 ~~
+   |                  +
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:5:8
@@ -20,7 +20,7 @@ LL | use std:fs::File;
 help: use double colon
    |
 LL | use std::fs::File;
-   |        ~~
+   |         +
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:7:8
@@ -32,7 +32,7 @@ LL | use std:collections:HashMap;
 help: use double colon
    |
 LL | use std::collections:HashMap;
-   |        ~~
+   |         +
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:7:20
@@ -44,7 +44,7 @@ LL | use std:collections:HashMap;
 help: use double colon
    |
 LL | use std:collections::HashMap;
-   |                    ~~
+   |                     +
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/parser/use-colon-as-mod-sep.stderr
+++ b/tests/ui/parser/use-colon-as-mod-sep.stderr
@@ -7,9 +7,8 @@ LL | use std::process:Command;
    = note: import paths are delimited using `::`
 help: use double colon
    |
-LL - use std::process:Command;
-LL + use std::process::Command;
-   |
+LL | use std::process::Command;
+   |                 ~~
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:5:8
@@ -20,9 +19,8 @@ LL | use std:fs::File;
    = note: import paths are delimited using `::`
 help: use double colon
    |
-LL - use std:fs::File;
-LL + use std::fs::File;
-   |
+LL | use std::fs::File;
+   |        ~~
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:7:8
@@ -33,9 +31,8 @@ LL | use std:collections:HashMap;
    = note: import paths are delimited using `::`
 help: use double colon
    |
-LL - use std:collections:HashMap;
-LL + use std::collections:HashMap;
-   |
+LL | use std::collections:HashMap;
+   |        ~~
 
 error: expected `::`, found `:`
   --> $DIR/use-colon-as-mod-sep.rs:7:20
@@ -46,9 +43,8 @@ LL | use std:collections:HashMap;
    = note: import paths are delimited using `::`
 help: use double colon
    |
-LL - use std:collections:HashMap;
-LL + use std:collections::HashMap;
-   |
+LL | use std:collections::HashMap;
+   |                    ~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/pat-tuple-field-count-cross.stderr
+++ b/tests/ui/pattern/pat-tuple-field-count-cross.stderr
@@ -121,9 +121,8 @@ LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
    |
 help: use the tuple variant pattern syntax instead
    |
-LL -         E1::Z1 => {}
-LL +         E1::Z1() => {}
-   |
+LL |         E1::Z1() => {}
+   |         ~~~~~~~~
 help: a unit variant with a similar name exists
    |
 LL -         E1::Z1 => {}

--- a/tests/ui/pattern/pat-tuple-field-count-cross.stderr
+++ b/tests/ui/pattern/pat-tuple-field-count-cross.stderr
@@ -122,7 +122,7 @@ LL | pub enum E1 { Z0, Z1(), S(u8, u8, u8) }
 help: use the tuple variant pattern syntax instead
    |
 LL |         E1::Z1() => {}
-   |         ~~~~~~~~
+   |               ++
 help: a unit variant with a similar name exists
    |
 LL -         E1::Z1 => {}

--- a/tests/ui/pattern/pat-tuple-overfield.stderr
+++ b/tests/ui/pattern/pat-tuple-overfield.stderr
@@ -156,7 +156,7 @@ LL |         E1::Z1 => {}
 help: use the tuple variant pattern syntax instead
    |
 LL |         E1::Z1() => {}
-   |         ~~~~~~~~
+   |               ++
 help: a unit variant with a similar name exists
    |
 LL -         E1::Z1 => {}

--- a/tests/ui/pattern/pat-tuple-overfield.stderr
+++ b/tests/ui/pattern/pat-tuple-overfield.stderr
@@ -155,9 +155,8 @@ LL |         E1::Z1 => {}
    |
 help: use the tuple variant pattern syntax instead
    |
-LL -         E1::Z1 => {}
-LL +         E1::Z1() => {}
-   |
+LL |         E1::Z1() => {}
+   |         ~~~~~~~~
 help: a unit variant with a similar name exists
    |
 LL -         E1::Z1 => {}

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
@@ -7,7 +7,7 @@ LL |         b.make_ascii_uppercase();
 help: consider changing this to be mutable
    |
 LL |         let &(mut b) = a;
-   |             ~~~~~  +
+   |              ++++  +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
@@ -6,9 +6,8 @@ LL |         b.make_ascii_uppercase();
    |
 help: consider changing this to be mutable
    |
-LL -         let &b = a;
-LL +         let &(mut b) = a;
-   |
+LL |         let &(mut b) = a;
+   |             ~~~~~  +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
@@ -7,7 +7,7 @@ LL |     mutate(&mut x);
 help: consider changing this to be mutable
    |
 LL | fn foo(&(mut x): &i32) {
-   |        ~~~~~  +
+   |         ++++  +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
@@ -6,9 +6,8 @@ LL |     mutate(&mut x);
    |
 help: consider changing this to be mutable
    |
-LL - fn foo(&x: &i32) {
-LL + fn foo(&(mut x): &i32) {
-   |
+LL | fn foo(&(mut x): &i32) {
+   |        ~~~~~  +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/usefulness/doc-hidden-fields.stderr
+++ b/tests/ui/pattern/usefulness/doc-hidden-fields.stderr
@@ -18,15 +18,15 @@ LL |     let HiddenStruct { one } = HiddenStruct::default();
 help: include the missing field in the pattern and ignore the inaccessible fields
    |
 LL |     let HiddenStruct { one, two, .. } = HiddenStruct::default();
-   |                           ~~~~~~~~~~~
+   |                           +++++++++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |     let HiddenStruct { one, two: _, .. } = HiddenStruct::default();
-   |                           ~~~~~~~~~~~~~~
+   |                           ++++++++++++
 help: or always ignore missing fields here
    |
 LL |     let HiddenStruct { one, .. } = HiddenStruct::default();
-   |                           ~~~~~~
+   |                           ++++
 
 error[E0027]: pattern does not mention field `two`
   --> $DIR/doc-hidden-fields.rs:21:9
@@ -37,15 +37,15 @@ LL |     let HiddenStruct { one, hide } = HiddenStruct::default();
 help: include the missing field in the pattern
    |
 LL |     let HiddenStruct { one, hide, two } = HiddenStruct::default();
-   |                                 ~~~~~~~
+   |                                 +++++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |     let HiddenStruct { one, hide, two: _ } = HiddenStruct::default();
-   |                                 ~~~~~~~~~~
+   |                                 ++++++++
 help: or always ignore missing fields here
    |
 LL |     let HiddenStruct { one, hide, .. } = HiddenStruct::default();
-   |                                 ~~~~~~
+   |                                 ++++
 
 error[E0027]: pattern does not mention field `im_hidden`
   --> $DIR/doc-hidden-fields.rs:24:9
@@ -56,15 +56,15 @@ LL |     let InCrate { a, b } = InCrate { a: 0, b: false, im_hidden: 0 };
 help: include the missing field in the pattern
    |
 LL |     let InCrate { a, b, im_hidden } = InCrate { a: 0, b: false, im_hidden: 0 };
-   |                       ~~~~~~~~~~~~~
+   |                       +++++++++++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |     let InCrate { a, b, im_hidden: _ } = InCrate { a: 0, b: false, im_hidden: 0 };
-   |                       ~~~~~~~~~~~~~~~~
+   |                       ++++++++++++++
 help: or always ignore missing fields here
    |
 LL |     let InCrate { a, b, .. } = InCrate { a: 0, b: false, im_hidden: 0 };
-   |                       ~~~~~~
+   |                       ++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/usefulness/doc-hidden-fields.stderr
+++ b/tests/ui/pattern/usefulness/doc-hidden-fields.stderr
@@ -17,19 +17,16 @@ LL |     let HiddenStruct { one } = HiddenStruct::default();
    |
 help: include the missing field in the pattern and ignore the inaccessible fields
    |
-LL -     let HiddenStruct { one } = HiddenStruct::default();
-LL +     let HiddenStruct { one, two, .. } = HiddenStruct::default();
-   |
+LL |     let HiddenStruct { one, two, .. } = HiddenStruct::default();
+   |                           ~~~~~~~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -     let HiddenStruct { one } = HiddenStruct::default();
-LL +     let HiddenStruct { one, two: _, .. } = HiddenStruct::default();
-   |
+LL |     let HiddenStruct { one, two: _, .. } = HiddenStruct::default();
+   |                           ~~~~~~~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -     let HiddenStruct { one } = HiddenStruct::default();
-LL +     let HiddenStruct { one, .. } = HiddenStruct::default();
-   |
+LL |     let HiddenStruct { one, .. } = HiddenStruct::default();
+   |                           ~~~~~~
 
 error[E0027]: pattern does not mention field `two`
   --> $DIR/doc-hidden-fields.rs:21:9
@@ -39,19 +36,16 @@ LL |     let HiddenStruct { one, hide } = HiddenStruct::default();
    |
 help: include the missing field in the pattern
    |
-LL -     let HiddenStruct { one, hide } = HiddenStruct::default();
-LL +     let HiddenStruct { one, hide, two } = HiddenStruct::default();
-   |
+LL |     let HiddenStruct { one, hide, two } = HiddenStruct::default();
+   |                                 ~~~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -     let HiddenStruct { one, hide } = HiddenStruct::default();
-LL +     let HiddenStruct { one, hide, two: _ } = HiddenStruct::default();
-   |
+LL |     let HiddenStruct { one, hide, two: _ } = HiddenStruct::default();
+   |                                 ~~~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -     let HiddenStruct { one, hide } = HiddenStruct::default();
-LL +     let HiddenStruct { one, hide, .. } = HiddenStruct::default();
-   |
+LL |     let HiddenStruct { one, hide, .. } = HiddenStruct::default();
+   |                                 ~~~~~~
 
 error[E0027]: pattern does not mention field `im_hidden`
   --> $DIR/doc-hidden-fields.rs:24:9
@@ -61,19 +55,16 @@ LL |     let InCrate { a, b } = InCrate { a: 0, b: false, im_hidden: 0 };
    |
 help: include the missing field in the pattern
    |
-LL -     let InCrate { a, b } = InCrate { a: 0, b: false, im_hidden: 0 };
-LL +     let InCrate { a, b, im_hidden } = InCrate { a: 0, b: false, im_hidden: 0 };
-   |
+LL |     let InCrate { a, b, im_hidden } = InCrate { a: 0, b: false, im_hidden: 0 };
+   |                       ~~~~~~~~~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -     let InCrate { a, b } = InCrate { a: 0, b: false, im_hidden: 0 };
-LL +     let InCrate { a, b, im_hidden: _ } = InCrate { a: 0, b: false, im_hidden: 0 };
-   |
+LL |     let InCrate { a, b, im_hidden: _ } = InCrate { a: 0, b: false, im_hidden: 0 };
+   |                       ~~~~~~~~~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -     let InCrate { a, b } = InCrate { a: 0, b: false, im_hidden: 0 };
-LL +     let InCrate { a, b, .. } = InCrate { a: 0, b: false, im_hidden: 0 };
-   |
+LL |     let InCrate { a, b, .. } = InCrate { a: 0, b: false, im_hidden: 0 };
+   |                       ~~~~~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/usefulness/stable-gated-fields.stderr
+++ b/tests/ui/pattern/usefulness/stable-gated-fields.stderr
@@ -7,15 +7,15 @@ LL |     let UnstableStruct { stable } = UnstableStruct::default();
 help: include the missing field in the pattern and ignore the inaccessible fields
    |
 LL |     let UnstableStruct { stable, stable2, .. } = UnstableStruct::default();
-   |                                ~~~~~~~~~~~~~~~
+   |                                +++++++++++++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |     let UnstableStruct { stable, stable2: _, .. } = UnstableStruct::default();
-   |                                ~~~~~~~~~~~~~~~~~~
+   |                                ++++++++++++++++
 help: or always ignore missing fields here
    |
 LL |     let UnstableStruct { stable, .. } = UnstableStruct::default();
-   |                                ~~~~~~
+   |                                ++++
 
 error: pattern requires `..` due to inaccessible fields
   --> $DIR/stable-gated-fields.rs:11:9

--- a/tests/ui/pattern/usefulness/stable-gated-fields.stderr
+++ b/tests/ui/pattern/usefulness/stable-gated-fields.stderr
@@ -6,19 +6,16 @@ LL |     let UnstableStruct { stable } = UnstableStruct::default();
    |
 help: include the missing field in the pattern and ignore the inaccessible fields
    |
-LL -     let UnstableStruct { stable } = UnstableStruct::default();
-LL +     let UnstableStruct { stable, stable2, .. } = UnstableStruct::default();
-   |
+LL |     let UnstableStruct { stable, stable2, .. } = UnstableStruct::default();
+   |                                ~~~~~~~~~~~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -     let UnstableStruct { stable } = UnstableStruct::default();
-LL +     let UnstableStruct { stable, stable2: _, .. } = UnstableStruct::default();
-   |
+LL |     let UnstableStruct { stable, stable2: _, .. } = UnstableStruct::default();
+   |                                ~~~~~~~~~~~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -     let UnstableStruct { stable } = UnstableStruct::default();
-LL +     let UnstableStruct { stable, .. } = UnstableStruct::default();
-   |
+LL |     let UnstableStruct { stable, .. } = UnstableStruct::default();
+   |                                ~~~~~~
 
 error: pattern requires `..` due to inaccessible fields
   --> $DIR/stable-gated-fields.rs:11:9

--- a/tests/ui/privacy/privacy5.stderr
+++ b/tests/ui/privacy/privacy5.stderr
@@ -52,9 +52,8 @@ LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider making the fields publicly accessible
    |
-LL -     pub struct C(pub isize, isize);
-LL +     pub struct C(pub isize, pub isize);
-   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:56:12
@@ -262,9 +261,8 @@ LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider making the fields publicly accessible
    |
-LL -     pub struct C(pub isize, isize);
-LL +     pub struct C(pub isize, pub isize);
-   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:69:12
@@ -282,9 +280,8 @@ LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider making the fields publicly accessible
    |
-LL -     pub struct C(pub isize, isize);
-LL +     pub struct C(pub isize, pub isize);
-   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:70:12
@@ -302,9 +299,8 @@ LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider making the fields publicly accessible
    |
-LL -     pub struct C(pub isize, isize);
-LL +     pub struct C(pub isize, pub isize);
-   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:71:12
@@ -322,9 +318,8 @@ LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider making the fields publicly accessible
    |
-LL -     pub struct C(pub isize, isize);
-LL +     pub struct C(pub isize, pub isize);
-   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:72:18
@@ -342,9 +337,8 @@ LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider making the fields publicly accessible
    |
-LL -     pub struct C(pub isize, isize);
-LL +     pub struct C(pub isize, pub isize);
-   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:73:18
@@ -362,9 +356,8 @@ LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider making the fields publicly accessible
    |
-LL -     pub struct C(pub isize, isize);
-LL +     pub struct C(pub isize, pub isize);
-   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:74:18
@@ -382,9 +375,8 @@ LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider making the fields publicly accessible
    |
-LL -     pub struct C(pub isize, isize);
-LL +     pub struct C(pub isize, pub isize);
-   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:75:18
@@ -402,9 +394,8 @@ LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider making the fields publicly accessible
    |
-LL -     pub struct C(pub isize, isize);
-LL +     pub struct C(pub isize, pub isize);
-   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:83:17
@@ -460,9 +451,8 @@ LL |     pub struct C(pub isize, isize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider making the fields publicly accessible
    |
-LL -     pub struct C(pub isize, isize);
-LL +     pub struct C(pub isize, pub isize);
-   |
+LL |     pub struct C(pub isize, pub isize);
+   |                             +++
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:90:20

--- a/tests/ui/privacy/suggest-box-new.stderr
+++ b/tests/ui/privacy/suggest-box-new.stderr
@@ -10,7 +10,7 @@ LL |     let _ = std::collections::HashMap();
 help: you might have meant to use an associated function to build this type
    |
 LL |     let _ = std::collections::HashMap::new();
-   |                                      ~~~~~~~
+   |                                      +++++
 LL -     let _ = std::collections::HashMap();
 LL +     let _ = std::collections::HashMap::with_capacity(_);
    |
@@ -23,7 +23,7 @@ LL +     let _ = std::collections::HashMap::with_capacity_and_hasher(_, _);
 help: consider using the `Default` trait
    |
 LL |     let _ = <std::collections::HashMap as std::default::Default>::default();
-   |             +                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |             +                          ++++++++++++++++++++++++++++++++++
 
 error[E0423]: cannot initialize a tuple struct which contains private fields
   --> $DIR/suggest-box-new.rs:8:19

--- a/tests/ui/privacy/suggest-box-new.stderr
+++ b/tests/ui/privacy/suggest-box-new.stderr
@@ -9,9 +9,8 @@ LL |     let _ = std::collections::HashMap();
    |
 help: you might have meant to use an associated function to build this type
    |
-LL -     let _ = std::collections::HashMap();
-LL +     let _ = std::collections::HashMap::new();
-   |
+LL |     let _ = std::collections::HashMap::new();
+   |                                      ~~~~~~~
 LL -     let _ = std::collections::HashMap();
 LL +     let _ = std::collections::HashMap::with_capacity(_);
    |
@@ -23,9 +22,8 @@ LL +     let _ = std::collections::HashMap::with_capacity_and_hasher(_, _);
    |
 help: consider using the `Default` trait
    |
-LL -     let _ = std::collections::HashMap();
-LL +     let _ = <std::collections::HashMap as std::default::Default>::default();
-   |
+LL |     let _ = <std::collections::HashMap as std::default::Default>::default();
+   |             +                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0423]: cannot initialize a tuple struct which contains private fields
   --> $DIR/suggest-box-new.rs:8:19

--- a/tests/ui/pub/pub-ident-fn-or-struct.stderr
+++ b/tests/ui/pub/pub-ident-fn-or-struct.stderr
@@ -7,7 +7,7 @@ LL | pub S (foo) bar
 help: if you meant to call a macro, try
    |
 LL | pub S! (foo) bar
-   |     ~~
+   |      +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pub/pub-ident-fn-or-struct.stderr
+++ b/tests/ui/pub/pub-ident-fn-or-struct.stderr
@@ -6,9 +6,8 @@ LL | pub S (foo) bar
    |
 help: if you meant to call a macro, try
    |
-LL - pub S (foo) bar
-LL + pub S! (foo) bar
-   |
+LL | pub S! (foo) bar
+   |     ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pub/pub-restricted.stderr
+++ b/tests/ui/pub/pub-restricted.stderr
@@ -11,7 +11,7 @@ LL | pub (a) fn afn() {}
 help: make this visible only to module `a` with `in`
    |
 LL | pub (in a) fn afn() {}
-   |      ~~~~
+   |      ++
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:4:6
@@ -26,7 +26,7 @@ LL | pub (b) fn bfn() {}
 help: make this visible only to module `b` with `in`
    |
 LL | pub (in b) fn bfn() {}
-   |      ~~~~
+   |      ++
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:5:6
@@ -41,7 +41,7 @@ LL | pub (crate::a) fn cfn() {}
 help: make this visible only to module `crate::a` with `in`
    |
 LL | pub (in crate::a) fn cfn() {}
-   |      ~~~~~~~~~~~
+   |      ++
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:22:14
@@ -56,7 +56,7 @@ LL |         pub (a) invalid: usize,
 help: make this visible only to module `a` with `in`
    |
 LL |         pub (in a) invalid: usize,
-   |              ~~~~
+   |              ++
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:31:6
@@ -71,7 +71,7 @@ LL | pub (xyz) fn xyz() {}
 help: make this visible only to module `xyz` with `in`
    |
 LL | pub (in xyz) fn xyz() {}
-   |      ~~~~~~
+   |      ++
 
 error[E0742]: visibilities can only be restricted to ancestor modules
   --> $DIR/pub-restricted.rs:23:17

--- a/tests/ui/pub/pub-restricted.stderr
+++ b/tests/ui/pub/pub-restricted.stderr
@@ -10,9 +10,8 @@ LL | pub (a) fn afn() {}
            `pub(in path::to::module)`: visible only on the specified path
 help: make this visible only to module `a` with `in`
    |
-LL - pub (a) fn afn() {}
-LL + pub (in a) fn afn() {}
-   |
+LL | pub (in a) fn afn() {}
+   |      ~~~~
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:4:6
@@ -26,9 +25,8 @@ LL | pub (b) fn bfn() {}
            `pub(in path::to::module)`: visible only on the specified path
 help: make this visible only to module `b` with `in`
    |
-LL - pub (b) fn bfn() {}
-LL + pub (in b) fn bfn() {}
-   |
+LL | pub (in b) fn bfn() {}
+   |      ~~~~
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:5:6
@@ -42,9 +40,8 @@ LL | pub (crate::a) fn cfn() {}
            `pub(in path::to::module)`: visible only on the specified path
 help: make this visible only to module `crate::a` with `in`
    |
-LL - pub (crate::a) fn cfn() {}
-LL + pub (in crate::a) fn cfn() {}
-   |
+LL | pub (in crate::a) fn cfn() {}
+   |      ~~~~~~~~~~~
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:22:14
@@ -58,9 +55,8 @@ LL |         pub (a) invalid: usize,
            `pub(in path::to::module)`: visible only on the specified path
 help: make this visible only to module `a` with `in`
    |
-LL -         pub (a) invalid: usize,
-LL +         pub (in a) invalid: usize,
-   |
+LL |         pub (in a) invalid: usize,
+   |              ~~~~
 
 error[E0704]: incorrect visibility restriction
   --> $DIR/pub-restricted.rs:31:6
@@ -74,9 +70,8 @@ LL | pub (xyz) fn xyz() {}
            `pub(in path::to::module)`: visible only on the specified path
 help: make this visible only to module `xyz` with `in`
    |
-LL - pub (xyz) fn xyz() {}
-LL + pub (in xyz) fn xyz() {}
-   |
+LL | pub (in xyz) fn xyz() {}
+   |      ~~~~~~
 
 error[E0742]: visibilities can only be restricted to ancestor modules
   --> $DIR/pub-restricted.rs:23:17

--- a/tests/ui/resolve/const-with-typo-in-pattern-binding.stderr
+++ b/tests/ui/resolve/const-with-typo-in-pattern-binding.stderr
@@ -73,9 +73,8 @@ LL |         _ => {}
    |
 help: you might have meant to pattern match against the value of constant `ARCH` instead of introducing a new catch-all binding
    |
-LL -         ARCH => {}
-LL +         std::env::consts::ARCH => {}
-   |
+LL |         std::env::consts::ARCH => {}
+   |         ~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/resolve/const-with-typo-in-pattern-binding.stderr
+++ b/tests/ui/resolve/const-with-typo-in-pattern-binding.stderr
@@ -74,7 +74,7 @@ LL |         _ => {}
 help: you might have meant to pattern match against the value of constant `ARCH` instead of introducing a new catch-all binding
    |
 LL |         std::env::consts::ARCH => {}
-   |         ~~~~~~~~~~~~~~~~~~~~~~
+   |         ++++++++++++++++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/resolve/issue-39226.stderr
+++ b/tests/ui/resolve/issue-39226.stderr
@@ -9,9 +9,8 @@ LL |         handle: Handle
    |
 help: use struct literal syntax instead
    |
-LL -         handle: Handle
-LL +         handle: Handle {}
-   |
+LL |         handle: Handle {}
+   |                 ~~~~~~~~~
 help: a local variable with a similar name exists
    |
 LL -         handle: Handle

--- a/tests/ui/resolve/issue-39226.stderr
+++ b/tests/ui/resolve/issue-39226.stderr
@@ -10,7 +10,7 @@ LL |         handle: Handle
 help: use struct literal syntax instead
    |
 LL |         handle: Handle {}
-   |                 ~~~~~~~~~
+   |                        ++
 help: a local variable with a similar name exists
    |
 LL -         handle: Handle

--- a/tests/ui/resolve/issue-55673.stderr
+++ b/tests/ui/resolve/issue-55673.stderr
@@ -19,7 +19,7 @@ LL |     T::Baa: std::fmt::Debug,
 help: consider further restricting type parameter `T` with trait `Foo`
    |
 LL |     T::Baa: std::fmt::Debug, T: Foo
-   |                            ~~~~~~~~
+   |                              ++++++
 help: ...and changing the associated type name
    |
 LL -     T::Baa: std::fmt::Debug,

--- a/tests/ui/resolve/issue-55673.stderr
+++ b/tests/ui/resolve/issue-55673.stderr
@@ -18,9 +18,8 @@ LL |     T::Baa: std::fmt::Debug,
    |
 help: consider further restricting type parameter `T` with trait `Foo`
    |
-LL -     T::Baa: std::fmt::Debug,
-LL +     T::Baa: std::fmt::Debug, T: Foo
-   |
+LL |     T::Baa: std::fmt::Debug, T: Foo
+   |                            ~~~~~~~~
 help: ...and changing the associated type name
    |
 LL -     T::Baa: std::fmt::Debug,

--- a/tests/ui/resolve/issue-73427.stderr
+++ b/tests/ui/resolve/issue-73427.stderr
@@ -21,7 +21,7 @@ LL -     A.foo();
 LL +     (A::Tuple()).foo();
    |
 LL |     A::Unit.foo();
-   |     ~~~~~~~
+   |      ++++++
 help: alternatively, the following enum variant is available
    |
 LL -     A.foo();
@@ -61,7 +61,7 @@ LL | | }
 help: you might have meant to use the following enum variant
    |
 LL |     C::Unit.foo();
-   |     ~~~~~~~
+   |      ++++++
 help: alternatively, the following enum variant is available
    |
 LL -     C.foo();
@@ -85,7 +85,7 @@ LL | | }
 help: you might have meant to use the following enum variant
    |
 LL |     D::Unit.foo();
-   |     ~~~~~~~
+   |      ++++++
 help: alternatively, the following enum variant is available
    |
 LL -     D.foo();
@@ -142,9 +142,9 @@ LL | | }
 help: try to match against one of the enum's variants
    |
 LL |     if let A::Tuple(3) = x { }
-   |            ~~~~~~~~
+   |             +++++++
 LL |     if let A::TupleWithFields(3) = x { }
-   |            ~~~~~~~~~~~~~~~~~~
+   |             +++++++++++++++++
 
 error[E0423]: expected function, tuple struct or tuple variant, found enum `A`
   --> $DIR/issue-73427.rs:46:13
@@ -167,9 +167,9 @@ LL | | }
 help: try to construct one of the enum's variants
    |
 LL |     let x = A::Tuple(3);
-   |             ~~~~~~~~
+   |              +++++++
 LL |     let x = A::TupleWithFields(3);
-   |             ~~~~~~~~~~~~~~~~~~
+   |              +++++++++++++++++
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/resolve/issue-73427.stderr
+++ b/tests/ui/resolve/issue-73427.stderr
@@ -20,9 +20,8 @@ help: you might have meant to use one of the following enum variants
 LL -     A.foo();
 LL +     (A::Tuple()).foo();
    |
-LL -     A.foo();
-LL +     A::Unit.foo();
-   |
+LL |     A::Unit.foo();
+   |     ~~~~~~~
 help: alternatively, the following enum variant is available
    |
 LL -     A.foo();
@@ -61,9 +60,8 @@ LL | | }
    | |_^
 help: you might have meant to use the following enum variant
    |
-LL -     C.foo();
-LL +     C::Unit.foo();
-   |
+LL |     C::Unit.foo();
+   |     ~~~~~~~
 help: alternatively, the following enum variant is available
    |
 LL -     C.foo();
@@ -86,9 +84,8 @@ LL | | }
    | |_^
 help: you might have meant to use the following enum variant
    |
-LL -     D.foo();
-LL +     D::Unit.foo();
-   |
+LL |     D::Unit.foo();
+   |     ~~~~~~~
 help: alternatively, the following enum variant is available
    |
 LL -     D.foo();
@@ -144,12 +141,10 @@ LL | | }
    | |_^
 help: try to match against one of the enum's variants
    |
-LL -     if let A(3) = x { }
-LL +     if let A::Tuple(3) = x { }
-   |
-LL -     if let A(3) = x { }
-LL +     if let A::TupleWithFields(3) = x { }
-   |
+LL |     if let A::Tuple(3) = x { }
+   |            ~~~~~~~~
+LL |     if let A::TupleWithFields(3) = x { }
+   |            ~~~~~~~~~~~~~~~~~~
 
 error[E0423]: expected function, tuple struct or tuple variant, found enum `A`
   --> $DIR/issue-73427.rs:46:13
@@ -171,12 +166,10 @@ LL | | }
    | |_^
 help: try to construct one of the enum's variants
    |
-LL -     let x = A(3);
-LL +     let x = A::Tuple(3);
-   |
-LL -     let x = A(3);
-LL +     let x = A::TupleWithFields(3);
-   |
+LL |     let x = A::Tuple(3);
+   |             ~~~~~~~~
+LL |     let x = A::TupleWithFields(3);
+   |             ~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -124,9 +124,8 @@ LL | |     }
    | |_____^
 help: you might have meant to use the following enum variant
    |
-LL -     let _: E = E;
-LL +     let _: E = E::Unit;
-   |
+LL |     let _: E = E::Unit;
+   |                ~~~~~~~
 help: alternatively, the following enum variant is available
    |
 LL -     let _: E = E;

--- a/tests/ui/resolve/privacy-enum-ctor.stderr
+++ b/tests/ui/resolve/privacy-enum-ctor.stderr
@@ -125,7 +125,7 @@ LL | |     }
 help: you might have meant to use the following enum variant
    |
 LL |     let _: E = E::Unit;
-   |                ~~~~~~~
+   |                 ++++++
 help: alternatively, the following enum variant is available
    |
 LL -     let _: E = E;

--- a/tests/ui/resolve/resolve-inconsistent-names.stderr
+++ b/tests/ui/resolve/resolve-inconsistent-names.stderr
@@ -35,7 +35,7 @@ LL |         (A, B) | (ref B, c) | (c, A) => ()
 help: if you meant to match on unit variant `E::A`, use the full path in the pattern
    |
 LL |         (E::A, B) | (ref B, c) | (c, A) => ()
-   |          ~~~~
+   |          +++
 
 error[E0408]: variable `B` is not bound in all patterns
   --> $DIR/resolve-inconsistent-names.rs:19:31
@@ -65,7 +65,7 @@ LL |         (CONST1, _) | (_, Const2) => ()
 help: if you meant to match on constant `m::Const2`, use the full path in the pattern
    |
 LL |         (CONST1, _) | (_, m::Const2) => ()
-   |                           ~~~~~~~~~
+   |                           +++
 
 error[E0408]: variable `CONST1` is not bound in all patterns
   --> $DIR/resolve-inconsistent-names.rs:31:23

--- a/tests/ui/resolve/resolve-inconsistent-names.stderr
+++ b/tests/ui/resolve/resolve-inconsistent-names.stderr
@@ -34,9 +34,8 @@ LL |         (A, B) | (ref B, c) | (c, A) => ()
    |
 help: if you meant to match on unit variant `E::A`, use the full path in the pattern
    |
-LL -         (A, B) | (ref B, c) | (c, A) => ()
-LL +         (E::A, B) | (ref B, c) | (c, A) => ()
-   |
+LL |         (E::A, B) | (ref B, c) | (c, A) => ()
+   |          ~~~~
 
 error[E0408]: variable `B` is not bound in all patterns
   --> $DIR/resolve-inconsistent-names.rs:19:31
@@ -65,9 +64,8 @@ LL |         (CONST1, _) | (_, Const2) => ()
    |
 help: if you meant to match on constant `m::Const2`, use the full path in the pattern
    |
-LL -         (CONST1, _) | (_, Const2) => ()
-LL +         (CONST1, _) | (_, m::Const2) => ()
-   |
+LL |         (CONST1, _) | (_, m::Const2) => ()
+   |                           ~~~~~~~~~
 
 error[E0408]: variable `CONST1` is not bound in all patterns
   --> $DIR/resolve-inconsistent-names.rs:31:23

--- a/tests/ui/resolve/resolve-issue-135614-assoc-const.import_trait_associated_functions.stderr
+++ b/tests/ui/resolve/resolve-issue-135614-assoc-const.import_trait_associated_functions.stderr
@@ -12,7 +12,7 @@ LL |     const DEFAULT: u32 = 0;
 help: introduce a variable instead
    |
 LL |     let DEFAULT_var: u32 = 0;
-   |         ~~~~~~~~~~~
+   |                ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/resolve-issue-135614-assoc-const.import_trait_associated_functions.stderr
+++ b/tests/ui/resolve/resolve-issue-135614-assoc-const.import_trait_associated_functions.stderr
@@ -11,9 +11,8 @@ LL |     const DEFAULT: u32 = 0;
    = note: the matched value is of type `u32`
 help: introduce a variable instead
    |
-LL -     let DEFAULT: u32 = 0;
-LL +     let DEFAULT_var: u32 = 0;
-   |
+LL |     let DEFAULT_var: u32 = 0;
+   |         ~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/resolve-issue-135614-assoc-const.normal.stderr
+++ b/tests/ui/resolve/resolve-issue-135614-assoc-const.normal.stderr
@@ -22,7 +22,7 @@ LL |     const DEFAULT: u32 = 0;
 help: introduce a variable instead
    |
 LL |     let DEFAULT_var: u32 = 0;
-   |         ~~~~~~~~~~~
+   |                ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/resolve-issue-135614-assoc-const.normal.stderr
+++ b/tests/ui/resolve/resolve-issue-135614-assoc-const.normal.stderr
@@ -21,9 +21,8 @@ LL |     const DEFAULT: u32 = 0;
    = note: the matched value is of type `u32`
 help: introduce a variable instead
    |
-LL -     let DEFAULT: u32 = 0;
-LL +     let DEFAULT_var: u32 = 0;
-   |
+LL |     let DEFAULT_var: u32 = 0;
+   |         ~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -67,7 +67,7 @@ LL |         Self::BAR;
 help: a constant with a similar name exists
    |
 LL |         BARR;
-   |         ~~~~
+   |            +
 
 error[E0412]: cannot find type `Baz` in this scope
   --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:37:18

--- a/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/tests/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -66,9 +66,8 @@ LL |         Self::BAR;
    |         ++++++
 help: a constant with a similar name exists
    |
-LL -         BAR;
-LL +         BARR;
-   |
+LL |         BARR;
+   |         ~~~~
 
 error[E0412]: cannot find type `Baz` in this scope
   --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:37:18

--- a/tests/ui/resolve/typo-suggestion-mistyped-in-path.stderr
+++ b/tests/ui/resolve/typo-suggestion-mistyped-in-path.stderr
@@ -40,7 +40,7 @@ LL |     modul::foo();
 help: there is a crate or module with a similar name
    |
 LL |     module::foo();
-   |     ~~~~~~
+   |          +
 
 error[E0433]: failed to resolve: use of undeclared type `Trai`
   --> $DIR/typo-suggestion-mistyped-in-path.rs:39:5

--- a/tests/ui/resolve/typo-suggestion-mistyped-in-path.stderr
+++ b/tests/ui/resolve/typo-suggestion-mistyped-in-path.stderr
@@ -39,9 +39,8 @@ LL |     modul::foo();
    |
 help: there is a crate or module with a similar name
    |
-LL -     modul::foo();
-LL +     module::foo();
-   |
+LL |     module::foo();
+   |     ~~~~~~
 
 error[E0433]: failed to resolve: use of undeclared type `Trai`
   --> $DIR/typo-suggestion-mistyped-in-path.rs:39:5

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/struct.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/struct.stderr
@@ -59,7 +59,7 @@ LL |     let NormalStruct { first_field, second_field } = ns;
 help: add `..` at the end of the field list to ignore all other fields
    |
 LL |     let NormalStruct { first_field, second_field , .. } = ns;
-   |                                                  ~~~~~~
+   |                                                  ++++
 
 error[E0423]: cannot initialize a tuple struct which contains private fields
   --> $DIR/struct.rs:20:14
@@ -76,7 +76,7 @@ LL |     let TupleStruct { 0: first_field, 1: second_field } = ts;
 help: add `..` at the end of the field list to ignore all other fields
    |
 LL |     let TupleStruct { 0: first_field, 1: second_field , .. } = ts;
-   |                                                       ~~~~~~
+   |                                                       ++++
 
 error[E0638]: `..` required with struct marked as non-exhaustive
   --> $DIR/struct.rs:35:9
@@ -87,7 +87,7 @@ LL |     let UnitStruct { } = us;
 help: add `..` at the end of the field list to ignore all other fields
    |
 LL |     let UnitStruct { .. } = us;
-   |                      ~~~~
+   |                      ++
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/struct.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/struct.stderr
@@ -58,9 +58,8 @@ LL |     let NormalStruct { first_field, second_field } = ns;
    |
 help: add `..` at the end of the field list to ignore all other fields
    |
-LL -     let NormalStruct { first_field, second_field } = ns;
-LL +     let NormalStruct { first_field, second_field , .. } = ns;
-   |
+LL |     let NormalStruct { first_field, second_field , .. } = ns;
+   |                                                  ~~~~~~
 
 error[E0423]: cannot initialize a tuple struct which contains private fields
   --> $DIR/struct.rs:20:14
@@ -76,9 +75,8 @@ LL |     let TupleStruct { 0: first_field, 1: second_field } = ts;
    |
 help: add `..` at the end of the field list to ignore all other fields
    |
-LL -     let TupleStruct { 0: first_field, 1: second_field } = ts;
-LL +     let TupleStruct { 0: first_field, 1: second_field , .. } = ts;
-   |
+LL |     let TupleStruct { 0: first_field, 1: second_field , .. } = ts;
+   |                                                       ~~~~~~
 
 error[E0638]: `..` required with struct marked as non-exhaustive
   --> $DIR/struct.rs:35:9
@@ -88,9 +86,8 @@ LL |     let UnitStruct { } = us;
    |
 help: add `..` at the end of the field list to ignore all other fields
    |
-LL -     let UnitStruct { } = us;
-LL +     let UnitStruct { .. } = us;
-   |
+LL |     let UnitStruct { .. } = us;
+   |                      ~~~~
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/variant.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/variant.stderr
@@ -83,7 +83,7 @@ LL |         NonExhaustiveVariants::Struct { field } => ""
 help: add `..` at the end of the field list to ignore all other fields
    |
 LL |         NonExhaustiveVariants::Struct { field , .. } => ""
-   |                                               ~~~~~~
+   |                                               ++++
 
 error[E0638]: `..` required with variant marked as non-exhaustive
   --> $DIR/variant.rs:30:12
@@ -94,7 +94,7 @@ LL |     if let NonExhaustiveVariants::Struct { field } = variant_struct {
 help: add `..` at the end of the field list to ignore all other fields
    |
 LL |     if let NonExhaustiveVariants::Struct { field , .. } = variant_struct {
-   |                                                  ~~~~~~
+   |                                                  ++++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/variant.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/variant.stderr
@@ -82,9 +82,8 @@ LL |         NonExhaustiveVariants::Struct { field } => ""
    |
 help: add `..` at the end of the field list to ignore all other fields
    |
-LL -         NonExhaustiveVariants::Struct { field } => ""
-LL +         NonExhaustiveVariants::Struct { field , .. } => ""
-   |
+LL |         NonExhaustiveVariants::Struct { field , .. } => ""
+   |                                               ~~~~~~
 
 error[E0638]: `..` required with variant marked as non-exhaustive
   --> $DIR/variant.rs:30:12
@@ -94,9 +93,8 @@ LL |     if let NonExhaustiveVariants::Struct { field } = variant_struct {
    |
 help: add `..` at the end of the field list to ignore all other fields
    |
-LL -     if let NonExhaustiveVariants::Struct { field } = variant_struct {
-LL +     if let NonExhaustiveVariants::Struct { field , .. } = variant_struct {
-   |
+LL |     if let NonExhaustiveVariants::Struct { field , .. } = variant_struct {
+   |                                                  ~~~~~~
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/not-allowed.stderr
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/not-allowed.stderr
@@ -7,7 +7,7 @@ LL | use alloc;
 help: consider importing this module instead
    |
 LL | use std::alloc;
-   |     ~~~~~~~~~~
+   |     +++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/not-allowed.stderr
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/not-allowed.stderr
@@ -6,9 +6,8 @@ LL | use alloc;
    |
 help: consider importing this module instead
    |
-LL - use alloc;
-LL + use std::alloc;
-   |
+LL | use std::alloc;
+   |     ~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rust-2018/trait-import-suggestions.stderr
+++ b/tests/ui/rust-2018/trait-import-suggestions.stderr
@@ -34,9 +34,8 @@ LL + use crate::foo::Bar;
    |
 help: there is a method `foobar` with a similar name
    |
-LL -     x.bar();
-LL +     x.foobar();
-   |
+LL |     x.foobar();
+   |       ~~~~~~
 
 error[E0599]: no method named `baz` found for type `u32` in the current scope
   --> $DIR/trait-import-suggestions.rs:29:7

--- a/tests/ui/rust-2018/trait-import-suggestions.stderr
+++ b/tests/ui/rust-2018/trait-import-suggestions.stderr
@@ -35,7 +35,7 @@ LL + use crate::foo::Bar;
 help: there is a method `foobar` with a similar name
    |
 LL |     x.foobar();
-   |       ~~~~~~
+   |       +++
 
 error[E0599]: no method named `baz` found for type `u32` in the current scope
   --> $DIR/trait-import-suggestions.rs:29:7

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-using-stable.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-using-stable.stderr
@@ -12,7 +12,7 @@ LL | #![deny(stable_features)]
 help: if you are using features which are still unstable, change to using `const_foobar`
    |
 LL | #![feature(const_foobar)]
-   |            ~~~~~~~~~~~~
+   |                     +++
 help: if you are using features which are now stable, remove this line
    |
 LL - #![feature(const_foo)]

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-using-stable.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-using-stable.stderr
@@ -11,9 +11,8 @@ LL | #![deny(stable_features)]
    |         ^^^^^^^^^^^^^^^
 help: if you are using features which are still unstable, change to using `const_foobar`
    |
-LL - #![feature(const_foo)]
-LL + #![feature(const_foobar)]
-   |
+LL | #![feature(const_foobar)]
+   |            ~~~~~~~~~~~~
 help: if you are using features which are now stable, remove this line
    |
 LL - #![feature(const_foo)]

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-using-unstable.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-using-unstable.stderr
@@ -12,7 +12,7 @@ LL | #![deny(stable_features)]
 help: if you are using features which are still unstable, change to using `const_foobar`
    |
 LL | #![feature(const_foobar)]
-   |            ~~~~~~~~~~~~
+   |                     +++
 help: if you are using features which are now stable, remove this line
    |
 LL - #![feature(const_foo)]

--- a/tests/ui/stability-attribute/const-stability-attribute-implies-using-unstable.stderr
+++ b/tests/ui/stability-attribute/const-stability-attribute-implies-using-unstable.stderr
@@ -11,9 +11,8 @@ LL | #![deny(stable_features)]
    |         ^^^^^^^^^^^^^^^
 help: if you are using features which are still unstable, change to using `const_foobar`
    |
-LL - #![feature(const_foo)]
-LL + #![feature(const_foobar)]
-   |
+LL | #![feature(const_foobar)]
+   |            ~~~~~~~~~~~~
 help: if you are using features which are now stable, remove this line
    |
 LL - #![feature(const_foo)]

--- a/tests/ui/stability-attribute/stability-attribute-implies-using-stable.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-implies-using-stable.stderr
@@ -12,7 +12,7 @@ LL | #![deny(stable_features)]
 help: if you are using features which are still unstable, change to using `foobar`
    |
 LL | #![feature(foobar)]
-   |            ~~~~~~
+   |               +++
 help: if you are using features which are now stable, remove this line
    |
 LL - #![feature(foo)]

--- a/tests/ui/stability-attribute/stability-attribute-implies-using-stable.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-implies-using-stable.stderr
@@ -11,9 +11,8 @@ LL | #![deny(stable_features)]
    |         ^^^^^^^^^^^^^^^
 help: if you are using features which are still unstable, change to using `foobar`
    |
-LL - #![feature(foo)]
-LL + #![feature(foobar)]
-   |
+LL | #![feature(foobar)]
+   |            ~~~~~~
 help: if you are using features which are now stable, remove this line
    |
 LL - #![feature(foo)]

--- a/tests/ui/stability-attribute/stability-attribute-implies-using-unstable.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-implies-using-unstable.stderr
@@ -12,7 +12,7 @@ LL | #![deny(stable_features)]
 help: if you are using features which are still unstable, change to using `foobar`
    |
 LL | #![feature(foobar)]
-   |            ~~~~~~
+   |               +++
 help: if you are using features which are now stable, remove this line
    |
 LL - #![feature(foo)]

--- a/tests/ui/stability-attribute/stability-attribute-implies-using-unstable.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-implies-using-unstable.stderr
@@ -11,9 +11,8 @@ LL | #![deny(stable_features)]
    |         ^^^^^^^^^^^^^^^
 help: if you are using features which are still unstable, change to using `foobar`
    |
-LL - #![feature(foo)]
-LL + #![feature(foobar)]
-   |
+LL | #![feature(foobar)]
+   |            ~~~~~~
 help: if you are using features which are now stable, remove this line
    |
 LL - #![feature(foo)]

--- a/tests/ui/statics/issue-15261.stderr
+++ b/tests/ui/statics/issue-15261.stderr
@@ -10,7 +10,7 @@ LL | static n: &'static usize = unsafe { &n_mut };
 help: use `&raw const` instead to create a raw pointer
    |
 LL | static n: &'static usize = unsafe { &raw const n_mut };
-   |                                     ~~~~~~~~~~
+   |                                      +++++++++
 
 warning: 1 warning emitted
 

--- a/tests/ui/statics/issue-15261.stderr
+++ b/tests/ui/statics/issue-15261.stderr
@@ -9,9 +9,8 @@ LL | static n: &'static usize = unsafe { &n_mut };
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
    |
-LL - static n: &'static usize = unsafe { &n_mut };
-LL + static n: &'static usize = unsafe { &raw const n_mut };
-   |
+LL | static n: &'static usize = unsafe { &raw const n_mut };
+   |                                     ~~~~~~~~~~
 
 warning: 1 warning emitted
 

--- a/tests/ui/statics/static-mut-shared-parens.stderr
+++ b/tests/ui/statics/static-mut-shared-parens.stderr
@@ -9,9 +9,8 @@ LL |     let _ = unsafe { (&TEST) as *const usize };
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
    |
-LL -     let _ = unsafe { (&TEST) as *const usize };
-LL +     let _ = unsafe { (&raw const TEST) as *const usize };
-   |
+LL |     let _ = unsafe { (&raw const TEST) as *const usize };
+   |                       ~~~~~~~~~~
 
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/static-mut-shared-parens.rs:11:22

--- a/tests/ui/statics/static-mut-shared-parens.stderr
+++ b/tests/ui/statics/static-mut-shared-parens.stderr
@@ -10,7 +10,7 @@ LL |     let _ = unsafe { (&TEST) as *const usize };
 help: use `&raw const` instead to create a raw pointer
    |
 LL |     let _ = unsafe { (&raw const TEST) as *const usize };
-   |                       ~~~~~~~~~~
+   |                        +++++++++
 
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/static-mut-shared-parens.rs:11:22

--- a/tests/ui/statics/static-mut-xc.stderr
+++ b/tests/ui/statics/static-mut-xc.stderr
@@ -54,9 +54,8 @@ LL |     static_bound(&static_mut_xc::a);
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 help: use `&raw const` instead to create a raw pointer
    |
-LL -     static_bound(&static_mut_xc::a);
-LL +     static_bound(&raw const static_mut_xc::a);
-   |
+LL |     static_bound(&raw const static_mut_xc::a);
+   |                  ~~~~~~~~~~
 
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/static-mut-xc.rs:35:22

--- a/tests/ui/statics/static-mut-xc.stderr
+++ b/tests/ui/statics/static-mut-xc.stderr
@@ -55,7 +55,7 @@ LL |     static_bound(&static_mut_xc::a);
 help: use `&raw const` instead to create a raw pointer
    |
 LL |     static_bound(&raw const static_mut_xc::a);
-   |                  ~~~~~~~~~~
+   |                   +++++++++
 
 warning: creating a mutable reference to mutable static is discouraged
   --> $DIR/static-mut-xc.rs:35:22

--- a/tests/ui/statics/static-recursive.stderr
+++ b/tests/ui/statics/static-recursive.stderr
@@ -9,9 +9,8 @@ LL | static mut S: *const u8 = unsafe { &S as *const *const u8 as *const u8 };
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw const` instead to create a raw pointer
    |
-LL - static mut S: *const u8 = unsafe { &S as *const *const u8 as *const u8 };
-LL + static mut S: *const u8 = unsafe { &raw const S as *const *const u8 as *const u8 };
-   |
+LL | static mut S: *const u8 = unsafe { &raw const S as *const *const u8 as *const u8 };
+   |                                    ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-recursive.rs:19:20

--- a/tests/ui/statics/static-recursive.stderr
+++ b/tests/ui/statics/static-recursive.stderr
@@ -10,7 +10,7 @@ LL | static mut S: *const u8 = unsafe { &S as *const *const u8 as *const u8 };
 help: use `&raw const` instead to create a raw pointer
    |
 LL | static mut S: *const u8 = unsafe { &raw const S as *const *const u8 as *const u8 };
-   |                                    ~~~~~~~~~~
+   |                                     +++++++++
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-recursive.rs:19:20

--- a/tests/ui/structs/struct-fields-hints-no-dupe.stderr
+++ b/tests/ui/structs/struct-fields-hints-no-dupe.stderr
@@ -7,7 +7,7 @@ LL |         bar : 42,
 help: a field with a similar name exists
    |
 LL |         barr : 42,
-   |         ~~~~
+   |            +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/structs/struct-fields-hints-no-dupe.stderr
+++ b/tests/ui/structs/struct-fields-hints-no-dupe.stderr
@@ -6,9 +6,8 @@ LL |         bar : 42,
    |
 help: a field with a similar name exists
    |
-LL -         bar : 42,
-LL +         barr : 42,
-   |
+LL |         barr : 42,
+   |         ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/structs/struct-pat-derived-error.stderr
+++ b/tests/ui/structs/struct-pat-derived-error.stderr
@@ -25,15 +25,15 @@ LL |         let A { x, y } = self.d;
 help: include the missing fields in the pattern
    |
 LL |         let A { x, y, b, c } = self.d;
-   |                     ~~~~~~~~
+   |                     ++++++
 help: if you don't care about these missing fields, you can explicitly ignore them
    |
 LL |         let A { x, y, b: _, c: _ } = self.d;
-   |                     ~~~~~~~~~~~~~~
+   |                     ++++++++++++
 help: or always ignore missing fields here
    |
 LL |         let A { x, y, .. } = self.d;
-   |                     ~~~~~~
+   |                     ++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/structs/struct-pat-derived-error.stderr
+++ b/tests/ui/structs/struct-pat-derived-error.stderr
@@ -24,19 +24,16 @@ LL |         let A { x, y } = self.d;
    |
 help: include the missing fields in the pattern
    |
-LL -         let A { x, y } = self.d;
-LL +         let A { x, y, b, c } = self.d;
-   |
+LL |         let A { x, y, b, c } = self.d;
+   |                     ~~~~~~~~
 help: if you don't care about these missing fields, you can explicitly ignore them
    |
-LL -         let A { x, y } = self.d;
-LL +         let A { x, y, b: _, c: _ } = self.d;
-   |
+LL |         let A { x, y, b: _, c: _ } = self.d;
+   |                     ~~~~~~~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -         let A { x, y } = self.d;
-LL +         let A { x, y, .. } = self.d;
-   |
+LL |         let A { x, y, .. } = self.d;
+   |                     ~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/structs/struct-tuple-field-names.stderr
+++ b/tests/ui/structs/struct-tuple-field-names.stderr
@@ -30,19 +30,16 @@ LL |     if let E::S { 0: a } = x {
    |
 help: include the missing field in the pattern
    |
-LL -     if let E::S { 0: a } = x {
-LL +     if let E::S { 0: a, 1: _ } = x {
-   |
+LL |     if let E::S { 0: a, 1: _ } = x {
+   |                       ~~~~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -     if let E::S { 0: a } = x {
-LL +     if let E::S { 0: a, 1: _ } = x {
-   |
+LL |     if let E::S { 0: a, 1: _ } = x {
+   |                       ~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -     if let E::S { 0: a } = x {
-LL +     if let E::S { 0: a, .. } = x {
-   |
+LL |     if let E::S { 0: a, .. } = x {
+   |                       ~~~~~~
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/structs/struct-tuple-field-names.stderr
+++ b/tests/ui/structs/struct-tuple-field-names.stderr
@@ -31,15 +31,15 @@ LL |     if let E::S { 0: a } = x {
 help: include the missing field in the pattern
    |
 LL |     if let E::S { 0: a, 1: _ } = x {
-   |                       ~~~~~~~~
+   |                       ++++++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |     if let E::S { 0: a, 1: _ } = x {
-   |                       ~~~~~~~~
+   |                       ++++++
 help: or always ignore missing fields here
    |
 LL |     if let E::S { 0: a, .. } = x {
-   |                       ~~~~~~
+   |                       ++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/structs/suggest-replacing-field-when-specifying-same-type.stderr
+++ b/tests/ui/structs/suggest-replacing-field-when-specifying-same-type.stderr
@@ -16,15 +16,15 @@ LL |         Foo::Bar { a, aa: 1, c } => (),
 help: include the missing field in the pattern
    |
 LL |         Foo::Bar { a, aa: 1, c, b } => (),
-   |                               ~~~~~
+   |                               +++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |         Foo::Bar { a, aa: 1, c, b: _ } => (),
-   |                               ~~~~~~~~
+   |                               ++++++
 help: or always ignore missing fields here
    |
 LL |         Foo::Bar { a, aa: 1, c, .. } => (),
-   |                               ~~~~~~
+   |                               ++++
 
 error[E0026]: variant `Foo::Baz` does not have a field named `bb`
   --> $DIR/suggest-replacing-field-when-specifying-same-type.rs:13:20
@@ -44,15 +44,15 @@ LL |         Foo::Baz { bb: 1.0 } => (),
 help: include the missing field in the pattern
    |
 LL |         Foo::Baz { bb: 1.0, a } => (),
-   |                           ~~~~~
+   |                           +++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |         Foo::Baz { bb: 1.0, a: _ } => (),
-   |                           ~~~~~~~~
+   |                           ++++++
 help: or always ignore missing fields here
    |
 LL |         Foo::Baz { bb: 1.0, .. } => (),
-   |                           ~~~~~~
+   |                           ++++
 
 error[E0026]: variant `Foo::Bar` does not have a field named `aa`
   --> $DIR/suggest-replacing-field-when-specifying-same-type.rs:20:23
@@ -69,15 +69,15 @@ LL |         Foo::Bar { a, aa: "", c } => (),
 help: include the missing field in the pattern
    |
 LL |         Foo::Bar { a, aa: "", c, b } => (),
-   |                                ~~~~~
+   |                                +++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |         Foo::Bar { a, aa: "", c, b: _ } => (),
-   |                                ~~~~~~~~
+   |                                ++++++
 help: or always ignore missing fields here
    |
 LL |         Foo::Bar { a, aa: "", c, .. } => (),
-   |                                ~~~~~~
+   |                                ++++
 
 error[E0026]: variant `Foo::Baz` does not have a field named `bb`
   --> $DIR/suggest-replacing-field-when-specifying-same-type.rs:23:20
@@ -94,15 +94,15 @@ LL |         Foo::Baz { bb: "" } => (),
 help: include the missing field in the pattern
    |
 LL |         Foo::Baz { bb: "", a } => (),
-   |                          ~~~~~
+   |                          +++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |         Foo::Baz { bb: "", a: _ } => (),
-   |                          ~~~~~~~~
+   |                          ++++++
 help: or always ignore missing fields here
    |
 LL |         Foo::Baz { bb: "", .. } => (),
-   |                          ~~~~~~
+   |                          ++++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/structs/suggest-replacing-field-when-specifying-same-type.stderr
+++ b/tests/ui/structs/suggest-replacing-field-when-specifying-same-type.stderr
@@ -15,19 +15,16 @@ LL |         Foo::Bar { a, aa: 1, c } => (),
    |
 help: include the missing field in the pattern
    |
-LL -         Foo::Bar { a, aa: 1, c } => (),
-LL +         Foo::Bar { a, aa: 1, c, b } => (),
-   |
+LL |         Foo::Bar { a, aa: 1, c, b } => (),
+   |                               ~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -         Foo::Bar { a, aa: 1, c } => (),
-LL +         Foo::Bar { a, aa: 1, c, b: _ } => (),
-   |
+LL |         Foo::Bar { a, aa: 1, c, b: _ } => (),
+   |                               ~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -         Foo::Bar { a, aa: 1, c } => (),
-LL +         Foo::Bar { a, aa: 1, c, .. } => (),
-   |
+LL |         Foo::Bar { a, aa: 1, c, .. } => (),
+   |                               ~~~~~~
 
 error[E0026]: variant `Foo::Baz` does not have a field named `bb`
   --> $DIR/suggest-replacing-field-when-specifying-same-type.rs:13:20
@@ -46,19 +43,16 @@ LL |         Foo::Baz { bb: 1.0 } => (),
    |
 help: include the missing field in the pattern
    |
-LL -         Foo::Baz { bb: 1.0 } => (),
-LL +         Foo::Baz { bb: 1.0, a } => (),
-   |
+LL |         Foo::Baz { bb: 1.0, a } => (),
+   |                           ~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -         Foo::Baz { bb: 1.0 } => (),
-LL +         Foo::Baz { bb: 1.0, a: _ } => (),
-   |
+LL |         Foo::Baz { bb: 1.0, a: _ } => (),
+   |                           ~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -         Foo::Baz { bb: 1.0 } => (),
-LL +         Foo::Baz { bb: 1.0, .. } => (),
-   |
+LL |         Foo::Baz { bb: 1.0, .. } => (),
+   |                           ~~~~~~
 
 error[E0026]: variant `Foo::Bar` does not have a field named `aa`
   --> $DIR/suggest-replacing-field-when-specifying-same-type.rs:20:23
@@ -74,19 +68,16 @@ LL |         Foo::Bar { a, aa: "", c } => (),
    |
 help: include the missing field in the pattern
    |
-LL -         Foo::Bar { a, aa: "", c } => (),
-LL +         Foo::Bar { a, aa: "", c, b } => (),
-   |
+LL |         Foo::Bar { a, aa: "", c, b } => (),
+   |                                ~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -         Foo::Bar { a, aa: "", c } => (),
-LL +         Foo::Bar { a, aa: "", c, b: _ } => (),
-   |
+LL |         Foo::Bar { a, aa: "", c, b: _ } => (),
+   |                                ~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -         Foo::Bar { a, aa: "", c } => (),
-LL +         Foo::Bar { a, aa: "", c, .. } => (),
-   |
+LL |         Foo::Bar { a, aa: "", c, .. } => (),
+   |                                ~~~~~~
 
 error[E0026]: variant `Foo::Baz` does not have a field named `bb`
   --> $DIR/suggest-replacing-field-when-specifying-same-type.rs:23:20
@@ -102,19 +93,16 @@ LL |         Foo::Baz { bb: "" } => (),
    |
 help: include the missing field in the pattern
    |
-LL -         Foo::Baz { bb: "" } => (),
-LL +         Foo::Baz { bb: "", a } => (),
-   |
+LL |         Foo::Baz { bb: "", a } => (),
+   |                          ~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -         Foo::Baz { bb: "" } => (),
-LL +         Foo::Baz { bb: "", a: _ } => (),
-   |
+LL |         Foo::Baz { bb: "", a: _ } => (),
+   |                          ~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -         Foo::Baz { bb: "" } => (),
-LL +         Foo::Baz { bb: "", .. } => (),
-   |
+LL |         Foo::Baz { bb: "", .. } => (),
+   |                          ~~~~~~
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -44,7 +44,7 @@ LL |     println!("{:?} {:?}", x, y);
 help: consider further restricting type parameter `Y` with trait `Debug`
    |
 LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
-   |                                                                   ~~~~~~~~~~~~~~~~~~~~
+   |                                                                     ++++++++++++++++++
 
 error[E0277]: `X` doesn't implement `Debug`
   --> $DIR/bound-suggestions.rs:33:22

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -43,9 +43,8 @@ LL |     println!("{:?} {:?}", x, y);
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `Y` with trait `Debug`
    |
-LL - fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, {
-LL + fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
-   |
+LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
+   |                                                                   ~~~~~~~~~~~~~~~~~~~~
 
 error[E0277]: `X` doesn't implement `Debug`
   --> $DIR/bound-suggestions.rs:33:22

--- a/tests/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
+++ b/tests/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
@@ -12,9 +12,8 @@ LL |     const A: i32 = 2;
    = note: the matched value is of type `i32`
 help: introduce a variable instead
    |
-LL -     let A = 3;
-LL +     let A_var = 3;
-   |
+LL |     let A_var = 3;
+   |         ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
+++ b/tests/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
@@ -13,7 +13,7 @@ LL |     const A: i32 = 2;
 help: introduce a variable instead
    |
 LL |     let A_var = 3;
-   |         ~~~~~
+   |          ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/crate-or-module-typo.stderr
+++ b/tests/ui/suggestions/crate-or-module-typo.stderr
@@ -6,9 +6,8 @@ LL | use st::cell::Cell;
    |
 help: there is a crate or module with a similar name
    |
-LL - use st::cell::Cell;
-LL + use std::cell::Cell;
-   |
+LL | use std::cell::Cell;
+   |     ~~~
 
 error[E0432]: unresolved import `bas`
   --> $DIR/crate-or-module-typo.rs:11:5
@@ -30,9 +29,8 @@ LL |     bar: st::cell::Cell<bool>
    |
 help: there is a crate or module with a similar name
    |
-LL -     bar: st::cell::Cell<bool>
-LL +     bar: std::cell::Cell<bool>
-   |
+LL |     bar: std::cell::Cell<bool>
+   |          ~~~
 help: consider importing this module
    |
 LL + use std::cell;

--- a/tests/ui/suggestions/crate-or-module-typo.stderr
+++ b/tests/ui/suggestions/crate-or-module-typo.stderr
@@ -7,7 +7,7 @@ LL | use st::cell::Cell;
 help: there is a crate or module with a similar name
    |
 LL | use std::cell::Cell;
-   |     ~~~
+   |       +
 
 error[E0432]: unresolved import `bas`
   --> $DIR/crate-or-module-typo.rs:11:5
@@ -30,7 +30,7 @@ LL |     bar: st::cell::Cell<bool>
 help: there is a crate or module with a similar name
    |
 LL |     bar: std::cell::Cell<bool>
-   |          ~~~
+   |            +
 help: consider importing this module
    |
 LL + use std::cell;

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.stderr
@@ -20,9 +20,8 @@ LL |     fn foo(&self) where Self: Other, { }
    |            +++++
 help: alternatively, consider constraining `foo` so it does not apply to trait objects
    |
-LL -     fn foo() where Self: Other, { }
-LL +     fn foo() where Self: Other, Self: Sized { }
-   |
+LL |     fn foo() where Self: Other, Self: Sized { }
+   |                               ~~~~~~~~~~~~~
 help: consider changing method `bar`'s `self` parameter to be `&self`
    |
 LL -     fn bar(self: ()) {}

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.stderr
@@ -21,7 +21,7 @@ LL |     fn foo(&self) where Self: Other, { }
 help: alternatively, consider constraining `foo` so it does not apply to trait objects
    |
 LL |     fn foo() where Self: Other, Self: Sized { }
-   |                               ~~~~~~~~~~~~~
+   |                                 +++++++++++
 help: consider changing method `bar`'s `self` parameter to be `&self`
    |
 LL -     fn bar(self: ()) {}

--- a/tests/ui/suggestions/field-access.stderr
+++ b/tests/ui/suggestions/field-access.stderr
@@ -12,7 +12,7 @@ LL |     if let B::Fst = a {};
 help: you might have meant to use field `b` whose type is `B`
    |
 LL |     if let B::Fst = a.b {};
-   |                     ~~~
+   |                      ++
 
 error[E0308]: mismatched types
   --> $DIR/field-access.rs:25:9
@@ -29,7 +29,7 @@ LL |         B::Fst => (),
 help: you might have meant to use field `b` whose type is `B`
    |
 LL |     match a.b {
-   |           ~~~
+   |            ++
 
 error[E0308]: mismatched types
   --> $DIR/field-access.rs:26:9
@@ -46,7 +46,7 @@ LL |         B::Snd => (),
 help: you might have meant to use field `b` whose type is `B`
    |
 LL |     match a.b {
-   |           ~~~
+   |            ++
 
 error[E0308]: mismatched types
   --> $DIR/field-access.rs:32:9

--- a/tests/ui/suggestions/field-access.stderr
+++ b/tests/ui/suggestions/field-access.stderr
@@ -11,9 +11,8 @@ LL |     if let B::Fst = a {};
    |
 help: you might have meant to use field `b` whose type is `B`
    |
-LL -     if let B::Fst = a {};
-LL +     if let B::Fst = a.b {};
-   |
+LL |     if let B::Fst = a.b {};
+   |                     ~~~
 
 error[E0308]: mismatched types
   --> $DIR/field-access.rs:25:9
@@ -29,9 +28,8 @@ LL |         B::Fst => (),
    |
 help: you might have meant to use field `b` whose type is `B`
    |
-LL -     match a {
-LL +     match a.b {
-   |
+LL |     match a.b {
+   |           ~~~
 
 error[E0308]: mismatched types
   --> $DIR/field-access.rs:26:9
@@ -47,9 +45,8 @@ LL |         B::Snd => (),
    |
 help: you might have meant to use field `b` whose type is `B`
    |
-LL -     match a {
-LL +     match a.b {
-   |
+LL |     match a.b {
+   |           ~~~
 
 error[E0308]: mismatched types
   --> $DIR/field-access.rs:32:9

--- a/tests/ui/suggestions/imm-ref-trait-object-literal.stderr
+++ b/tests/ui/suggestions/imm-ref-trait-object-literal.stderr
@@ -15,7 +15,7 @@ LL | fn foo<X: Trait>(_: X) {}
 help: consider changing this borrow's mutability
    |
 LL |   foo(&mut s);
-   |       ~~~~
+   |        +++
 
 error[E0277]: the trait bound `S: Trait` is not satisfied
   --> $DIR/imm-ref-trait-object-literal.rs:13:7

--- a/tests/ui/suggestions/imm-ref-trait-object-literal.stderr
+++ b/tests/ui/suggestions/imm-ref-trait-object-literal.stderr
@@ -14,9 +14,8 @@ LL | fn foo<X: Trait>(_: X) {}
    |           ^^^^^ required by this bound in `foo`
 help: consider changing this borrow's mutability
    |
-LL -   foo(&s);
-LL +   foo(&mut s);
-   |
+LL |   foo(&mut s);
+   |       ~~~~
 
 error[E0277]: the trait bound `S: Trait` is not satisfied
   --> $DIR/imm-ref-trait-object-literal.rs:13:7

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -12,7 +12,7 @@ LL |     fn g(mut x: impl Iterator<Item = &()>) -> Option<&'static ()> { x.next(
 help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
-   |         ++++                             ~~~                ~~~
+   |         ++++                              ++                 ++
 help: alternatively, you might want to return an owned value
    |
 LL -     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
@@ -33,7 +33,7 @@ LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&'static ()> { x
 help: consider introducing a named lifetime parameter
    |
 LL |     async fn i<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
-   |               ++++                             ~~~                ~~~
+   |               ++++                              ++                 ++
 help: alternatively, you might want to return an owned value
    |
 LL -     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
@@ -100,7 +100,7 @@ LL |     fn g(mut x: impl Foo) -> Option<&'static ()> { x.next() }
 help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Foo) -> Option<&'a ()> { x.next() }
-   |         ++++                            ~~~
+   |         ++++                             ++
 help: alternatively, you might want to return an owned value
    |
 LL -     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
@@ -121,7 +121,7 @@ LL |     fn g(mut x: impl Foo<()>) -> Option<&'static ()> { x.next() }
 help: consider introducing a named lifetime parameter
    |
 LL |     fn g<'a>(mut x: impl Foo<()>) -> Option<&'a ()> { x.next() }
-   |         ++++                                ~~~
+   |         ++++                                 ++
 help: alternatively, you might want to return an owned value
    |
 LL -     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -11,9 +11,8 @@ LL |     fn g(mut x: impl Iterator<Item = &()>) -> Option<&'static ()> { x.next(
    |                                                       +++++++
 help: consider introducing a named lifetime parameter
    |
-LL -     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
-LL +     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
-   |
+LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
+   |         ++++                             ~~~                ~~~
 help: alternatively, you might want to return an owned value
    |
 LL -     fn g(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
@@ -33,9 +32,8 @@ LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&'static ()> { x
    |                                                             +++++++
 help: consider introducing a named lifetime parameter
    |
-LL -     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
-LL +     async fn i<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
-   |
+LL |     async fn i<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'a ()> { x.next() }
+   |               ++++                             ~~~                ~~~
 help: alternatively, you might want to return an owned value
    |
 LL -     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
@@ -101,9 +99,8 @@ LL |     fn g(mut x: impl Foo) -> Option<&'static ()> { x.next() }
    |                                      +++++++
 help: consider introducing a named lifetime parameter
    |
-LL -     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
-LL +     fn g<'a>(mut x: impl Foo) -> Option<&'a ()> { x.next() }
-   |
+LL |     fn g<'a>(mut x: impl Foo) -> Option<&'a ()> { x.next() }
+   |         ++++                            ~~~
 help: alternatively, you might want to return an owned value
    |
 LL -     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
@@ -123,9 +120,8 @@ LL |     fn g(mut x: impl Foo<()>) -> Option<&'static ()> { x.next() }
    |                                          +++++++
 help: consider introducing a named lifetime parameter
    |
-LL -     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
-LL +     fn g<'a>(mut x: impl Foo<()>) -> Option<&'a ()> { x.next() }
-   |
+LL |     fn g<'a>(mut x: impl Foo<()>) -> Option<&'a ()> { x.next() }
+   |         ++++                                ~~~
 help: alternatively, you might want to return an owned value
    |
 LL -     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }

--- a/tests/ui/suggestions/recover-missing-turbofish-surrounding-angle-braket.stderr
+++ b/tests/ui/suggestions/recover-missing-turbofish-surrounding-angle-braket.stderr
@@ -41,9 +41,8 @@ LL |     let _ = vec![1, 2, 3].into_iter().collect::Vec<_>>();
    |
 help: surround the type parameters with angle brackets
    |
-LL -     let _ = vec![1, 2, 3].into_iter().collect::Vec<_>>();
-LL +     let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>();
-   |
+LL |     let _ = vec![1, 2, 3].into_iter().collect::<Vec<_>>();
+   |                                                +
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
@@ -7,7 +7,7 @@ LL |     a: foo:A,
 help: write a path separator here
    |
 LL |     a: foo::A,
-   |           ~~
+   |            +
 
 error: expected `,`, or `}`, found `:`
   --> $DIR/struct-field-type-including-single-colon.rs:9:11
@@ -26,7 +26,7 @@ LL |     b: foo::bar:B,
 help: write a path separator here
    |
 LL |     b: foo::bar::B,
-   |                ~~
+   |                 +
 
 error: expected `,`, or `}`, found `:`
   --> $DIR/struct-field-type-including-single-colon.rs:15:16

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
@@ -6,9 +6,8 @@ LL |     a: foo:A,
    |
 help: write a path separator here
    |
-LL -     a: foo:A,
-LL +     a: foo::A,
-   |
+LL |     a: foo::A,
+   |           ~~
 
 error: expected `,`, or `}`, found `:`
   --> $DIR/struct-field-type-including-single-colon.rs:9:11
@@ -26,9 +25,8 @@ LL |     b: foo::bar:B,
    |
 help: write a path separator here
    |
-LL -     b: foo::bar:B,
-LL +     b: foo::bar::B,
-   |
+LL |     b: foo::bar::B,
+   |                ~~
 
 error: expected `,`, or `}`, found `:`
   --> $DIR/struct-field-type-including-single-colon.rs:15:16

--- a/tests/ui/suggestions/suggest-change-mut.stderr
+++ b/tests/ui/suggestions/suggest-change-mut.stderr
@@ -20,7 +20,7 @@ LL | fn issue_81421<T: Read + Write>(mut stream: T) where &T: std::io::Read {
 help: consider changing this borrow's mutability
    |
 LL |         let mut stream_reader = BufReader::new(&mut stream);
-   |                                                ~~~~
+   |                                                 +++
 
 error[E0599]: the method `read_until` exists for struct `BufReader<&T>`, but its trait bounds were not satisfied
   --> $DIR/suggest-change-mut.rs:16:23

--- a/tests/ui/suggestions/suggest-change-mut.stderr
+++ b/tests/ui/suggestions/suggest-change-mut.stderr
@@ -19,9 +19,8 @@ LL | fn issue_81421<T: Read + Write>(mut stream: T) where &T: std::io::Read {
    |                                                +++++++++++++++++++++++
 help: consider changing this borrow's mutability
    |
-LL -         let mut stream_reader = BufReader::new(&stream);
-LL +         let mut stream_reader = BufReader::new(&mut stream);
-   |
+LL |         let mut stream_reader = BufReader::new(&mut stream);
+   |                                                ~~~~
 
 error[E0599]: the method `read_until` exists for struct `BufReader<&T>`, but its trait bounds were not satisfied
   --> $DIR/suggest-change-mut.rs:16:23

--- a/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
+++ b/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
@@ -12,7 +12,7 @@ LL |         Some(_) => {}
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match *x {
-   |           ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:9:9
@@ -28,7 +28,7 @@ LL |         None => {}
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match *x {
-   |           ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:16:9
@@ -78,7 +78,7 @@ LL |         Some(_) => {}
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match *y {
-   |           ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:28:9
@@ -94,7 +94,7 @@ LL |         None => {}
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match *y {
-   |           ~~
+   |           +
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:36:9
@@ -144,7 +144,7 @@ LL |         Some(_) => {}
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**z_const {
-   |           ~~~~~~~~~~
+   |           +++
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:48:9
@@ -160,7 +160,7 @@ LL |         None => {}
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**z_const {
-   |           ~~~~~~~~~~
+   |           +++
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:57:9
@@ -176,7 +176,7 @@ LL |         Some(_) => {}
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**z_mut {
-   |           ~~~~~~~~
+   |           +++
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:59:9
@@ -192,7 +192,7 @@ LL |         None => {}
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**z_mut {
-   |           ~~~~~~~~
+   |           +++
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:68:9
@@ -208,7 +208,7 @@ LL |         Some(_) => {}
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**y_mut {
-   |           ~~~~~~~~
+   |           +++
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:70:9
@@ -224,7 +224,7 @@ LL |         None => {}
 help: consider dereferencing to access the inner value using the Deref trait
    |
 LL |     match &**y_mut {
-   |           ~~~~~~~~
+   |           +++
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:79:9

--- a/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
+++ b/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
@@ -11,9 +11,8 @@ LL |         Some(_) => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match x {
-LL +     match *x {
-   |
+LL |     match *x {
+   |           ~~
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:9:9
@@ -28,9 +27,8 @@ LL |         None => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match x {
-LL +     match *x {
-   |
+LL |     match *x {
+   |           ~~
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:16:9
@@ -79,9 +77,8 @@ LL |         Some(_) => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match y {
-LL +     match *y {
-   |
+LL |     match *y {
+   |           ~~
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:28:9
@@ -96,9 +93,8 @@ LL |         None => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match y {
-LL +     match *y {
-   |
+LL |     match *y {
+   |           ~~
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:36:9
@@ -147,9 +143,8 @@ LL |         Some(_) => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match z_const {
-LL +     match &**z_const {
-   |
+LL |     match &**z_const {
+   |           ~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:48:9
@@ -164,9 +159,8 @@ LL |         None => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match z_const {
-LL +     match &**z_const {
-   |
+LL |     match &**z_const {
+   |           ~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:57:9
@@ -181,9 +175,8 @@ LL |         Some(_) => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match z_mut {
-LL +     match &**z_mut {
-   |
+LL |     match &**z_mut {
+   |           ~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:59:9
@@ -198,9 +191,8 @@ LL |         None => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match z_mut {
-LL +     match &**z_mut {
-   |
+LL |     match &**z_mut {
+   |           ~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:68:9
@@ -215,9 +207,8 @@ LL |         Some(_) => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match y_mut {
-LL +     match &**y_mut {
-   |
+LL |     match &**y_mut {
+   |           ~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:70:9
@@ -232,9 +223,8 @@ LL |         None => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match y_mut {
-LL +     match &**y_mut {
-   |
+LL |     match &**y_mut {
+   |           ~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:79:9

--- a/tests/ui/suggestions/suggest-methods.stderr
+++ b/tests/ui/suggestions/suggest-methods.stderr
@@ -46,7 +46,7 @@ LL |     let _ = 63u32.count_o();
 help: there is a method `count_ones` with a similar name
    |
 LL |     let _ = 63u32.count_ones();
-   |                   ~~~~~~~~~~
+   |                          +++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/suggestions/suggest-methods.stderr
+++ b/tests/ui/suggestions/suggest-methods.stderr
@@ -45,9 +45,8 @@ LL |     let _ = 63u32.count_o();
    |
 help: there is a method `count_ones` with a similar name
    |
-LL -     let _ = 63u32.count_o();
-LL +     let _ = 63u32.count_ones();
-   |
+LL |     let _ = 63u32.count_ones();
+   |                   ~~~~~~~~~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/suggestions/suggest-variants.stderr
+++ b/tests/ui/suggestions/suggest-variants.stderr
@@ -25,7 +25,7 @@ LL |     println!("My shape is {:?}", Shape::Circl { size: 5});
 help: there is a variant with a similar name
    |
 LL |     println!("My shape is {:?}", Shape::Circle { size: 5});
-   |                                         ~~~~~~
+   |                                              +
 
 error[E0599]: no variant named `Rombus` found for enum `Shape`
   --> $DIR/suggest-variants.rs:14:41
@@ -63,7 +63,7 @@ LL |     Shape::Circl;
 help: there is a variant with a similar name
    |
 LL |     Shape::Circle { radius: /* value */ };
-   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                 +++++++++++++++++++++++++
 
 error[E0599]: no variant or associated item named `Rombus` found for enum `Shape` in the current scope
   --> $DIR/suggest-variants.rs:17:12

--- a/tests/ui/suggestions/suggest-variants.stderr
+++ b/tests/ui/suggestions/suggest-variants.stderr
@@ -24,9 +24,8 @@ LL |     println!("My shape is {:?}", Shape::Circl { size: 5});
    |
 help: there is a variant with a similar name
    |
-LL -     println!("My shape is {:?}", Shape::Circl { size: 5});
-LL +     println!("My shape is {:?}", Shape::Circle { size: 5});
-   |
+LL |     println!("My shape is {:?}", Shape::Circle { size: 5});
+   |                                         ~~~~~~
 
 error[E0599]: no variant named `Rombus` found for enum `Shape`
   --> $DIR/suggest-variants.rs:14:41
@@ -63,9 +62,8 @@ LL |     Shape::Circl;
    |
 help: there is a variant with a similar name
    |
-LL -     Shape::Circl;
-LL +     Shape::Circle { radius: /* value */ };
-   |
+LL |     Shape::Circle { radius: /* value */ };
+   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0599]: no variant or associated item named `Rombus` found for enum `Shape` in the current scope
   --> $DIR/suggest-variants.rs:17:12

--- a/tests/ui/suggestions/type-ascription-instead-of-path-2.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-2.stderr
@@ -8,7 +8,7 @@ LL |     let _ = vec![Ok(2)].into_iter().collect:<Result<Vec<_>,_>>()?;
 help: maybe write a path separator here
    |
 LL |     let _ = vec![Ok(2)].into_iter().collect::<Result<Vec<_>,_>>()?;
-   |                                            ~~
+   |                                             +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/type-ascription-instead-of-path-2.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-2.stderr
@@ -7,9 +7,8 @@ LL |     let _ = vec![Ok(2)].into_iter().collect:<Result<Vec<_>,_>>()?;
    = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: maybe write a path separator here
    |
-LL -     let _ = vec![Ok(2)].into_iter().collect:<Result<Vec<_>,_>>()?;
-LL +     let _ = vec![Ok(2)].into_iter().collect::<Result<Vec<_>,_>>()?;
-   |
+LL |     let _ = vec![Ok(2)].into_iter().collect::<Result<Vec<_>,_>>()?;
+   |                                            ~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
@@ -7,7 +7,7 @@ LL |     let _: Vec<A:B> = A::B;
 help: you might have meant to write a path instead of an associated type bound
    |
 LL |     let _: Vec<A::B> = A::B;
-   |                 ~~
+   |                  +
 
 error[E0107]: struct takes at least 1 generic argument but 0 generic arguments were supplied
   --> $DIR/type-ascription-instead-of-path-in-type.rs:6:12

--- a/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
@@ -6,9 +6,8 @@ LL |     let _: Vec<A:B> = A::B;
    |
 help: you might have meant to write a path instead of an associated type bound
    |
-LL -     let _: Vec<A:B> = A::B;
-LL +     let _: Vec<A::B> = A::B;
-   |
+LL |     let _: Vec<A::B> = A::B;
+   |                 ~~
 
 error[E0107]: struct takes at least 1 generic argument but 0 generic arguments were supplied
   --> $DIR/type-ascription-instead-of-path-in-type.rs:6:12

--- a/tests/ui/suggestions/type-mismatch-byte-literal.stderr
+++ b/tests/ui/suggestions/type-mismatch-byte-literal.stderr
@@ -9,7 +9,7 @@ LL |     let _x: u8 = 'X';
 help: if you meant to write a byte literal, prefix with `b`
    |
 LL |     let _x: u8 = b'X';
-   |                  ~~~~
+   |                  +
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-byte-literal.rs:11:9
@@ -27,7 +27,7 @@ LL | fn foo(_t: u8) {}
 help: if you meant to write a byte literal, prefix with `b`
    |
 LL |     foo(b'#');
-   |         ~~~~
+   |         +
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-byte-literal.rs:15:18
@@ -40,7 +40,7 @@ LL |     let _a: u8 = '\x20';
 help: if you meant to write a byte literal, prefix with `b`
    |
 LL |     let _a: u8 = b'\x20';
-   |                  ~~~~~~~
+   |                  +
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-byte-literal.rs:20:9

--- a/tests/ui/suggestions/type-mismatch-byte-literal.stderr
+++ b/tests/ui/suggestions/type-mismatch-byte-literal.stderr
@@ -8,9 +8,8 @@ LL |     let _x: u8 = 'X';
    |
 help: if you meant to write a byte literal, prefix with `b`
    |
-LL -     let _x: u8 = 'X';
-LL +     let _x: u8 = b'X';
-   |
+LL |     let _x: u8 = b'X';
+   |                  ~~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-byte-literal.rs:11:9
@@ -27,9 +26,8 @@ LL | fn foo(_t: u8) {}
    |    ^^^ ------
 help: if you meant to write a byte literal, prefix with `b`
    |
-LL -     foo('#');
-LL +     foo(b'#');
-   |
+LL |     foo(b'#');
+   |         ~~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-byte-literal.rs:15:18
@@ -41,9 +39,8 @@ LL |     let _a: u8 = '\x20';
    |
 help: if you meant to write a byte literal, prefix with `b`
    |
-LL -     let _a: u8 = '\x20';
-LL +     let _a: u8 = b'\x20';
-   |
+LL |     let _a: u8 = b'\x20';
+   |                  ~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/type-mismatch-byte-literal.rs:20:9

--- a/tests/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/tests/ui/test-attrs/inaccessible-test-modules.stderr
@@ -12,9 +12,8 @@ LL | use test as y;
    |
 help: consider importing this module instead
    |
-LL - use test as y;
-LL + use test::test as y;
-   |
+LL | use test::test as y;
+   |     ~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/tests/ui/test-attrs/inaccessible-test-modules.stderr
@@ -13,7 +13,7 @@ LL | use test as y;
 help: consider importing this module instead
    |
 LL | use test::test as y;
-   |     ~~~~~~~~~~~~~~~
+   |     ++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
+++ b/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
@@ -15,7 +15,7 @@ LL + struct Foo<T> where T: Bar, T: Bar<Baz = String> {
 help: a trait with a similar name exists
    |
 LL | struct Foo<T> where T: Bar, <T as Bar>::Baz: ToString {
-   |                                              ~~~~~~~~
+   |                                              ++
 
 error[E0404]: expected trait, found struct `String`
   --> $DIR/assoc_type_bound_with_struct.rs:9:54
@@ -34,7 +34,7 @@ LL + struct Qux<'a, T> where T: Bar, &'a T: Bar<Baz = String> {
 help: a trait with a similar name exists
    |
 LL | struct Qux<'a, T> where T: Bar, <&'a T as Bar>::Baz: ToString {
-   |                                                      ~~~~~~~~
+   |                                                      ++
 
 error[E0404]: expected trait, found struct `String`
   --> $DIR/assoc_type_bound_with_struct.rs:13:45
@@ -53,7 +53,7 @@ LL + fn foo<T: Bar>(_: T) where T: Bar<Baz = String> {
 help: a trait with a similar name exists
    |
 LL | fn foo<T: Bar>(_: T) where <T as Bar>::Baz: ToString {
-   |                                             ~~~~~~~~
+   |                                             ++
 
 error[E0404]: expected trait, found struct `String`
   --> $DIR/assoc_type_bound_with_struct.rs:16:57
@@ -72,7 +72,7 @@ LL + fn qux<'a, T: Bar>(_: &'a T) where &'a T: Bar<Baz = String> {
 help: a trait with a similar name exists
    |
 LL | fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: ToString {
-   |                                                         ~~~~~~~~
+   |                                                         ++
 
 error[E0405]: cannot find trait `Unresolved` in this scope
   --> $DIR/assoc_type_bound_with_struct.rs:19:31

--- a/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
+++ b/tests/ui/traits/associated_type_bound/assoc_type_bound_with_struct.stderr
@@ -14,9 +14,8 @@ LL + struct Foo<T> where T: Bar, T: Bar<Baz = String> {
    |
 help: a trait with a similar name exists
    |
-LL - struct Foo<T> where T: Bar, <T as Bar>::Baz: String {
-LL + struct Foo<T> where T: Bar, <T as Bar>::Baz: ToString {
-   |
+LL | struct Foo<T> where T: Bar, <T as Bar>::Baz: ToString {
+   |                                              ~~~~~~~~
 
 error[E0404]: expected trait, found struct `String`
   --> $DIR/assoc_type_bound_with_struct.rs:9:54
@@ -34,9 +33,8 @@ LL + struct Qux<'a, T> where T: Bar, &'a T: Bar<Baz = String> {
    |
 help: a trait with a similar name exists
    |
-LL - struct Qux<'a, T> where T: Bar, <&'a T as Bar>::Baz: String {
-LL + struct Qux<'a, T> where T: Bar, <&'a T as Bar>::Baz: ToString {
-   |
+LL | struct Qux<'a, T> where T: Bar, <&'a T as Bar>::Baz: ToString {
+   |                                                      ~~~~~~~~
 
 error[E0404]: expected trait, found struct `String`
   --> $DIR/assoc_type_bound_with_struct.rs:13:45
@@ -54,9 +52,8 @@ LL + fn foo<T: Bar>(_: T) where T: Bar<Baz = String> {
    |
 help: a trait with a similar name exists
    |
-LL - fn foo<T: Bar>(_: T) where <T as Bar>::Baz: String {
-LL + fn foo<T: Bar>(_: T) where <T as Bar>::Baz: ToString {
-   |
+LL | fn foo<T: Bar>(_: T) where <T as Bar>::Baz: ToString {
+   |                                             ~~~~~~~~
 
 error[E0404]: expected trait, found struct `String`
   --> $DIR/assoc_type_bound_with_struct.rs:16:57
@@ -74,9 +71,8 @@ LL + fn qux<'a, T: Bar>(_: &'a T) where &'a T: Bar<Baz = String> {
    |
 help: a trait with a similar name exists
    |
-LL - fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: String {
-LL + fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: ToString {
-   |
+LL | fn qux<'a, T: Bar>(_: &'a T) where <&'a T as Bar>::Baz: ToString {
+   |                                                         ~~~~~~~~
 
 error[E0405]: cannot find trait `Unresolved` in this scope
   --> $DIR/assoc_type_bound_with_struct.rs:19:31

--- a/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.stderr
+++ b/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.stderr
@@ -26,7 +26,7 @@ LL |     for<F> F: 'a,
 help: consider adding an explicit lifetime bound
    |
 LL |     for<F> F: 'a, !1_"F": 'a
-   |                 ~~~~~~~~~~~~
+   |                   ++++++++++
 
 error[E0309]: the placeholder type `!1_"F"` may not live long enough
   --> $DIR/type-match-with-late-bound.rs:11:1
@@ -40,7 +40,7 @@ LL | {}
 help: consider adding an explicit lifetime bound
    |
 LL |     for<F> F: 'a, !1_"F": 'a
-   |                 ~~~~~~~~~~~~
+   |                   ++++++++++
 
 error[E0309]: the placeholder type `!2_"F"` may not live long enough
   --> $DIR/type-match-with-late-bound.rs:11:1
@@ -54,7 +54,7 @@ LL | {}
 help: consider adding an explicit lifetime bound
    |
 LL |     for<F> F: 'a, !2_"F": 'a
-   |                 ~~~~~~~~~~~~
+   |                   ++++++++++
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.stderr
+++ b/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.stderr
@@ -25,9 +25,8 @@ LL |     for<F> F: 'a,
    |               ^^
 help: consider adding an explicit lifetime bound
    |
-LL -     for<F> F: 'a,
-LL +     for<F> F: 'a, !1_"F": 'a
-   |
+LL |     for<F> F: 'a, !1_"F": 'a
+   |                 ~~~~~~~~~~~~
 
 error[E0309]: the placeholder type `!1_"F"` may not live long enough
   --> $DIR/type-match-with-late-bound.rs:11:1
@@ -40,9 +39,8 @@ LL | {}
    |
 help: consider adding an explicit lifetime bound
    |
-LL -     for<F> F: 'a,
-LL +     for<F> F: 'a, !1_"F": 'a
-   |
+LL |     for<F> F: 'a, !1_"F": 'a
+   |                 ~~~~~~~~~~~~
 
 error[E0309]: the placeholder type `!2_"F"` may not live long enough
   --> $DIR/type-match-with-late-bound.rs:11:1
@@ -55,9 +53,8 @@ LL | {}
    |
 help: consider adding an explicit lifetime bound
    |
-LL -     for<F> F: 'a,
-LL +     for<F> F: 'a, !2_"F": 'a
-   |
+LL |     for<F> F: 'a, !2_"F": 'a
+   |                 ~~~~~~~~~~~~
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/tests/ui/transmutability/assoc-bound.stderr
+++ b/tests/ui/transmutability/assoc-bound.stderr
@@ -13,7 +13,7 @@ LL |     type AssocB: std::mem::TransmuteFrom<()>;
 help: consider further restricting the associated type
    |
 LL |     T: A, <T as A>::AssocA: TransmuteFrom<(), Assume { alignment: false, lifetimes: false, safety: false, validity: false }>
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |           ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0277]: `()` cannot be safely transmuted into `<&i32 as A>::AssocA`
   --> $DIR/assoc-bound.rs:24:19

--- a/tests/ui/transmutability/assoc-bound.stderr
+++ b/tests/ui/transmutability/assoc-bound.stderr
@@ -12,9 +12,8 @@ LL |     type AssocB: std::mem::TransmuteFrom<()>;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `B::AssocB`
 help: consider further restricting the associated type
    |
-LL -     T: A,
-LL +     T: A, <T as A>::AssocA: TransmuteFrom<(), Assume { alignment: false, lifetimes: false, safety: false, validity: false }>
-   |
+LL |     T: A, <T as A>::AssocA: TransmuteFrom<(), Assume { alignment: false, lifetimes: false, safety: false, validity: false }>
+   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0277]: `()` cannot be safely transmuted into `<&i32 as A>::AssocA`
   --> $DIR/assoc-bound.rs:24:19

--- a/tests/ui/type/issue-100584.stderr
+++ b/tests/ui/type/issue-100584.stderr
@@ -20,7 +20,7 @@ LL |     let _ = format!("{xyza}");
 help: if this is intentional, prefix it with an underscore
    |
 LL | fn foo(_xyza: &str) {
-   |        ~~~~~
+   |        +
 
 error: unused variable: `xyza`
   --> $DIR/issue-100584.rs:7:9
@@ -38,7 +38,7 @@ LL |     let _ = format!("aaa{xyza}bbb");
 help: if this is intentional, prefix it with an underscore
    |
 LL | fn foo3(_xyza: &str) {
-   |         ~~~~~
+   |         +
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type/issue-100584.stderr
+++ b/tests/ui/type/issue-100584.stderr
@@ -19,9 +19,8 @@ LL |     let _ = format!("{xyza}");
    |             ++++++++        +
 help: if this is intentional, prefix it with an underscore
    |
-LL - fn foo(xyza: &str) {
-LL + fn foo(_xyza: &str) {
-   |
+LL | fn foo(_xyza: &str) {
+   |        ~~~~~
 
 error: unused variable: `xyza`
   --> $DIR/issue-100584.rs:7:9
@@ -38,9 +37,8 @@ LL |     let _ = format!("aaa{xyza}bbb");
    |             ++++++++              +
 help: if this is intentional, prefix it with an underscore
    |
-LL - fn foo3(xyza: &str) {
-LL + fn foo3(_xyza: &str) {
-   |
+LL | fn foo3(_xyza: &str) {
+   |         ~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type/pattern_types/pattern_type_mismatch.stderr
+++ b/tests/ui/type/pattern_types/pattern_type_mismatch.stderr
@@ -6,9 +6,8 @@ LL | const BAD_NESTING4: pattern_type!(u8 is 'a'..='a') = todo!();
    |
 help: if you meant to write a byte literal, prefix with `b`
    |
-LL - const BAD_NESTING4: pattern_type!(u8 is 'a'..='a') = todo!();
-LL + const BAD_NESTING4: pattern_type!(u8 is b'a'..='a') = todo!();
-   |
+LL | const BAD_NESTING4: pattern_type!(u8 is b'a'..='a') = todo!();
+   |                                         ~~~~
 
 error[E0308]: mismatched types
   --> $DIR/pattern_type_mismatch.rs:8:47
@@ -18,9 +17,8 @@ LL | const BAD_NESTING4: pattern_type!(u8 is 'a'..='a') = todo!();
    |
 help: if you meant to write a byte literal, prefix with `b`
    |
-LL - const BAD_NESTING4: pattern_type!(u8 is 'a'..='a') = todo!();
-LL + const BAD_NESTING4: pattern_type!(u8 is 'a'..=b'a') = todo!();
-   |
+LL | const BAD_NESTING4: pattern_type!(u8 is 'a'..=b'a') = todo!();
+   |                                               ~~~~
 
 error[E0308]: mismatched types
   --> $DIR/pattern_type_mismatch.rs:12:43

--- a/tests/ui/type/pattern_types/pattern_type_mismatch.stderr
+++ b/tests/ui/type/pattern_types/pattern_type_mismatch.stderr
@@ -7,7 +7,7 @@ LL | const BAD_NESTING4: pattern_type!(u8 is 'a'..='a') = todo!();
 help: if you meant to write a byte literal, prefix with `b`
    |
 LL | const BAD_NESTING4: pattern_type!(u8 is b'a'..='a') = todo!();
-   |                                         ~~~~
+   |                                         +
 
 error[E0308]: mismatched types
   --> $DIR/pattern_type_mismatch.rs:8:47
@@ -18,7 +18,7 @@ LL | const BAD_NESTING4: pattern_type!(u8 is 'a'..='a') = todo!();
 help: if you meant to write a byte literal, prefix with `b`
    |
 LL | const BAD_NESTING4: pattern_type!(u8 is 'a'..=b'a') = todo!();
-   |                                               ~~~~
+   |                                               +
 
 error[E0308]: mismatched types
   --> $DIR/pattern_type_mismatch.rs:12:43

--- a/tests/ui/typeck/issue-29181.stderr
+++ b/tests/ui/typeck/issue-29181.stderr
@@ -13,7 +13,7 @@ LL |     let _ = |x: f64| x * 2.0.exp();
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |     let _ = |x: f64| x * 2.0_f32.exp();
-   |                          ~~~~~~~
+   |                             ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/issue-29181.stderr
+++ b/tests/ui/typeck/issue-29181.stderr
@@ -12,9 +12,8 @@ LL |     let _ = |x: f64| x * 2.0.exp();
    |
 help: you must specify a concrete type for this numeric value, like `f32`
    |
-LL -     let _ = |x: f64| x * 2.0.exp();
-LL +     let _ = |x: f64| x * 2.0_f32.exp();
-   |
+LL |     let _ = |x: f64| x * 2.0_f32.exp();
+   |                          ~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/method-chain-gats.stderr
+++ b/tests/ui/typeck/method-chain-gats.stderr
@@ -20,7 +20,7 @@ LL |         Self::Base<B>: Functor<B>;
 help: consider further restricting the associated type
    |
 LL |     T::Base<B>: Functor<B, Base<C> = T::Base<C>>, <T as Base>::Base<C>: Functor<C>
-   |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                                   ++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/method-chain-gats.stderr
+++ b/tests/ui/typeck/method-chain-gats.stderr
@@ -19,9 +19,8 @@ LL |         Self::Base<B>: Functor<B>;
    |                        ^^^^^^^^^^ required by this bound in `Functor::fmap`
 help: consider further restricting the associated type
    |
-LL -     T::Base<B>: Functor<B, Base<C> = T::Base<C>>,
-LL +     T::Base<B>: Functor<B, Base<C> = T::Base<C>>, <T as Base>::Base<C>: Functor<C>
-   |
+LL |     T::Base<B>: Functor<B, Base<C> = T::Base<C>>, <T as Base>::Base<C>: Functor<C>
+   |                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/mismatched-map-under-self.stderr
+++ b/tests/ui/typeck/mismatched-map-under-self.stderr
@@ -14,7 +14,7 @@ LL |     fn values(&self) -> Self::Values;
 help: change the self-receiver type to match the trait
    |
 LL |     fn values(&self) -> Self::Values {
-   |               ~~~~~
+   |               +
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/mismatched-map-under-self.rs:12:18

--- a/tests/ui/typeck/mismatched-map-under-self.stderr
+++ b/tests/ui/typeck/mismatched-map-under-self.stderr
@@ -13,9 +13,8 @@ LL |     fn values(&self) -> Self::Values;
               found signature `fn(Option<_>)`
 help: change the self-receiver type to match the trait
    |
-LL -     fn values(self) -> Self::Values {
-LL +     fn values(&self) -> Self::Values {
-   |
+LL |     fn values(&self) -> Self::Values {
+   |               ~~~~~
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/mismatched-map-under-self.rs:12:18

--- a/tests/ui/unresolved/unresolved-candidates.stderr
+++ b/tests/ui/unresolved/unresolved-candidates.stderr
@@ -7,7 +7,7 @@ LL |     use Trait;
 help: consider importing this trait instead
    |
 LL |     use a::Trait;
-   |         ~~~~~~~~
+   |         +++
 
 error[E0405]: cannot find trait `Trait` in this scope
   --> $DIR/unresolved-candidates.rs:10:10

--- a/tests/ui/unresolved/unresolved-candidates.stderr
+++ b/tests/ui/unresolved/unresolved-candidates.stderr
@@ -6,9 +6,8 @@ LL |     use Trait;
    |
 help: consider importing this trait instead
    |
-LL -     use Trait;
-LL +     use a::Trait;
-   |
+LL |     use a::Trait;
+   |         ~~~~~~~~
 
 error[E0405]: cannot find trait `Trait` in this scope
   --> $DIR/unresolved-candidates.rs:10:10


### PR DESCRIPTION
#127541 changes replacement suggestions to use the "diff" view always, which I think is really verbose in cases where a replacement snippet is a "superset" of the snippet that is being replaced.

Consider:

```
LL -     Self::Baz: Clone,
LL +     Self::Baz: Clone, T: std::clone::Clone
```

In this code, we suggest replacing `", "` with `", T: std::clone::Clone"`. This is a consequence of how the snippet is constructed. I believe that since the string that is being replaced is a subset of the replacement string, it's not providing much value to present this as a diff. Users should be able to clearly understand what's being suggested here using the `~` underline view we've been suggesting for some time now.

Given that this affects ~100 tests out of the ~1000 UI tests affected, I expect this to be a pretty meaningful improvement of the fallout of #127541.

---

In the last commit, this PR also "trims" replacement parts so that they are turned into their purely additive subset, if possible. See the diff for what this means.

---

r? estebank