### PR TITLE
doc: Remove a wrong information in `core::ptr::eq<T>()`

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2031,8 +2031,7 @@ pub(crate) unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usize {
 /// not anything that implements `PartialEq`.
 ///
 /// This can be used to compare `&T` references (which coerce to `*const T` implicitly)
-/// by their address rather than comparing the values they point to
-/// (which is what the `PartialEq for &T` implementation does).
+/// by their address rather than comparing the values they point to.
 ///
 /// When comparing wide pointers, both the address and the metadata are tested for equality.
 /// However, note that comparing trait object pointers (`*const dyn Trait`) is unreliable: pointers


### PR DESCRIPTION
It says that `PartialEq for &T` implementation calls `core::ptr::eq<T>` but this is not true as `&T` does not implement `PartialEq` unless `T` implements `PartialEq`; the following code is not compiled.

```rust
struct Foo;

fn main() {
    let a = Foo;
    let b = Foo;
    assert!(&a == &b);
}
```
```
error[E0369]: binary operation `==` cannot be applied to type `&Foo`
 --> src/main.rs:6:16
  |
6 |     assert!(&a == &b);
  |             -- ^^ -- &Foo
  |             |
  |             &Foo
  |
note: an implementation of `PartialEq` might be missing for `Foo`
 --> src/main.rs:1:1
  |
1 | struct Foo;
  | ^^^^^^^^^^ must implement `PartialEq`
help: consider annotating `Foo` with `#[derive(PartialEq)]`
  |
1 + #[derive(PartialEq)]
2 | struct Foo;
  |

For more information about this error, try `rustc --explain E0369`.
``` 

And even if it implements `PartialEq`, it does not actually call `core::ptr::eq<T>` for the reference comparision.

```rust
#[derive(PartialEq)]
struct Foo;

fn main() {
    let a = Foo;
    let b = Foo;
    assert!(&a == &b);
    assert!(!std::ptr::eq::<Foo>(&a, &b));
}
```