### PR TITLE
rustdoc: Properly restore search input placeholder

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -5318,8 +5318,9 @@ function registerSearchEvents() {
 
     // @ts-expect-error
     searchState.input.addEventListener("blur", () => {
-        // @ts-expect-error
-        searchState.input.placeholder = searchState.input.origPlaceholder;
+        if (window.searchState.input) {
+            window.searchState.input.placeholder = window.searchState.origPlaceholder;
+        }
     });
 
     // Push and pop states are used to add search results to the browser


### PR DESCRIPTION
Fix the search input placeholder literally getting set to the string *undefined* on blur/defocus.
This was caused by us trying to access an undefined property in the event listener.
To prevent this from regressing again, stop typescript from ignoring the relevant site.

Steps to reproduce the bug fixed in this PR:

1. Focus the search input field by clicking on it and clear the input if necessary
2. Blur/defocus it by clicking somewhere outside of it

---

First bug that would've been caught by TSC if we had had it earlier! Type (quasi-)safety, ahoy! :)