### PR TITLE
Enable `f16` for MIPS

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -107,7 +107,6 @@ fn main() {
         ("csky", _) => false,
         ("hexagon", _) => false,
         ("loongarch64", _) => false,
-        ("mips" | "mips64" | "mips32r6" | "mips64r6", _) => false,
         ("powerpc" | "powerpc64", _) => false,
         ("sparc" | "sparc64", _) => false,
         ("wasm32" | "wasm64", _) => false,


### PR DESCRIPTION

Blocked on https://github.com/rust-lang/compiler-builtins/pull/762

It seems as if `f16` works on MIPS now according to my testing on Rust master with LLVM 20, and I was asked [here](https://github.com/rust-lang/rust/pull/137167#issuecomment-2669387820) to create PRs with my changes.

I only tested on the flavour of `mipsel-unknown-linux-gnu` hardware that happens to be available to me, so I can't say anything about other MIPS hardware, but from a casual skimming of the LLVM code ([1], [2]) it seems like `f16` should work on all MIPS hardware. So enable it for all MIPS hardware.

[1]: https://github.com/rust-lang/llvm-project/blob/rustc/20.1-2025-02-13/llvm/lib/Target/Mips/MipsISelLowering.h#L370
[2]: https://github.com/rust-lang/llvm-project/blob/rustc/20.1-2025-02-13/llvm/lib/CodeGen/TargetLoweringBase.cpp#L1367-L1388

@rustbot label +O-MIPS +F-f16_and_f128 +S-blocked

Tracking issue for f16: https://github.com/rust-lang/rust/issues/116909

r? @tgross35 