### PR TITLE
Unstable `gen_future` Feature Tracking  

### DIFF
--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -46,19 +46,19 @@ pub use self::join::join;
 /// It also simplifies the HIR lowering of `.await`.
 #[lang = "ResumeTy"]
 #[doc(hidden)]
-#[unstable(feature = "gen_future", issue = "50547")]
+#[unstable(feature = "gen_future", issue= "none")]
 #[derive(Debug, Copy, Clone)]
 pub struct ResumeTy(NonNull<Context<'static>>);
 
-#[unstable(feature = "gen_future", issue = "50547")]
+#[unstable(feature = "gen_future", issue= "none")]
 unsafe impl Send for ResumeTy {}
 
-#[unstable(feature = "gen_future", issue = "50547")]
+#[unstable(feature = "gen_future", issue= "none")]
 unsafe impl Sync for ResumeTy {}
 
 #[lang = "get_context"]
 #[doc(hidden)]
-#[unstable(feature = "gen_future", issue = "50547")]
+#[unstable(feature = "gen_future", issue= "none")]
 #[must_use]
 #[inline]
 pub unsafe fn get_context<'a, 'b>(cx: ResumeTy) -> &'a mut Context<'b> {

--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -46,19 +46,19 @@ pub use self::join::join;
 /// It also simplifies the HIR lowering of `.await`.
 #[lang = "ResumeTy"]
 #[doc(hidden)]
-#[unstable(feature = "gen_future", issue= "none")]
+#[unstable(feature = "gen_future", issue = "none")]
 #[derive(Debug, Copy, Clone)]
 pub struct ResumeTy(NonNull<Context<'static>>);
 
-#[unstable(feature = "gen_future", issue= "none")]
+#[unstable(feature = "gen_future", issue = "none")]
 unsafe impl Send for ResumeTy {}
 
-#[unstable(feature = "gen_future", issue= "none")]
+#[unstable(feature = "gen_future", issue = "none")]
 unsafe impl Sync for ResumeTy {}
 
 #[lang = "get_context"]
 #[doc(hidden)]
-#[unstable(feature = "gen_future", issue= "none")]
+#[unstable(feature = "gen_future", issue = "none")]
 #[must_use]
 #[inline]
 pub unsafe fn get_context<'a, 'b>(cx: ResumeTy) -> &'a mut Context<'b> {


### PR DESCRIPTION
This PR removes the reference to the closed tracking issue **#50547** for the `gen_future` feature. Since `gen_future` is an internal feature used in async block desugaring, it does not require a public tracking issue.  

#### Changes:  
- Replaced `issue = "50547"` with `issue = "none"` in **library/core/src/future/mod.rs**.  
- Ensures that it is correctly identified as an internal feature.  

#### Rationale:  
With this change, the Unstable Book will now state:  
> *"This feature has no tracking issue and is therefore likely internal to the compiler, not being intended for general use."*  

Closes **#76249**. 🚀🦀