### PR TITLE
Add UTF-8 validation fast paths in `Wtf8Buf`

### DIFF
--- a/library/std/src/sys/os_str/wtf8.rs
+++ b/library/std/src/sys/os_str/wtf8.rs
@@ -41,13 +41,13 @@ impl AsInner<Wtf8> for Buf {
 
 impl fmt::Debug for Buf {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self.as_slice(), f)
+        fmt::Debug::fmt(&self.inner, f)
     }
 }
 
 impl fmt::Display for Buf {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self.as_slice(), f)
+        fmt::Display::fmt(&self.inner, f)
     }
 }
 

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -388,7 +388,7 @@ impl Wtf8Buf {
             _ => {
                 // If we'll be pushing a string containing a surrogate, we may
                 // no longer have UTF-8.
-                if other.next_surrogate(0).is_some() {
+                if self.is_known_utf8 && other.next_surrogate(0).is_some() {
                     self.is_known_utf8 = false;
                 }
 


### PR DESCRIPTION
This adds two more fast paths for UTF-8 validation in `Wtf8Buf`, making use of the `is_known_utf8` flag added in https://github.com/rust-lang/rust/pull/96869 (Optimize `Wtf8Buf::into_string` for the case where it contains UTF-8).

r? @ChrisDenton