### PR TITLE
tests: Also gate `f16::erfc()` doctest with `reliable_f16_math` cfg

### DIFF
--- a/library/std/src/f16.rs
+++ b/library/std/src/f16.rs
@@ -1321,12 +1321,14 @@ impl f16 {
     /// ```
     /// #![feature(f16)]
     /// #![feature(float_erf)]
+    /// # #[cfg(reliable_f16_math)] {
     /// let x: f16 = 0.123;
     ///
     /// let one = x.erf() + x.erfc();
     /// let abs_difference = (one - 1.0).abs();
     ///
     /// assert!(abs_difference <= f16::EPSILON);
+    /// # }
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]


### PR DESCRIPTION
In #136324 the doctest for `f16::erf()` was gated with `reliable_f16_math`. Add the same gate on `f16::erfc()` to avoid:

    rust_out.71e2e529d20ea47d-cgu.0:\
    (.text._ZN8rust_out4main43_doctest_main_library_std_src_f16_rs_1321_017h485f3ffe6bf2a981E+0x38): \
    undefined reference to `__gnu_h2f_ieee'

on MIPS (and maybe other architectures).

r? tgross35
