### PR TITLE
Normalize closure instance before eagerly monomorphizing it

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1509,6 +1509,13 @@ impl<'v> RootCollector<'_, 'v> {
                         }
                         _ => unreachable!(),
                     };
+                    let Ok(instance) = self.tcx.try_normalize_erasing_regions(
+                        ty::TypingEnv::fully_monomorphized(),
+                        instance,
+                    ) else {
+                        // Don't ICE on an impossible-to-normalize closure.
+                        return;
+                    };
                     let mono_item = create_fn_mono_item(self.tcx, instance, DUMMY_SP);
                     if mono_item.node.is_instantiable(self.tcx) {
                         self.output.push(mono_item);

--- a/tests/ui/closures/eager-mono-with-normalizable-upvars.rs
+++ b/tests/ui/closures/eager-mono-with-normalizable-upvars.rs
@@ -1,0 +1,19 @@
+//@ compile-flags: -Clink-dead-code -Csymbol-mangling-version=v0
+//@ build-pass
+
+// Ensure that when eagerly collecting `test::{closure#0}`, we don't try
+// collecting an unnormalized version of the closure (specifically its
+// upvars), since the closure captures the RPIT `opaque::{opaque#0}`.
+
+fn opaque() -> impl Sized {}
+
+fn test() -> impl FnOnce() {
+    let opaque = opaque();
+    move || {
+        let opaque = opaque;
+    }
+}
+
+fn main() {
+    test()();
+}


### PR DESCRIPTION
We were monomorphizing two versions of the closure (or in the original issue, coroutine) -- one with normalized captures and one with unnormalized captures. This led to a symbol collision.

Fixes #137009
 
r? @saethlin or reassign