### PR TITLE
Tweak "expected ident" parse error to avoid talking about doc comments

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -301,13 +301,6 @@ impl<'a> Parser<'a> {
         &mut self,
         recover: bool,
     ) -> PResult<'a, (Ident, IdentIsRaw)> {
-        if let TokenKind::DocComment(..) = self.prev_token.kind {
-            return Err(self.dcx().create_err(DocCommentDoesNotDocumentAnything {
-                span: self.prev_token.span,
-                missing_comma: None,
-            }));
-        }
-
         let valid_follow = &[
             TokenKind::Eq,
             TokenKind::Colon,
@@ -319,6 +312,15 @@ impl<'a> Parser<'a> {
             TokenKind::CloseDelim(Delimiter::Brace),
             TokenKind::CloseDelim(Delimiter::Parenthesis),
         ];
+        if let TokenKind::DocComment(..) = self.prev_token.kind
+            && valid_follow.contains(&self.token.kind)
+        {
+            let err = self.dcx().create_err(DocCommentDoesNotDocumentAnything {
+                span: self.prev_token.span,
+                missing_comma: None,
+            });
+            return Err(err);
+        }
 
         let mut recovered_ident = None;
         // we take this here so that the correct original token is retained in

--- a/tests/ui/parser/doc-before-bad-variant.rs
+++ b/tests/ui/parser/doc-before-bad-variant.rs
@@ -1,0 +1,6 @@
+enum TestEnum {
+    Works,
+    /// Some documentation
+    Self, //~ ERROR expected identifier, found keyword `Self`
+    //~^ HELP enum variants can be
+}

--- a/tests/ui/parser/doc-before-bad-variant.stderr
+++ b/tests/ui/parser/doc-before-bad-variant.stderr
@@ -1,0 +1,13 @@
+error: expected identifier, found keyword `Self`
+  --> $DIR/doc-before-bad-variant.rs:4:5
+   |
+LL | enum TestEnum {
+   |      -------- while parsing this enum
+...
+LL |     Self,
+   |     ^^^^ expected identifier, found keyword
+   |
+   = help: enum variants can be `Variant`, `Variant = <integer>`, `Variant(Type, ..., TypeN)` or `Variant { fields: Types }`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/doc-before-syntax-error.rs
+++ b/tests/ui/parser/doc-before-syntax-error.rs
@@ -1,0 +1,2 @@
+/// Some documentation
+<> //~ ERROR expected identifier

--- a/tests/ui/parser/doc-before-syntax-error.stderr
+++ b/tests/ui/parser/doc-before-syntax-error.stderr
@@ -1,0 +1,8 @@
+error: expected identifier, found `<`
+  --> $DIR/doc-before-syntax-error.rs:2:1
+   |
+LL | <>
+   | ^ expected identifier
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
When encountering a doc comment without an identifier after, we'd unconditionally state "this doc comment doesn't document anything", swallowing the *actual* error which is that the thing *after* the doc comment wasn't expected. Added a check that the found token is something that "conceptually" closes the previous item before emitting that error, otherwise just complain about the missing identifier.

In both of the following cases, the syntax error follows a doc comment:
```
error: expected identifier, found keyword `Self`
  --> $DIR/doc-before-bad-variant.rs:4:5
   |
LL | enum TestEnum {
   |      -------- while parsing this enum
...
LL |     Self,
   |     ^^^^ expected identifier, found keyword
   |
   = help: enum variants can be `Variant`, `Variant = <integer>`, `Variant(Type, ..., TypeN)` or `Variant { fields: Types }`
```
```
error: expected identifier, found `<`
  --> $DIR/doc-before-syntax-error.rs:2:1
   |
LL | <>
   | ^ expected identifier
```

Fix #71982.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
