### PR TITLE
Use a probe to avoid registering stray region obligations when re-checking drops in MIR typeck

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -950,7 +950,7 @@ impl<'tcx> InferCtxt<'tcx> {
         let inner = self.inner.borrow();
         assert!(!UndoLogs::<UndoLog<'_>>::in_snapshot(&inner.undo_log));
         let storage = inner.region_constraint_storage.as_ref().expect("regions already resolved");
-        assert!(storage.data.is_empty());
+        assert!(storage.data.is_empty(), "{:#?}", storage.data);
         // We clone instead of taking because borrowck still wants to use the
         // inference context after calling this for diagnostics and the new
         // trait solver.

--- a/tests/ui/borrowck/bad-drop-side-effects.rs
+++ b/tests/ui/borrowck/bad-drop-side-effects.rs
@@ -1,0 +1,18 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/137288>.
+
+trait B {
+    type C;
+}
+
+impl<U> B for &Missing {
+//~^ ERROR cannot find type `Missing` in this scope
+    type C = ();
+}
+
+struct E<T: B> {
+    g: <T as B>::C,
+}
+
+fn h(i: Box<E<&()>>) {}
+
+fn main() {}

--- a/tests/ui/borrowck/bad-drop-side-effects.stderr
+++ b/tests/ui/borrowck/bad-drop-side-effects.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Missing` in this scope
+  --> $DIR/bad-drop-side-effects.rs:7:16
+   |
+LL | impl<U> B for &Missing {
+   |                ^^^^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes #137288. 

See the comment I left on the probe. I'm not totally sure why this depends on *both* an unconstrained type parameter in the impl and a type error for the self type, but I think the fix is at least theoretically well motivated.

r? @matthewjasper