### PR TITLE
Add a new check-pass UI test for returning `impl Fn(T) -> impl Trait`

### DIFF
--- a/tests/ui/impl-trait/impl-fn-rpit-opaque-107883.rs
+++ b/tests/ui/impl-trait/impl-fn-rpit-opaque-107883.rs
@@ -1,0 +1,37 @@
+//@ check-pass
+// Regression test for <https;//github.com/rust-lang/rust/issues/107883>
+#![feature(impl_trait_in_fn_trait_return)]
+#![feature(unboxed_closures)] // only for `h`
+
+use std::fmt::Debug;
+
+fn f<T>() -> impl Fn(T) -> impl Debug {
+    |_x| 15
+}
+
+fn g<T>() -> impl MyFn<(T,), Out = impl Debug> {
+    |_x| 15
+}
+
+trait MyFn<T> {
+    type Out;
+}
+
+impl<T, U, F: Fn(T) -> U> MyFn<(T,)> for F {
+    type Out = U;
+}
+
+fn h<T>() -> impl Fn<(T,), Output = impl Debug> {
+    |_x| 15
+}
+
+fn f_<T>() -> impl Fn(T) -> impl Debug {
+    std::convert::identity(|_x| 15)
+}
+
+fn f__<T>() -> impl Fn(T) -> impl Debug {
+    let r = |_x| 15;
+    r
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? WaffleLapkin
-->
<!-- homu-ignore:end -->

This PR closes #107883 by adding a ui test.