### PR TITLE
Mark desugaring of `..=` as such when lowering

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1523,7 +1523,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
     fn lower_expr_range_closed(&mut self, span: Span, e1: &Expr, e2: &Expr) -> hir::ExprKind<'hir> {
         let e1 = self.lower_expr_mut(e1);
         let e2 = self.lower_expr_mut(e2);
-        let fn_path = hir::QPath::LangItem(hir::LangItem::RangeInclusiveNew, self.lower_span(span));
+        let span = self.mark_span_with_reason(DesugaringKind::Range, self.lower_span(span), None);
+        let fn_path = hir::QPath::LangItem(hir::LangItem::RangeInclusiveNew, span);
         let fn_expr = self.arena.alloc(self.expr(span, hir::ExprKind::Path(fn_path)));
         hir::ExprKind::Call(fn_expr, arena_vec![self; e1, e2])
     }
@@ -1587,8 +1588,10 @@ impl<'hir> LoweringContext<'_, 'hir> {
             ),
         );
 
+        let struct_span =
+            self.mark_span_with_reason(DesugaringKind::Range, self.lower_span(span), None);
         hir::ExprKind::Struct(
-            self.arena.alloc(hir::QPath::LangItem(lang_item, self.lower_span(span))),
+            self.arena.alloc(hir::QPath::LangItem(lang_item, struct_span)),
             fields,
             hir::StructTailExpr::None,
         )

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1162,6 +1162,7 @@ pub enum DesugaringKind {
     Await,
     ForLoop,
     WhileLoop,
+    Range,
     /// `async Fn()` bound modifier
     BoundModifier,
     /// Calls to contract checks (`#[requires]` to precond, `#[ensures]` to postcond)
@@ -1181,6 +1182,7 @@ impl DesugaringKind {
             DesugaringKind::OpaqueTy => "`impl Trait`",
             DesugaringKind::ForLoop => "`for` loop",
             DesugaringKind::WhileLoop => "`while` loop",
+            DesugaringKind::Range => "`..` or `..=` range",
             DesugaringKind::BoundModifier => "trait bound modifier",
             DesugaringKind::Contract => "contract check",
         }


### PR DESCRIPTION
When lowering, `a..=b` is transformed into `RangeInclusive::new(a, b)` without any desugaring information on the spans. It looks like `a..=b` requires Rust 1.27 (stabilization of `RangeInclusive::new()`), while `a..=b` was introduced in Rust 1.26.

Marking the desugaring as such in the HIR allows Clippy to filter it out and realize that this is not the original code coming from the user.