### PR TITLE
Stabilize query cache size by fixing encoding order of some query results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4435,6 +4435,7 @@ dependencies = [
 name = "rustc_query_system"
 version = "0.0.0"
 dependencies = [
+ "indexmap",
  "parking_lot",
  "rustc-rayon-core",
  "rustc_abi",

--- a/compiler/rustc_middle/src/query/keys.rs
+++ b/compiler/rustc_middle/src/query/keys.rs
@@ -3,7 +3,7 @@
 use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE, LocalDefId, LocalModDefId, ModDefId};
 use rustc_hir::hir_id::{HirId, OwnerId};
 use rustc_query_system::dep_graph::DepNodeIndex;
-use rustc_query_system::query::{DefIdCache, DefaultCache, SingleCache, VecCache};
+use rustc_query_system::query::{DefIdCache, DefaultCache, IndexCache, SingleCache, VecCache};
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol};
 
 use crate::infer::canonical::CanonicalQueryInput;
@@ -471,7 +471,7 @@ impl<'tcx> Key for ty::ParamEnv<'tcx> {
 }
 
 impl<'tcx, T: Key> Key for ty::PseudoCanonicalInput<'tcx, T> {
-    type Cache<V> = DefaultCache<Self, V>;
+    type Cache<V> = IndexCache<Self, V>;
 
     fn default_span(&self, tcx: TyCtxt<'_>) -> Span {
         self.value.default_span(tcx)

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
+indexmap = "2.4"
 parking_lot = "0.12"
 rustc-rayon-core = { version = "0.5.0" }
 rustc_abi = { path = "../rustc_abi" }

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -8,7 +8,7 @@ pub use self::job::{
 };
 
 mod caches;
-pub use self::caches::{DefIdCache, DefaultCache, QueryCache, SingleCache, VecCache};
+pub use self::caches::{DefIdCache, DefaultCache, IndexCache, QueryCache, SingleCache, VecCache};
 
 mod config;
 use rustc_data_structures::sync::Lock;


### PR DESCRIPTION
r? ghost

Our query cache sizes fluctuate randomly in perf reports because of this combination of effects:
`Instance` and `ParamEnv` (as well as some other things, but those are the types that matter) have `Hash` impls that hash pointers, so when we encode our query caches by iterating over the `FxHashMap` that implements the cache, we get a random iteration order.
The shorthand encoding system that `Ty` uses causes us to varint-encode the current encoding offset. This turns unstable encoding order into unstable encoded size.

There are quite a few ways this could be fixed:
* Make the `Hash` impl on `Interned` hash the contents instead of the pointer. This would involve adding `Hash` impls to a *lot* of types that do not have any.
* Teach the `Hash` impl on `Interned` about what the base address of the interner is, so that it can hash the offset into the arena. Each arena is actually duplicated N times because they are all thread-local, so I don't know that this is realistic.
* Sort the query results before we write them out. This is a pretty bad kludge IMO because we still have nondeterministic execution, we're just then doing extra nondet compute to paper over it.
* Change the query cache type for the affected queries to `IndexMap` (surely this has compile-time overhead right? And it'll probably be whack-a-mole going forward)
* Encode the shorthand offsets with a fixed-width encoding instead of varint. (surely this has file size overhead, but probably not much?)

I think the last two options have the most promise by far. I can implement the `IndexMap` change easily so I'm trying that first.