### PR TITLE
stabilize ptr::swap_nonoverlapping in const

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3320,7 +3320,6 @@ pub const fn is_val_statically_known<T: Copy>(_arg: T) -> bool {
 #[inline]
 #[rustc_intrinsic]
 #[rustc_intrinsic_const_stable_indirect]
-#[rustc_allow_const_fn_unstable(const_swap_nonoverlapping)] // this is anyway not called since CTFE implements the intrinsic
 pub const unsafe fn typed_swap_nonoverlapping<T>(x: *mut T, y: *mut T) {
     // SAFETY: The caller provided single non-overlapping items behind
     // pointers, so swapping them with `count: 1` is fine.

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -15,7 +15,6 @@
 #![feature(char_max_len)]
 #![feature(clone_to_uninit)]
 #![feature(const_eval_select)]
-#![feature(const_swap_nonoverlapping)]
 #![feature(const_trait_impl)]
 #![feature(core_intrinsics)]
 #![feature(core_intrinsics_fallbacks)]

--- a/library/coretests/tests/ptr.rs
+++ b/library/coretests/tests/ptr.rs
@@ -949,6 +949,10 @@ fn test_const_swap_ptr() {
         // Make sure they still work.
         assert!(*s1.0.ptr == 1);
         assert!(*s2.0.ptr == 666);
+
+        // This is where we'd swap again using a `u8` type and a `count` of `size_of::<T>()` if it
+        // were not for the limitation of `swap_nonoverlapping` around pointers crossing multiple
+        // elements.
     };
 }
 

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -1,7 +1,5 @@
 //@ compile-flags: -Z ui-testing=no
 
-
-#![feature(const_swap_nonoverlapping)]
 use std::{
     mem::{self, MaybeUninit},
     ptr,

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/missing_span_in_backtrace.rs:16:9
+  --> $DIR/missing_span_in_backtrace.rs:14:9
    |
-16 | /         ptr::swap_nonoverlapping(
-17 | |             &mut ptr1 as *mut _ as *mut MaybeUninit<u8>,
-18 | |             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
-19 | |             mem::size_of::<&i32>(),
-20 | |         );
+14 | /         ptr::swap_nonoverlapping(
+15 | |             &mut ptr1 as *mut _ as *mut MaybeUninit<u8>,
+16 | |             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
+17 | |             mem::size_of::<&i32>(),
+18 | |         );
    | |_________^ unable to copy parts of a pointer from memory at ALLOC0
    |
 note: inside `swap_nonoverlapping::<MaybeUninit<u8>>`


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/133668

The blocking issue mentioned there is resolved by documentation. We may in the future actually support such code, but that is blocked on https://github.com/rust-lang/const-eval/issues/72 which is non-trivial to implement. Meanwhile, this completes stabilization of all `const fn` in `ptr`. :)

Here's a version of the problematic example to play around with:
https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=6c390452379fb593e109b8f8ee854d2a

Should be FCP'd with both @rust-lang/libs-api  and @rust-lang/lang  since  `swap_nonoverlapping` is documented to work as an "untyped" operation but due to the limitation mentioned above, that's not entirely true during const evaluation. I expect this limitation will only be hit in niche corner cases, so the benefits of having this function work most of the time outweigh the downsides of users running into this problem. (Note that unsafe code could already hit this limitation before this PR by doing cursed pointer casts, but having it hidden inside `swap_nonoverlapping` feels a bit different.)