### PR TITLE
ci: switch loongarch jobs to free runners

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -168,10 +168,10 @@ auto:
     <<: *job-linux-4c
 
   - name: dist-loongarch64-linux
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-4c
 
   - name: dist-loongarch64-musl
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-4c
 
   - name: dist-ohos
     <<: *job-linux-4c


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
After https://github.com/rust-lang/rust/pull/136535 we don't need the large runners with more disk space anymore for these jobs, so we use the free runner instead.

<!-- homu-ignore:end -->
try-job: dist-loongarch64-linux
try-job: dist-loongarch64-musl
