### PR TITLE
fix(rustdoc): Fixed `Copy Item Path` in rust doc

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -2039,7 +2039,10 @@ function preLoadCss(cssUrl) {
         // Most page titles are '<Item> in <path::to::module> - Rust', except
         // modules (which don't have the first part) and keywords/primitives
         // (which don't have a module path)
-        const [item, module] = document.title.split(" in ");
+        const titleElement = document.querySelector("title");
+        const title = titleElement && titleElement.textContent ?
+                      titleElement.textContent.replace(" - Rust", "") : "";
+        const [item, module] = title.split(" in ");
         const path = [item];
         if (module !== undefined) {
             path.unshift(module);


### PR DESCRIPTION
This PR aims to address the issue reported by https://github.com/rust-lang/rust/issues/137048
Issue caused by previous changes for removing @ts-expect-error by this change https://github.com/rust-lang/rust/commit/2ea95f867012e91fa742e60b7b6424abf86c05cf 