### PR TITLE
UB-check for alignment of ptr to Box::from_raw{,_in}

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -154,6 +154,7 @@
 #![feature(try_trait_v2)]
 #![feature(try_with_capacity)]
 #![feature(tuple_trait)]
+#![feature(ub_checks)]
 #![feature(unicode_internals)]
 #![feature(unsize)]
 #![feature(unwrap_infallible)]

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3839,7 +3839,7 @@ where
 /// markes as `#[inline]`.
 ///
 /// See [`const_eval_select()`] for the rules and requirements around that intrinsic.
-pub(crate) macro const_eval_select {
+pub macro const_eval_select {
     (
         @capture$([$($binders:tt)*])? { $($arg:ident : $ty:ty = $val:expr),* $(,)? } $( -> $ret:ty )? :
         if const
@@ -4169,7 +4169,7 @@ pub const fn size_of<T>() -> usize {
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
 #[rustc_intrinsic_must_be_overridden]
-pub const fn min_align_of<T>() -> usize {
+pub const fn min_align_of<T: ?Sized>() -> usize {
     unreachable!()
 }
 

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -463,7 +463,7 @@ pub fn min_align_of_val<T: ?Sized>(val: &T) -> usize {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_promotable]
 #[rustc_const_stable(feature = "const_align_of", since = "1.24.0")]
-pub const fn align_of<T>() -> usize {
+pub const fn align_of<T: ?Sized>() -> usize {
     intrinsics::min_align_of::<T>()
 }
 

--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -90,7 +90,7 @@ pub use intrinsics::ub_checks as check_library_ub;
 /// language UB checks which generally produce better errors.
 #[inline]
 #[rustc_allow_const_fn_unstable(const_eval_select)]
-pub(crate) const fn check_language_ub() -> bool {
+pub const fn check_language_ub() -> bool {
     // Only used for UB checks so we may const_eval_select.
     intrinsics::ub_checks()
         && const_eval_select!(
@@ -127,6 +127,19 @@ pub(crate) const fn maybe_is_aligned_and_not_null(
             ptr.is_aligned_to(align) && (is_zst || !ptr.is_null())
         }
     )
+}
+
+/// Specialized version of `assert_unsafe_precondition` for checking that a pointer is properly aligned and not null
+#[macro_export]
+#[unstable(feature = "ub_checks", issue = "none")]
+macro_rules! assert_pointer_is_aligned_and_not_null {
+    ($function_name: literal, $ptr: expr, $align: expr, $is_zst: expr) => {
+        ::core::assert_unsafe_precondition!(
+            check_language_ub,
+            concat!($function_name, " requires that its pointer argument is properly aligned and not null"),
+            () => ::core::ub_checks::maybe_is_aligned_and_not_null(ptr as *const (), $align, $is_zst)
+        );
+    }
 }
 
 #[inline]


### PR DESCRIPTION
This adds a missing UB-check for proper alignment of pointers to Box::from_raw{,_in}. See https://github.com/rust-lang/rust/issues/69283#issuecomment-2669481289 for some background.