### PR TITLE
Call implementations of the Fn* traits on references

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -224,8 +224,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             //
             // The simplest fix by far is to just ignore this case and deref again,
             // so we wind up with `FnMut::call_mut(&mut *f, ())`.
-            ty::Ref(..) if autoderef.step_count() == 0 => {
-                return None;
+            ty::Ref(_, deref_ty, _) if autoderef.step_count() == 0 => {
+                match deref_ty.kind() {
+                    ty::Adt(..) => {},
+                    _ => {return None}
+                }
             }
 
             ty::Error(_) => {

--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -223,12 +223,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             //            ^ without this hack `f` would have to be declared as mutable
             //
             // The simplest fix by far is to just ignore this case and deref again,
-            // so we wind up with `FnMut::call_mut(&mut *f, ())`.
+            // so we wind up with `FnMut::call_mut(&mut *f, ())`.  This does not 
+            // apply to structs, enums, or unions; because they should be `mut` 
+            // if they use `call_mut()`.
             ty::Ref(_, deref_ty, _) if autoderef.step_count() == 0 => {
                 match deref_ty.kind() {
-                    ty::Adt(..) => {},
-                    _ => {return None}
-                }
+                    ty::Adt(..) => {}
+                    _ => return None,
+                };
             }
 
             ty::Error(_) => {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This pull request fixes [Issue #42736](https://github.com/rust-lang/rust/issues/42736), allowing references of `struct`s, `enum`s, and `union`s to implement `Fn*` traits and be called.  For example, the code below will compile and run properly.  If approved this should also push [Issue #29625](https://github.com/rust-lang/rust/issues/29625) forward as well.

```
#![feature(fn_traits)]
#![feature(unboxed_closures)]

struct S;

impl FnOnce<()> for &S {
    type Output = ();

    extern "rust-call" fn call_once(self, _arg: ()) {
        println!("Haldo, world!");
    }
}

fn main() {
    let s = S;
    (&s)();
}
```
