### PR TITLE
Fix test that relies on error language

### DIFF
--- a/tests/ui/unpretty/staged-api-invalid-path-108697.rs
+++ b/tests/ui/unpretty/staged-api-invalid-path-108697.rs
@@ -2,8 +2,8 @@
 // ICE: tcx.resolutions(()) is not supported for local crate -Zunpretty=mir
 // on invalid module path with staged_api
 //@ compile-flags: -Zunpretty=mir
-//@ normalize-stderr: "The system cannot find the file specified." -> "No such file or directory"
+//@ normalize-stderr: "lol`: .*\(" -> "lol`: $$FILE_NOT_FOUND_MSG ("
 #![feature(staged_api)]
 #[path = "lol"]
 mod foo;
-//~^ ERROR couldn't read
+//~^ ERROR couldn't read `$DIR/lol`

--- a/tests/ui/unpretty/staged-api-invalid-path-108697.stderr
+++ b/tests/ui/unpretty/staged-api-invalid-path-108697.stderr
@@ -1,4 +1,4 @@
-error: couldn't read `$DIR/lol`: No such file or directory (os error 2)
+error: couldn't read `$DIR/lol`: $FILE_NOT_FOUND_MSG (os error 2)
   --> $DIR/staged-api-invalid-path-108697.rs:8:1
    |
 LL | mod foo;


### PR DESCRIPTION
We shouldn't care about the OS error message text in this test.
