### PR TITLE
boostrap: skip no_std targets in Std doc step

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -580,6 +580,10 @@ impl Step for Std {
 
     fn make_run(run: RunConfig<'_>) {
         let crates = compile::std_crates_for_run_make(&run);
+        let target_is_no_std = run.builder.no_std(run.target).unwrap_or(false);
+        if crates.is_empty() && target_is_no_std {
+            return;
+        }
         run.builder.ensure(Std {
             stage: run.builder.top_stage,
             target: run.target,


### PR DESCRIPTION
This fixes a bug that currently prevents us from adding no_std library targets to rustc in nixpkgs (https://github.com/NixOS/nixpkgs/pull/382166).

When running `./x.py doc`, the `Std` doc step generally fails for no_std targets, logs: https://gist.github.com/niklaskorz/fb83f9503ce19b75e8b1af02cdebd592

Skipping no_std targets in this step will allow using no_std targets such as `bpfel-unknown-none` together with other targets in the same config without blocking the doc generator for them, e.g.

```
./configure --release-channel=stable --tools=rustc,rustdoc,rust-analyzer-proc-macro-srv --build=aarch64-apple-darwin --host=aarch64-apple-darwin --target=aarch64-apple-darwin,bpfel-unknown-none

./x.py doc
```

Logs with this fix applied: https://gist.github.com/niklaskorz/cdd50aaea33ede579f737434286d800b