### PR TITLE
eval_outlives: bail out early if both regions are in the same SCC

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1267,6 +1267,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let sub_region_scc = self.constraint_sccs.scc(sub_region);
         let sup_region_scc = self.constraint_sccs.scc(sup_region);
 
+        if sub_region_scc == sup_region_scc {
+            debug!("{sup_region:?}: {sub_region:?} holds trivially; they are in the same SCC");
+            return true;
+        }
+
         // If we are checking that `'sup: 'sub`, and `'sub` contains
         // some placeholder that `'sup` cannot name, then this is only
         // true if `'sup` outlives static.


### PR DESCRIPTION
A drive-by optimisation of region outlives evaluation: if we are evaluating whether an outlives holds for two regions, bail out early if they are both in the same SCC.

This probably won't make a huge difference, but the cost is one comparison of SCC indices (integers).

May want a perf run, depending on how confident whomever reviewing this is!