### PR TITLE
Fix musl's CVE-2025-26519

### DIFF
--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -30,6 +30,47 @@ MUSL=musl-1.2.3
 # may have been downloaded in a previous run
 if [ ! -d $MUSL ]; then
   curl https://www.musl-libc.org/releases/$MUSL.tar.gz | tar xzf -
+
+  # Apply patches for CVE-2025-26519. At the time of adding these patches no release containing them
+  # has been published by the musl project, so we just apply them directly on top of the version we
+  # were distributing already. The patches should be removed once we upgrade to musl >= 1.2.6.
+  #
+  # Advisory: https://www.openwall.com/lists/musl/2025/02/13/1
+  #
+  # Patches applied:
+  # - https://www.openwall.com/lists/musl/2025/02/13/1/1
+  # - https://www.openwall.com/lists/musl/2025/02/13/1/2
+  #
+  # ignore-tidy-tab
+  # ignore-tidy-linelength
+  patch -p1 -d $MUSL <<EOF
+--- a/src/locale/iconv.c
++++ b/src/locale/iconv.c
+@@ -502,7 +502,7 @@ size_t iconv(iconv_t cd, char **restrict in, size_t *restrict inb, char **restri
+ 			if (c >= 93 || d >= 94) {
+ 				c += (0xa1-0x81);
+ 				d += 0xa1;
+-				if (c >= 93 || c>=0xc6-0x81 && d>0x52)
++				if (c > 0xc6-0x81 || c==0xc6-0x81 && d>0x52)
+ 					goto ilseq;
+ 				if (d-'A'<26) d = d-'A';
+ 				else if (d-'a'<26) d = d-'a'+26;
+EOF
+  patch -p1 -d $MUSL <<EOF
+--- a/src/locale/iconv.c
++++ b/src/locale/iconv.c
+@@ -545,6 +545,10 @@ size_t iconv(iconv_t cd, char **restrict in, size_t *restrict inb, char **restri
+ 				if (*outb < k) goto toobig;
+ 				memcpy(*out, tmp, k);
+ 			} else k = wctomb_utf8(*out, c);
++			/* This failure condition should be unreachable, but
++			 * is included to prevent decoder bugs from translating
++			 * into advancement outside the output buffer range. */
++			if (k>4) goto ilseq;
+ 			*out += k;
+ 			*outb -= k;
+ 			break;
+EOF
 fi
 
 cd $MUSL


### PR DESCRIPTION
The musl project [announced CVE-2025-26519](https://www.openwall.com/lists/musl/2025/02/13/1), which could result in out-of-bounds writes when calling the `iconv` function. There is no musl release available with the fixes at this point in time (and we're using an older version of musl anyway), so this PR applies the provided patches on top of the musl source tarball we download.