### PR TITLE
llvm: Tolerate captures in tests

### DIFF
--- a/tests/codegen/common_prim_int_ptr.rs
+++ b/tests/codegen/common_prim_int_ptr.rs
@@ -40,7 +40,7 @@ pub unsafe fn extract_int(x: Result<usize, Box<()>>) -> usize {
 }
 
 // CHECK-LABEL: @extract_box
-// CHECK-SAME: (i{{[0-9]+}} {{[^%]+}} [[DISCRIMINANT:%[0-9]+]], ptr {{[^,]+}} [[PAYLOAD:%[0-9]+]])
+// CHECK-SAME: (i{{[0-9]+}} {{[^%]+}} [[DISCRIMINANT:%[0-9]+]], ptr {{[^%]+}} [[PAYLOAD:%[0-9]+]])
 #[no_mangle]
 pub unsafe fn extract_box(x: Result<usize, Box<i32>>) -> Box<i32> {
     // CHECK: ret ptr [[PAYLOAD]]


### PR DESCRIPTION
llvm/llvm-project@7e3735d1a1b85cea48feb45cb7c2b5d8eaa216ae introduces `captures` annotations. Adjust regexes to be tolerant of these.

@rustbot label:+llvm-main
