### PR TITLE
Use the new solver in the `impossible_predicates`

### DIFF
--- a/tests/ui/traits/vtable/impossible-method.rs
+++ b/tests/ui/traits/vtable/impossible-method.rs
@@ -1,0 +1,38 @@
+//@ run-pass
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
+trait Id {
+    type This<'a>;
+}
+impl<T> Id for T {
+    type This<'a> = T;
+}
+
+trait Trait<T> {}
+impl<T: Id> Trait<for<'a> fn(T::This<'a>)> for T {}
+
+trait Method<T: Id> {
+    fn call_me(&self)
+    where
+        T: Trait<for<'a> fn(T::This<'a>)>;
+}
+
+impl<T, U> Method<U> for T {
+    fn call_me(&self) {
+        println!("method was reachable");
+    }
+}
+
+fn generic<T: Id>(x: &dyn Method<T>) {
+    // Proving `T: Trait<for<'a> fn(T::This<'a>)>` holds.
+    x.call_me();
+}
+
+fn main() {
+    // Proving `u32: Trait<fn(u32)>` fails due to incompleteness.
+    // We don't add the method to the vtable of `dyn Method`, so
+    // calling it causes UB.
+    generic::<u32>(&());
+}


### PR DESCRIPTION
The old solver is unsound for many reasons. One of which was weaponized by @lcnr in #140212, where the old solver was incompletely considering a dyn vtable method to be impossible and replacing its vtable entry with a null value. This null function could be called post-mono. 

The new solver is expected to be less incomplete due to its correct handling of higher-ranked aliases in relate. This PR switches the `impossible_predicates` query to use the new solver, which patches this UB.

r? lcnr