### PR TITLE
[CRATER] Detect presence of .ctors/.dtors in linked objects

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -820,7 +820,7 @@ fn link_natively(
                 for lib_dir in &library_search_dirs {
                     let candidate_path = lib_dir.join(candidate);
                     if candidate_path.is_file() {
-                        eprintln!("Found native library at {candidate_path:?}");
+                        // eprintln!("Found native library at {candidate_path:?}");
                         obj_candidates.push(candidate_path);
                     }
                 }


### PR DESCRIPTION
This PR serves for a crater run to examine the frequency of object files in the wild that use the `.ctors`/`.dtors` sections, which are problematic for LLD (https://github.com/rust-lang/rust/issues/128286).

I'm not sure if there are any other sections that cause problems for LLD (?). I used `readelf -S` instead of the `object` crate, because it had a problem with opening some object files (notably CUDA, although we probably won't find these in crater anyway...). If it becomes a problem, I can also scan the libraries with `object`.

I'm pretty clueless about crater, so:

r? @lqd