### PR TITLE
librustdoc: Use `pulldown-cmark-escape` for HTML escaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4577,6 +4577,7 @@ dependencies = [
  "itertools",
  "minifier",
  "pulldown-cmark 0.9.6",
+ "pulldown-cmark-escape",
  "regex",
  "rinja",
  "rustdoc-json-types",

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -15,6 +15,7 @@ itertools = "0.12"
 indexmap = "2"
 minifier = { version = "0.3.5", default-features = false }
 pulldown-cmark-old = { version = "0.9.6", package = "pulldown-cmark", default-features = false }
+pulldown-cmark-escape = { version = "0.11.0", features = ["simd"] }
 regex = "1"
 rustdoc-json-types = { path = "../rustdoc-json-types" }
 serde_json = "1.0"

--- a/src/librustdoc/html/escape.rs
+++ b/src/librustdoc/html/escape.rs
@@ -5,6 +5,7 @@
 
 use std::fmt;
 
+use pulldown_cmark_escape::FmtWriter;
 use unicode_segmentation::UnicodeSegmentation;
 
 /// Wrapper struct which will emit the HTML-escaped version of the contained
@@ -13,31 +14,7 @@ pub(crate) struct Escape<'a>(pub &'a str);
 
 impl fmt::Display for Escape<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Because the internet is always right, turns out there's not that many
-        // characters to escape: http://stackoverflow.com/questions/7381974
-        let Escape(s) = *self;
-        let pile_o_bits = s;
-        let mut last = 0;
-        for (i, ch) in s.char_indices() {
-            let s = match ch {
-                '>' => "&gt;",
-                '<' => "&lt;",
-                '&' => "&amp;",
-                '\'' => "&#39;",
-                '"' => "&quot;",
-                _ => continue,
-            };
-            fmt.write_str(&pile_o_bits[last..i])?;
-            fmt.write_str(s)?;
-            // NOTE: we only expect single byte characters here - which is fine as long as we
-            // only match single byte characters
-            last = i + 1;
-        }
-
-        if last < s.len() {
-            fmt.write_str(&pile_o_bits[last..])?;
-        }
-        Ok(())
+        pulldown_cmark_escape::escape_html(FmtWriter(fmt), self.0)
     }
 }
 
@@ -51,29 +28,7 @@ pub(crate) struct EscapeBodyText<'a>(pub &'a str);
 
 impl fmt::Display for EscapeBodyText<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Because the internet is always right, turns out there's not that many
-        // characters to escape: http://stackoverflow.com/questions/7381974
-        let EscapeBodyText(s) = *self;
-        let pile_o_bits = s;
-        let mut last = 0;
-        for (i, ch) in s.char_indices() {
-            let s = match ch {
-                '>' => "&gt;",
-                '<' => "&lt;",
-                '&' => "&amp;",
-                _ => continue,
-            };
-            fmt.write_str(&pile_o_bits[last..i])?;
-            fmt.write_str(s)?;
-            // NOTE: we only expect single byte characters here - which is fine as long as we
-            // only match single byte characters
-            last = i + 1;
-        }
-
-        if last < s.len() {
-            fmt.write_str(&pile_o_bits[last..])?;
-        }
-        Ok(())
+        pulldown_cmark_escape::escape_html_body_text(FmtWriter(fmt), self.0)
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Implementation of @notriddle 's [suggestion](https://github.com/rust-lang/rust/pull/137274#issuecomment-2669001585).
Somewhat related to #137274 , but the two PRs should be complementary.

Local perf results look like a nice improvement! (so would love a perf run on the CI)