### PR TITLE
Make some suggestions "verbose"

### DIFF
--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -14,7 +14,11 @@ pub(crate) struct GenericTypeWithParentheses {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(ast_lowering_use_angle_brackets, applicability = "maybe-incorrect")]
+#[multipart_suggestion(
+    ast_lowering_use_angle_brackets,
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
 pub(crate) struct UseAngleBrackets {
     #[suggestion_part(code = "<")]
     pub open_param: Span,
@@ -47,7 +51,8 @@ pub(crate) struct TupleStructWithDefault {
 #[suggestion(
     ast_lowering_invalid_abi_suggestion,
     code = "{suggestion}",
-    applicability = "maybe-incorrect"
+    applicability = "maybe-incorrect",
+    style = "verbose"
 )]
 pub(crate) struct InvalidAbiSuggestion {
     #[primary_span]
@@ -134,7 +139,7 @@ pub(crate) struct ClosureCannotBeStatic {
 #[diag(ast_lowering_functional_record_update_destructuring_assignment)]
 pub(crate) struct FunctionalRecordUpdateDestructuringAssignment {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
 }
 
@@ -335,7 +340,7 @@ pub(crate) struct MisplacedRelaxTraitBound {
 pub(crate) struct MatchArmWithNoBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " => todo!(),", applicability = "has-placeholders")]
+    #[suggestion(code = " => todo!(),", applicability = "has-placeholders", style = "verbose")]
     pub suggestion: Span,
 }
 
@@ -344,7 +349,7 @@ pub(crate) struct MatchArmWithNoBody {
 pub(crate) struct NeverPatternWithBody {
     #[primary_span]
     #[label]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     pub span: Span,
 }
 
@@ -352,7 +357,7 @@ pub(crate) struct NeverPatternWithBody {
 #[diag(ast_lowering_never_pattern_with_guard)]
 pub(crate) struct NeverPatternWithGuard {
     #[primary_span]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     pub span: Span,
 }
 
@@ -377,19 +382,19 @@ pub(crate) enum BadReturnTypeNotation {
     #[diag(ast_lowering_bad_return_type_notation_inputs)]
     Inputs {
         #[primary_span]
-        #[suggestion(code = "()", applicability = "maybe-incorrect")]
+        #[suggestion(code = "()", applicability = "maybe-incorrect", style = "verbose")]
         span: Span,
     },
     #[diag(ast_lowering_bad_return_type_notation_output)]
     Output {
         #[primary_span]
-        #[suggestion(code = "", applicability = "maybe-incorrect")]
+        #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
         span: Span,
     },
     #[diag(ast_lowering_bad_return_type_notation_needs_dots)]
     NeedsDots {
         #[primary_span]
-        #[suggestion(code = "(..)", applicability = "maybe-incorrect")]
+        #[suggestion(code = "(..)", applicability = "maybe-incorrect", style = "verbose")]
         span: Span,
     },
     #[diag(ast_lowering_bad_return_type_notation_position)]
@@ -457,7 +462,8 @@ pub(crate) struct InvalidLegacyConstGenericArg {
 #[derive(Subdiagnostic)]
 #[multipart_suggestion(
     ast_lowering_invalid_legacy_const_generic_arg_suggestion,
-    applicability = "maybe-incorrect"
+    applicability = "maybe-incorrect",
+    style = "verbose"
 )]
 pub(crate) struct UseConstGenericArg {
     #[suggestion_part(code = "::<{const_args}>")]

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -18,7 +18,8 @@ pub(crate) struct VisibilityNotPermitted {
     #[suggestion(
         ast_passes_remove_qualifier_sugg,
         code = "",
-        applicability = "machine-applicable"
+        applicability = "machine-applicable",
+        style = "verbose"
     )]
     pub remove_qualifier_sugg: Span,
 }
@@ -44,19 +45,21 @@ pub(crate) struct TraitFnConst {
     pub in_impl: bool,
     #[label(ast_passes_const_context_label)]
     pub const_context_label: Option<Span>,
-    #[suggestion(ast_passes_remove_const_sugg, code = "")]
+    #[suggestion(ast_passes_remove_const_sugg, code = "", style = "verbose")]
     pub remove_const_sugg: (Span, Applicability),
     pub requires_multiple_changes: bool,
     #[suggestion(
         ast_passes_make_impl_const_sugg,
         code = "const ",
-        applicability = "maybe-incorrect"
+        applicability = "maybe-incorrect",
+        style = "verbose"
     )]
     pub make_impl_const_sugg: Option<Span>,
     #[suggestion(
         ast_passes_make_trait_const_sugg,
         code = "#[const_trait]\n",
-        applicability = "maybe-incorrect"
+        applicability = "maybe-incorrect",
+        style = "verbose"
     )]
     pub make_trait_const_sugg: Option<Span>,
 }
@@ -128,7 +131,7 @@ pub(crate) struct ForbiddenDefault {
 pub(crate) struct AssocConstWithoutBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " = <expr>;", applicability = "has-placeholders")]
+    #[suggestion(code = " = <expr>;", applicability = "has-placeholders", style = "verbose")]
     pub replace_span: Span,
 }
 
@@ -137,7 +140,7 @@ pub(crate) struct AssocConstWithoutBody {
 pub(crate) struct AssocFnWithoutBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " {{ <body> }}", applicability = "has-placeholders")]
+    #[suggestion(code = " {{ <body> }}", applicability = "has-placeholders", style = "verbose")]
     pub replace_span: Span,
 }
 
@@ -146,7 +149,7 @@ pub(crate) struct AssocFnWithoutBody {
 pub(crate) struct AssocTypeWithoutBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " = <type>;", applicability = "has-placeholders")]
+    #[suggestion(code = " = <type>;", applicability = "has-placeholders", style = "verbose")]
     pub replace_span: Span,
 }
 
@@ -155,7 +158,7 @@ pub(crate) struct AssocTypeWithoutBody {
 pub(crate) struct ConstWithoutBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " = <expr>;", applicability = "has-placeholders")]
+    #[suggestion(code = " = <expr>;", applicability = "has-placeholders", style = "verbose")]
     pub replace_span: Span,
 }
 
@@ -164,7 +167,7 @@ pub(crate) struct ConstWithoutBody {
 pub(crate) struct StaticWithoutBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " = <expr>;", applicability = "has-placeholders")]
+    #[suggestion(code = " = <expr>;", applicability = "has-placeholders", style = "verbose")]
     pub replace_span: Span,
 }
 
@@ -173,7 +176,7 @@ pub(crate) struct StaticWithoutBody {
 pub(crate) struct TyAliasWithoutBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " = <type>;", applicability = "has-placeholders")]
+    #[suggestion(code = " = <type>;", applicability = "has-placeholders", style = "verbose")]
     pub replace_span: Span,
 }
 
@@ -182,7 +185,7 @@ pub(crate) struct TyAliasWithoutBody {
 pub(crate) struct FnWithoutBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " {{ <body> }}", applicability = "has-placeholders")]
+    #[suggestion(code = " {{ <body> }}", applicability = "has-placeholders", style = "verbose")]
     pub replace_span: Span,
     #[subdiagnostic]
     pub extern_block_suggestion: Option<ExternBlockSuggestion>,
