### PR TITLE
Use `tell` for `<File as Seek>::stream_position`

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1229,6 +1229,9 @@ impl Seek for &File {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         self.inner.seek(pos)
     }
+    fn stream_position(&mut self) -> io::Result<u64> {
+        self.inner.tell()
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1274,6 +1277,9 @@ impl Write for File {
 impl Seek for File {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         (&*self).seek(pos)
+    }
+    fn stream_position(&mut self) -> io::Result<u64> {
+        (&*self).stream_position()
     }
 }
 

--- a/library/std/src/sys/pal/hermit/fs.rs
+++ b/library/std/src/sys/pal/hermit/fs.rs
@@ -425,6 +425,10 @@ impl File {
         Err(Error::from_raw_os_error(22))
     }
 
+    pub fn tell(&self) -> io::Result<u64> {
+        self.seek(SeekFrom::Current(0))
+    }
+
     pub fn duplicate(&self) -> io::Result<File> {
         Err(Error::from_raw_os_error(22))
     }

--- a/library/std/src/sys/pal/solid/fs.rs
+++ b/library/std/src/sys/pal/solid/fs.rs
@@ -452,8 +452,11 @@ impl File {
             abi::SOLID_FS_Lseek(self.fd.raw(), pos, whence)
         })
         .map_err(|e| e.as_io_error())?;
-
         // Get the new offset
+        self.tell()
+    }
+
+    pub fn tell(&self) -> io::Result<u64> {
         unsafe {
             let mut out_offset = MaybeUninit::uninit();
             error::SolidError::err_if_negative(abi::SOLID_FS_Ftell(

--- a/library/std/src/sys/pal/uefi/fs.rs
+++ b/library/std/src/sys/pal/uefi/fs.rs
@@ -258,6 +258,10 @@ impl File {
         self.0
     }
 
+    pub fn tell(&self) -> io::Result<u64> {
+        self.0
+    }
+
     pub fn duplicate(&self) -> io::Result<File> {
         self.0
     }

--- a/library/std/src/sys/pal/unix/fs.rs
+++ b/library/std/src/sys/pal/unix/fs.rs
@@ -1438,6 +1438,10 @@ impl File {
         Ok(n as u64)
     }
 
+    pub fn tell(&self) -> io::Result<u64> {
+        self.seek(SeekFrom::Current(0))
+    }
+
     pub fn duplicate(&self) -> io::Result<File> {
         self.0.duplicate().map(File)
     }

--- a/library/std/src/sys/pal/unsupported/fs.rs
+++ b/library/std/src/sys/pal/unsupported/fs.rs
@@ -258,6 +258,10 @@ impl File {
         self.0
     }
 
+    pub fn tell(&self) -> io::Result<u64> {
+        self.0
+    }
+
     pub fn duplicate(&self) -> io::Result<File> {
         self.0
     }

--- a/library/std/src/sys/pal/wasi/fs.rs
+++ b/library/std/src/sys/pal/wasi/fs.rs
@@ -517,6 +517,10 @@ impl File {
         self.fd.seek(pos)
     }
 
+    pub fn tell(&self) -> io::Result<u64> {
+        self.fd.tell()
+    }
+
     pub fn duplicate(&self) -> io::Result<File> {
         // https://github.com/CraneStation/wasmtime/blob/master/docs/WASI-rationale.md#why-no-dup
         unsupported()

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -631,6 +631,10 @@ impl File {
         Ok(newpos as u64)
     }
 
+    pub fn tell(&self) -> io::Result<u64> {
+        self.seek(SeekFrom::Current(0))
+    }
+
     pub fn duplicate(&self) -> io::Result<File> {
         Ok(Self { handle: self.handle.try_clone()? })
     }


### PR DESCRIPTION
Some platforms have a more efficient way to get the current offset of the file than by seeking. For example, Wasi has `fd_tell` and SOLID has `SOLID_FS_Ftell`. Implement `<File as Seek>::stream_position()` in terms of those.

I do not use any APIs that were not already used in `std`. Although, the `libc` crate has [`ftell`](https://docs.rs/libc/latest/libc/fn.ftell.html), [`ftello`](https://docs.rs/libc/latest/libc/fn.ftello.html), and [`ftello64`](https://docs.rs/libc/latest/libc/fn.ftello64.html), I do not know platform coverage. It appears that Windows has no `tell`-like API.

I have checked that it builds on each relevant platform.