### PR TITLE
[perf] benchmark symbol mangling hashed linking

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1265,7 +1265,7 @@ impl Options {
     }
 
     pub fn get_symbol_mangling_version(&self) -> SymbolManglingVersion {
-        self.cg.symbol_mangling_version.unwrap_or(SymbolManglingVersion::Legacy)
+        self.cg.symbol_mangling_version.unwrap_or(SymbolManglingVersion::Hashed)
     }
 }
 


### PR DESCRIPTION
I was chatting with @eddyb and they thought that the hashed symbol mangling might be beneficial for link times. Let's see if that's the case.

(this was cooked up via the web ui on my phone lol I hope it works)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
