### PR TITLE
Fix early lint check desc in query

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -116,7 +116,7 @@ rustc_queries! {
     }
 
     query early_lint_checks(_: ()) {
-        desc { "perform lints prior to macro expansion" }
+        desc { "perform lints prior to AST lowering" }
     }
 
     query resolutions(_: ()) -> &'tcx ty::ResolverGlobalCtxt {


### PR DESCRIPTION
When I debugging this issue: https://github.com/rust-lang/rust/pull/136906#discussion_r1954151036

I found early lint checking is performed after [macro expansion](https://github.com/chenyukang/rust/blob/37520e6d89eeea96b966ab281a7adf1775f7e207/compiler/rustc_interface/src/passes.rs#L267), but [prior to AST lowering](https://github.com/chenyukang/rust/blob/37520e6d89eeea96b966ab281a7adf1775f7e207/compiler/rustc_ast_lowering/src/lib.rs#L427).

r? @cjgillot 