### PR TITLE
Ignore Self in bounds check for associated types with Self:Sized

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -187,7 +187,10 @@ fn predicates_reference_self(
 fn bounds_reference_self(tcx: TyCtxt<'_>, trait_def_id: DefId) -> SmallVec<[Span; 1]> {
     tcx.associated_items(trait_def_id)
         .in_definition_order()
+        // We're only looking at associated type bounds
         .filter(|item| item.kind == ty::AssocKind::Type)
+        // Ignore GATs with `Self: Sized`
+        .filter(|item| !tcx.generics_require_sized_self(item.def_id))
         .flat_map(|item| tcx.explicit_item_bounds(item.def_id).iter_identity_copied())
         .filter_map(|(clause, sp)| {
             // Item bounds *can* have self projections, since they never get

--- a/tests/ui/dyn-compatibility/associated_type_bound_mentions_self.rs
+++ b/tests/ui/dyn-compatibility/associated_type_bound_mentions_self.rs
@@ -1,0 +1,14 @@
+// Ensure that we properly ignore the `B<Self>` associated type bound on `A::T`
+// since that associated type requires `Self: Sized`.
+
+//@ check-pass
+
+struct X(&'static dyn A);
+
+trait A {
+    type T: B<Self> where Self: Sized;
+}
+
+trait B<T> {}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/137053

This is morally a fix of https://github.com/rust-lang/rust/pull/112319, since the `Self: Sized` check was just missing here.

r? oli-obk