### PR TITLE
Update cargo

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -132,6 +132,7 @@ const EXCEPTIONS_CARGO: ExceptionList = &[
     ("dunce", "CC0-1.0 OR MIT-0 OR Apache-2.0"),
     ("encoding_rs", "(Apache-2.0 OR MIT) AND BSD-3-Clause"),
     ("fiat-crypto", "MIT OR Apache-2.0 OR BSD-1-Clause"),
+    ("foldhash", "Zlib"),
     ("im-rc", "MPL-2.0+"),
     ("normalize-line-endings", "Apache-2.0"),
     ("openssl", "Apache-2.0"),


### PR DESCRIPTION
13 commits in 2928e32734b04925ee51e1ae88bea9a83d2fd451..ce948f4616e3d4277e30c75c8bb01e094910df39
2025-02-07 16:50:22 +0000 to 2025-02-14 20:32:07 +0000
- util: provide a better error message for invalid SSH URLs (rust-lang/cargo#15185)
- Fix the description of the `"root"` field of the `cargo metadata`'s output (rust-lang/cargo#15182)
- refactor: Consolidate creation of SourceId from manifest path (rust-lang/cargo#15172)
- docs(embedded): Note the shebang deviation (rust-lang/cargo#15173)
- refactor(embedded): Integrate cargo-script logic into main parser (rust-lang/cargo#15168)
- feat: implement workspace feature unification (rust-lang/cargo#15157)
- Fix race condition in panic_abort_tests (rust-lang/cargo#15169)
- Update all dependencies (rust-lang/cargo#15166)
- Update curl from 8.9.0 to 8.12.0 (rust-lang/cargo#15162)
- Update annotate-snippets from 0.11.4 to 0.11.5 (rust-lang/cargo#15165)
- Update deny.toml (rust-lang/cargo#15164)
- Update rusqlite from 0.32.1 to 0.33.0 (rust-lang/cargo#15163)
- fix: align first line of unordered list with following (rust-lang/cargo#15161)