### PR TITLE
Check signature WF when lowering MIR body

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -745,14 +745,10 @@ fn check_static_linkage(tcx: TyCtxt<'_>, def_id: LocalDefId) {
 pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) {
     match tcx.def_kind(def_id) {
         DefKind::Static { .. } => {
-            tcx.ensure_ok().typeck(def_id);
-            maybe_check_static_with_link_section(tcx, def_id);
             check_static_inhabited(tcx, def_id);
             check_static_linkage(tcx, def_id);
         }
-        DefKind::Const => {
-            tcx.ensure_ok().typeck(def_id);
-        }
+        DefKind::Const => {}
         DefKind::Enum => {
             check_enum(tcx, def_id);
         }
@@ -766,7 +762,6 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) {
                     ExternAbi::Rust,
                 )
             }
-            // Everything else is checked entirely within check_item_body
         }
         DefKind::Impl { of_trait } => {
             if of_trait && let Some(impl_trait_header) = tcx.impl_trait_header(def_id) {

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -145,7 +145,7 @@ pub fn forbid_intrinsic_abi(tcx: TyCtxt<'_>, sp: Span, abi: ExternAbi) {
     }
 }
 
-fn maybe_check_static_with_link_section(tcx: TyCtxt<'_>, id: LocalDefId) {
+pub(super) fn maybe_check_static_with_link_section(tcx: TyCtxt<'_>, id: LocalDefId) {
     // Only restricted on wasm target for now
     if !tcx.sess.target.is_like_wasm {
         return;

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1108,7 +1108,13 @@ fn check_associated_item(
                 let ty = tcx.type_of(item.def_id).instantiate_identity();
                 let ty = wfcx.normalize(span, Some(WellFormedLoc::Ty(item_id)), ty);
                 wfcx.register_wf_obligation(span, loc, ty.into());
-                check_sized_if_body(wfcx, item.def_id.expect_local(), ty, Some(span));
+                check_sized_if_body(
+                    wfcx,
+                    item.def_id.expect_local(),
+                    ty,
+                    Some(span),
+                    ObligationCauseCode::SizedConstOrStatic,
+                );
                 Ok(())
             }
             ty::AssocKind::Fn => {
@@ -1354,7 +1360,7 @@ fn check_item_type(
                 traits::ObligationCause::new(
                     ty_span,
                     wfcx.body_def_id,
-                    ObligationCauseCode::WellFormed(None),
+                    ObligationCauseCode::SizedConstOrStatic,
                 ),
                 wfcx.param_env,
                 item_ty,
@@ -1698,6 +1704,7 @@ fn check_fn_or_method<'tcx>(
             hir::FnRetTy::Return(ty) => Some(ty.span),
             hir::FnRetTy::DefaultReturn(_) => None,
         },
+        ObligationCauseCode::SizedReturnType,
     );
 }
 
@@ -1706,13 +1713,14 @@ fn check_sized_if_body<'tcx>(
     def_id: LocalDefId,
     ty: Ty<'tcx>,
     maybe_span: Option<Span>,
+    code: ObligationCauseCode<'tcx>,
 ) {
     let tcx = wfcx.tcx();
     if let Some(body) = tcx.hir_maybe_body_owned_by(def_id) {
         let span = maybe_span.unwrap_or(body.value.span);
 
         wfcx.register_bound(
-            ObligationCause::new(span, def_id, traits::ObligationCauseCode::SizedReturnType),
+            ObligationCause::new(span, def_id, code),
             wfcx.param_env,
             ty,
             tcx.require_lang_item(LangItem::Sized, Some(span)),

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -201,7 +201,7 @@ fn check_well_formed(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(), ErrorGua
         hir::Node::ImplItem(item) => check_impl_item(tcx, item),
         hir::Node::ForeignItem(item) => check_foreign_item(tcx, item),
         hir::Node::OpaqueTy(_) => Ok(crate::check::check::check_item_type(tcx, def_id)),
-        _ => unreachable!(),
+        _ => unreachable!("{node:?}"),
     };
 
     if let Some(generics) = node.generics() {

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1806,7 +1806,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         crate::GatherLocalsVisitor::new(&fcx).visit_body(body);
 
         let ty = fcx.check_expr_with_expectation(body.value, expected);
-        fcx.require_type_is_sized(ty, body.value.span, ObligationCauseCode::ConstSized);
+        fcx.require_type_is_sized(ty, body.value.span, ObligationCauseCode::SizedConstOrStatic);
         fcx.write_ty(block.hir_id, ty);
         ty
     }

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -266,7 +266,7 @@ pub enum ObligationCauseCode<'tcx> {
     },
 
     /// Constant expressions must be sized.
-    ConstSized,
+    SizedConstOrStatic,
 
     /// `static` items must have `Sync` type.
     SharedStatic,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3126,8 +3126,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     Applicability::MachineApplicable,
                 );
             }
-            ObligationCauseCode::ConstSized => {
-                err.note("constant expressions must have a statically known size");
+            ObligationCauseCode::SizedConstOrStatic => {
+                err.note("statics and constants must have a statically known size");
             }
             ObligationCauseCode::InlineAsmSized => {
                 err.note("all inline asm arguments must have a statically known size");

--- a/tests/crashes/129095.rs
+++ b/tests/crashes/129095.rs
@@ -1,10 +1,13 @@
 //@ known-bug: rust-lang/rust#129095
 //@ compile-flags: -Zmir-enable-passes=+GVN -Zmir-enable-passes=+Inline -Zvalidate-mir
 
+#![feature(adt_const_params, unsized_const_params)]
+#![allow(incomplete_features)]
+
 pub fn function_with_bytes<const BYTES: &'static [u8; 4]>() -> &'static [u8] {
     BYTES
 }
 
 pub fn main() {
-    assert_eq!(function_with_bytes::<b"AAAAb">(), &[0x41, 0x41, 0x41, 0x41]);
+    assert_eq!(function_with_bytes::<b"AAAAA">(), &[0x41, 0x41, 0x41, 0x41]);
 }

--- a/tests/crashes/132960.rs
+++ b/tests/crashes/132960.rs
@@ -1,6 +1,6 @@
 //@ known-bug: #132960
 
-#![feature(adt_const_params, const_ptr_read, generic_const_exprs)]
+#![feature(adt_const_params, const_ptr_read, generic_const_exprs, unsized_const_params)]
 
 const fn concat_strs<const A: &'static str, const B: &'static str>() -> &'static str
 where

--- a/tests/crashes/134654.rs
+++ b/tests/crashes/134654.rs
@@ -2,6 +2,9 @@
 //@ compile-flags: -Zmir-enable-passes=+GVN -Zmir-enable-passes=+Inline -Zvalidate-mir
 //@ only-x86_64
 
+#![feature(adt_const_params, unsized_const_params)]
+#![allow(incomplete_features)]
+
 fn function_with_bytes<const BYTES:
     &'static [u8; 0xa9008fb6c9d81e42_0e25730562a601c8_u128]>() -> &'static [u8] {
     BYTES

--- a/tests/crashes/135128.rs
+++ b/tests/crashes/135128.rs
@@ -1,6 +1,8 @@
 //@ known-bug: #135128
 //@ compile-flags: -Copt-level=1 --edition=2021
 
+#![feature(trivial_bounds)]
+
 async fn return_str() -> str
 where
     str: Sized,

--- a/tests/crashes/135570.rs
+++ b/tests/crashes/135570.rs
@@ -2,6 +2,9 @@
 //@compile-flags: -Zvalidate-mir -Zmir-enable-passes=+Inline -Copt-level=0 -Zmir-enable-passes=+GVN
 //@ only-x86_64
 
+#![feature(adt_const_params, unsized_const_params)]
+#![allow(incomplete_features)]
+
 fn function_with_bytes<const BYTES: &'static [u8; 0xc7b889180b67b07d_bc1a3c88783d35b5_u128]>(
 ) -> &'static [u8] {
     BYTES

--- a/tests/rustdoc-ui/issues/issue-79494.rs
+++ b/tests/rustdoc-ui/issues/issue-79494.rs
@@ -2,4 +2,4 @@
 
 #![feature(const_transmute)]
 
-const ZST: &[u8] = unsafe { std::mem::transmute(1usize) }; //~ ERROR cannot transmute between types of different sizes, or dependently-sized types
+pub const ZST: &[u8] = unsafe { std::mem::transmute(1usize) }; //~ ERROR cannot transmute between types of different sizes, or dependently-sized types

--- a/tests/rustdoc-ui/issues/issue-79494.stderr
+++ b/tests/rustdoc-ui/issues/issue-79494.stderr
@@ -1,8 +1,8 @@
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/issue-79494.rs:5:29
+  --> $DIR/issue-79494.rs:5:33
    |
-LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
-   |                             ^^^^^^^^^^^^^^^^^^^
+LL | pub const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
+   |                                 ^^^^^^^^^^^^^^^^^^^
    |
    = note: source type: `usize` (64 bits)
    = note: target type: `&[u8]` (128 bits)

--- a/tests/rustdoc-ui/track-diagnostics.rs
+++ b/tests/rustdoc-ui/track-diagnostics.rs
@@ -7,4 +7,5 @@
 
 struct A;
 struct B;
-const S: A = B;
+
+pub const S: A = B;

--- a/tests/rustdoc-ui/track-diagnostics.stderr
+++ b/tests/rustdoc-ui/track-diagnostics.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
   --> $DIR/track-diagnostics.rs:LL:CC
    |
-LL | const S: A = B;
-   |              ^ expected `A`, found `B`
+LL | pub const S: A = B;
+   |                  ^ expected `A`, found `B`
 -Ztrack-diagnostics: created at compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs:LL:CC
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -54,12 +54,6 @@ warning: type `v17` should have an upper camel case name
 LL |     pub struct v17<const v10: usize, const v7: v11> {
    |                ^^^ help: convert the identifier to upper camel case (notice the capitalization): `V17`
 
-error[E0425]: cannot find function `v6` in this scope
-  --> $DIR/unevaluated-const-ice-119731.rs:13:35
-   |
-LL |     const v0: [[usize; v4]; v4] = v6(v8);
-   |                                   ^^ not found in this scope
-
 error: `[[usize; v4]; v4]` is forbidden as the type of a const generic parameter
   --> $DIR/unevaluated-const-ice-119731.rs:16:48
    |
@@ -71,6 +65,12 @@ help: add `#![feature(adt_const_params)]` to the crate attributes to enable more
    |
 LL + #![feature(adt_const_params)]
    |
+
+error[E0425]: cannot find function `v6` in this scope
+  --> $DIR/unevaluated-const-ice-119731.rs:13:35
+   |
+LL |     const v0: [[usize; v4]; v4] = v6(v8);
+   |                                   ^^ not found in this scope
 
 error: maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#0}
   --> $DIR/unevaluated-const-ice-119731.rs:28:37

--- a/tests/ui/consts/const-slice-array-deref.stderr
+++ b/tests/ui/consts/const-slice-array-deref.stderr
@@ -5,6 +5,7 @@ LL | const ONE: [u16] = [1];
    |            ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u16]`
+   = note: statics and constants must have a statically known size
 
 error[E0308]: mismatched types
   --> $DIR/const-slice-array-deref.rs:1:20

--- a/tests/ui/consts/const-unsized.stderr
+++ b/tests/ui/consts/const-unsized.stderr
@@ -5,6 +5,7 @@ LL | const CONST_0: dyn Debug + Sync = *(&0 as &(dyn Debug + Sync));
    |                ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:7:18
@@ -13,6 +14,7 @@ LL | const CONST_FOO: str = *"foo";
    |                  ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `(dyn Debug + Sync + 'static)` cannot be known at compilation time
   --> $DIR/const-unsized.rs:11:18
@@ -21,6 +23,7 @@ LL | static STATIC_1: dyn Debug + Sync = *(&1 as &(dyn Debug + Sync));
    |                  ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Debug + Sync + 'static)`
+   = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/const-unsized.rs:15:20
@@ -29,6 +32,7 @@ LL | static STATIC_BAR: str = *"bar";
    |                    ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/const-unsized.rs:3:35

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -30,6 +30,7 @@ LL |     static FOO: Sync = AtomicUsize::new(0);
    |                 ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Sync + 'static)`
+   = note: statics and constants must have a statically known size
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/consts/dont-ctfe-unsized-initializer.rs
+++ b/tests/ui/consts/dont-ctfe-unsized-initializer.rs
@@ -1,0 +1,7 @@
+static S: str = todo!();
+//~^ ERROR the size for values of type `str` cannot be known at compilation time
+
+const C: str = todo!();
+//~^ ERROR the size for values of type `str` cannot be known at compilation time
+
+fn main() {}

--- a/tests/ui/consts/dont-ctfe-unsized-initializer.stderr
+++ b/tests/ui/consts/dont-ctfe-unsized-initializer.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/dont-ctfe-unsized-initializer.rs:1:11
+   |
+LL | static S: str = todo!();
+   |           ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/dont-ctfe-unsized-initializer.rs:4:10
+   |
+LL | const C: str = todo!();
+   |          ^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `str`
+   = note: statics and constants must have a statically known size
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/consts/issue-39974.stderr
+++ b/tests/ui/consts/issue-39974.stderr
@@ -1,4 +1,10 @@
 error[E0308]: mismatched types
+  --> $DIR/issue-39974.rs:5:19
+   |
+LL |     f: [[f64; 2]; LENGTH],
+   |                   ^^^^^^ expected `usize`, found `f64`
+
+error[E0308]: mismatched types
   --> $DIR/issue-39974.rs:1:21
    |
 LL | const LENGTH: f64 = 2;
@@ -8,12 +14,6 @@ help: use a float literal
    |
 LL | const LENGTH: f64 = 2.0;
    |                      ++
-
-error[E0308]: mismatched types
-  --> $DIR/issue-39974.rs:5:19
-   |
-LL |     f: [[f64; 2]; LENGTH],
-   |                   ^^^^^^ expected `usize`, found `f64`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/extern/issue-36122-accessing-externed-dst.stderr
+++ b/tests/ui/extern/issue-36122-accessing-externed-dst.stderr
@@ -5,6 +5,7 @@ LL |         static symbol: [usize];
    |                        ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[usize]`
+   = note: statics and constants must have a statically known size
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
   --> $DIR/issue-36122-accessing-externed-dst.rs:5:20

--- a/tests/ui/issues/issue-54410.stderr
+++ b/tests/ui/issues/issue-54410.stderr
@@ -5,6 +5,7 @@ LL |     pub static mut symbol: [i8];
    |                            ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[i8]`
+   = note: statics and constants must have a statically known size
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/layout/issue-84108.stderr
+++ b/tests/ui/layout/issue-84108.stderr
@@ -30,6 +30,15 @@ LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
    = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/issue-84108.rs:15:13
+   |
+LL | static BAZ: ([u8], usize) = ([], 0);
+   |             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[u8]`
+   = note: only the last element of a tuple may have a dynamically sized type
+
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/issue-84108.rs:9:12
    |
 LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
@@ -47,15 +56,6 @@ LL | const BAR: (&Path, [u8], usize) = ("hello", [], 42);
    |
    = note: expected slice `[u8]`
               found array `[_; 0]`
-
-error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/issue-84108.rs:15:13
-   |
-LL | static BAZ: ([u8], usize) = ([], 0);
-   |             ^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[u8]`
-   = note: only the last element of a tuple may have a dynamically sized type
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/issue-84108.rs:15:13

--- a/tests/ui/static/issue-24446.stderr
+++ b/tests/ui/static/issue-24446.stderr
@@ -14,6 +14,7 @@ LL |     static foo: dyn Fn() -> u32 = || -> u32 {
    |                 ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() -> u32 + 'static)`
+   = note: statics and constants must have a statically known size
 
 error[E0308]: mismatched types
   --> $DIR/issue-24446.rs:2:35

--- a/tests/ui/statics/unsized_type2.stderr
+++ b/tests/ui/statics/unsized_type2.stderr
@@ -10,6 +10,7 @@ note: required because it appears within the type `Foo`
    |
 LL | pub struct Foo {
    |            ^^^
+   = note: statics and constants must have a statically known size
 
 error[E0308]: mismatched types
   --> $DIR/unsized_type2.rs:14:45

--- a/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
+++ b/tests/ui/trait-bounds/ice-unsized-tuple-const-issue-121443.stderr
@@ -11,6 +11,7 @@ LL | const TEST: Fn = some_fn;
    |             ^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn FnOnce() -> u8 + 'static)`
+   = note: statics and constants must have a statically known size
 
 error[E0277]: the size for values of type `(dyn FnOnce() -> u8 + 'static)` cannot be known at compilation time
   --> $DIR/ice-unsized-tuple-const-issue-121443.rs:11:14

--- a/tests/ui/type-alias-impl-trait/issue-53092-2.rs
+++ b/tests/ui/type-alias-impl-trait/issue-53092-2.rs
@@ -2,10 +2,12 @@
 #![allow(dead_code)]
 
 type Bug<T, U> = impl Fn(T) -> U + Copy;
+//~^ ERROR cycle detected
 
 const CONST_BUG: Bug<u8, ()> = unsafe { std::mem::transmute(|_: u8| ()) };
-//~^ ERROR cycle detected
-//~| ERROR: non-defining opaque type use
+//~^ ERROR item does not constrain `Bug::{opaque#0}`, but has it in its signature
+//~| ERROR item does not constrain `Bug::{opaque#0}`, but has it in its signature
+//~| ERROR non-defining opaque type use in defining scope
 
 fn make_bug<T, U: From<T>>() -> Bug<T, U> {
     |x| x.into()

--- a/tests/ui/type-alias-impl-trait/issue-53092-2.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53092-2.stderr
@@ -1,5 +1,5 @@
 error[E0792]: non-defining opaque type use in defining scope
-  --> $DIR/issue-53092-2.rs:6:18
+  --> $DIR/issue-53092-2.rs:7:18
    |
 LL | const CONST_BUG: Bug<u8, ()> = unsafe { std::mem::transmute(|_: u8| ()) };
    |                  ^^^^^^^^^^^ argument `u8` is not a generic parameter
@@ -10,33 +10,59 @@ note: for this opaque type
 LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
    |                  ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0391]: cycle detected when type-checking `CONST_BUG`
-  --> $DIR/issue-53092-2.rs:6:1
-   |
-LL | const CONST_BUG: Bug<u8, ()> = unsafe { std::mem::transmute(|_: u8| ()) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: ...which requires computing layout of `Bug<u8, ()>`...
-   = note: ...which requires normalizing `Bug<u8, ()>`...
-note: ...which requires computing type of `Bug::{opaque#0}`...
+error[E0391]: cycle detected when computing type of `Bug::{opaque#0}`
   --> $DIR/issue-53092-2.rs:4:18
    |
 LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
    |                  ^^^^^^^^^^^^^^^^^^^^^^
+   |
 note: ...which requires computing type of opaque `Bug::{opaque#0}`...
   --> $DIR/issue-53092-2.rs:4:18
    |
 LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
    |                  ^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which again requires type-checking `CONST_BUG`, completing the cycle
-note: cycle used when checking that `CONST_BUG` is well-formed
-  --> $DIR/issue-53092-2.rs:6:1
+note: ...which requires type-checking `CONST_BUG`...
+  --> $DIR/issue-53092-2.rs:7:1
    |
 LL | const CONST_BUG: Bug<u8, ()> = unsafe { std::mem::transmute(|_: u8| ()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which requires computing layout of `Bug<u8, ()>`...
+   = note: ...which requires normalizing `Bug<u8, ()>`...
+   = note: ...which again requires computing type of `Bug::{opaque#0}`, completing the cycle
+note: cycle used when checking that `Bug::{opaque#0}` is well-formed
+  --> $DIR/issue-53092-2.rs:4:18
+   |
+LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 2 previous errors
+error: item does not constrain `Bug::{opaque#0}`, but has it in its signature
+  --> $DIR/issue-53092-2.rs:7:7
+   |
+LL | const CONST_BUG: Bug<u8, ()> = unsafe { std::mem::transmute(|_: u8| ()) };
+   |       ^^^^^^^^^
+   |
+   = note: consider moving the opaque type's declaration and defining uses into a separate module
+note: this opaque type is in the signature
+  --> $DIR/issue-53092-2.rs:4:18
+   |
+LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+
+error: item does not constrain `Bug::{opaque#0}`, but has it in its signature
+  --> $DIR/issue-53092-2.rs:7:61
+   |
+LL | const CONST_BUG: Bug<u8, ()> = unsafe { std::mem::transmute(|_: u8| ()) };
+   |                                                             ^^^^^^^
+   |
+   = note: consider moving the opaque type's declaration and defining uses into a separate module
+note: this opaque type is in the signature
+  --> $DIR/issue-53092-2.rs:4:18
+   |
+LL | type Bug<T, U> = impl Fn(T) -> U + Copy;
+   |                  ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0391, E0792.
 For more information about an error, try `rustc --explain E0391`.

--- a/tests/ui/wf/wf-normalization-sized.next.stderr
+++ b/tests/ui/wf/wf-normalization-sized.next.stderr
@@ -7,16 +7,6 @@ LL | const _: <[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize = ();
    = help: the trait `Sized` is not implemented for `[[[[[u8]]]]]`
    = note: slice and array elements must have `Sized` type
 
-error[E0277]: the size for values of type `[[[[[u8]]]]]` cannot be known at compilation time
-  --> $DIR/wf-normalization-sized.rs:19:11
-   |
-LL | const _: <[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize = ();
-   |           ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-   |
-   = help: the trait `Sized` is not implemented for `[[[[[u8]]]]]`
-   = note: slice and array elements must have `Sized` type
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/wf-normalization-sized.rs:22:11
    |
@@ -26,6 +16,16 @@ LL | const _: <Vec<str> as WellUnformed>::RequestNormalize = ();
    = help: the trait `Sized` is not implemented for `str`
 note: required by an implicit `Sized` bound in `Vec`
   --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+
+error[E0277]: the size for values of type `[[[[[u8]]]]]` cannot be known at compilation time
+  --> $DIR/wf-normalization-sized.rs:19:11
+   |
+LL | const _: <[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize = ();
+   |           ^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `[[[[[u8]]]]]`
+   = note: slice and array elements must have `Sized` type
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/wf-normalization-sized.rs:22:11


### PR DESCRIPTION
Alternative to #137233.

https://github.com/rust-lang/rust/pull/137233#issuecomment-2667879143

Fixes https://github.com/rust-lang/rust/issues/137186

We do this check in `mir_drops_elaborated_and_const_checked` and not during `mir_promoted` because that may result in borrowck cycles if WF requires looking into an opaque hidden type. This causes some TAIT tests to fail unnecessarily.

r? lcnr

try-job: test-various