### PR TITLE
Unconditionally check sizedness of body in typeck to taint typeck results

### DIFF
--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -113,19 +113,16 @@ pub(super) fn check_fn<'a, 'tcx>(
 
     fcx.typeck_results.borrow_mut().liberated_fn_sigs_mut().insert(fn_id, fn_sig);
 
-    // We checked the root's ret ty during wfcheck, but not the child.
-    if fcx.tcx.is_typeck_child(fn_def_id.to_def_id()) {
-        let return_or_body_span = match decl.output {
-            hir::FnRetTy::DefaultReturn(_) => body.value.span,
-            hir::FnRetTy::Return(ty) => ty.span,
-        };
+    let return_or_body_span = match decl.output {
+        hir::FnRetTy::DefaultReturn(_) => body.value.span,
+        hir::FnRetTy::Return(ty) => ty.span,
+    };
 
-        fcx.require_type_is_sized(
-            declared_ret_ty,
-            return_or_body_span,
-            ObligationCauseCode::SizedReturnType,
-        );
-    }
+    fcx.require_type_is_sized(
+        declared_ret_ty,
+        return_or_body_span,
+        ObligationCauseCode::SizedReturnType,
+    );
 
     fcx.is_whole_body.set(true);
     fcx.check_return_or_body_tail(body.value, false);

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1809,7 +1809,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         crate::GatherLocalsVisitor::new(&fcx).visit_body(body);
 
         let ty = fcx.check_expr_with_expectation(body.value, expected);
-        fcx.require_type_is_sized(ty, body.value.span, ObligationCauseCode::ConstSized);
+        fcx.require_type_is_sized(ty, body.value.span, ObligationCauseCode::SizedConstOrStatic);
         fcx.write_ty(block.hir_id, ty);
         ty
     }

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -185,6 +185,11 @@ fn typeck_with_inspect<'tcx>(
 
         let wf_code = ObligationCauseCode::WellFormed(Some(WellFormedLoc::Ty(def_id)));
         fcx.register_wf_obligation(expected_type.into(), body.value.span, wf_code);
+        fcx.require_type_is_sized(
+            expected_type,
+            node.ty().map_or(body.value.span, |ty| ty.span),
+            ObligationCauseCode::SizedConstOrStatic,
+        );
 
         // Gather locals in statics (because of block expressions).
         GatherLocalsVisitor::new(&fcx).visit_body(body);

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -273,7 +273,7 @@ pub enum ObligationCauseCode<'tcx> {
     },
 
     /// Constant expressions must be sized.
-    ConstSized,
+    SizedConstOrStatic,
 
     /// `static` items must have `Sync` type.
     SharedStatic,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3125,8 +3125,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     Applicability::MachineApplicable,
                 );
             }
-            ObligationCauseCode::ConstSized => {
-                err.note("constant expressions must have a statically known size");
+            ObligationCauseCode::SizedConstOrStatic => {
+                err.note("statics and constants must have a statically known size");
             }
             ObligationCauseCode::InlineAsmSized => {
                 err.note("all inline asm arguments must have a statically known size");

--- a/tests/ui/associated-consts/issue-58022.rs
+++ b/tests/ui/associated-consts/issue-58022.rs
@@ -12,6 +12,7 @@ impl Bar<[u8]> {
 
     fn new(slice: &[u8; Self::SIZE]) -> Self {
         //~^ ERROR: the size for values of type `[u8]` cannot be known at compilation time
+        //~| ERROR: the size for values of type `[u8]` cannot be known at compilation time
         Foo(Box::new(*slice))
         //~^ ERROR: expected function, tuple struct or tuple variant, found trait `Foo`
     }

--- a/tests/ui/associated-consts/issue-58022.stderr
+++ b/tests/ui/associated-consts/issue-58022.stderr
@@ -21,13 +21,28 @@ LL |
 LL |     fn new(slice: &[u8; Foo::SIZE]) -> Self;
    |                         ^^^^^^^^^ cannot refer to the associated constant of trait
 
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/issue-58022.rs:13:41
+   |
+LL |     fn new(slice: &[u8; Self::SIZE]) -> Self {
+   |                                         ^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `Bar<[u8]>`, the trait `Sized` is not implemented for `[u8]`
+note: required because it appears within the type `Bar<[u8]>`
+  --> $DIR/issue-58022.rs:8:12
+   |
+LL | pub struct Bar<T: ?Sized>(T);
+   |            ^^^
+   = note: the return type of a function must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0423]: expected function, tuple struct or tuple variant, found trait `Foo`
-  --> $DIR/issue-58022.rs:15:9
+  --> $DIR/issue-58022.rs:16:9
    |
 LL |         Foo(Box::new(*slice))
    |         ^^^ not a function, tuple struct or tuple variant
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0277, E0423, E0790.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/consts/const-slice-array-deref.rs
+++ b/tests/ui/consts/const-slice-array-deref.rs
@@ -1,5 +1,6 @@
 const ONE: [u16] = [1];
 //~^ ERROR the size for values of type `[u16]` cannot be known at compilation time
+//~| ERROR the size for values of type `[u16]` cannot be known at compilation time
 //~| ERROR mismatched types
 
 const TWO: &'static u16 = &ONE[0];

--- a/tests/ui/consts/const-slice-array-deref.stderr
+++ b/tests/ui/consts/const-slice-array-deref.stderr
@@ -5,6 +5,7 @@ LL | const ONE: [u16] = [1];
    |            ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u16]`
+   = note: statics and constants must have a statically known size
 
 error[E0308]: mismatched types
   --> $DIR/const-slice-array-deref.rs:1:20

--- a/tests/ui/consts/const-slice-array-deref.stderr
+++ b/tests/ui/consts/const-slice-array-deref.stderr
@@ -13,13 +13,23 @@ error[E0308]: mismatched types
 LL | const ONE: [u16] = [1];
    |                    ^^^ expected `[u16]`, found `[u16; 1]`
 
+error[E0277]: the size for values of type `[u16]` cannot be known at compilation time
+  --> $DIR/const-slice-array-deref.rs:1:12
+   |
+LL | const ONE: [u16] = [1];
+   |            ^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u16]`
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0161]: cannot move a value of type `[u16]`
-  --> $DIR/const-slice-array-deref.rs:5:28
+  --> $DIR/const-slice-array-deref.rs:6:28
    |
 LL | const TWO: &'static u16 = &ONE[0];
    |                            ^^^ the size of `[u16]` cannot be statically determined
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0161, E0277, E0308.
 For more information about an error, try `rustc --explain E0161`.

--- a/tests/ui/consts/const-unsized.rs
+++ b/tests/ui/consts/const-unsized.rs
@@ -2,19 +2,19 @@ use std::fmt::Debug;
 
 const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
 //~^ ERROR the size for values of type
-//~| ERROR cannot move out of a shared reference
+//~| ERROR the size for values of type
 
 const CONST_FOO: str = *"foo";
 //~^ ERROR the size for values of type
-//~| ERROR cannot move out of a shared reference
+//~| ERROR the size for values of type
 
 static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
 //~^ ERROR the size for values of type
-//~| ERROR cannot move out of a shared reference
+//~| ERROR the size for values of type
 
 static STATIC_BAR: str = *"bar";
 //~^ ERROR the size for values of type
-//~| ERROR cannot move out of a shared reference
+//~| ERROR the size for values of type
 
 fn main() {
     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATIC_BAR);

--- a/tests/ui/consts/const-unsized.stderr
+++ b/tests/ui/consts/const-unsized.stderr
@@ -5,6 +5,7 @@ LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
    |                ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:7:18
@@ -13,6 +14,7 @@ LL | const CONST_FOO: str = *"foo";
    |                  ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
   --> $DIR/const-unsized.rs:11:18
@@ -21,6 +23,7 @@ LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
    |                  ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:15:20
@@ -29,6 +32,7 @@ LL | static STATIC_BAR: str = *"bar";
    |                    ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/const-unsized.rs:3:35

--- a/tests/ui/consts/const-unsized.stderr
+++ b/tests/ui/consts/const-unsized.stderr
@@ -7,6 +7,16 @@ LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
    = note: statics and constants must have a statically known size
 
+error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
+  --> $DIR/const-unsized.rs:3:16
+   |
+LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
+   |                ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:7:18
    |
@@ -15,6 +25,16 @@ LL | const CONST_FOO: str = *"foo";
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: statics and constants must have a statically known size
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/const-unsized.rs:7:18
+   |
+LL | const CONST_FOO: str = *"foo";
+   |                  ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
   --> $DIR/const-unsized.rs:11:18
@@ -25,6 +45,16 @@ LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
    = note: statics and constants must have a statically known size
 
+error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
+  --> $DIR/const-unsized.rs:11:18
+   |
+LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
+   |                  ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:15:20
    |
@@ -34,29 +64,15 @@ LL | static STATIC_BAR: str = *"bar";
    = help: the trait `Sized` is not implemented for `str`
    = note: statics and constants must have a statically known size
 
-error[E0507]: cannot move out of a shared reference
-  --> $DIR/const-unsized.rs:3:35
-   |
-LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `dyn Debug + Sync`, which does not implement the `Copy` trait
-
-error[E0507]: cannot move out of a shared reference
-  --> $DIR/const-unsized.rs:7:24
-   |
-LL | const CONST_FOO: str = *"foo";
-   |                        ^^^^^^ move occurs because value has type `str`, which does not implement the `Copy` trait
-
-error[E0507]: cannot move out of a shared reference
-  --> $DIR/const-unsized.rs:11:37
-   |
-LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `dyn Debug + Sync`, which does not implement the `Copy` trait
-
-error[E0507]: cannot move out of a shared reference
-  --> $DIR/const-unsized.rs:15:26
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/const-unsized.rs:15:20
    |
 LL | static STATIC_BAR: str = *"bar";
-   |                          ^^^^^^ move occurs because value has type `str`, which does not implement the `Copy` trait
+   |                    ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0161]: cannot move a value of type `str`
   --> $DIR/const-unsized.rs:20:48
