### PR TITLE
Ignore fake borrows for packed field check

### DIFF
--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -1364,13 +1364,13 @@ impl PlaceContext {
         matches!(self, PlaceContext::MutatingUse(MutatingUseContext::Drop))
     }
 
-    /// Returns `true` if this place context represents a borrow.
+    /// Returns `true` if this place context represents a borrow, excluding fake borrows
+    /// (which are an artifact of borrowck and not actually borrows in runtime MIR).
     pub fn is_borrow(self) -> bool {
         matches!(
             self,
-            PlaceContext::NonMutatingUse(
-                NonMutatingUseContext::SharedBorrow | NonMutatingUseContext::FakeBorrow
-            ) | PlaceContext::MutatingUse(MutatingUseContext::Borrow)
+            PlaceContext::NonMutatingUse(NonMutatingUseContext::SharedBorrow)
+                | PlaceContext::MutatingUse(MutatingUseContext::Borrow)
         )
     }
 

--- a/tests/ui/lint/unaligned_references_fake_borrow.rs
+++ b/tests/ui/lint/unaligned_references_fake_borrow.rs
@@ -1,0 +1,27 @@
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/137250>.
+
+// Ensure that we don't emit unaligned packed field reference errors for the fake
+// borrows that we generate during match lowering. These fake borrows are there to
+// ensure in *borrow-checking* that we don't modify the value being matched, but
+// they are removed after the MIR is processed by `CleanupPostBorrowck`.
+
+#[repr(packed)]
+pub struct Packed(i32);
+
+fn f(x: Packed) {
+    match &x {
+        Packed(4) => {},
+        _ if true => {},
+        _ => {}
+    }
+
+    match x {
+        Packed(4) => {},
+        _ if true => {},
+        _ => {}
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
We should not emit unaligned packed field reference errors for the fake borrows that we generate during match lowering. 

These fake borrows are there to ensure in *borrow-checking* that we don't modify the value being matched (which is why this only occurs when there's a match guard, in this case `if true`), but they are removed after the MIR is processed by `CleanupPostBorrowck`, since they're really just there to cause borrowck errors if necessary.

I modified `PlaceContext::is_borrow` since that's used by the packed field check:
https://github.com/rust-lang/rust/blob/17c1c329a5512d718b67ef6797538b154016cd34/compiler/rustc_mir_transform/src/check_packed_ref.rs#L40

It's only used in one other place, in the SROA optimization (by which fake borrows are removed, so it doesn't matter):
https://github.com/rust-lang/rust/blob/17c1c329a5512d718b67ef6797538b154016cd34/compiler/rustc_mir_dataflow/src/value_analysis.rs#L922

Fixes https://github.com/rust-lang/rust/issues/137250