### PR TITLE
Add customized compare for Link in rustdoc

### DIFF
--- a/tests/rustdoc-gui/sidebar-foreign-impl-sort.goml
+++ b/tests/rustdoc-gui/sidebar-foreign-impl-sort.goml
@@ -1,0 +1,15 @@
+// Checks sidebar resizing close the Settings popover
+go-to: "file://" + |DOC_PATH| + "/test_docs/SidebarSort/trait.Sort.html#foreign-impls"
+
+// Check that the sidebar contains the expected foreign implementations
+assert-text: (".sidebar-elems section ul > li:nth-child(1)", "&'a str")
+assert-text: (".sidebar-elems section ul > li:nth-child(2)", "AtomicBool")
+assert-text: (".sidebar-elems section ul > li:nth-child(3)", "AtomicU8")
+assert-text: (".sidebar-elems section ul > li:nth-child(4)", "AtomicU16")
+assert-text: (".sidebar-elems section ul > li:nth-child(5)", "AtomicU32")
+assert-text: (".sidebar-elems section ul > li:nth-child(6)", "Cell<u8>")
+assert-text: (".sidebar-elems section ul > li:nth-child(7)", "Cell<u16>")
+assert-text: (".sidebar-elems section ul > li:nth-child(8)", "u8")
+assert-text: (".sidebar-elems section ul > li:nth-child(9)", "u16")
+assert-text: (".sidebar-elems section ul > li:nth-child(10)", "u32")
+assert-text: (".sidebar-elems section ul > li:nth-child(11)", "usize")

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -713,3 +713,21 @@ pub trait ItemsTrait {
     /// blablala
     fn bar();
 }
+
+pub mod SidebarSort {
+    use std::cell::Cell;
+    use std::sync::atomic::*;
+    pub trait Sort {}
+
+    impl Sort for u32 {}
+    impl Sort for u8 {}
+    impl Sort for u16 {}
+    impl Sort for usize {}
+    impl Sort for AtomicU32 {}
+    impl Sort for AtomicU16 {}
+    impl Sort for AtomicU8 {}
+    impl Sort for AtomicBool {}
+    impl Sort for Cell<u16> {}
+    impl Sort for Cell<u8> {}
+    impl<'a> Sort for &'a str {}
+}


### PR DESCRIPTION
Maybe some other types in sidebar need to be sorted in this way, maybe add this crate `natord` is ok?

r?  clubby789

Fixes #137098

