### PR TITLE
Bump bootstrap cc to 1.2.14 and cmake to 0.1.54

### DIFF
--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.0"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "shlex",
 ]
@@ -150,9 +150,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cmake"
-version = "0.1.48"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -37,8 +37,8 @@ test = false
 # Most of the time updating these dependencies requires modifications to the
 # bootstrap codebase(e.g., https://github.com/rust-lang/rust/issues/124565);
 # otherwise, some targets will fail. That's why these dependencies are explicitly pinned.
-cc = "=1.2.0"
-cmake = "=0.1.48"
+cc = "=1.2.14"
+cmake = "=0.1.54"
 
 build_helper = { path = "../build_helper" }
 clap = { version = "4.4", default-features = false, features = ["std", "usage", "help", "derive", "error-context"] }


### PR DESCRIPTION
## Summary

Bump bootstrap's `cc` and `cmake` deps:

1. To make it easier to add new/unofficial targets. In particular, `cc` v1.2.4+ allows using env vars to pass target parameters to the `cc` crate. This was previously attempted in #134344 but ran into macos-cross-to-iOS problems with `cmake` (and also #136440, #136720). See also discussions in https://github.com/rust-lang/cc-rs/issues/1317.
2. Fix some flag inheritance warnings. Fixes #136338.


## `cc` changelogs between `1.2.0` and `1.2.14`