@@ -72,5 +88,5 @@ LL |     println!("{:?} {:?} {:?} {:?}", &CONST_0, &CONST_FOO, &STATIC_1, &STATI
 
 error: aborting due to 10 previous errors
 
-Some errors have detailed explanations: E0161, E0277, E0507.
+Some errors have detailed explanations: E0161, E0277.
 For more information about an error, try `rustc --explain E0161`.

--- a/tests/ui/consts/const_refs_to_static-ice-121413.rs
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.rs
@@ -9,8 +9,10 @@ const REF_INTERIOR_MUT: &usize = {
     //~^ ERROR failed to resolve: use of undeclared type `AtomicUsize`
     //~| WARN trait objects without an explicit `dyn` are deprecated
     //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+    //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| HELP if this is a dyn-compatible trait, use `dyn`
+    //~| HELP the trait `Sized` is not implemented for `(dyn Sync + 'static)`
     //~| HELP the trait `Sized` is not implemented for `(dyn Sync + 'static)`
     unsafe { &*(&FOO as *const _ as *const usize) }
 };

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -30,6 +30,7 @@ LL |     static FOO: Sync = AtomicUsize::new(0);
    |                 ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+   = note: statics and constants must have a statically known size
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -32,7 +32,17 @@ LL |     static FOO: Sync = AtomicUsize::new(0);
    = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
    = note: statics and constants must have a statically known size
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error[E0277]: the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
+  --> $DIR/const_refs_to_static-ice-121413.rs:8:17
+   |
+LL |     static FOO: Sync = AtomicUsize::new(0);
+   |                 ^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0277, E0433.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/consts/unsized.rs
+++ b/tests/ui/consts/unsized.rs
@@ -1,0 +1,9 @@
+static S: str = todo!();
+//~^ ERROR the size for values of type `str` cannot be known at compilation time
+//~| ERROR the size for values of type `str` cannot be known at compilation time
+
+const A: str = todo!();
+//~^ ERROR the size for values of type `str` cannot be known at compilation time
+//~| ERROR the size for values of type `str` cannot be known at compilation time
+
+fn main() {}

--- a/tests/ui/consts/unsized.stderr
+++ b/tests/ui/consts/unsized.stderr
@@ -1,0 +1,41 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/unsized.rs:1:11
+   |
+LL | static S: str = todo!();
+   |           ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/unsized.rs:1:11
+   |
+LL | static S: str = todo!();
+   |           ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/unsized.rs:5:10
+   |
+LL | const A: str = todo!();
+   |          ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/unsized.rs:5:10
+   |
+LL | const A: str = todo!();
+   |          ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/error-codes/E0746.rs
+++ b/tests/ui/error-codes/E0746.rs
@@ -6,9 +6,12 @@ impl Trait for Struct {}
 impl Trait for u32 {}
 
 fn foo() -> dyn Trait { Struct }
-//~^ ERROR E0746
+//~^ ERROR return type cannot be a trait object without pointer indirection
+//~| ERROR return type cannot be a trait object without pointer indirection
 
-fn bar() -> dyn Trait { //~ ERROR E0746
+fn bar() -> dyn Trait {
+    //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     if true {
         return 0;
     }

--- a/tests/ui/error-codes/E0746.stderr
+++ b/tests/ui/error-codes/E0746.stderr
@@ -15,7 +15,7 @@ LL | fn foo() -> Box<dyn Trait> { Box::new(Struct) }
    |             ++++         +   +++++++++      +
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/E0746.rs:11:13
+  --> $DIR/E0746.rs:12:13
    |
 LL | fn bar() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -28,12 +28,54 @@ LL + fn bar() -> impl Trait {
 help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bar() -> Box<dyn Trait> {
+LL |
+LL |
 LL |     if true {
 LL ~         return Box::new(0);
 LL |     }
 LL ~     Box::new(42)
    |
 
-error: aborting due to 2 previous errors
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/E0746.rs:8:13
+   |
+LL | fn foo() -> dyn Trait { Struct }
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn foo() -> dyn Trait { Struct }
+LL + fn foo() -> impl Trait { Struct }
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL | fn foo() -> Box<dyn Trait> { Box::new(Struct) }
+   |             ++++         +   +++++++++      +
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/E0746.rs:12:13
+   |
+LL | fn bar() -> dyn Trait {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bar() -> dyn Trait {
+LL + fn bar() -> impl Trait {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bar() -> Box<dyn Trait> {
+LL |
+LL |
+LL |     if true {
+LL ~         return Box::new(0);
+LL |     }
+LL ~     Box::new(42)
+   |
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0746`.

--- a/tests/ui/extern/issue-36122-accessing-externed-dst.stderr
+++ b/tests/ui/extern/issue-36122-accessing-externed-dst.stderr
@@ -5,6 +5,7 @@ LL |         static symbol: [usize];
    |                        ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[usize]`
+   = note: statics and constants must have a statically known size
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
   --> $DIR/issue-36122-accessing-externed-dst.rs:5:20

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.rs
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.rs
@@ -19,8 +19,10 @@ impl DynIncompatible for B {
     }
 }
 
-fn car() -> dyn DynIncompatible { //~ ERROR the trait `DynIncompatible` is not dyn compatible
-//~^ ERROR return type cannot be a trait object without pointer indirection
+fn car() -> dyn DynIncompatible {
+    //~^ ERROR the trait `DynIncompatible` is not dyn compatible
+    //~| ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     if true {
         return A;
     }

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
@@ -41,6 +41,7 @@ help: alternatively, box the return type, and wrap all of the returned values in
    |
 LL ~ fn car() -> Box<dyn DynIncompatible> {
 LL |
+...
 LL |     if true {
 LL ~         return Box::new(A);
 LL |     }
@@ -48,7 +49,7 @@ LL ~     Box::new(B)
    |
 
 error[E0038]: the trait `DynIncompatible` is not dyn compatible
-  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:30:17
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:32:17
    |
 LL | fn cat() -> Box<dyn DynIncompatible> {
    |                 ^^^^^^^^^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
@@ -75,8 +76,31 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:22:13
+   |
+LL | fn car() -> dyn DynIncompatible {
+   |             ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn car() -> dyn DynIncompatible {
+LL + fn car() -> impl DynIncompatible {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn car() -> Box<dyn DynIncompatible> {
+LL |
+...
+LL |     if true {
+LL ~         return Box::new(A);
+LL |     }
+LL ~     Box::new(B)
+   |
+
 error[E0038]: the trait `DynIncompatible` is not dyn compatible
-  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:32:16
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:34:16
    |
 LL |         return Box::new(A);
    |                ^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
@@ -105,7 +129,7 @@ LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
 error[E0038]: the trait `DynIncompatible` is not dyn compatible
-  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:34:5
+  --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:36:5
    |
 LL |     Box::new(B)
    |     ^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
@@ -133,7 +157,7 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0038, E0746.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.rs
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.rs
@@ -5,44 +5,60 @@ impl Trait for Struct {}
 impl Trait for u32 {}
 
 fn fuz() -> (usize, Trait) { (42, Struct) }
-//~^ ERROR E0277
-//~| ERROR E0277
-//~| ERROR E0308
+//~^ ERROR the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+//~| ERROR the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+//~| ERROR mismatched types
+
 fn bar() -> (usize, dyn Trait) { (42, Struct) }
-//~^ ERROR E0277
-//~| ERROR E0277
-//~| ERROR E0308
+//~^ ERROR the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+//~| ERROR the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
+//~| ERROR mismatched types
+
 fn bap() -> Trait { Struct }
-//~^ ERROR E0746
+//~^ ERROR return type cannot be a trait object without pointer indirection
+//~| ERROR return type cannot be a trait object without pointer indirection
+
 fn ban() -> dyn Trait { Struct }
-//~^ ERROR E0746
-fn bak() -> dyn Trait { unimplemented!() } //~ ERROR E0746
-// Suggest using `Box<dyn Trait>`
-fn bal() -> dyn Trait { //~ ERROR E0746
+//~^ ERROR return type cannot be a trait object without pointer indirection
+//~| ERROR return type cannot be a trait object without pointer indirection
+
+fn bak() -> dyn Trait { unimplemented!() }
+//~^ ERROR return type cannot be a trait object without pointer indirection
+//~| ERROR return type cannot be a trait object without pointer indirection
+
+fn bal() -> dyn Trait {
+    //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     if true {
         return Struct;
     }
     42
 }
-fn bax() -> dyn Trait { //~ ERROR E0746
+
+fn bax() -> dyn Trait {
+    //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     if true {
         Struct
     } else {
         42
     }
 }
+
 fn bam() -> Box<dyn Trait> {
     if true {
         return Struct; //~ ERROR mismatched types
     }
     42 //~ ERROR mismatched types
 }
+
 fn baq() -> Box<dyn Trait> {
     if true {
         return 0; //~ ERROR mismatched types
     }
     42 //~ ERROR mismatched types
 }
+
 fn baz() -> Box<dyn Trait> {
     if true {
         Struct //~ ERROR mismatched types
@@ -50,6 +66,7 @@ fn baz() -> Box<dyn Trait> {
         42 //~ ERROR mismatched types
     }
 }
+
 fn baw() -> Box<dyn Trait> {
     if true {
         0 //~ ERROR mismatched types
@@ -59,13 +76,18 @@ fn baw() -> Box<dyn Trait> {
 }
 
 // Suggest using `impl Trait`
-fn bat() -> dyn Trait { //~ ERROR E0746
+fn bat() -> dyn Trait {
+    //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     if true {
         return 0;
     }
     42
 }
-fn bay() -> dyn Trait { //~ ERROR E0746
+
+fn bay() -> dyn Trait {
+    //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     if true {
         0
     } else {

--- a/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
+++ b/tests/ui/impl-trait/dyn-trait-return-should-be-impl-trait.stderr
@@ -9,7 +9,7 @@ LL | fn fuz() -> (usize, Trait) { (42, Struct) }
    = note: the return type of a function must have a statically known size
 
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:11:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:12:13
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |             ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -19,7 +19,7 @@ LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    = note: the return type of a function must have a statically known size
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:15:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:17:13
    |
 LL | fn bap() -> Trait { Struct }
    |             ^^^^^ doesn't have a size known at compile-time
@@ -34,7 +34,7 @@ LL | fn bap() -> Box<dyn Trait> { Box::new(Struct) }
    |             +++++++      +   +++++++++      +
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:17:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:21:13
    |
 LL | fn ban() -> dyn Trait { Struct }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -50,7 +50,7 @@ LL | fn ban() -> Box<dyn Trait> { Box::new(Struct) }
    |             ++++         +   +++++++++      +
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:19:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:25:13
    |
 LL | fn bak() -> dyn Trait { unimplemented!() }
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -66,7 +66,7 @@ LL | fn bak() -> Box<dyn Trait> { Box::new(unimplemented!()) }
    |             ++++         +   +++++++++                +
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:21:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:29:13
    |
 LL | fn bal() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -79,6 +79,8 @@ LL + fn bal() -> impl Trait {
 help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bal() -> Box<dyn Trait> {
+LL |
+LL |
 LL |     if true {
 LL ~         return Box::new(Struct);
 LL |     }
@@ -86,7 +88,7 @@ LL ~     Box::new(42)
    |
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:27:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:38:13
    |
 LL | fn bax() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -99,6 +101,8 @@ LL + fn bax() -> impl Trait {
 help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bax() -> Box<dyn Trait> {
+LL |
+LL |
 LL |     if true {
 LL ~         Box::new(Struct)
 LL |     } else {
@@ -106,7 +110,7 @@ LL ~         Box::new(42)
    |
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:62:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:79:13
    |
 LL | fn bat() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -119,6 +123,8 @@ LL + fn bat() -> impl Trait {
 help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bat() -> Box<dyn Trait> {
+LL |
+LL |
 LL |     if true {
 LL ~         return Box::new(0);
 LL |     }
@@ -126,7 +132,7 @@ LL ~     Box::new(42)
    |
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:68:13
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:88:13
    |
 LL | fn bay() -> dyn Trait {
    |             ^^^^^^^^^ doesn't have a size known at compile-time
@@ -139,6 +145,8 @@ LL + fn bay() -> impl Trait {
 help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn bay() -> Box<dyn Trait> {
+LL |
+LL |
 LL |     if true {
 LL ~         Box::new(0)
 LL |     } else {
@@ -156,17 +164,18 @@ LL | fn fuz() -> (usize, Trait) { (42, Struct) }
    = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
 
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:7:30
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:7:13
    |
 LL | fn fuz() -> (usize, Trait) { (42, Struct) }
-   |                              ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |             ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
    = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
-   = note: tuples must have a statically known size to be initialized
+   = note: the return type of a function must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:11:39
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:12:39
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    |                                       ^^^^^^ expected `dyn Trait`, found `Struct`
@@ -176,17 +185,114 @@ LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
    = help: `Struct` implements `Trait` so you could box the found value and coerce it to the trait object `Box<dyn Trait>`, you will have to change the expected type as well
 
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:11:34
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:12:13
    |
 LL | fn bar() -> (usize, dyn Trait) { (42, Struct) }
-   |                                  ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |             ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `(usize, (dyn Trait + 'static))`, the trait `Sized` is not implemented for `(dyn Trait + 'static)`
    = note: required because it appears within the type `(usize, (dyn Trait + 'static))`
-   = note: tuples must have a statically known size to be initialized
+   = note: the return type of a function must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:17:13
+   |
+LL | fn bap() -> Trait { Struct }
+   |             ^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn bap() -> impl Trait { Struct }
+   |             ++++
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL | fn bap() -> Box<dyn Trait> { Box::new(Struct) }
+   |             +++++++      +   +++++++++      +
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:21:13
+   |
+LL | fn ban() -> dyn Trait { Struct }
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn ban() -> dyn Trait { Struct }
+LL + fn ban() -> impl Trait { Struct }
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL | fn ban() -> Box<dyn Trait> { Box::new(Struct) }
+   |             ++++         +   +++++++++      +
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:25:13
+   |
+LL | fn bak() -> dyn Trait { unimplemented!() }
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bak() -> dyn Trait { unimplemented!() }
+LL + fn bak() -> impl Trait { unimplemented!() }
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL | fn bak() -> Box<dyn Trait> { Box::new(unimplemented!()) }
+   |             ++++         +   +++++++++                +
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:29:13
+   |
+LL | fn bal() -> dyn Trait {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bal() -> dyn Trait {
+LL + fn bal() -> impl Trait {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bal() -> Box<dyn Trait> {
+LL |
+LL |
+LL |     if true {
+LL ~         return Box::new(Struct);
+LL |     }
+LL ~     Box::new(42)
+   |
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:38:13
+   |
+LL | fn bax() -> dyn Trait {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bax() -> dyn Trait {
+LL + fn bax() -> impl Trait {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bax() -> Box<dyn Trait> {
+LL |
+LL |
+LL |     if true {
+LL ~         Box::new(Struct)
+LL |     } else {
+LL ~         Box::new(42)
+   |
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:36:16
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:50:16
    |
 LL | fn bam() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -203,7 +309,7 @@ LL |         return Box::new(Struct);
    |                +++++++++      +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:38:5
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:52:5
    |
 LL | fn bam() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -220,7 +326,7 @@ LL |     Box::new(42)
    |     +++++++++  +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:42:16
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:57:16
    |
 LL | fn baq() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -237,7 +343,7 @@ LL |         return Box::new(0);
    |                +++++++++ +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:44:5
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:59:5
    |
 LL | fn baq() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -254,7 +360,7 @@ LL |     Box::new(42)
    |     +++++++++  +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:48:9
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:64:9
    |
 LL | fn baz() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -271,7 +377,7 @@ LL |         Box::new(Struct)
    |         +++++++++      +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:50:9
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:66:9
    |
 LL | fn baz() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -288,7 +394,7 @@ LL |         Box::new(42)
    |         +++++++++  +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:55:9
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:72:9
    |
 LL | fn baw() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -305,7 +411,7 @@ LL |         Box::new(0)
    |         +++++++++ +
 
 error[E0308]: mismatched types
-  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:57:9
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:74:9
    |
 LL | fn baw() -> Box<dyn Trait> {
    |             -------------- expected `Box<(dyn Trait + 'static)>` because of return type
@@ -321,7 +427,53 @@ help: store this in the heap by calling `Box::new`
 LL |         Box::new(42)
    |         +++++++++  +
 
-error: aborting due to 21 previous errors
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:79:13
+   |
+LL | fn bat() -> dyn Trait {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bat() -> dyn Trait {
+LL + fn bat() -> impl Trait {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bat() -> Box<dyn Trait> {
+LL |
+LL |
+LL |     if true {
+LL ~         return Box::new(0);
+LL |     }
+LL ~     Box::new(42)
+   |
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/dyn-trait-return-should-be-impl-trait.rs:88:13
+   |
+LL | fn bay() -> dyn Trait {
+   |             ^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn bay() -> dyn Trait {
+LL + fn bay() -> impl Trait {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn bay() -> Box<dyn Trait> {
+LL |
+LL |
+LL |     if true {
+LL ~         Box::new(0)
+LL |     } else {
+LL ~         Box::new(42)
+   |
+
+error: aborting due to 28 previous errors
 
 Some errors have detailed explanations: E0277, E0308, E0746.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/impl-trait/ice-unexpected-param-type-whensubstituting-in-region-112823.next.stderr
+++ b/tests/ui/impl-trait/ice-unexpected-param-type-whensubstituting-in-region-112823.next.stderr
@@ -17,11 +17,19 @@ LL |     type LineStream<'c, 'd> = impl Stream;
    |                     |
    |                     found 0 type parameters
 
-error[E0271]: type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> == ()`
+error[E0271]: type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> normalizes-to ()`
   --> $DIR/ice-unexpected-param-type-whensubstituting-in-region-112823.rs:28:43
    |
 LL |     fn line_stream<'a, Repr>(&'a self) -> Self::LineStreamFut<'a, Repr> {}
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ
+
+error[E0271]: type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> normalizes-to _`
+  --> $DIR/ice-unexpected-param-type-whensubstituting-in-region-112823.rs:28:43
+   |
+LL |     fn line_stream<'a, Repr>(&'a self) -> Self::LineStreamFut<'a, Repr> {}
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ
+   |
+   = note: the return type of a function must have a statically known size
 
 error[E0271]: type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> normalizes-to _`
   --> $DIR/ice-unexpected-param-type-whensubstituting-in-region-112823.rs:28:73
@@ -35,7 +43,7 @@ error[E0271]: type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> normali
 LL |     fn line_stream<'a, Repr>(&'a self) -> Self::LineStreamFut<'a, Repr> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ types differ
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0049, E0271, E0407.
 For more information about an error, try `rustc --explain E0049`.

--- a/tests/ui/impl-trait/ice-unexpected-param-type-whensubstituting-in-region-112823.rs
+++ b/tests/ui/impl-trait/ice-unexpected-param-type-whensubstituting-in-region-112823.rs
@@ -28,7 +28,8 @@ impl X for Y {
     fn line_stream<'a, Repr>(&'a self) -> Self::LineStreamFut<'a, Repr> {}
     //~^ method `line_stream` is not a member of trait `X`
     //[current]~^^ ERROR `()` is not a future
-    //[next]~^^^ ERROR type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> == ()`
+    //[next]~^^^ ERROR type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> normalizes-to ()`
+    //[next]~| ERROR type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> normalizes-to _`
     //[next]~| ERROR type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> normalizes-to _`
     //[next]~| ERROR type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> normalizes-to _`
 }

--- a/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.rs
+++ b/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.rs
@@ -63,7 +63,9 @@ fn dog() -> impl std::fmt::Display {
     }
 }
 
-fn hat() -> dyn std::fmt::Display { //~ ERROR return type cannot be a trait object without pointer indirection
+fn hat() -> dyn std::fmt::Display {
+    //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     match 13 {
         0 => {
             return 0i32;
@@ -74,7 +76,9 @@ fn hat() -> dyn std::fmt::Display { //~ ERROR return type cannot be a trait obje
     }
 }
 
-fn pug() -> dyn std::fmt::Display { //~ ERROR return type cannot be a trait object without pointer indirection
+fn pug() -> dyn std::fmt::Display {
+    //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     match 13 {
         0 => 0i32,
         1 => 1u32,
@@ -82,7 +86,9 @@ fn pug() -> dyn std::fmt::Display { //~ ERROR return type cannot be a trait obje
     }
 }
 
-fn man() -> dyn std::fmt::Display { //~ ERROR return type cannot be a trait object without pointer indirection
+fn man() -> dyn std::fmt::Display {
+    //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     if false {
         0i32
     } else {

--- a/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
+++ b/tests/ui/impl-trait/point-to-type-err-cause-on-impl-trait-return.stderr
@@ -12,7 +12,8 @@ LL + fn hat() -> impl std::fmt::Display {
 help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn hat() -> Box<dyn std::fmt::Display> {
-LL |     match 13 {
+LL |
+...
 LL |         0 => {
 LL ~             return Box::new(0i32);
 LL |         }
@@ -21,7 +22,7 @@ LL ~             Box::new(1u32)
    |
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:77:13
+  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:79:13
    |
 LL | fn pug() -> dyn std::fmt::Display {
    |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -34,6 +35,8 @@ LL + fn pug() -> impl std::fmt::Display {
 help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn pug() -> Box<dyn std::fmt::Display> {
+LL |
+LL |
 LL |     match 13 {
 LL ~         0 => Box::new(0i32),
 LL ~         1 => Box::new(1u32),
@@ -41,7 +44,7 @@ LL ~         _ => Box::new(2u32),
    |
 
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:85:13
+  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:89:13
    |
 LL | fn man() -> dyn std::fmt::Display {
    |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -54,6 +57,8 @@ LL + fn man() -> impl std::fmt::Display {
 help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
 LL ~ fn man() -> Box<dyn std::fmt::Display> {
+LL |
+LL |
 LL |     if false {
 LL ~         Box::new(0i32)
 LL |     } else {
@@ -207,7 +212,7 @@ LL +         1 => 1i32,
    |
 
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:97:9
+  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:103:9
    |
 LL | /     if let Some(42) = Some(42) {
 LL | |         0i32
@@ -235,7 +240,77 @@ LL -         1u32
 LL +         1i32
    |
 
-error: aborting due to 12 previous errors
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:66:13
+   |
+LL | fn hat() -> dyn std::fmt::Display {
+   |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn hat() -> dyn std::fmt::Display {
+LL + fn hat() -> impl std::fmt::Display {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn hat() -> Box<dyn std::fmt::Display> {
+LL |
+...
+LL |         0 => {
+LL ~             return Box::new(0i32);
+LL |         }
+LL |         _ => {
+LL ~             Box::new(1u32)
+   |
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:79:13
+   |
+LL | fn pug() -> dyn std::fmt::Display {
+   |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn pug() -> dyn std::fmt::Display {
+LL + fn pug() -> impl std::fmt::Display {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn pug() -> Box<dyn std::fmt::Display> {
+LL |
+LL |
+LL |     match 13 {
+LL ~         0 => Box::new(0i32),
+LL ~         1 => Box::new(1u32),
+LL ~         _ => Box::new(2u32),
+   |
+
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/point-to-type-err-cause-on-impl-trait-return.rs:89:13
+   |
+LL | fn man() -> dyn std::fmt::Display {
+   |             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn man() -> dyn std::fmt::Display {
+LL + fn man() -> impl std::fmt::Display {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn man() -> Box<dyn std::fmt::Display> {
+LL |
+LL |
+LL |     if false {
+LL ~         Box::new(0i32)
+LL |     } else {
+LL ~         Box::new(1u32)
+   |
+
+error: aborting due to 15 previous errors
 
 Some errors have detailed explanations: E0308, E0746.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/rpit-not-sized.rs
+++ b/tests/ui/impl-trait/rpit-not-sized.rs
@@ -1,5 +1,6 @@
 fn foo() -> impl ?Sized {
     //~^ ERROR the size for values of type `impl ?Sized` cannot be known at compilation time
+    //~| ERROR the size for values of type `impl ?Sized` cannot be known at compilation time
     ()
 }
 

--- a/tests/ui/impl-trait/rpit-not-sized.stderr
+++ b/tests/ui/impl-trait/rpit-not-sized.stderr
@@ -7,6 +7,16 @@ LL | fn foo() -> impl ?Sized {
    = help: the trait `Sized` is not implemented for `impl ?Sized`
    = note: the return type of a function must have a statically known size
 
-error: aborting due to 1 previous error
+error[E0277]: the size for values of type `impl ?Sized` cannot be known at compilation time
+  --> $DIR/rpit-not-sized.rs:1:13
+   |
+LL | fn foo() -> impl ?Sized {
+   |             ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `impl ?Sized`
+   = note: the return type of a function must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/issues/issue-18107.rs
+++ b/tests/ui/issues/issue-18107.rs
@@ -1,8 +1,8 @@
 pub trait AbstractRenderer {}
 
-fn _create_render(_: &()) ->
-    dyn AbstractRenderer
+fn _create_render(_: &()) -> dyn AbstractRenderer
 //~^ ERROR return type cannot be a trait object without pointer indirection
+//~| ERROR return type cannot be a trait object without pointer indirection
 {
     match 0 {
         _ => unimplemented!()

--- a/tests/ui/issues/issue-18107.stderr
+++ b/tests/ui/issues/issue-18107.stderr
@@ -1,23 +1,44 @@
 error[E0746]: return type cannot be a trait object without pointer indirection
-  --> $DIR/issue-18107.rs:4:5
+  --> $DIR/issue-18107.rs:3:30
    |
-LL |     dyn AbstractRenderer
-   |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+LL | fn _create_render(_: &()) -> dyn AbstractRenderer
+   |                              ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
 help: consider returning an `impl Trait` instead of a `dyn Trait`
    |
-LL -     dyn AbstractRenderer
-LL +     impl AbstractRenderer
+LL - fn _create_render(_: &()) -> dyn AbstractRenderer
+LL + fn _create_render(_: &()) -> impl AbstractRenderer
    |
 help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
    |
-LL ~     Box<dyn AbstractRenderer>
+LL ~ fn _create_render(_: &()) -> Box<dyn AbstractRenderer>
 LL |
-LL | {
+...
 LL |     match 0 {
 LL ~         _ => Box::new(unimplemented!())
    |
 
-error: aborting due to 1 previous error
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/issue-18107.rs:3:30
+   |
+LL | fn _create_render(_: &()) -> dyn AbstractRenderer
+   |                              ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn _create_render(_: &()) -> dyn AbstractRenderer
+LL + fn _create_render(_: &()) -> impl AbstractRenderer
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn _create_render(_: &()) -> Box<dyn AbstractRenderer>
+LL |
+...
+LL |     match 0 {
+LL ~         _ => Box::new(unimplemented!())
+   |
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0746`.

--- a/tests/ui/issues/issue-54410.stderr
+++ b/tests/ui/issues/issue-54410.stderr
@@ -5,6 +5,7 @@ LL |     pub static mut symbol: [i8];
    |                            ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i8]`
+   = note: statics and constants must have a statically known size
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/issue-24446.rs
+++ b/tests/ui/static/issue-24446.rs
@@ -1,6 +1,7 @@
 fn main() {
     static foo: dyn Fn() -> u32 = || -> u32 {
         //~^ ERROR the size for values of type
+        //~| ERROR the size for values of type
         //~| ERROR cannot be shared between threads safely
         //~| ERROR mismatched types
         0

--- a/tests/ui/static/issue-24446.stderr
+++ b/tests/ui/static/issue-24446.stderr
@@ -14,6 +14,7 @@ LL |     static foo: dyn Fn() -> u32 = || -> u32 {
    |                 ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
+   = note: statics and constants must have a statically known size
 
 error[E0308]: mismatched types
   --> $DIR/issue-24446.rs:2:35

--- a/tests/ui/static/issue-24446.stderr
+++ b/tests/ui/static/issue-24446.stderr
@@ -16,19 +16,30 @@ LL |     static foo: dyn Fn() -> u32 = || -> u32 {
    = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
    = note: statics and constants must have a statically known size
 
+error[E0277]: the size for values of type `(dyn Fn() -> u32 + 'static)` cannot be known at compilation time
+  --> $DIR/issue-24446.rs:2:17
+   |
+LL |     static foo: dyn Fn() -> u32 = || -> u32 {
+   |                 ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0308]: mismatched types
   --> $DIR/issue-24446.rs:2:35
    |
 LL |       static foo: dyn Fn() -> u32 = || -> u32 {
    |  ___________________________________^
 ...  |
+LL | |         0
 LL | |     };
    | |_____^ expected `dyn Fn`, found closure
    |
    = note: expected trait object `(dyn Fn() -> u32 + 'static)`
                    found closure `{closure@$DIR/issue-24446.rs:2:35: 2:44}`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/statics/unsized_type2.rs
+++ b/tests/ui/statics/unsized_type2.rs
@@ -14,6 +14,7 @@ pub struct Bar {
 pub static WITH_ERROR: Foo = Foo { version: 0 };
 //~^ ERROR the size for values of type `str` cannot be known at compilation time
 //~| ERROR the size for values of type `str` cannot be known at compilation time
+//~| ERROR the size for values of type `str` cannot be known at compilation time
 //~| ERROR mismatched types
 
 pub static USE_WITH_ERROR: Bar = Bar { ok: &[], bad: &WITH_ERROR };

--- a/tests/ui/statics/unsized_type2.stderr
+++ b/tests/ui/statics/unsized_type2.stderr
@@ -10,6 +10,7 @@ note: required because it appears within the type `Foo`
    |
 LL | pub struct Foo {
    |            ^^^
+   = note: statics and constants must have a statically known size
 
 error[E0308]: mismatched types
   --> $DIR/unsized_type2.rs:14:45

--- a/tests/ui/statics/unsized_type2.stderr
+++ b/tests/ui/statics/unsized_type2.stderr
@@ -12,6 +12,21 @@ LL | pub struct Foo {
    |            ^^^
    = note: statics and constants must have a statically known size
 
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/unsized_type2.rs:14:24
+   |
+LL | pub static WITH_ERROR: Foo = Foo { version: 0 };
+   |                        ^^^ doesn't have a size known at compile-time
+   |
+   = help: within `Foo`, the trait `Sized` is not implemented for `str`
+note: required because it appears within the type `Foo`
+  --> $DIR/unsized_type2.rs:5:12
+   |
+LL | pub struct Foo {
+   |            ^^^
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0308]: mismatched types
   --> $DIR/unsized_type2.rs:14:45
    |
@@ -32,7 +47,7 @@ LL | pub struct Foo {
    |            ^^^
    = note: structs must have a statically known size to be initialized
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/suggestions/dyn-incompatible-trait-references-self.rs
+++ b/tests/ui/suggestions/dyn-incompatible-trait-references-self.rs
@@ -4,6 +4,7 @@ trait Trait {
     fn bat(&self) -> Self {}
     //~^ ERROR mismatched types
     //~| ERROR the size for values of type `Self` cannot be known
+    //~| ERROR the size for values of type `Self` cannot be known
 }
 
 fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` is not dyn compatible

--- a/tests/ui/suggestions/dyn-incompatible-trait-references-self.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-references-self.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Trait` is not dyn compatible
-  --> $DIR/dyn-incompatible-trait-references-self.rs:9:12
+  --> $DIR/dyn-incompatible-trait-references-self.rs:10:12
    |
 LL | fn bar(x: &dyn Trait) {}
    |            ^^^^^^^^^ `Trait` is not dyn compatible
@@ -19,14 +19,14 @@ LL |     fn bat(&self) -> Self {}
    = help: consider moving `bat` to another trait
 
 error[E0038]: the trait `Other` is not dyn compatible
-  --> $DIR/dyn-incompatible-trait-references-self.rs:13:12
+  --> $DIR/dyn-incompatible-trait-references-self.rs:14:12
    |
 LL | fn foo(x: &dyn Other) {}
    |            ^^^^^^^^^ `Other` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/dyn-incompatible-trait-references-self.rs:11:14
+  --> $DIR/dyn-incompatible-trait-references-self.rs:12:14
    |
 LL | trait Other: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
@@ -73,7 +73,20 @@ LL |     fn bat(&self) -> Self {}
    = note: expected type parameter `Self`
                    found unit type `()`
 
-error: aborting due to 5 previous errors
+error[E0277]: the size for values of type `Self` cannot be known at compilation time
+  --> $DIR/dyn-incompatible-trait-references-self.rs:4:22
+   |
+LL |     fn bat(&self) -> Self {}
+   |                      ^^^^ doesn't have a size known at compile-time
+   |
+   = note: the return type of a function must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider further restricting `Self`
+   |
+LL |     fn bat(&self) -> Self where Self: Sized {}
+   |                           +++++++++++++++++
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0038, E0277, E0308.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.rs
+++ b/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.rs
@@ -8,6 +8,7 @@ type Fn = dyn FnOnce() -> u8;
 const TEST: Fn = some_fn;
 //~^ ERROR cannot find value `some_fn` in this scope
 //~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+//~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
 const TEST2: (Fn, u8) = (TEST, 0);
 //~^ ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
 //~| ERROR the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time

--- a/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
+++ b/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
@@ -11,6 +11,7 @@ LL | const TEST: Fn = some_fn;
    |             ^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
+   = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
   --> $DIR/ice-unsized-tuple-const-issue-121443.rs:11:14

--- a/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
+++ b/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
@@ -14,7 +14,17 @@ LL | const TEST: Fn = some_fn;
    = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
-  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:11:14
+  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:8:13
+   |
+LL | const TEST: Fn = some_fn;
+   |             ^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
+   = note: statics and constants must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
+  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:12:14
    |
 LL | const TEST2: (Fn, u8) = (TEST, 0);
    |              ^^^^^^^^ doesn't have a size known at compile-time
@@ -23,7 +33,7 @@ LL | const TEST2: (Fn, u8) = (TEST, 0);
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
-  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:11:25
+  --> $DIR/ice-unsized-tuple-const-issue-121443.rs:12:25
    |
 LL | const TEST2: (Fn, u8) = (TEST, 0);
    |                         ^^^^^^^^^ doesn't have a size known at compile-time
@@ -31,7 +41,7 @@ LL | const TEST2: (Fn, u8) = (TEST, 0);
    = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
    = note: only the last element of a tuple may have a dynamically sized type
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/span-bug-issue-121418.rs
+++ b/tests/ui/traits/const-traits/span-bug-issue-121418.rs
@@ -8,6 +8,7 @@ impl const dyn T {
     pub const fn new() -> std::sync::Mutex<dyn T> {}
     //~^ ERROR mismatched types
     //~| ERROR cannot be known at compilation time
+    //~| ERROR cannot be known at compilation time
 }
 
 fn main() {}

--- a/tests/ui/traits/const-traits/span-bug-issue-121418.stderr
+++ b/tests/ui/traits/const-traits/span-bug-issue-121418.stderr
@@ -30,7 +30,19 @@ LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
    = note: expected struct `Mutex<(dyn T + 'static)>`
            found unit type `()`
 
-error: aborting due to 3 previous errors
+error[E0277]: the size for values of type `(dyn T + 'static)` cannot be known at compilation time
+  --> $DIR/span-bug-issue-121418.rs:8:27
+   |
+LL |     pub const fn new() -> std::sync::Mutex<dyn T> {}
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: within `Mutex<(dyn T + 'static)>`, the trait `Sized` is not implemented for `(dyn T + 'static)`
+note: required because it appears within the type `Mutex<(dyn T + 'static)>`
+  --> $SRC_DIR/std/src/sync/poison/mutex.rs:LL:COL
+   = note: the return type of a function must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.rs
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.rs
@@ -13,9 +13,9 @@ fn main() {
 }
 
 fn weird0() -> impl Sized + !Sized {}
-//~^ ERROR type mismatch resolving
+//~^ ERROR the trait bound `(): !Sized` is not satisfied
 fn weird1() -> impl !Sized + Sized {}
-//~^ ERROR type mismatch resolving
+//~^ ERROR the trait bound `(): !Sized` is not satisfied
 fn weird2() -> impl !Sized {}
-//~^ ERROR type mismatch resolving
+//~^ ERROR the trait bound `(): !Sized` is not satisfied
 //~| ERROR the size for values of type

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.stderr
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-bound.stderr
@@ -7,23 +7,23 @@ LL | fn weird2() -> impl !Sized {}
    = help: the trait `Sized` is not implemented for `impl !Sized`
    = note: the return type of a function must have a statically known size
 
-error[E0271]: type mismatch resolving `impl !Sized + Sized == ()`
+error[E0277]: the trait bound `(): !Sized` is not satisfied
   --> $DIR/opaque-type-unsatisfied-bound.rs:15:16
    |
 LL | fn weird0() -> impl Sized + !Sized {}
-   |                ^^^^^^^^^^^^^^^^^^^ types differ
+   |                ^^^^^^^^^^^^^^^^^^^ the trait bound `(): !Sized` is not satisfied
 
-error[E0271]: type mismatch resolving `impl !Sized + Sized == ()`
+error[E0277]: the trait bound `(): !Sized` is not satisfied
   --> $DIR/opaque-type-unsatisfied-bound.rs:17:16
    |
 LL | fn weird1() -> impl !Sized + Sized {}
-   |                ^^^^^^^^^^^^^^^^^^^ types differ
+   |                ^^^^^^^^^^^^^^^^^^^ the trait bound `(): !Sized` is not satisfied
 
-error[E0271]: type mismatch resolving `impl !Sized == ()`
+error[E0277]: the trait bound `(): !Sized` is not satisfied
   --> $DIR/opaque-type-unsatisfied-bound.rs:19:16
    |
 LL | fn weird2() -> impl !Sized {}
-   |                ^^^^^^^^^^^ types differ
+   |                ^^^^^^^^^^^ the trait bound `(): !Sized` is not satisfied
 
 error[E0277]: the trait bound `impl !Trait: Trait` is not satisfied
   --> $DIR/opaque-type-unsatisfied-bound.rs:12:13
@@ -41,5 +41,4 @@ LL | fn consume(_: impl Trait) {}
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0271, E0277.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.rs
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.rs
@@ -3,6 +3,6 @@
 #![feature(negative_bounds, unboxed_closures)]
 
 fn produce() -> impl !Fn<(u32,)> {}
-//~^ ERROR type mismatch resolving
+//~^ ERROR the trait bound `(): !Fn(u32)` is not satisfied
 
 fn main() {}

--- a/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.stderr
+++ b/tests/ui/traits/negative-bounds/opaque-type-unsatisfied-fn-bound.stderr
@@ -1,9 +1,9 @@
-error[E0271]: type mismatch resolving `impl !Fn<(u32,)> == ()`
+error[E0277]: the trait bound `(): !Fn(u32)` is not satisfied
   --> $DIR/opaque-type-unsatisfied-fn-bound.rs:5:17
    |
 LL | fn produce() -> impl !Fn<(u32,)> {}
-   |                 ^^^^^^^^^^^^^^^^ types differ
+   |                 ^^^^^^^^^^^^^^^^ the trait bound `(): !Fn(u32)` is not satisfied
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/trivial-bounds/trivial-bounds-leak.rs
+++ b/tests/ui/trivial-bounds/trivial-bounds-leak.rs
@@ -9,7 +9,9 @@ fn return_str() -> str where str: Sized {
     *"Sized".to_string().into_boxed_str()
 }
 
-fn cant_return_str() -> str { //~ ERROR
+fn cant_return_str() -> str {
+    //~^ ERROR the size for values of type `str` cannot be known at compilation time
+    //~| ERROR the size for values of type `str` cannot be known at compilation time
     *"Sized".to_string().into_boxed_str()
 }
 

--- a/tests/ui/trivial-bounds/trivial-bounds-leak.stderr
+++ b/tests/ui/trivial-bounds/trivial-bounds-leak.stderr
@@ -7,8 +7,18 @@ LL | fn cant_return_str() -> str {
    = help: the trait `Sized` is not implemented for `str`
    = note: the return type of a function must have a statically known size
 
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/trivial-bounds-leak.rs:12:25
+   |
+LL | fn cant_return_str() -> str {
+   |                         ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: the return type of a function must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0599]: no method named `test` found for type `i32` in the current scope
-  --> $DIR/trivial-bounds-leak.rs:24:10
+  --> $DIR/trivial-bounds-leak.rs:26:10
    |
 LL |     3i32.test();
    |          ^^^^ method not found in `i32`
@@ -21,7 +31,7 @@ LL | pub trait Foo {
    | ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/trivial-bounds-leak.rs:25:15
+  --> $DIR/trivial-bounds-leak.rs:27:15
    |
 LL |     Foo::test(&4i32);
    |     --------- ^^^^^ the trait `Foo` is not implemented for `i32`
@@ -35,7 +45,7 @@ LL | pub trait Foo {
    | ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/trivial-bounds-leak.rs:26:22
+  --> $DIR/trivial-bounds-leak.rs:28:22
    |
 LL |     generic_function(5i32);
    |     ---------------- ^^^^ the trait `Foo` is not implemented for `i32`
@@ -48,12 +58,12 @@ help: this trait has no implementations, consider adding one
 LL | pub trait Foo {
    | ^^^^^^^^^^^^^
 note: required by a bound in `generic_function`
-  --> $DIR/trivial-bounds-leak.rs:29:24
+  --> $DIR/trivial-bounds-leak.rs:31:24
    |
 LL | fn generic_function<T: Foo>(t: T) {}
    |                        ^^^ required by this bound in `generic_function`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0277, E0599.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/typeck/issue-105946.rs
+++ b/tests/ui/typeck/issue-105946.rs
@@ -1,5 +1,6 @@
 fn digit() -> str {
     //~^ ERROR the size for values of type
+    //~| ERROR the size for values of type
     return {};
     //~^ ERROR: mismatched types [E0308]
 }

--- a/tests/ui/typeck/issue-105946.stderr
+++ b/tests/ui/typeck/issue-105946.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `_y` in this scope
-  --> $DIR/issue-105946.rs:7:10
+  --> $DIR/issue-105946.rs:8:10
    |
 LL |     let [_y..] = [Box::new(1), Box::new(2)];
    |          ^^ not found in this scope
@@ -10,7 +10,7 @@ LL |     let [_y @ ..] = [Box::new(1), Box::new(2)];
    |             +
 
 error[E0658]: `X..` patterns in slices are experimental
-  --> $DIR/issue-105946.rs:7:10
+  --> $DIR/issue-105946.rs:8:10
    |
 LL |     let [_y..] = [Box::new(1), Box::new(2)];
    |          ^^^^
@@ -29,18 +29,28 @@ LL | fn digit() -> str {
    = note: the return type of a function must have a statically known size
 
 error[E0308]: mismatched types
-  --> $DIR/issue-105946.rs:3:12
+  --> $DIR/issue-105946.rs:4:12
    |
 LL |     return {};
    |            ^^ expected `str`, found `()`
 
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/issue-105946.rs:1:15
+   |
+LL | fn digit() -> str {
+   |               ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: the return type of a function must have a statically known size
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error[E0527]: pattern requires 1 element but array has 2
-  --> $DIR/issue-105946.rs:7:9
+  --> $DIR/issue-105946.rs:8:9
    |
 LL |     let [_y..] = [Box::new(1), Box::new(2)];
    |         ^^^^^^ expected 2 elements
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0277, E0308, E0425, E0527, E0658.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/unsized/box-instead-of-dyn-fn.rs
+++ b/tests/ui/unsized/box-instead-of-dyn-fn.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 
 fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> dyn Fn() + 'a {
     //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     if a % 2 == 0 {
         move || println!("{a}")
     } else {

--- a/tests/ui/unsized/box-instead-of-dyn-fn.stderr
+++ b/tests/ui/unsized/box-instead-of-dyn-fn.stderr
@@ -13,10 +13,32 @@ help: alternatively, box the return type, and wrap all of the returned values in
    |
 LL ~ fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> Box<dyn Fn() + 'a> {
 LL |
+LL |
 LL |     if a % 2 == 0 {
 LL ~         Box::new(move || println!("{a}"))
    |
 
-error: aborting due to 1 previous error
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/box-instead-of-dyn-fn.rs:5:56
+   |
+LL | fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> dyn Fn() + 'a {
+   |                                                        ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> dyn Fn() + 'a {
+LL + fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> impl Fn() + 'a {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL ~ fn print_on_or_the_other<'a>(a: i32, b: &'a String) -> Box<dyn Fn() + 'a> {
+LL |
+LL |
+LL |     if a % 2 == 0 {
+LL ~         Box::new(move || println!("{a}"))
+   |
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0746`.

--- a/tests/ui/unsized/issue-91801.rs
+++ b/tests/ui/unsized/issue-91801.rs
@@ -7,6 +7,7 @@ pub static ALL_VALIDATORS: &[(&'static str, &'static Validator)] =
 
 fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Validator<'a> {
     //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     return Box::new(move |something: &'_ Something| -> Result<(), ()> {
         first(something).or_else(|_| second(something))
     });

--- a/tests/ui/unsized/issue-91801.stderr
+++ b/tests/ui/unsized/issue-91801.stderr
@@ -13,6 +13,22 @@ help: alternatively, box the return type, and wrap all of the returned values in
 LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Box<dyn Validator<'a>> {
    |                                                                             +++++++              +
 
-error: aborting due to 1 previous error
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/issue-91801.rs:8:77
+   |
+LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Validator<'a> {
+   |                                                                             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> impl Validator<'a> {
+   |                                                                             ++++
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL | fn or<'a>(first: &'static Validator<'a>, second: &'static Validator<'a>) -> Box<dyn Validator<'a>> {
+   |                                                                             +++++++              +
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0746`.

--- a/tests/ui/unsized/issue-91803.rs
+++ b/tests/ui/unsized/issue-91803.rs
@@ -2,6 +2,7 @@ trait Foo<'a> {}
 
 fn or<'a>(first: &'static dyn Foo<'a>) -> dyn Foo<'a> {
     //~^ ERROR return type cannot be a trait object without pointer indirection
+    //~| ERROR return type cannot be a trait object without pointer indirection
     return Box::new(panic!());
 }
 

--- a/tests/ui/unsized/issue-91803.stderr
+++ b/tests/ui/unsized/issue-91803.stderr
@@ -14,6 +14,23 @@ help: alternatively, box the return type, and wrap all of the returned values in
 LL | fn or<'a>(first: &'static dyn Foo<'a>) -> Box<dyn Foo<'a>> {
    |                                           ++++           +
 
-error: aborting due to 1 previous error
+error[E0746]: return type cannot be a trait object without pointer indirection
+  --> $DIR/issue-91803.rs:3:43
+   |
+LL | fn or<'a>(first: &'static dyn Foo<'a>) -> dyn Foo<'a> {
+   |                                           ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: consider returning an `impl Trait` instead of a `dyn Trait`
+   |
+LL - fn or<'a>(first: &'static dyn Foo<'a>) -> dyn Foo<'a> {
+LL + fn or<'a>(first: &'static dyn Foo<'a>) -> impl Foo<'a> {
+   |
+help: alternatively, box the return type, and wrap all of the returned values in `Box::new`
+   |
+LL | fn or<'a>(first: &'static dyn Foo<'a>) -> Box<dyn Foo<'a>> {
+   |                                           ++++           +
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0746`.


### PR DESCRIPTION
Puts the sized check back into typeck (duplicated -- we still have it in wfcheck) so that we properly taint bodies. These duplicated diagnostics will all be deduplicated with `-Zdeduplicate-diagnostics`, so it's just UI test fallout and not an actual regression in user-facing diagnostics.

We could perhaps do this without duplicating all the diagnostics if we put this check into something like mir build 🤔 Ideally CTFE would just be more fallible to non-WF code but 🤷 

Fixes #137186