### PR TITLE
Undeprecate env::home_dir

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -641,11 +641,6 @@ impl Error for JoinPathsError {
 ///     None => println!("Impossible to get your home dir!"),
 /// }
 /// ```
-#[deprecated(
-    since = "1.29.0",
-    note = "This function's behavior may be unexpected on Windows. \
-            Consider using a crate from crates.io instead."
-)]
 #[must_use]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn home_dir() -> Option<PathBuf> {


### PR DESCRIPTION
#132515 fixed the implementation of `env::home_dir`, but didn't remove the deprecation.

Based on [this comment](https://github.com/rust-lang/rust/pull/132515#discussion_r1829715262), libs-api decided to undeprecate in the next release. Let's do that!

cc #132650