### PR TITLE
[beta] Prepare Rust 1.86.0

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -387,7 +387,7 @@ declare_features! (
     /// Allows `#[target_feature(...)]`.
     (accepted, target_feature, "1.27.0", None),
     /// Allows the use of `#[target_feature]` on safe functions.
-    (accepted, target_feature_11, "CURRENT_RUSTC_VERSION", Some(69098)),
+    (accepted, target_feature_11, "1.86.0", Some(69098)),
     /// Allows `fn main()` with return types which implements `Termination` (RFC 1937).
     (accepted, termination_trait, "1.26.0", Some(43301)),
     /// Allows `#[test]` functions where the return type implements `Termination` (RFC 1937).
@@ -401,7 +401,7 @@ declare_features! (
     (accepted, track_caller, "1.46.0", Some(47809)),
     /// Allows dyn upcasting trait objects via supertraits.
     /// Dyn upcasting is casting, e.g., `dyn Foo -> dyn Bar` where `Foo: Bar`.
-    (accepted, trait_upcasting, "CURRENT_RUSTC_VERSION", Some(65991)),
+    (accepted, trait_upcasting, "1.86.0", Some(65991)),
     /// Allows #[repr(transparent)] on univariant enums (RFC 2645).
     (accepted, transparent_enums, "1.42.0", Some(60405)),
     /// Allows indexing tuples.

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -203,7 +203,7 @@ declare_features! (
     /// Allows using anonymous lifetimes in argument-position impl-trait.
     (unstable, anonymous_lifetime_in_impl_trait, "1.63.0", None),
     /// Allows access to the emscripten_wasm_eh config, used by panic_unwind and unwind
-    (internal, cfg_emscripten_wasm_eh, "CURRENT_RUSTC_VERSION", None),
+    (internal, cfg_emscripten_wasm_eh, "1.86.0", None),
     /// Allows identifying the `compiler_builtins` crate.
     (internal, compiler_builtins, "1.13.0", None),
     /// Allows writing custom MIR
@@ -360,7 +360,7 @@ declare_features! (
     /// Allows `extern "C-cmse-nonsecure-call" fn()`.
     (unstable, abi_c_cmse_nonsecure_call, "1.51.0", Some(81391)),
     /// Allows `extern "gpu-kernel" fn()`.
-    (unstable, abi_gpu_kernel, "CURRENT_RUSTC_VERSION", Some(135467)),
+    (unstable, abi_gpu_kernel, "1.86.0", Some(135467)),
     /// Allows `extern "msp430-interrupt" fn()`.
     (unstable, abi_msp430_interrupt, "1.16.0", Some(38487)),
     /// Allows `extern "ptx-*" fn()`.
@@ -404,7 +404,7 @@ declare_features! (
     /// Allows the use of `#[cfg(<true/false>)]`.
     (unstable, cfg_boolean_literals, "1.83.0", Some(131204)),
     /// Allows the use of `#[cfg(contract_checks)` to check if contract checks are enabled.
-    (unstable, cfg_contract_checks, "CURRENT_RUSTC_VERSION", Some(128044)),
+    (unstable, cfg_contract_checks, "1.86.0", Some(128044)),
     /// Allows the use of `#[cfg(overflow_checks)` to check if integer overflow behaviour.
     (unstable, cfg_overflow_checks, "1.71.0", Some(111466)),
     /// Provides the relocation model information as cfg entry
@@ -448,9 +448,9 @@ declare_features! (
     /// Allows the `?` operator in const contexts.
     (unstable, const_try, "1.56.0", Some(74935)),
     /// Allows use of contracts attributes.
-    (incomplete, contracts, "CURRENT_RUSTC_VERSION", Some(128044)),
+    (incomplete, contracts, "1.86.0", Some(128044)),
     /// Allows access to internal machinery used to implement contracts.
-    (internal, contracts_internals, "CURRENT_RUSTC_VERSION", Some(128044)),
+    (internal, contracts_internals, "1.86.0", Some(128044)),
     /// Allows coroutines to be cloned.
     (unstable, coroutine_clone, "1.65.0", Some(95360)),
     /// Allows defining coroutines.
@@ -491,7 +491,7 @@ declare_features! (
     /// for functions with varargs.
     (unstable, extended_varargs_abi_support, "1.65.0", Some(100189)),
     /// Allows using `system` as a calling convention with varargs.
-    (unstable, extern_system_varargs, "CURRENT_RUSTC_VERSION", Some(136946)),
+    (unstable, extern_system_varargs, "1.86.0", Some(136946)),
     /// Allows defining `extern type`s.
     (unstable, extern_types, "1.23.0", Some(43467)),
     /// Allow using 128-bit (quad precision) floating point numbers.
@@ -519,7 +519,7 @@ declare_features! (
     /// Allows generic parameters and where-clauses on free & associated const items.
     (incomplete, generic_const_items, "1.73.0", Some(113521)),
     /// Allows any generic constants being used as pattern type range ends
-    (incomplete, generic_pattern_types, "CURRENT_RUSTC_VERSION", Some(136574)),
+    (incomplete, generic_pattern_types, "1.86.0", Some(136574)),
     /// Allows registering static items globally, possibly across crates, to iterate over at runtime.
     (unstable, global_registration, "1.80.0", Some(125119)),
     /// Allows using guards in patterns.
@@ -535,7 +535,7 @@ declare_features! (
     /// Allows `impl Trait` as output type in `Fn` traits in return position of functions.
     (unstable, impl_trait_in_fn_trait_return, "1.64.0", Some(99697)),
     /// Allows `use` associated functions from traits.
-    (unstable, import_trait_associated_functions, "CURRENT_RUSTC_VERSION", Some(134691)),
+    (unstable, import_trait_associated_functions, "1.86.0", Some(134691)),
     /// Allows associated types in inherent impls.
     (incomplete, inherent_associated_types, "1.52.0", Some(8995)),
     /// Allow anonymous constants from an inline `const` block in pattern position
@@ -543,7 +543,7 @@ declare_features! (
     /// Allows using `pointer` and `reference` in intra-doc links
     (unstable, intra_doc_pointers, "1.51.0", Some(80896)),
     // Allows using the `kl` and `widekl` target features and the associated intrinsics
-    (unstable, keylocker_x86, "CURRENT_RUSTC_VERSION", Some(134813)),
+    (unstable, keylocker_x86, "1.86.0", Some(134813)),
     // Allows setting the threshold for the `large_assignments` lint.
     (unstable, large_assignments, "1.52.0", Some(83518)),
     /// Allow to have type alias types for inter-crate use.
@@ -584,7 +584,7 @@ declare_features! (
     /// Allows diverging expressions to fall back to `!` rather than `()`.
     (unstable, never_type_fallback, "1.41.0", Some(65992)),
     /// Switch `..` syntax to use the new (`Copy + IntoIterator`) range types.
-    (unstable, new_range, "CURRENT_RUSTC_VERSION", Some(123741)),
+    (unstable, new_range, "1.86.0", Some(123741)),
     /// Allows `#![no_core]`.
     (unstable, no_core, "1.3.0", Some(29639)),
     /// Allows the use of `no_sanitize` attribute.
@@ -636,7 +636,7 @@ declare_features! (
     /// Allows string patterns to dereference values to match them.
     (unstable, string_deref_patterns, "1.67.0", Some(87121)),
     /// Allows subtrait items to shadow supertrait items.
-    (unstable, supertrait_item_shadowing, "CURRENT_RUSTC_VERSION", Some(89151)),
+    (unstable, supertrait_item_shadowing, "1.86.0", Some(89151)),
     /// Allows using `#[thread_local]` on `static` items.
     (unstable, thread_local, "1.0.0", Some(29594)),
     /// Allows defining `trait X = A + B;` alias items.

--- a/compiler/rustc_lint/src/deref_into_dyn_supertrait.rs
+++ b/compiler/rustc_lint/src/deref_into_dyn_supertrait.rs
@@ -12,7 +12,7 @@ declare_lint! {
     /// for `dyn SubTrait` with a `dyn SuperTrait` type as the `Output` type.
     ///
     /// These implementations are "shadowed" by trait upcasting (stabilized since
-    /// CURRENT_RUSTC_VERSION). The `deref` functions is no longer called implicitly, which might
+    /// 1.86.0). The `deref` functions is no longer called implicitly, which might
     /// change behavior compared to previous rustc versions.
     ///
     /// ### Example

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -27,7 +27,7 @@ pub use core::slice::ArrayChunksMut;
 pub use core::slice::ArrayWindows;
 #[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
 pub use core::slice::EscapeAscii;
-#[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "get_many_mut", since = "1.86.0")]
 pub use core::slice::GetDisjointMutError;
 #[stable(feature = "slice_get_slice", since = "1.28.0")]
 pub use core::slice::SliceIndex;

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2526,7 +2526,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(vec, [1, 2, 3]);
     /// assert_eq!(vec.pop_if(pred), None);
     /// ```
-    #[stable(feature = "vec_pop_if", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "vec_pop_if", since = "1.86.0")]
     pub fn pop_if(&mut self, predicate: impl FnOnce(&mut T) -> bool) -> Option<T> {
         let last = self.last_mut()?;
         if predicate(last) { self.pop() } else { None }

--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -1075,5 +1075,5 @@ impl Error for crate::time::TryFromFloatSecsError {}
 #[stable(feature = "cstr_from_bytes_until_nul", since = "1.69.0")]
 impl Error for crate::ffi::FromBytesUntilNulError {}
 
-#[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "get_many_mut", since = "1.86.0")]
 impl Error for crate::slice::GetDisjointMutError {}

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -472,7 +472,7 @@ pub fn spin_loop() {
 /// During constant evaluation, `black_box` is treated as a no-op.
 #[inline]
 #[stable(feature = "bench_black_box", since = "1.66.0")]
-#[rustc_const_stable(feature = "const_black_box", since = "CURRENT_RUSTC_VERSION")]
+#[rustc_const_stable(feature = "const_black_box", since = "1.86.0")]
 pub const fn black_box<T>(dummy: T) -> T {
     crate::intrinsics::black_box(dummy)
 }

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -741,8 +741,8 @@ impl f32 {
     /// [`MAX`]: Self::MAX
     #[inline]
     #[doc(alias = "nextUp")]
-    #[stable(feature = "float_next_up_down", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "float_next_up_down", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "float_next_up_down", since = "1.86.0")]
+    #[rustc_const_stable(feature = "float_next_up_down", since = "1.86.0")]
     pub const fn next_up(self) -> Self {
         // Some targets violate Rust's assumption of IEEE semantics, e.g. by flushing
         // denormals to zero. This is in general unsound and unsupported, but here
@@ -792,8 +792,8 @@ impl f32 {
     /// [`MAX`]: Self::MAX
     #[inline]
     #[doc(alias = "nextDown")]
-    #[stable(feature = "float_next_up_down", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "float_next_up_down", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "float_next_up_down", since = "1.86.0")]
+    #[rustc_const_stable(feature = "float_next_up_down", since = "1.86.0")]
     pub const fn next_down(self) -> Self {
         // Some targets violate Rust's assumption of IEEE semantics, e.g. by flushing
         // denormals to zero. This is in general unsound and unsupported, but here

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -758,8 +758,8 @@ impl f64 {
     /// [`MAX`]: Self::MAX
     #[inline]
     #[doc(alias = "nextUp")]
-    #[stable(feature = "float_next_up_down", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "float_next_up_down", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "float_next_up_down", since = "1.86.0")]
+    #[rustc_const_stable(feature = "float_next_up_down", since = "1.86.0")]
     pub const fn next_up(self) -> Self {
         // Some targets violate Rust's assumption of IEEE semantics, e.g. by flushing
         // denormals to zero. This is in general unsound and unsupported, but here
@@ -809,8 +809,8 @@ impl f64 {
     /// [`MAX`]: Self::MAX
     #[inline]
     #[doc(alias = "nextDown")]
-    #[stable(feature = "float_next_up_down", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "float_next_up_down", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "float_next_up_down", since = "1.86.0")]
+    #[rustc_const_stable(feature = "float_next_up_down", since = "1.86.0")]
     pub const fn next_down(self) -> Self {
         // Some targets violate Rust's assumption of IEEE semantics, e.g. by flushing
         // denormals to zero. This is in general unsound and unsupported, but here

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -625,8 +625,8 @@ macro_rules! nonzero_integer {
             /// # }
             /// ```
             ///
-            #[stable(feature = "non_zero_count_ones", since = "CURRENT_RUSTC_VERSION")]
-            #[rustc_const_stable(feature = "non_zero_count_ones", since = "CURRENT_RUSTC_VERSION")]
+            #[stable(feature = "non_zero_count_ones", since = "1.86.0")]
+            #[rustc_const_stable(feature = "non_zero_count_ones", since = "1.86.0")]
             #[doc(alias = "popcount")]
             #[doc(alias = "popcnt")]
             #[must_use = "this returns the result of the operation, \

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -4569,7 +4569,7 @@ impl<T> [T] {
     ///
     /// [`get_disjoint_mut`]: slice::get_disjoint_mut
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    #[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "get_many_mut", since = "1.86.0")]
     #[inline]
     pub unsafe fn get_disjoint_unchecked_mut<I, const N: usize>(
         &mut self,
@@ -4636,7 +4636,7 @@ impl<T> [T] {
     /// }
     /// assert_eq!(v, &[1, 11, 111]);
     /// ```
-    #[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "get_many_mut", since = "1.86.0")]
     #[inline]
     pub fn get_disjoint_mut<I, const N: usize>(
         &mut self,
@@ -5025,7 +5025,7 @@ fn get_disjoint_check_valid<I: GetDisjointMutIndex, const N: usize>(
 /// assert_eq!(v.get_disjoint_mut([0, 999]), Err(GetDisjointMutError::IndexOutOfBounds));
 /// assert_eq!(v.get_disjoint_mut([1, 1]), Err(GetDisjointMutError::OverlappingIndices));
 /// ```
-#[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "get_many_mut", since = "1.86.0")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GetDisjointMutError {
     /// An index provided was out-of-bounds for the slice.
@@ -5034,7 +5034,7 @@ pub enum GetDisjointMutError {
     OverlappingIndices,
 }
 
-#[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
+#[stable(feature = "get_many_mut", since = "1.86.0")]
 impl fmt::Display for GetDisjointMutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match self {

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -361,7 +361,7 @@ impl str {
     /// ```
     #[must_use]
     #[stable(feature = "is_char_boundary", since = "1.9.0")]
-    #[rustc_const_stable(feature = "const_is_char_boundary", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "const_is_char_boundary", since = "1.86.0")]
     #[inline]
     pub const fn is_char_boundary(&self, index: usize) -> bool {
         // 0 is always ok.
@@ -818,7 +818,7 @@ impl str {
     #[inline]
     #[must_use]
     #[stable(feature = "str_split_at", since = "1.4.0")]
-    #[rustc_const_stable(feature = "const_str_split_at", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "const_str_split_at", since = "1.86.0")]
     pub const fn split_at(&self, mid: usize) -> (&str, &str) {
         match self.split_at_checked(mid) {
             None => slice_error_fail(self, 0, mid),
@@ -859,7 +859,7 @@ impl str {
     #[inline]
     #[must_use]
     #[stable(feature = "str_split_at", since = "1.4.0")]
-    #[rustc_const_stable(feature = "const_str_split_at", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "const_str_split_at", since = "1.86.0")]
     pub const fn split_at_mut(&mut self, mid: usize) -> (&mut str, &mut str) {
         // is_char_boundary checks that the index is in [0, .len()]
         if self.is_char_boundary(mid) {
@@ -899,7 +899,7 @@ impl str {
     #[inline]
     #[must_use]
     #[stable(feature = "split_at_checked", since = "1.80.0")]
-    #[rustc_const_stable(feature = "const_str_split_at", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "const_str_split_at", since = "1.86.0")]
     pub const fn split_at_checked(&self, mid: usize) -> Option<(&str, &str)> {
         // is_char_boundary checks that the index is in [0, .len()]
         if self.is_char_boundary(mid) {
@@ -940,7 +940,7 @@ impl str {
     #[inline]
     #[must_use]
     #[stable(feature = "split_at_checked", since = "1.80.0")]
-    #[rustc_const_stable(feature = "const_str_split_at", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "const_str_split_at", since = "1.86.0")]
     pub const fn split_at_mut_checked(&mut self, mid: usize) -> Option<(&mut str, &mut str)> {
         // is_char_boundary checks that the index is in [0, .len()]
         if self.is_char_boundary(mid) {

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -1024,7 +1024,7 @@ where
     /// ```
     #[inline]
     #[doc(alias = "get_many_mut")]
-    #[stable(feature = "map_many_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "map_many_mut", since = "1.86.0")]
     pub fn get_disjoint_mut<Q: ?Sized, const N: usize>(
         &mut self,
         ks: [&Q; N],
@@ -1091,7 +1091,7 @@ where
     /// ```
     #[inline]
     #[doc(alias = "get_many_unchecked_mut")]
-    #[stable(feature = "map_many_mut", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "map_many_mut", since = "1.86.0")]
     pub unsafe fn get_disjoint_unchecked_mut<Q: ?Sized, const N: usize>(
         &mut self,
         ks: [&Q; N],

--- a/library/std/src/io/cursor.rs
+++ b/library/std/src/io/cursor.rs
@@ -153,7 +153,7 @@ impl<T> Cursor<T> {
     /// let reference = buff.get_mut();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_mut_cursor", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "const_mut_cursor", since = "1.86.0")]
     pub const fn get_mut(&mut self) -> &mut T {
         &mut self.inner
     }
@@ -201,7 +201,7 @@ impl<T> Cursor<T> {
     /// assert_eq!(buff.position(), 4);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_mut_cursor", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "const_mut_cursor", since = "1.86.0")]
     pub const fn set_position(&mut self, pos: u64) {
         self.pos = pos;
     }

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -191,7 +191,7 @@ impl<T> OnceLock<T> {
     /// })
     /// ```
     #[inline]
-    #[stable(feature = "once_wait", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_wait", since = "1.86.0")]
     pub fn wait(&self) -> &T {
         self.once.wait_force();
 

--- a/library/std/src/sync/poison/once.rs
+++ b/library/std/src/sync/poison/once.rs
@@ -284,7 +284,7 @@ impl Once {
     /// If this [`Once`] has been poisoned because an initialization closure has
     /// panicked, this method will also panic. Use [`wait_force`](Self::wait_force)
     /// if this behavior is not desired.
-    #[stable(feature = "once_wait", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_wait", since = "1.86.0")]
     pub fn wait(&self) {
         if !self.inner.is_completed() {
             self.inner.wait(false);
@@ -293,7 +293,7 @@ impl Once {
 
     /// Blocks the current thread until initialization has completed, ignoring
     /// poisoning.
-    #[stable(feature = "once_wait", since = "CURRENT_RUSTC_VERSION")]
+    #[stable(feature = "once_wait", since = "1.86.0")]
     pub fn wait_force(&self) {
         if !self.inner.is_completed() {
             self.inner.wait(true);

--- a/src/ci/channel
+++ b/src/ci/channel
@@ -1,1 +1,1 @@
-nightly
+beta

--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -30,6 +30,47 @@ MUSL=musl-1.2.3
 # may have been downloaded in a previous run
 if [ ! -d $MUSL ]; then
   curl https://www.musl-libc.org/releases/$MUSL.tar.gz | tar xzf -
+
+  # Apply patches for CVE-2025-26519. At the time of adding these patches no release containing them
+  # has been published by the musl project, so we just apply them directly on top of the version we
+  # were distributing already. The patches should be removed once we upgrade to musl >= 1.2.6.
+  #
+  # Advisory: https://www.openwall.com/lists/musl/2025/02/13/1
+  #
+  # Patches applied:
+  # - https://www.openwall.com/lists/musl/2025/02/13/1/1
+  # - https://www.openwall.com/lists/musl/2025/02/13/1/2
+  #
+  # ignore-tidy-tab
+  # ignore-tidy-linelength
+  patch -p1 -d $MUSL <<EOF
+--- a/src/locale/iconv.c
++++ b/src/locale/iconv.c
+@@ -502,7 +502,7 @@ size_t iconv(iconv_t cd, char **restrict in, size_t *restrict inb, char **restri
+ 			if (c >= 93 || d >= 94) {
+ 				c += (0xa1-0x81);
+ 				d += 0xa1;
+-				if (c >= 93 || c>=0xc6-0x81 && d>0x52)
++				if (c > 0xc6-0x81 || c==0xc6-0x81 && d>0x52)
+ 					goto ilseq;
+ 				if (d-'A'<26) d = d-'A';
+ 				else if (d-'a'<26) d = d-'a'+26;
+EOF
+  patch -p1 -d $MUSL <<EOF
+--- a/src/locale/iconv.c
++++ b/src/locale/iconv.c
+@@ -545,6 +545,10 @@ size_t iconv(iconv_t cd, char **restrict in, size_t *restrict inb, char **restri
+ 				if (*outb < k) goto toobig;
+ 				memcpy(*out, tmp, k);
+ 			} else k = wctomb_utf8(*out, c);
++			/* This failure condition should be unreachable, but
++			 * is included to prevent decoder bugs from translating
++			 * into advancement outside the output buffer range. */
++			if (k>4) goto ilseq;
+ 			*out += k;
+ 			*outb -= k;
+ 			break;
+EOF
 fi
 
 cd $MUSL


### PR DESCRIPTION
This includes one backport:

- fix musl's CVE-2025-26519 #137127

r? cuviper
