### PR TITLE
Use `slice::fill` in `io::Repeat` implementation

### DIFF
--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -7,6 +7,7 @@ use crate::fmt;
 use crate::io::{
     self, BorrowedCursor, BufRead, IoSlice, IoSliceMut, Read, Seek, SeekFrom, SizeHint, Write,
 };
+use crate::mem::MaybeUninit;
 
 /// `Empty` ignores any data written via [`Write`], and will always be empty
 /// (returning zero bytes) when read via [`Read`].
@@ -182,35 +183,26 @@ pub const fn repeat(byte: u8) -> Repeat {
 impl Read for Repeat {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        for slot in &mut *buf {
-            *slot = self.byte;
-        }
+        buf.fill(self.byte);
         Ok(buf.len())
     }
 
+    #[inline]
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        for slot in &mut *buf {
-            *slot = self.byte;
-        }
+        buf.fill(self.byte);
         Ok(())
     }
 
+    #[inline]
     fn read_buf(&mut self, mut buf: BorrowedCursor<'_>) -> io::Result<()> {
-        // SAFETY: No uninit bytes are being written
-        for slot in unsafe { buf.as_mut() } {
-            slot.write(self.byte);
-        }
-
-        let remaining = buf.capacity();
-
-        // SAFETY: the entire unfilled portion of buf has been initialized
-        unsafe {
-            buf.advance_unchecked(remaining);
-        }
-
+        // SAFETY: No uninit bytes are being written.
+        MaybeUninit::fill(unsafe { buf.as_mut() }, self.byte);
+        // SAFETY: the entire unfilled portion of buf has been initialized.
+        unsafe { buf.advance_unchecked(buf.capacity()) };
         Ok(())
     }
 
+    #[inline]
     fn read_buf_exact(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
         self.read_buf(buf)
     }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -302,6 +302,7 @@
 #![feature(link_cfg)]
 #![feature(linkage)]
 #![feature(macro_metavar_expr_concat)]
+#![feature(maybe_uninit_fill)]
 #![feature(min_specialization)]
 #![feature(must_not_suspend)]
 #![feature(needs_panic_runtime)]


### PR DESCRIPTION
Use the existing `fill` methods on slices instead of manually writing the fill loop.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
