### PR TITLE
added some new test to check for result and options opt

### DIFF
--- a/tests/codegen/try_question_mark_nop.rs
+++ b/tests/codegen/try_question_mark_nop.rs
@@ -63,6 +63,57 @@ pub fn result_nop_traits_32(x: Result<i32, u32>) -> Result<i32, u32> {
     try { x? }
 }
 
+// CHECK-LABEL: @control_flow_nop_match_32
+#[no_mangle]
+pub fn control_flow_nop_match_32(x: ControlFlow<i32, u32>) -> ControlFlow<i32, u32> {
+    // CHECK: start:
+    // CHECK-NEXT: insertvalue { i32, i32 }
+    // CHECK-NEXT: insertvalue { i32, i32 }
+    // CHECK-NEXT: ret { i32, i32 }
+    match x {
+        Continue(x) => Continue(x),
+        Break(x) => Break(x),
+    }
+}
+
+// CHECK-LABEL: @control_flow_nop_traits_32
+#[no_mangle]
+pub fn control_flow_nop_traits_32(x: ControlFlow<i32, u32>) -> ControlFlow<i32, u32> {
+    // CHECK: start:
+    // CHECK-NEXT: insertvalue { i32, i32 }
+    // CHECK-NEXT: insertvalue { i32, i32 }
+    // CHECK-NEXT: ret { i32, i32 }
+    try { x? }
+}
+
+// CHECK-LABEL: @option_nop_match_64
+#[no_mangle]
+pub fn option_nop_match_64(x: Option<u64>) -> Option<u64> {
+    // CHECK: start:
+    // TWENTY-NEXT: %[[TRUNC:[0-9]+]] = trunc nuw i64 %0 to i1
+    // TWENTY-NEXT: %[[SEL:\.[0-9]+]] = select i1 %[[TRUNC]], i64 %1, i64 undef
+    // CHECK-NEXT: [[REG1:%[0-9a-zA-Z_.]+]] = insertvalue { i64, i64 } poison, i64 %0, 0
+    // NINETEEN-NEXT: [[REG2:%[0-9a-zA-Z_.]+]] = insertvalue { i64, i64 } [[REG1]], i64 %1, 1
+    // TWENTY-NEXT: [[REG2:%[0-9a-zA-Z_.]+]] = insertvalue { i64, i64 } [[REG1]], i64 %[[SEL]], 1
+    // CHECK-NEXT: ret { i64, i64 } [[REG2]]
+    match x {
+        Some(x) => Some(x),
+        None => None,
+    }
+}
+
+// CHECK-LABEL: @option_nop_traits_64
+#[no_mangle]
+pub fn option_nop_traits_64(x: Option<u64>) -> Option<u64> {
+    // CHECK: start:
+    // TWENTY-NEXT: %[[TRUNC:[0-9]+]] = trunc nuw i64 %0 to i1
+    // TWENTY-NEXT: %[[SEL:\.[0-9]+]] = select i1 %[[TRUNC]], i64 %1, i64 undef
+    // CHECK-NEXT: insertvalue { i64, i64 }
+    // CHECK-NEXT: insertvalue { i64, i64 }
+    // CHECK-NEXT: ret { i64, i64 }
+    try { x? }
+}
+
 // CHECK-LABEL: @result_nop_match_64
 #[no_mangle]
 pub fn result_nop_match_64(x: Result<i64, u64>) -> Result<i64, u64> {
@@ -86,6 +137,79 @@ pub fn result_nop_traits_64(x: Result<i64, u64>) -> Result<i64, u64> {
     try { x? }
 }
 
+// CHECK-LABEL: @control_flow_nop_match_64
+#[no_mangle]
+pub fn control_flow_nop_match_64(x: ControlFlow<i64, u64>) -> ControlFlow<i64, u64> {
+    // CHECK: start:
+    // CHECK-NEXT: insertvalue { i64, i64 }
+    // CHECK-NEXT: insertvalue { i64, i64 }
+    // CHECK-NEXT: ret { i64, i64 }
+    match x {
+        Continue(x) => Continue(x),
+        Break(x) => Break(x),
+    }
+}
+
+// CHECK-LABEL: @control_flow_nop_traits_64
+#[no_mangle]
+pub fn control_flow_nop_traits_64(x: ControlFlow<i64, u64>) -> ControlFlow<i64, u64> {
+    // CHECK: start:
+    // CHECK-NEXT: insertvalue { i64, i64 }
+    // CHECK-NEXT: insertvalue { i64, i64 }
+    // CHECK-NEXT: ret { i64, i64 }
+    try { x? }
+}
+
+// CHECK-LABEL: @result_nop_match_128
+#[no_mangle]
+pub fn result_nop_match_128(x: Result<i128, u128>) -> Result<i128, u128> {
+    // CHECK: start:
+    // CHECK-NEXT: getelementptr inbounds {{(nuw )?}}i8
+    // CHECK-NEXT: store i128
+    // CHECK-NEXT: store i128
+    // CHECK-NEXT: ret void
+    match x {
+        Ok(x) => Ok(x),
+        Err(x) => Err(x),
+    }
+}
+
+// CHECK-LABEL: @result_nop_traits_128
+#[no_mangle]
+pub fn result_nop_traits_128(x: Result<i128, u128>) -> Result<i128, u128> {
+    // CHECK: start:
+    // CHECK-NEXT: getelementptr inbounds {{(nuw )?}}i8
+    // CHECK-NEXT: store i128
+    // CHECK-NEXT: store i128
+    // CHECK-NEXT: ret void
+    try { x? }
+}
+
+// CHECK-LABEL: @control_flow_nop_match_128
+#[no_mangle]
+pub fn control_flow_nop_match_128(x: ControlFlow<i128, u128>) -> ControlFlow<i128, u128> {
+    // CHECK: start:
+    // CHECK-NEXT: getelementptr inbounds {{(nuw )?}}i8
+    // CHECK-NEXT: store i128
+    // CHECK-NEXT: store i128
+    // CHECK-NEXT: ret void
+    match x {
+        Continue(x) => Continue(x),
+        Break(x) => Break(x),
+    }
+}
+
+// CHECK-LABEL: @control_flow_nop_traits_128
+#[no_mangle]
+pub fn control_flow_nop_traits_128(x: ControlFlow<i128, u128>) -> ControlFlow<i128, u128> {
+    // CHECK: start:
+    // CHECK-NEXT: getelementptr inbounds {{(nuw )?}}i8
+    // CHECK-NEXT: store i128
+    // CHECK-NEXT: store i128
+    // CHECK-NEXT: ret void
+    try { x? }
+}
+
 // CHECK-LABEL: @result_nop_match_ptr
 #[no_mangle]
 pub fn result_nop_match_ptr(x: Result<usize, Box<()>>) -> Result<usize, Box<()>> {
@@ -106,28 +230,5 @@ pub fn result_nop_traits_ptr(x: Result<u64, NonNull<()>>) -> Result<u64, NonNull
     // CHECK-NEXT: insertvalue { i{{[0-9]+}}, ptr }
     // CHECK-NEXT: insertvalue { i{{[0-9]+}}, ptr }
     // CHECK-NEXT: ret
-    try { x? }
-}
-
-// CHECK-LABEL: @control_flow_nop_match_32
-#[no_mangle]
-pub fn control_flow_nop_match_32(x: ControlFlow<i32, u32>) -> ControlFlow<i32, u32> {
-    // CHECK: start:
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: ret { i32, i32 }
-    match x {
-        Continue(x) => Continue(x),
-        Break(x) => Break(x),
-    }
-}
-
-// CHECK-LABEL: @control_flow_nop_traits_32
-#[no_mangle]
-pub fn control_flow_nop_traits_32(x: ControlFlow<i32, u32>) -> ControlFlow<i32, u32> {
-    // CHECK: start:
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: insertvalue { i32, i32 }
-    // CHECK-NEXT: ret { i32, i32 }
     try { x? }
 }


### PR DESCRIPTION
Apologies for the delay. Finally have some time to get back into contributing.

## Context
- Added some tests to show optimization on result and options for 64 and 128 bits
- Relevant issue https://github.com/rust-lang/rust/issues/101210

## Some newb questions from me
- [x] My local llvm IR has `nuw` in `result_nop_match_128` etc whereas [godbolt version](https://rust.godbolt.org/z/Td9zoT5zn) doesn't have. So I put optional there, but not sure if it's desirable (maybe I'm not using the compiled llvm in the repo). I ran the test with
```bash
./x test tests/codegen/try_question_mark_nop.rs
```
- [x] Unless I'm reading it wrongly, but `option_nop_match_128` and `option_nop_traits_128` look to be **not** optimized away?

Update:
Here's the test for future reference
```rust
// CHECK-LABEL: @option_nop_match_128
#[no_mangle]
pub fn option_nop_match_128(x: Option<i128>) -> Option<i128> {
    // CHECK: start:
    // CHECK-NEXT: %trunc = trunc nuw i128 %0 to i1
    // CHECK-NEXT: br i1 %trunc, label %bb3, label %bb4
    // CHECK: bb3:
    // CHECK-NEXT: %2 = getelementptr inbounds {{(nuw )?}}i8, ptr %_0, i64 16
    // CHECK-NEXT: store i128 %1, ptr %2, align 16
    // CHECK: bb4:
    // CHECK-NEXT: %storemerge = phi i128 [ 1, %bb3 ], [ 0, %start ]
    // CHECK-NEXT: store i128 %storemerge, ptr %_0, align 16
    // CHECK-NEXT: ret void
    match x {
        Some(x) => Some(x),
        None => None,
    }
}
```

r? @scottmcm