### PR TITLE
[DO NOT MERGE] what if we don't allow unused filecheck prefixes?

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1970,11 +1970,6 @@ impl<'test> TestCx<'test> {
             filecheck.arg("--check-prefix").arg(rev);
         }
 
-        // HACK: the filecheck tool normally fails if a prefix is defined but not used. However,
-        // sometimes revisions are used to specify *compiletest* directives which are not FileCheck
-        // concerns.
-        filecheck.arg("--allow-unused-prefixes");
-
         // Provide more context on failures.
         filecheck.args(&["--dump-input-context", "100"]);
 


### PR DESCRIPTION
I'm fairly sure this is load-bearing, checking to identify examples where this is necessary.

r? @ghost

try-job: aarch64-gnu
try-job: aarch64-apple
try-job: test-various
try-job: armhf-gnu
try-job: i686-mingw-1
try-job: i686-msvc-1