### PR TITLE
ci: move `x86_64-gnu-debug` job to the free runner

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -294,9 +294,7 @@ auto:
     <<: *job-linux-4c
 
   - name: x86_64-gnu-debug
-    # This seems to be needed because a full stage 2 build + run-make tests
-    # overwhelms the storage capacity of the standard 4c runner.
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-4c
 
   - name: x86_64-gnu-distcheck
     <<: *job-linux-8c


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

After https://github.com/rust-lang/rust/pull/136535 we don't need the large runner with more disk space anymore for this job, so we use the free runner instead.
<!-- homu-ignore:end -->
try-job: x86_64-gnu-debug