### PR TITLE
Emit `llvm.{memcpy,memset}.inline` when no-builtins attribute is enabled

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1565,9 +1565,17 @@ extern "C" LLVMValueRef LLVMRustBuildMemCpy(LLVMBuilderRef B, LLVMValueRef Dst,
                                             unsigned SrcAlign,
                                             LLVMValueRef Size,
                                             bool IsVolatile) {
-  return wrap(unwrap(B)->CreateMemCpy(unwrap(Dst), MaybeAlign(DstAlign),
-                                      unwrap(Src), MaybeAlign(SrcAlign),
-                                      unwrap(Size), IsVolatile));
+  if (unwrap(B)->GetInsertBlock()->getParent()->hasFnAttribute("no-builtins") ||
+      unwrap(B)->GetInsertBlock()->getParent()->hasFnAttribute(
+          "no-builtin-memcpy")) {
+    return wrap(unwrap(B)->CreateMemCpyInline(unwrap(Dst), MaybeAlign(DstAlign),
+                                              unwrap(Src), MaybeAlign(SrcAlign),
+                                              unwrap(Size), IsVolatile));
+  } else {
+    return wrap(unwrap(B)->CreateMemCpy(unwrap(Dst), MaybeAlign(DstAlign),
+                                        unwrap(Src), MaybeAlign(SrcAlign),
+                                        unwrap(Size), IsVolatile));
+  }
 }
 
 extern "C" LLVMValueRef
@@ -1583,8 +1591,16 @@ extern "C" LLVMValueRef LLVMRustBuildMemSet(LLVMBuilderRef B, LLVMValueRef Dst,
                                             unsigned DstAlign, LLVMValueRef Val,
                                             LLVMValueRef Size,
                                             bool IsVolatile) {
-  return wrap(unwrap(B)->CreateMemSet(unwrap(Dst), unwrap(Val), unwrap(Size),
-                                      MaybeAlign(DstAlign), IsVolatile));
+  if (unwrap(B)->GetInsertBlock()->getParent()->hasFnAttribute("no-builtins") ||
+      unwrap(B)->GetInsertBlock()->getParent()->hasFnAttribute(
+          "no-builtin-memset")) {
+    return wrap(unwrap(B)->CreateMemSetInline(unwrap(Dst), MaybeAlign(DstAlign),
+                                              unwrap(Val), unwrap(Size),
+                                              IsVolatile));
+  } else {
+    return wrap(unwrap(B)->CreateMemSet(unwrap(Dst), unwrap(Val), unwrap(Size),
+                                        MaybeAlign(DstAlign), IsVolatile));
+  }
 }
 
 // Polyfill for `LLVMBuildCallBr`, which was added in LLVM 19.

--- a/tests/codegen/no_builtin-mem.rs
+++ b/tests/codegen/no_builtin-mem.rs
@@ -1,0 +1,16 @@
+#![crate_type = "lib"]
+#![no_builtins]
+
+type T = [u8; 256];
+
+#[no_mangle]
+pub fn f() -> [i32; 1000] {
+    // CHECK: call void @llvm.memset.inline.{{.*}}(ptr nonnull align 4 %{{.*}}, i8 0, i64 4000, i1 false)
+    [0; 1000]
+}
+
+#[no_mangle]
+pub fn g(x: &[i32; 1000], y: &mut [i32; 1000]) {
+    // CHECK: call void @llvm.memcpy.inline.{{.*}}(ptr nonnull align 4 %{{.*}}, ptr nonnull align 4 %{{.*}}, i64 4000, i1 false)
+    *y = *x;
+}


### PR DESCRIPTION
Today we emit `memcpy`/`memset` llvm intrinsics in `rustc_codegen_llvm` even when `#![no_builtins]` is enabled on the crate. This PR adjusts LLVM's `memcpy`/`memset` lowering to not do that, since llvm doesn't care to avoid builtins even when the `"no-builtins"` attribute is enabled on the function.

Curiously, I didn't find an inline version for `memmove`, lol.

The approach that I took with reading the function attrs on the C++ side is a bit janky, but I couldn't find a good way to thread `no_builtins: bool` through the various `BuilderCx`/`CodegenCx`/`Builder`/`LlvmModule`/etc that we have in `rustc_codegen_llvm`. This seems to be how clang handles lowering inline builtins too -- reading the attrs directly from the function it's building.

I also added support for the `"no-builtin-memcpy"`/`"no-builtin-memmove"` attrs even though Rust doesn't emit those today, because it wasn't difficult and it's possible we could add more granularity than `#![no_builtins]` in the future.

r? @nikic perhaps? I have no idea who else reviews LLVM codegen in rustc, so please reassign if you're busy or not the right person for this. I'm also open to other impl strategies.