### PR TITLE
Apply unsafe_op_in_unsafe_fn to the standard library

### DIFF
--- a/library/core/src/alloc/global.rs
+++ b/library/core/src/alloc/global.rs
@@ -70,7 +70,7 @@ use crate::{cmp, ptr};
 ///         {
 ///             return null_mut();
 ///         };
-///         self.arena.get().cast::<u8>().add(allocated)
+///         unsafe { self.arena.get().cast::<u8>().add(allocated) }
 ///     }
 ///     unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
 /// }

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -52,7 +52,7 @@ use crate::{intrinsics, ub_checks};
 ///             // Safety: `divisor` can't be zero because of `prepare_inputs`,
 ///             // but the compiler does not know about this. We *promise*
 ///             // that we always call `prepare_inputs`.
-///             std::hint::unreachable_unchecked()
+///             unsafe { std::hint::unreachable_unchecked() }
 ///         }
 ///         // The compiler would normally introduce a check here that prevents
 ///         // a division by zero. However, if `divisor` was zero, the branch

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -1703,12 +1703,12 @@ pub const fn forget<T: ?Sized>(_: T) {
 /// ```
 /// struct R<'a>(&'a i32);
 /// unsafe fn extend_lifetime<'b>(r: R<'b>) -> R<'static> {
-///     std::mem::transmute::<R<'b>, R<'static>>(r)
+///     unsafe { std::mem::transmute::<R<'b>, R<'static>>(r) }
 /// }
 ///
 /// unsafe fn shorten_invariant_lifetime<'b, 'c>(r: &'b mut R<'static>)
 ///                                              -> &'b mut R<'c> {
-///     std::mem::transmute::<&'b mut R<'static>, &'b mut R<'c>>(r)
+///     unsafe { std::mem::transmute::<&'b mut R<'static>, &'b mut R<'c>>(r) }
 /// }
 /// ```
 ///
@@ -4498,11 +4498,11 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 ///
 ///     // SAFETY: Our precondition ensures the source is aligned and valid,
 ///     // and `Vec::with_capacity` ensures that we have usable space to write them.
-///     ptr::copy(ptr, dst.as_mut_ptr(), elts);
+///     unsafe { ptr::copy(ptr, dst.as_mut_ptr(), elts); }
 ///
 ///     // SAFETY: We created it with this much capacity earlier,
 ///     // and the previous `copy` has initialized these elements.
-///     dst.set_len(elts);
+///     unsafe { dst.set_len(elts); }
 ///     dst
 /// }
 /// ```

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -98,7 +98,7 @@ use crate::{fmt, intrinsics, ptr, slice};
 ///
 /// unsafe fn make_vec(out: *mut Vec<i32>) {
 ///     // `write` does not drop the old contents, which is important.
-///     out.write(vec![1, 2, 3]);
+///     unsafe { out.write(vec![1, 2, 3]); }
 /// }
 ///
 /// let mut v = MaybeUninit::uninit();
@@ -844,7 +844,7 @@ impl<T> MaybeUninit<T> {
     /// # #![allow(unexpected_cfgs)]
     /// use std::mem::MaybeUninit;
     ///
-    /// # unsafe extern "C" fn initialize_buffer(buf: *mut [u8; 1024]) { *buf = [0; 1024] }
+    /// # unsafe extern "C" fn initialize_buffer(buf: *mut [u8; 1024]) { unsafe { *buf = [0; 1024] } }
     /// # #[cfg(FALSE)]
     /// extern "C" {
     ///     /// Initializes *all* the bytes of the input buffer.

--- a/library/core/src/mem/transmutability.rs
+++ b/library/core/src/mem/transmutability.rs
@@ -32,7 +32,7 @@ use crate::marker::{ConstParamTy_, UnsizedConstParamTy};
 ///         src: ManuallyDrop::new(src),
 ///     };
 ///
-///     let dst = transmute.dst;
+///     let dst = unsafe { transmute.dst };
 ///
 ///     ManuallyDrop::into_inner(dst)
 /// }

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -724,13 +724,13 @@ impl<T: ?Sized> *const T {
     /// that their safety preconditions are met:
     /// ```rust
     /// # #![feature(ptr_sub_ptr)]
-    /// # unsafe fn blah(ptr: *const i32, origin: *const i32, count: usize) -> bool {
+    /// # unsafe fn blah(ptr: *const i32, origin: *const i32, count: usize) -> bool { unsafe {
     /// ptr.sub_ptr(origin) == count
     /// # &&
     /// origin.add(count) == ptr
     /// # &&
     /// ptr.sub(count) == origin
-    /// # }
+    /// # } }
     /// ```
     ///
     /// # Safety

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -896,13 +896,13 @@ impl<T: ?Sized> *mut T {
     /// that their safety preconditions are met:
     /// ```rust
     /// # #![feature(ptr_sub_ptr)]
-    /// # unsafe fn blah(ptr: *mut i32, origin: *mut i32, count: usize) -> bool {
+    /// # unsafe fn blah(ptr: *mut i32, origin: *mut i32, count: usize) -> bool { unsafe {
     /// ptr.sub_ptr(origin) == count
     /// # &&
     /// origin.add(count) == ptr
     /// # &&
     /// ptr.sub(count) == origin
-    /// # }
+    /// # } }
     /// ```
     ///
     /// # Safety

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -857,13 +857,13 @@ impl<T: ?Sized> NonNull<T> {
     /// that their safety preconditions are met:
     /// ```rust
     /// # #![feature(ptr_sub_ptr)]
-    /// # unsafe fn blah(ptr: std::ptr::NonNull<u32>, origin: std::ptr::NonNull<u32>, count: usize) -> bool {
+    /// # unsafe fn blah(ptr: std::ptr::NonNull<u32>, origin: std::ptr::NonNull<u32>, count: usize) -> bool { unsafe {
     /// ptr.sub_ptr(origin) == count
     /// # &&
     /// origin.add(count) == ptr
     /// # &&
     /// ptr.sub(count) == origin
-    /// # }
+    /// # } }
     /// ```
     ///
     /// # Safety

--- a/library/panic_abort/src/android.rs
+++ b/library/panic_abort/src/android.rs
@@ -16,9 +16,10 @@ type SetAbortMessageType = unsafe extern "C" fn(*const libc::c_char) -> ();
 // Weakly resolve the symbol for android_set_abort_message. This function is only available
 // for API >= 21.
 pub(crate) unsafe fn android_set_abort_message(payload: &mut dyn PanicPayload) {
-    let func_addr =
+    let func_addr = unsafe {
         libc::dlsym(libc::RTLD_DEFAULT, ANDROID_SET_ABORT_MESSAGE.as_ptr() as *const libc::c_char)
-            as usize;
+            as usize
+    };
     if func_addr == 0 {
         return;
     }
@@ -37,13 +38,14 @@ pub(crate) unsafe fn android_set_abort_message(payload: &mut dyn PanicPayload) {
 
     // Allocate a new buffer to append the null byte.
     let size = msg.len() + 1usize;
-    let buf = libc::malloc(size) as *mut libc::c_char;
+    let buf = unsafe { libc::malloc(size) as *mut libc::c_char };
     if buf.is_null() {
         return; // allocation failure
     }
-    copy_nonoverlapping(msg.as_ptr(), buf as *mut u8, msg.len());
-    buf.add(msg.len()).write(0);
-
-    let func = transmute::<usize, SetAbortMessageType>(func_addr);
-    func(buf);
+    unsafe {
+        copy_nonoverlapping(msg.as_ptr(), buf as *mut u8, msg.len());
+        buf.add(msg.len()).write(0);
+        let func = transmute::<usize, SetAbortMessageType>(func_addr);
+        func(buf);
+    }
 }

--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -15,6 +15,7 @@
 #![feature(staged_api)]
 #![feature(rustc_attrs)]
 #![allow(internal_features)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 #[cfg(target_os = "android")]
 mod android;
@@ -36,16 +37,22 @@ pub unsafe extern "C" fn __rust_panic_cleanup(_: *mut u8) -> *mut (dyn Any + Sen
 pub unsafe fn __rust_start_panic(_payload: &mut dyn PanicPayload) -> u32 {
     // Android has the ability to attach a message as part of the abort.
     #[cfg(target_os = "android")]
-    android::android_set_abort_message(_payload);
+    unsafe {
+        android::android_set_abort_message(_payload);
+    }
     #[cfg(target_os = "zkvm")]
-    zkvm::zkvm_set_abort_message(_payload);
+    unsafe {
+        zkvm::zkvm_set_abort_message(_payload);
+    }
 
-    abort();
+    unsafe {
+        abort();
+    }
 
     cfg_if::cfg_if! {
         if #[cfg(any(unix, target_os = "solid_asp3"))] {
             unsafe fn abort() -> ! {
-                libc::abort();
+                unsafe { libc::abort(); }
             }
         } else if #[cfg(any(target_os = "hermit",
                             all(target_vendor = "fortanix", target_env = "sgx"),
@@ -57,7 +64,7 @@ pub unsafe fn __rust_start_panic(_payload: &mut dyn PanicPayload) -> u32 {
                 unsafe extern "C" {
                     pub fn __rust_abort() -> !;
                 }
-                __rust_abort();
+                unsafe { __rust_abort(); }
             }
         } else if #[cfg(all(windows, not(miri)))] {
             // On Windows, use the processor-specific __fastfail mechanism. In Windows 8
@@ -75,11 +82,17 @@ pub unsafe fn __rust_start_panic(_payload: &mut dyn PanicPayload) -> u32 {
                 const FAST_FAIL_FATAL_APP_EXIT: usize = 7;
                 cfg_if::cfg_if! {
                     if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
-                        core::arch::asm!("int $$0x29", in("ecx") FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
+                        unsafe {
+                            core::arch::asm!("int $$0x29", in("ecx") FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
+                        }
                     } else if #[cfg(all(target_arch = "arm", target_feature = "thumb-mode"))] {
-                        core::arch::asm!(".inst 0xDEFB", in("r0") FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
+                        unsafe {
+                            core::arch::asm!(".inst 0xDEFB", in("r0") FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
+                        }
                     } else if #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))] {
-                        core::arch::asm!("brk 0xF003", in("x0") FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
+                        unsafe {
+                            core::arch::asm!("brk 0xF003", in("x0") FAST_FAIL_FATAL_APP_EXIT, options(noreturn, nostack));
+                        }
                     } else {
                         core::intrinsics::abort();
                     }
@@ -93,7 +106,7 @@ pub unsafe fn __rust_start_panic(_payload: &mut dyn PanicPayload) -> u32 {
             }
 
             unsafe fn abort() -> ! {
-                teeos::TEE_Panic(1);
+                unsafe { teeos::TEE_Panic(1); }
             }
         } else {
             unsafe fn abort() -> ! {

--- a/library/panic_abort/src/zkvm.rs
+++ b/library/panic_abort/src/zkvm.rs
@@ -20,5 +20,7 @@ pub(crate) unsafe fn zkvm_set_abort_message(payload: &mut dyn PanicPayload) {
         fn sys_panic(msg_ptr: *const u8, len: usize) -> !;
     }
 
-    sys_panic(msg.as_ptr(), msg.len());
+    unsafe {
+        sys_panic(msg.as_ptr(), msg.len());
+    }
 }

--- a/library/panic_unwind/src/hermit.rs
+++ b/library/panic_unwind/src/hermit.rs
@@ -9,12 +9,16 @@ pub(crate) unsafe fn cleanup(_ptr: *mut u8) -> Box<dyn Any + Send> {
     unsafe extern "C" {
         fn __rust_abort() -> !;
     }
-    __rust_abort();
+    unsafe {
+        __rust_abort();
+    }
 }
 
 pub(crate) unsafe fn panic(_data: Box<dyn Any + Send>) -> u32 {
     unsafe extern "C" {
         fn __rust_abort() -> !;
     }
-    __rust_abort();
+    unsafe {
+        __rust_abort();
+    }
 }

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -27,6 +27,7 @@
 #![allow(internal_features)]
 #![cfg_attr(not(bootstrap), feature(cfg_emscripten_wasm_eh))]
 #![warn(unreachable_pub)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use alloc::boxed::Box;
 use core::any::Any;
@@ -87,14 +88,16 @@ unsafe extern "C" {
 #[rustc_std_internal_symbol]
 #[allow(improper_ctypes_definitions)]
 pub unsafe extern "C" fn __rust_panic_cleanup(payload: *mut u8) -> *mut (dyn Any + Send + 'static) {
-    Box::into_raw(imp::cleanup(payload))
+    unsafe { Box::into_raw(imp::cleanup(payload)) }
 }
 
 // Entry point for raising an exception, just delegates to the platform-specific
 // implementation.
 #[rustc_std_internal_symbol]
 pub unsafe fn __rust_start_panic(payload: &mut dyn PanicPayload) -> u32 {
-    let payload = Box::from_raw(payload.take_box());
+    unsafe {
+        let payload = Box::from_raw(payload.take_box());
 
-    imp::panic(payload)
+        imp::panic(payload)
+    }
 }

--- a/library/panic_unwind/src/miri.rs
+++ b/library/panic_unwind/src/miri.rs
@@ -16,11 +16,11 @@ pub(crate) unsafe fn panic(payload: Box<dyn Any + Send>) -> u32 {
     // The payload we pass to `miri_start_unwind` will be exactly the argument we get
     // in `cleanup` below. So we just box it up once, to get something pointer-sized.
     let payload_box: Payload = Box::new(payload);
-    miri_start_unwind(Box::into_raw(payload_box) as *mut u8)
+    unsafe { miri_start_unwind(Box::into_raw(payload_box) as *mut u8) }
 }
 
 pub(crate) unsafe fn cleanup(payload_box: *mut u8) -> Box<dyn Any + Send> {
     // Recover the underlying `Box`.
-    let payload_box: Payload = Box::from_raw(payload_box as *mut _);
+    let payload_box: Payload = unsafe { Box::from_raw(payload_box as *mut _) };
     *payload_box
 }

--- a/library/proc_macro/src/bridge/closure.rs
+++ b/library/proc_macro/src/bridge/closure.rs
@@ -19,7 +19,7 @@ struct Env;
 impl<'a, A, R, F: FnMut(A) -> R> From<&'a mut F> for Closure<'a, A, R> {
     fn from(f: &'a mut F) -> Self {
         unsafe extern "C" fn call<A, R, F: FnMut(A) -> R>(env: *mut Env, arg: A) -> R {
-            (*(env as *mut _ as *mut F))(arg)
+            unsafe { (*(env as *mut _ as *mut F))(arg) }
         }
         Closure { call: call::<A, R, F>, env: f as *mut _ as *mut Env, _marker: PhantomData }
     }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -33,6 +33,7 @@
 #![deny(ffi_unwind_calls)]
 #![warn(rustdoc::unescaped_backticks)]
 #![warn(unreachable_pub)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 #[unstable(feature = "proc_macro_internals", issue = "27812")]
 #[doc(hidden)]

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -20,11 +20,11 @@
 //!
 //! unsafe impl GlobalAlloc for MyAllocator {
 //!     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-//!         System.alloc(layout)
+//!         unsafe { System.alloc(layout) }
 //!     }
 //!
 //!     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-//!         System.dealloc(ptr, layout)
+//!         unsafe { System.dealloc(ptr, layout) }
 //!     }
 //! }
 //!
@@ -102,7 +102,7 @@ pub use alloc_crate::alloc::*;
 ///
 /// unsafe impl GlobalAlloc for Counter {
 ///     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-///         let ret = System.alloc(layout);
+///         let ret = unsafe { System.alloc(layout) };
 ///         if !ret.is_null() {
 ///             ALLOCATED.fetch_add(layout.size(), Relaxed);
 ///         }
@@ -110,7 +110,7 @@ pub use alloc_crate::alloc::*;
 ///     }
 ///
 ///     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-///         System.dealloc(ptr, layout);
+///         unsafe { System.dealloc(ptr, layout); }
 ///         ALLOCATED.fetch_sub(layout.size(), Relaxed);
 ///     }
 /// }

--- a/library/std/src/sys/pal/teeos/thread.rs
+++ b/library/std/src/sys/pal/teeos/thread.rs
@@ -56,7 +56,7 @@ impl Thread {
             }
         };
 
-        let ret = libc::pthread_create(&mut native, &attr, thread_start, p as *mut _);
+        let ret = unsafe { libc::pthread_create(&mut native, &attr, thread_start, p as *mut _) };
         // Note: if the thread creation fails and this assert fails, then p will
         // be leaked. However, an alternative design could cause double-free
         // which is clearly worse.

--- a/library/std/src/sys/pal/windows/stack_overflow_uwp.rs
+++ b/library/std/src/sys/pal/windows/stack_overflow_uwp.rs
@@ -1,4 +1,4 @@
 #![cfg_attr(test, allow(dead_code))]
 
-pub unsafe fn reserve_stack() {}
-pub unsafe fn init() {}
+pub fn reserve_stack() {}
+pub fn init() {}

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -9,6 +9,7 @@
 )]
 #![allow(internal_features)]
 #![cfg_attr(not(bootstrap), feature(cfg_emscripten_wasm_eh))]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 // Force libc to be included even if unused. This is required by many platforms.
 #[cfg(not(all(windows, target_env = "msvc")))]

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -218,36 +218,38 @@ if #[cfg(any(target_vendor = "apple", target_os = "netbsd", not(target_arch = "a
 
     pub unsafe fn _Unwind_GetGR(ctx: *mut _Unwind_Context, reg_index: c_int) -> _Unwind_Word {
         let mut val: _Unwind_Word = core::ptr::null();
-        _Unwind_VRS_Get(ctx, _UVRSC_CORE, reg_index as _Unwind_Word, _UVRSD_UINT32,
-                        (&raw mut val) as *mut c_void);
+        unsafe { _Unwind_VRS_Get(ctx, _UVRSC_CORE, reg_index as _Unwind_Word, _UVRSD_UINT32,
+                        (&raw mut val) as *mut c_void); }
         val
     }
 
     pub unsafe fn _Unwind_SetGR(ctx: *mut _Unwind_Context, reg_index: c_int, value: _Unwind_Word) {
         let mut value = value;
-        _Unwind_VRS_Set(ctx, _UVRSC_CORE, reg_index as _Unwind_Word, _UVRSD_UINT32,
-                        (&raw mut value) as *mut c_void);
+        unsafe { _Unwind_VRS_Set(ctx, _UVRSC_CORE, reg_index as _Unwind_Word, _UVRSD_UINT32,
+                        (&raw mut value) as *mut c_void); }
     }
 
     pub unsafe fn _Unwind_GetIP(ctx: *mut _Unwind_Context)
                                 -> _Unwind_Word {
-        let val = _Unwind_GetGR(ctx, UNWIND_IP_REG);
+        let val = unsafe { _Unwind_GetGR(ctx, UNWIND_IP_REG) };
         val.map_addr(|v| v & !1)
     }
 
     pub unsafe fn _Unwind_SetIP(ctx: *mut _Unwind_Context,
                                 value: _Unwind_Word) {
         // Propagate thumb bit to instruction pointer
-        let thumb_state = _Unwind_GetGR(ctx, UNWIND_IP_REG).addr() & 1;
+        let thumb_state = unsafe { _Unwind_GetGR(ctx, UNWIND_IP_REG).addr() & 1 };
         let value = value.map_addr(|v| v | thumb_state);
-        _Unwind_SetGR(ctx, UNWIND_IP_REG, value);
+        unsafe { _Unwind_SetGR(ctx, UNWIND_IP_REG, value); }
     }
 
     pub unsafe fn _Unwind_GetIPInfo(ctx: *mut _Unwind_Context,
                                     ip_before_insn: *mut c_int)
                                     -> _Unwind_Word {
-        *ip_before_insn = 0;
-        _Unwind_GetIP(ctx)
+        unsafe {
+            *ip_before_insn = 0;
+            _Unwind_GetIP(ctx)
+        }
     }
 
     // This function also doesn't exist on Android or ARM/Linux, so make it a no-op

--- a/src/tools/miri/tests/fail/panic/panic_abort1.rs
+++ b/src/tools/miri/tests/fail/panic/panic_abort1.rs
@@ -1,6 +1,6 @@
 //@error-in-other-file: the program aborted execution
 //@normalize-stderr-test: "\| +\^+" -> "| ^"
-//@normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
+//@normalize-stderr-test: "unsafe \{ libc::abort\(\); \}|core::intrinsics::abort\(\);" -> "ABORT();"
 //@compile-flags: -C panic=abort
 
 fn main() {

--- a/src/tools/miri/tests/fail/panic/panic_abort2.rs
+++ b/src/tools/miri/tests/fail/panic/panic_abort2.rs
@@ -1,6 +1,6 @@
 //@error-in-other-file: the program aborted execution
 //@normalize-stderr-test: "\| +\^+" -> "| ^"
-//@normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
+//@normalize-stderr-test: "unsafe \{ libc::abort\(\); \}|core::intrinsics::abort\(\);" -> "ABORT();"
 //@compile-flags: -C panic=abort
 
 fn main() {

--- a/src/tools/miri/tests/fail/panic/panic_abort3.rs
+++ b/src/tools/miri/tests/fail/panic/panic_abort3.rs
@@ -1,6 +1,6 @@
 //@error-in-other-file: the program aborted execution
 //@normalize-stderr-test: "\| +\^+" -> "| ^"
-//@normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
+//@normalize-stderr-test: "unsafe \{ libc::abort\(\); \}|core::intrinsics::abort\(\);" -> "ABORT();"
 //@compile-flags: -C panic=abort
 
 fn main() {

--- a/src/tools/miri/tests/fail/panic/panic_abort4.rs
+++ b/src/tools/miri/tests/fail/panic/panic_abort4.rs
@@ -1,6 +1,6 @@
 //@error-in-other-file: the program aborted execution
 //@normalize-stderr-test: "\| +\^+" -> "| ^"
-//@normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
+//@normalize-stderr-test: "unsafe \{ libc::abort\(\); \}|core::intrinsics::abort\(\);" -> "ABORT();"
 //@compile-flags: -C panic=abort
 
 fn main() {


### PR DESCRIPTION
This applies unsafe_op_in_unsafe_fn to the standard library in preparation for updating to Rust 2024.

Closes https://github.com/rust-lang/rust/issues/127747 (I think?) cc @workingjubilee 
I have been testing a variety of targets, and I feel like they are all pretty much covered. I'll continue doing some testing async, but I don't expect to catch any more.
