### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,130 @@
+Version 1.85.0 (2025-02-20)
+==========================
+
+<a id="1.85.0-Language"></a>
+
+Language
+--------
+- [The 2024 Edition is now stable.](https://github.com/rust-lang/rust/pull/133349)
+  See [the edition guide](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html) for more details.
+- [Stabilize async closures](https://github.com/rust-lang/rust/pull/132706)
+  See [RFC 3668](https://rust-lang.github.io/rfcs/3668-async-closures.html) for more details.
+- [Stabilize `#[diagnostic::do_not_recommend]`](https://github.com/rust-lang/rust/pull/132056)
+- [Add `unpredictable_function_pointer_comparisons` lint to warn against function pointer comparisons](https://github.com/rust-lang/rust/pull/118833)
+- [Lint on combining `#[no_mangle]` and `#[export_name]` attributes.](https://github.com/rust-lang/rust/pull/131558)
+
+<a id="1.85.0-Compiler"></a>
+
+Compiler
+--------
+- [The unstable flag `-Zpolymorphize` has been removed](https://github.com/rust-lang/rust/pull/133883), see https://github.com/rust-lang/compiler-team/issues/810 for some background.
+
+<a id="1.85.0-Platform-Support"></a>
+
+Platform Support
+----------------
+- [Promote `powerpc64le-unknown-linux-musl` to tier 2 with host tools](https://github.com/rust-lang/rust/pull/133801)
+
+Refer to Rust's [platform support page][platform-support-doc]
+for more information on Rust's tiered platform support.
+
+<a id="1.85.0-Libraries"></a>
+
+Libraries
+---------
+- [Panics in the standard library now have a leading `library/` in their path](https://github.com/rust-lang/rust/pull/132390)
+- [`std::env::home_dir()` on Windows now ignores the non-standard `$HOME` environment variable](https://github.com/rust-lang/rust/pull/132515)
+   It will be un-deprecated in a subsequent release.
+- [Add `AsyncFn*` to the prelude in all editions.](https://github.com/rust-lang/rust/pull/132611)
+
+<a id="1.85.0-Stabilized-APIs"></a>
+
+Stabilized APIs
+---------------
+
+- [`BuildHasherDefault::new`](https://doc.rust-lang.org/stable/std/hash/struct.BuildHasherDefault.html#method.new)
+- [`ptr::fn_addr_eq`](https://doc.rust-lang.org/std/ptr/fn.fn_addr_eq.html)
+- [`io::ErrorKind::QuotaExceeded`](https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#variant.QuotaExceeded)
+- [`io::ErrorKind::CrossesDevices`](https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#variant.CrossesDevices)
+- [`{float}::midpoint`](https://doc.rust-lang.org/core/primitive.f32.html#method.midpoint)
+- [Unsigned `{integer}::midpoint`](https://doc.rust-lang.org/std/primitive.u64.html#method.midpoint)
+- [`NonZeroU*::midpoint`](https://doc.rust-lang.org/std/num/type.NonZeroU32.html#method.midpoint)
+- [impl `std::iter::Extend` for tuples with arity 1 through 12](https://doc.rust-lang.org/stable/std/iter/trait.Extend.html#impl-Extend%3C(A,)%3E-for-(EA,))
+- [`FromIterator<(A, ...)>` for tuples with arity 1 through 12](https://doc.rust-lang.org/stable/std/iter/trait.FromIterator.html#impl-FromIterator%3C(EA,)%3E-for-(A,))
+- [`std::task::Waker::noop`](https://doc.rust-lang.org/stable/std/task/struct.Waker.html#method.noop)
+
+These APIs are now stable in const contexts:
+
+- [`mem::size_of_val`](https://doc.rust-lang.org/stable/std/mem/fn.size_of_val.html)
+- [`mem::align_of_val`](https://doc.rust-lang.org/stable/std/mem/fn.align_of_val.html)
+- [`Layout::for_value`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.for_value)
+- [`Layout::align_to`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.align_to)
+- [`Layout::pad_to_align`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.pad_to_align)
+- [`Layout::extend`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.extend)
+- [`Layout::array`](https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.array)
+- [`std::mem::swap`](https://doc.rust-lang.org/stable/std/mem/fn.swap.html)
+- [`std::ptr::swap`](https://doc.rust-lang.org/stable/std/ptr/fn.swap.html)
+- [`NonNull::new`](https://doc.rust-lang.org/stable/std/ptr/struct.NonNull.html#method.new)
+- [`HashMap::with_hasher`](https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html#method.with_hasher)
+- [`HashSet::with_hasher`](https://doc.rust-lang.org/stable/std/collections/struct.HashSet.html#method.with_hasher)
+- [`BuildHasherDefault::new`](https://doc.rust-lang.org/stable/std/hash/struct.BuildHasherDefault.html#method.new)
+- [`<float>::recip`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.recip)
+- [`<float>::to_degrees`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.to_degrees)
+- [`<float>::to_radians`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.to_radians)
+- [`<float>::max`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.max)
+- [`<float>::min`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.min)
+- [`<float>::clamp`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.clamp)
+- [`<float>::abs`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.abs)
+- [`<float>::signum`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.signum)
+- [`<float>::copysign`](https://doc.rust-lang.org/stable/std/primitive.f32.html#method.copysign)
+- [`MaybeUninit::write`](https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.write)
+
+<a id="1.85.0-Cargo"></a>
+
+Cargo
+-----
+- [Add future-incompatibility warning against keywords in cfgs and add raw-idents](https://github.com/rust-lang/cargo/pull/14671/)
+- [Stabilize higher precedence trailing flags](https://github.com/rust-lang/cargo/pull/14900/)
+- [Pass `CARGO_CFG_FEATURE` to build scripts](https://github.com/rust-lang/cargo/pull/14902/)
+
+<a id="1.85.0-Rustdoc"></a>
+
+Rustdoc
+-----
+- [Doc comment on impl blocks shows the first line, even when the impl block is collapsed](https://github.com/rust-lang/rust/pull/132155)
+
+<a id="1.85.0-Compatibility-Notes"></a>
+
+Compatibility Notes
+-------------------
+- [`rustc` no longer treats the `test` cfg as a well known check-cfg](https://github.com/rust-lang/rust/pull/131729), instead it is up to the build systems and users of `--check-cfg`[^check-cfg] to set it as a well known cfg using `--check-cfg=cfg(test)`.
+  This is done to enable build systems like Cargo to set it conditionally, as not all source files are suitable for unit tests.
+  [Cargo (for now) unconditionally sets the `test` cfg as a well known cfg](https://github.com/rust-lang/cargo/pull/14963).
+[^check-cfg]: https://doc.rust-lang.org/nightly/rustc/check-cfg.html
+- [Disable potentially incorrect type inference if there are trivial and non-trivial where-clauses](https://github.com/rust-lang/rust/pull/132325)
+- `std::env::home_dir()` has been deprecated for years, because it can give surprising results in some Windows configurations if the `HOME` environment variable is set (which is not the normal configuration on Windows). We had previously avoided changing its behavior, out of concern for compatibility with code depending on this non-standard configuration. Given how long this function has been deprecated, we're now fixing its behavior as a bugfix. A subsequent release will remove the deprecation for this function.
+- [Make `core::ffi::c_char` signedness more closely match that of the platform-default `char`](https://github.com/rust-lang/rust/pull/132975)
+  This changed `c_char` from an `i8` to `u8` or vice versa on many Tier 2 and 3
+  targets (mostly Arm and RISC-V embedded targets). The new definition may
+  result in compilation failures but fixes compatibility issues with C.
+  The `libc` crate matches this change as of its 0.2.169 release.
+- [When compiling a nested `macro_rules` macro from an external crate, the content of the inner `macro_rules` is now built with the edition of the external crate, not the local crate.](https://github.com/rust-lang/rust/pull/133274)
+- [Increase `sparcv9-sun-solaris` and `x86_64-pc-solaris` Solaris baseline to 11.4.](https://github.com/rust-lang/rust/pull/133293)
+- [Show `abi_unsupported_vector_types` lint in future breakage reports](https://github.com/rust-lang/rust/pull/133374)
+- [Error if multiple super-trait instantiations of `dyn Trait` need associated types to be specified but only one is provided](https://github.com/rust-lang/rust/pull/133392)
+- [Change `powerpc64-ibm-aix` default `codemodel` to large](https://github.com/rust-lang/rust/pull/133811)
+
+<a id="1.85.0-Internal-Changes"></a>
+
+Internal Changes
+----------------
+
+These changes do not affect any public interfaces of Rust, but they represent
+significant improvements to the performance or internals of rustc and related
+tools.
+
+- [Build `x86_64-unknown-linux-gnu` with LTO for C/C++ code (e.g., `jemalloc`)](https://github.com/rust-lang/rust/pull/134690)
+
 Version 1.84.1 (2025-01-30)
 ==========================
 

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -194,6 +194,12 @@ pub(crate) unsafe fn create_module<'ll>(
             target_data_layout = target_data_layout.replace("-i128:128", "");
         }
     }
+    if llvm_version < (21, 0, 0) {
+        if sess.target.arch == "nvptx64" {
+            // LLVM 21 updated the default layout on nvptx: https://github.com/llvm/llvm-project/pull/124961
+            target_data_layout = target_data_layout.replace("e-p6:32:32-i64", "e-i64");
+        }
+    }
 
     // Ensure the data-layout values hardcoded remain the defaults.
     {

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1776,6 +1776,7 @@ fn exported_symbols_for_non_proc_macro(tcx: TyCtxt<'_>, crate_type: CrateType) -
             symbols.push(symbol_export::exporting_symbol_name_for_instance_in_crate(
                 tcx, symbol, cnum,
             ));
+            symbol_export::extend_exported_symbols(&mut symbols, tcx, symbol, cnum);
         }
     });
 

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -10,9 +10,10 @@ use rustc_middle::middle::exported_symbols::{
     ExportedSymbol, SymbolExportInfo, SymbolExportKind, SymbolExportLevel, metadata_symbol_name,
 };
 use rustc_middle::query::LocalCrate;
-use rustc_middle::ty::{self, GenericArgKind, GenericArgsRef, Instance, SymbolName, TyCtxt};
+use rustc_middle::ty::{self, GenericArgKind, GenericArgsRef, Instance, SymbolName, Ty, TyCtxt};
 use rustc_middle::util::Providers;
 use rustc_session::config::{CrateType, OomStrategy};
+use rustc_target::callconv::Conv;
 use rustc_target::spec::{SanitizerSet, TlsModel};
 use tracing::debug;
 
@@ -551,6 +552,42 @@ pub(crate) fn symbol_name_for_instance_in_crate<'tcx>(
     }
 }
 
+fn calling_convention_for_symbol<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    symbol: ExportedSymbol<'tcx>,
+) -> (Conv, &'tcx [rustc_target::callconv::ArgAbi<'tcx, Ty<'tcx>>]) {
+    let instance = match symbol {
+        ExportedSymbol::NonGeneric(def_id) | ExportedSymbol::Generic(def_id, _)
+            if tcx.is_static(def_id) =>
+        {
+            None
+        }
+        ExportedSymbol::NonGeneric(def_id) => Some(Instance::mono(tcx, def_id)),
+        ExportedSymbol::Generic(def_id, args) => Some(Instance::new(def_id, args)),
+        // DropGlue always use the Rust calling convention and thus follow the target's default
+        // symbol decoration scheme.
+        ExportedSymbol::DropGlue(..) => None,
+        // AsyncDropGlueCtorShim always use the Rust calling convention and thus follow the
+        // target's default symbol decoration scheme.
+        ExportedSymbol::AsyncDropGlueCtorShim(..) => None,
+        // NoDefId always follow the target's default symbol decoration scheme.
+        ExportedSymbol::NoDefId(..) => None,
+        // ThreadLocalShim always follow the target's default symbol decoration scheme.
+        ExportedSymbol::ThreadLocalShim(..) => None,
+    };
+
+    instance
+        .map(|i| {
+            tcx.fn_abi_of_instance(
+                ty::TypingEnv::fully_monomorphized().as_query_input((i, ty::List::empty())),
+            )
+            .unwrap_or_else(|_| bug!("fn_abi_of_instance({i:?}) failed"))
+        })
+        .map(|fnabi| (fnabi.conv, &fnabi.args[..]))
+        // FIXME(workingjubilee): why don't we know the convention here?
+        .unwrap_or((Conv::Rust, &[]))
+}
+
 /// This is the symbol name of the given instance as seen by the linker.
 ///
 /// On 32-bit Windows symbols are decorated according to their calling conventions.
@@ -559,8 +596,6 @@ pub(crate) fn linking_symbol_name_for_instance_in_crate<'tcx>(
     symbol: ExportedSymbol<'tcx>,
     instantiating_crate: CrateNum,
 ) -> String {
-    use rustc_target::callconv::Conv;
-
     let mut undecorated = symbol_name_for_instance_in_crate(tcx, symbol, instantiating_crate);
 
     // thread local will not be a function call,
@@ -584,35 +619,7 @@ pub(crate) fn linking_symbol_name_for_instance_in_crate<'tcx>(
         _ => return undecorated,
     };
 
-    let instance = match symbol {
-        ExportedSymbol::NonGeneric(def_id) | ExportedSymbol::Generic(def_id, _)
-            if tcx.is_static(def_id) =>
-        {
-            None
-        }
-        ExportedSymbol::NonGeneric(def_id) => Some(Instance::mono(tcx, def_id)),
-        ExportedSymbol::Generic(def_id, args) => Some(Instance::new(def_id, args)),
-        // DropGlue always use the Rust calling convention and thus follow the target's default
-        // symbol decoration scheme.
-        ExportedSymbol::DropGlue(..) => None,
-        // AsyncDropGlueCtorShim always use the Rust calling convention and thus follow the
-        // target's default symbol decoration scheme.
-        ExportedSymbol::AsyncDropGlueCtorShim(..) => None,
-        // NoDefId always follow the target's default symbol decoration scheme.
-        ExportedSymbol::NoDefId(..) => None,
-        // ThreadLocalShim always follow the target's default symbol decoration scheme.
-        ExportedSymbol::ThreadLocalShim(..) => None,
-    };
-
-    let (conv, args) = instance
-        .map(|i| {
-            tcx.fn_abi_of_instance(
-                ty::TypingEnv::fully_monomorphized().as_query_input((i, ty::List::empty())),
-            )
-            .unwrap_or_else(|_| bug!("fn_abi_of_instance({i:?}) failed"))
-        })
-        .map(|fnabi| (fnabi.conv, &fnabi.args[..]))
-        .unwrap_or((Conv::Rust, &[]));
+    let (conv, args) = calling_convention_for_symbol(tcx, symbol);
 
     // Decorate symbols with prefixes, suffixes and total number of bytes of arguments.
     // Reference: https://docs.microsoft.com/en-us/cpp/build/reference/decorated-names?view=msvc-170
@@ -642,6 +649,27 @@ pub(crate) fn exporting_symbol_name_for_instance_in_crate<'tcx>(
 ) -> String {
     let undecorated = symbol_name_for_instance_in_crate(tcx, symbol, cnum);
     maybe_emutls_symbol_name(tcx, symbol, &undecorated).unwrap_or(undecorated)
+}
+
+/// On amdhsa, `gpu-kernel` functions have an associated metadata object with a `.kd` suffix.
+/// Add it to the symbols list for all kernel functions, so that it is exported in the linked
+/// object.
+pub(crate) fn extend_exported_symbols<'tcx>(
+    symbols: &mut Vec<String>,
+    tcx: TyCtxt<'tcx>,
+    symbol: ExportedSymbol<'tcx>,
+    instantiating_crate: CrateNum,
+) {
+    let (conv, _) = calling_convention_for_symbol(tcx, symbol);
+
+    if conv != Conv::GpuKernel || tcx.sess.target.os != "amdhsa" {
+        return;
+    }
+
+    let undecorated = symbol_name_for_instance_in_crate(tcx, symbol, instantiating_crate);
+
+    // Add the symbol for the kernel descriptor (with .kd suffix)
+    symbols.push(format!("{undecorated}.kd"));
 }
 
 fn maybe_emutls_symbol_name<'tcx>(

--- a/compiler/rustc_monomorphize/messages.ftl
+++ b/compiler/rustc_monomorphize/messages.ftl
@@ -1,17 +1,17 @@
 monomorphize_abi_error_disabled_vector_type_call =
-  this function call uses a SIMD vector type that (with the chosen ABI) requires the `{$required_feature}` target feature, which is not enabled in the caller
+  this function call uses SIMD vector type `{$ty}` which (with the chosen ABI) requires the `{$required_feature}` target feature, which is not enabled in the caller
   .label = function called here
   .help = consider enabling it globally (`-C target-feature=+{$required_feature}`) or locally (`#[target_feature(enable="{$required_feature}")]`)
 monomorphize_abi_error_disabled_vector_type_def =
-  this function definition uses a SIMD vector type that (with the chosen ABI) requires the `{$required_feature}` target feature, which is not enabled
+  this function definition uses SIMD vector type `{$ty}` which (with the chosen ABI) requires the `{$required_feature}` target feature, which is not enabled
   .label = function defined here
   .help = consider enabling it globally (`-C target-feature=+{$required_feature}`) or locally (`#[target_feature(enable="{$required_feature}")]`)
 
 monomorphize_abi_error_unsupported_vector_type_call =
-  this function call uses a SIMD vector type that is not currently supported with the chosen ABI
+  this function call uses SIMD vector type `{$ty}` which is not currently supported with the chosen ABI
   .label = function called here
 monomorphize_abi_error_unsupported_vector_type_def =
-  this function definition uses a SIMD vector type that is not currently supported with the chosen ABI
+  this function definition uses SIMD vector type `{$ty}` which is not currently supported with the chosen ABI
   .label = function defined here
 
 monomorphize_couldnt_dump_mono_stats =

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use rustc_macros::{Diagnostic, LintDiagnostic};
+use rustc_middle::ty::Ty;
 use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
@@ -75,6 +76,7 @@ pub(crate) struct AbiErrorDisabledVectorTypeDef<'a> {
     #[label]
     pub span: Span,
     pub required_feature: &'a str,
+    pub ty: Ty<'a>,
 }
 
 #[derive(LintDiagnostic)]
@@ -84,18 +86,21 @@ pub(crate) struct AbiErrorDisabledVectorTypeCall<'a> {
     #[label]
     pub span: Span,
     pub required_feature: &'a str,
+    pub ty: Ty<'a>,
 }
 
 #[derive(LintDiagnostic)]
 #[diag(monomorphize_abi_error_unsupported_vector_type_def)]
-pub(crate) struct AbiErrorUnsupportedVectorTypeDef {
+pub(crate) struct AbiErrorUnsupportedVectorTypeDef<'a> {
     #[label]
     pub span: Span,
+    pub ty: Ty<'a>,
 }
 
 #[derive(LintDiagnostic)]
 #[diag(monomorphize_abi_error_unsupported_vector_type_call)]
-pub(crate) struct AbiErrorUnsupportedVectorTypeCall {
+pub(crate) struct AbiErrorUnsupportedVectorTypeCall<'a> {
     #[label]
     pub span: Span,
+    pub ty: Ty<'a>,
 }

--- a/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
+++ b/compiler/rustc_target/src/spec/targets/nvptx64_nvidia_cuda.rs
@@ -5,7 +5,7 @@ use crate::spec::{
 pub(crate) fn target() -> Target {
     Target {
         arch: "nvptx64".into(),
-        data_layout: "e-i64:64-i128:128-v16:16-v32:32-n16:32:64".into(),
+        data_layout: "e-p6:32:32-i64:64-i128:128-v16:16-v32:32-n16:32:64".into(),
         llvm_target: "nvptx64-nvidia-cuda".into(),
         metadata: crate::spec::TargetMetadata {
             description: Some("--emit=asm generates PTX code that runs on NVIDIA GPUs".into()),

--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -187,7 +187,10 @@ fn predicates_reference_self(
 fn bounds_reference_self(tcx: TyCtxt<'_>, trait_def_id: DefId) -> SmallVec<[Span; 1]> {
     tcx.associated_items(trait_def_id)
         .in_definition_order()
+        // We're only looking at associated type bounds
         .filter(|item| item.kind == ty::AssocKind::Type)
+        // Ignore GATs with `Self: Sized`
+        .filter(|item| !tcx.generics_require_sized_self(item.def_id))
         .flat_map(|item| tcx.explicit_item_bounds(item.def_id).iter_identity_copied())
         .filter_map(|(clause, sp)| {
             // Item bounds *can* have self projections, since they never get

--- a/tests/run-make/amdgpu-kd/foo.rs
+++ b/tests/run-make/amdgpu-kd/foo.rs
@@ -1,0 +1,11 @@
+#![allow(internal_features)]
+#![feature(no_core, lang_items, abi_gpu_kernel)]
+#![no_core]
+#![no_std]
+
+// This is needed because of #![no_core]:
+#[lang = "sized"]
+trait Sized {}
+
+#[no_mangle]
+extern "gpu-kernel" fn kernel() {}

--- a/tests/run-make/amdgpu-kd/rmake.rs
+++ b/tests/run-make/amdgpu-kd/rmake.rs
@@ -1,0 +1,20 @@
+// On the amdhsa OS, the host runtime (HIP or HSA) expects a kernel descriptor object for each
+// kernel in the ELF file. The amdgpu LLVM backend generates the object. It is created as a symbol
+// with the name of the kernel plus a .kd suffix.
+// Check that the produced object has the .kd symbol exported.
+
+//@ needs-llvm-components: amdgpu
+//@ needs-rust-lld
+
+use run_make_support::{llvm_readobj, rustc};
+
+fn main() {
+    rustc()
+        .crate_name("foo")
+        .target("amdgcn-amd-amdhsa")
+        .arg("-Ctarget-cpu=gfx900")
+        .crate_type("cdylib")
+        .input("foo.rs")
+        .run();
+    llvm_readobj().input("foo.elf").symbols().run().assert_stdout_contains("kernel.kd");
+}

--- a/tests/ui/dyn-compatibility/associated_type_bound_mentions_self.rs
+++ b/tests/ui/dyn-compatibility/associated_type_bound_mentions_self.rs
@@ -1,0 +1,14 @@
+// Ensure that we properly ignore the `B<Self>` associated type bound on `A::T`
+// since that associated type requires `Self: Sized`.
+
+//@ check-pass
+
+struct X(&'static dyn A);
+
+trait A {
+    type T: B<Self> where Self: Sized;
+}
+
+trait B<T> {}
+
+fn main() {}

--- a/tests/ui/simd-abi-checks-empty-list.rs
+++ b/tests/ui/simd-abi-checks-empty-list.rs
@@ -15,5 +15,5 @@ trait Copy {}
 pub struct SimdVec([i32; 4]);
 
 pub extern "C" fn pass_by_vec(_: SimdVec) {}
-//~^ this function definition uses a SIMD vector type that is not currently supported with the chosen ABI
+//~^ this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
 //~| WARNING this was previously accepted by the compiler

--- a/tests/ui/simd-abi-checks-empty-list.stderr
+++ b/tests/ui/simd-abi-checks-empty-list.stderr
@@ -1,4 +1,4 @@
-warning: this function definition uses a SIMD vector type that is not currently supported with the chosen ABI
+warning: this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
   --> $DIR/simd-abi-checks-empty-list.rs:17:1
    |
 LL | pub extern "C" fn pass_by_vec(_: SimdVec) {}
@@ -11,7 +11,7 @@ LL | pub extern "C" fn pass_by_vec(_: SimdVec) {}
 warning: 1 warning emitted
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function definition uses a SIMD vector type that is not currently supported with the chosen ABI
+warning: this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
   --> $DIR/simd-abi-checks-empty-list.rs:17:1
    |
 LL | pub extern "C" fn pass_by_vec(_: SimdVec) {}

--- a/tests/ui/simd-abi-checks-s390x.rs
+++ b/tests/ui/simd-abi-checks-s390x.rs
@@ -44,13 +44,13 @@ impl<T: Copy> Copy for TransparentWrapper<T> {}
 
 #[no_mangle]
 extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
-    //~^ ERROR this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+    //~^ ERROR requires the `vector` target feature, which is not enabled
     //~^^ WARN this was previously accepted
     *x
 }
 #[no_mangle]
 extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
-    //~^ ERROR this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+    //~^ ERROR requires the `vector` target feature, which is not enabled
     //~^^ WARN this was previously accepted
     *x
 }
@@ -99,7 +99,7 @@ extern "C" fn vector_wrapper_ret_large(x: &Wrapper<i8x32>) -> Wrapper<i8x32> {
 extern "C" fn vector_transparent_wrapper_ret_small(
     x: &TransparentWrapper<i8x8>,
 ) -> TransparentWrapper<i8x8> {
-    //~^^^ ERROR this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+    //~^^^ ERROR requires the `vector` target feature, which is not enabled
     //~^^^^ WARN this was previously accepted
     *x
 }
@@ -107,7 +107,7 @@ extern "C" fn vector_transparent_wrapper_ret_small(
 extern "C" fn vector_transparent_wrapper_ret(
     x: &TransparentWrapper<i8x16>,
 ) -> TransparentWrapper<i8x16> {
-    //~^^^ ERROR this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+    //~^^^ ERROR requires the `vector` target feature, which is not enabled
     //~^^^^ WARN this was previously accepted
     *x
 }
@@ -121,13 +121,13 @@ extern "C" fn vector_transparent_wrapper_ret_large(
 
 #[no_mangle]
 extern "C" fn vector_arg_small(x: i8x8) -> i64 {
-    //~^ ERROR this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+    //~^ ERROR requires the `vector` target feature, which is not enabled
     //~^^ WARN this was previously accepted
     unsafe { *(&x as *const i8x8 as *const i64) }
 }
 #[no_mangle]
 extern "C" fn vector_arg(x: i8x16) -> i64 {
-    //~^ ERROR this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+    //~^ ERROR requires the `vector` target feature, which is not enabled
     //~^^ WARN this was previously accepted
     unsafe { *(&x as *const i8x16 as *const i64) }
 }
@@ -139,13 +139,13 @@ extern "C" fn vector_arg_large(x: i8x32) -> i64 {
 
 #[no_mangle]
 extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
-    //~^ ERROR this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+    //~^ ERROR requires the `vector` target feature, which is not enabled
     //~^^ WARN this was previously accepted
     unsafe { *(&x as *const Wrapper<i8x8> as *const i64) }
 }
 #[no_mangle]
 extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
-    //~^ ERROR this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+    //~^ ERROR requires the `vector` target feature, which is not enabled
     //~^^ WARN this was previously accepted
     unsafe { *(&x as *const Wrapper<i8x16> as *const i64) }
 }
@@ -157,13 +157,13 @@ extern "C" fn vector_wrapper_arg_large(x: Wrapper<i8x32>) -> i64 {
 
 #[no_mangle]
 extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
-    //~^ ERROR this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+    //~^ ERROR requires the `vector` target feature, which is not enabled
     //~^^ WARN this was previously accepted
     unsafe { *(&x as *const TransparentWrapper<i8x8> as *const i64) }
 }
 #[no_mangle]
 extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
-    //~^ ERROR this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+    //~^ ERROR requires the `vector` target feature, which is not enabled
     //~^^ WARN this was previously accepted
     unsafe { *(&x as *const TransparentWrapper<i8x16> as *const i64) }
 }

--- a/tests/ui/simd-abi-checks-s390x.z10.stderr
+++ b/tests/ui/simd-abi-checks-s390x.z10.stderr
@@ -1,4 +1,4 @@
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:46:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
@@ -13,7 +13,7 @@ note: the lint level is defined here
 LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:52:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
@@ -23,7 +23,7 @@ LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:99:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
@@ -35,7 +35,7 @@ LL | | ) -> TransparentWrapper<i8x8> {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:107:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
@@ -47,7 +47,7 @@ LL | | ) -> TransparentWrapper<i8x16> {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:123:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
@@ -57,7 +57,7 @@ LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:129:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
@@ -67,7 +67,7 @@ LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:141:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
@@ -77,7 +77,7 @@ LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:147:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
@@ -87,7 +87,7 @@ LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:159:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
@@ -97,7 +97,7 @@ LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:165:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
@@ -110,7 +110,7 @@ LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) 
 error: aborting due to 10 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:46:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
@@ -126,7 +126,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:52:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
@@ -142,7 +142,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:99:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
@@ -160,7 +160,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:107:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
@@ -178,7 +178,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:123:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
@@ -194,7 +194,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:129:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
@@ -210,7 +210,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:141:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
@@ -226,7 +226,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:147:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
@@ -242,7 +242,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:159:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
@@ -258,7 +258,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:165:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {

--- a/tests/ui/simd-abi-checks-s390x.z13_no_vector.stderr
+++ b/tests/ui/simd-abi-checks-s390x.z13_no_vector.stderr
@@ -1,4 +1,4 @@
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:46:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
@@ -13,7 +13,7 @@ note: the lint level is defined here
 LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:52:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
@@ -23,7 +23,7 @@ LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:99:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
@@ -35,7 +35,7 @@ LL | | ) -> TransparentWrapper<i8x8> {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:107:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
@@ -47,7 +47,7 @@ LL | | ) -> TransparentWrapper<i8x16> {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:123:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
@@ -57,7 +57,7 @@ LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:129:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
@@ -67,7 +67,7 @@ LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:141:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
@@ -77,7 +77,7 @@ LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:147:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
@@ -87,7 +87,7 @@ LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:159:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
@@ -97,7 +97,7 @@ LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:165:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
@@ -110,7 +110,7 @@ LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) 
 error: aborting due to 10 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:46:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
@@ -126,7 +126,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:52:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
@@ -142,7 +142,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:99:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
@@ -160,7 +160,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:107:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
@@ -178,7 +178,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:123:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
@@ -194,7 +194,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:129:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
@@ -210,7 +210,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:141:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
@@ -226,7 +226,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:147:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
@@ -242,7 +242,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:159:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
@@ -258,7 +258,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:165:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {

--- a/tests/ui/simd-abi-checks-s390x.z13_soft_float.stderr
+++ b/tests/ui/simd-abi-checks-s390x.z13_soft_float.stderr
@@ -1,4 +1,4 @@
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:46:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
@@ -13,7 +13,7 @@ note: the lint level is defined here
 LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:52:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
@@ -23,7 +23,7 @@ LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:99:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
@@ -35,7 +35,7 @@ LL | | ) -> TransparentWrapper<i8x8> {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:107:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
@@ -47,7 +47,7 @@ LL | | ) -> TransparentWrapper<i8x16> {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:123:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
@@ -57,7 +57,7 @@ LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:129:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
@@ -67,7 +67,7 @@ LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:141:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
@@ -77,7 +77,7 @@ LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:147:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
@@ -87,7 +87,7 @@ LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:159:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
@@ -97,7 +97,7 @@ LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:165:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
@@ -110,7 +110,7 @@ LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) 
 error: aborting due to 10 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:46:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
@@ -126,7 +126,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:52:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
@@ -142,7 +142,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:99:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
@@ -160,7 +160,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:107:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
@@ -178,7 +178,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:123:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
@@ -194,7 +194,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:129:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
@@ -210,7 +210,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:141:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
@@ -226,7 +226,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:147:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
@@ -242,7 +242,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:159:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
@@ -258,7 +258,7 @@ LL | #![deny(abi_unsupported_vector_types)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-error: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `vector` target feature, which is not enabled
+error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
   --> $DIR/simd-abi-checks-s390x.rs:165:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {

--- a/tests/ui/simd-abi-checks.rs
+++ b/tests/ui/simd-abi-checks.rs
@@ -13,19 +13,19 @@ use std::arch::x86_64::*;
 struct Wrapper(__m256);
 
 unsafe extern "C" fn w(_: Wrapper) {
-    //~^ this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
+    //~^ requires the `avx` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
     todo!()
 }
 
 unsafe extern "C" fn f(_: __m256) {
-    //~^ this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
+    //~^ requires the `avx` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
     todo!()
 }
 
 unsafe extern "C" fn g() -> __m256 {
-    //~^ this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
+    //~^ requires the `avx` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
     todo!()
 }
@@ -55,23 +55,23 @@ unsafe fn test() {
 unsafe fn in_closure() -> impl FnOnce() -> __m256 {
     #[inline(always)] // this disables target-feature inheritance
     || g()
-    //~^ WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+    //~^ WARNING requires the `avx` target feature, which is not enabled in the caller
     //~| WARNING this was previously accepted by the compiler
 }
 
 fn main() {
     unsafe {
         f(g());
-        //~^ WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+        //~^ WARNING requires the `avx` target feature, which is not enabled in the caller
+        //~| WARNING requires the `avx` target feature, which is not enabled in the caller
         //~| WARNING this was previously accepted by the compiler
         //~| WARNING this was previously accepted by the compiler
     }
 
     unsafe {
         gavx(favx());
-        //~^ WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+        //~^ WARNING requires the `avx` target feature, which is not enabled in the caller
+        //~| WARNING requires the `avx` target feature, which is not enabled in the caller
         //~| WARNING this was previously accepted by the compiler
         //~| WARNING this was previously accepted by the compiler
     }
@@ -82,8 +82,8 @@ fn main() {
 
     unsafe {
         w(Wrapper(g()));
-        //~^ WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+        //~^ WARNING requires the `avx` target feature, which is not enabled in the caller
+        //~| WARNING requires the `avx` target feature, which is not enabled in the caller
         //~| WARNING this was previously accepted by the compiler
         //~| WARNING this was previously accepted by the compiler
     }
@@ -98,7 +98,7 @@ fn main() {
             fn some_extern() -> __m256;
         }
         some_extern();
-        //~^ WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+        //~^ WARNING requires the `avx` target feature, which is not enabled in the caller
         //~| WARNING this was previously accepted by the compiler
     }
 }

--- a/tests/ui/simd-abi-checks.stderr
+++ b/tests/ui/simd-abi-checks.stderr
@@ -1,4 +1,4 @@
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:64:11
    |
 LL |         f(g());
@@ -9,7 +9,7 @@ LL |         f(g());
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:64:9
    |
 LL |         f(g());
@@ -19,7 +19,7 @@ LL |         f(g());
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:72:14
    |
 LL |         gavx(favx());
@@ -29,7 +29,7 @@ LL |         gavx(favx());
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:72:9
    |
 LL |         gavx(favx());
@@ -39,7 +39,7 @@ LL |         gavx(favx());
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:84:19
    |
 LL |         w(Wrapper(g()));
@@ -49,7 +49,7 @@ LL |         w(Wrapper(g()));
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:84:9
    |
 LL |         w(Wrapper(g()));
@@ -59,7 +59,7 @@ LL |         w(Wrapper(g()));
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:100:9
    |
 LL |         some_extern();
@@ -69,7 +69,7 @@ LL |         some_extern();
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
+warning: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks.rs:27:1
    |
 LL | unsafe extern "C" fn g() -> __m256 {
@@ -79,7 +79,7 @@ LL | unsafe extern "C" fn g() -> __m256 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
+warning: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks.rs:21:1
    |
 LL | unsafe extern "C" fn f(_: __m256) {
@@ -89,7 +89,7 @@ LL | unsafe extern "C" fn f(_: __m256) {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
+warning: this function definition uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks.rs:15:1
    |
 LL | unsafe extern "C" fn w(_: Wrapper) {
@@ -99,7 +99,7 @@ LL | unsafe extern "C" fn w(_: Wrapper) {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:57:8
    |
 LL |     || g()
@@ -112,7 +112,7 @@ LL |     || g()
 warning: 11 warnings emitted
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:64:11
    |
 LL |         f(g());
@@ -124,7 +124,7 @@ LL |         f(g());
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
 Future breakage diagnostic:
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:64:9
    |
 LL |         f(g());
@@ -136,7 +136,7 @@ LL |         f(g());
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
 Future breakage diagnostic:
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:72:14
    |
 LL |         gavx(favx());
@@ -148,7 +148,7 @@ LL |         gavx(favx());
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
 Future breakage diagnostic:
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:72:9
    |
 LL |         gavx(favx());
@@ -160,7 +160,7 @@ LL |         gavx(favx());
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
 Future breakage diagnostic:
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:84:19
    |
 LL |         w(Wrapper(g()));
@@ -172,7 +172,7 @@ LL |         w(Wrapper(g()));
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
 Future breakage diagnostic:
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:84:9
    |
 LL |         w(Wrapper(g()));
@@ -184,7 +184,7 @@ LL |         w(Wrapper(g()));
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
 Future breakage diagnostic:
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:100:9
    |
 LL |         some_extern();
@@ -196,7 +196,7 @@ LL |         some_extern();
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
 Future breakage diagnostic:
-warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
+warning: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks.rs:27:1
    |
 LL | unsafe extern "C" fn g() -> __m256 {
@@ -208,7 +208,7 @@ LL | unsafe extern "C" fn g() -> __m256 {
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
 Future breakage diagnostic:
-warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
+warning: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks.rs:21:1
    |
 LL | unsafe extern "C" fn f(_: __m256) {
@@ -220,7 +220,7 @@ LL | unsafe extern "C" fn f(_: __m256) {
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
 Future breakage diagnostic:
-warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
+warning: this function definition uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks.rs:15:1
    |
 LL | unsafe extern "C" fn w(_: Wrapper) {
@@ -232,7 +232,7 @@ LL | unsafe extern "C" fn w(_: Wrapper) {
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
 Future breakage diagnostic:
-warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:57:8
    |
 LL |     || g()

--- a/tests/ui/sse-abi-checks.rs
+++ b/tests/ui/sse-abi-checks.rs
@@ -19,6 +19,6 @@ pub struct SseVector([i64; 2]);
 
 #[no_mangle]
 pub unsafe extern "C" fn f(_: SseVector) {
-    //~^ this function definition uses a SIMD vector type that (with the chosen ABI) requires the `sse` target feature, which is not enabled
+    //~^ this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
 }

--- a/tests/ui/sse-abi-checks.stderr
+++ b/tests/ui/sse-abi-checks.stderr
@@ -1,4 +1,4 @@
-warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `sse` target feature, which is not enabled
+warning: this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
   --> $DIR/sse-abi-checks.rs:21:1
    |
 LL | pub unsafe extern "C" fn f(_: SseVector) {
@@ -12,7 +12,7 @@ LL | pub unsafe extern "C" fn f(_: SseVector) {
 warning: 1 warning emitted
 
 Future incompatibility report: Future breakage diagnostic:
-warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `sse` target feature, which is not enabled
+warning: this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
   --> $DIR/sse-abi-checks.rs:21:1
    |
 LL | pub unsafe extern "C" fn f(_: SseVector) {


### PR DESCRIPTION
Successful merges:

 - #135797 (Import initial generated 1.85 relnotes)
 - #135909 (Export kernel descriptor for amdgpu kernels)
 - #136545 (nvptx64: update default alignment to match LLVM 21)
 - #137092 (abi_unsupported_vector_types: say which type is the problem)
 - #137097 (Ignore Self in bounds check for associated types with Self:Sized)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135797,135909,136545,137092,137097)
<!-- homu-ignore:end -->