### PR TITLE
Workaround Cranelift not yet properly supporting vectors smaller than 128bit

### DIFF
--- a/compiler/rustc_target/src/callconv/mod.rs
+++ b/compiler/rustc_target/src/callconv/mod.rs
@@ -737,7 +737,9 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             // to 128-bit-sized vectors.
             "x86" if spec.rustc_abi == Some(RustcAbi::X86Sse2) => arg.layout.size.bits() <= 128,
             "x86_64" if spec.rustc_abi != Some(RustcAbi::X86Softfloat) => {
-                arg.layout.size.bits() <= 128
+                // FIXME once https://github.com/bytecodealliance/wasmtime/issues/10254 is fixed
+                // accept vectors up to 128bit rather than vectors of exactly 128bit.
+                arg.layout.size.bits() == 128
             }
             // So far, we haven't implemented this logic for any other target.
             _ => false,


### PR DESCRIPTION
While it would technically be possible to workaround this in cg_clif, it quickly becomes very messy and would likely cause correctness issues. Working around it in rustc instead is much simper and won't have any negative impact for code running on stable as vectors smaller than 128bit can only be made on nightly using core::simd or #[repr(simd)].