### PR TITLE
Remove `std::os::wasi::fs::FileExt::tell`

### DIFF
--- a/library/std/src/os/wasi/fs.rs
+++ b/library/std/src/os/wasi/fs.rs
@@ -162,13 +162,6 @@ pub trait FileExt {
         Ok(())
     }
 
-    /// Returns the current position within the file.
-    ///
-    /// This corresponds to the `fd_tell` syscall and is similar to
-    /// `seek` where you offset 0 bytes from the current position.
-    #[doc(alias = "fd_tell")]
-    fn tell(&self) -> io::Result<u64>;
-
     /// Adjusts the flags associated with this file.
     ///
     /// This corresponds to the `fd_fdstat_set_flags` syscall.
@@ -238,10 +231,6 @@ impl FileExt for fs::File {
 
     fn write_vectored_at(&self, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
         self.as_inner().as_inner().pwrite(bufs, offset)
-    }
-
-    fn tell(&self) -> io::Result<u64> {
-        self.as_inner().as_inner().tell()
     }
 
     fn fdstat_set_flags(&self, flags: u16) -> io::Result<()> {


### PR DESCRIPTION
Following #137165 (Use `tell` for `<File as Seek>::stream_position`), `tell` is now directly exposed via `stream_position`, making `<File as FileExt>::tell` redundant. Remove it.

`std::os::wasi::fs::FileExt::tell` is currently unstable and tracked in https://github.com/rust-lang/rust/issues/71213.

@rustbot ping wasi