@@ -190,14 +193,22 @@ pub(crate) struct FnWithoutBody {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum ExternBlockSuggestion {
-    #[multipart_suggestion(ast_passes_extern_block_suggestion, applicability = "maybe-incorrect")]
+    #[multipart_suggestion(
+        ast_passes_extern_block_suggestion,
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
     Implicit {
         #[suggestion_part(code = "extern {{")]
         start_span: Span,
         #[suggestion_part(code = " }}")]
         end_span: Span,
     },
-    #[multipart_suggestion(ast_passes_extern_block_suggestion, applicability = "maybe-incorrect")]
+    #[multipart_suggestion(
+        ast_passes_extern_block_suggestion,
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
     Explicit {
         #[suggestion_part(code = "extern \"{abi}\" {{")]
         start_span: Span,
@@ -250,7 +261,7 @@ pub(crate) struct BoundInContext<'a> {
 #[note(ast_passes_extern_keyword_link)]
 pub(crate) struct ExternTypesCannotHave<'a> {
     #[primary_span]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     pub span: Span,
     pub descr: &'a str,
     pub remove_descr: &'a str,
@@ -280,7 +291,7 @@ pub(crate) struct FnBodyInExtern {
     #[primary_span]
     #[label(ast_passes_cannot_have)]
     pub span: Span,
-    #[suggestion(code = ";", applicability = "maybe-incorrect")]
+    #[suggestion(code = ";", applicability = "maybe-incorrect", style = "verbose")]
     pub body: Span,
     #[label]
     pub block: Span,
@@ -290,7 +301,7 @@ pub(crate) struct FnBodyInExtern {
 #[diag(ast_passes_extern_fn_qualifiers)]
 pub(crate) struct FnQualifierInExtern {
     #[primary_span]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     pub span: Span,
     #[label]
     pub block: Span,
@@ -343,7 +354,7 @@ pub(crate) struct ModuleNonAscii {
 #[diag(ast_passes_auto_generic, code = E0567)]
 pub(crate) struct AutoTraitGeneric {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
     #[label]
     pub ident: Span,
@@ -353,7 +364,7 @@ pub(crate) struct AutoTraitGeneric {
 #[diag(ast_passes_auto_super_lifetime, code = E0568)]
 pub(crate) struct AutoTraitBounds {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
     #[label]
     pub ident: Span,
@@ -364,7 +375,7 @@ pub(crate) struct AutoTraitBounds {
 pub(crate) struct AutoTraitItems {
     #[primary_span]
     pub spans: Vec<Span>,
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub total: Span,
     #[label]
     pub ident: Span,
@@ -440,7 +451,11 @@ pub(crate) struct AtLeastOneTrait {
 pub(crate) struct OutOfOrderParams<'a> {
     #[primary_span]
     pub spans: Vec<Span>,
-    #[suggestion(code = "{ordered_params}", applicability = "machine-applicable")]
+    #[suggestion(
+        code = "{ordered_params}",
+        applicability = "machine-applicable",
+        style = "verbose"
+    )]
     pub sugg_span: Span,
     pub param_ord: &'a ParamKindOrd,
     pub max_param: &'a ParamKindOrd,
@@ -536,7 +551,12 @@ pub(crate) struct WhereClauseBeforeTypeAlias {
 
 #[derive(Subdiagnostic)]
 pub(crate) enum WhereClauseBeforeTypeAliasSugg {
-    #[suggestion(ast_passes_remove_suggestion, applicability = "machine-applicable", code = "")]
+    #[suggestion(
+        ast_passes_remove_suggestion,
+        applicability = "machine-applicable",
+        code = "",
+        style = "verbose"
+    )]
     Remove {
         #[primary_span]
         span: Span,
@@ -720,7 +740,11 @@ pub(crate) struct AssociatedSuggestion {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(ast_passes_suggestion_path, applicability = "maybe-incorrect")]
+#[multipart_suggestion(
+    ast_passes_suggestion_path,
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
 pub(crate) struct AssociatedSuggestion2 {
     #[suggestion_part(code = "{args}")]
     pub span: Span,
@@ -739,7 +763,7 @@ pub(crate) struct FeatureOnNonNightly {
     pub channel: &'static str,
     #[subdiagnostic]
     pub stable_features: Vec<StableFeature>,
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub sugg: Option<Span>,
 }
 

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -41,7 +41,7 @@ pub(crate) struct AssertRequiresBoolean {
 pub(crate) struct AssertRequiresExpression {
     #[primary_span]
     pub(crate) span: Span,
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
+    #[suggestion(code = "", applicability = "maybe-incorrect", style = "verbose")]
     pub(crate) token: Span,
 }
 
@@ -231,7 +231,8 @@ pub(crate) enum ConcatBytesInvalidSuggestion {
     #[suggestion(
         builtin_macros_byte_char,
         code = "b{snippet}",
-        applicability = "machine-applicable"
+        applicability = "machine-applicable",
+        style = "verbose"
     )]
     CharLit {
         #[primary_span]
@@ -241,7 +242,8 @@ pub(crate) enum ConcatBytesInvalidSuggestion {
     #[suggestion(
         builtin_macros_byte_str,
         code = "b{snippet}",
-        applicability = "machine-applicable"
+        applicability = "machine-applicable",
+        style = "verbose"
     )]
     StrLit {
         #[primary_span]
@@ -251,7 +253,8 @@ pub(crate) enum ConcatBytesInvalidSuggestion {
     #[suggestion(
         builtin_macros_number_array,
         code = "[{snippet}]",
-        applicability = "machine-applicable"
+        applicability = "machine-applicable",
+        style = "verbose"
     )]
     IntLit {
         #[primary_span]
@@ -355,7 +358,7 @@ pub(crate) enum BadDeriveLitHelp {
 #[derive(Diagnostic)]
 #[diag(builtin_macros_derive_path_args_list)]
 pub(crate) struct DerivePathArgsList {
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     #[primary_span]
     pub(crate) span: Span,
 }
@@ -363,7 +366,7 @@ pub(crate) struct DerivePathArgsList {
 #[derive(Diagnostic)]
 #[diag(builtin_macros_derive_path_args_value)]
 pub(crate) struct DerivePathArgsValue {
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     #[primary_span]
     pub(crate) span: Span,
 }
@@ -380,7 +383,12 @@ pub(crate) struct NoDefaultVariant {
 }
 
 #[derive(Subdiagnostic)]
-#[suggestion(builtin_macros_suggestion, code = "#[default] ", applicability = "maybe-incorrect")]
+#[suggestion(
+    builtin_macros_suggestion,
+    code = "#[default] ",
+    applicability = "maybe-incorrect",
+    style = "verbose"
+)]
 pub(crate) struct NoDefaultVariantSugg {
     #[primary_span]
     pub(crate) span: Span,
@@ -612,7 +620,8 @@ pub(crate) enum InvalidFormatStringSuggestion {
     #[suggestion(
         builtin_macros_format_remove_raw_ident,
         code = "",
-        applicability = "machine-applicable"
+        applicability = "machine-applicable",
+        style = "verbose"
     )]
     RemoveRawIdent {
         #[primary_span]

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -55,12 +55,14 @@ pub(crate) struct UnstableInStableExposed {
     #[suggestion(
         const_eval_unstable_sugg,
         code = "#[rustc_const_unstable(feature = \"...\", issue = \"...\")]\n",
-        applicability = "has-placeholders"
+        applicability = "has-placeholders",
+        style = "verbose"
     )]
     #[suggestion(
         const_eval_bypass_sugg,
         code = "#[rustc_allow_const_fn_unstable({gate})]\n",
-        applicability = "has-placeholders"
+        applicability = "has-placeholders",
+        style = "verbose"
     )]
     pub attr_span: Span,
 }
@@ -138,7 +140,8 @@ pub(crate) struct UnstableIntrinsic {
     #[suggestion(
         const_eval_unstable_intrinsic_suggestion,
         code = "#![feature({feature})]\n",
-        applicability = "machine-applicable"
+        applicability = "machine-applicable",
+        style = "verbose"
     )]
     pub suggestion: Option<Span>,
     #[help(const_eval_unstable_intrinsic_suggestion)]

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -203,7 +203,12 @@ pub(crate) enum MalformedFeatureAttributeHelp {
         #[primary_span]
         span: Span,
     },
-    #[suggestion(expand_expected, code = "{suggestion}", applicability = "maybe-incorrect")]
+    #[suggestion(
+        expand_expected,
+        code = "{suggestion}",
+        applicability = "maybe-incorrect",
+        style = "verbose"
+    )]
     Suggestion {
         #[primary_span]
         span: Span,
@@ -226,7 +231,8 @@ pub(crate) enum InvalidCfg {
         #[suggestion(
             expand_invalid_cfg_expected_syntax,
             code = "cfg(/* predicate */)",
-            applicability = "has-placeholders"
+            applicability = "has-placeholders",
+            style = "verbose"
         )]
         span: Span,
     },
@@ -236,7 +242,8 @@ pub(crate) enum InvalidCfg {
         #[suggestion(
             expand_invalid_cfg_expected_syntax,
             code = "cfg(/* predicate */)",
-            applicability = "has-placeholders"
+            applicability = "has-placeholders",
+            style = "verbose"
         )]
         span: Span,
     },

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -51,7 +51,8 @@ pub(crate) struct AssocKindMismatch {
 #[derive(Subdiagnostic)]
 #[multipart_suggestion(
     hir_analysis_assoc_kind_mismatch_wrap_in_braces_sugg,
-    applicability = "maybe-incorrect"
+    applicability = "maybe-incorrect",
+    style = "verbose"
 )]
 pub(crate) struct AssocKindMismatchWrapInBracesSugg {
     #[suggestion_part(code = "{{ ")]
@@ -110,7 +111,8 @@ pub(crate) enum AssocItemNotFoundSugg<'a> {
     #[suggestion(
         hir_analysis_assoc_item_not_found_similar_sugg,
         code = "{suggested_name}",
-        applicability = "maybe-incorrect"
+        applicability = "maybe-incorrect",
+        style = "verbose"
     )]
     Similar {
         #[primary_span]
@@ -150,7 +152,8 @@ pub(crate) enum AssocItemNotFoundSugg<'a> {
     #[suggestion(
         hir_analysis_assoc_item_not_found_other_sugg,
         code = "{suggested_name}",
-        applicability = "maybe-incorrect"
+        applicability = "maybe-incorrect",
+        style = "verbose"
     )]
     Other {
         #[primary_span]
@@ -607,7 +610,7 @@ pub(crate) struct WhereClauseOnMain {
 #[diag(hir_analysis_track_caller_on_main)]
 pub(crate) struct TrackCallerOnMain {
     #[primary_span]
-    #[suggestion(applicability = "maybe-incorrect", code = "")]
+    #[suggestion(applicability = "maybe-incorrect", code = "", style = "verbose")]
     pub span: Span,
     #[label(hir_analysis_track_caller_on_main)]
     pub annotated: Span,
@@ -734,7 +737,11 @@ pub(crate) struct ReturnTypeNotationOnNonRpitit<'tcx> {
 }
 
 #[derive(Subdiagnostic)]
-#[multipart_suggestion(hir_analysis_invalid_union_field_sugg, applicability = "machine-applicable")]
+#[multipart_suggestion(
+    hir_analysis_invalid_union_field_sugg,
+    applicability = "machine-applicable",
+    style = "verbose"
+)]
 pub(crate) struct InvalidUnionFieldSuggestion {
     #[suggestion_part(code = "std::mem::ManuallyDrop<")]
     pub lo: Span,
@@ -745,7 +752,8 @@ pub(crate) struct InvalidUnionFieldSuggestion {
 #[derive(Subdiagnostic)]
 #[multipart_suggestion(
     hir_analysis_invalid_unsafe_field_sugg,
-    applicability = "machine-applicable"
+    applicability = "machine-applicable",
+    style = "verbose"
 )]
 pub(crate) struct InvalidUnsafeFieldSuggestion {
     #[suggestion_part(code = "std::mem::ManuallyDrop<")]
@@ -786,7 +794,8 @@ pub(crate) struct AssociatedItemTraitUninferredGenericParams {
 #[derive(Subdiagnostic)]
 #[multipart_suggestion(
     hir_analysis_associated_type_trait_uninferred_generic_params_multipart_suggestion,
-    applicability = "maybe-incorrect"
+    applicability = "maybe-incorrect",
+    style = "verbose"
 )]
 pub(crate) struct AssociatedItemTraitUninferredGenericParamsMultipartSuggestion {
     #[suggestion_part(code = "{first}")]
@@ -1128,7 +1137,7 @@ pub(crate) enum LateBoundInApit {
 #[diag(hir_analysis_unused_associated_type_bounds)]
 #[note]
 pub(crate) struct UnusedAssociatedTypeBounds {
-    #[suggestion(code = "")]
+    #[suggestion(code = "", style = "verbose")]
     pub span: Span,
 }
 
@@ -1137,7 +1146,11 @@ pub(crate) struct UnusedAssociatedTypeBounds {
 #[note]
 #[note(hir_analysis_feedback_note)]
 pub(crate) struct ReturnPositionImplTraitInTraitRefined<'tcx> {
-    #[suggestion(applicability = "maybe-incorrect", code = "{pre}{return_ty}{post}")]
+    #[suggestion(
+        applicability = "maybe-incorrect",
+        code = "{pre}{return_ty}{post}",
+        style = "verbose"
+    )]
     pub impl_return_span: Span,
     #[label]
     pub trait_return_span: Option<Span>,
@@ -1154,7 +1167,7 @@ pub(crate) struct ReturnPositionImplTraitInTraitRefined<'tcx> {
 #[note]
 #[note(hir_analysis_feedback_note)]
 pub(crate) struct ReturnPositionImplTraitInTraitRefinedLifetimes {
-    #[suggestion(applicability = "maybe-incorrect", code = "{suggestion}")]
+    #[suggestion(applicability = "maybe-incorrect", code = "{suggestion}", style = "verbose")]
     pub suggestion_span: Span,
     pub suggestion: String,
 }
@@ -1527,7 +1540,8 @@ pub(crate) struct OnlyCurrentTraitsAdt {
 #[derive(Subdiagnostic)]
 #[multipart_suggestion(
     hir_analysis_only_current_traits_pointer_sugg,
-    applicability = "maybe-incorrect"
+    applicability = "maybe-incorrect",
+    style = "verbose"
 )]
 pub(crate) struct OnlyCurrentTraitsPointerSugg<'a> {
     #[suggestion_part(code = "WrapperType")]

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
@@ -2,23 +2,26 @@ error[E0703]: invalid ABI: found `riscv-interrupt`
   --> $DIR/riscv-discoverability-guidance.rs:17:8
    |
 LL | extern "riscv-interrupt" fn isr() {}
-   |        ^^^^^^^^^^^^^^^^^
-   |        |
-   |        invalid ABI
-   |        help: did you mean: `"riscv-interrupt-m"`
+   |        ^^^^^^^^^^^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: did you mean
+   |
+LL | extern "riscv-interrupt-m" fn isr() {}
+   |                        ++
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
   --> $DIR/riscv-discoverability-guidance.rs:22:8
    |
 LL | extern "riscv-interrupt-u" fn isr_U() {}
-   |        ^^^^^^^^^^^^^^^^^^^
-   |        |
-   |        invalid ABI
-   |        help: did you mean: `"riscv-interrupt-m"`
+   |        ^^^^^^^^^^^^^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: did you mean
+   |
+LL - extern "riscv-interrupt-u" fn isr_U() {}
+LL + extern "riscv-interrupt-m" fn isr_U() {}
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
@@ -2,23 +2,26 @@ error[E0703]: invalid ABI: found `riscv-interrupt`
   --> $DIR/riscv-discoverability-guidance.rs:17:8
    |
 LL | extern "riscv-interrupt" fn isr() {}
-   |        ^^^^^^^^^^^^^^^^^
-   |        |
-   |        invalid ABI
-   |        help: did you mean: `"riscv-interrupt-m"`
+   |        ^^^^^^^^^^^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: did you mean
+   |
+LL | extern "riscv-interrupt-m" fn isr() {}
+   |                        ++
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
   --> $DIR/riscv-discoverability-guidance.rs:22:8
    |
 LL | extern "riscv-interrupt-u" fn isr_U() {}
-   |        ^^^^^^^^^^^^^^^^^^^
-   |        |
-   |        invalid ABI
-   |        help: did you mean: `"riscv-interrupt-m"`
+   |        ^^^^^^^^^^^^^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: did you mean
+   |
+LL - extern "riscv-interrupt-u" fn isr_U() {}
+LL + extern "riscv-interrupt-m" fn isr_U() {}
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/associated-consts/assoc-const-eq-missing.stderr
+++ b/tests/ui/associated-consts/assoc-const-eq-missing.stderr
@@ -2,7 +2,13 @@ error[E0220]: associated constant `Z` not found for `Foo`
   --> $DIR/assoc-const-eq-missing.rs:14:16
    |
 LL | fn foo1<F: Foo<Z = 3>>() {}
-   |                ^ help: there is an associated constant with a similar name: `N`
+   |                ^
+   |
+help: there is an associated constant with a similar name
+   |
+LL - fn foo1<F: Foo<Z = 3>>() {}
+LL + fn foo1<F: Foo<N = 3>>() {}
+   |
 
 error[E0220]: associated type `Z` not found for `Foo`
   --> $DIR/assoc-const-eq-missing.rs:16:16
@@ -14,7 +20,13 @@ error[E0220]: associated constant `Z` not found for `Foo`
   --> $DIR/assoc-const-eq-missing.rs:18:16
    |
 LL | fn foo3<F: Foo<Z = 5>>() {}
-   |                ^ help: there is an associated constant with a similar name: `N`
+   |                ^
+   |
+help: there is an associated constant with a similar name
+   |
+LL - fn foo3<F: Foo<Z = 5>>() {}
+LL + fn foo3<F: Foo<N = 5>>() {}
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/associated-inherent-types/assoc-inherent-no-body.stderr
+++ b/tests/ui/associated-inherent-types/assoc-inherent-no-body.stderr
@@ -2,9 +2,12 @@ error: associated type in `impl` without body
   --> $DIR/assoc-inherent-no-body.rs:7:5
    |
 LL |     type Baz;
-   |     ^^^^^^^^-
-   |             |
-   |             help: provide a definition for the type: `= <type>;`
+   |     ^^^^^^^^^
+   |
+help: provide a definition for the type
+   |
+LL |     type Baz = <type>;
+   |              ++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-inherent-types/substitute-params-bad.stderr
+++ b/tests/ui/associated-inherent-types/substitute-params-bad.stderr
@@ -2,7 +2,13 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/substitute-params-bad.rs:9:9
    |
 LL | impl<T, 'a> S<T> {
-   |     ----^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, T>`
+   |         ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - impl<T, 'a> S<T> {
+LL + impl<'a, T> S<T> {
+   |
 
 error[E0308]: mismatched types
   --> $DIR/substitute-params-bad.rs:22:35

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
@@ -20,37 +20,71 @@ error: argument types not allowed with return type notation
   --> $DIR/bad-inputs-and-output.rs:9:23
    |
 LL | fn foo<T: Trait<method(i32): Send>>() {}
-   |                       ^^^^^ help: remove the input types: `()`
+   |                       ^^^^^
+   |
+help: remove the input types
+   |
+LL - fn foo<T: Trait<method(i32): Send>>() {}
+LL + fn foo<T: Trait<method(): Send>>() {}
+   |
 
 error: return type not allowed with return type notation
   --> $DIR/bad-inputs-and-output.rs:12:25
    |
 LL | fn bar<T: Trait<method() -> (): Send>>() {}
-   |                         ^^^^^^ help: remove the return type
+   |                         ^^^^^^
+   |
+help: remove the return type
+   |
+LL - fn bar<T: Trait<method() -> (): Send>>() {}
+LL + fn bar<T: Trait<method(): Send>>() {}
+   |
 
 error: return type notation arguments must be elided with `..`
   --> $DIR/bad-inputs-and-output.rs:15:23
    |
 LL | fn baz<T: Trait<method(): Send>>() {}
-   |                       ^^ help: add `..`: `(..)`
+   |                       ^^
+   |
+help: add `..`
+   |
+LL | fn baz<T: Trait<method(..): Send>>() {}
+   |                        ++
 
 error: argument types not allowed with return type notation
   --> $DIR/bad-inputs-and-output.rs:18:40
    |
 LL | fn foo_path<T: Trait>() where T::method(i32): Send {}
-   |                                        ^^^^^ help: remove the input types: `()`
+   |                                        ^^^^^
+   |
+help: remove the input types
+   |
+LL - fn foo_path<T: Trait>() where T::method(i32): Send {}
+LL + fn foo_path<T: Trait>() where T::method(): Send {}
+   |
 
 error: return type not allowed with return type notation
   --> $DIR/bad-inputs-and-output.rs:21:42
    |
 LL | fn bar_path<T: Trait>() where T::method() -> (): Send {}
-   |                                          ^^^^^^ help: remove the return type
+   |                                          ^^^^^^
+   |
+help: remove the return type
+   |
+LL - fn bar_path<T: Trait>() where T::method() -> (): Send {}
+LL + fn bar_path<T: Trait>() where T::method(): Send {}
+   |
 
 error: return type notation arguments must be elided with `..`
   --> $DIR/bad-inputs-and-output.rs:24:40
    |
 LL | fn baz_path<T: Trait>() where T::method(): Send {}
-   |                                        ^^ help: add `..`: `(..)`
+   |                                        ^^
+   |
+help: add `..`
+   |
+LL | fn baz_path<T: Trait>() where T::method(..): Send {}
+   |                                         ++
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/associated-type-bounds/return-type-notation/missing.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/missing.stderr
@@ -2,7 +2,13 @@ error[E0220]: associated function `methid` not found for `Trait`
   --> $DIR/missing.rs:9:17
    |
 LL | fn bar<T: Trait<methid(..): Send>>() {}
-   |                 ^^^^^^ help: there is an associated function with a similar name: `method`
+   |                 ^^^^^^
+   |
+help: there is an associated function with a similar name
+   |
+LL - fn bar<T: Trait<methid(..): Send>>() {}
+LL + fn bar<T: Trait<method(..): Send>>() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-types/issue-23595-2.stderr
+++ b/tests/ui/associated-types/issue-23595-2.stderr
@@ -2,7 +2,13 @@ error[E0220]: associated type `anything_here_kills_it` not found for `Self`
   --> $DIR/issue-23595-2.rs:6:22
    |
 LL |     type B = C<Self::anything_here_kills_it>;
-   |                      ^^^^^^^^^^^^^^^^^^^^^^ help: `Self` has the following associated type: `B`
+   |                      ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: `Self` has the following associated type
+   |
+LL -     type B = C<Self::anything_here_kills_it>;
+LL +     type B = C<Self::B>;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/unsafe/derive-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/derive-unsafe-attributes.stderr
@@ -13,7 +13,13 @@ error: traits in `#[derive(...)]` don't accept arguments
   --> $DIR/derive-unsafe-attributes.rs:1:16
    |
 LL | #[derive(unsafe(Debug))]
-   |                ^^^^^^^ help: remove the arguments
+   |                ^^^^^^^
+   |
+help: remove the arguments
+   |
+LL - #[derive(unsafe(Debug))]
+LL + #[derive(unsafe)]
+   |
 
 error: `derive` is not an unsafe attribute
   --> $DIR/derive-unsafe-attributes.rs:10:3

--- a/tests/ui/auto-traits/assoc-ty.current.stderr
+++ b/tests/ui/auto-traits/assoc-ty.current.stderr
@@ -5,7 +5,12 @@ LL | auto trait Trait {
    |            ----- auto traits cannot have associated items
 LL |
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
+   |
+help: remove these associated items
+   |
+LL -     type Output;
+   |
 
 error[E0658]: auto traits are experimental and possibly buggy
   --> $DIR/assoc-ty.rs:8:1

--- a/tests/ui/auto-traits/assoc-ty.next.stderr
+++ b/tests/ui/auto-traits/assoc-ty.next.stderr
@@ -5,7 +5,12 @@ LL | auto trait Trait {
    |            ----- auto traits cannot have associated items
 LL |
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
+   |
+help: remove these associated items
+   |
+LL -     type Output;
+   |
 
 error[E0658]: auto traits are experimental and possibly buggy
   --> $DIR/assoc-ty.rs:8:1

--- a/tests/ui/auto-traits/auto-trait-validation.stderr
+++ b/tests/ui/auto-traits/auto-trait-validation.stderr
@@ -2,34 +2,57 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/auto-trait-validation.rs:6:19
    |
 LL | auto trait Generic<T> {}
-   |            -------^^^ help: remove the parameters
+   |            -------^^^
    |            |
    |            auto trait cannot have generic parameters
+   |
+help: remove the parameters
+   |
+LL - auto trait Generic<T> {}
+LL + auto trait Generic {}
+   |
 
 error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/auto-trait-validation.rs:8:17
    |
 LL | auto trait Bound : Copy {}
-   |            -----^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
+   |
+help: remove the super traits or lifetime bounds
+   |
+LL - auto trait Bound : Copy {}
+LL + auto trait Bound {}
+   |
 
 error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/auto-trait-validation.rs:10:25
    |
 LL | auto trait LifetimeBound : 'static {}
-   |            -------------^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -------------^^^^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
+   |
+help: remove the super traits or lifetime bounds
+   |
+LL - auto trait LifetimeBound : 'static {}
+LL + auto trait LifetimeBound {}
+   |
 
 error[E0380]: auto traits cannot have associated items
   --> $DIR/auto-trait-validation.rs:12:25
    |
 LL | auto trait MyTrait { fn foo() {} }
-   |            -------   ---^^^-----
-   |            |         |
-   |            |         help: remove these associated items
+   |            -------      ^^^
+   |            |
    |            auto traits cannot have associated items
+   |
+help: remove these associated items
+   |
+LL - auto trait MyTrait { fn foo() {} }
+LL + auto trait MyTrait {  }
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/auto-traits/bad-generics-on-dyn.stderr
+++ b/tests/ui/auto-traits/bad-generics-on-dyn.stderr
@@ -2,9 +2,15 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/bad-generics-on-dyn.rs:3:18
    |
 LL | auto trait Trait1<'a> {}
-   |            ------^^^^ help: remove the parameters
+   |            ------^^^^
    |            |
    |            auto trait cannot have generic parameters
+   |
+help: remove the parameters
+   |
+LL - auto trait Trait1<'a> {}
+LL + auto trait Trait1 {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/has-arguments.stderr
+++ b/tests/ui/auto-traits/has-arguments.stderr
@@ -2,9 +2,15 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/has-arguments.rs:3:18
    |
 LL | auto trait Trait1<'outer> {}
-   |            ------^^^^^^^^ help: remove the parameters
+   |            ------^^^^^^^^
    |            |
    |            auto trait cannot have generic parameters
+   |
+help: remove the parameters
+   |
+LL - auto trait Trait1<'outer> {}
+LL + auto trait Trait1 {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/issue-117789.stderr
+++ b/tests/ui/auto-traits/issue-117789.stderr
@@ -2,9 +2,15 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/issue-117789.rs:1:17
    |
 LL | auto trait Trait<P> {}
-   |            -----^^^ help: remove the parameters
+   |            -----^^^
    |            |
    |            auto trait cannot have generic parameters
+   |
+help: remove the parameters
+   |
+LL - auto trait Trait<P> {}
+LL + auto trait Trait {}
+   |
 
 error[E0658]: auto traits are experimental and possibly buggy
   --> $DIR/issue-117789.rs:1:1

--- a/tests/ui/auto-traits/issue-23080-2.current.stderr
+++ b/tests/ui/auto-traits/issue-23080-2.current.stderr
@@ -4,7 +4,13 @@ error[E0380]: auto traits cannot have associated items
 LL | unsafe auto trait Trait {
    |                   ----- auto traits cannot have associated items
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
+   |
+help: remove these associated items
+   |
+LL -     type Output;
+LL +
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/issue-23080-2.next.stderr
+++ b/tests/ui/auto-traits/issue-23080-2.next.stderr
@@ -4,7 +4,13 @@ error[E0380]: auto traits cannot have associated items
 LL | unsafe auto trait Trait {
    |                   ----- auto traits cannot have associated items
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
+   |
+help: remove these associated items
+   |
+LL -     type Output;
+LL +
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/issue-23080.stderr
+++ b/tests/ui/auto-traits/issue-23080.stderr
@@ -1,13 +1,17 @@
 error[E0380]: auto traits cannot have associated items
   --> $DIR/issue-23080.rs:5:8
    |
-LL |   unsafe auto trait Trait {
-   |                     ----- auto traits cannot have associated items
-LL |       fn method(&self) {
-   |  _____-  ^^^^^^
-LL | |         println!("Hello");
-LL | |     }
-   | |_____- help: remove these associated items
+LL | unsafe auto trait Trait {
+   |                   ----- auto traits cannot have associated items
+LL |     fn method(&self) {
+   |        ^^^^^^
+   |
+help: remove these associated items
+   |
+LL -     fn method(&self) {
+LL -         println!("Hello");
+LL -     }
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/issue-84075.stderr
+++ b/tests/ui/auto-traits/issue-84075.stderr
@@ -2,9 +2,15 @@ error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/issue-84075.rs:5:18
    |
 LL | auto trait Magic where Self: Copy {}
-   |            ----- ^^^^^^^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            ----- ^^^^^^^^^^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
+   |
+help: remove the super traits or lifetime bounds
+   |
+LL - auto trait Magic where Self: Copy {}
+LL + auto trait Magic  {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
@@ -2,17 +2,29 @@ error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:17
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   |            -----^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----^^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
+   |
+help: remove the super traits or lifetime bounds
+   |
+LL - auto trait Magic : Sized where Option<Self> : Magic {}
+LL + auto trait Magic where Option<Self> : Magic {}
+   |
 
 error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:26
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   |            -----         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
+   |
+help: remove the super traits or lifetime bounds
+   |
+LL - auto trait Magic : Sized where Option<Self> : Magic {}
+LL + auto trait Magic : Sized  {}
+   |
 
 error[E0382]: use of moved value: `x`
   --> $DIR/typeck-auto-trait-no-supertraits-2.rs:8:41

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits.stderr
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits.stderr
@@ -2,9 +2,15 @@ error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/typeck-auto-trait-no-supertraits.rs:28:17
    |
 LL | auto trait Magic: Copy {}
-   |            -----^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
+   |
+help: remove the super traits or lifetime bounds
+   |
+LL - auto trait Magic: Copy {}
+LL + auto trait Magic {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -2,19 +2,37 @@ error: `cfg` is not followed by parentheses
   --> $DIR/cfg-attr-syntax-validation.rs:1:1
    |
 LL | #[cfg]
-   | ^^^^^^ help: expected syntax is: `cfg(/* predicate */)`
+   | ^^^^^^
+   |
+help: expected syntax is
+   |
+LL - #[cfg]
+LL + cfg(/* predicate */)
+   |
 
 error: `cfg` is not followed by parentheses
   --> $DIR/cfg-attr-syntax-validation.rs:4:1
    |
 LL | #[cfg = 10]
-   | ^^^^^^^^^^^ help: expected syntax is: `cfg(/* predicate */)`
+   | ^^^^^^^^^^^
+   |
+help: expected syntax is
+   |
+LL - #[cfg = 10]
+LL + cfg(/* predicate */)
+   |
 
 error: `cfg` predicate is not specified
   --> $DIR/cfg-attr-syntax-validation.rs:7:1
    |
 LL | #[cfg()]
-   | ^^^^^^^^ help: expected syntax is: `cfg(/* predicate */)`
+   | ^^^^^^^^
+   |
+help: expected syntax is
+   |
+LL - #[cfg()]
+LL + cfg(/* predicate */)
+   |
 
 error: multiple `cfg` predicates are specified
   --> $DIR/cfg-attr-syntax-validation.rs:10:10

--- a/tests/ui/const-generics/argument_order.stderr
+++ b/tests/ui/const-generics/argument_order.stderr
@@ -2,7 +2,13 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/argument_order.rs:6:32
    |
 LL | struct AlsoBad<const N: usize, 'a, T, 'b, const M: usize, U> {
-   |               -----------------^^-----^^-------------------- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, const N: usize, T, const M: usize, U>`
+   |                                ^^     ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct AlsoBad<const N: usize, 'a, T, 'b, const M: usize, U> {
+LL + struct AlsoBad<'a, 'b, const N: usize, T, const M: usize, U> {
+   |
 
 error[E0747]: lifetime provided when a type was expected
   --> $DIR/argument_order.rs:13:23

--- a/tests/ui/const-generics/const-param-before-other-params.stderr
+++ b/tests/ui/const-generics/const-param-before-other-params.stderr
@@ -2,7 +2,13 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/const-param-before-other-params.rs:1:21
    |
 LL | fn bar<const X: u8, 'a>(_: &'a ()) {
-   |       --------------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, const X: u8>`
+   |                     ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - fn bar<const X: u8, 'a>(_: &'a ()) {
+LL + fn bar<'a, const X: u8>(_: &'a ()) {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/defaults/intermixed-lifetime.stderr
+++ b/tests/ui/const-generics/defaults/intermixed-lifetime.stderr
@@ -2,13 +2,25 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/intermixed-lifetime.rs:3:28
    |
 LL | struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
-   |           -----------------^^---------- help: reorder the parameters: lifetimes, then consts and types: `<'a, const N: usize, T = u32>`
+   |                            ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
+LL + struct Foo<'a, const N: usize, T = u32>(&'a (), T);
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/intermixed-lifetime.rs:6:37
    |
 LL | struct Bar<const N: usize, T = u32, 'a>(&'a (), T);
-   |           --------------------------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, const N: usize, T = u32>`
+   |                                     ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct Bar<const N: usize, T = u32, 'a>(&'a (), T);
+LL + struct Bar<'a, const N: usize, T = u32>(&'a (), T);
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/defaults/param-order-err-pretty-prints-default.stderr
+++ b/tests/ui/const-generics/defaults/param-order-err-pretty-prints-default.stderr
@@ -2,7 +2,13 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/param-order-err-pretty-prints-default.rs:1:33
    |
 LL | struct Foo<const M: usize = 10, 'a>(&'a u32);
-   |           ----------------------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, const M: usize = 10>`
+   |                                 ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct Foo<const M: usize = 10, 'a>(&'a u32);
+LL + struct Foo<'a, const M: usize = 10>(&'a u32);
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-2.stderr
+++ b/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-2.stderr
@@ -5,9 +5,12 @@ LL | / const _: A<
 ...  |
 LL | |     },
 LL | | >;
-   | |  ^ help: provide a definition for the constant: `= <expr>;`
-   | |__|
+   | |__^
    |
+help: provide a definition for the constant
+   |
+LL | > = <expr>;
+   |   ++++++++
 
 error[E0412]: cannot find type `A` in this scope
   --> $DIR/const_arg_trivial_macro_expansion-2.rs:12:10

--- a/tests/ui/consts/const-fn-mismatch.stderr
+++ b/tests/ui/consts/const-fn-mismatch.stderr
@@ -2,10 +2,13 @@ error[E0379]: functions in trait impls cannot be declared const
   --> $DIR/const-fn-mismatch.rs:11:5
    |
 LL |     const fn f() -> u32 {
-   |     ^^^^^-
-   |     |
-   |     functions in trait impls cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in trait impls cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn f() -> u32 {
+LL +     fn f() -> u32 {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-fn-not-in-trait.stderr
+++ b/tests/ui/consts/const-fn-not-in-trait.stderr
@@ -2,19 +2,25 @@ error[E0379]: functions in traits cannot be declared const
   --> $DIR/const-fn-not-in-trait.rs:5:5
    |
 LL |     const fn f() -> u32;
-   |     ^^^^^-
-   |     |
-   |     functions in traits cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in traits cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn f() -> u32;
+LL +     fn f() -> u32;
+   |
 
 error[E0379]: functions in traits cannot be declared const
   --> $DIR/const-fn-not-in-trait.rs:7:5
    |
 LL |     const fn g() -> u32 {
-   |     ^^^^^-
-   |     |
-   |     functions in traits cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in traits cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn g() -> u32 {
+LL +     fn g() -> u32 {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/issue-54954.stderr
+++ b/tests/ui/consts/issue-54954.stderr
@@ -2,10 +2,13 @@ error[E0379]: functions in traits cannot be declared const
   --> $DIR/issue-54954.rs:5:5
    |
 LL |     const fn const_val<T: Sized>() -> usize {
-   |     ^^^^^-
-   |     |
-   |     functions in traits cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in traits cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn const_val<T: Sized>() -> usize {
+LL +     fn const_val<T: Sized>() -> usize {
+   |
 
 error[E0790]: cannot call associated function on trait without specifying the corresponding `impl` type
   --> $DIR/issue-54954.rs:1:24

--- a/tests/ui/destructuring-assignment/note-unsupported.stderr
+++ b/tests/ui/destructuring-assignment/note-unsupported.stderr
@@ -2,7 +2,13 @@ error: functional record updates are not allowed in destructuring assignments
   --> $DIR/note-unsupported.rs:20:17
    |
 LL |     S { x: a, ..s } = S { x: 3, y: 4 };
-   |                 ^ help: consider removing the trailing pattern
+   |                 ^
+   |
+help: consider removing the trailing pattern
+   |
+LL -     S { x: a, ..s } = S { x: 3, y: 4 };
+LL +     S { x: a, .. } = S { x: 3, y: 4 };
+   |
 
 error[E0368]: binary assignment operation `+=` cannot be applied to type `({integer}, {integer})`
   --> $DIR/note-unsupported.rs:7:5

--- a/tests/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/tests/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -10,7 +10,13 @@ error: functional record updates are not allowed in destructuring assignments
   --> $DIR/struct_destructure_fail.rs:13:19
    |
 LL |     Struct { a, ..d } = Struct { a: 1, b: 2 };
-   |                   ^ help: consider removing the trailing pattern
+   |                   ^
+   |
+help: consider removing the trailing pattern
+   |
+LL -     Struct { a, ..d } = Struct { a: 1, b: 2 };
+LL +     Struct { a, .. } = Struct { a: 1, b: 2 };
+   |
 
 error[E0026]: struct `Struct` does not have a field named `c`
   --> $DIR/struct_destructure_fail.rs:10:20

--- a/tests/ui/dyn-compatibility/assoc_type_bounds_sized_unnecessary.stderr
+++ b/tests/ui/dyn-compatibility/assoc_type_bounds_sized_unnecessary.stderr
@@ -2,10 +2,15 @@ warning: unnecessary associated type bound for dyn-incompatible associated type
   --> $DIR/assoc_type_bounds_sized_unnecessary.rs:9:20
    |
 LL | fn foo(_: &dyn Foo<Bar = ()>) {}
-   |                    ^^^^^^^^ help: remove this bound
+   |                    ^^^^^^^^
    |
    = note: this associated type has a `where Self: Sized` bound, and while the associated type can be specified, it cannot be used because trait objects are never `Sized`
    = note: `#[warn(unused_associated_type_bounds)]` on by default
+help: remove this bound
+   |
+LL - fn foo(_: &dyn Foo<Bar = ()>) {}
+LL + fn foo(_: &dyn Foo<>) {}
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/error-codes/E0220.stderr
+++ b/tests/ui/error-codes/E0220.stderr
@@ -2,7 +2,13 @@ error[E0220]: associated type `F` not found for `Trait`
   --> $DIR/E0220.rs:5:22
    |
 LL | type Foo = dyn Trait<F=i32>;
-   |                      ^ help: `Trait` has the following associated type: `Bar`
+   |                      ^
+   |
+help: `Trait` has the following associated type
+   |
+LL - type Foo = dyn Trait<F=i32>;
+LL + type Foo = dyn Trait<Bar=i32>;
+   |
 
 error[E0191]: the value of the associated type `Bar` in `Trait` must be specified
   --> $DIR/E0220.rs:5:16

--- a/tests/ui/error-codes/E0449.stderr
+++ b/tests/ui/error-codes/E0449.stderr
@@ -2,25 +2,40 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/E0449.rs:11:1
    |
 LL | pub impl Bar {}
-   | ^^^ help: remove the qualifier
+   | ^^^
    |
    = note: place qualifiers on individual impl items instead
+help: remove the qualifier
+   |
+LL - pub impl Bar {}
+LL +  impl Bar {}
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/E0449.rs:13:1
    |
 LL | pub impl Foo for Bar {
-   | ^^^ help: remove the qualifier
+   | ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL - pub impl Foo for Bar {
+LL +  impl Foo for Bar {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/E0449.rs:14:5
    |
 LL |     pub fn foo() {}
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub fn foo() {}
+LL +      fn foo() {}
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/extern/extern-ffi-fn-with-body.stderr
+++ b/tests/ui/extern/extern-ffi-fn-with-body.stderr
@@ -1,18 +1,20 @@
 error: incorrect function inside `extern` block
   --> $DIR/extern-ffi-fn-with-body.rs:2:8
    |
-LL |   extern "C" {
-   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
-LL |       fn foo() -> i32 {
-   |  ________^^^__________-
-   | |        |
-   | |        cannot have a body
-LL | |         return 0;
-LL | |     }
-   | |_____- help: remove the invalid body: `;`
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |     fn foo() -> i32 {
+   |        ^^^ cannot have a body
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the invalid body
+   |
+LL -     fn foo() -> i32 {
+LL -         return 0;
+LL -     }
+LL +     fn foo() -> i32 ;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/extern/issue-112363-extern-item-where-clauses-debug-ice.stderr
+++ b/tests/ui/extern/issue-112363-extern-item-where-clauses-debug-ice.stderr
@@ -16,9 +16,14 @@ error: `type`s inside `extern` blocks cannot have `where` clauses
 LL | extern "C" {
    | ---------- `extern` block begins here
 LL |     type Item = [T] where [T]: Sized;
-   |                     ^^^^^^^^^^^^^^^^ help: remove the `where` clause
+   |                     ^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the `where` clause
+   |
+LL -     type Item = [T] where [T]: Sized;
+LL +     type Item = [T] ;
+   |
 
 error[E0412]: cannot find type `T` in this scope
   --> $DIR/issue-112363-extern-item-where-clauses-debug-ice.rs:2:28

--- a/tests/ui/extern/issue-95829.stderr
+++ b/tests/ui/extern/issue-95829.stderr
@@ -1,19 +1,21 @@
 error: incorrect function inside `extern` block
   --> $DIR/issue-95829.rs:4:14
    |
-LL |   extern "C" {
-   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
-LL |       async fn L() {
-   |  ______________^___-
-   | |              |
-   | |              cannot have a body
-LL | |
-LL | |         async fn M() {}
-LL | |     }
-   | |_____- help: remove the invalid body: `;`
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |     async fn L() {
+   |              ^ cannot have a body
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the invalid body
+   |
+LL -     async fn L() {
+LL -
+LL -         async fn M() {}
+LL -     }
+LL +     async fn L() ;
+   |
 
 error: functions in `extern` blocks cannot have `async` qualifier
   --> $DIR/issue-95829.rs:4:5
@@ -21,7 +23,13 @@ error: functions in `extern` blocks cannot have `async` qualifier
 LL | extern "C" {
    | ---------- in this `extern` block
 LL |     async fn L() {
-   |     ^^^^^ help: remove the `async` qualifier
+   |     ^^^^^
+   |
+help: remove the `async` qualifier
+   |
+LL -     async fn L() {
+LL +      fn L() {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-min_const_fn.stderr
+++ b/tests/ui/feature-gates/feature-gate-min_const_fn.stderr
@@ -2,28 +2,37 @@ error[E0379]: functions in traits cannot be declared const
   --> $DIR/feature-gate-min_const_fn.rs:6:5
    |
 LL |     const fn foo() -> u32;
-   |     ^^^^^-
-   |     |
-   |     functions in traits cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in traits cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn foo() -> u32;
+LL +     fn foo() -> u32;
+   |
 
 error[E0379]: functions in traits cannot be declared const
   --> $DIR/feature-gate-min_const_fn.rs:7:5
    |
 LL |     const fn bar() -> u32 { 0 }
-   |     ^^^^^-
-   |     |
-   |     functions in traits cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in traits cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn bar() -> u32 { 0 }
+LL +     fn bar() -> u32 { 0 }
+   |
 
 error[E0379]: functions in trait impls cannot be declared const
   --> $DIR/feature-gate-min_const_fn.rs:11:5
    |
 LL |     const fn foo() -> u32 { 0 }
-   |     ^^^^^-
-   |     |
-   |     functions in trait impls cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in trait impls cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn foo() -> u32 { 0 }
+LL +     fn foo() -> u32 { 0 }
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-never_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_patterns.stderr
@@ -133,7 +133,13 @@ error: a guard on a never pattern will never be run
   --> $DIR/feature-gate-never_patterns.rs:54:19
    |
 LL |         Err(!) if false,
-   |                   ^^^^^ help: remove this guard
+   |                   ^^^^^
+   |
+help: remove this guard
+   |
+LL -         Err(!) if false,
+LL +         Err(!) if ,
+   |
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/feature-gates/gated-bad-feature.stderr
+++ b/tests/ui/feature-gates/gated-bad-feature.stderr
@@ -2,13 +2,25 @@ error[E0556]: malformed `feature` attribute input
   --> $DIR/gated-bad-feature.rs:1:25
    |
 LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
-   |                         ^^^^^^^^ help: expected just one word: `foo`
+   |                         ^^^^^^^^
+   |
+help: expected just one word
+   |
+LL - #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
+LL + #![feature(foo_bar_baz, foo, foo = "baz", foo)]
+   |
 
 error[E0556]: malformed `feature` attribute input
   --> $DIR/gated-bad-feature.rs:1:35
    |
 LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
-   |                                   ^^^^^^^^^^^ help: expected just one word: `foo`
+   |                                   ^^^^^^^^^^^
+   |
+help: expected just one word
+   |
+LL - #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
+LL + #![feature(foo_bar_baz, foo(bar), foo, foo)]
+   |
 
 error[E0557]: feature has been removed
   --> $DIR/gated-bad-feature.rs:8:12

--- a/tests/ui/fmt/raw-idents.stderr
+++ b/tests/ui/fmt/raw-idents.stderr
@@ -2,23 +2,27 @@ error: invalid format string: raw identifiers are not supported
   --> $DIR/raw-idents.rs:8:22
    |
 LL |     println!("It is {r#type}");
-   |                      --^^^^
-   |                      |
-   |                      raw identifier used here in format string
-   |                      help: remove the `r#`
+   |                      ^^^^^^ raw identifier used here in format string
    |
    = note: identifiers in format strings can be keywords and don't need to be prefixed with `r#`
+help: remove the `r#`
+   |
+LL -     println!("It is {r#type}");
+LL +     println!("It is {type}");
+   |
 
 error: invalid format string: raw identifiers are not supported
   --> $DIR/raw-idents.rs:9:31
    |
 LL |     println!(r##"It still is {r#type}"##);
-   |                               --^^^^
-   |                               |
-   |                               raw identifier used here in format string
-   |                               help: remove the `r#`
+   |                               ^^^^^^ raw identifier used here in format string
    |
    = note: identifiers in format strings can be keywords and don't need to be prefixed with `r#`
+help: remove the `r#`
+   |
+LL -     println!(r##"It still is {r#type}"##);
+LL +     println!(r##"It still is {type}"##);
+   |
 
 error: invalid format string: raw identifiers are not supported
   --> $DIR/raw-idents.rs:10:14
@@ -33,12 +37,14 @@ error: invalid format string: raw identifiers are not supported
   --> $DIR/raw-idents.rs:11:16
    |
 LL |     println!("{\x72\x23type:?}");
-   |                --------^^^^
-   |                |
-   |                raw identifier used here in format string
-   |                help: remove the `r#`
+   |                ^^^^^^^^^^^^ raw identifier used here in format string
    |
    = note: identifiers in format strings can be keywords and don't need to be prefixed with `r#`
+help: remove the `r#`
+   |
+LL -     println!("{\x72\x23type:?}");
+LL +     println!("{type:?}");
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/foreign/issue-74120-lowering-of-ffi-block-bodies.stderr
+++ b/tests/ui/foreign/issue-74120-lowering-of-ffi-block-bodies.stderr
@@ -1,19 +1,21 @@
 error: incorrect function inside `extern` block
   --> $DIR/issue-74120-lowering-of-ffi-block-bodies.rs:7:8
    |
-LL |   extern "C" {
-   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
-LL |       fn f() {
-   |  ________^___-
-   | |        |
-   | |        cannot have a body
-LL | |
-LL | |         fn g() {}
-LL | |     }
-   | |_____- help: remove the invalid body: `;`
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |     fn f() {
+   |        ^ cannot have a body
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the invalid body
+   |
+LL -     fn f() {
+LL -
+LL -         fn g() {}
+LL -     }
+LL +     fn f() ;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/foreign/issue-91370-foreign-fn-block-impl.stderr
+++ b/tests/ui/foreign/issue-91370-foreign-fn-block-impl.stderr
@@ -1,21 +1,23 @@
 error: incorrect function inside `extern` block
   --> $DIR/issue-91370-foreign-fn-block-impl.rs:5:8
    |
-LL |   extern "C" {
-   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
 LL |
-LL |       fn f() {
-   |  ________^___-
-   | |        |
-   | |        cannot have a body
-LL | |
-LL | |
-LL | |         impl Copy for u8 {}
-LL | |     }
-   | |_____- help: remove the invalid body: `;`
+LL |     fn f() {
+   |        ^ cannot have a body
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the invalid body
+   |
+LL -     fn f() {
+LL -
+LL -
+LL -         impl Copy for u8 {}
+LL -     }
+LL +     fn f() ;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/issue-59508-1.stderr
+++ b/tests/ui/generics/issue-59508-1.stderr
@@ -2,7 +2,13 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/issue-59508-1.rs:10:25
    |
 LL |     pub fn do_things<T, 'a, 'b: 'a>() {
-   |                     ----^^--^^----- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b: 'a, T>`
+   |                         ^^  ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL -     pub fn do_things<T, 'a, 'b: 'a>() {
+LL +     pub fn do_things<'a, 'b: 'a, T>() {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/issue-59508.stderr
+++ b/tests/ui/generics/issue-59508.stderr
@@ -2,7 +2,13 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/issue-59508.rs:10:25
    |
 LL |     pub fn do_things<T, 'a, 'b: 'a>() {
-   |                     ----^^--^^----- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b: 'a, T>`
+   |                         ^^  ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL -     pub fn do_things<T, 'a, 'b: 'a>() {
+LL +     pub fn do_things<'a, 'b: 'a, T>() {
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/issue-80512-param-reordering-with-defaults.stderr
+++ b/tests/ui/generics/issue-80512-param-reordering-with-defaults.stderr
@@ -2,7 +2,13 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/issue-80512-param-reordering-with-defaults.rs:3:18
    |
 LL | struct S<T = (), 'a>(&'a T);
-   |         ---------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, T = ()>`
+   |                  ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct S<T = (), 'a>(&'a T);
+LL + struct S<'a, T = ()>(&'a T);
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/issue-83556.stderr
+++ b/tests/ui/generics/issue-83556.stderr
@@ -2,7 +2,13 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/issue-83556.rs:1:15
    |
 LL | struct Foo<T, 'a>(&'a ());
-   |           ----^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, T>`
+   |               ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct Foo<T, 'a>(&'a ());
+LL + struct Foo<'a, T>(&'a ());
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/lifetime-before-type-params.stderr
+++ b/tests/ui/generics/lifetime-before-type-params.stderr
@@ -2,25 +2,49 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/lifetime-before-type-params.rs:2:13
    |
 LL | fn first<T, 'a, 'b>() {}
-   |         ----^^--^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, T>`
+   |             ^^  ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - fn first<T, 'a, 'b>() {}
+LL + fn first<'a, 'b, T>() {}
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/lifetime-before-type-params.rs:4:18
    |
 LL | fn second<'a, T, 'b>() {}
-   |          --------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, T>`
+   |                  ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - fn second<'a, T, 'b>() {}
+LL + fn second<'a, 'b, T>() {}
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/lifetime-before-type-params.rs:6:16
    |
 LL | fn third<T, U, 'a>() {}
-   |         -------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, T, U>`
+   |                ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - fn third<T, U, 'a>() {}
+LL + fn third<'a, T, U>() {}
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/lifetime-before-type-params.rs:8:18
    |
 LL | fn fourth<'a, T, 'b, U, 'c, V>() {}
-   |          --------^^-----^^---- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, 'c, T, U, V>`
+   |                  ^^     ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - fn fourth<'a, T, 'b, U, 'c, V>() {}
+LL + fn fourth<'a, 'b, 'c, T, U, V>() {}
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/issues/issue-28433.stderr
+++ b/tests/ui/issues/issue-28433.stderr
@@ -2,17 +2,27 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/issue-28433.rs:2:5
    |
 LL |     pub Duck,
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: enum variants and their fields always share the visibility of the enum they are in
+help: remove the qualifier
+   |
+LL -     pub Duck,
+LL +      Duck,
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/issue-28433.rs:5:5
    |
 LL |     pub(crate) Dove
-   |     ^^^^^^^^^^ help: remove the qualifier
+   |     ^^^^^^^^^^
    |
    = note: enum variants and their fields always share the visibility of the enum they are in
+help: remove the qualifier
+   |
+LL -     pub(crate) Dove
+LL +      Dove
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-75283.stderr
+++ b/tests/ui/issues/issue-75283.stderr
@@ -1,18 +1,20 @@
 error: incorrect function inside `extern` block
   --> $DIR/issue-75283.rs:2:8
    |
-LL |   extern "C" {
-   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
-LL |       fn lol() {
-   |  ________^^^___-
-   | |        |
-   | |        cannot have a body
-LL | |         println!("");
-LL | |     }
-   | |_____- help: remove the invalid body: `;`
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |     fn lol() {
+   |        ^^^ cannot have a body
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the invalid body
+   |
+LL -     fn lol() {
+LL -         println!("");
+LL -     }
+LL +     fn lol() ;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lazy-type-alias/leading-where-clause.stderr
+++ b/tests/ui/lazy-type-alias/leading-where-clause.stderr
@@ -45,9 +45,14 @@ error: where clauses are not allowed before the type for type aliases
   --> $DIR/leading-where-clause.rs:24:27
    |
 LL | pub type EmptyLeading1<T> where = T where T: Copy;
-   |                           ^^^^^ help: remove this `where`
+   |                           ^^^^^
    |
    = note: see issue #89122 <https://github.com/rust-lang/rust/issues/89122> for more information
+help: remove this `where`
+   |
+LL - pub type EmptyLeading1<T> where = T where T: Copy;
+LL + pub type EmptyLeading1<T>  = T where T: Copy;
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/lifetimes/issue-83907-invalid-fn-like-path.stderr
+++ b/tests/ui/lifetimes/issue-83907-invalid-fn-like-path.stderr
@@ -2,9 +2,12 @@ error: free static item without body
   --> $DIR/issue-83907-invalid-fn-like-path.rs:3:1
    |
 LL | static STATIC_VAR_FIVE: &One();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                               |
-   |                               help: provide a definition for the static: `= <expr>;`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the static
+   |
+LL | static STATIC_VAR_FIVE: &One() = <expr>;
+   |                                ++++++++
 
 error[E0412]: cannot find type `One` in this scope
   --> $DIR/issue-83907-invalid-fn-like-path.rs:3:26

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -2,9 +2,13 @@ error: associated function in `impl` without body
   --> $DIR/issue-95023.rs:8:5
    |
 LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                                                    |
-   |                                                    help: provide a definition for the function: `{ <body> }`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL -     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
+LL +     fn foo<const N: usize>(&self) -> Self::B<{ N }> { <body> }
+   |
 
 error[E0407]: method `foo` is not a member of trait `Fn`
   --> $DIR/issue-95023.rs:8:5
@@ -54,7 +58,13 @@ error[E0220]: associated type `B` not found for `Self`
   --> $DIR/issue-95023.rs:8:44
    |
 LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
-   |                                            ^ help: `Self` has the following associated type: `Output`
+   |                                            ^
+   |
+help: `Self` has the following associated type
+   |
+LL -     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
+LL +     fn foo<const N: usize>(&self) -> Self::Output<{ N }>;
+   |
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/lifetimes/issue-97193.stderr
+++ b/tests/ui/lifetimes/issue-97193.stderr
@@ -1,20 +1,22 @@
 error: incorrect function inside `extern` block
   --> $DIR/issue-97193.rs:2:8
    |
-LL |   extern "C" {
-   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
-LL |       fn a(&mut self) {
-   |  ________^____________-
-   | |        |
-   | |        cannot have a body
-LL | |
-LL | |
-LL | |         fn b(buf: &Self) {}
-LL | |     }
-   | |_____- help: remove the invalid body: `;`
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |     fn a(&mut self) {
+   |        ^ cannot have a body
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the invalid body
+   |
+LL -     fn a(&mut self) {
+LL -
+LL -
+LL -         fn b(buf: &Self) {}
+LL -     }
+LL +     fn a(&mut self) ;
+   |
 
 error: `self` parameter is only allowed in associated functions
   --> $DIR/issue-97193.rs:2:10

--- a/tests/ui/lifetimes/issue-97194.stderr
+++ b/tests/ui/lifetimes/issue-97194.stderr
@@ -1,18 +1,23 @@
 error: incorrect function inside `extern` block
   --> $DIR/issue-97194.rs:2:8
    |
-LL |   extern "C" {
-   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
-LL |       fn bget(&self, index: [usize; Self::DIM]) -> bool {
-   |  ________^^^^___________________________________________-
-   | |        |
-   | |        cannot have a body
-...  |
-LL | |     }
-   | |_____- help: remove the invalid body: `;`
+LL | extern "C" {
+   | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |     fn bget(&self, index: [usize; Self::DIM]) -> bool {
+   |        ^^^^ cannot have a body
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the invalid body
+   |
+LL -     fn bget(&self, index: [usize; Self::DIM]) -> bool {
+LL -
+LL -
+LL -
+LL -         type T<'a> = &'a str;
+LL -     }
+LL +     fn bget(&self, index: [usize; Self::DIM]) -> bool ;
+   |
 
 error: `self` parameter is only allowed in associated functions
   --> $DIR/issue-97194.rs:2:13

--- a/tests/ui/macros/assert-trailing-junk.with-generic-asset.stderr
+++ b/tests/ui/macros/assert-trailing-junk.with-generic-asset.stderr
@@ -42,9 +42,13 @@ error: macro requires an expression as an argument
   --> $DIR/assert-trailing-junk.rs:22:5
    |
 LL |     assert!(true;);
-   |     ^^^^^^^^^^^^-^
-   |                 |
-   |                 help: try removing semicolon
+   |     ^^^^^^^^^^^^^^
+   |
+help: try removing semicolon
+   |
+LL -     assert!(true;);
+LL +     assert!(true);
+   |
 
 error: unexpected string literal
   --> $DIR/assert-trailing-junk.rs:25:27

--- a/tests/ui/macros/assert-trailing-junk.without-generic-asset.stderr
+++ b/tests/ui/macros/assert-trailing-junk.without-generic-asset.stderr
@@ -42,9 +42,13 @@ error: macro requires an expression as an argument
   --> $DIR/assert-trailing-junk.rs:22:5
    |
 LL |     assert!(true;);
-   |     ^^^^^^^^^^^^-^
-   |                 |
-   |                 help: try removing semicolon
+   |     ^^^^^^^^^^^^^^
+   |
+help: try removing semicolon
+   |
+LL -     assert!(true;);
+LL +     assert!(true);
+   |
 
 error: unexpected string literal
   --> $DIR/assert-trailing-junk.rs:25:27

--- a/tests/ui/macros/concat-bytes-error.stderr
+++ b/tests/ui/macros/concat-bytes-error.stderr
@@ -18,7 +18,12 @@ error: cannot concatenate string literals
   --> $DIR/concat-bytes-error.rs:6:19
    |
 LL |     concat_bytes!("tnrsi", "tnri");
-   |                   ^^^^^^^ help: try using a byte string: `b"tnrsi"`
+   |                   ^^^^^^^
+   |
+help: try using a byte string
+   |
+LL |     concat_bytes!(b"tnrsi", "tnri");
+   |                   +
 
 error: cannot concatenate float literals
   --> $DIR/concat-bytes-error.rs:7:19
@@ -30,13 +35,24 @@ error: cannot concatenate numeric literals
   --> $DIR/concat-bytes-error.rs:8:19
    |
 LL |     concat_bytes!(300);
-   |                   ^^^ help: try wrapping the number in an array: `[300]`
+   |                   ^^^
+   |
+help: try wrapping the number in an array
+   |
+LL -     concat_bytes!(300);
+LL +     concat_bytes!([300]);
+   |
 
 error: cannot concatenate character literals
   --> $DIR/concat-bytes-error.rs:9:19
    |
 LL |     concat_bytes!('a');
-   |                   ^^^ help: try using a byte character: `b'a'`
+   |                   ^^^
+   |
+help: try using a byte character
+   |
+LL |     concat_bytes!(b'a');
+   |                   +
 
 error: cannot concatenate boolean literals
   --> $DIR/concat-bytes-error.rs:10:19
@@ -48,13 +64,25 @@ error: cannot concatenate numeric literals
   --> $DIR/concat-bytes-error.rs:11:19
    |
 LL |     concat_bytes!(42, b"va", b'l');
-   |                   ^^ help: try wrapping the number in an array: `[42]`
+   |                   ^^
+   |
+help: try wrapping the number in an array
+   |
+LL -     concat_bytes!(42, b"va", b'l');
+LL +     concat_bytes!([42], b"va", b'l');
+   |
 
 error: cannot concatenate numeric literals
   --> $DIR/concat-bytes-error.rs:12:19
    |
 LL |     concat_bytes!(42, b"va", b'l', [1, 2]);
-   |                   ^^ help: try wrapping the number in an array: `[42]`
+   |                   ^^
+   |
+help: try wrapping the number in an array
+   |
+LL -     concat_bytes!(42, b"va", b'l', [1, 2]);
+LL +     concat_bytes!([42], b"va", b'l', [1, 2]);
+   |
 
 error: cannot concatenate string literals
   --> $DIR/concat-bytes-error.rs:14:9
@@ -66,7 +94,12 @@ error: cannot concatenate character literals
   --> $DIR/concat-bytes-error.rs:17:9
    |
 LL |         'a',
-   |         ^^^ help: try using a byte character: `b'a'`
+   |         ^^^
+   |
+help: try using a byte character
+   |
+LL |         b'a',
+   |         +
 
 error: cannot concatenate boolean literals
   --> $DIR/concat-bytes-error.rs:20:9
@@ -119,7 +152,13 @@ error: cannot concatenate numeric literals
   --> $DIR/concat-bytes-error.rs:40:19
    |
 LL |     concat_bytes!(5u16);
-   |                   ^^^^ help: try wrapping the number in an array: `[5u16]`
+   |                   ^^^^
+   |
+help: try wrapping the number in an array
+   |
+LL -     concat_bytes!(5u16);
+LL +     concat_bytes!([5u16]);
+   |
 
 error: numeric literal is not a `u8`
   --> $DIR/concat-bytes-error.rs:41:20

--- a/tests/ui/malformed/malformed-derive-entry.stderr
+++ b/tests/ui/malformed/malformed-derive-entry.stderr
@@ -2,13 +2,25 @@ error: traits in `#[derive(...)]` don't accept arguments
   --> $DIR/malformed-derive-entry.rs:1:14
    |
 LL | #[derive(Copy(Bad))]
-   |              ^^^^^ help: remove the arguments
+   |              ^^^^^
+   |
+help: remove the arguments
+   |
+LL - #[derive(Copy(Bad))]
+LL + #[derive(Copy)]
+   |
 
 error: traits in `#[derive(...)]` don't accept values
   --> $DIR/malformed-derive-entry.rs:6:14
    |
 LL | #[derive(Copy="bad")]
-   |              ^^^^^^ help: remove the value
+   |              ^^^^^^
+   |
+help: remove the value
+   |
+LL - #[derive(Copy="bad")]
+LL + #[derive(Copy)]
+   |
 
 error: malformed `derive` attribute input
   --> $DIR/malformed-derive-entry.rs:11:1

--- a/tests/ui/methods/issues/issue-105732.stderr
+++ b/tests/ui/methods/issues/issue-105732.stderr
@@ -4,7 +4,13 @@ error[E0380]: auto traits cannot have associated items
 LL | auto trait Foo {
    |            --- auto traits cannot have associated items
 LL |     fn g(&self);
-   |     ---^-------- help: remove these associated items
+   |        ^
+   |
+help: remove these associated items
+   |
+LL -     fn g(&self);
+LL +
+   |
 
 error[E0599]: no method named `g` found for reference `&Self` in the current scope
   --> $DIR/issue-105732.rs:10:14

--- a/tests/ui/mismatched_types/const-fn-in-trait.stderr
+++ b/tests/ui/mismatched_types/const-fn-in-trait.stderr
@@ -2,19 +2,25 @@ error[E0379]: functions in traits cannot be declared const
   --> $DIR/const-fn-in-trait.rs:3:5
    |
 LL |     const fn g();
-   |     ^^^^^-
-   |     |
-   |     functions in traits cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in traits cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn g();
+LL +     fn g();
+   |
 
 error[E0379]: functions in trait impls cannot be declared const
   --> $DIR/const-fn-in-trait.rs:7:5
    |
 LL |     const fn f() -> u32 { 22 }
-   |     ^^^^^-
-   |     |
-   |     functions in trait impls cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in trait impls cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn f() -> u32 { 22 }
+LL +     fn f() -> u32 { 22 }
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/assoc/assoc-static-semantic-fail.stderr
+++ b/tests/ui/parser/assoc/assoc-static-semantic-fail.stderr
@@ -122,49 +122,71 @@ error: associated constant in `impl` without body
   --> $DIR/assoc-static-semantic-fail.rs:12:5
    |
 LL |     static IB: u8;
-   |     ^^^^^^^^^^^^^-
-   |                  |
-   |                  help: provide a definition for the constant: `= <expr>;`
+   |     ^^^^^^^^^^^^^^
+   |
+help: provide a definition for the constant
+   |
+LL |     static IB: u8 = <expr>;
+   |                   ++++++++
 
 error: associated constant in `impl` without body
   --> $DIR/assoc-static-semantic-fail.rs:18:5
    |
 LL |     pub(crate) default static ID: u8;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                                     |
-   |                                     help: provide a definition for the constant: `= <expr>;`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the constant
+   |
+LL |     pub(crate) default static ID: u8 = <expr>;
+   |                                      ++++++++
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/assoc-static-semantic-fail.rs:32:5
    |
 LL |     pub(crate) default static TD: u8;
-   |     ^^^^^^^^^^ help: remove the qualifier
+   |     ^^^^^^^^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub(crate) default static TD: u8;
+LL +      default static TD: u8;
+   |
 
 error: associated constant in `impl` without body
   --> $DIR/assoc-static-semantic-fail.rs:41:5
    |
 LL |     static TB: u8;
-   |     ^^^^^^^^^^^^^-
-   |                  |
-   |                  help: provide a definition for the constant: `= <expr>;`
+   |     ^^^^^^^^^^^^^^
+   |
+help: provide a definition for the constant
+   |
+LL |     static TB: u8 = <expr>;
+   |                   ++++++++
 
 error: associated constant in `impl` without body
   --> $DIR/assoc-static-semantic-fail.rs:47:5
    |
 LL |     pub default static TD: u8;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                              |
-   |                              help: provide a definition for the constant: `= <expr>;`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the constant
+   |
+LL |     pub default static TD: u8 = <expr>;
+   |                               ++++++++
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/assoc-static-semantic-fail.rs:47:5
    |
 LL |     pub default static TD: u8;
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub default static TD: u8;
+LL +      default static TD: u8;
+   |
 
 warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/assoc-static-semantic-fail.rs:3:12

--- a/tests/ui/parser/default.stderr
+++ b/tests/ui/parser/default.stderr
@@ -21,9 +21,14 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/default.rs:17:5
    |
 LL |     pub default fn foo<T: Default>() -> T {
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub default fn foo<T: Default>() -> T {
+LL +      default fn foo<T: Default>() -> T {
+   |
 
 warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/default.rs:3:12

--- a/tests/ui/parser/fn-body-eq-expr-semi.stderr
+++ b/tests/ui/parser/fn-body-eq-expr-semi.stderr
@@ -100,12 +100,15 @@ error: incorrect function inside `extern` block
 LL | extern "C" {
    | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
 LL |     fn foo() = 42;
-   |        ^^^   ----- help: remove the invalid body: `;`
-   |        |
-   |        cannot have a body
+   |        ^^^ cannot have a body
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the invalid body
+   |
+LL -     fn foo() = 42;
+LL +     fn foo() ;
+   |
 
 error: incorrect function inside `extern` block
   --> $DIR/fn-body-eq-expr-semi.rs:11:8
@@ -114,12 +117,15 @@ LL | extern "C" {
    | ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
 ...
 LL |     fn bar() -> u8 = 42;
-   |        ^^^         ----- help: remove the invalid body: `;`
-   |        |
-   |        cannot have a body
+   |        ^^^ cannot have a body
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the invalid body
+   |
+LL -     fn bar() -> u8 = 42;
+LL +     fn bar() -> u8 ;
+   |
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/parser/fn-body-optional-semantic-fail.stderr
+++ b/tests/ui/parser/fn-body-optional-semantic-fail.stderr
@@ -2,33 +2,49 @@ error: free function without a body
   --> $DIR/fn-body-optional-semantic-fail.rs:7:5
    |
 LL |     fn f1();
-   |     ^^^^^^^-
-   |            |
-   |            help: provide a definition for the function: `{ <body> }`
+   |     ^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL -     fn f1();
+LL +     fn f1() { <body> }
+   |
 
 error: free function without a body
   --> $DIR/fn-body-optional-semantic-fail.rs:8:5
    |
 LL |     fn f1_rpit() -> impl Trait;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                               |
-   |                               help: provide a definition for the function: `{ <body> }`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL -     fn f1_rpit() -> impl Trait;
+LL +     fn f1_rpit() -> impl Trait { <body> }
+   |
 
 error: associated function in `impl` without body
   --> $DIR/fn-body-optional-semantic-fail.rs:18:9
    |
 LL |         fn f1();
-   |         ^^^^^^^-
-   |                |
-   |                help: provide a definition for the function: `{ <body> }`
+   |         ^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL -         fn f1();
+LL +         fn f1() { <body> }
+   |
 
 error: associated function in `impl` without body
   --> $DIR/fn-body-optional-semantic-fail.rs:23:9
    |
 LL |         fn f3();
-   |         ^^^^^^^-
-   |                |
-   |                help: provide a definition for the function: `{ <body> }`
+   |         ^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL -         fn f3();
+LL +         fn f3() { <body> }
+   |
 
 error: incorrect function inside `extern` block
   --> $DIR/fn-body-optional-semantic-fail.rs:29:12
@@ -37,12 +53,15 @@ LL |     extern "C" {
    |     ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
 LL |         fn f5(); // OK.
 LL |         fn f6() {}
-   |            ^^   -- help: remove the invalid body: `;`
-   |            |
-   |            cannot have a body
+   |            ^^ cannot have a body
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the invalid body
+   |
+LL -         fn f6() {}
+LL +         fn f6() ;
+   |
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/parser/fn-header-semantic-fail.stderr
+++ b/tests/ui/parser/fn-header-semantic-fail.stderr
@@ -11,19 +11,25 @@ error[E0379]: functions in traits cannot be declared const
   --> $DIR/fn-header-semantic-fail.rs:16:9
    |
 LL |         const fn ft3();
-   |         ^^^^^-
-   |         |
-   |         functions in traits cannot be const
-   |         help: remove the `const`
+   |         ^^^^^ functions in traits cannot be const
+   |
+help: remove the `const`
+   |
+LL -         const fn ft3();
+LL +         fn ft3();
+   |
 
 error[E0379]: functions in traits cannot be declared const
   --> $DIR/fn-header-semantic-fail.rs:18:9
    |
 LL |         const async unsafe extern "C" fn ft5();
-   |         ^^^^^-
-   |         |
-   |         functions in traits cannot be const
-   |         help: remove the `const`
+   |         ^^^^^ functions in traits cannot be const
+   |
+help: remove the `const`
+   |
+LL -         const async unsafe extern "C" fn ft5();
+LL +         async unsafe extern "C" fn ft5();
+   |
 
 error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:18:9
@@ -38,19 +44,25 @@ error[E0379]: functions in trait impls cannot be declared const
   --> $DIR/fn-header-semantic-fail.rs:27:9
    |
 LL |         const fn ft3() {}
-   |         ^^^^^-
-   |         |
-   |         functions in trait impls cannot be const
-   |         help: remove the `const`
+   |         ^^^^^ functions in trait impls cannot be const
+   |
+help: remove the `const`
+   |
+LL -         const fn ft3() {}
+LL +         fn ft3() {}
+   |
 
 error[E0379]: functions in trait impls cannot be declared const
   --> $DIR/fn-header-semantic-fail.rs:29:9
    |
 LL |         const async unsafe extern "C" fn ft5() {}
-   |         ^^^^^-
-   |         |
-   |         functions in trait impls cannot be const
-   |         help: remove the `const`
+   |         ^^^^^ functions in trait impls cannot be const
+   |
+help: remove the `const`
+   |
+LL -         const async unsafe extern "C" fn ft5() {}
+LL +         async unsafe extern "C" fn ft5() {}
+   |
 
 error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:29:9
@@ -76,7 +88,13 @@ error: functions in `extern` blocks cannot have `async` qualifier
 LL |     extern "C" {
    |     ---------- in this `extern` block
 LL |         async fn fe1();
-   |         ^^^^^ help: remove the `async` qualifier
+   |         ^^^^^
+   |
+help: remove the `async` qualifier
+   |
+LL -         async fn fe1();
+LL +          fn fe1();
+   |
 
 error: items in `extern` blocks without an `unsafe` qualifier cannot have safety qualifiers
   --> $DIR/fn-header-semantic-fail.rs:45:9
@@ -96,7 +114,13 @@ LL |     extern "C" {
    |     ---------- in this `extern` block
 ...
 LL |         const fn fe3();
-   |         ^^^^^ help: remove the `const` qualifier
+   |         ^^^^^
+   |
+help: remove the `const` qualifier
+   |
+LL -         const fn fe3();
+LL +          fn fe3();
+   |
 
 error: functions in `extern` blocks cannot have `extern` qualifier
   --> $DIR/fn-header-semantic-fail.rs:47:9
@@ -105,7 +129,13 @@ LL |     extern "C" {
    |     ---------- in this `extern` block
 ...
 LL |         extern "C" fn fe4();
-   |         ^^^^^^^^^^ help: remove the `extern` qualifier
+   |         ^^^^^^^^^^
+   |
+help: remove the `extern` qualifier
+   |
+LL -         extern "C" fn fe4();
+LL +          fn fe4();
+   |
 
 error: functions in `extern` blocks cannot have `async` qualifier
   --> $DIR/fn-header-semantic-fail.rs:48:15
@@ -114,7 +144,13 @@ LL |     extern "C" {
    |     ---------- in this `extern` block
 ...
 LL |         const async unsafe extern "C" fn fe5();
-   |               ^^^^^ help: remove the `async` qualifier
+   |               ^^^^^
+   |
+help: remove the `async` qualifier
+   |
+LL -         const async unsafe extern "C" fn fe5();
+LL +         const  unsafe extern "C" fn fe5();
+   |
 
 error: functions in `extern` blocks cannot have `const` qualifier
   --> $DIR/fn-header-semantic-fail.rs:48:9
@@ -123,7 +159,13 @@ LL |     extern "C" {
    |     ---------- in this `extern` block
 ...
 LL |         const async unsafe extern "C" fn fe5();
-   |         ^^^^^ help: remove the `const` qualifier
+   |         ^^^^^
+   |
+help: remove the `const` qualifier
+   |
+LL -         const async unsafe extern "C" fn fe5();
+LL +          async unsafe extern "C" fn fe5();
+   |
 
 error: functions in `extern` blocks cannot have `extern` qualifier
   --> $DIR/fn-header-semantic-fail.rs:48:28
@@ -132,7 +174,13 @@ LL |     extern "C" {
    |     ---------- in this `extern` block
 ...
 LL |         const async unsafe extern "C" fn fe5();
-   |                            ^^^^^^^^^^ help: remove the `extern` qualifier
+   |                            ^^^^^^^^^^
+   |
+help: remove the `extern` qualifier
+   |
+LL -         const async unsafe extern "C" fn fe5();
+LL +         const async unsafe  fn fe5();
+   |
 
 error: items in `extern` blocks without an `unsafe` qualifier cannot have safety qualifiers
   --> $DIR/fn-header-semantic-fail.rs:48:9

--- a/tests/ui/parser/foreign-ty-semantic-fail.stderr
+++ b/tests/ui/parser/foreign-ty-semantic-fail.stderr
@@ -11,9 +11,14 @@ LL | extern "C" {
    | ---------- `extern` block begins here
 ...
 LL |     type B<'a> where 'a: 'static;
-   |           ^^^^ help: remove the generic parameters
+   |           ^^^^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the generic parameters
+   |
+LL -     type B<'a> where 'a: 'static;
+LL +     type B where 'a: 'static;
+   |
 
 error: `type`s inside `extern` blocks cannot have `where` clauses
   --> $DIR/foreign-ty-semantic-fail.rs:8:16
@@ -22,9 +27,14 @@ LL | extern "C" {
    | ---------- `extern` block begins here
 ...
 LL |     type B<'a> where 'a: 'static;
-   |                ^^^^^^^^^^^^^^^^^ help: remove the `where` clause
+   |                ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the `where` clause
+   |
+LL -     type B<'a> where 'a: 'static;
+LL +     type B<'a> ;
+   |
 
 error: `type`s inside `extern` blocks cannot have generic parameters
   --> $DIR/foreign-ty-semantic-fail.rs:11:11
@@ -33,9 +43,14 @@ LL | extern "C" {
    | ---------- `extern` block begins here
 ...
 LL |     type C<T: Ord> where T: 'static;
-   |           ^^^^^^^^ help: remove the generic parameters
+   |           ^^^^^^^^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the generic parameters
+   |
+LL -     type C<T: Ord> where T: 'static;
+LL +     type C where T: 'static;
+   |
 
 error: `type`s inside `extern` blocks cannot have `where` clauses
   --> $DIR/foreign-ty-semantic-fail.rs:11:20
@@ -44,9 +59,14 @@ LL | extern "C" {
    | ---------- `extern` block begins here
 ...
 LL |     type C<T: Ord> where T: 'static;
-   |                    ^^^^^^^^^^^^^^^^ help: remove the `where` clause
+   |                    ^^^^^^^^^^^^^^^^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the `where` clause
+   |
+LL -     type C<T: Ord> where T: 'static;
+LL +     type C<T: Ord> ;
+   |
 
 error: incorrect `type` inside `extern` block
   --> $DIR/foreign-ty-semantic-fail.rs:14:10
@@ -68,9 +88,14 @@ LL | extern "C" {
    | ---------- `extern` block begins here
 ...
 LL |     type E: where;
-   |             ^^^^^ help: remove the `where` clause
+   |             ^^^^^
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+help: remove the `where` clause
+   |
+LL -     type E: where;
+LL +     type E: ;
+   |
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/parser/impl-item-const-semantic-fail.stderr
+++ b/tests/ui/parser/impl-item-const-semantic-fail.stderr
@@ -2,9 +2,12 @@ error: associated constant in `impl` without body
   --> $DIR/impl-item-const-semantic-fail.rs:6:5
    |
 LL |     const Y: u8;
-   |     ^^^^^^^^^^^-
-   |                |
-   |                help: provide a definition for the constant: `= <expr>;`
+   |     ^^^^^^^^^^^^
+   |
+help: provide a definition for the constant
+   |
+LL |     const Y: u8 = <expr>;
+   |                 ++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/impl-item-fn-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/impl-item-fn-no-body-semantic-fail.stderr
@@ -2,9 +2,13 @@ error: associated function in `impl` without body
   --> $DIR/impl-item-fn-no-body-semantic-fail.rs:6:5
    |
 LL |     fn f();
-   |     ^^^^^^-
-   |           |
-   |           help: provide a definition for the function: `{ <body> }`
+   |     ^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL -     fn f();
+LL +     fn f() { <body> }
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/impl-item-type-no-body-semantic-fail.stderr
@@ -2,17 +2,23 @@ error: associated type in `impl` without body
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:6:5
    |
 LL |     type Y;
-   |     ^^^^^^-
-   |           |
-   |           help: provide a definition for the type: `= <type>;`
+   |     ^^^^^^^
+   |
+help: provide a definition for the type
+   |
+LL |     type Y = <type>;
+   |            ++++++++
 
 error: associated type in `impl` without body
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:9:5
    |
 LL |     type Z: Ord;
-   |     ^^^^^^^^^^^-
-   |                |
-   |                help: provide a definition for the type: `= <type>;`
+   |     ^^^^^^^^^^^^
+   |
+help: provide a definition for the type
+   |
+LL |     type Z: Ord = <type>;
+   |                 ++++++++
 
 error: bounds on `type`s in `impl`s have no effect
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:9:13
@@ -24,9 +30,12 @@ error: associated type in `impl` without body
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:13:5
    |
 LL |     type W: Ord where Self: Eq;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                               |
-   |                               help: provide a definition for the type: `= <type>;`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the type
+   |
+LL |     type W: Ord where Self: Eq = <type>;
+   |                                ++++++++
 
 error: bounds on `type`s in `impl`s have no effect
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:13:13
@@ -38,9 +47,12 @@ error: associated type in `impl` without body
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:18:5
    |
 LL |     type W where Self: Eq;
-   |     ^^^^^^^^^^^^^^^^^^^^^-
-   |                          |
-   |                          help: provide a definition for the type: `= <type>;`
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the type
+   |
+LL |     type W where Self: Eq = <type>;
+   |                           ++++++++
 
 error[E0658]: inherent associated types are unstable
   --> $DIR/impl-item-type-no-body-semantic-fail.rs:6:5

--- a/tests/ui/parser/issues/issue-14303.stderr
+++ b/tests/ui/parser/issues/issue-14303.stderr
@@ -2,31 +2,61 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/issue-14303.rs:1:18
    |
 LL | enum Enum<'a, T, 'b> {
-   |          --------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, T>`
+   |                  ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - enum Enum<'a, T, 'b> {
+LL + enum Enum<'a, 'b, T> {
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/issue-14303.rs:6:22
    |
 LL | struct Struct<'a, T, 'b> {
-   |              --------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, T>`
+   |                      ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct Struct<'a, T, 'b> {
+LL + struct Struct<'a, 'b, T> {
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/issue-14303.rs:11:20
    |
 LL | trait Trait<'a, T, 'b> {}
-   |            --------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, T>`
+   |                    ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - trait Trait<'a, T, 'b> {}
+LL + trait Trait<'a, 'b, T> {}
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/issue-14303.rs:14:15
    |
 LL | fn foo<'a, T, 'b>(x: &'a T) {}
-   |       --------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, T>`
+   |               ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - fn foo<'a, T, 'b>(x: &'a T) {}
+LL + fn foo<'a, 'b, T>(x: &'a T) {}
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/issue-14303.rs:18:13
    |
 LL | impl<'a, T, 'b> Y<T> {}
-   |     --------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, T>`
+   |             ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - impl<'a, T, 'b> Y<T> {}
+LL + impl<'a, 'b, T> Y<T> {}
+   |
 
 error[E0747]: type provided when a lifetime was expected
   --> $DIR/issue-14303.rs:30:37

--- a/tests/ui/parser/issues/issue-87635.stderr
+++ b/tests/ui/parser/issues/issue-87635.stderr
@@ -13,7 +13,12 @@ error: associated function in `impl` without body
   --> $DIR/issue-87635.rs:4:5
    |
 LL |     pub fn bar()
-   |     ^^^^^^^^^^^^- help: provide a definition for the function: `{ <body> }`
+   |     ^^^^^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL |     pub fn bar() { <body> }
+   |                  ++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/item-free-const-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/item-free-const-no-body-semantic-fail.stderr
@@ -2,17 +2,23 @@ error: free constant item without body
   --> $DIR/item-free-const-no-body-semantic-fail.rs:5:1
    |
 LL | const A: u8;
-   | ^^^^^^^^^^^-
-   |            |
-   |            help: provide a definition for the constant: `= <expr>;`
+   | ^^^^^^^^^^^^
+   |
+help: provide a definition for the constant
+   |
+LL | const A: u8 = <expr>;
+   |             ++++++++
 
 error: free constant item without body
   --> $DIR/item-free-const-no-body-semantic-fail.rs:6:1
    |
 LL | const B;
-   | ^^^^^^^-
-   |        |
-   |        help: provide a definition for the constant: `= <expr>;`
+   | ^^^^^^^^
+   |
+help: provide a definition for the constant
+   |
+LL | const B = <expr>;
+   |         ++++++++
 
 error: missing type for `const` item
   --> $DIR/item-free-const-no-body-semantic-fail.rs:6:8

--- a/tests/ui/parser/item-free-static-no-body-semantic-fail.stderr
+++ b/tests/ui/parser/item-free-static-no-body-semantic-fail.stderr
@@ -2,33 +2,45 @@ error: free static item without body
   --> $DIR/item-free-static-no-body-semantic-fail.rs:5:1
    |
 LL | static A: u8;
-   | ^^^^^^^^^^^^-
-   |             |
-   |             help: provide a definition for the static: `= <expr>;`
+   | ^^^^^^^^^^^^^
+   |
+help: provide a definition for the static
+   |
+LL | static A: u8 = <expr>;
+   |              ++++++++
 
 error: free static item without body
   --> $DIR/item-free-static-no-body-semantic-fail.rs:6:1
    |
 LL | static B;
-   | ^^^^^^^^-
-   |         |
-   |         help: provide a definition for the static: `= <expr>;`
+   | ^^^^^^^^^
+   |
+help: provide a definition for the static
+   |
+LL | static B = <expr>;
+   |          ++++++++
 
 error: free static item without body
   --> $DIR/item-free-static-no-body-semantic-fail.rs:9:1
    |
 LL | static mut C: u8;
-   | ^^^^^^^^^^^^^^^^-
-   |                 |
-   |                 help: provide a definition for the static: `= <expr>;`
+   | ^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the static
+   |
+LL | static mut C: u8 = <expr>;
+   |                  ++++++++
 
 error: free static item without body
   --> $DIR/item-free-static-no-body-semantic-fail.rs:10:1
    |
 LL | static mut D;
-   | ^^^^^^^^^^^^-
-   |             |
-   |             help: provide a definition for the static: `= <expr>;`
+   | ^^^^^^^^^^^^^
+   |
+help: provide a definition for the static
+   |
+LL | static mut D = <expr>;
+   |              ++++++++
 
 error: missing type for `static` item
   --> $DIR/item-free-static-no-body-semantic-fail.rs:6:9

--- a/tests/ui/parser/item-free-type-bounds-semantic-fail.stderr
+++ b/tests/ui/parser/item-free-type-bounds-semantic-fail.stderr
@@ -2,9 +2,12 @@ error: free type alias without body
   --> $DIR/item-free-type-bounds-semantic-fail.rs:4:5
    |
 LL |     type A: Ord;
-   |     ^^^^^^^^^^^-
-   |                |
-   |                help: provide a definition for the type: `= <type>;`
+   |     ^^^^^^^^^^^^
+   |
+help: provide a definition for the type
+   |
+LL |     type A: Ord = <type>;
+   |                 ++++++++
 
 error: bounds on `type`s in this context have no effect
   --> $DIR/item-free-type-bounds-semantic-fail.rs:4:13
@@ -28,9 +31,12 @@ error: free type alias without body
   --> $DIR/item-free-type-bounds-semantic-fail.rs:11:5
    |
 LL |     type D<_T>: Ord;
-   |     ^^^^^^^^^^^^^^^-
-   |                    |
-   |                    help: provide a definition for the type: `= <type>;`
+   |     ^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the type
+   |
+LL |     type D<_T>: Ord = <type>;
+   |                     ++++++++
 
 error: bounds on `type`s in this context have no effect
   --> $DIR/item-free-type-bounds-semantic-fail.rs:11:17

--- a/tests/ui/parser/no-const-fn-in-extern-block.stderr
+++ b/tests/ui/parser/no-const-fn-in-extern-block.stderr
@@ -4,7 +4,13 @@ error: functions in `extern` blocks cannot have `const` qualifier
 LL | extern "C" {
    | ---------- in this `extern` block
 LL |     const fn foo();
-   |     ^^^^^ help: remove the `const` qualifier
+   |     ^^^^^
+   |
+help: remove the `const` qualifier
+   |
+LL -     const fn foo();
+LL +      fn foo();
+   |
 
 error: functions in `extern` blocks cannot have `const` qualifier
   --> $DIR/no-const-fn-in-extern-block.rs:4:5
@@ -13,7 +19,13 @@ LL | extern "C" {
    | ---------- in this `extern` block
 ...
 LL |     const unsafe fn bar();
-   |     ^^^^^ help: remove the `const` qualifier
+   |     ^^^^^
+   |
+help: remove the `const` qualifier
+   |
+LL -     const unsafe fn bar();
+LL +      unsafe fn bar();
+   |
 
 error: items in `extern` blocks without an `unsafe` qualifier cannot have safety qualifiers
   --> $DIR/no-const-fn-in-extern-block.rs:4:5

--- a/tests/ui/parser/trait-pub-assoc-const.stderr
+++ b/tests/ui/parser/trait-pub-assoc-const.stderr
@@ -2,9 +2,14 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/trait-pub-assoc-const.rs:2:5
    |
 LL |     pub const Foo: u32;
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub const Foo: u32;
+LL +      const Foo: u32;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/trait-pub-assoc-ty.stderr
+++ b/tests/ui/parser/trait-pub-assoc-ty.stderr
@@ -2,9 +2,14 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/trait-pub-assoc-ty.rs:2:5
    |
 LL |     pub type Foo;
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub type Foo;
+LL +      type Foo;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/trait-pub-method.stderr
+++ b/tests/ui/parser/trait-pub-method.stderr
@@ -2,9 +2,14 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/trait-pub-method.rs:2:5
    |
 LL |     pub fn foo();
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub fn foo();
+LL +      fn foo();
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/privacy/issue-113860-1.stderr
+++ b/tests/ui/privacy/issue-113860-1.stderr
@@ -2,9 +2,14 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/issue-113860-1.rs:12:5
    |
 LL |     pub(self) fn fun() {}
-   |     ^^^^^^^^^ help: remove the qualifier
+   |     ^^^^^^^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub(self) fn fun() {}
+LL +      fn fun() {}
+   |
 
 error: module has missing stability attribute
   --> $DIR/issue-113860-1.rs:1:1

--- a/tests/ui/privacy/issue-113860-2.stderr
+++ b/tests/ui/privacy/issue-113860-2.stderr
@@ -2,9 +2,14 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/issue-113860-2.rs:12:5
    |
 LL |     pub(self) type X = Self;
-   |     ^^^^^^^^^ help: remove the qualifier
+   |     ^^^^^^^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub(self) type X = Self;
+LL +      type X = Self;
+   |
 
 error: module has missing stability attribute
   --> $DIR/issue-113860-2.rs:1:1

--- a/tests/ui/privacy/issue-113860.stderr
+++ b/tests/ui/privacy/issue-113860.stderr
@@ -2,9 +2,14 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/issue-113860.rs:12:5
    |
 LL |     pub(self) const X: u32 = 3;
-   |     ^^^^^^^^^ help: remove the qualifier
+   |     ^^^^^^^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub(self) const X: u32 = 3;
+LL +      const X: u32 = 3;
+   |
 
 error: module has missing stability attribute
   --> $DIR/issue-113860.rs:1:1

--- a/tests/ui/privacy/issue-29161.stderr
+++ b/tests/ui/privacy/issue-29161.stderr
@@ -2,9 +2,14 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/issue-29161.rs:5:9
    |
 LL |         pub fn default() -> A {
-   |         ^^^ help: remove the qualifier
+   |         ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -         pub fn default() -> A {
+LL +          fn default() -> A {
+   |
 
 error[E0603]: struct `A` is private
   --> $DIR/issue-29161.rs:13:8

--- a/tests/ui/privacy/priv-in-bad-locations.stderr
+++ b/tests/ui/privacy/priv-in-bad-locations.stderr
@@ -2,33 +2,53 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/priv-in-bad-locations.rs:1:1
    |
 LL | pub extern "C" {
-   | ^^^ help: remove the qualifier
+   | ^^^
    |
    = note: place qualifiers on individual foreign items instead
+help: remove the qualifier
+   |
+LL - pub extern "C" {
+LL +  extern "C" {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/priv-in-bad-locations.rs:11:1
    |
 LL | pub impl B {}
-   | ^^^ help: remove the qualifier
+   | ^^^
    |
    = note: place qualifiers on individual impl items instead
+help: remove the qualifier
+   |
+LL - pub impl B {}
+LL +  impl B {}
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/priv-in-bad-locations.rs:13:1
    |
 LL | pub impl A for B {
-   | ^^^ help: remove the qualifier
+   | ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL - pub impl A for B {
+LL +  impl A for B {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/priv-in-bad-locations.rs:14:5
    |
 LL |     pub fn foo(&self) {}
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub fn foo(&self) {}
+LL +      fn foo(&self) {}
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/privacy/privacy-sanity.stderr
+++ b/tests/ui/privacy/privacy-sanity.stderr
@@ -2,145 +2,235 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:13:1
    |
 LL | pub impl Tr for S {
-   | ^^^ help: remove the qualifier
+   | ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL - pub impl Tr for S {
+LL +  impl Tr for S {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:14:5
    |
 LL |     pub fn f() {}
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub fn f() {}
+LL +      fn f() {}
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:15:5
    |
 LL |     pub const C: u8 = 0;
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub const C: u8 = 0;
+LL +      const C: u8 = 0;
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:16:5
    |
 LL |     pub type T = u8;
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub type T = u8;
+LL +      type T = u8;
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:18:1
    |
 LL | pub impl S {
-   | ^^^ help: remove the qualifier
+   | ^^^
    |
    = note: place qualifiers on individual impl items instead
+help: remove the qualifier
+   |
+LL - pub impl S {
+LL +  impl S {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:23:1
    |
 LL | pub extern "C" {
-   | ^^^ help: remove the qualifier
+   | ^^^
    |
    = note: place qualifiers on individual foreign items instead
+help: remove the qualifier
+   |
+LL - pub extern "C" {
+LL +  extern "C" {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:39:5
    |
 LL |     pub impl Tr for S {
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub impl Tr for S {
+LL +      impl Tr for S {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:40:9
    |
 LL |         pub fn f() {}
-   |         ^^^ help: remove the qualifier
+   |         ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -         pub fn f() {}
+LL +          fn f() {}
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:41:9
    |
 LL |         pub const C: u8 = 0;
-   |         ^^^ help: remove the qualifier
+   |         ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -         pub const C: u8 = 0;
+LL +          const C: u8 = 0;
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:42:9
    |
 LL |         pub type T = u8;
-   |         ^^^ help: remove the qualifier
+   |         ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -         pub type T = u8;
+LL +          type T = u8;
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:44:5
    |
 LL |     pub impl S {
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: place qualifiers on individual impl items instead
+help: remove the qualifier
+   |
+LL -     pub impl S {
+LL +      impl S {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:49:5
    |
 LL |     pub extern "C" {
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: place qualifiers on individual foreign items instead
+help: remove the qualifier
+   |
+LL -     pub extern "C" {
+LL +      extern "C" {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:68:5
    |
 LL |     pub impl Tr for S {
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub impl Tr for S {
+LL +      impl Tr for S {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:69:9
    |
 LL |         pub fn f() {}
-   |         ^^^ help: remove the qualifier
+   |         ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -         pub fn f() {}
+LL +          fn f() {}
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:70:9
    |
 LL |         pub const C: u8 = 0;
-   |         ^^^ help: remove the qualifier
+   |         ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -         pub const C: u8 = 0;
+LL +          const C: u8 = 0;
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:71:9
    |
 LL |         pub type T = u8;
-   |         ^^^ help: remove the qualifier
+   |         ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -         pub type T = u8;
+LL +          type T = u8;
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:73:5
    |
 LL |     pub impl S {
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: place qualifiers on individual impl items instead
+help: remove the qualifier
+   |
+LL -     pub impl S {
+LL +      impl S {
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/privacy-sanity.rs:78:5
    |
 LL |     pub extern "C" {
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: place qualifiers on individual foreign items instead
+help: remove the qualifier
+   |
+LL -     pub extern "C" {
+LL +      extern "C" {
+   |
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/privacy/sysroot-private.default.stderr
+++ b/tests/ui/privacy/sysroot-private.default.stderr
@@ -26,7 +26,13 @@ error[E0220]: associated type `ExpressionStack` not found for `Trait`
   --> $DIR/sysroot-private.rs:22:31
    |
 LL | type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
-   |                               ^^^^^^^^^^^^^^^ help: `Trait` has the following associated type: `Bar`
+   |                               ^^^^^^^^^^^^^^^
+   |
+help: `Trait` has the following associated type
+   |
+LL - type AssociatedTy = dyn Trait<ExpressionStack = i32, Bar = i32>;
+LL + type AssociatedTy = dyn Trait<Bar = i32, Bar = i32>;
+   |
 
 error[E0425]: cannot find function `memchr2` in this scope
   --> $DIR/sysroot-private.rs:40:5

--- a/tests/ui/privacy/useless-pub.stderr
+++ b/tests/ui/privacy/useless-pub.stderr
@@ -2,25 +2,40 @@ error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/useless-pub.rs:8:5
    |
 LL |     pub fn foo(&self) {}
-   |     ^^^ help: remove the qualifier
+   |     ^^^
    |
    = note: trait items always share the visibility of their trait
+help: remove the qualifier
+   |
+LL -     pub fn foo(&self) {}
+LL +      fn foo(&self) {}
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/useless-pub.rs:12:10
    |
 LL |     V1 { pub f: i32 },
-   |          ^^^ help: remove the qualifier
+   |          ^^^
    |
    = note: enum variants and their fields always share the visibility of the enum they are in
+help: remove the qualifier
+   |
+LL -     V1 { pub f: i32 },
+LL +     V1 {  f: i32 },
+   |
 
 error[E0449]: visibility qualifiers are not permitted here
   --> $DIR/useless-pub.rs:13:8
    |
 LL |     V2(pub i32),
-   |        ^^^ help: remove the qualifier
+   |        ^^^
    |
    = note: enum variants and their fields always share the visibility of the enum they are in
+help: remove the qualifier
+   |
+LL -     V2(pub i32),
+LL +     V2( i32),
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/query-system/issue-83479.stderr
+++ b/tests/ui/query-system/issue-83479.stderr
@@ -15,17 +15,23 @@ error: free static item without body
   --> $DIR/issue-83479.rs:7:9
    |
 LL |         static FOO: usize;
-   |         ^^^^^^^^^^^^^^^^^-
-   |                          |
-   |                          help: provide a definition for the static: `= <expr>;`
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the static
+   |
+LL |         static FOO: usize = <expr>;
+   |                           ++++++++
 
 error: free static item without body
   --> $DIR/issue-83479.rs:12:9
    |
 LL |         static FOO: usize;
-   |         ^^^^^^^^^^^^^^^^^-
-   |                          |
-   |                          help: provide a definition for the static: `= <expr>;`
+   |         ^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the static
+   |
+LL |         static FOO: usize = <expr>;
+   |                           ++++++++
 
 error[E0405]: cannot find trait `Trait` in this scope
   --> $DIR/issue-83479.rs:3:24

--- a/tests/ui/repr/issue-83505-repr-simd.stderr
+++ b/tests/ui/repr/issue-83505-repr-simd.stderr
@@ -2,9 +2,12 @@ error: free static item without body
   --> $DIR/issue-83505-repr-simd.rs:11:1
    |
 LL | static CLs: Es;
-   | ^^^^^^^^^^^^^^-
-   |               |
-   |               help: provide a definition for the static: `= <expr>;`
+   | ^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the static
+   |
+LL | static CLs: Es = <expr>;
+   |                ++++++++
 
 error[E0658]: SIMD types are experimental and possibly buggy
   --> $DIR/issue-83505-repr-simd.rs:5:1

--- a/tests/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/tests/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -2,25 +2,37 @@ error: free function without a body
   --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:3:1
    |
 LL | async fn free();
-   | ^^^^^^^^^^^^^^^-
-   |                |
-   |                help: provide a definition for the function: `{ <body> }`
+   | ^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL - async fn free();
+LL + async fn free() { <body> }
+   |
 
 error: associated function in `impl` without body
   --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:7:5
    |
 LL |     async fn inherent();
-   |     ^^^^^^^^^^^^^^^^^^^-
-   |                        |
-   |                        help: provide a definition for the function: `{ <body> }`
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL -     async fn inherent();
+LL +     async fn inherent() { <body> }
+   |
 
 error: associated function in `impl` without body
   --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:14:5
    |
 LL |     async fn associated();
-   |     ^^^^^^^^^^^^^^^^^^^^^-
-   |                          |
-   |                          help: provide a definition for the function: `{ <body> }`
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL -     async fn associated();
+LL +     async fn associated() { <body> }
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
@@ -22,7 +22,13 @@ error: a guard on a never pattern will never be run
   --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:8:13
    |
 LL |             false
-   |             ^^^^^ help: remove this guard
+   |             ^^^^^
+   |
+help: remove this guard
+   |
+LL -             false
+LL +
+   |
 
 error: mismatched types
   --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:5:14

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block.stderr
@@ -16,10 +16,13 @@ error: a never pattern is always unreachable
   --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:10:20
    |
 LL |         if true => {}
-   |                    ^^
-   |                    |
-   |                    this will never be executed
-   |                    help: remove this expression
+   |                    ^^ this will never be executed
+   |
+help: remove this expression
+   |
+LL -         if true => {}
+LL +         if true =>
+   |
 
 error: mismatched types
   --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:8:9

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
@@ -2,10 +2,13 @@ error: a never pattern is always unreachable
   --> $DIR/ICE-133063-never-arm-no-otherwise-block.rs:10:31
    |
 LL |             (!|!) if false => {}
-   |                               ^^
-   |                               |
-   |                               this will never be executed
-   |                               help: remove this expression
+   |                               ^^ this will never be executed
+   |
+help: remove this expression
+   |
+LL -             (!|!) if false => {}
+LL +             (!|!) if false =>
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
@@ -2,19 +2,25 @@ error: a never pattern is always unreachable
   --> $DIR/ICE-133117-duplicate-never-arm.rs:9:26
    |
 LL |         (!|!) if true => {}
-   |                          ^^
-   |                          |
-   |                          this will never be executed
-   |                          help: remove this expression
+   |                          ^^ this will never be executed
+   |
+help: remove this expression
+   |
+LL -         (!|!) if true => {}
+LL +         (!|!) if true =>
+   |
 
 error: a never pattern is always unreachable
   --> $DIR/ICE-133117-duplicate-never-arm.rs:10:26
    |
 LL |         (!|!) if true => {}
-   |                          ^^
-   |                          |
-   |                          this will never be executed
-   |                          help: remove this expression
+   |                          ^^ this will never be executed
+   |
+help: remove this expression
+   |
+LL -         (!|!) if true => {}
+LL +         (!|!) if true =>
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
@@ -2,34 +2,49 @@ error: a never pattern is always unreachable
   --> $DIR/check.rs:15:20
    |
 LL |         Some(!) => {}
-   |                    ^^
-   |                    |
-   |                    this will never be executed
-   |                    help: remove this expression
+   |                    ^^ this will never be executed
+   |
+help: remove this expression
+   |
+LL -         Some(!) => {}
+LL +         Some(!) => 
+   |
 
 error: a guard on a never pattern will never be run
   --> $DIR/check.rs:20:20
    |
 LL |         Some(!) if true,
-   |                    ^^^^ help: remove this guard
+   |                    ^^^^
+   |
+help: remove this guard
+   |
+LL -         Some(!) if true,
+LL +         Some(!) if ,
+   |
 
 error: a never pattern is always unreachable
   --> $DIR/check.rs:25:28
    |
 LL |         Some(!) if true => {}
-   |                            ^^
-   |                            |
-   |                            this will never be executed
-   |                            help: remove this expression
+   |                            ^^ this will never be executed
+   |
+help: remove this expression
+   |
+LL -         Some(!) if true => {}
+LL +         Some(!) if true => 
+   |
 
 error: a never pattern is always unreachable
   --> $DIR/check.rs:30:27
    |
 LL |         Some(never!()) => {}
-   |                           ^^
-   |                           |
-   |                           this will never be executed
-   |                           help: remove this expression
+   |                           ^^ this will never be executed
+   |
+help: remove this expression
+   |
+LL -         Some(never!()) => {}
+LL +         Some(never!()) => 
+   |
 
 error[E0004]: non-exhaustive patterns: `&Some(!)` not covered
   --> $DIR/check.rs:19:11

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
@@ -47,19 +47,37 @@ error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:31:20
    |
 LL |         Some(!) if true
-   |                    ^^^^ help: remove this guard
+   |                    ^^^^
+   |
+help: remove this guard
+   |
+LL -         Some(!) if true
+LL +         Some(!) if 
+   |
 
 error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:37:20
    |
 LL |         Some(!) if true,
-   |                    ^^^^ help: remove this guard
+   |                    ^^^^
+   |
+help: remove this guard
+   |
+LL -         Some(!) if true,
+LL +         Some(!) if ,
+   |
 
 error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:49:21
    |
 LL |         never!() if true,
-   |                     ^^^^ help: remove this guard
+   |                     ^^^^
+   |
+help: remove this guard
+   |
+LL -         never!() if true,
+LL +         never!() if ,
+   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-main.stderr
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-main.stderr
@@ -2,9 +2,15 @@ error: `main` function is not allowed to be `#[track_caller]`
   --> $DIR/error-with-main.rs:1:1
    |
 LL | #[track_caller]
-   | ^^^^^^^^^^^^^^^ help: remove this annotation
+   | ^^^^^^^^^^^^^^^
 LL | fn main() {
    | --------- `main` function is not allowed to be `#[track_caller]`
+   |
+help: remove this annotation
+   |
+LL - #[track_caller]
+LL +
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/type-binding.stderr
+++ b/tests/ui/span/type-binding.stderr
@@ -2,7 +2,12 @@ error[E0220]: associated type `Trget` not found for `Deref`
   --> $DIR/type-binding.rs:6:20
    |
 LL | fn homura<T: Deref<Trget = i32>>(_: T) {}
-   |                    ^^^^^ help: there is an associated type with a similar name: `Target`
+   |                    ^^^^^
+   |
+help: there is an associated type with a similar name
+   |
+LL | fn homura<T: Deref<Target = i32>>(_: T) {}
+   |                     +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/abi-typo.stderr
+++ b/tests/ui/suggestions/abi-typo.stderr
@@ -2,12 +2,14 @@ error[E0703]: invalid ABI: found `cdedl`
   --> $DIR/abi-typo.rs:2:8
    |
 LL | extern "cdedl" fn cdedl() {}
-   |        ^^^^^^^
-   |        |
-   |        invalid ABI
-   |        help: did you mean: `"cdecl"`
+   |        ^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: did you mean
+   |
+LL - extern "cdedl" fn cdedl() {}
+LL + extern "cdecl" fn cdedl() {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-105226.stderr
+++ b/tests/ui/suggestions/issue-105226.stderr
@@ -15,17 +15,25 @@ error: associated function in `impl` without body
   --> $DIR/issue-105226.rs:7:5
    |
 LL |     fn hello<P>(&self, val: &P) where P: fmt::Display; {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                                                      |
-   |                                                      help: provide a definition for the function: `{ <body> }`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL -     fn hello<P>(&self, val: &P) where P: fmt::Display; {
+LL +     fn hello<P>(&self, val: &P) where P: fmt::Display { <body> } {
+   |
 
 error: associated function in `impl` without body
   --> $DIR/issue-105226.rs:15:5
    |
 LL |     fn hello_empty<P>(&self, val: &P) where P: fmt::Display;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                                                            |
-   |                                                            help: provide a definition for the function: `{ <body> }`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: provide a definition for the function
+   |
+LL -     fn hello_empty<P>(&self, val: &P) where P: fmt::Display;
+LL +     fn hello_empty<P>(&self, val: &P) where P: fmt::Display { <body> }
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -10,11 +10,16 @@ error: argument types not allowed with return type notation
   --> $DIR/let-binding-init-expr-as-ty.rs:2:26
    |
 LL |     let foo: i32::from_be(num);
-   |                          ^^^^^ help: remove the input types: `()`
+   |                          ^^^^^
    |
    = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
    = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+help: remove the input types
+   |
+LL -     let foo: i32::from_be(num);
+LL +     let foo: i32::from_be();
+   |
 
 error: return type notation not allowed in this position yet
   --> $DIR/let-binding-init-expr-as-ty.rs:2:14

--- a/tests/ui/suggestions/suggest-move-lifetimes.stderr
+++ b/tests/ui/suggestions/suggest-move-lifetimes.stderr
@@ -2,25 +2,49 @@ error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/suggest-move-lifetimes.rs:1:13
    |
 LL | struct A<T, 'a> {
-   |         ----^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, T>`
+   |             ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct A<T, 'a> {
+LL + struct A<'a, T> {
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/suggest-move-lifetimes.rs:5:13
    |
 LL | struct B<T, 'a, U> {
-   |         ----^^---- help: reorder the parameters: lifetimes, then consts and types: `<'a, T, U>`
+   |             ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct B<T, 'a, U> {
+LL + struct B<'a, T, U> {
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/suggest-move-lifetimes.rs:10:16
    |
 LL | struct C<T, U, 'a> {
-   |         -------^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, T, U>`
+   |                ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct C<T, U, 'a> {
+LL + struct C<'a, T, U> {
+   |
 
 error: lifetime parameters must be declared prior to type and const parameters
   --> $DIR/suggest-move-lifetimes.rs:15:16
    |
 LL | struct D<T, U, 'a, 'b, V, 'c> {
-   |         -------^^--^^-----^^- help: reorder the parameters: lifetimes, then consts and types: `<'a, 'b, 'c, T, U, V>`
+   |                ^^  ^^     ^^
+   |
+help: reorder the parameters: lifetimes, then consts and types
+   |
+LL - struct D<T, U, 'a, 'b, V, 'c> {
+LL + struct D<'a, 'b, 'c, T, U, V> {
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/traits/const-traits/ice-120503-async-const-method.stderr
+++ b/tests/ui/traits/const-traits/ice-120503-async-const-method.stderr
@@ -13,10 +13,13 @@ error[E0379]: functions in trait impls cannot be declared const
   --> $DIR/ice-120503-async-const-method.rs:6:11
    |
 LL |     async const fn bar(&self) {
-   |           ^^^^^-
-   |           |
-   |           functions in trait impls cannot be const
-   |           help: remove the `const`
+   |           ^^^^^ functions in trait impls cannot be const
+   |
+help: remove the `const`
+   |
+LL -     async const fn bar(&self) {
+LL +     async fn bar(&self) {
+   |
 
 error: functions cannot be both `const` and `async`
   --> $DIR/ice-120503-async-const-method.rs:6:5

--- a/tests/ui/traits/const-traits/trait-fn-const.stderr
+++ b/tests/ui/traits/const-traits/trait-fn-const.stderr
@@ -5,10 +5,13 @@ LL | #[const_trait]
    | -------------- this declares all associated functions implicitly const
 LL | trait Trait {
 LL |     const fn fun();
-   |     ^^^^^-
-   |     |
-   |     functions in traits cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in traits cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn fun();
+LL +     fn fun();
+   |
 
 error[E0379]: functions in trait impls cannot be declared const
   --> $DIR/trait-fn-const.rs:10:5
@@ -16,10 +19,13 @@ error[E0379]: functions in trait impls cannot be declared const
 LL | impl const Trait for () {
    |      ----- this declares all associated functions implicitly const
 LL |     const fn fun() {}
-   |     ^^^^^-
-   |     |
-   |     functions in trait impls cannot be const
-   |     help: remove the `const`
+   |     ^^^^^ functions in trait impls cannot be const
+   |
+help: remove the `const`
+   |
+LL -     const fn fun() {}
+LL +     fn fun() {}
+   |
 
 error[E0379]: functions in trait impls cannot be declared const
   --> $DIR/trait-fn-const.rs:14:5

--- a/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
+++ b/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
@@ -2,9 +2,15 @@ error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/supertrait-auto-trait.rs:8:17
    |
 LL | auto trait Magic: Copy {}
-   |            -----^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
+   |
+help: remove the super traits or lifetime bounds
+   |
+LL - auto trait Magic: Copy {}
+LL + auto trait Magic {}
+   |
 
 error[E0277]: the trait bound `NoClone: Magic` is not satisfied
   --> $DIR/supertrait-auto-trait.rs:16:23

--- a/tests/ui/traits/object/pretty.stderr
+++ b/tests/ui/traits/object/pretty.stderr
@@ -2,10 +2,15 @@ warning: unnecessary associated type bound for dyn-incompatible associated type
   --> $DIR/pretty.rs:41:35
    |
 LL | fn dyn_has_gat(x: &dyn HasGat<u8, Assoc<bool> = ()>) { x }
-   |                                   ^^^^^^^^^^^^^^^^ help: remove this bound
+   |                                   ^^^^^^^^^^^^^^^^
    |
    = note: this associated type has a `where Self: Sized` bound, and while the associated type can be specified, it cannot be used because trait objects are never `Sized`
    = note: `#[warn(unused_associated_type_bounds)]` on by default
+help: remove this bound
+   |
+LL - fn dyn_has_gat(x: &dyn HasGat<u8, Assoc<bool> = ()>) { x }
+LL + fn dyn_has_gat(x: &dyn HasGat<u8, >) { x }
+   |
 
 error[E0308]: mismatched types
   --> $DIR/pretty.rs:25:43

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -32,9 +32,12 @@ error: associated constant in `impl` without body
   --> $DIR/typeck_type_placeholder_item.rs:206:5
    |
 LL |     const C: _;
-   |     ^^^^^^^^^^-
-   |               |
-   |               help: provide a definition for the constant: `= <expr>;`
+   |     ^^^^^^^^^^^
+   |
+help: provide a definition for the constant
+   |
+LL |     const C: _ = <expr>;
+   |                ++++++++
 
 error[E0403]: the name `_` is already used for a generic parameter in this item's generic parameters
   --> $DIR/typeck_type_placeholder_item.rs:167:22


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/137343)*
<!-- homu-ignore:end -->

The verbose "diff" suggestion format is easier to read (specially since https://github.com/rust-lang/rust/pull/136958), and the only one supported by annotate-snippets (which we want to migrate to).

Making verbose the default in one go would result in a huge PR that is too hard to land: https://github.com/rust-lang/rust/pull/127282.

CC https://github.com/rust-lang/rust-playground/issues/1117

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