> ## [1.2.14](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.13...cc-v1.2.14) - 2025-02-14
> 
> ### Other
> 
> - Regenerate target info ([#1398](https://github.com/rust-lang/cc-rs/pull/1398))
> - Add support for setting `-gdwarf-{version}` based on RUSTFLAGS ([#1395](https://github.com/rust-lang/cc-rs/pull/1395))
> - Add support for alternative network stack io-sock on QNX 7.1 aarch64 and x86_64 ([#1312](https://github.com/rust-lang/cc-rs/pull/1312))
> 
> ## [1.2.13](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.12...cc-v1.2.13) - 2025-02-08
> 
> ### Other
> 
> - Fix cross-compiling for Apple platforms ([#1389](https://github.com/rust-lang/cc-rs/pull/1389))
> 
> ## [1.2.12](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.11...cc-v1.2.12) - 2025-02-04
> 
> ### Other
> 
> - Split impl Build ([#1382](https://github.com/rust-lang/cc-rs/pull/1382))
> - Don't specify both `-target` and `-mtargetos=` on Apple targets ([#1384](https://github.com/rust-lang/cc-rs/pull/1384))
> 
> ## [1.2.11](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.10...cc-v1.2.11) - 2025-01-31
> 
> ### Other
> 
> - Fix more flag inheritance ([#1380](https://github.com/rust-lang/cc-rs/pull/1380))
> - Include wrapper args. in `stdout` family heuristics to restore classifying `clang --driver-mode=cl` as `Msvc { clang_cl: true }` ([#1378](https://github.com/rust-lang/cc-rs/pull/1378))
> - Constrain `-Clto` and `-Cembed-bitcode` flag inheritance to be `clang`-only ([#1379](https://github.com/rust-lang/cc-rs/pull/1379))
> - Pass deployment target with `-m*-version-min=` ([#1339](https://github.com/rust-lang/cc-rs/pull/1339))
> - Regenerate target info ([#1376](https://github.com/rust-lang/cc-rs/pull/1376))
> 
> ## [1.2.10](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.9...cc-v1.2.10) - 2025-01-17
> 
> ### Other
> 
> - Fix CC_FORCE_DISABLE=0 evaluating to true ([#1371](https://github.com/rust-lang/cc-rs/pull/1371))
> - Regenerate target info ([#1369](https://github.com/rust-lang/cc-rs/pull/1369))
> - Make hidden lifetimes explicit. ([#1366](https://github.com/rust-lang/cc-rs/pull/1366))
> 
> ## [1.2.9](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.8...cc-v1.2.9) - 2025-01-12
> 
> ### Other
> 
> - Don't pass inherited PGO flags to GNU compilers (#1363)
> - Adjusted zig cc judgment and avoided zigbuild errors([#1360](https://github.com/rust-lang/cc-rs/pull/1360)) ([#1361](https://github.com/rust-lang/cc-rs/pull/1361))
> - Fix compilation on macOS using clang and fix compilation using zig-cc ([#1364](https://github.com/rust-lang/cc-rs/pull/1364))
> 
> ## [1.2.8](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.7...cc-v1.2.8) - 2025-01-11
> 
> ### Other
> 
> - Add `is_like_clang_cl()` getter (#1357)
> - Fix clippy error in lib.rs ([#1356](https://github.com/rust-lang/cc-rs/pull/1356))
> - Regenerate target info ([#1352](https://github.com/rust-lang/cc-rs/pull/1352))
> - Fix compiler family detection issue with clang-cl on macOS ([#1328](https://github.com/rust-lang/cc-rs/pull/1328))
> - Update `windows-bindgen` dependency ([#1347](https://github.com/rust-lang/cc-rs/pull/1347))
> - Fix clippy warnings ([#1346](https://github.com/rust-lang/cc-rs/pull/1346))
> 
> ## [1.2.7](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.6...cc-v1.2.7) - 2025-01-03
> 
> ### Other
> 
> - Regenerate target info ([#1342](https://github.com/rust-lang/cc-rs/pull/1342))
> - Document new supported architecture names in windows::find
> - Make is_flag_supported_inner take an &Tool ([#1337](https://github.com/rust-lang/cc-rs/pull/1337))
> - Fix is_flag_supported on msvc ([#1336](https://github.com/rust-lang/cc-rs/pull/1336))
> - Allow using Visual Studio target names in `find_tool` ([#1335](https://github.com/rust-lang/cc-rs/pull/1335))
> 
> ## [1.2.6](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.5...cc-v1.2.6) - 2024-12-27
> 
> ### Other
> 
> - Don't inherit the `/Oy` flag for 64-bit targets ([#1330](https://github.com/rust-lang/cc-rs/pull/1330))
> 
> ## [1.2.5](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.4...cc-v1.2.5) - 2024-12-19
> 
> ### Other
> 
> - Check linking when testing if compiler flags are supported ([#1322](https://github.com/rust-lang/cc-rs/pull/1322))
> 
> ## [1.2.4](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.3...cc-v1.2.4) - 2024-12-13
> 
> ### Other
> 
> - Add support for C/C++ compiler for Neutrino QNX: `qcc` ([#1319](https://github.com/rust-lang/cc-rs/pull/1319))
> - use -maix64 instead of -m64 ([#1307](https://github.com/rust-lang/cc-rs/pull/1307))
> 
> ## [1.2.3](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.2...cc-v1.2.3) - 2024-12-06
> 
> ### Other
> 
> - Improve detection of environment when compiling from msbuild or msvc ([#1310](https://github.com/rust-lang/cc-rs/pull/1310))
> - Better error message when failing on unknown targets ([#1313](https://github.com/rust-lang/cc-rs/pull/1313))
> - Optimize RustcCodegenFlags ([#1305](https://github.com/rust-lang/cc-rs/pull/1305))
> 
> ## [1.2.2](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.1...cc-v1.2.2) - 2024-11-29
> 
> ### Other
> 
> - Inherit flags from rustc ([#1279](https://github.com/rust-lang/cc-rs/pull/1279))
> - Add support for using sccache wrapper with cuda/nvcc ([#1304](https://github.com/rust-lang/cc-rs/pull/1304))
> - Fix msvc stdout not shown on error ([#1303](https://github.com/rust-lang/cc-rs/pull/1303))
> - Regenerate target info ([#1301](https://github.com/rust-lang/cc-rs/pull/1301))
> - Fix compilation of C++ code for armv7-unknown-linux-gnueabihf ([#1298](https://github.com/rust-lang/cc-rs/pull/1298))
> - Fetch target info from Cargo even if `Build::target` is manually set ([#1299](https://github.com/rust-lang/cc-rs/pull/1299))
> - Fix two files with different extensions having the same object name ([#1295](https://github.com/rust-lang/cc-rs/pull/1295))
> - Allow disabling cc's ability to compile via env var CC_FORCE_DISABLE ([#1292](https://github.com/rust-lang/cc-rs/pull/1292))
> - Regenerate target info ([#1293](https://github.com/rust-lang/cc-rs/pull/1293))
> 
> ## [1.2.1](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.0...cc-v1.2.1) - 2024-11-14
> 
> ### Other
> 
> - When invoking `cl -?`, set stdin to null ([#1288](https://github.com/rust-lang/cc-rs/pull/1288))

## `cmake` changelogs `0.1.51` to `0.1.54`

> ## [0.1.54](https://github.com/rust-lang/cmake-rs/compare/v0.1.53...v0.1.54) - 2025-02-10
> 
> ### Other
> 
> - Remove workaround for broken `cc-rs` versions ([#235](https://github.com/rust-lang/cmake-rs/pull/235))
> - Be more precise in the description of `register_dep` ([#238](https://github.com/rust-lang/cmake-rs/pull/238))
> 
> ## [0.1.53](https://github.com/rust-lang/cmake-rs/compare/v0.1.52...v0.1.53) - 2025-01-27
> 
> ### Other
> 
> - Disable broken Make jobserver support on OSX to fix parallel builds ([#229](https://github.com/rust-lang/cmake-rs/pull/229))
> 
> ## [0.1.52](https://github.com/rust-lang/cmake-rs/compare/v0.1.51...v0.1.52) - 2024-11-25
> 
> ### Other
> 
> - Expose cc-rs no_default_flags for hassle-free cross-compilation ([#225](https://github.com/rust-lang/cmake-rs/pull/225))
> - Add a `success` job to CI
> - Change `--build` to use an absolute path
> - Merge pull request [#195](https://github.com/rust-lang/cmake-rs/pull/195) from meowtec/feat/improve-fail-hint
> - Improve hint for cmake not installed in Linux (code 127)
> 
> ## [0.1.51](https://github.com/rust-lang/cmake-rs/compare/v0.1.50...v0.1.51) - 2024-08-15
> 
> ### Added
> 
> - Add JOM generator support ([#183](https://github.com/rust-lang/cmake-rs/pull/183))
> - Improve visionOS support ([#209](https://github.com/rust-lang/cmake-rs/pull/209))
> - Use `Generic` for bare-metal systems ([#187](https://github.com/rust-lang/cmake-rs/pull/187))
> 
> ### Fixed
> 
> - Fix cross compilation on android armv7 and x86 ([#186](https://github.com/rust-lang/cmake-rs/pull/186))


try-job: dist-apple-various