### PR TITLE
Enable `relative-path-include-bytes-132203` rustdoc-ui test on Windows

### DIFF
--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
@@ -5,7 +5,7 @@ test $DIR/relative-path-include-bytes-132203.rs - (line 18) ... FAILED
 failures:
 
 ---- $DIR/relative-path-include-bytes-132203.rs - (line 18) stdout ----
-error: couldn't read `$DIR/relative-dir-empty-file`: No such file or directory (os error 2)
+error: couldn't read `$DIR/relative-dir-empty-file`: $FILE_NOT_FOUND_MSG (os error 2)
   --> $DIR/relative-path-include-bytes-132203.rs:19:9
    |
 LL | let x = include_bytes!("relative-dir-empty-file");

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows different error message
 //@ revisions: edition2015 edition2024
 //@[edition2015]edition:2015
 //@[edition2015]check-fail
@@ -7,8 +6,9 @@
 //@[edition2024]edition:2024
 //@[edition2024]check-pass
 //@[edition2024]compile-flags:--test --test-args=--test-threads=1
-//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "tests.rustdoc-ui.doctest." -> "$$DIR/"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "`: .* \(os error 2\)" -> "`: $$FILE_NOT_FOUND_MSG (os error 2)"
 
 // https://github.com/rust-lang/rust/issues/132203
 // This version, because it's edition2024, passes thanks to the new


### PR DESCRIPTION
The problem with the error message on Windows is:

- The path separators are different
- The OS error message string is different

Normalizing those two things makes the test pass on Windows.