### PR TITLE
Allow lazy HTML escaping

### DIFF
--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -189,14 +189,16 @@ impl Cfg {
     }
 
     /// Renders the configuration for long display, as a long plain text description.
-    pub(crate) fn render_long_plain(&self) -> String {
+    pub(crate) fn render_long_plain(&self) -> impl fmt::Display + '_ {
         let on = if self.should_use_with_in_description() { "with" } else { "on" };
 
-        let mut msg = format!("Available {on} {}", Display(self, Format::LongPlain));
-        if self.should_append_only_to_description() {
-            msg.push_str(" only");
-        }
-        msg
+        fmt::from_fn(move |f| {
+            write!(f, "Available {on} {}", Display(self, Format::LongPlain))?;
+            if self.should_append_only_to_description() {
+                f.write_str(" only")?;
+            }
+            Ok(())
+        })
     }
 
     fn should_capitalize_first_letter(&self) -> bool {

--- a/src/librustdoc/html/escape/tests.rs
+++ b/src/librustdoc/html/escape/tests.rs
@@ -47,21 +47,8 @@ fn escape_body_text_with_wbr_makes_sense() {
     use itertools::Itertools as _;
 
     use super::EscapeBodyTextWithWbr as E;
-    const C: [u8; 3] = [b'a', b'A', b'_'];
-    for chars in [
-        C.into_iter(),
-        C.into_iter(),
-        C.into_iter(),
-        C.into_iter(),
-        C.into_iter(),
-        C.into_iter(),
-        C.into_iter(),
-        C.into_iter(),
-    ]
-    .into_iter()
-    .multi_cartesian_product()
-    {
-        let s = String::from_utf8(chars).unwrap();
+    for chars in iter::repeat("aA_").take(8).map(str::chars).multi_cartesian_product() {
+        let s = chars.into_iter().collect::<String>();
         assert_eq!(s.len(), 8);
         let esc = E(&s).to_string();
         assert!(!esc.contains("<wbr><wbr>"));

--- a/src/librustdoc/html/escape/tests.rs
+++ b/src/librustdoc/html/escape/tests.rs
@@ -1,3 +1,11 @@
+use std::iter;
+
+#[test]
+fn escape() {
+    use super::Escape as E;
+    assert_eq!(format!("<Hello> {}", E("<World>")), "<Hello> &lt;World&gt;");
+}
+
 // basic examples
 #[test]
 fn escape_body_text_with_wbr() {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -853,7 +853,7 @@ pub(crate) fn anchor<'a: 'cx, 'cx>(
                 f,
                 r#"<a class="{short_ty}" href="{url}" title="{short_ty} {path}">{text}</a>"#,
                 path = join_with_double_colon(&fqp),
-                text = EscapeBodyText(text.as_str()),
+                text = EscapeBodyText(text),
             )
         } else {
             f.write_str(text.as_str())

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -720,7 +720,7 @@ fn short_item_info(
             }
             DeprecatedSince::Future => String::from("Deprecating in a future version"),
             DeprecatedSince::NonStandard(since) => {
-                format!("Deprecated since {}", Escape(since.as_str()))
+                format!("Deprecated since {}", Escape(since))
             }
             DeprecatedSince::Unspecified | DeprecatedSince::Err => String::from("Deprecated"),
         };
@@ -1518,8 +1518,8 @@ pub(crate) fn notable_traits_button<'a, 'tcx>(
         fmt::from_fn(|f| {
             write!(
                 f,
-                " <a href=\"#\" class=\"tooltip\" data-notable-ty=\"{ty}\">ⓘ</a>",
-                ty = Escape(&format!("{:#}", ty.print(cx))),
+                " <a href=\"#\" class=\"tooltip\" data-notable-ty=\"{ty:#}\">ⓘ</a>",
+                ty = Escape(ty.print(cx)),
             )
         })
     })

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -534,12 +534,16 @@ fn extra_info_tags<'a, 'tcx: 'a>(
     import_def_id: Option<DefId>,
 ) -> impl Display + 'a + Captures<'tcx> {
     fmt::from_fn(move |f| {
-        fn tag_html<'a>(class: &'a str, title: &'a str, contents: &'a str) -> impl Display + 'a {
+        fn tag_html<'a>(
+            class: impl fmt::Display + 'a,
+            title: impl fmt::Display + 'a,
+            contents: impl fmt::Display + 'a,
+        ) -> impl Display + 'a {
             fmt::from_fn(move |f| {
                 write!(
                     f,
                     r#"<wbr><span class="stab {class}" title="{title}">{contents}</span>"#,
-                    title = Escape(title),
+                    title = Escape(&title),
                 )
             })
         }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -8,6 +8,7 @@
 #![feature(debug_closure_helpers)]
 #![feature(file_buffered)]
 #![feature(format_args_nl)]
+#![feature(formatting_options)]
 #![feature(if_let_guard)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(iter_intersperse)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Inspired by [this comment](https://github.com/rust-lang/rust/pull/136828#discussion_r1950073699) by @aDotInTheVoid .
Makes `Escape` and `EscapeBodyText` accept any `impl fmt::Display`, instead of a `&str`, which allows us to avoid a few interim `String` allocations.
This opens up room for more lazifying, but I'll keep those for a separate PR.

Unfortunately, I think there might be a hit to performance because of the double vtable-indirection caused by wrapping a `fmt::Formatter` in another one, but I think that I should be able to gain that perf back by doing more lazy printing (either the small things improvements I made in this PR, or in later ones)

Probably better to review each commit individually.