### PR TITLE
Promote ohos targets to tier2 with host tools.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "measureme-mirror"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe110855993552cfa51a5018e8cdf2acf7f948c46136322017a9a8484ffc5ea8"
+dependencies = [
+ "log",
+ "memmap2",
+ "parking_lot",
+ "perf-event-open-sys",
+ "rustc-hash 1.1.0",
+ "smallvec",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,7 +3379,7 @@ dependencies = [
  "gimli 0.30.0",
  "itertools",
  "libc",
- "measureme",
+ "measureme-mirror",
  "object 0.36.7",
  "rustc-demangle",
  "rustc_abi",
@@ -3483,7 +3497,7 @@ dependencies = [
  "indexmap",
  "jobserver",
  "libc",
- "measureme",
+ "measureme-mirror",
  "memmap2",
  "parking_lot",
  "portable-atomic",
@@ -4249,8 +4263,7 @@ dependencies = [
 name = "rustc_query_impl"
 version = "0.0.0"
 dependencies = [
- "measureme",
- "rustc_attr_data_structures",
+ "measureme-mirror",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_hashes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,22 +1997,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "libffi-sys2"
-version = "2.4.0"
+name = "libffi"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aedd9774ffb3dcab5c96f593cb5a0caf421a5e38b16bab3b8cdef5facb6ea2"
+checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
 dependencies = [
- "cc",
+ "libc",
+ "libffi-sys",
 ]
 
 [[package]]
-name = "libffi2"
-version = "3.3.0"
+name = "libffi-sys"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88a3402cad8ff58216ec6d07e5ecfa9e15fc36613c0a832db541e4e1a718a7b"
+checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
 dependencies = [
- "libc",
- "libffi-sys2",
+ "cc",
 ]
 
 [[package]]
@@ -2273,7 +2273,7 @@ dependencies = [
  "directories",
  "getrandom 0.3.1",
  "libc",
- "libffi2",
+ "libffi",
  "libloading",
  "measureme 11.0.1",
  "rand 0.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,10 +2179,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "measureme-mirror"
+name = "measureme"
 version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe110855993552cfa51a5018e8cdf2acf7f948c46136322017a9a8484ffc5ea8"
+checksum = "570a507d8948a66a97f42cbbaf8a6bb9516a51017d4ee949502ad7a10a864395"
 dependencies = [
  "log",
  "memmap2",
@@ -2275,7 +2275,7 @@ dependencies = [
  "libc",
  "libffi",
  "libloading",
- "measureme",
+ "measureme 11.0.1",
  "rand 0.9.0",
  "regex",
  "rustc_version",
@@ -3379,7 +3379,7 @@ dependencies = [
  "gimli 0.30.0",
  "itertools",
  "libc",
- "measureme-mirror",
+ "measureme 12.0.1",
  "object 0.36.7",
  "rustc-demangle",
  "rustc_abi",
@@ -3497,7 +3497,7 @@ dependencies = [
  "indexmap",
  "jobserver",
  "libc",
- "measureme-mirror",
+ "measureme 12.0.1",
  "memmap2",
  "parking_lot",
  "portable-atomic",
@@ -4263,7 +4263,7 @@ dependencies = [
 name = "rustc_query_impl"
 version = "0.0.0"
 dependencies = [
- "measureme-mirror",
+ "measureme 12.0.1",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_hashes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,22 +1997,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "libffi"
-version = "3.2.0"
+name = "libffi-sys2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
+checksum = "47aedd9774ffb3dcab5c96f593cb5a0caf421a5e38b16bab3b8cdef5facb6ea2"
 dependencies = [
- "libc",
- "libffi-sys",
+ "cc",
 ]
 
 [[package]]
-name = "libffi-sys"
-version = "2.3.0"
+name = "libffi2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
+checksum = "c88a3402cad8ff58216ec6d07e5ecfa9e15fc36613c0a832db541e4e1a718a7b"
 dependencies = [
- "cc",
+ "libc",
+ "libffi-sys2",
 ]
 
 [[package]]
@@ -2273,7 +2273,7 @@ dependencies = [
  "directories",
  "getrandom 0.3.1",
  "libc",
- "libffi",
+ "libffi2",
  "libloading",
  "measureme 11.0.1",
  "rand 0.9.0",

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -14,7 +14,8 @@ bitflags = "2.4.1"
 gimli = "0.30"
 itertools = "0.12"
 libc = "0.2"
-measureme = "11"
+# FIXME: waiting for the new version of measureme. (https://github.com/rust-lang/measureme/pull/240)
+measureme = { package = "measureme-mirror", version = "12.0.1" }
 object = { version = "0.36.3", default-features = false, features = ["std", "read"] }
 rustc-demangle = "0.1.21"
 rustc_abi = { path = "../rustc_abi" }

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -14,8 +14,7 @@ bitflags = "2.4.1"
 gimli = "0.30"
 itertools = "0.12"
 libc = "0.2"
-# FIXME: waiting for the new version of measureme. (https://github.com/rust-lang/measureme/pull/240)
-measureme = { package = "measureme-mirror", version = "12.0.1" }
+measureme = "12.0.1"
 object = { version = "0.36.3", default-features = false, features = ["std", "read"] }
 rustc-demangle = "0.1.21"
 rustc_abi = { path = "../rustc_abi" }

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -12,7 +12,8 @@ elsa = "1.11.0"
 ena = "0.14.3"
 indexmap = "2.4.0"
 jobserver_crate = { version = "0.1.28", package = "jobserver" }
-measureme = "11"
+# FIXME: waiting for the new version of measureme. (https://github.com/rust-lang/measureme/pull/240)
+measureme = { package = "measureme-mirror", version = "12.0.1" }
 rustc-hash = "2.0.0"
 rustc-rayon = { version = "0.5.1", features = ["indexmap"] }
 rustc-stable-hash = { version = "0.1.0", features = ["nightly"] }

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -12,8 +12,7 @@ elsa = "1.11.0"
 ena = "0.14.3"
 indexmap = "2.4.0"
 jobserver_crate = { version = "0.1.28", package = "jobserver" }
-# FIXME: waiting for the new version of measureme. (https://github.com/rust-lang/measureme/pull/240)
-measureme = { package = "measureme-mirror", version = "12.0.1" }
+measureme = "12.0.1"
 rustc-hash = "2.0.0"
 rustc-rayon = { version = "0.5.1", features = ["indexmap"] }
 rustc-stable-hash = { version = "0.1.0", features = ["nightly"] }

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -241,7 +241,7 @@ fn main() {
         println!("cargo:rustc-link-lib=kstat");
     }
 
-    if (target.starts_with("arm") && !target.contains("freebsd"))
+    if (target.starts_with("arm") && !target.contains("freebsd")) && !target.contains("ohos")
         || target.starts_with("mips-")
         || target.starts_with("mipsel-")
         || target.starts_with("powerpc-")
@@ -371,6 +371,7 @@ fn main() {
         || target.contains("freebsd")
         || target.contains("windows-gnullvm")
         || target.contains("aix")
+        || target.contains("ohos")
     {
         "c++"
     } else if target.contains("netbsd") && llvm_static_stdcpp.is_some() {

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-# FIXME: waiting for the new version of measureme. (https://github.com/rust-lang/measureme/pull/240)
-measureme = { package = "measureme-mirror", version = "12.0.1" }
+measureme = "12.0.1"
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_hashes = { path = "../rustc_hashes" }

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 
 [dependencies]
 # tidy-alphabetical-start
-measureme = "11"
-rustc_attr_data_structures = { path = "../rustc_attr_data_structures" }
+# FIXME: waiting for the new version of measureme. (https://github.com/rust-lang/measureme/pull/240)
+measureme = { package = "measureme-mirror", version = "12.0.1" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_hashes = { path = "../rustc_hashes" }

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -471,6 +471,10 @@ impl Step for Llvm {
             cfg.define("LLVM_BUILD_32_BITS", "ON");
         }
 
+        if target.starts_with("x86_64") && target.contains("ohos") {
+            cfg.define("LLVM_TOOL_LLVM_RTDYLD_BUILD", "OFF");
+        }
+
         let mut enabled_llvm_projects = Vec::new();
 
         if helpers::forcing_clang_based_tests() {

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -814,6 +814,10 @@ fn configure_cmake(
         cflags.push(s);
     }
 
+    if target.contains("ohos") {
+        cflags.push(" -D_LINUX_SYSINFO_H");
+    }
+
     if builder.config.llvm_clang_cl.is_some() {
         cflags.push(format!(" --target={target}"));
     }
@@ -834,6 +838,11 @@ fn configure_cmake(
         cxxflags.push(" ");
         cxxflags.push(s);
     }
+
+    if target.contains("ohos") {
+        cxxflags.push(" -D_LINUX_SYSINFO_H");
+    }
+
     if builder.config.llvm_clang_cl.is_some() {
         cxxflags.push(format!(" --target={target}"));
     }
@@ -1219,6 +1228,10 @@ impl Step for Sanitizers {
         cfg.define("COMPILER_RT_DEFAULT_TARGET_ONLY", "ON");
         cfg.define("COMPILER_RT_USE_LIBCXX", "OFF");
         cfg.define("LLVM_CONFIG_PATH", &llvm_config);
+
+        if self.target.contains("ohos") {
+            cfg.define("COMPILER_RT_USE_BUILTINS_LIBRARY", "ON");
+        }
 
         // On Darwin targets the sanitizer runtimes are build as universal binaries.
         // Unfortunately sccache currently lacks support to build them successfully.

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -814,10 +814,6 @@ fn configure_cmake(
         cflags.push(s);
     }
 
-    if target.contains("ohos") {
-        cflags.push(" -D_LINUX_SYSINFO_H");
-    }
-
     if builder.config.llvm_clang_cl.is_some() {
         cflags.push(format!(" --target={target}"));
     }
@@ -838,11 +834,6 @@ fn configure_cmake(
         cxxflags.push(" ");
         cxxflags.push(s);
     }
-
-    if target.contains("ohos") {
-        cxxflags.push(" -D_LINUX_SYSINFO_H");
-    }
-
     if builder.config.llvm_clang_cl.is_some() {
         cxxflags.push(format!(" --target={target}"));
     }
@@ -1228,10 +1219,6 @@ impl Step for Sanitizers {
         cfg.define("COMPILER_RT_DEFAULT_TARGET_ONLY", "ON");
         cfg.define("COMPILER_RT_USE_LIBCXX", "OFF");
         cfg.define("LLVM_CONFIG_PATH", &llvm_config);
-
-        if self.target.contains("ohos") {
-            cfg.define("COMPILER_RT_USE_BUILTINS_LIBRARY", "ON");
-        }
 
         // On Darwin targets the sanitizer runtimes are build as universal binaries.
         // Unfortunately sccache currently lacks support to build them successfully.

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -813,7 +813,9 @@ fn configure_cmake(
         cflags.push(" ");
         cflags.push(s);
     }
-
+    if target.contains("ohos") {
+        cflags.push(" -D_LINUX_SYSINFO_H");
+    }
     if builder.config.llvm_clang_cl.is_some() {
         cflags.push(format!(" --target={target}"));
     }
@@ -833,6 +835,9 @@ fn configure_cmake(
     if let Some(ref s) = builder.config.llvm_cxxflags {
         cxxflags.push(" ");
         cxxflags.push(s);
+    }
+    if target.contains("ohos") {
+        cxxflags.push(" -D_LINUX_SYSINFO_H");
     }
     if builder.config.llvm_clang_cl.is_some() {
         cxxflags.push(format!(" --target={target}"));
@@ -1219,6 +1224,10 @@ impl Step for Sanitizers {
         cfg.define("COMPILER_RT_DEFAULT_TARGET_ONLY", "ON");
         cfg.define("COMPILER_RT_USE_LIBCXX", "OFF");
         cfg.define("LLVM_CONFIG_PATH", &llvm_config);
+
+        if self.target.contains("ohos") {
+            cfg.define("COMPILER_RT_USE_BUILTINS_LIBRARY", "ON");
+        }
 
         // On Darwin targets the sanitizer runtimes are build as universal binaries.
         // Unfortunately sccache currently lacks support to build them successfully.

--- a/src/ci/docker/host-x86_64/dist-ohos/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-ohos/Dockerfile
@@ -60,10 +60,7 @@ ENV \
 
 ENV RUST_CONFIGURE_ARGS \
     --enable-profiler \
-    --disable-docs \
-    --tools=cargo,clippy,rustdocs,rustfmt,rust-analyzer,rust-analyzer-proc-macro-srv,analysis,src,wasm-component-ld \
-    --enable-extended \
-    --enable-sanitizers
+    --disable-docs
 
 ENV SCRIPT python3 ../x.py dist --host=$TARGETS --target $TARGETS
 

--- a/src/ci/docker/host-x86_64/dist-ohos/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-ohos/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY scripts/ohos-sdk.sh /scripts/
 RUN sh /scripts/ohos-sdk.sh
 
+COPY scripts/ohos-openssl.sh /scripts/
+RUN sh /scripts/ohos-openssl.sh
+
 COPY scripts/ohos/aarch64-unknown-linux-ohos-clang.sh /usr/local/bin/
 COPY scripts/ohos/aarch64-unknown-linux-ohos-clang++.sh /usr/local/bin/
 COPY scripts/ohos/armv7-unknown-linux-ohos-clang.sh /usr/local/bin/
@@ -30,6 +33,14 @@ COPY scripts/ohos/x86_64-unknown-linux-ohos-clang.sh /usr/local/bin/
 COPY scripts/ohos/x86_64-unknown-linux-ohos-clang++.sh /usr/local/bin/
 
 # env
+ENV AARCH64_UNKNOWN_LINUX_OHOS_OPENSSL_DIR=/opt/ohos-openssl/prelude/arm64-v8a
+ENV ARMV7_UNKNOWN_LINUX_OHOS_OPENSSL_DIR=/opt/ohos-openssl/prelude/armeabi-v7a
+ENV X86_64_UNKNOWN_LINUX_OHOS_OPENSSL_DIR=/opt/ohos-openssl/prelude/x86_64
+
+ENV AARCH64_UNKNOWN_LINUX_OHOS_OPENSSL_NO_VENDOR=1
+ENV ARMV7_UNKNOWN_LINUX_OHOS_OPENSSL_NO_VENDOR=1
+ENV X86_64_UNKNOWN_LINUX_OHOS_OPENSSL_NO_VENDOR=1
+
 ENV TARGETS=aarch64-unknown-linux-ohos
 ENV TARGETS=$TARGETS,armv7-unknown-linux-ohos
 ENV TARGETS=$TARGETS,x86_64-unknown-linux-ohos
@@ -51,7 +62,7 @@ ENV RUST_CONFIGURE_ARGS \
     --enable-profiler \
     --disable-docs
 
-ENV SCRIPT python3 ../x.py dist --host='' --target $TARGETS
+ENV SCRIPT python3 ../x.py dist --host=$TARGETS --target $TARGETS
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/dist-ohos/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-ohos/Dockerfile
@@ -60,7 +60,10 @@ ENV \
 
 ENV RUST_CONFIGURE_ARGS \
     --enable-profiler \
-    --disable-docs
+    --disable-docs \
+    --tools=cargo,clippy,rustdocs,rustfmt,rust-analyzer,rust-analyzer-proc-macro-srv,analysis,src,wasm-component-ld \
+    --enable-extended \
+    --enable-sanitizers
 
 ENV SCRIPT python3 ../x.py dist --host=$TARGETS --target $TARGETS
 

--- a/src/ci/docker/scripts/ohos-openssl.sh
+++ b/src/ci/docker/scripts/ohos-openssl.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -ex
+
+URL=https://github.com/ohos-rs/ohos-openssl/archive/refs/tags/0.1.0.tar.gz
+
+mkdir -p /opt/ohos-openssl
+curl -fL $URL | tar xz -C /opt/ohos-openssl --strip-components=1

--- a/src/ci/docker/scripts/ohos-sdk.sh
+++ b/src/ci/docker/scripts/ohos-sdk.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -ex
 
-URL=https://repo.huaweicloud.com/openharmony/os/4.0-Release/ohos-sdk-windows_linux-public.tar.gz
+URL=https://repo.huaweicloud.com/openharmony/os/5.0.0-Release/ohos-sdk-windows_linux-public.tar.gz
 
-curl $URL | tar xz -C /tmp ohos-sdk/linux/native-linux-x64-4.0.10.13-Release.zip
+curl $URL | tar xz -C /tmp linux/native-linux-x64-5.0.0.71-Release.zip
 mkdir /opt/ohos-sdk
 cd /opt/ohos-sdk
-unzip -qq /tmp/ohos-sdk/linux/native-linux-x64-4.0.10.13-Release.zip
+unzip -qq /tmp/linux/native-linux-x64-5.0.0.71-Release.zip

--- a/src/ci/docker/scripts/ohos-sdk.sh
+++ b/src/ci/docker/scripts/ohos-sdk.sh
@@ -7,3 +7,4 @@ curl $URL | tar xz -C /tmp linux/native-linux-x64-5.0.0.71-Release.zip
 mkdir /opt/ohos-sdk
 cd /opt/ohos-sdk
 unzip -qq /tmp/linux/native-linux-x64-5.0.0.71-Release.zip
+rm /tmp/linux/native-linux-x64-5.0.0.71-Release.zip

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -176,7 +176,7 @@ auto:
     <<: *job-linux-4c
 
   - name: dist-ohos
-    <<: *job-linux-4c
+    <<: *job-linux-4c-largedisk
 
   - name: dist-powerpc-linux
     <<: *job-linux-4c

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -113,7 +113,11 @@ export RUST_RELEASE_CHANNEL=$(releaseChannel)
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
 
 if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
+  if [[ "$CI_JOB_NAME" == *ohos* ]]; then
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-llvm-static-stdcpp"
+  else
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
+  fi
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.remap-debuginfo"
 
   if [ "$DEPLOY_ALT" != "" ] && isLinux; then

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -89,9 +89,11 @@ target | notes
 -------|-------
 `aarch64-pc-windows-msvc` | ARM64 Windows MSVC
 `aarch64-unknown-linux-musl` | ARM64 Linux with musl 1.2.3
+[`aarch64-unknown-linux-ohos`](platform-support/openharmony.md) | ✓ | ARM64 OpenHarmony
 `arm-unknown-linux-gnueabi` | Armv6 Linux (kernel 3.2, glibc 2.17)
 `arm-unknown-linux-gnueabihf` | Armv6 Linux, hardfloat (kernel 3.2, glibc 2.17)
 `armv7-unknown-linux-gnueabihf` | Armv7-A Linux, hardfloat (kernel 3.2, glibc 2.17)
+[`armv7-unknown-linux-ohos`](platform-support/openharmony.md) | ✓ | Armv7-A OpenHarmony
 [`loongarch64-unknown-linux-gnu`](platform-support/loongarch-linux.md) | LoongArch64 Linux, LP64D ABI (kernel 5.19, glibc 2.36)
 [`loongarch64-unknown-linux-musl`](platform-support/loongarch-linux.md) | LoongArch64 Linux, LP64D ABI (kernel 5.19, musl 1.2.5)
 `powerpc-unknown-linux-gnu` | PowerPC Linux (kernel 3.2, glibc 2.17)
@@ -104,6 +106,7 @@ target | notes
 [`x86_64-unknown-freebsd`](platform-support/freebsd.md) | 64-bit x86 FreeBSD
 [`x86_64-unknown-illumos`](platform-support/illumos.md) | illumos
 `x86_64-unknown-linux-musl` | 64-bit Linux with musl 1.2.3
+[`x86_64-unknown-linux-ohos`](platform-support/openharmony.md) | ✓ | x86_64 OpenHarmony
 [`x86_64-unknown-netbsd`](platform-support/netbsd.md) | NetBSD/amd64
 
 ## Tier 2 without Host Tools
@@ -142,7 +145,6 @@ target | std | notes
 [`aarch64-linux-android`](platform-support/android.md) | ✓ | ARM64 Android
 [`aarch64-pc-windows-gnullvm`](platform-support/pc-windows-gnullvm.md) | ✓ | ARM64 MinGW (Windows 10+), LLVM ABI
 [`aarch64-unknown-fuchsia`](platform-support/fuchsia.md) | ✓ | ARM64 Fuchsia
-[`aarch64-unknown-linux-ohos`](platform-support/openharmony.md) | ✓ | ARM64 OpenHarmony
 `aarch64-unknown-none` | * | Bare ARM64, hardfloat
 `aarch64-unknown-none-softfloat` | * | Bare ARM64, softfloat
 [`aarch64-unknown-uefi`](platform-support/unknown-uefi.md) | ? | ARM64 UEFI
@@ -158,7 +160,6 @@ target | std | notes
 `armv7-unknown-linux-gnueabi` | ✓ | Armv7-A Linux (kernel 4.15, glibc 2.27)
 `armv7-unknown-linux-musleabi` | ✓ | Armv7-A Linux with musl 1.2.3
 `armv7-unknown-linux-musleabihf` | ✓ | Armv7-A Linux with musl 1.2.3, hardfloat
-[`armv7-unknown-linux-ohos`](platform-support/openharmony.md) | ✓ | Armv7-A OpenHarmony
 [`armv7a-none-eabi`](platform-support/arm-none-eabi.md) | * | Bare Armv7-A
 [`armv7r-none-eabi`](platform-support/armv7r-none-eabi.md) | * | Bare Armv7-R
 [`armv7r-none-eabihf`](platform-support/armv7r-none-eabi.md) | * | Bare Armv7-R, hardfloat
@@ -205,7 +206,6 @@ target | std | notes
 [`x86_64-pc-windows-gnullvm`](platform-support/pc-windows-gnullvm.md) | ✓ | 64-bit x86 MinGW (Windows 10+), LLVM ABI
 [`x86_64-unknown-fuchsia`](platform-support/fuchsia.md) | ✓ | 64-bit x86 Fuchsia
 `x86_64-unknown-linux-gnux32` | ✓ | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)
-[`x86_64-unknown-linux-ohos`](platform-support/openharmony.md) | ✓ | x86_64 OpenHarmony
 [`x86_64-unknown-none`](platform-support/x86_64-unknown-none.md) | * | Freestanding/bare-metal x86_64, softfloat
 [`x86_64-unknown-redox`](platform-support/redox.md) | ✓ | Redox OS
 [`x86_64-unknown-uefi`](platform-support/unknown-uefi.md) | ? | 64-bit UEFI

--- a/src/doc/rustc/src/platform-support/openharmony.md
+++ b/src/doc/rustc/src/platform-support/openharmony.md
@@ -1,6 +1,6 @@
 # `*-unknown-linux-ohos`
 
-**Tier: 2（with Host Tools）**
+**Tier: 2**
 
 * aarch64-unknown-linux-ohos
 * armv7-unknown-linux-ohos
@@ -17,17 +17,6 @@ system.
 
 - Amanieu d'Antras ([@Amanieu](https://github.com/Amanieu))
 - Lu Binglun ([@lubinglun](https://github.com/lubinglun))
-
-## Requirements
-
-All the ohos targets of Tier 2 with host tools support all extended rust tools.
-(exclude `miri`, the support of `miri` will be added soon)
-
-### Host toolchain
-
-The targets require a reasonably up-to-date OpenHarmony SDK on the host.
-
-The targets support `cargo`, which require [ohos-openssl](https://github.com/ohos-rs/ohos-openssl).
 
 ## Setup
 

--- a/src/doc/rustc/src/platform-support/openharmony.md
+++ b/src/doc/rustc/src/platform-support/openharmony.md
@@ -29,6 +29,9 @@ The targets require a reasonably up-to-date OpenHarmony SDK on the host.
 
 The targets support `cargo`, which require [ohos-openssl](https://github.com/ohos-rs/ohos-openssl).
 
+`miri` isn't supported yet, since its dependencies (`libffi` and `tikv-jemalloc-sys`) don't support
+compiling for the OHOS targets.
+
 ## Setup
 
 The OpenHarmony SDK doesn't currently support Rust compilation directly, so

--- a/src/doc/rustc/src/platform-support/openharmony.md
+++ b/src/doc/rustc/src/platform-support/openharmony.md
@@ -1,6 +1,6 @@
 # `*-unknown-linux-ohos`
 
-**Tier: 2**
+**Tier: 2 (with Host Tools)**
 
 * aarch64-unknown-linux-ohos
 * armv7-unknown-linux-ohos
@@ -17,6 +17,17 @@ system.
 
 - Amanieu d'Antras ([@Amanieu](https://github.com/Amanieu))
 - Lu Binglun ([@lubinglun](https://github.com/lubinglun))
+
+## Requirements
+
+All the ohos targets of Tier 2 with host tools support all extended rust tools.
+(exclude `miri`, the support of `miri` will be added soon)
+
+### Host toolchain
+
+The targets require a reasonably up-to-date OpenHarmony SDK on the host.
+
+The targets support `cargo`, which require [ohos-openssl](https://github.com/ohos-rs/ohos-openssl).
 
 ## Setup
 

--- a/src/doc/rustc/src/platform-support/openharmony.md
+++ b/src/doc/rustc/src/platform-support/openharmony.md
@@ -1,6 +1,6 @@
 # `*-unknown-linux-ohos`
 
-**Tier: 2**
+**Tier: 2（with Host Tools）**
 
 * aarch64-unknown-linux-ohos
 * armv7-unknown-linux-ohos
@@ -17,6 +17,17 @@ system.
 
 - Amanieu d'Antras ([@Amanieu](https://github.com/Amanieu))
 - Lu Binglun ([@lubinglun](https://github.com/lubinglun))
+
+## Requirements
+
+All the ohos targets of Tier 2 with host tools support all extended rust tools.
+(exclude `miri`, the support of `miri` will be added soon)
+
+### Host toolchain
+
+The targets require a reasonably up-to-date OpenHarmony SDK on the host.
+
+The targets support `cargo`, which require [ohos-openssl](https://github.com/ohos-rs/ohos-openssl).
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR try to resolve?

Try to promote the following [[Tier 2 without Host Tools](https://doc.rust-lang.org/rustc/platform-support.html#tier-2-without-host-tools)](https://doc.rust-lang.org/rustc/platform-support.html#tier-2-without-host-tools) targets to [[Tier 2 with Host Tools](https://doc.rust-lang.org/rustc/platform-support.html#tier-2-with-host-tools)](https://doc.rust-lang.org/rustc/platform-support.html#tier-2-with-host-tools):

- `aarch64-unknown-linux-ohos`
- `armv7-unknown-linux-ohos`
- `x86_64-unknown-linux-ohos`

### More Information?

see MCP: https://github.com/rust-lang/compiler-team/issues/811

### Blockage to be solved?

- [x] Submit an MCP
- [x] Submit code of promote ohos targets
- [x] Resolve related dependencies （`measureme`）

The modified code of the measureme has been merged （see https://github.com/rust-lang/measureme/pull/238）. [done]
The new version will was released (https://github.com/rust-lang/measureme/pull/240). [done]