### PR TITLE
Rename `cfg_match!` to `cfg_select!`

### DIFF
--- a/compiler/rustc_codegen_cranelift/patches/0027-sysroot_tests-128bit-atomic-operations.patch
+++ b/compiler/rustc_codegen_cranelift/patches/0027-sysroot_tests-128bit-atomic-operations.patch
@@ -17,7 +17,7 @@ index 1e336bf..35e6f54 100644
 @@ -2,5 +2,4 @@
  // tidy-alphabetical-start
 -#![cfg_attr(target_has_atomic = "128", feature(integer_atomics))]
- #![cfg_attr(test, feature(cfg_match))]
+ #![cfg_attr(test, feature(cfg_select))]
  #![feature(alloc_layout_extra)]
  #![feature(array_chunks)]
 diff --git a/coretests/tests/atomic.rs b/coretests/tests/atomic.rs

--- a/compiler/rustc_data_structures/src/flock.rs
+++ b/compiler/rustc_data_structures/src/flock.rs
@@ -4,7 +4,7 @@
 //! green/native threading. This is just a bare-bones enough solution for
 //! librustdoc, it is not production quality at all.
 
-cfg_match! {
+cfg_select! {
     target_os = "linux" => {
         mod linux;
         use linux as imp;

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -19,7 +19,7 @@
 #![feature(ascii_char_variants)]
 #![feature(assert_matches)]
 #![feature(auto_traits)]
-#![feature(cfg_match)]
+#![feature(cfg_select)]
 #![feature(core_intrinsics)]
 #![feature(dropck_eyepatch)]
 #![feature(extend_one)]

--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -860,7 +860,7 @@ fn get_thread_id() -> u32 {
 }
 
 // Memory reporting
-cfg_match! {
+cfg_select! {
     windows => {
         pub fn get_resident_set_size() -> Option<usize> {
             use windows::{

--- a/compiler/rustc_span/src/analyze_source_file.rs
+++ b/compiler/rustc_span/src/analyze_source_file.rs
@@ -29,7 +29,7 @@ pub(crate) fn analyze_source_file(src: &str) -> (Vec<RelativeBytePos>, Vec<Multi
     (lines, multi_byte_chars)
 }
 
-cfg_match! {
+cfg_select! {
     any(target_arch = "x86", target_arch = "x86_64") => {
         fn analyze_source_file_dispatch(
             src: &str,

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -20,7 +20,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(array_windows)]
-#![feature(cfg_match)]
+#![feature(cfg_select)]
 #![feature(core_io_borrowed_buf)]
 #![feature(hash_set_entry)]
 #![feature(if_let_guard)]

--- a/library/core/src/ffi/primitives.rs
+++ b/library/core/src/ffi/primitives.rs
@@ -35,7 +35,7 @@ type_alias! { "c_float.md", c_float = f32; }
 type_alias! { "c_double.md", c_double = f64; }
 
 mod c_char_definition {
-    crate::cfg_match! {
+    crate::cfg_select! {
         // These are the targets on which c_char is unsigned. Usually the
         // signedness is the same for all target_os values on a given architecture
         // but there are some exceptions (see isSignedCharDefault() in clang).
@@ -133,7 +133,7 @@ mod c_char_definition {
 }
 
 mod c_long_definition {
-    crate::cfg_match! {
+    crate::cfg_select! {
         any(
             all(target_pointer_width = "64", not(windows)),
             // wasm32 Linux ABI uses 64-bit long
@@ -172,7 +172,7 @@ pub type c_ptrdiff_t = isize;
 pub type c_ssize_t = isize;
 
 mod c_int_definition {
-    crate::cfg_match! {
+    crate::cfg_select! {
         any(target_arch = "avr", target_arch = "msp430") => {
             pub(super) type c_int = i16;
             pub(super) type c_uint = u16;

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -100,7 +100,7 @@
 #![feature(bigint_helper_methods)]
 #![feature(bstr)]
 #![feature(bstr_internals)]
-#![feature(cfg_match)]
+#![feature(cfg_select)]
 #![feature(cfg_target_has_reliable_f16_f128)]
 #![feature(const_carrying_mul_add)]
 #![feature(const_eval_select)]
@@ -235,8 +235,8 @@ pub mod autodiff {
 #[unstable(feature = "contracts", issue = "128044")]
 pub mod contracts;
 
-#[unstable(feature = "cfg_match", issue = "115585")]
-pub use crate::macros::cfg_match;
+#[unstable(feature = "cfg_select", issue = "115585")]
+pub use crate::macros::cfg_select;
 
 #[macro_use]
 mod internal_macros;

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -210,9 +210,9 @@ pub macro assert_matches {
 /// # Example
 ///
 /// ```
-/// #![feature(cfg_match)]
+/// #![feature(cfg_select)]
 ///
-/// cfg_match! {
+/// cfg_select! {
 ///     unix => {
 ///         fn foo() { /* unix specific functionality */ }
 ///     }
@@ -228,19 +228,19 @@ pub macro assert_matches {
 /// If desired, it is possible to return expressions through the use of surrounding braces:
 ///
 /// ```
-/// #![feature(cfg_match)]
+/// #![feature(cfg_select)]
 ///
-/// let _some_string = cfg_match! {{
+/// let _some_string = cfg_select! {{
 ///     unix => { "With great power comes great electricity bills" }
 ///     _ => { "Behind every successful diet is an unwatched pizza" }
 /// }};
 /// ```
-#[unstable(feature = "cfg_match", issue = "115585")]
-#[rustc_diagnostic_item = "cfg_match"]
+#[unstable(feature = "cfg_select", issue = "115585")]
+#[rustc_diagnostic_item = "cfg_select"]
 #[rustc_macro_transparency = "semitransparent"]
-pub macro cfg_match {
+pub macro cfg_select {
     ({ $($tt:tt)* }) => {{
-        $crate::cfg_match! { $($tt)* }
+        $crate::cfg_select! { $($tt)* }
     }},
     (_ => { $($output:tt)* }) => {
         $($output)*
@@ -250,10 +250,10 @@ pub macro cfg_match {
         $($( $rest:tt )+)?
     ) => {
         #[cfg($cfg)]
-        $crate::cfg_match! { _ => $output }
+        $crate::cfg_select! { _ => $output }
         $(
             #[cfg(not($cfg))]
-            $crate::cfg_match! { $($rest)+ }
+            $crate::cfg_select! { $($rest)+ }
         )?
     },
 }

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -14,7 +14,7 @@
 use crate::convert::FloatToInt;
 use crate::num::{FpCategory, libm};
 use crate::panic::const_assert;
-use crate::{cfg_match, intrinsics, mem};
+use crate::{cfg_select, intrinsics, mem};
 
 /// The radix or base of the internal representation of `f32`.
 /// Use [`f32::RADIX`] instead.
@@ -990,7 +990,7 @@ impl f32 {
     #[stable(feature = "num_midpoint", since = "1.85.0")]
     #[rustc_const_stable(feature = "num_midpoint", since = "1.85.0")]
     pub const fn midpoint(self, other: f32) -> f32 {
-        cfg_match! {
+        cfg_select! {
             // Allow faster implementation that have known good 64-bit float
             // implementations. Falling back to the branchy code on targets that don't
             // have 64-bit hardware floats or buggy implementations.

--- a/library/core/src/slice/sort/select.rs
+++ b/library/core/src/slice/sort/select.rs
@@ -6,7 +6,7 @@
 //! for pivot selection. Using this as a fallback ensures O(n) worst case running time with
 //! better performance than one would get using heapsort as fallback.
 
-use crate::cfg_match;
+use crate::cfg_select;
 use crate::mem::{self, SizedTypeProperties};
 #[cfg(not(feature = "optimize_for_size"))]
 use crate::slice::sort::shared::pivot::choose_pivot;
@@ -42,7 +42,7 @@ where
         let min_idx = min_index(v, &mut is_less).unwrap();
         v.swap(min_idx, index);
     } else {
-        cfg_match! {
+        cfg_select! {
             feature = "optimize_for_size" => {
                 median_of_medians(v, &mut is_less, index);
             }

--- a/library/core/src/slice/sort/stable/mod.rs
+++ b/library/core/src/slice/sort/stable/mod.rs
@@ -7,7 +7,7 @@ use crate::mem::{MaybeUninit, SizedTypeProperties};
 use crate::slice::sort::shared::smallsort::{
     SMALL_SORT_GENERAL_SCRATCH_LEN, StableSmallSortTypeImpl, insertion_sort_shift_left,
 };
-use crate::{cfg_match, intrinsics};
+use crate::{cfg_select, intrinsics};
 
 pub(crate) mod merge;
 
@@ -39,13 +39,13 @@ pub fn sort<T, F: FnMut(&T, &T) -> bool, BufT: BufGuard<T>>(v: &mut [T], is_less
         return;
     }
 
-    cfg_match! {
+    cfg_select! {
         any(feature = "optimize_for_size", target_pointer_width = "16") => {
             // Unlike driftsort, mergesort only requires len / 2,
             // not len - len / 2.
             let alloc_len = len / 2;
 
-            cfg_match! {
+            cfg_select! {
                 target_pointer_width = "16" => {
                     let mut heap_buf = BufT::with_capacity(alloc_len);
                     let scratch = heap_buf.as_uninit_slice_mut();

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -5,7 +5,7 @@ use crate::mem::SizedTypeProperties;
 use crate::slice::sort::shared::find_existing_run;
 #[cfg(not(any(feature = "optimize_for_size", target_pointer_width = "16")))]
 use crate::slice::sort::shared::smallsort::insertion_sort_shift_left;
-use crate::{cfg_match, intrinsics};
+use crate::{cfg_select, intrinsics};
 
 pub(crate) mod heapsort;
 pub(crate) mod quicksort;
@@ -30,7 +30,7 @@ pub fn sort<T, F: FnMut(&T, &T) -> bool>(v: &mut [T], is_less: &mut F) {
         return;
     }
 
-    cfg_match! {
+    cfg_select! {
         any(feature = "optimize_for_size", target_pointer_width = "16") => {
             heapsort::heapsort(v, is_less);
         }

--- a/library/core/src/slice/sort/unstable/quicksort.rs
+++ b/library/core/src/slice/sort/unstable/quicksort.rs
@@ -9,7 +9,7 @@ use crate::slice::sort::shared::pivot::choose_pivot;
 use crate::slice::sort::shared::smallsort::UnstableSmallSortTypeImpl;
 #[cfg(not(feature = "optimize_for_size"))]
 use crate::slice::sort::unstable::heapsort;
-use crate::{cfg_match, intrinsics, ptr};
+use crate::{cfg_select, intrinsics, ptr};
 
 /// Sorts `v` recursively.
 ///
@@ -142,7 +142,7 @@ const fn inst_partition<T, F: FnMut(&T, &T) -> bool>() -> fn(&mut [T], &T, &mut 
     if size_of::<T>() <= MAX_BRANCHLESS_PARTITION_SIZE {
         // Specialize for types that are relatively cheap to copy, where branchless optimizations
         // have large leverage e.g. `u64` and `String`.
-        cfg_match! {
+        cfg_select! {
             feature = "optimize_for_size" => {
                 partition_lomuto_branchless_simple::<T, F>
             }

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -1,6 +1,6 @@
 // tidy-alphabetical-start
 #![cfg_attr(target_has_atomic = "128", feature(integer_atomics))]
-#![cfg_attr(test, feature(cfg_match))]
+#![cfg_attr(test, feature(cfg_select))]
 #![feature(alloc_layout_extra)]
 #![feature(array_chunks)]
 #![feature(array_ptr_get)]

--- a/library/coretests/tests/macros.rs
+++ b/library/coretests/tests/macros.rs
@@ -9,7 +9,7 @@ trait Trait {
 struct Struct;
 
 impl Trait for Struct {
-    cfg_match! {
+    cfg_select! {
         feature = "blah" => {
             fn blah(&self) {
                 unimplemented!();
@@ -45,22 +45,22 @@ fn matches_leading_pipe() {
 }
 
 #[test]
-fn cfg_match_basic() {
-    cfg_match! {
+fn cfg_select_basic() {
+    cfg_select! {
         target_pointer_width = "64" => { fn f0_() -> bool { true }}
     }
 
-    cfg_match! {
+    cfg_select! {
         unix => { fn f1_() -> bool { true } }
         any(target_os = "macos", target_os = "linux") => { fn f1_() -> bool { false }}
     }
 
-    cfg_match! {
+    cfg_select! {
         target_pointer_width = "32" => { fn f2_() -> bool { false } }
         target_pointer_width = "64" => { fn f2_() -> bool { true } }
     }
 
-    cfg_match! {
+    cfg_select! {
         target_pointer_width = "16" => { fn f3_() -> i32 { 1 } }
         _ => { fn f3_() -> i32 { 2 }}
     }
@@ -81,8 +81,8 @@ fn cfg_match_basic() {
 }
 
 #[test]
-fn cfg_match_debug_assertions() {
-    cfg_match! {
+fn cfg_select_debug_assertions() {
+    cfg_select! {
         debug_assertions => {
             assert!(cfg!(debug_assertions));
             assert_eq!(4, 2+2);
@@ -96,8 +96,8 @@ fn cfg_match_debug_assertions() {
 
 #[cfg(target_pointer_width = "64")]
 #[test]
-fn cfg_match_no_duplication_on_64() {
-    cfg_match! {
+fn cfg_select_no_duplication_on_64() {
+    cfg_select! {
         windows => {
             fn foo() {}
         }
@@ -112,8 +112,8 @@ fn cfg_match_no_duplication_on_64() {
 }
 
 #[test]
-fn cfg_match_options() {
-    cfg_match! {
+fn cfg_select_options() {
+    cfg_select! {
         test => {
             use core::option::Option as Option2;
             fn works1() -> Option2<u32> { Some(1) }
@@ -121,25 +121,25 @@ fn cfg_match_options() {
         _ => { fn works1() -> Option<u32> { None } }
     }
 
-    cfg_match! {
+    cfg_select! {
         feature = "foo" => { fn works2() -> bool { false } }
         test => { fn works2() -> bool { true } }
         _ => { fn works2() -> bool { false } }
     }
 
-    cfg_match! {
+    cfg_select! {
         feature = "foo" => { fn works3() -> bool { false } }
         _ => { fn works3() -> bool { true } }
     }
 
-    cfg_match! {
+    cfg_select! {
         test => {
             use core::option::Option as Option3;
             fn works4() -> Option3<u32> { Some(1) }
         }
     }
 
-    cfg_match! {
+    cfg_select! {
         feature = "foo" => { fn works5() -> bool { false } }
         test => { fn works5() -> bool { true } }
     }
@@ -152,8 +152,8 @@ fn cfg_match_options() {
 }
 
 #[test]
-fn cfg_match_two_functions() {
-    cfg_match! {
+fn cfg_select_two_functions() {
+    cfg_select! {
         target_pointer_width = "64" => {
             fn foo1() {}
             fn bar1() {}
@@ -177,7 +177,7 @@ fn cfg_match_two_functions() {
 }
 
 fn _accepts_expressions() -> i32 {
-    cfg_match! {
+    cfg_select! {
         unix => { 1 }
         _ => { 2 }
     }
@@ -188,14 +188,14 @@ fn _accepts_expressions() -> i32 {
 fn _allows_stmt_expr_attributes() {
     let one = 1;
     let two = 2;
-    cfg_match! {
+    cfg_select! {
         unix => { one * two; }
         _ => { one + two; }
     }
 }
 
 fn _expression() {
-    let _ = cfg_match!({
+    let _ = cfg_select!({
         windows => {
             " XP"
         }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -700,8 +700,8 @@ mod panicking;
 #[allow(dead_code, unused_attributes, fuzzy_provenance_casts, unsafe_op_in_unsafe_fn)]
 mod backtrace_rs;
 
-#[unstable(feature = "cfg_match", issue = "115585")]
-pub use core::cfg_match;
+#[unstable(feature = "cfg_select", issue = "115585")]
+pub use core::cfg_select;
 #[unstable(
     feature = "concat_bytes",
     issue = "87555",

--- a/src/tools/miri/src/concurrency/mod.rs
+++ b/src/tools/miri/src/concurrency/mod.rs
@@ -9,7 +9,7 @@ mod vector_clock;
 pub mod weak_memory;
 
 // Import either the real genmc adapter or a dummy module.
-cfg_match! {
+cfg_select! {
     feature = "genmc" => {
         mod genmc;
         pub use self::genmc::{GenmcCtx, GenmcConfig};

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(rustc_private)]
-#![feature(cfg_match)]
+#![feature(cfg_select)]
 #![feature(float_gamma)]
 #![feature(float_erf)]
 #![feature(map_try_insert)]

--- a/src/tools/miri/src/shims/unix/fs.rs
+++ b/src/tools/miri/src/shims/unix/fs.rs
@@ -90,7 +90,7 @@ impl UnixFileDescription for FileHandle {
         op: FlockOp,
     ) -> InterpResult<'tcx, io::Result<()>> {
         assert!(communicate_allowed, "isolation should have prevented even opening a file");
-        cfg_match! {
+        cfg_select! {
             all(target_family = "unix", not(target_os = "solaris")) => {
                 use std::os::fd::AsRawFd;
 


### PR DESCRIPTION
[@Nemo157 pointed out](https://github.com/rust-lang/rust/issues/115585#issuecomment-2346307605) that `cfg_match!` syntax does not actually align well with match syntax, which is a possible source of confusion. The comment points out that usage is instead more similar to ecosystem `select!` macros. Rename `cfg_match!` to `cfg_select!` to match this.

Tracking issue: https://github.com/rust-lang/rust/issues/115585

[1]: https://github.com/rust-lang/rust/issues/115585#issuecomment-2346307605