### PR TITLE
Vec, String: add some missing const-hack comments

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1081,6 +1081,7 @@ impl String {
     pub const fn as_str(&self) -> &str {
         // SAFETY: String contents are stipulated to be valid UTF-8, invalid contents are an error
         // at construction.
+        // FIXME(const-hack): just deref `self` instead
         unsafe { str::from_utf8_unchecked(self.vec.as_slice()) }
     }
 
@@ -1104,6 +1105,7 @@ impl String {
     pub const fn as_mut_str(&mut self) -> &mut str {
         // SAFETY: String contents are stipulated to be valid UTF-8, invalid contents are an error
         // at construction.
+        // FIXME(const-hack): just deref `self` instead
         unsafe { str::from_utf8_unchecked_mut(self.vec.as_mut_slice()) }
     }
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1572,6 +1572,7 @@ impl<T, A: Allocator> Vec<T, A> {
         // * We only construct `&mut` references to `self.buf` through `&mut self` methods; borrow-
         //   check ensures that it is not possible to mutably alias `self.buf` within the
         //   returned lifetime.
+        // FIXME(const-hack): just deref `self` instead
         unsafe { slice::from_raw_parts(self.as_ptr(), self.len) }
     }
 
@@ -1604,6 +1605,7 @@ impl<T, A: Allocator> Vec<T, A> {
         // * We only construct references to `self.buf` through `&self` and `&mut self` methods;
         //   borrow-check ensures that it is not possible to construct a reference to `self.buf`
         //   within the returned lifetime.
+        // FIXME(const-hack): just deref `self` instead
         unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len) }
     }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/128399 added these `unsafe` blocks and as far as I can tell that's entirely due to const-eval limitations.

r? @tgross35 