### PR TITLE
Rework `name_regions` to not rely on reverse scc graph for non-member-constrain usages

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -204,7 +204,13 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     /// that the regions produced are in fact equal to the named region they are
     /// replaced with. This is fine because this function is only to improve the
     /// region names in error messages.
-    pub(crate) fn name_regions<T>(&self, tcx: TyCtxt<'tcx>, ty: T) -> T
+    ///
+    /// This differs from `MirBorrowckCtxt::name_regions` since it is particularly
+    /// lax with mapping region vids that are *shorter* than a universal region to
+    /// that universal region. This is useful for member region constraints since
+    /// we want to suggest a universal region name to capture even if it's technically
+    /// not equal to the error region.
+    pub(crate) fn name_regions_for_member_constraint<T>(&self, tcx: TyCtxt<'tcx>, ty: T) -> T
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
     {

--- a/tests/ui/borrowck/alias-liveness/name-region.rs
+++ b/tests/ui/borrowck/alias-liveness/name-region.rs
@@ -1,0 +1,13 @@
+// Make sure we don't ICE when trying to name the regions that appear in the alias
+// of the type test error.
+
+trait AnotherTrait {
+    type Ty2<'a>;
+}
+
+fn test_alias<T: AnotherTrait>(_: &'static T::Ty2<'_>) {
+    let _: &'static T::Ty2<'_>;
+    //~^ ERROR the associated type `<T as AnotherTrait>::Ty2<'_>` may not live long enough
+}
+
+fn main() {}

--- a/tests/ui/borrowck/alias-liveness/name-region.stderr
+++ b/tests/ui/borrowck/alias-liveness/name-region.stderr
@@ -1,0 +1,14 @@
+error[E0310]: the associated type `<T as AnotherTrait>::Ty2<'_>` may not live long enough
+  --> $DIR/name-region.rs:9:12
+   |
+LL |     let _: &'static T::Ty2<'_>;
+   |            ^^^^^^^^^^^^^^^^^^^
+   |            |
+   |            the associated type `<T as AnotherTrait>::Ty2<'_>` must be valid for the static lifetime...
+   |            ...so that the type `<T as AnotherTrait>::Ty2<'_>` will meet its required lifetime bounds
+   |
+   = help: consider adding an explicit lifetime bound `<T as AnotherTrait>::Ty2<'_>: 'static`...
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0310`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/137015

Splits the `name_regions` into two versions: One meant for member region constraint error reporting (which I've renamed to `name_regions_for_member_constraint`), and one meant *just* to replace region vids with an external region. 

Use the latter in the usage sites I added in #136559, since the regions returned by `name_regions_for_member_constraint` are also not *totally* accurate (which is fine for how they're used for member region constraint error reporting -- they're intentionally returning overapproximated universal regions so that we have something to name in `+ use<'a>` suggestions, because opaques can only capture universal regions and since member region constraints don't insert any edges into the region graph, the error region is probably gonna be shorter than a universal region) and because that function requires the reverse scc graph to have been computed which isn't done for our usages in #136559.