### PR TITLE
More sophisticated span trimming for suggestions

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -2216,12 +2216,7 @@ impl HumanEmitter {
             if let DisplaySuggestion::Diff | DisplaySuggestion::Underline | DisplaySuggestion::Add =
                 show_code_change
             {
-                for mut part in parts {
-                    // If this is a replacement of, e.g. `"a"` into `"ab"`, adjust the
-                    // suggestion and snippet to look as if we just suggested to add
-                    // `"b"`, which is typically much easier for the user to understand.
-                    part.trim_trivial_replacements(sm);
-
+                for part in parts {
                     let snippet = if let Ok(snippet) = sm.span_to_snippet(part.span) {
                         snippet
                     } else {

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -71,7 +71,7 @@ use rustc_macros::{Decodable, Encodable};
 pub use rustc_span::ErrorGuaranteed;
 pub use rustc_span::fatal_error::{FatalError, FatalErrorMarker};
 use rustc_span::source_map::SourceMap;
-use rustc_span::{DUMMY_SP, Loc, Span};
+use rustc_span::{BytePos, DUMMY_SP, Loc, Span};
 pub use snippet::Style;
 // Used by external projects such as `rust-gpu`.
 // See https://github.com/rust-lang/rust/pull/115393.
@@ -237,10 +237,9 @@ impl SubstitutionPart {
     /// it with "abx" is, since the "c" character is lost.
     pub fn is_destructive_replacement(&self, sm: &SourceMap) -> bool {
         self.is_replacement(sm)
-            && !sm.span_to_snippet(self.span).is_ok_and(|snippet| {
-                self.snippet.trim_start().starts_with(snippet.trim_start())
-                    || self.snippet.trim_end().ends_with(snippet.trim_end())
-            })
+            && !sm
+                .span_to_snippet(self.span)
+                .is_ok_and(|snippet| as_substr(snippet.trim(), self.snippet.trim()).is_some())
     }
 
     fn replaces_meaningful_content(&self, sm: &SourceMap) -> bool {
@@ -257,13 +256,37 @@ impl SubstitutionPart {
         let Ok(snippet) = sm.span_to_snippet(self.span) else {
             return;
         };
-        if self.snippet.starts_with(&snippet) {
-            self.span = self.span.shrink_to_hi();
-            self.snippet = self.snippet[snippet.len()..].to_string();
-        } else if self.snippet.ends_with(&snippet) {
-            self.span = self.span.shrink_to_lo();
-            self.snippet = self.snippet[..self.snippet.len() - snippet.len()].to_string();
+
+        if let Some((prefix, substr, suffix)) = as_substr(&snippet, &self.snippet) {
+            self.span = Span::new(
+                self.span.lo() + BytePos(prefix as u32),
+                self.span.hi() - BytePos(suffix as u32),
+                self.span.ctxt(),
+                self.span.parent(),
+            );
+            self.snippet = substr.to_string();
         }
+    }
+}
+
+/// Given an original string like `AACC`, and a suggestion like `AABBCC`, try to detect
+/// the case where a substring of the suggestion is "sandwiched" in the original, like
+/// `BB` is. Return the length of the prefix, the "trimmed" suggestion, and the length
+/// of the suffix.
+fn as_substr<'a>(original: &'a str, suggestion: &'a str) -> Option<(usize, &'a str, usize)> {
+    let common_prefix = original
+        .chars()
+        .zip(suggestion.chars())
+        .take_while(|(c1, c2)| c1 == c2)
+        .map(|(c, _)| c.len_utf8())
+        .sum();
+    let original = &original[common_prefix..];
+    let suggestion = &suggestion[common_prefix..];
+    if suggestion.ends_with(original) {
+        let common_suffix = original.len();
+        Some((common_prefix, &suggestion[..suggestion.len() - original.len()], common_suffix))
+    } else {
+        None
     }
 }
 

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -403,7 +403,12 @@ impl CodeSuggestion {
                 // or deleted code in order to point at the correct column *after* substitution.
                 let mut acc = 0;
                 let mut only_capitalization = false;
-                for part in &substitution.parts {
+                for part in &mut substitution.parts {
+                    // If this is a replacement of, e.g. `"a"` into `"ab"`, adjust the
+                    // suggestion and snippet to look as if we just suggested to add
+                    // `"b"`, which is typically much easier for the user to understand.
+                    part.trim_trivial_replacements(sm);
+
                     only_capitalization |= is_case_difference(sm, &part.snippet, part.span);
                     let cur_lo = sm.lookup_char_pos(part.span.lo());
                     if prev_hi.line == cur_lo.line {

--- a/src/tools/clippy/tests/ui/async_yields_async.stderr
+++ b/src/tools/clippy/tests/ui/async_yields_async.stderr
@@ -14,9 +14,9 @@ LL | |      };
    = help: to override `-D warnings` add `#[allow(clippy::async_yields_async)]`
 help: consider awaiting this value
    |
-LL ~         async {
-LL +             3
-LL +         }.await
+LL |         async {
+LL |             3
+LL ~         }.await
    |
 
 error: an async construct yields a type which is itself awaitable
@@ -46,9 +46,9 @@ LL | |      };
    |
 help: consider awaiting this value
    |
-LL ~         async {
-LL +             3
-LL +         }.await
+LL |         async {
+LL |             3
+LL ~         }.await
    |
 
 error: an async construct yields a type which is itself awaitable

--- a/src/tools/clippy/tests/ui/borrow_deref_ref_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/borrow_deref_ref_unfixable.stderr
@@ -13,9 +13,8 @@ LL +         let x: &str = s;
    |
 help: if you would like to deref, try using `&**`
    |
-LL -         let x: &str = &*s;
-LL +         let x: &str = &**s;
-   |
+LL |         let x: &str = &**s;
+   |                         +
 
 error: aborting due to 1 previous error
 

--- a/src/tools/clippy/tests/ui/fn_to_numeric_cast_any.stderr
+++ b/src/tools/clippy/tests/ui/fn_to_numeric_cast_any.stderr
@@ -152,7 +152,7 @@ LL |     f as usize
 help: did you mean to invoke the function?
    |
 LL |     f() as usize
-   |
+   |      ++
 
 error: casting function pointer `T::static_method` to `usize`
   --> tests/ui/fn_to_numeric_cast_any.rs:62:5
@@ -163,7 +163,7 @@ LL |     T::static_method as usize
 help: did you mean to invoke the function?
    |
 LL |     T::static_method() as usize
-   |
+   |                     ++
 
 error: casting function pointer `(clos as fn(u32) -> u32)` to `usize`
   --> tests/ui/fn_to_numeric_cast_any.rs:69:13

--- a/src/tools/clippy/tests/ui/fn_to_numeric_cast_any.stderr
+++ b/src/tools/clippy/tests/ui/fn_to_numeric_cast_any.stderr
@@ -8,9 +8,8 @@ LL |     let _ = foo as i8;
    = help: to override `-D warnings` add `#[allow(clippy::fn_to_numeric_cast_any)]`
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as i8;
-LL +     let _ = foo() as i8;
-   |
+LL |     let _ = foo() as i8;
+   |                ++
 
 error: casting function pointer `foo` to `i16`
   --> tests/ui/fn_to_numeric_cast_any.rs:26:13
@@ -20,9 +19,8 @@ LL |     let _ = foo as i16;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as i16;
-LL +     let _ = foo() as i16;
-   |
+LL |     let _ = foo() as i16;
+   |                ++
 
 error: casting function pointer `foo` to `i32`
   --> tests/ui/fn_to_numeric_cast_any.rs:28:13
@@ -32,9 +30,8 @@ LL |     let _ = foo as i32;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as i32;
-LL +     let _ = foo() as i32;
-   |
+LL |     let _ = foo() as i32;
+   |                ++
 
 error: casting function pointer `foo` to `i64`
   --> tests/ui/fn_to_numeric_cast_any.rs:30:13
@@ -44,9 +41,8 @@ LL |     let _ = foo as i64;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as i64;
-LL +     let _ = foo() as i64;
-   |
+LL |     let _ = foo() as i64;
+   |                ++
 
 error: casting function pointer `foo` to `i128`
   --> tests/ui/fn_to_numeric_cast_any.rs:32:13
@@ -56,9 +52,8 @@ LL |     let _ = foo as i128;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as i128;
-LL +     let _ = foo() as i128;
-   |
+LL |     let _ = foo() as i128;
+   |                ++
 
 error: casting function pointer `foo` to `isize`
   --> tests/ui/fn_to_numeric_cast_any.rs:34:13
@@ -68,9 +63,8 @@ LL |     let _ = foo as isize;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as isize;
-LL +     let _ = foo() as isize;
-   |
+LL |     let _ = foo() as isize;
+   |                ++
 
 error: casting function pointer `foo` to `u8`
   --> tests/ui/fn_to_numeric_cast_any.rs:37:13
@@ -80,9 +74,8 @@ LL |     let _ = foo as u8;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as u8;
-LL +     let _ = foo() as u8;
-   |
+LL |     let _ = foo() as u8;
+   |                ++
 
 error: casting function pointer `foo` to `u16`
   --> tests/ui/fn_to_numeric_cast_any.rs:39:13
@@ -92,9 +85,8 @@ LL |     let _ = foo as u16;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as u16;
-LL +     let _ = foo() as u16;
-   |
+LL |     let _ = foo() as u16;
+   |                ++
 
 error: casting function pointer `foo` to `u32`
   --> tests/ui/fn_to_numeric_cast_any.rs:41:13
@@ -104,9 +96,8 @@ LL |     let _ = foo as u32;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as u32;
-LL +     let _ = foo() as u32;
-   |
+LL |     let _ = foo() as u32;
+   |                ++
 
 error: casting function pointer `foo` to `u64`
   --> tests/ui/fn_to_numeric_cast_any.rs:43:13
@@ -116,9 +107,8 @@ LL |     let _ = foo as u64;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as u64;
-LL +     let _ = foo() as u64;
-   |
+LL |     let _ = foo() as u64;
+   |                ++
 
 error: casting function pointer `foo` to `u128`
   --> tests/ui/fn_to_numeric_cast_any.rs:45:13
@@ -128,9 +118,8 @@ LL |     let _ = foo as u128;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as u128;
-LL +     let _ = foo() as u128;
-   |
+LL |     let _ = foo() as u128;
+   |                ++
 
 error: casting function pointer `foo` to `usize`
   --> tests/ui/fn_to_numeric_cast_any.rs:47:13
@@ -140,9 +129,8 @@ LL |     let _ = foo as usize;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as usize;
-LL +     let _ = foo() as usize;
-   |
+LL |     let _ = foo() as usize;
+   |                ++
 
 error: casting function pointer `Struct::static_method` to `usize`
   --> tests/ui/fn_to_numeric_cast_any.rs:52:13
@@ -152,9 +140,8 @@ LL |     let _ = Struct::static_method as usize;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = Struct::static_method as usize;
-LL +     let _ = Struct::static_method() as usize;
-   |
+LL |     let _ = Struct::static_method() as usize;
+   |                                  ++
 
 error: casting function pointer `f` to `usize`
   --> tests/ui/fn_to_numeric_cast_any.rs:57:5
@@ -164,8 +151,7 @@ LL |     f as usize
    |
 help: did you mean to invoke the function?
    |
-LL -     f as usize
-LL +     f() as usize
+LL |     f() as usize
    |
 
 error: casting function pointer `T::static_method` to `usize`
@@ -176,8 +162,7 @@ LL |     T::static_method as usize
    |
 help: did you mean to invoke the function?
    |
-LL -     T::static_method as usize
-LL +     T::static_method() as usize
+LL |     T::static_method() as usize
    |
 
 error: casting function pointer `(clos as fn(u32) -> u32)` to `usize`
@@ -188,9 +173,8 @@ LL |     let _ = (clos as fn(u32) -> u32) as usize;
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = (clos as fn(u32) -> u32) as usize;
-LL +     let _ = (clos as fn(u32) -> u32)() as usize;
-   |
+LL |     let _ = (clos as fn(u32) -> u32)() as usize;
+   |                                     ++
 
 error: casting function pointer `foo` to `*const ()`
   --> tests/ui/fn_to_numeric_cast_any.rs:74:13
@@ -200,9 +184,8 @@ LL |     let _ = foo as *const ();
    |
 help: did you mean to invoke the function?
    |
-LL -     let _ = foo as *const ();
-LL +     let _ = foo() as *const ();
-   |
+LL |     let _ = foo() as *const ();
+   |                ++
 
 error: aborting due to 17 previous errors
 

--- a/src/tools/clippy/tests/ui/implicit_hasher.stderr
+++ b/src/tools/clippy/tests/ui/implicit_hasher.stderr
@@ -78,9 +78,8 @@ LL | pub fn map(map: &mut HashMap<i32, i32>) {}
    |
 help: add a type parameter for `BuildHasher`
    |
-LL - pub fn map(map: &mut HashMap<i32, i32>) {}
-LL + pub fn map<S: ::std::hash::BuildHasher>(map: &mut HashMap<i32, i32, S>) {}
-   |
+LL | pub fn map<S: ::std::hash::BuildHasher>(map: &mut HashMap<i32, i32, S>) {}
+   |           +++++++++++++++++++++++++++++                           +++
 
 error: parameter of type `HashSet` should be generalized over different hashers
   --> tests/ui/implicit_hasher.rs:70:22
@@ -90,9 +89,8 @@ LL | pub fn set(set: &mut HashSet<i32>) {}
    |
 help: add a type parameter for `BuildHasher`
    |
-LL - pub fn set(set: &mut HashSet<i32>) {}
-LL + pub fn set<S: ::std::hash::BuildHasher>(set: &mut HashSet<i32, S>) {}
-   |
+LL | pub fn set<S: ::std::hash::BuildHasher>(set: &mut HashSet<i32, S>) {}
+   |           +++++++++++++++++++++++++++++                      +++
 
 error: impl for `HashMap` should be generalized over different hashers
   --> tests/ui/implicit_hasher.rs:76:43
@@ -116,9 +114,8 @@ LL | pub async fn election_vote(_data: HashMap<i32, i32>) {}
    |
 help: add a type parameter for `BuildHasher`
    |
-LL - pub async fn election_vote(_data: HashMap<i32, i32>) {}
-LL + pub async fn election_vote<S: ::std::hash::BuildHasher>(_data: HashMap<i32, i32, S>) {}
-   |
+LL | pub async fn election_vote<S: ::std::hash::BuildHasher>(_data: HashMap<i32, i32, S>) {}
+   |                           +++++++++++++++++++++++++++++                        +++
 
 error: aborting due to 9 previous errors
 

--- a/src/tools/clippy/tests/ui/implicit_return.stderr
+++ b/src/tools/clippy/tests/ui/implicit_return.stderr
@@ -9,7 +9,7 @@ LL |     true
 help: add `return` as shown
    |
 LL |     return true
-   |
+   |     ++++++
 
 error: missing `return` statement
   --> tests/ui/implicit_return.rs:19:15
@@ -122,7 +122,7 @@ LL |     format!("test {}", "test")
 help: add `return` as shown
    |
 LL |     return format!("test {}", "test")
-   |
+   |     ++++++
 
 error: missing `return` statement
   --> tests/ui/implicit_return.rs:90:5
@@ -133,7 +133,7 @@ LL |     m!(true, false)
 help: add `return` as shown
    |
 LL |     return m!(true, false)
-   |
+   |     ++++++
 
 error: missing `return` statement
   --> tests/ui/implicit_return.rs:96:13
@@ -169,10 +169,8 @@ LL | |     }
    |
 help: add `return` as shown
    |
-LL ~     return loop {
-LL +         m!(true);
-LL +     }
-   |
+LL |     return loop {
+   |     ++++++
 
 error: missing `return` statement
   --> tests/ui/implicit_return.rs:130:5
@@ -183,7 +181,7 @@ LL |     true
 help: add `return` as shown
    |
 LL |     return true
-   |
+   |     ++++++
 
 error: aborting due to 16 previous errors
 

--- a/src/tools/clippy/tests/ui/literals.stderr
+++ b/src/tools/clippy/tests/ui/literals.stderr
@@ -99,9 +99,8 @@ LL +     let fail8 = 123;
    |
 help: if you mean to use an octal constant, use `0o`
    |
-LL -     let fail8 = 0123;
-LL +     let fail8 = 0o123;
-   |
+LL |     let fail8 = 0o123;
+   |                  +
 
 error: integer type suffix should not be separated by an underscore
   --> tests/ui/literals.rs:48:16

--- a/src/tools/clippy/tests/ui/manual_flatten.stderr
+++ b/src/tools/clippy/tests/ui/manual_flatten.stderr
@@ -196,11 +196,9 @@ LL | |         }
    | |_________^
 help: try
    |
-LL ~     for n in vec![
-LL +
-LL +         Some(1),
-LL +         Some(2),
-LL +         Some(3)
+LL |     for n in vec![
+...
+LL |         Some(3)
 LL ~     ].iter().flatten() {
    |
 

--- a/src/tools/clippy/tests/ui/octal_escapes.stderr
+++ b/src/tools/clippy/tests/ui/octal_escapes.stderr
@@ -14,9 +14,8 @@ LL +     let _bad1 = "\x1b[0m";
    |
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad1 = "\033[0m";
-LL +     let _bad1 = "\x0033[0m";
-   |
+LL |     let _bad1 = "\x0033[0m";
+   |                   ++
 
 error: octal-looking escape in a literal
   --> tests/ui/octal_escapes.rs:6:19
@@ -31,9 +30,8 @@ LL +     let _bad2 = b"\x1b[0m";
    |
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad2 = b"\033[0m";
-LL +     let _bad2 = b"\x0033[0m";
-   |
+LL |     let _bad2 = b"\x0033[0m";
+   |                    ++
 
 error: octal-looking escape in a literal
   --> tests/ui/octal_escapes.rs:7:20
@@ -48,9 +46,8 @@ LL +     let _bad3 = "\\\x1b[0m";
    |
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad3 = "\\\033[0m";
-LL +     let _bad3 = "\\\x0033[0m";
-   |
+LL |     let _bad3 = "\\\x0033[0m";
+   |                     ++
 
 error: octal-looking escape in a literal
   --> tests/ui/octal_escapes.rs:9:18
@@ -65,9 +62,8 @@ LL +     let _bad4 = "\x0a34567";
    |
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad4 = "\01234567";
-LL +     let _bad4 = "\x001234567";
-   |
+LL |     let _bad4 = "\x001234567";
+   |                   ++
 
 error: octal-looking escape in a literal
   --> tests/ui/octal_escapes.rs:10:20
@@ -77,14 +73,12 @@ LL |     let _bad5 = "\0\03";
    |
 help: if an octal escape is intended, use a hex escape instead
    |
-LL -     let _bad5 = "\0\03";
-LL +     let _bad5 = "\0\x03";
-   |
+LL |     let _bad5 = "\0\x03";
+   |                     +
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad5 = "\0\03";
-LL +     let _bad5 = "\0\x0003";
-   |
+LL |     let _bad5 = "\0\x0003";
+   |                     +++
 
 error: octal-looking escape in a literal
   --> tests/ui/octal_escapes.rs:11:23
@@ -99,9 +93,8 @@ LL +     let _bad6 = "Text-\x2d\077-MoreText";
    |
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad6 = "Text-\055\077-MoreText";
-LL +     let _bad6 = "Text-\x0055\077-MoreText";
-   |
+LL |     let _bad6 = "Text-\x0055\077-MoreText";
+   |                        ++
 
 error: octal-looking escape in a literal
   --> tests/ui/octal_escapes.rs:11:27
@@ -116,9 +109,8 @@ LL +     let _bad6 = "Text-\055\x3f-MoreText";
    |
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad6 = "Text-\055\077-MoreText";
-LL +     let _bad6 = "Text-\055\x0077-MoreText";
-   |
+LL |     let _bad6 = "Text-\055\x0077-MoreText";
+   |                            ++
 
 error: octal-looking escape in a literal
   --> tests/ui/octal_escapes.rs:14:31
@@ -128,14 +120,12 @@ LL |     let _bad7 = "EvenMoreText-\01\02-ShortEscapes";
    |
 help: if an octal escape is intended, use a hex escape instead
    |
-LL -     let _bad7 = "EvenMoreText-\01\02-ShortEscapes";
-LL +     let _bad7 = "EvenMoreText-\x01\02-ShortEscapes";
-   |
+LL |     let _bad7 = "EvenMoreText-\x01\02-ShortEscapes";
+   |                                +
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad7 = "EvenMoreText-\01\02-ShortEscapes";
-LL +     let _bad7 = "EvenMoreText-\x0001\02-ShortEscapes";
-   |
+LL |     let _bad7 = "EvenMoreText-\x0001\02-ShortEscapes";
+   |                                +++
 
 error: octal-looking escape in a literal
   --> tests/ui/octal_escapes.rs:14:34
@@ -145,14 +135,12 @@ LL |     let _bad7 = "EvenMoreText-\01\02-ShortEscapes";
    |
 help: if an octal escape is intended, use a hex escape instead
    |
-LL -     let _bad7 = "EvenMoreText-\01\02-ShortEscapes";
-LL +     let _bad7 = "EvenMoreText-\01\x02-ShortEscapes";
-   |
+LL |     let _bad7 = "EvenMoreText-\01\x02-ShortEscapes";
+   |                                   +
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad7 = "EvenMoreText-\01\02-ShortEscapes";
-LL +     let _bad7 = "EvenMoreText-\01\x0002-ShortEscapes";
-   |
+LL |     let _bad7 = "EvenMoreText-\01\x0002-ShortEscapes";
+   |                                   +++
 
 error: octal-looking escape in a literal
   --> tests/ui/octal_escapes.rs:17:19
@@ -162,14 +150,12 @@ LL |     let _bad8 = "锈\01锈";
    |
 help: if an octal escape is intended, use a hex escape instead
    |
-LL -     let _bad8 = "锈\01锈";
-LL +     let _bad8 = "锈\x01锈";
-   |
+LL |     let _bad8 = "锈\x01锈";
+   |                     +
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad8 = "锈\01锈";
-LL +     let _bad8 = "锈\x0001锈";
-   |
+LL |     let _bad8 = "锈\x0001锈";
+   |                     +++
 
 error: octal-looking escape in a literal
   --> tests/ui/octal_escapes.rs:18:19
@@ -184,9 +170,8 @@ LL +     let _bad9 = "锈\x09锈";
    |
 help: if a null escape is intended, disambiguate using
    |
-LL -     let _bad9 = "锈\011锈";
-LL +     let _bad9 = "锈\x0011锈";
-   |
+LL |     let _bad9 = "锈\x0011锈";
+   |                     ++
 
 error: aborting due to 11 previous errors
 

--- a/src/tools/clippy/tests/ui/suspicious_to_owned.stderr
+++ b/src/tools/clippy/tests/ui/suspicious_to_owned.stderr
@@ -8,9 +8,8 @@ LL |     let _ = cow.to_owned();
    = help: to override `-D warnings` add `#[allow(clippy::suspicious_to_owned)]`
 help: depending on intent, either make the Cow an Owned variant
    |
-LL -     let _ = cow.to_owned();
-LL +     let _ = cow.into_owned();
-   |
+LL |     let _ = cow.into_owned();
+   |                 ++
 help: or clone the Cow itself
    |
 LL -     let _ = cow.to_owned();
@@ -25,9 +24,8 @@ LL |     let _ = cow.to_owned();
    |
 help: depending on intent, either make the Cow an Owned variant
    |
-LL -     let _ = cow.to_owned();
-LL +     let _ = cow.into_owned();
-   |
+LL |     let _ = cow.into_owned();
+   |                 ++
 help: or clone the Cow itself
    |
 LL -     let _ = cow.to_owned();
@@ -42,9 +40,8 @@ LL |     let _ = cow.to_owned();
    |
 help: depending on intent, either make the Cow an Owned variant
    |
-LL -     let _ = cow.to_owned();
-LL +     let _ = cow.into_owned();
-   |
+LL |     let _ = cow.into_owned();
+   |                 ++
 help: or clone the Cow itself
    |
 LL -     let _ = cow.to_owned();
@@ -59,9 +56,8 @@ LL |     let _ = cow.to_owned();
    |
 help: depending on intent, either make the Cow an Owned variant
    |
-LL -     let _ = cow.to_owned();
-LL +     let _ = cow.into_owned();
-   |
+LL |     let _ = cow.into_owned();
+   |                 ++
 help: or clone the Cow itself
    |
 LL -     let _ = cow.to_owned();

--- a/src/tools/clippy/tests/ui/too_long_first_doc_paragraph-fix.stderr
+++ b/src/tools/clippy/tests/ui/too_long_first_doc_paragraph-fix.stderr
@@ -12,7 +12,7 @@ LL | | /// 200 characters so I needed to write something longeeeeeeer.
    = help: to override `-D warnings` add `#[allow(clippy::too_long_first_doc_paragraph)]`
 help: add an empty line
    |
-LL ~ /// A very short summary.
+LL | /// A very short summary.
 LL + ///
    |
 

--- a/src/tools/clippy/tests/ui/too_long_first_doc_paragraph.stderr
+++ b/src/tools/clippy/tests/ui/too_long_first_doc_paragraph.stderr
@@ -12,8 +12,8 @@ LL | |     //! 200 characters so I needed to write something longeeeeeeer.
    = help: to override `-D warnings` add `#[allow(clippy::too_long_first_doc_paragraph)]`
 help: add an empty line
    |
-LL ~     //! A very short summary.
-LL +     //!
+LL |     //! A very short summary.
+LL ~     //!
 LL ~     //! A much longer explanation that goes into a lot more detail about
    |
 

--- a/tests/ui/argument-suggestions/basic.stderr
+++ b/tests/ui/argument-suggestions/basic.stderr
@@ -42,9 +42,8 @@ LL | fn missing(_i: u32) {}
    |    ^^^^^^^ -------
 help: provide the argument
    |
-LL -     missing();
-LL +     missing(/* u32 */);
-   |
+LL |     missing(/* u32 */);
+   |             +++++++++
 
 error[E0308]: arguments to this function are incorrect
   --> $DIR/basic.rs:23:5
@@ -98,9 +97,8 @@ LL |     let closure = |x| x;
    |                   ^^^
 help: provide the argument
    |
-LL -     closure();
-LL +     closure(/* x */);
-   |
+LL |     closure(/* x */);
+   |             +++++++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/argument-suggestions/display-is-suggestable.stderr
+++ b/tests/ui/argument-suggestions/display-is-suggestable.stderr
@@ -11,9 +11,8 @@ LL | fn foo(x: &(dyn Display + Send)) {}
    |    ^^^ ------------------------
 help: provide the argument
    |
-LL -     foo();
-LL +     foo(/* &dyn std::fmt::Display + Send */);
-   |
+LL |     foo(/* &dyn std::fmt::Display + Send */);
+   |         +++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/argument-suggestions/extern-fn-arg-names.stderr
+++ b/tests/ui/argument-suggestions/extern-fn-arg-names.stderr
@@ -17,9 +17,8 @@ LL |     fn dstfn(src: i32, dst: err);
    |        ^^^^^           ---
 help: provide the argument
    |
-LL -     dstfn(1);
-LL +     dstfn(1, /* dst */);
-   |
+LL |     dstfn(1, /* dst */);
+   |            +++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/argument-suggestions/issue-97197.stderr
+++ b/tests/ui/argument-suggestions/issue-97197.stderr
@@ -11,9 +11,8 @@ LL | pub fn g(a1: (), a2: bool, a3: bool, a4: bool, a5: bool, a6: ()) -> () {}
    |        ^         --------  --------  --------  --------
 help: provide the arguments
    |
-LL -     g((), ());
-LL +     g((), /* bool */, /* bool */, /* bool */, /* bool */, ());
-   |
+LL |     g((), /* bool */, /* bool */, /* bool */, /* bool */, ());
+   |           +++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/argument-suggestions/issue-98894.stderr
+++ b/tests/ui/argument-suggestions/issue-98894.stderr
@@ -11,9 +11,8 @@ LL |     (|_, ()| ())(if true {} else {return;});
    |      ^^^^^^^
 help: provide the argument
    |
-LL -     (|_, ()| ())(if true {} else {return;});
-LL +     (|_, ()| ())(if true {} else {return;}, ());
-   |
+LL |     (|_, ()| ())(if true {} else {return;}, ());
+   |                                           ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/argument-suggestions/issue-98897.stderr
+++ b/tests/ui/argument-suggestions/issue-98897.stderr
@@ -11,9 +11,8 @@ LL |     (|_, ()| ())([return, ()]);
    |      ^^^^^^^
 help: provide the argument
    |
-LL -     (|_, ()| ())([return, ()]);
-LL +     (|_, ()| ())([return, ()], ());
-   |
+LL |     (|_, ()| ())([return, ()], ());
+   |                              ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/argument-suggestions/issue-99482.stderr
+++ b/tests/ui/argument-suggestions/issue-99482.stderr
@@ -11,9 +11,8 @@ LL |     let f = |_: (), f: fn()| f;
    |             ^^^^^^^^^^^^^^^^
 help: provide the argument
    |
-LL -     let _f = f(main);
-LL +     let _f = f((), main);
-   |
+LL |     let _f = f((), main);
+   |                +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/argument-suggestions/missing_arguments.stderr
+++ b/tests/ui/argument-suggestions/missing_arguments.stderr
@@ -11,9 +11,8 @@ LL | fn one_arg(_a: i32) {}
    |    ^^^^^^^ -------
 help: provide the argument
    |
-LL -   one_arg();
-LL +   one_arg(/* i32 */);
-   |
+LL |   one_arg(/* i32 */);
+   |           +++++++++
 
 error[E0061]: this function takes 2 arguments but 0 arguments were supplied
   --> $DIR/missing_arguments.rs:14:3

--- a/tests/ui/associated-consts/associated-const-ambiguity-report.stderr
+++ b/tests/ui/associated-consts/associated-const-ambiguity-report.stderr
@@ -16,12 +16,10 @@ LL |     const ID: i32 = 1;
    |     ^^^^^^^^^^^^^
 help: use fully-qualified syntax to disambiguate
    |
-LL - const X: i32 = <i32>::ID;
-LL + const X: i32 = <i32 as Bar>::ID;
-   |
-LL - const X: i32 = <i32>::ID;
-LL + const X: i32 = <i32 as Foo>::ID;
-   |
+LL | const X: i32 = <i32 as Bar>::ID;
+   |                     ++++++
+LL | const X: i32 = <i32 as Foo>::ID;
+   |                     ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/associated-inherent-types/issue-109768.stderr
+++ b/tests/ui/associated-inherent-types/issue-109768.stderr
@@ -43,9 +43,8 @@ LL | struct Wrapper<T>(T);
    |        ^^^^^^^
 help: provide the argument
    |
-LL -     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper();
-LL +     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper(/* value */);
-   |
+LL |     const WRAPPED_ASSOC_3: Wrapper<Self::AssocType3> = Wrapper(/* value */);
+   |                                                                +++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/associated-item/associated-item-enum.stderr
+++ b/tests/ui/associated-item/associated-item-enum.stderr
@@ -9,9 +9,8 @@ LL |     Enum::mispellable();
    |
 help: there is an associated function `misspellable` with a similar name
    |
-LL -     Enum::mispellable();
-LL +     Enum::misspellable();
-   |
+LL |     Enum::misspellable();
+   |              +
 
 error[E0599]: no variant or associated item named `mispellable_trait` found for enum `Enum` in the current scope
   --> $DIR/associated-item-enum.rs:18:11
@@ -24,9 +23,8 @@ LL |     Enum::mispellable_trait();
    |
 help: there is an associated function `misspellable_trait` with a similar name
    |
-LL -     Enum::mispellable_trait();
-LL +     Enum::misspellable_trait();
-   |
+LL |     Enum::misspellable_trait();
+   |              +
 
 error[E0599]: no variant or associated item named `MISPELLABLE` found for enum `Enum` in the current scope
   --> $DIR/associated-item-enum.rs:19:11
@@ -39,9 +37,8 @@ LL |     Enum::MISPELLABLE;
    |
 help: there is an associated constant `MISSPELLABLE` with a similar name
    |
-LL -     Enum::MISPELLABLE;
-LL +     Enum::MISSPELLABLE;
-   |
+LL |     Enum::MISSPELLABLE;
+   |              +
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/binop/placement-syntax.stderr
+++ b/tests/ui/binop/placement-syntax.stderr
@@ -6,9 +6,8 @@ LL |     if x<-1 {
    |
 help: if you meant to write a comparison against a negative value, add a space in between `<` and `-`
    |
-LL -     if x<-1 {
-LL +     if x< -1 {
-   |
+LL |     if x< -1 {
+   |          +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/borrowck-struct-update-with-dtor.stderr
+++ b/tests/ui/borrowck/borrowck-struct-update-with-dtor.stderr
@@ -116,9 +116,8 @@ LL |         let _s2 = T { ..s0 };
    |
 help: clone the value from the field instead of using the functional record update syntax
    |
-LL -         let _s2 = T { ..s0 };
-LL +         let _s2 = T { b: s0.b.clone(), ..s0 };
-   |
+LL |         let _s2 = T { b: s0.b.clone(), ..s0 };
+   |                       ++++++++++++++++
 
 error[E0509]: cannot move out of type `T`, which implements the `Drop` trait
   --> $DIR/borrowck-struct-update-with-dtor.rs:47:32

--- a/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
+++ b/tests/ui/borrowck/borrowck-unsafe-static-mutable-borrows.stderr
@@ -9,9 +9,8 @@ LL |         let sfoo: *mut Foo = &mut SFOO;
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw mut` instead to create a raw pointer
    |
-LL -         let sfoo: *mut Foo = &mut SFOO;
-LL +         let sfoo: *mut Foo = &raw mut SFOO;
-   |
+LL |         let sfoo: *mut Foo = &raw mut SFOO;
+   |                               +++
 
 warning: 1 warning emitted
 

--- a/tests/ui/borrowck/issue-85765-closure.stderr
+++ b/tests/ui/borrowck/issue-85765-closure.stderr
@@ -6,9 +6,8 @@ LL |         rofl.push(Vec::new());
    |
 help: consider changing this binding's type
    |
-LL -         let rofl: &Vec<Vec<i32>> = &mut test;
-LL +         let rofl: &mut Vec<Vec<i32>> = &mut test;
-   |
+LL |         let rofl: &mut Vec<Vec<i32>> = &mut test;
+   |                    +++
 
 error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:13:9
@@ -29,9 +28,8 @@ LL |         *x = 1;
    |
 help: consider changing this binding's type
    |
-LL -         let x: &usize = &mut{0};
-LL +         let x: &mut usize = &mut{0};
-   |
+LL |         let x: &mut usize = &mut{0};
+   |                 +++
 
 error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765-closure.rs:27:9
@@ -41,9 +39,8 @@ LL |         *y = 1;
    |
 help: consider changing this binding's type
    |
-LL -         let y: &usize = &mut(0);
-LL +         let y: &mut usize = &mut(0);
-   |
+LL |         let y: &mut usize = &mut(0);
+   |                 +++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/borrowck/issue-85765.stderr
+++ b/tests/ui/borrowck/issue-85765.stderr
@@ -6,9 +6,8 @@ LL |     rofl.push(Vec::new());
    |
 help: consider changing this binding's type
    |
-LL -     let rofl: &Vec<Vec<i32>> = &mut test;
-LL +     let rofl: &mut Vec<Vec<i32>> = &mut test;
-   |
+LL |     let rofl: &mut Vec<Vec<i32>> = &mut test;
+   |                +++
 
 error[E0594]: cannot assign to `*r`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:12:5
@@ -29,9 +28,8 @@ LL |     *x = 1;
    |
 help: consider changing this binding's type
    |
-LL -     let x: &usize = &mut{0};
-LL +     let x: &mut usize = &mut{0};
-   |
+LL |     let x: &mut usize = &mut{0};
+   |             +++
 
 error[E0594]: cannot assign to `*y`, which is behind a `&` reference
   --> $DIR/issue-85765.rs:26:5
@@ -41,9 +39,8 @@ LL |     *y = 1;
    |
 help: consider changing this binding's type
    |
-LL -     let y: &usize = &mut(0);
-LL +     let y: &mut usize = &mut(0);
-   |
+LL |     let y: &mut usize = &mut(0);
+   |             +++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/c-variadic/variadic-ffi-1.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-1.stderr
@@ -17,9 +17,8 @@ LL |     fn foo(f: isize, x: u8, ...);
    |        ^^^ -         -
 help: provide the arguments
    |
-LL -         foo();
-LL +         foo(/* isize */, /* u8 */);
-   |
+LL |         foo(/* isize */, /* u8 */);
+   |             +++++++++++++++++++++
 
 error[E0060]: this function takes at least 2 arguments but 1 argument was supplied
   --> $DIR/variadic-ffi-1.rs:23:9
@@ -34,9 +33,8 @@ LL |     fn foo(f: isize, x: u8, ...);
    |        ^^^           -
 help: provide the argument
    |
-LL -         foo(1);
-LL +         foo(1, /* u8 */);
-   |
+LL |         foo(1, /* u8 */);
+   |              ++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/variadic-ffi-1.rs:25:56

--- a/tests/ui/cast/ice-cast-type-with-error-124848.stderr
+++ b/tests/ui/cast/ice-cast-type-with-error-124848.stderr
@@ -48,9 +48,8 @@ LL | struct MyType<'a>(Cell<Option<&'unpinned mut MyType<'a>>>, Pin);
    |        ^^^^^^
 help: provide the argument
    |
-LL -     let mut unpinned = MyType(Cell::new(None));
-LL +     let mut unpinned = MyType(Cell::new(None), /* value */);
-   |
+LL |     let mut unpinned = MyType(Cell::new(None), /* value */);
+   |                                              +++++++++++++
 
 error[E0606]: casting `&MyType<'_>` as `*const Cell<Option<&mut MyType<'_>>>` is invalid
   --> $DIR/ice-cast-type-with-error-124848.rs:14:20

--- a/tests/ui/conditional-compilation/cfg-attr-parse.stderr
+++ b/tests/ui/conditional-compilation/cfg-attr-parse.stderr
@@ -7,9 +7,8 @@ LL | #[cfg_attr()]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 help: missing condition and attribute
    |
-LL - #[cfg_attr()]
-LL + #[cfg_attr(condition, attribute, other_attribute, ...)]
-   |
+LL | #[cfg_attr(condition, attribute, other_attribute, ...)]
+   |            ++++++++++++++++++++++++++++++++++++++++++
 
 error: expected `,`, found end of `cfg_attr` input
   --> $DIR/cfg-attr-parse.rs:8:17

--- a/tests/ui/consts/const_let_assign2.stderr
+++ b/tests/ui/consts/const_let_assign2.stderr
@@ -9,9 +9,8 @@ LL |     let ptr = unsafe { &mut BB };
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw mut` instead to create a raw pointer
    |
-LL -     let ptr = unsafe { &mut BB };
-LL +     let ptr = unsafe { &raw mut BB };
-   |
+LL |     let ptr = unsafe { &raw mut BB };
+   |                         +++
 
 warning: 1 warning emitted
 

--- a/tests/ui/coroutine/issue-102645.stderr
+++ b/tests/ui/coroutine/issue-102645.stderr
@@ -8,9 +8,8 @@ note: method defined here
   --> $SRC_DIR/core/src/ops/coroutine.rs:LL:COL
 help: provide the argument
    |
-LL -     Pin::new(&mut b).resume();
-LL +     Pin::new(&mut b).resume(());
-   |
+LL |     Pin::new(&mut b).resume(());
+   |                             ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/resume-arg-outlives.stderr
+++ b/tests/ui/coroutine/resume-arg-outlives.stderr
@@ -9,9 +9,8 @@ LL |     generator
    |
 help: consider changing `impl Coroutine<&'not_static str> + 'static`'s explicit `'static` bound to the lifetime of argument `s`
    |
-LL - fn demo<'not_static>(s: &'not_static str) -> Pin<Box<impl Coroutine<&'not_static str> + 'static>> {
-LL + fn demo<'not_static>(s: &'not_static str) -> Pin<Box<impl Coroutine<&'not_static str> + 'not_static>> {
-   |
+LL | fn demo<'not_static>(s: &'not_static str) -> Pin<Box<impl Coroutine<&'not_static str> + 'not_static>> {
+   |                                                                                          ++++
 help: alternatively, add an explicit `'static` bound to this reference
    |
 LL - fn demo<'not_static>(s: &'not_static str) -> Pin<Box<impl Coroutine<&'not_static str> + 'static>> {

--- a/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
@@ -7,9 +7,9 @@ LL | #[coverage]
 help: the following are the possible correct uses
    |
 LL | #[coverage(off)]
-   |
+   |           +++++
 LL | #[coverage(on)]
-   |
+   |           ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
@@ -6,11 +6,9 @@ LL | #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL - #[coverage]
-LL + #[coverage(off)]
+LL | #[coverage(off)]
    |
-LL - #[coverage]
-LL + #[coverage(on)]
+LL | #[coverage(on)]
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
@@ -7,9 +7,9 @@ LL | #[coverage]
 help: the following are the possible correct uses
    |
 LL | #[coverage(off)]
-   |
+   |           +++++
 LL | #[coverage(on)]
-   |
+   |           ++++
 
 error[E0658]: the `#[coverage]` attribute is an experimental feature
   --> $DIR/bad-attr-ice.rs:11:1

--- a/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
@@ -6,11 +6,9 @@ LL | #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL - #[coverage]
-LL + #[coverage(off)]
+LL | #[coverage(off)]
    |
-LL - #[coverage]
-LL + #[coverage(on)]
+LL | #[coverage(on)]
    |
 
 error[E0658]: the `#[coverage]` attribute is an experimental feature

--- a/tests/ui/coverage-attr/bad-syntax.stderr
+++ b/tests/ui/coverage-attr/bad-syntax.stderr
@@ -6,12 +6,10 @@ LL | #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL - #[coverage]
-LL + #[coverage(off)]
-   |
-LL - #[coverage]
-LL + #[coverage(on)]
-   |
+LL | #[coverage(off)]
+   |           +++++
+LL | #[coverage(on)]
+   |           ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/bad-syntax.rs:20:1
@@ -36,12 +34,10 @@ LL | #[coverage()]
    |
 help: the following are the possible correct uses
    |
-LL - #[coverage()]
-LL + #[coverage(off)]
-   |
-LL - #[coverage()]
-LL + #[coverage(on)]
-   |
+LL | #[coverage(off)]
+   |            +++
+LL | #[coverage(on)]
+   |            ++
 
 error: malformed `coverage` attribute input
   --> $DIR/bad-syntax.rs:26:1

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -7,9 +7,9 @@ LL | #[coverage]
 help: the following are the possible correct uses
    |
 LL | #[coverage(off)]
-   |
+   |           +++++
 LL | #[coverage(on)]
-   |
+   |           ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:17:5
@@ -20,9 +20,9 @@ LL |     #![coverage]
 help: the following are the possible correct uses
    |
 LL |     #![coverage(off)]
-   |
+   |                +++++
 LL |     #![coverage(on)]
-   |
+   |                ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:21:1
@@ -33,9 +33,9 @@ LL | #[coverage]
 help: the following are the possible correct uses
    |
 LL | #[coverage(off)]
-   |
+   |           +++++
 LL | #[coverage(on)]
-   |
+   |           ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:29:5
@@ -46,9 +46,9 @@ LL |     #[coverage]
 help: the following are the possible correct uses
    |
 LL |     #[coverage(off)]
-   |
+   |               +++++
 LL |     #[coverage(on)]
-   |
+   |               ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:26:1
@@ -59,9 +59,9 @@ LL | #[coverage]
 help: the following are the possible correct uses
    |
 LL | #[coverage(off)]
-   |
+   |           +++++
 LL | #[coverage(on)]
-   |
+   |           ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:39:5
@@ -72,9 +72,9 @@ LL |     #[coverage]
 help: the following are the possible correct uses
    |
 LL |     #[coverage(off)]
-   |
+   |               +++++
 LL |     #[coverage(on)]
-   |
+   |               ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:44:5
@@ -85,9 +85,9 @@ LL |     #[coverage]
 help: the following are the possible correct uses
    |
 LL |     #[coverage(off)]
-   |
+   |               +++++
 LL |     #[coverage(on)]
-   |
+   |               ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:35:1
@@ -98,9 +98,9 @@ LL | #[coverage]
 help: the following are the possible correct uses
    |
 LL | #[coverage(off)]
-   |
+   |           +++++
 LL | #[coverage(on)]
-   |
+   |           ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:53:5
@@ -111,9 +111,9 @@ LL |     #[coverage]
 help: the following are the possible correct uses
    |
 LL |     #[coverage(off)]
-   |
+   |               +++++
 LL |     #[coverage(on)]
-   |
+   |               ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:58:5
@@ -124,9 +124,9 @@ LL |     #[coverage]
 help: the following are the possible correct uses
    |
 LL |     #[coverage(off)]
-   |
+   |               +++++
 LL |     #[coverage(on)]
-   |
+   |               ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:50:1
@@ -137,9 +137,9 @@ LL | #[coverage]
 help: the following are the possible correct uses
    |
 LL | #[coverage(off)]
-   |
+   |           +++++
 LL | #[coverage(on)]
-   |
+   |           ++++
 
 error: malformed `coverage` attribute input
   --> $DIR/word-only.rs:64:1
@@ -150,9 +150,9 @@ LL | #[coverage]
 help: the following are the possible correct uses
    |
 LL | #[coverage(off)]
-   |
+   |           +++++
 LL | #[coverage(on)]
-   |
+   |           ++++
 
 error[E0788]: coverage attribute not allowed here
   --> $DIR/word-only.rs:21:1

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -6,11 +6,9 @@ LL | #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL - #[coverage]
-LL + #[coverage(off)]
+LL | #[coverage(off)]
    |
-LL - #[coverage]
-LL + #[coverage(on)]
+LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -21,11 +19,9 @@ LL |     #![coverage]
    |
 help: the following are the possible correct uses
    |
-LL -     #![coverage]
-LL +     #![coverage(off)]
+LL |     #![coverage(off)]
    |
-LL -     #![coverage]
-LL +     #![coverage(on)]
+LL |     #![coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -36,11 +32,9 @@ LL | #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL - #[coverage]
-LL + #[coverage(off)]
+LL | #[coverage(off)]
    |
-LL - #[coverage]
-LL + #[coverage(on)]
+LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -51,11 +45,9 @@ LL |     #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL -     #[coverage]
-LL +     #[coverage(off)]
+LL |     #[coverage(off)]
    |
-LL -     #[coverage]
-LL +     #[coverage(on)]
+LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -66,11 +58,9 @@ LL | #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL - #[coverage]
-LL + #[coverage(off)]
+LL | #[coverage(off)]
    |
-LL - #[coverage]
-LL + #[coverage(on)]
+LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -81,11 +71,9 @@ LL |     #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL -     #[coverage]
-LL +     #[coverage(off)]
+LL |     #[coverage(off)]
    |
-LL -     #[coverage]
-LL +     #[coverage(on)]
+LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -96,11 +84,9 @@ LL |     #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL -     #[coverage]
-LL +     #[coverage(off)]
+LL |     #[coverage(off)]
    |
-LL -     #[coverage]
-LL +     #[coverage(on)]
+LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -111,11 +97,9 @@ LL | #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL - #[coverage]
-LL + #[coverage(off)]
+LL | #[coverage(off)]
    |
-LL - #[coverage]
-LL + #[coverage(on)]
+LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -126,11 +110,9 @@ LL |     #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL -     #[coverage]
-LL +     #[coverage(off)]
+LL |     #[coverage(off)]
    |
-LL -     #[coverage]
-LL +     #[coverage(on)]
+LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -141,11 +123,9 @@ LL |     #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL -     #[coverage]
-LL +     #[coverage(off)]
+LL |     #[coverage(off)]
    |
-LL -     #[coverage]
-LL +     #[coverage(on)]
+LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -156,11 +136,9 @@ LL | #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL - #[coverage]
-LL + #[coverage(off)]
+LL | #[coverage(off)]
    |
-LL - #[coverage]
-LL + #[coverage(on)]
+LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
@@ -171,11 +149,9 @@ LL | #[coverage]
    |
 help: the following are the possible correct uses
    |
-LL - #[coverage]
-LL + #[coverage(off)]
+LL | #[coverage(off)]
    |
-LL - #[coverage]
-LL + #[coverage(on)]
+LL | #[coverage(on)]
    |
 
 error[E0788]: coverage attribute not allowed here

--- a/tests/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/tests/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -31,9 +31,8 @@ LL +     Struct { a, b } = Struct { a: 1, b: 2 };
    |
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -     Struct { a, _ } = Struct { a: 1, b: 2 };
-LL +     Struct { a, b: _ } = Struct { a: 1, b: 2 };
-   |
+LL |     Struct { a, b: _ } = Struct { a: 1, b: 2 };
+   |                 ++
 help: or always ignore missing fields here
    |
 LL -     Struct { a, _ } = Struct { a: 1, b: 2 };

--- a/tests/ui/diagnostic_namespace/suggest_typos.stderr
+++ b/tests/ui/diagnostic_namespace/suggest_typos.stderr
@@ -11,9 +11,8 @@ LL | #![deny(unknown_or_malformed_diagnostic_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: an attribute with a similar name exists
    |
-LL - #[diagnostic::onunimplemented]
-LL + #[diagnostic::on_unimplemented]
-   |
+LL | #[diagnostic::on_unimplemented]
+   |                 +
 
 error: unknown diagnostic attribute
   --> $DIR/suggest_typos.rs:9:15
@@ -35,9 +34,8 @@ LL | #[diagnostic::on_implemented]
    |
 help: an attribute with a similar name exists
    |
-LL - #[diagnostic::on_implemented]
-LL + #[diagnostic::on_unimplemented]
-   |
+LL | #[diagnostic::on_unimplemented]
+   |                  ++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/error-codes/E0027.stderr
+++ b/tests/ui/error-codes/E0027.stderr
@@ -25,19 +25,16 @@ LL |         Dog { name: x, } => {}
    |
 help: include the missing field in the pattern
    |
-LL -         Dog { name: x, } => {}
-LL +         Dog { name: x, age } => {}
-   |
+LL |         Dog { name: x, age } => {}
+   |                        +++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -         Dog { name: x, } => {}
-LL +         Dog { name: x, age: _ } => {}
-   |
+LL |         Dog { name: x, age: _ } => {}
+   |                        ++++++
 help: or always ignore missing fields here
    |
-LL -         Dog { name: x, } => {}
-LL +         Dog { name: x, .. } => {}
-   |
+LL |         Dog { name: x, .. } => {}
+   |                        ++
 
 error[E0027]: pattern does not mention field `age`
   --> $DIR/E0027.rs:19:9
@@ -47,19 +44,16 @@ LL |         Dog { name: x  , } => {}
    |
 help: include the missing field in the pattern
    |
-LL -         Dog { name: x  , } => {}
-LL +         Dog { name: x, age } => {}
-   |
+LL |         Dog { name: x, age } => {}
+   |                      ~~~~~~~
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -         Dog { name: x  , } => {}
-LL +         Dog { name: x, age: _ } => {}
-   |
+LL |         Dog { name: x, age: _ } => {}
+   |                      ~~~~~~~~~~
 help: or always ignore missing fields here
    |
-LL -         Dog { name: x  , } => {}
-LL +         Dog { name: x, .. } => {}
-   |
+LL |         Dog { name: x, .. } => {}
+   |                      ~~~~~~
 
 error[E0027]: pattern does not mention fields `name`, `age`
   --> $DIR/E0027.rs:22:9
@@ -69,19 +63,16 @@ LL |         Dog {} => {}
    |
 help: include the missing fields in the pattern
    |
-LL -         Dog {} => {}
-LL +         Dog { name, age } => {}
-   |
+LL |         Dog { name, age } => {}
+   |               +++++++++
 help: if you don't care about these missing fields, you can explicitly ignore them
    |
-LL -         Dog {} => {}
-LL +         Dog { name: _, age: _ } => {}
-   |
+LL |         Dog { name: _, age: _ } => {}
+   |               +++++++++++++++
 help: or always ignore missing fields here
    |
-LL -         Dog {} => {}
-LL +         Dog { .. } => {}
-   |
+LL |         Dog { .. } => {}
+   |               ++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/error-codes/E0057.stderr
+++ b/tests/ui/error-codes/E0057.stderr
@@ -11,9 +11,8 @@ LL |     let f = |x| x * 3;
    |             ^^^
 help: provide the argument
    |
-LL -     let a = f();
-LL +     let a = f(/* x */);
-   |
+LL |     let a = f(/* x */);
+   |               +++++++
 
 error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/E0057.rs:5:13

--- a/tests/ui/error-codes/E0060.stderr
+++ b/tests/ui/error-codes/E0060.stderr
@@ -11,9 +11,8 @@ LL |     fn printf(_: *const u8, ...) -> u32;
    |        ^^^^^^ -
 help: provide the argument
    |
-LL -     unsafe { printf(); }
-LL +     unsafe { printf(/* *const u8 */); }
-   |
+LL |     unsafe { printf(/* *const u8 */); }
+   |                     +++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0061.stderr
+++ b/tests/ui/error-codes/E0061.stderr
@@ -11,9 +11,8 @@ LL | fn f(a: u16, b: &str) {}
    |    ^         -------
 help: provide the argument
    |
-LL -     f(0);
-LL +     f(0, /* &str */);
-   |
+LL |     f(0, /* &str */);
+   |        ++++++++++++
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/E0061.rs:9:5
@@ -28,9 +27,8 @@ LL | fn f2(a: u16) {}
    |    ^^ ------
 help: provide the argument
    |
-LL -     f2();
-LL +     f2(/* u16 */);
-   |
+LL |     f2(/* u16 */);
+   |        +++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0259.stderr
+++ b/tests/ui/error-codes/E0259.stderr
@@ -11,7 +11,7 @@ LL | extern crate test as alloc;
 help: you can use `as` to change the binding name of the import
    |
 LL | extern crate test as other_alloc;
-   |
+   |                      ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0259.stderr
+++ b/tests/ui/error-codes/E0259.stderr
@@ -10,8 +10,7 @@ LL | extern crate test as alloc;
    = note: `alloc` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - extern crate test as alloc;
-LL + extern crate test as other_alloc;
+LL | extern crate test as other_alloc;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/error-codes/E0260.stderr
+++ b/tests/ui/error-codes/E0260.stderr
@@ -11,7 +11,7 @@ LL | mod alloc {
 help: you can use `as` to change the binding name of the import
    |
 LL | extern crate alloc as other_alloc;
-   |
+   |                    ++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0260.stderr
+++ b/tests/ui/error-codes/E0260.stderr
@@ -10,8 +10,7 @@ LL | mod alloc {
    = note: `alloc` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - extern crate alloc;
-LL + extern crate alloc as other_alloc;
+LL | extern crate alloc as other_alloc;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/errors/issue-89280-emitter-overflow-splice-lines.stderr
+++ b/tests/ui/errors/issue-89280-emitter-overflow-splice-lines.stderr
@@ -12,11 +12,8 @@ LL | |     )) {}
    = note: `#[warn(anonymous_parameters)]` on by default
 help: try naming the parameter or explicitly ignoring it
    |
-LL ~     fn test(x: u32, _: (
-LL +
-LL +
-LL ~     )) {}
-   |
+LL |     fn test(x: u32, _: (
+   |                     ++
 
 warning: 1 warning emitted
 

--- a/tests/ui/extern/extern-crate-rename.stderr
+++ b/tests/ui/extern/extern-crate-rename.stderr
@@ -9,9 +9,8 @@ LL | extern crate m2 as m1;
    = note: `m1` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - extern crate m2 as m1;
-LL + extern crate m2 as other_m1;
-   |
+LL | extern crate m2 as other_m1;
+   |                    ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -165,9 +165,8 @@ LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
               found signature `extern "rust-call" fn(&Bar, ()) -> ()`
 help: change the self-receiver type to match the trait
    |
-LL -     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
-LL +     extern "rust-call" fn call_mut(&mut self, args: ()) -> () {}
-   |
+LL |     extern "rust-call" fn call_mut(&mut self, args: ()) -> () {}
+   |                                     +++
 
 error[E0046]: not all trait items implemented, missing: `Output`
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:35:1

--- a/tests/ui/fmt/no-inline-literals-out-of-range.stderr
+++ b/tests/ui/fmt/no-inline-literals-out-of-range.stderr
@@ -13,9 +13,8 @@ LL +     format_args!("{}", 0x8f_u8); // issue #115423
    |
 help: to use as a negative number (decimal `-113`), consider using the type `u8` for the literal and cast it to `i8`
    |
-LL -     format_args!("{}", 0x8f_i8); // issue #115423
-LL +     format_args!("{}", 0x8f_u8 as i8); // issue #115423
-   |
+LL |     format_args!("{}", 0x8f_u8 as i8); // issue #115423
+   |                             +++++
 
 error: literal out of range for `u8`
   --> $DIR/no-inline-literals-out-of-range.rs:6:24

--- a/tests/ui/fn/issue-3044.stderr
+++ b/tests/ui/fn/issue-3044.stderr
@@ -11,8 +11,8 @@ note: method defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 help: provide the argument
    |
-LL ~     needlesArr.iter().fold(|x, y| {
-LL +
+LL |     needlesArr.iter().fold(|x, y| {
+LL |
 LL ~     }, /* f */);
    |
 

--- a/tests/ui/fn/param-mismatch-foreign.stderr
+++ b/tests/ui/fn/param-mismatch-foreign.stderr
@@ -11,9 +11,8 @@ LL |     fn foo(x: i32, y: u32, z: i32);
    |        ^^^         -
 help: provide the argument
    |
-LL -     foo(1i32, 2i32);
-LL +     foo(1i32, /* u32 */, 2i32);
-   |
+LL |     foo(1i32, /* u32 */, 2i32);
+   |               ++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/higher-ranked/trait-bounds/issue-58451.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/issue-58451.stderr
@@ -11,9 +11,8 @@ LL | fn f<I>(i: I)
    |    ^    ----
 help: provide the argument
    |
-LL -     f(&[f()]);
-LL +     f(&[f(/* i */)]);
-   |
+LL |     f(&[f(/* i */)]);
+   |           +++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-trait/expeced-refree-to-map-to-reearlybound-ice-108580.stderr
+++ b/tests/ui/impl-trait/in-trait/expeced-refree-to-map-to-reearlybound-ice-108580.stderr
@@ -12,9 +12,8 @@ LL |     fn bar(&self) -> impl Iterator + '_ {
    = note: `#[warn(refining_impl_trait_internal)]` on by default
 help: replace the return type so that it matches the trait
    |
-LL -     fn bar(&self) -> impl Iterator + '_ {
-LL +     fn bar(&self) -> impl Iterator<Item = impl Sized> + '_ {
-   |
+LL |     fn bar(&self) -> impl Iterator<Item = impl Sized> + '_ {
+   |                                   +++++++++++++++++++
 
 warning: 1 warning emitted
 

--- a/tests/ui/impl-trait/in-trait/refine-captures.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-captures.stderr
@@ -9,9 +9,8 @@ LL |     fn test() -> impl Sized + use<> {}
    = note: `#[warn(refining_impl_trait_internal)]` on by default
 help: modify the `use<..>` bound to capture the same lifetimes that the trait does
    |
-LL -     fn test() -> impl Sized + use<> {}
-LL +     fn test() -> impl Sized + use<'a> {}
-   |
+LL |     fn test() -> impl Sized + use<'a> {}
+   |                                   ++
 
 warning: impl trait in impl method captures fewer lifetimes than in trait
   --> $DIR/refine-captures.rs:22:31
@@ -23,9 +22,8 @@ LL |     fn test() -> impl Sized + use<> {}
    = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
 help: modify the `use<..>` bound to capture the same lifetimes that the trait does
    |
-LL -     fn test() -> impl Sized + use<> {}
-LL +     fn test() -> impl Sized + use<'a> {}
-   |
+LL |     fn test() -> impl Sized + use<'a> {}
+   |                                   ++
 
 warning: impl trait in impl method captures fewer lifetimes than in trait
   --> $DIR/refine-captures.rs:27:31
@@ -37,9 +35,8 @@ LL |     fn test() -> impl Sized + use<'b> {}
    = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
 help: modify the `use<..>` bound to capture the same lifetimes that the trait does
    |
-LL -     fn test() -> impl Sized + use<'b> {}
-LL +     fn test() -> impl Sized + use<'a, 'b> {}
-   |
+LL |     fn test() -> impl Sized + use<'a, 'b> {}
+   |                                    ++++
 
 error: `impl Trait` must mention all type parameters in scope in `use<...>`
   --> $DIR/refine-captures.rs:32:18

--- a/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/tests/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -41,9 +41,8 @@ LL + fn elided2(x: &i32) -> impl Copy + '_ { x }
    |
 help: alternatively, add an explicit `'static` bound to this reference
    |
-LL - fn elided2(x: &i32) -> impl Copy + 'static { x }
-LL + fn elided2(x: &'static i32) -> impl Copy + 'static { x }
-   |
+LL | fn elided2(x: &'static i32) -> impl Copy + 'static { x }
+   |                +++++++
 
 error: lifetime may not live long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:12:55
@@ -172,9 +171,8 @@ LL + fn elided4(x: &i32) -> Box<dyn Debug + '_> { Box::new(x) }
    |
 help: alternatively, add an explicit `'static` bound to this reference
    |
-LL - fn elided4(x: &i32) -> Box<dyn Debug + 'static> { Box::new(x) }
-LL + fn elided4(x: &'static i32) -> Box<dyn Debug + 'static> { Box::new(x) }
-   |
+LL | fn elided4(x: &'static i32) -> Box<dyn Debug + 'static> { Box::new(x) }
+   |                +++++++
 
 error: lifetime may not live long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:27:60

--- a/tests/ui/imports/extern-crate-self/extern-crate-self-fail.stderr
+++ b/tests/ui/imports/extern-crate-self/extern-crate-self-fail.stderr
@@ -6,9 +6,8 @@ LL | extern crate self;
    |
 help: rename the `self` crate to be able to import it
    |
-LL - extern crate self;
-LL + extern crate self as name;
-   |
+LL | extern crate self as name;
+   |                   +++++++
 
 error: `#[macro_use]` is not supported on `extern crate self`
   --> $DIR/extern-crate-self-fail.rs:3:1

--- a/tests/ui/imports/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
+++ b/tests/ui/imports/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
@@ -8,7 +8,7 @@ LL | extern crate std;
 help: you can use `as` to change the binding name of the import
    |
 LL | extern crate std as other_std;
-   |
+   |                  ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
+++ b/tests/ui/imports/issue-45799-bad-extern-crate-rename-suggestion-formatting.stderr
@@ -7,8 +7,7 @@ LL | extern crate std;
    = note: `std` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - extern crate std;
-LL + extern crate std as other_std;
+LL | extern crate std as other_std;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/imports/issue-45829/import-self.stderr
+++ b/tests/ui/imports/issue-45829/import-self.stderr
@@ -62,9 +62,8 @@ LL | use foo::{self as A};
    = note: `A` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - use foo::{self as A};
-LL + use foo::{self as OtherA};
-   |
+LL | use foo::{self as OtherA};
+   |                   +++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/imports/issue-45829/issue-45829.stderr
+++ b/tests/ui/imports/issue-45829/issue-45829.stderr
@@ -9,9 +9,8 @@ LL | use foo::{A, B as A};
    = note: `A` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - use foo::{A, B as A};
-LL + use foo::{A, B as OtherA};
-   |
+LL | use foo::{A, B as OtherA};
+   |                   +++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45829/rename-extern-vs-use.stderr
+++ b/tests/ui/imports/issue-45829/rename-extern-vs-use.stderr
@@ -10,7 +10,7 @@ LL | extern crate issue_45829_b as bar;
 help: you can use `as` to change the binding name of the import
    |
 LL | extern crate issue_45829_b as other_bar;
-   |
+   |                               ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45829/rename-extern-vs-use.stderr
+++ b/tests/ui/imports/issue-45829/rename-extern-vs-use.stderr
@@ -9,8 +9,7 @@ LL | extern crate issue_45829_b as bar;
    = note: `bar` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - extern crate issue_45829_b as bar;
-LL + extern crate issue_45829_b as other_bar;
+LL | extern crate issue_45829_b as other_bar;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/imports/issue-45829/rename-extern.stderr
+++ b/tests/ui/imports/issue-45829/rename-extern.stderr
@@ -10,7 +10,7 @@ LL | extern crate issue_45829_b as issue_45829_a;
 help: you can use `as` to change the binding name of the import
    |
 LL | extern crate issue_45829_b as other_issue_45829_a;
-   |
+   |                               ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45829/rename-extern.stderr
+++ b/tests/ui/imports/issue-45829/rename-extern.stderr
@@ -9,8 +9,7 @@ LL | extern crate issue_45829_b as issue_45829_a;
    = note: `issue_45829_a` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - extern crate issue_45829_b as issue_45829_a;
-LL + extern crate issue_45829_b as other_issue_45829_a;
+LL | extern crate issue_45829_b as other_issue_45829_a;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/imports/issue-45829/rename-use-vs-extern.stderr
+++ b/tests/ui/imports/issue-45829/rename-use-vs-extern.stderr
@@ -9,9 +9,8 @@ LL | use std as issue_45829_b;
    = note: `issue_45829_b` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - use std as issue_45829_b;
-LL + use std as other_issue_45829_b;
-   |
+LL | use std as other_issue_45829_b;
+   |            ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45829/rename-with-path.stderr
+++ b/tests/ui/imports/issue-45829/rename-with-path.stderr
@@ -9,9 +9,8 @@ LL | use std::{collections::HashMap as A, sync::Arc as A};
    = note: `A` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - use std::{collections::HashMap as A, sync::Arc as A};
-LL + use std::{collections::HashMap as A, sync::Arc as OtherA};
-   |
+LL | use std::{collections::HashMap as A, sync::Arc as OtherA};
+   |                                                   +++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-45829/rename.stderr
+++ b/tests/ui/imports/issue-45829/rename.stderr
@@ -9,9 +9,8 @@ LL | use std as core;
    = note: `core` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - use std as core;
-LL + use std as other_core;
-   |
+LL | use std as other_core;
+   |            ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/multiple-extern-by-macro-for-buitlin.stderr
+++ b/tests/ui/imports/multiple-extern-by-macro-for-buitlin.stderr
@@ -15,7 +15,7 @@ LL | m!();
 help: you can use `as` to change the binding name of the import
    |
 LL |         extern crate std as other_core;
-   |
+   |                             ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/multiple-extern-by-macro-for-buitlin.stderr
+++ b/tests/ui/imports/multiple-extern-by-macro-for-buitlin.stderr
@@ -14,8 +14,7 @@ LL | m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you can use `as` to change the binding name of the import
    |
-LL -         extern crate std as core;
-LL +         extern crate std as other_core;
+LL |         extern crate std as other_core;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/imports/multiple-extern-by-macro-for-custom.stderr
+++ b/tests/ui/imports/multiple-extern-by-macro-for-custom.stderr
@@ -15,7 +15,7 @@ LL | m!();
 help: you can use `as` to change the binding name of the import
    |
 LL |         extern crate std as other_empty;
-   |
+   |                             ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/multiple-extern-by-macro-for-custom.stderr
+++ b/tests/ui/imports/multiple-extern-by-macro-for-custom.stderr
@@ -14,8 +14,7 @@ LL | m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you can use `as` to change the binding name of the import
    |
-LL -         extern crate std as empty;
-LL +         extern crate std as other_empty;
+LL |         extern crate std as other_empty;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/imports/multiple-extern-by-macro-for-inexist.stderr
+++ b/tests/ui/imports/multiple-extern-by-macro-for-inexist.stderr
@@ -21,7 +21,7 @@ LL | m!();
 help: you can use `as` to change the binding name of the import
    |
 LL |         extern crate std as other_non_existent;
-   |
+   |                             ++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/imports/multiple-extern-by-macro-for-inexist.stderr
+++ b/tests/ui/imports/multiple-extern-by-macro-for-inexist.stderr
@@ -20,8 +20,7 @@ LL | m!();
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you can use `as` to change the binding name of the import
    |
-LL -         extern crate std as non_existent;
-LL +         extern crate std as other_non_existent;
+LL |         extern crate std as other_non_existent;
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/imports/no-std-inject.stderr
+++ b/tests/ui/imports/no-std-inject.stderr
@@ -7,9 +7,8 @@ LL | extern crate core;
    = note: `core` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - extern crate core;
-LL + extern crate core as other_core;
-   |
+LL | extern crate core as other_core;
+   |                   +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/include-macros/parent_dir.stderr
+++ b/tests/ui/include-macros/parent_dir.stderr
@@ -20,9 +20,8 @@ LL |     let _ = include_str!("hello.rs");
    = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: there is a file with the same name in a different directory
    |
-LL -     let _ = include_str!("hello.rs");
-LL +     let _ = include_str!("../hello.rs");
-   |
+LL |     let _ = include_str!("../hello.rs");
+   |                           +++
 
 error: couldn't read `$DIR/../../data.bin`: $FILE_NOT_FOUND_MSG
   --> $DIR/parent_dir.rs:8:13

--- a/tests/ui/issues/issue-20225.stderr
+++ b/tests/ui/issues/issue-20225.stderr
@@ -10,9 +10,8 @@ LL |   extern "rust-call" fn call(&self, (_,): (T,)) {}
               found signature `extern "rust-call" fn(&Foo, (_,))`
 help: change the parameter type to match the trait
    |
-LL -   extern "rust-call" fn call(&self, (_,): (T,)) {}
-LL +   extern "rust-call" fn call(&self, (_,): (&'a T,)) {}
-   |
+LL |   extern "rust-call" fn call(&self, (_,): (&'a T,)) {}
+   |                                            +++
 
 error[E0053]: method `call_mut` has an incompatible type for trait
   --> $DIR/issue-20225.rs:11:51
@@ -26,9 +25,8 @@ LL |   extern "rust-call" fn call_mut(&mut self, (_,): (T,)) {}
               found signature `extern "rust-call" fn(&mut Foo, (_,))`
 help: change the parameter type to match the trait
    |
-LL -   extern "rust-call" fn call_mut(&mut self, (_,): (T,)) {}
-LL +   extern "rust-call" fn call_mut(&mut self, (_,): (&'a T,)) {}
-   |
+LL |   extern "rust-call" fn call_mut(&mut self, (_,): (&'a T,)) {}
+   |                                                    +++
 
 error[E0053]: method `call_once` has an incompatible type for trait
   --> $DIR/issue-20225.rs:18:47
@@ -43,9 +41,8 @@ LL |   extern "rust-call" fn call_once(self, (_,): (T,)) {}
               found signature `extern "rust-call" fn(Foo, (_,))`
 help: change the parameter type to match the trait
    |
-LL -   extern "rust-call" fn call_once(self, (_,): (T,)) {}
-LL +   extern "rust-call" fn call_once(self, (_,): (&'a T,)) {}
-   |
+LL |   extern "rust-call" fn call_once(self, (_,): (&'a T,)) {}
+   |                                                +++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/issues/issue-23073.stderr
+++ b/tests/ui/issues/issue-23073.stderr
@@ -6,9 +6,8 @@ LL |     type FooT = <<Self as Bar>::Foo>::T;
    |
 help: if there were a trait named `Example` with associated type `T` implemented for `<Self as Bar>::Foo`, you could use the fully-qualified path
    |
-LL -     type FooT = <<Self as Bar>::Foo>::T;
-LL +     type FooT = <<Self as Bar>::Foo as Example>::T;
-   |
+LL |     type FooT = <<Self as Bar>::Foo as Example>::T;
+   |                                     ++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-76077-inaccesible-private-fields/issue-76077-1.stderr
+++ b/tests/ui/issues/issue-76077-inaccesible-private-fields/issue-76077-1.stderr
@@ -6,9 +6,8 @@ LL |     let foo::Foo {} = foo::Foo::default();
    |
 help: ignore the inaccessible and unused fields
    |
-LL -     let foo::Foo {} = foo::Foo::default();
-LL +     let foo::Foo { .. } = foo::Foo::default();
-   |
+LL |     let foo::Foo { .. } = foo::Foo::default();
+   |                    ++
 
 error: pattern requires `..` due to inaccessible fields
   --> $DIR/issue-76077-1.rs:16:9

--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -13,7 +13,7 @@ LL |     x.use_mut();
 help: consider consuming the `Vec<i32>` when turning it into an `Iterator`
    |
 LL |     let mut x = vec![1].into_iter();
-   |                         +++++
+   |                          +++++
 help: consider using a `let` binding to create a longer lived value
    |
 LL ~     let binding = vec![1];

--- a/tests/ui/lifetimes/issue-26638.stderr
+++ b/tests/ui/lifetimes/issue-26638.stderr
@@ -56,9 +56,8 @@ LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
    |
 help: provide the argument
    |
-LL - fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
-LL + fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter(/* &u8 */) }
-   |
+LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter(/* &u8 */) }
+   |                                                    +++++++++
 
 error[E0308]: mismatched types
   --> $DIR/issue-26638.rs:4:47

--- a/tests/ui/lint/static-mut-refs.e2021.stderr
+++ b/tests/ui/lint/static-mut-refs.e2021.stderr
@@ -22,9 +22,8 @@ LL |         let _y = &mut X;
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |
-LL -         let _y = &mut X;
-LL +         let _y = &raw mut X;
-   |
+LL |         let _y = &raw mut X;
+   |                   +++
 
 warning: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:50:22

--- a/tests/ui/lint/static-mut-refs.e2024.stderr
+++ b/tests/ui/lint/static-mut-refs.e2024.stderr
@@ -22,9 +22,8 @@ LL |         let _y = &mut X;
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |
-LL -         let _y = &mut X;
-LL +         let _y = &raw mut X;
-   |
+LL |         let _y = &raw mut X;
+   |                   +++
 
 error: creating a shared reference to mutable static is discouraged
   --> $DIR/static-mut-refs.rs:50:22

--- a/tests/ui/lint/type-overflow.stderr
+++ b/tests/ui/lint/type-overflow.stderr
@@ -26,9 +26,8 @@ LL +     let fail = 0b1000_0001u8;
    |
 help: to use as a negative number (decimal `-127`), consider using the type `u8` for the literal and cast it to `i8`
    |
-LL -     let fail = 0b1000_0001i8;
-LL +     let fail = 0b1000_0001u8 as i8;
-   |
+LL |     let fail = 0b1000_0001u8 as i8;
+   |                           +++++
 
 warning: literal out of range for `i64`
   --> $DIR/type-overflow.rs:15:16
@@ -44,9 +43,8 @@ LL +     let fail = 0x8000_0000_0000_0000u64;
    |
 help: to use as a negative number (decimal `-9223372036854775808`), consider using the type `u64` for the literal and cast it to `i64`
    |
-LL -     let fail = 0x8000_0000_0000_0000i64;
-LL +     let fail = 0x8000_0000_0000_0000u64 as i64;
-   |
+LL |     let fail = 0x8000_0000_0000_0000u64 as i64;
+   |                                     ++++++
 
 warning: literal out of range for `u32`
   --> $DIR/type-overflow.rs:19:16

--- a/tests/ui/malformed/malformed-special-attrs.stderr
+++ b/tests/ui/malformed/malformed-special-attrs.stderr
@@ -7,9 +7,8 @@ LL | #[cfg_attr]
    = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
 help: missing condition and attribute
    |
-LL - #[cfg_attr]
-LL + #[cfg_attr(condition, attribute, other_attribute, ...)]
-   |
+LL | #[cfg_attr(condition, attribute, other_attribute, ...)]
+   |           ++++++++++++++++++++++++++++++++++++++++++++
 
 error: malformed `cfg_attr` attribute input
   --> $DIR/malformed-special-attrs.rs:4:1

--- a/tests/ui/methods/method-call-err-msg.stderr
+++ b/tests/ui/methods/method-call-err-msg.stderr
@@ -28,9 +28,8 @@ LL |     fn one(self, _: isize) -> Foo { self }
    |        ^^^       --------
 help: provide the argument
    |
-LL -      .one()
-LL +      .one(/* isize */)
-   |
+LL |      .one(/* isize */)
+   |           +++++++++++
 
 error[E0061]: this method takes 2 arguments but 1 argument was supplied
   --> $DIR/method-call-err-msg.rs:15:7
@@ -45,9 +44,8 @@ LL |     fn two(self, _: isize, _: isize) -> Foo { self }
    |        ^^^                 --------
 help: provide the argument
    |
-LL -      .two(0);
-LL +      .two(0, /* isize */);
-   |
+LL |      .two(0, /* isize */);
+   |            +++++++++++++
 
 error[E0599]: `Foo` is not an iterator
   --> $DIR/method-call-err-msg.rs:19:7
@@ -84,9 +82,8 @@ LL |     fn three<T>(self, _: T, _: T, _: T) -> Foo { self }
    |        ^^^^^          ----  ----  ----
 help: provide the arguments
    |
-LL -     y.three::<usize>();
-LL +     y.three::<usize>(/* usize */, /* usize */, /* usize */);
-   |
+LL |     y.three::<usize>(/* usize */, /* usize */, /* usize */);
+   |                      +++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/mismatched_types/closure-arg-count.stderr
+++ b/tests/ui/mismatched_types/closure-arg-count.stderr
@@ -8,9 +8,8 @@ LL |     [1, 2, 3].sort_by(|| panic!());
    |
 help: consider changing the closure to take and ignore the expected arguments
    |
-LL -     [1, 2, 3].sort_by(|| panic!());
-LL +     [1, 2, 3].sort_by(|_, _| panic!());
-   |
+LL |     [1, 2, 3].sort_by(|_, _| panic!());
+   |                        ++++
 
 error[E0593]: closure is expected to take 2 arguments, but it takes 1 argument
   --> $DIR/closure-arg-count.rs:7:15
@@ -64,9 +63,8 @@ LL | fn f<F: Fn<(usize,)>>(_: F) {}
    |         ^^^^^^^^^^^^ required by this bound in `f`
 help: consider changing the closure to take and ignore the expected argument
    |
-LL -     f(|| panic!());
-LL +     f(|_| panic!());
-   |
+LL |     f(|_| panic!());
+   |        +
 
 error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:15:5
@@ -84,9 +82,8 @@ LL | fn f<F: Fn<(usize,)>>(_: F) {}
    |         ^^^^^^^^^^^^ required by this bound in `f`
 help: consider changing the closure to take and ignore the expected argument
    |
-LL -     f(  move    || panic!());
-LL +     f(  move    |_| panic!());
-   |
+LL |     f(  move    |_| panic!());
+   |                  +
 
 error[E0593]: closure is expected to take a single 2-tuple as argument, but it takes 2 distinct arguments
   --> $DIR/closure-arg-count.rs:18:53

--- a/tests/ui/mismatched_types/issue-13033.stderr
+++ b/tests/ui/mismatched_types/issue-13033.stderr
@@ -13,9 +13,8 @@ LL |     fn bar(&mut self, other: &mut dyn Foo);
               found signature `fn(&mut Baz, &dyn Foo)`
 help: change the parameter type to match the trait
    |
-LL -     fn bar(&mut self, other: &dyn Foo) {}
-LL +     fn bar(&mut self, other: &mut dyn Foo) {}
-   |
+LL |     fn bar(&mut self, other: &mut dyn Foo) {}
+   |                               +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/mismatched_types/mismatch-args-crash-issue-128848.stderr
+++ b/tests/ui/mismatched_types/mismatch-args-crash-issue-128848.stderr
@@ -8,9 +8,8 @@ note: method defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 help: provide the argument
    |
-LL -     f.call_once()
-LL +     f.call_once(/* args */)
-   |
+LL |     f.call_once(/* args */)
+   |                 ++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/mismatched_types/mismatch-args-crash-issue-130400.stderr
+++ b/tests/ui/mismatched_types/mismatch-args-crash-issue-130400.stderr
@@ -11,9 +11,8 @@ LL |     fn foo(&mut self) -> _ {
    |        ^^^ ---------
 help: provide the argument
    |
-LL -         Self::foo()
-LL +         Self::foo(/* value */)
-   |
+LL |         Self::foo(/* value */)
+   |                   +++++++++++
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/mismatch-args-crash-issue-130400.rs:2:26

--- a/tests/ui/mismatched_types/mismatch-args-vargs-issue-130372.stderr
+++ b/tests/ui/mismatched_types/mismatch-args-vargs-issue-130372.stderr
@@ -11,9 +11,8 @@ LL | unsafe extern "C" fn test_va_copy(_: u64, mut ap: ...) {}
    |                      ^^^^^^^^^^^^ ------
 help: provide the argument
    |
-LL -         test_va_copy();
-LL +         test_va_copy(/* u64 */);
-   |
+LL |         test_va_copy(/* u64 */);
+   |                      +++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/tests/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -25,9 +25,8 @@ LL | impl FnMut<(isize,)> for S {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: provide the argument
    |
-LL -     let ans = s();
-LL +     let ans = s(/* isize */);
-   |
+LL |     let ans = s(/* isize */);
+   |                 +++++++++++
 
 error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:37:15

--- a/tests/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
+++ b/tests/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
@@ -32,9 +32,8 @@ LL |     fn bar(&mut self, bar: &mut Bar);
               found signature `fn(&mut Bar, &Bar)`
 help: change the parameter type to match the trait
    |
-LL -     fn bar(&mut self, bar: &Bar) { }
-LL +     fn bar(&mut self, bar: &mut Bar) { }
-   |
+LL |     fn bar(&mut self, bar: &mut Bar) { }
+   |                             +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
+++ b/tests/ui/nll/borrowck-thread-local-static-mut-borrow-outlives-fn.stderr
@@ -9,9 +9,8 @@ LL |         S1 { a: unsafe { &mut X1 } }
    = note: `#[warn(static_mut_refs)]` on by default
 help: use `&raw mut` instead to create a raw pointer
    |
-LL -         S1 { a: unsafe { &mut X1 } }
-LL +         S1 { a: unsafe { &raw mut X1 } }
-   |
+LL |         S1 { a: unsafe { &raw mut X1 } }
+   |                           +++
 
 warning: 1 warning emitted
 

--- a/tests/ui/not-enough-arguments.stderr
+++ b/tests/ui/not-enough-arguments.stderr
@@ -11,9 +11,8 @@ LL | fn foo(a: isize, b: isize, c: isize, d:isize) {
    |    ^^^                               -------
 help: provide the argument
    |
-LL -   foo(1, 2, 3);
-LL +   foo(1, 2, 3, /* isize */);
-   |
+LL |   foo(1, 2, 3, /* isize */);
+   |              +++++++++++++
 
 error[E0061]: this function takes 6 arguments but 3 arguments were supplied
   --> $DIR/not-enough-arguments.rs:29:3
@@ -35,9 +34,8 @@ LL |     f: i32,
    |     ------
 help: provide the arguments
    |
-LL -   bar(1, 2, 3);
-LL +   bar(1, 2, 3, /* i32 */, /* i32 */, /* i32 */);
-   |
+LL |   bar(1, 2, 3, /* i32 */, /* i32 */, /* i32 */);
+   |              +++++++++++++++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/obsolete-in-place/bad.stderr
+++ b/tests/ui/obsolete-in-place/bad.stderr
@@ -6,9 +6,8 @@ LL |     x <- y;
    |
 help: if you meant to write a comparison against a negative value, add a space in between `<` and `-`
    |
-LL -     x <- y;
-LL +     x < - y;
-   |
+LL |     x < - y;
+   |        +
 
 error: expected expression, found keyword `in`
   --> $DIR/bad.rs:10:5

--- a/tests/ui/on-unimplemented/bad-annotation.stderr
+++ b/tests/ui/on-unimplemented/bad-annotation.stderr
@@ -6,11 +6,9 @@ LL | #[rustc_on_unimplemented]
    |
 help: the following are the possible correct uses
    |
-LL - #[rustc_on_unimplemented]
-LL + #[rustc_on_unimplemented = "message"]
+LL | #[rustc_on_unimplemented = "message"]
    |
-LL - #[rustc_on_unimplemented]
-LL + #[rustc_on_unimplemented(/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...")]
+LL | #[rustc_on_unimplemented(/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...")]
    |
 
 error[E0230]: there is no parameter `C` on trait `BadAnnotation2`

--- a/tests/ui/on-unimplemented/bad-annotation.stderr
+++ b/tests/ui/on-unimplemented/bad-annotation.stderr
@@ -7,9 +7,9 @@ LL | #[rustc_on_unimplemented]
 help: the following are the possible correct uses
    |
 LL | #[rustc_on_unimplemented = "message"]
-   |
+   |                          +++++++++++
 LL | #[rustc_on_unimplemented(/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...")]
-   |
+   |                         ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0230]: there is no parameter `C` on trait `BadAnnotation2`
   --> $DIR/bad-annotation.rs:22:1

--- a/tests/ui/on-unimplemented/issue-104140.stderr
+++ b/tests/ui/on-unimplemented/issue-104140.stderr
@@ -6,12 +6,10 @@ LL | #[rustc_on_unimplemented]
    |
 help: the following are the possible correct uses
    |
-LL - #[rustc_on_unimplemented]
-LL + #[rustc_on_unimplemented = "message"]
-   |
-LL - #[rustc_on_unimplemented]
-LL + #[rustc_on_unimplemented(/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...")]
-   |
+LL | #[rustc_on_unimplemented = "message"]
+   |                          +++++++++++
+LL | #[rustc_on_unimplemented(/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...")]
+   |                         ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/panic-handler/weak-lang-item.stderr
+++ b/tests/ui/panic-handler/weak-lang-item.stderr
@@ -7,8 +7,7 @@ LL | extern crate core;
    = note: `core` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - extern crate core;
-LL + extern crate core as other_core;
+LL | extern crate core as other_core;
    |
 
 error: `#[panic_handler]` function required, but not found

--- a/tests/ui/panic-handler/weak-lang-item.stderr
+++ b/tests/ui/panic-handler/weak-lang-item.stderr
@@ -8,7 +8,7 @@ LL | extern crate core;
 help: you can use `as` to change the binding name of the import
    |
 LL | extern crate core as other_core;
-   |
+   |                   +++++++++++++
 
 error: `#[panic_handler]` function required, but not found
 

--- a/tests/ui/parser/emoji-identifiers.stderr
+++ b/tests/ui/parser/emoji-identifiers.stderr
@@ -81,9 +81,8 @@ LL |     fn full_of_✨() -> 👀 {
    |     ^^^^^^^^^^^^^^^^^^^^^
 help: there is an associated function `full_of_✨` with a similar name
    |
-LL -     👀::full_of✨()
-LL +     👀::full_of_✨()
-   |
+LL |     👀::full_of_✨()
+   |                +
 
 error[E0425]: cannot find function `i_like_to_😄_a_lot` in this scope
   --> $DIR/emoji-identifiers.rs:13:13

--- a/tests/ui/parser/extern-crate-unexpected-token.stderr
+++ b/tests/ui/parser/extern-crate-unexpected-token.stderr
@@ -6,9 +6,8 @@ LL | extern crte foo;
    |
 help: there is a keyword `crate` with a similar name
    |
-LL - extern crte foo;
-LL + extern crate foo;
-   |
+LL | extern crate foo;
+   |          +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/const-fn.stderr
+++ b/tests/ui/parser/misspelled-keywords/const-fn.stderr
@@ -6,9 +6,8 @@ LL | cnst fn code() {}
    |
 help: there is a keyword `const` with a similar name
    |
-LL - cnst fn code() {}
-LL + const fn code() {}
-   |
+LL | const fn code() {}
+   |  +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -37,7 +37,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match ref_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern
@@ -100,7 +100,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match res_u32_never {
 LL +         Ok(_) => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern
@@ -374,7 +374,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match slice_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `&[]` not covered
@@ -415,7 +415,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match *slice_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern
@@ -462,7 +462,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match array_0_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -46,7 +46,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match ref_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern
@@ -76,7 +76,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match res_u32_never {
 LL +         Ok(_) => todo!(),
-LL +     }
+LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
@@ -321,7 +321,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match slice_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `&[!, ..]` not covered
@@ -376,7 +376,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match *slice_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
@@ -390,7 +390,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match array_0_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern
@@ -502,7 +502,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match *ref_tuple_half_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -37,7 +37,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match ref_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern
@@ -67,7 +67,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match res_u32_never {
 LL +         Ok(_) => todo!(),
-LL +     }
+LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
@@ -312,7 +312,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match slice_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `&[_, ..]` not covered
@@ -367,7 +367,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match *slice_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
@@ -381,7 +381,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match array_0_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern
@@ -493,7 +493,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match *ref_tuple_half_never {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern

--- a/tests/ui/pattern/usefulness/impl-trait.stderr
+++ b/tests/ui/pattern/usefulness/impl-trait.stderr
@@ -36,7 +36,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match return_never_rpit(x) {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern
@@ -118,7 +118,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match return_never_tait(x) {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: unreachable pattern

--- a/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
@@ -154,7 +154,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match 7usize {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: aborting due to 12 previous errors

--- a/tests/ui/pattern/usefulness/issue-78123-non-exhaustive-reference.stderr
+++ b/tests/ui/pattern/usefulness/issue-78123-non-exhaustive-reference.stderr
@@ -15,7 +15,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match a {
 LL +         _ => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/unstable-gated-fields.stderr
+++ b/tests/ui/pattern/usefulness/unstable-gated-fields.stderr
@@ -6,19 +6,16 @@ LL |     let UnstableStruct { stable, stable2, } = UnstableStruct::default();
    |
 help: include the missing field in the pattern
    |
-LL -     let UnstableStruct { stable, stable2, } = UnstableStruct::default();
-LL +     let UnstableStruct { stable, stable2, unstable } = UnstableStruct::default();
-   |
+LL |     let UnstableStruct { stable, stable2, unstable } = UnstableStruct::default();
+   |                                           ++++++++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -     let UnstableStruct { stable, stable2, } = UnstableStruct::default();
-LL +     let UnstableStruct { stable, stable2, unstable: _ } = UnstableStruct::default();
-   |
+LL |     let UnstableStruct { stable, stable2, unstable: _ } = UnstableStruct::default();
+   |                                           +++++++++++
 help: or always ignore missing fields here
    |
-LL -     let UnstableStruct { stable, stable2, } = UnstableStruct::default();
-LL +     let UnstableStruct { stable, stable2, .. } = UnstableStruct::default();
-   |
+LL |     let UnstableStruct { stable, stable2, .. } = UnstableStruct::default();
+   |                                           ++
 
 error[E0027]: pattern does not mention field `stable2`
   --> $DIR/unstable-gated-fields.rs:13:9
@@ -28,19 +25,16 @@ LL |     let UnstableStruct { stable, unstable, } = UnstableStruct::default();
    |
 help: include the missing field in the pattern
    |
-LL -     let UnstableStruct { stable, unstable, } = UnstableStruct::default();
-LL +     let UnstableStruct { stable, unstable, stable2 } = UnstableStruct::default();
-   |
+LL |     let UnstableStruct { stable, unstable, stable2 } = UnstableStruct::default();
+   |                                            +++++++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -     let UnstableStruct { stable, unstable, } = UnstableStruct::default();
-LL +     let UnstableStruct { stable, unstable, stable2: _ } = UnstableStruct::default();
-   |
+LL |     let UnstableStruct { stable, unstable, stable2: _ } = UnstableStruct::default();
+   |                                            ++++++++++
 help: or always ignore missing fields here
    |
-LL -     let UnstableStruct { stable, unstable, } = UnstableStruct::default();
-LL +     let UnstableStruct { stable, unstable, .. } = UnstableStruct::default();
-   |
+LL |     let UnstableStruct { stable, unstable, .. } = UnstableStruct::default();
+   |                                            ++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/regions/region-object-lifetime-in-coercion.stderr
+++ b/tests/ui/regions/region-object-lifetime-in-coercion.stderr
@@ -13,9 +13,8 @@ LL + fn a(v: &[u8]) -> Box<dyn Foo + '_> {
    |
 help: alternatively, add an explicit `'static` bound to this reference
    |
-LL - fn a(v: &[u8]) -> Box<dyn Foo + 'static> {
-LL + fn a(v: &'static [u8]) -> Box<dyn Foo + 'static> {
-   |
+LL | fn a(v: &'static [u8]) -> Box<dyn Foo + 'static> {
+   |          +++++++
 
 error: lifetime may not live long enough
   --> $DIR/region-object-lifetime-in-coercion.rs:14:5
@@ -32,9 +31,8 @@ LL + fn b(v: &[u8]) -> Box<dyn Foo + '_> {
    |
 help: alternatively, add an explicit `'static` bound to this reference
    |
-LL - fn b(v: &[u8]) -> Box<dyn Foo + 'static> {
-LL + fn b(v: &'static [u8]) -> Box<dyn Foo + 'static> {
-   |
+LL | fn b(v: &'static [u8]) -> Box<dyn Foo + 'static> {
+   |          +++++++
 
 error: lifetime may not live long enough
   --> $DIR/region-object-lifetime-in-coercion.rs:21:5

--- a/tests/ui/regions/regions-proc-bound-capture.stderr
+++ b/tests/ui/regions/regions-proc-bound-capture.stderr
@@ -14,9 +14,8 @@ LL + fn static_proc(x: &isize) -> Box<dyn FnMut() -> (isize) + '_> {
    |
 help: alternatively, add an explicit `'static` bound to this reference
    |
-LL - fn static_proc(x: &isize) -> Box<dyn FnMut() -> (isize) + 'static> {
-LL + fn static_proc(x: &'static isize) -> Box<dyn FnMut() -> (isize) + 'static> {
-   |
+LL | fn static_proc(x: &'static isize) -> Box<dyn FnMut() -> (isize) + 'static> {
+   |                    +++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/resolve-conflict-extern-crate-vs-extern-crate.stderr
+++ b/tests/ui/resolve/resolve-conflict-extern-crate-vs-extern-crate.stderr
@@ -4,7 +4,7 @@ error[E0259]: the name `std` is defined multiple times
 help: you can use `as` to change the binding name of the import
    |
 LL | extern crate std as other_std;
-   |
+   |                  ++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/resolve-conflict-extern-crate-vs-extern-crate.stderr
+++ b/tests/ui/resolve/resolve-conflict-extern-crate-vs-extern-crate.stderr
@@ -3,8 +3,7 @@ error[E0259]: the name `std` is defined multiple times
    = note: `std` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - extern crate std;
-LL + extern crate std as other_std;
+LL | extern crate std as other_std;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/resolve/resolve-conflict-import-vs-extern-crate.stderr
+++ b/tests/ui/resolve/resolve-conflict-import-vs-extern-crate.stderr
@@ -7,9 +7,8 @@ LL | use std::slice as std;
    = note: `std` must be defined only once in the type namespace of this module
 help: you can use `as` to change the binding name of the import
    |
-LL - use std::slice as std;
-LL + use std::slice as other_std;
-   |
+LL | use std::slice as other_std;
+   |                   ++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -38,7 +38,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match NonExhaustiveEnum::Unit {
 LL +         NonExhaustiveEnum::Unit | NonExhaustiveEnum::Tuple(_) | NonExhaustiveEnum::Struct { .. } => todo!(),
-LL +     }
+LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `NormalEnum::Unit`, `NormalEnum::Tuple(_)` and `NormalEnum::Struct { .. }` not covered
@@ -65,7 +65,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match NormalEnum::Unit {
 LL +         NormalEnum::Unit | NormalEnum::Tuple(_) | NormalEnum::Struct { .. } => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: aborting due to 3 previous errors

--- a/tests/ui/self/arbitrary_self_types_not_allow_call_with_no_deref.stderr
+++ b/tests/ui/self/arbitrary_self_types_not_allow_call_with_no_deref.stderr
@@ -13,9 +13,8 @@ LL |     foo_cpp_ref.0.frobnicate_ref();
    |                 ++
 help: there is a method `frobnicate_cpp_ref` with a similar name
    |
-LL -     foo_cpp_ref.frobnicate_ref();
-LL +     foo_cpp_ref.frobnicate_cpp_ref();
-   |
+LL |     foo_cpp_ref.frobnicate_cpp_ref();
+   |                            ++++
 
 error[E0599]: no method named `frobnicate_self` found for struct `CppRef` in the current scope
   --> $DIR/arbitrary_self_types_not_allow_call_with_no_deref.rs:32:17

--- a/tests/ui/span/missing-unit-argument.stderr
+++ b/tests/ui/span/missing-unit-argument.stderr
@@ -8,9 +8,8 @@ note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
 help: provide the argument
    |
-LL -     let _: Result<(), String> = Ok();
-LL +     let _: Result<(), String> = Ok(());
-   |
+LL |     let _: Result<(), String> = Ok(());
+   |                                    ++
 
 error[E0061]: this function takes 2 arguments but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:12:5
@@ -25,9 +24,8 @@ LL | fn foo(():(), ():()) {}
    |    ^^^ -----  -----
 help: provide the arguments
    |
-LL -     foo();
-LL +     foo((), ());
-   |
+LL |     foo((), ());
+   |         ++++++
 
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/missing-unit-argument.rs:13:5
@@ -42,9 +40,8 @@ LL | fn foo(():(), ():()) {}
    |    ^^^        -----
 help: provide the argument
    |
-LL -     foo(());
-LL +     foo((), ());
-   |
+LL |     foo((), ());
+   |           ++++
 
 error[E0061]: this function takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:14:5
@@ -59,9 +56,8 @@ LL | fn bar(():()) {}
    |    ^^^ -----
 help: provide the argument
    |
-LL -     bar();
-LL +     bar(());
-   |
+LL |     bar(());
+   |         ++
 
 error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:15:7
@@ -76,9 +72,8 @@ LL |     fn baz(self, (): ()) { }
    |        ^^^       ------
 help: provide the argument
    |
-LL -     S.baz();
-LL +     S.baz(());
-   |
+LL |     S.baz(());
+   |           ++
 
 error[E0061]: this method takes 1 argument but 0 arguments were supplied
   --> $DIR/missing-unit-argument.rs:16:7
@@ -93,9 +88,8 @@ LL |     fn generic<T>(self, _: T) { }
    |        ^^^^^^^          ----
 help: provide the argument
    |
-LL -     S.generic::<()>();
-LL +     S.generic::<()>(());
-   |
+LL |     S.generic::<()>(());
+   |                     ++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/statics/static-mut-shared-parens.stderr
+++ b/tests/ui/statics/static-mut-shared-parens.stderr
@@ -22,9 +22,8 @@ LL |     let _ = unsafe { ((&mut TEST)) as *const usize };
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |
-LL -     let _ = unsafe { ((&mut TEST)) as *const usize };
-LL +     let _ = unsafe { ((&raw mut TEST)) as *const usize };
-   |
+LL |     let _ = unsafe { ((&raw mut TEST)) as *const usize };
+   |                         +++
 
 warning: 2 warnings emitted
 

--- a/tests/ui/statics/static-mut-xc.stderr
+++ b/tests/ui/statics/static-mut-xc.stderr
@@ -67,9 +67,8 @@ LL |     static_bound_set(&mut static_mut_xc::a);
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
 help: use `&raw mut` instead to create a raw pointer
    |
-LL -     static_bound_set(&mut static_mut_xc::a);
-LL +     static_bound_set(&raw mut static_mut_xc::a);
-   |
+LL |     static_bound_set(&raw mut static_mut_xc::a);
+   |                       +++
 
 warning: 7 warnings emitted
 

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor.disabled.stderr
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor.disabled.stderr
@@ -66,9 +66,8 @@ LL |     let _ = S { };
    |
 help: all remaining fields have default values, if you added `#![feature(default_field_values)]` to your crate you could use those values with `..`
    |
-LL -     let _ = S { };
-LL +     let _ = S { .. };
-   |
+LL |     let _ = S { .. };
+   |                 ++
 
 error[E0063]: missing fields `field1` and `field2` in initializer of `S`
   --> $DIR/non-exhaustive-ctor.rs:26:13

--- a/tests/ui/structs/default-field-values/non-exhaustive-ctor.enabled.stderr
+++ b/tests/ui/structs/default-field-values/non-exhaustive-ctor.enabled.stderr
@@ -6,9 +6,8 @@ LL |     let _ = S { };
    |
 help: all remaining fields have default values, you can use those values with `..`
    |
-LL -     let _ = S { };
-LL +     let _ = S { .. };
-   |
+LL |     let _ = S { .. };
+   |                 ++
 
 error[E0063]: missing fields `field1` and `field2` in initializer of `S`
   --> $DIR/non-exhaustive-ctor.rs:26:13

--- a/tests/ui/suggestions/args-instead-of-tuple-errors.stderr
+++ b/tests/ui/suggestions/args-instead-of-tuple-errors.stderr
@@ -60,9 +60,8 @@ note: tuple variant defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
 help: provide the argument
    |
-LL -     let _: Option<(i8,)> = Some();
-LL +     let _: Option<(i8,)> = Some(/* (i8,) */);
-   |
+LL |     let _: Option<(i8,)> = Some(/* (i8,) */);
+   |                                 +++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/args-instead-of-tuple-errors.rs:14:34

--- a/tests/ui/suggestions/args-instead-of-tuple.stderr
+++ b/tests/ui/suggestions/args-instead-of-tuple.stderr
@@ -34,9 +34,8 @@ note: tuple variant defined here
   --> $SRC_DIR/core/src/option.rs:LL:COL
 help: provide the argument
    |
-LL -     let _: Option<()> = Some();
-LL +     let _: Option<()> = Some(());
-   |
+LL |     let _: Option<()> = Some(());
+   |                              ++
 
 error[E0308]: mismatched types
   --> $DIR/args-instead-of-tuple.rs:14:34

--- a/tests/ui/suggestions/bad-hex-float-lit.stderr
+++ b/tests/ui/suggestions/bad-hex-float-lit.stderr
@@ -8,9 +8,8 @@ LL |     let _f: f32 = 0xAAf32;
    |
 help: rewrite this as a decimal floating point literal, or use `as` to turn a hex literal into a float
    |
-LL -     let _f: f32 = 0xAAf32;
-LL +     let _f: f32 = 0xAA as f32;
-   |
+LL |     let _f: f32 = 0xAA as f32;
+   |                        ++
 LL -     let _f: f32 = 0xAAf32;
 LL +     let _f: f32 = 170_f32;
    |

--- a/tests/ui/suggestions/incorrect-variant-literal.svg
+++ b/tests/ui/suggestions/incorrect-variant-literal.svg
@@ -1,4 +1,4 @@
-<svg width="886px" height="9542px" xmlns="http://www.w3.org/2000/svg">
+<svg width="886px" height="9524px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -103,981 +103,979 @@
 </tspan>
     <tspan x="10px" y="748px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-009">()</tspan><tspan>;</tspan>
+    <tspan x="10px" y="766px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="784px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 </tspan><tspan class="fg-ansi256-010">+++++++++</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="802px">
 </tspan>
-    <tspan x="10px" y="820px">
+    <tspan x="10px" y="820px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="838px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
+    <tspan x="10px" y="838px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:16:5</tspan>
 </tspan>
-    <tspan x="10px" y="856px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:16:5</tspan>
+    <tspan x="10px" y="856px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="874px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="874px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct();</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct();</tspan>
+    <tspan x="10px" y="892px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
+    <tspan x="10px" y="910px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="928px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: you might have meant to create a new value of the struct</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: you might have meant to create a new value of the struct</tspan>
+    <tspan x="10px" y="946px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="964px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-009">()</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-009">()</tspan><tspan>;</tspan>
+    <tspan x="10px" y="982px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-010"> { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-010"> { x: /* value */ }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="1000px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1018px">
 </tspan>
-    <tspan x="10px" y="1036px">
+    <tspan x="10px" y="1036px"><tspan class="fg-ansi256-009 bold">error[E0063]</tspan><tspan class="bold">: missing field `0` in initializer of `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan class="fg-ansi256-009 bold">error[E0063]</tspan><tspan class="bold">: missing field `0` in initializer of `Enum`</tspan>
+    <tspan x="10px" y="1054px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:18:5</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:18:5</tspan>
+    <tspan x="10px" y="1072px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1090px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1090px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple {};</tspan>
 </tspan>
-    <tspan x="10px" y="1108px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple {};</tspan>
+    <tspan x="10px" y="1108px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">missing `0`</tspan>
 </tspan>
-    <tspan x="10px" y="1126px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">missing `0`</tspan>
+    <tspan x="10px" y="1126px">
 </tspan>
-    <tspan x="10px" y="1144px">
+    <tspan x="10px" y="1144px"><tspan class="fg-ansi256-009 bold">error[E0063]</tspan><tspan class="bold">: missing field `x` in initializer of `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="1162px"><tspan class="fg-ansi256-009 bold">error[E0063]</tspan><tspan class="bold">: missing field `x` in initializer of `Enum`</tspan>
+    <tspan x="10px" y="1162px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:19:5</tspan>
 </tspan>
-    <tspan x="10px" y="1180px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:19:5</tspan>
+    <tspan x="10px" y="1180px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1198px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1198px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct {};</tspan>
 </tspan>
-    <tspan x="10px" y="1216px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct {};</tspan>
+    <tspan x="10px" y="1216px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">missing `x`</tspan>
 </tspan>
-    <tspan x="10px" y="1234px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">missing `x`</tspan>
+    <tspan x="10px" y="1234px">
 </tspan>
-    <tspan x="10px" y="1252px">
+    <tspan x="10px" y="1252px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="1270px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found `Enum`</tspan>
+    <tspan x="10px" y="1270px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:20:5</tspan>
 </tspan>
-    <tspan x="10px" y="1288px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:20:5</tspan>
+    <tspan x="10px" y="1288px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1306px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1306px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
 </tspan>
-    <tspan x="10px" y="1324px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
+    <tspan x="10px" y="1324px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Unit` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="1342px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Unit` defined here</tspan>
+    <tspan x="10px" y="1342px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="1360px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="1360px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit(0);</tspan>
 </tspan>
-    <tspan x="10px" y="1378px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit(0);</tspan>
+    <tspan x="10px" y="1378px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">---</tspan>
 </tspan>
-    <tspan x="10px" y="1396px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">---</tspan>
+    <tspan x="10px" y="1396px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1414px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1414px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
 </tspan>
-    <tspan x="10px" y="1432px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
+    <tspan x="10px" y="1432px">
 </tspan>
-    <tspan x="10px" y="1450px">
+    <tspan x="10px" y="1450px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="1468px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
+    <tspan x="10px" y="1468px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:22:5</tspan>
 </tspan>
-    <tspan x="10px" y="1486px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:22:5</tspan>
+    <tspan x="10px" y="1486px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1504px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1504px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct(0);</tspan>
 </tspan>
-    <tspan x="10px" y="1522px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct(0);</tspan>
+    <tspan x="10px" y="1522px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
 </tspan>
-    <tspan x="10px" y="1540px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
+    <tspan x="10px" y="1540px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1558px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1558px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: you might have meant to create a new value of the struct</tspan>
 </tspan>
-    <tspan x="10px" y="1576px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: you might have meant to create a new value of the struct</tspan>
+    <tspan x="10px" y="1576px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1594px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1594px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-009">(0)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="1612px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-009">(0)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="1612px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-010"> { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="1630px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-010"> { x: /* value */ }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="1630px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1648px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1648px">
 </tspan>
-    <tspan x="10px" y="1666px">
+    <tspan x="10px" y="1666px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `x`</tspan>
 </tspan>
-    <tspan x="10px" y="1684px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `x`</tspan>
+    <tspan x="10px" y="1684px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:23:18</tspan>
 </tspan>
-    <tspan x="10px" y="1702px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:23:18</tspan>
+    <tspan x="10px" y="1702px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1720px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1720px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="1738px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0 };</tspan>
+    <tspan x="10px" y="1738px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
 </tspan>
-    <tspan x="10px" y="1756px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
+    <tspan x="10px" y="1756px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1774px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1774px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
 </tspan>
-    <tspan x="10px" y="1792px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+    <tspan x="10px" y="1792px">
 </tspan>
-    <tspan x="10px" y="1810px">
+    <tspan x="10px" y="1810px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `x`</tspan>
 </tspan>
-    <tspan x="10px" y="1828px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `x`</tspan>
+    <tspan x="10px" y="1828px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:24:19</tspan>
 </tspan>
-    <tspan x="10px" y="1846px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:24:19</tspan>
+    <tspan x="10px" y="1846px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1864px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1864px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
 </tspan>
-    <tspan x="10px" y="1882px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+    <tspan x="10px" y="1882px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="1900px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
+    <tspan x="10px" y="1900px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="1918px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="1918px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="1936px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0 };</tspan>
+    <tspan x="10px" y="1936px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                   </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
 </tspan>
-    <tspan x="10px" y="1954px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                   </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
+    <tspan x="10px" y="1954px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="1972px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="1972px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
 </tspan>
-    <tspan x="10px" y="1990px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
+    <tspan x="10px" y="1990px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2008px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2008px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-009"> { x: 0 }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="2026px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-009"> { x: 0 }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="2026px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="2044px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="2044px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2062px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2062px">
 </tspan>
-    <tspan x="10px" y="2080px">
+    <tspan x="10px" y="2080px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="2098px"><tspan class="fg-ansi256-009 bold">error[E0618]</tspan><tspan class="bold">: expected function, found `Enum`</tspan>
+    <tspan x="10px" y="2098px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:26:5</tspan>
 </tspan>
-    <tspan x="10px" y="2116px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:26:5</tspan>
+    <tspan x="10px" y="2116px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2134px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2134px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
 </tspan>
-    <tspan x="10px" y="2152px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Unit,</tspan>
+    <tspan x="10px" y="2152px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Unit` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="2170px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Unit` defined here</tspan>
+    <tspan x="10px" y="2170px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="2188px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="2188px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit(0, 0);</tspan>
 </tspan>
-    <tspan x="10px" y="2206px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit(0, 0);</tspan>
+    <tspan x="10px" y="2206px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">------</tspan>
 </tspan>
-    <tspan x="10px" y="2224px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^</tspan><tspan class="fg-ansi256-012 bold">------</tspan>
+    <tspan x="10px" y="2224px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2242px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2242px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
 </tspan>
-    <tspan x="10px" y="2260px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">call expression requires function</tspan>
+    <tspan x="10px" y="2260px">
 </tspan>
-    <tspan x="10px" y="2278px">
+    <tspan x="10px" y="2278px"><tspan class="fg-ansi256-009 bold">error[E0061]</tspan><tspan class="bold">: this enum variant takes 1 argument but 2 arguments were supplied</tspan>
 </tspan>
-    <tspan x="10px" y="2296px"><tspan class="fg-ansi256-009 bold">error[E0061]</tspan><tspan class="bold">: this enum variant takes 1 argument but 2 arguments were supplied</tspan>
+    <tspan x="10px" y="2296px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:27:5</tspan>
 </tspan>
-    <tspan x="10px" y="2314px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:27:5</tspan>
+    <tspan x="10px" y="2314px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2332px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2332px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple(0, 0);</tspan>
 </tspan>
-    <tspan x="10px" y="2350px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple(0, 0);</tspan>
+    <tspan x="10px" y="2350px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan>    </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">unexpected argument #2 of type `{integer}`</tspan>
 </tspan>
-    <tspan x="10px" y="2368px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^</tspan><tspan>    </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">unexpected argument #2 of type `{integer}`</tspan>
+    <tspan x="10px" y="2368px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2386px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2386px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: tuple variant defined here</tspan>
 </tspan>
-    <tspan x="10px" y="2404px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: tuple variant defined here</tspan>
+    <tspan x="10px" y="2404px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:6:5</tspan>
 </tspan>
-    <tspan x="10px" y="2422px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:6:5</tspan>
+    <tspan x="10px" y="2422px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2440px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2440px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
 </tspan>
-    <tspan x="10px" y="2458px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+    <tspan x="10px" y="2458px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="2476px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^^^^^</tspan>
+    <tspan x="10px" y="2476px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: remove the extra argument</tspan>
 </tspan>
-    <tspan x="10px" y="2494px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: remove the extra argument</tspan>
+    <tspan x="10px" y="2494px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2512px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2512px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple(0</tspan><tspan class="fg-ansi256-009">, 0</tspan><tspan>);</tspan>
 </tspan>
-    <tspan x="10px" y="2530px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple(0</tspan><tspan class="fg-ansi256-009">, 0</tspan><tspan>);</tspan>
+    <tspan x="10px" y="2530px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple(0);</tspan>
 </tspan>
-    <tspan x="10px" y="2548px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple(0);</tspan>
+    <tspan x="10px" y="2548px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2566px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2566px">
 </tspan>
-    <tspan x="10px" y="2584px">
+    <tspan x="10px" y="2584px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="2602px"><tspan class="fg-ansi256-009 bold">error[E0533]</tspan><tspan class="bold">: expected value, found struct variant `Enum::Struct`</tspan>
+    <tspan x="10px" y="2602px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:28:5</tspan>
 </tspan>
-    <tspan x="10px" y="2620px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:28:5</tspan>
+    <tspan x="10px" y="2620px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2638px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2638px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct(0, 0);</tspan>
 </tspan>
-    <tspan x="10px" y="2656px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct(0, 0);</tspan>
+    <tspan x="10px" y="2656px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
 </tspan>
-    <tspan x="10px" y="2674px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">not a value</tspan>
+    <tspan x="10px" y="2674px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2692px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2692px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: you might have meant to create a new value of the struct</tspan>
 </tspan>
-    <tspan x="10px" y="2710px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: you might have meant to create a new value of the struct</tspan>
+    <tspan x="10px" y="2710px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2728px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2728px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-009">(0, 0)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="2746px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-009">(0, 0)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="2746px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-010"> { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="2764px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Struct</tspan><tspan class="fg-ansi256-010"> { x: /* value */ }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="2764px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2782px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2782px">
 </tspan>
-    <tspan x="10px" y="2800px">
+    <tspan x="10px" y="2800px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `x`</tspan>
 </tspan>
-    <tspan x="10px" y="2818px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `x`</tspan>
+    <tspan x="10px" y="2818px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:29:18</tspan>
 </tspan>
-    <tspan x="10px" y="2836px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:29:18</tspan>
+    <tspan x="10px" y="2836px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2854px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2854px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="2872px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="2872px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
 </tspan>
-    <tspan x="10px" y="2890px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
+    <tspan x="10px" y="2890px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2908px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2908px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
 </tspan>
-    <tspan x="10px" y="2926px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+    <tspan x="10px" y="2926px">
 </tspan>
-    <tspan x="10px" y="2944px">
+    <tspan x="10px" y="2944px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `y`</tspan>
 </tspan>
-    <tspan x="10px" y="2962px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Unit` has no field named `y`</tspan>
+    <tspan x="10px" y="2962px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:29:24</tspan>
 </tspan>
-    <tspan x="10px" y="2980px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:29:24</tspan>
+    <tspan x="10px" y="2980px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="2998px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="2998px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="3016px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Unit { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="3016px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                        </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
 </tspan>
-    <tspan x="10px" y="3034px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                        </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Unit` does not have this field</tspan>
+    <tspan x="10px" y="3034px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3052px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3052px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
 </tspan>
-    <tspan x="10px" y="3070px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+    <tspan x="10px" y="3070px">
 </tspan>
-    <tspan x="10px" y="3088px">
+    <tspan x="10px" y="3088px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `x`</tspan>
 </tspan>
-    <tspan x="10px" y="3106px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `x`</tspan>
+    <tspan x="10px" y="3106px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:31:19</tspan>
 </tspan>
-    <tspan x="10px" y="3124px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:31:19</tspan>
+    <tspan x="10px" y="3124px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3142px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3142px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
 </tspan>
-    <tspan x="10px" y="3160px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+    <tspan x="10px" y="3160px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="3178px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
+    <tspan x="10px" y="3178px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="3196px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="3196px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="3214px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="3214px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                   </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
 </tspan>
-    <tspan x="10px" y="3232px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                   </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
+    <tspan x="10px" y="3232px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3250px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3250px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
 </tspan>
-    <tspan x="10px" y="3268px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
+    <tspan x="10px" y="3268px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3286px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3286px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-009"> { x: 0, y: 0 }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="3304px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-009"> { x: 0, y: 0 }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="3304px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="3322px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="3322px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3340px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3340px">
 </tspan>
-    <tspan x="10px" y="3358px">
+    <tspan x="10px" y="3358px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `y`</tspan>
 </tspan>
-    <tspan x="10px" y="3376px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Tuple` has no field named `y`</tspan>
+    <tspan x="10px" y="3376px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:31:25</tspan>
 </tspan>
-    <tspan x="10px" y="3394px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:31:25</tspan>
+    <tspan x="10px" y="3394px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3412px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3412px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
 </tspan>
-    <tspan x="10px" y="3430px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Tuple(i32),</tspan>
+    <tspan x="10px" y="3430px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
 </tspan>
-    <tspan x="10px" y="3448px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">-----</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">`Enum::Tuple` defined here</tspan>
+    <tspan x="10px" y="3448px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="3466px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="3466px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="3484px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Tuple { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="3484px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                         </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
 </tspan>
-    <tspan x="10px" y="3502px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                         </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">field does not exist</tspan>
+    <tspan x="10px" y="3502px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3520px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3520px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
 </tspan>
-    <tspan x="10px" y="3538px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: `Enum::Tuple` is a tuple variant, use the appropriate syntax</tspan>
+    <tspan x="10px" y="3538px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3556px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3556px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-009"> { x: 0, y: 0 }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="3574px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-009"> { x: 0, y: 0 }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="3574px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="3592px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="3592px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3610px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3610px">
 </tspan>
-    <tspan x="10px" y="3628px">
+    <tspan x="10px" y="3628px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Struct` has no field named `y`</tspan>
 </tspan>
-    <tspan x="10px" y="3646px"><tspan class="fg-ansi256-009 bold">error[E0559]</tspan><tspan class="bold">: variant `Enum::Struct` has no field named `y`</tspan>
+    <tspan x="10px" y="3646px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:33:26</tspan>
 </tspan>
-    <tspan x="10px" y="3664px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:33:26</tspan>
+    <tspan x="10px" y="3664px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3682px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3682px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="3700px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::Struct { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="3700px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                          </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Struct` does not have this field</tspan>
 </tspan>
-    <tspan x="10px" y="3718px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                          </tspan><tspan class="fg-ansi256-009 bold">^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`Enum::Struct` does not have this field</tspan>
+    <tspan x="10px" y="3718px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3736px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3736px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
 </tspan>
-    <tspan x="10px" y="3754px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: all struct fields are already assigned</tspan>
+    <tspan x="10px" y="3754px">
 </tspan>
-    <tspan x="10px" y="3772px">
+    <tspan x="10px" y="3772px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="3790px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="3790px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:34:11</tspan>
 </tspan>
-    <tspan x="10px" y="3808px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:34:11</tspan>
+    <tspan x="10px" y="3808px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3826px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3826px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="3844px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="3844px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="3862px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+    <tspan x="10px" y="3862px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="3880px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="3880px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit;</tspan>
 </tspan>
-    <tspan x="10px" y="3898px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit;</tspan>
+    <tspan x="10px" y="3898px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="3916px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="3916px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3934px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3934px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name (notice the capitalization difference)</tspan>
 </tspan>
-    <tspan x="10px" y="3952px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name (notice the capitalization difference)</tspan>
+    <tspan x="10px" y="3952px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="3970px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="3970px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="3988px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit</tspan><tspan>;</tspan>
+    <tspan x="10px" y="3988px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4006px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
+    <tspan x="10px" y="4006px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4024px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4024px">
 </tspan>
-    <tspan x="10px" y="4042px">
+    <tspan x="10px" y="4042px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="4060px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="4060px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:35:11</tspan>
 </tspan>
-    <tspan x="10px" y="4078px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:35:11</tspan>
+    <tspan x="10px" y="4078px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4096px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4096px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="4114px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="4114px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="4132px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+    <tspan x="10px" y="4132px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="4150px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="4150px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple;</tspan>
 </tspan>
-    <tspan x="10px" y="4168px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple;</tspan>
+    <tspan x="10px" y="4168px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="4186px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="4186px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4204px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4204px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="4222px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="4222px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4240px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4240px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4258px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple</tspan><tspan>;</tspan>
+    <tspan x="10px" y="4258px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4276px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="4276px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4294px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4294px">
 </tspan>
-    <tspan x="10px" y="4312px">
+    <tspan x="10px" y="4312px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="4330px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="4330px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:36:11</tspan>
 </tspan>
-    <tspan x="10px" y="4348px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:36:11</tspan>
+    <tspan x="10px" y="4348px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4366px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4366px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="4384px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="4384px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="4402px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+    <tspan x="10px" y="4402px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="4420px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="4420px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct;</tspan>
 </tspan>
-    <tspan x="10px" y="4438px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct;</tspan>
+    <tspan x="10px" y="4438px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="4456px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="4456px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4474px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4474px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="4492px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="4492px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4510px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4510px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4528px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct</tspan><tspan>;</tspan>
+    <tspan x="10px" y="4528px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4546px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="4546px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4564px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4564px">
 </tspan>
-    <tspan x="10px" y="4582px">
+    <tspan x="10px" y="4582px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="4600px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="4600px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:37:11</tspan>
 </tspan>
-    <tspan x="10px" y="4618px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:37:11</tspan>
+    <tspan x="10px" y="4618px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4636px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4636px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="4654px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="4654px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="4672px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+    <tspan x="10px" y="4672px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="4690px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="4690px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit();</tspan>
 </tspan>
-    <tspan x="10px" y="4708px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit();</tspan>
+    <tspan x="10px" y="4708px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="4726px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="4726px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4744px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4744px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="4762px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="4762px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4780px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4780px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit()</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4798px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit()</tspan><tspan>;</tspan>
+    <tspan x="10px" y="4798px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="4816px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
+    <tspan x="10px" y="4816px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4834px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4834px">
 </tspan>
-    <tspan x="10px" y="4852px">
+    <tspan x="10px" y="4852px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="4870px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="4870px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:38:11</tspan>
 </tspan>
-    <tspan x="10px" y="4888px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:38:11</tspan>
+    <tspan x="10px" y="4888px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="4906px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="4906px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="4924px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="4924px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="4942px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+    <tspan x="10px" y="4942px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="4960px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="4960px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple();</tspan>
 </tspan>
-    <tspan x="10px" y="4978px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple();</tspan>
+    <tspan x="10px" y="4978px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="4996px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="4996px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5014px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5014px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="5032px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="5032px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5050px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5050px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple</tspan><tspan>();</tspan>
 </tspan>
-    <tspan x="10px" y="5068px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple()</tspan><tspan>;</tspan>
+    <tspan x="10px" y="5068px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5086px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="5086px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5104px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5104px">
 </tspan>
-    <tspan x="10px" y="5122px">
+    <tspan x="10px" y="5122px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="5140px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="5140px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:39:11</tspan>
 </tspan>
-    <tspan x="10px" y="5158px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:39:11</tspan>
+    <tspan x="10px" y="5158px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5176px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5176px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="5194px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="5194px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="5212px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+    <tspan x="10px" y="5212px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="5230px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="5230px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct();</tspan>
 </tspan>
-    <tspan x="10px" y="5248px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct();</tspan>
+    <tspan x="10px" y="5248px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="5266px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="5266px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5284px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5284px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="5302px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="5302px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5320px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5320px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct()</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5338px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct()</tspan><tspan>;</tspan>
+    <tspan x="10px" y="5338px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5356px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="5356px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5374px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5374px">
 </tspan>
-    <tspan x="10px" y="5392px">
+    <tspan x="10px" y="5392px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="5410px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
+    <tspan x="10px" y="5410px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:40:11</tspan>
 </tspan>
-    <tspan x="10px" y="5428px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:40:11</tspan>
+    <tspan x="10px" y="5428px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5446px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5446px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="5464px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="5464px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="5482px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
+    <tspan x="10px" y="5482px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="5500px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="5500px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit {};</tspan>
 </tspan>
-    <tspan x="10px" y="5518px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit {};</tspan>
+    <tspan x="10px" y="5518px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="5536px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+    <tspan x="10px" y="5536px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5554px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5554px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="5572px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="5572px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5590px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5590px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit {}</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5608px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit {}</tspan><tspan>;</tspan>
+    <tspan x="10px" y="5608px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5626px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
+    <tspan x="10px" y="5626px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5644px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5644px">
 </tspan>
-    <tspan x="10px" y="5662px">
+    <tspan x="10px" y="5662px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="5680px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
+    <tspan x="10px" y="5680px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:41:11</tspan>
 </tspan>
-    <tspan x="10px" y="5698px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:41:11</tspan>
+    <tspan x="10px" y="5698px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5716px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5716px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="5734px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="5734px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="5752px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
+    <tspan x="10px" y="5752px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="5770px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="5770px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple {};</tspan>
 </tspan>
-    <tspan x="10px" y="5788px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple {};</tspan>
+    <tspan x="10px" y="5788px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="5806px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+    <tspan x="10px" y="5806px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5824px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5824px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="5842px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="5842px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5860px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5860px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple {}</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5878px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple {}</tspan><tspan>;</tspan>
+    <tspan x="10px" y="5878px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="5896px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="5896px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5914px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5914px">
 </tspan>
-    <tspan x="10px" y="5932px">
+    <tspan x="10px" y="5932px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="5950px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
+    <tspan x="10px" y="5950px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:42:11</tspan>
 </tspan>
-    <tspan x="10px" y="5968px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:42:11</tspan>
+    <tspan x="10px" y="5968px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="5986px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="5986px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="6004px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="6004px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="6022px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
+    <tspan x="10px" y="6022px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="6040px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="6040px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct {};</tspan>
 </tspan>
-    <tspan x="10px" y="6058px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct {};</tspan>
+    <tspan x="10px" y="6058px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="6076px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+    <tspan x="10px" y="6076px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6094px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6094px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="6112px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="6112px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6130px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6130px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct {}</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="6148px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct {}</tspan><tspan>;</tspan>
+    <tspan x="10px" y="6148px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="6166px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="6166px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6184px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6184px">
 </tspan>
-    <tspan x="10px" y="6202px">
+    <tspan x="10px" y="6202px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="6220px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="6220px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:43:11</tspan>
 </tspan>
-    <tspan x="10px" y="6238px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:43:11</tspan>
+    <tspan x="10px" y="6238px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6256px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6256px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="6274px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="6274px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="6292px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+    <tspan x="10px" y="6292px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="6310px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="6310px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit(0);</tspan>
 </tspan>
-    <tspan x="10px" y="6328px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit(0);</tspan>
+    <tspan x="10px" y="6328px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="6346px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="6346px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6364px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6364px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="6382px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="6382px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6400px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6400px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit(0)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="6418px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit(0)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="6418px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="6436px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
+    <tspan x="10px" y="6436px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6454px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6454px">
 </tspan>
-    <tspan x="10px" y="6472px">
+    <tspan x="10px" y="6472px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="6490px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="6490px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:44:11</tspan>
 </tspan>
-    <tspan x="10px" y="6508px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:44:11</tspan>
+    <tspan x="10px" y="6508px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6526px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6526px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="6544px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="6544px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="6562px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+    <tspan x="10px" y="6562px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="6580px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="6580px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple(0);</tspan>
 </tspan>
-    <tspan x="10px" y="6598px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple(0);</tspan>
+    <tspan x="10px" y="6598px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="6616px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="6616px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6634px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6634px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="6652px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="6652px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6670px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6670px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple</tspan><tspan>(0);</tspan>
 </tspan>
-    <tspan x="10px" y="6688px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple</tspan><tspan>(0);</tspan>
+    <tspan x="10px" y="6688px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple</tspan><tspan>(0);</tspan>
 </tspan>
-    <tspan x="10px" y="6706px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple</tspan><tspan>(0);</tspan>
+    <tspan x="10px" y="6706px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6724px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6724px">
 </tspan>
-    <tspan x="10px" y="6742px">
+    <tspan x="10px" y="6742px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="6760px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="6760px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:45:11</tspan>
 </tspan>
-    <tspan x="10px" y="6778px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:45:11</tspan>
+    <tspan x="10px" y="6778px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6796px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6796px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="6814px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="6814px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="6832px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+    <tspan x="10px" y="6832px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="6850px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="6850px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct(0);</tspan>
 </tspan>
-    <tspan x="10px" y="6868px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct(0);</tspan>
+    <tspan x="10px" y="6868px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="6886px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="6886px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6904px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6904px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="6922px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="6922px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6940px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6940px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct(0)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="6958px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct(0)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="6958px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="6976px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="6976px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="6994px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="6994px">
 </tspan>
-    <tspan x="10px" y="7012px">
+    <tspan x="10px" y="7012px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="7030px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
+    <tspan x="10px" y="7030px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:46:11</tspan>
 </tspan>
-    <tspan x="10px" y="7048px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:46:11</tspan>
+    <tspan x="10px" y="7048px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7066px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7066px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="7084px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="7084px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="7102px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
+    <tspan x="10px" y="7102px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="7120px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="7120px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit { x: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="7138px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit { x: 0 };</tspan>
+    <tspan x="10px" y="7138px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="7156px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+    <tspan x="10px" y="7156px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7174px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7174px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="7192px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="7192px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7210px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7210px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit { x: 0 }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="7228px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit { x: 0 }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="7228px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="7246px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
+    <tspan x="10px" y="7246px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7264px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7264px">
 </tspan>
-    <tspan x="10px" y="7282px">
+    <tspan x="10px" y="7282px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="7300px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
+    <tspan x="10px" y="7300px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:47:11</tspan>
 </tspan>
-    <tspan x="10px" y="7318px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:47:11</tspan>
+    <tspan x="10px" y="7318px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7336px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7336px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="7354px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="7354px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="7372px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
+    <tspan x="10px" y="7372px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="7390px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="7390px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple { x: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="7408px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple { x: 0 };</tspan>
+    <tspan x="10px" y="7408px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="7426px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+    <tspan x="10px" y="7426px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7444px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7444px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="7462px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="7462px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7480px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7480px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple { x: 0 }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="7498px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple { x: 0 }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="7498px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="7516px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="7516px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7534px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7534px">
 </tspan>
-    <tspan x="10px" y="7552px">
+    <tspan x="10px" y="7552px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="7570px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
+    <tspan x="10px" y="7570px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:48:11</tspan>
 </tspan>
-    <tspan x="10px" y="7588px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:48:11</tspan>
+    <tspan x="10px" y="7588px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7606px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7606px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="7624px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="7624px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="7642px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
+    <tspan x="10px" y="7642px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="7660px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="7660px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct { x: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="7678px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct { x: 0 };</tspan>
+    <tspan x="10px" y="7678px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="7696px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+    <tspan x="10px" y="7696px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7714px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7714px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="7732px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="7732px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7750px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7750px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct { x: 0 }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="7768px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct { x: 0 }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="7768px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="7786px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="7786px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7804px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7804px">
 </tspan>
-    <tspan x="10px" y="7822px">
+    <tspan x="10px" y="7822px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="7840px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `unit` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="7840px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:49:11</tspan>
 </tspan>
-    <tspan x="10px" y="7858px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:49:11</tspan>
+    <tspan x="10px" y="7858px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7876px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7876px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="7894px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="7894px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="7912px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `unit` not found for this enum</tspan>
+    <tspan x="10px" y="7912px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="7930px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="7930px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit(0, 0);</tspan>
 </tspan>
-    <tspan x="10px" y="7948px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit(0, 0);</tspan>
+    <tspan x="10px" y="7948px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="7966px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="7966px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="7984px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="7984px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="8002px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="8002px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8020px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8020px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit(0, 0)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="8038px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit(0, 0)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="8038px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="8056px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
+    <tspan x="10px" y="8056px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8074px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8074px">
 </tspan>
-    <tspan x="10px" y="8092px">
+    <tspan x="10px" y="8092px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="8110px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `tuple` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="8110px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:50:11</tspan>
 </tspan>
-    <tspan x="10px" y="8128px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:50:11</tspan>
+    <tspan x="10px" y="8128px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8146px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8146px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="8164px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="8164px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="8182px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `tuple` not found for this enum</tspan>
+    <tspan x="10px" y="8182px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="8200px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="8200px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple(0, 0);</tspan>
 </tspan>
-    <tspan x="10px" y="8218px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple(0, 0);</tspan>
+    <tspan x="10px" y="8218px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="8236px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="8236px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8254px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8254px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="8272px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="8272px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8290px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8290px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple</tspan><tspan>(</tspan><tspan class="fg-ansi256-009">0, 0</tspan><tspan>);</tspan>
 </tspan>
-    <tspan x="10px" y="8308px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple</tspan><tspan>(</tspan><tspan class="fg-ansi256-009">0, 0</tspan><tspan>);</tspan>
+    <tspan x="10px" y="8308px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple</tspan><tspan>(</tspan><tspan class="fg-ansi256-010">/* i32 */</tspan><tspan>);</tspan>
 </tspan>
-    <tspan x="10px" y="8326px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple</tspan><tspan>(</tspan><tspan class="fg-ansi256-010">/* i32 */</tspan><tspan>);</tspan>
+    <tspan x="10px" y="8326px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8344px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8344px">
 </tspan>
-    <tspan x="10px" y="8362px">
+    <tspan x="10px" y="8362px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
 </tspan>
-    <tspan x="10px" y="8380px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant or associated item named `r#struct` found for enum `Enum` in the current scope</tspan>
+    <tspan x="10px" y="8380px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:51:11</tspan>
 </tspan>
-    <tspan x="10px" y="8398px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:51:11</tspan>
+    <tspan x="10px" y="8398px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8416px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8416px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="8434px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="8434px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
 </tspan>
-    <tspan x="10px" y="8452px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant or associated item `r#struct` not found for this enum</tspan>
+    <tspan x="10px" y="8452px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="8470px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="8470px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct(0, 0);</tspan>
 </tspan>
-    <tspan x="10px" y="8488px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct(0, 0);</tspan>
+    <tspan x="10px" y="8488px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="8506px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">variant or associated item not found in `Enum`</tspan>
+    <tspan x="10px" y="8506px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8524px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8524px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="8542px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="8542px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8560px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8560px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct(0, 0)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="8578px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct(0, 0)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="8578px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="8596px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="8596px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8614px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8614px">
 </tspan>
-    <tspan x="10px" y="8632px">
+    <tspan x="10px" y="8632px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="8650px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `unit` found for enum `Enum`</tspan>
+    <tspan x="10px" y="8650px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:52:11</tspan>
 </tspan>
-    <tspan x="10px" y="8668px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:52:11</tspan>
+    <tspan x="10px" y="8668px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8686px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8686px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="8704px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="8704px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="8722px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `unit` not found here</tspan>
+    <tspan x="10px" y="8722px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="8740px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="8740px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="8758px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::unit { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="8758px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="8776px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^</tspan>
+    <tspan x="10px" y="8776px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8794px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8794px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="8812px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="8812px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8830px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8830px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit { x: 0, y: 0 }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="8848px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">unit { x: 0, y: 0 }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="8848px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="8866px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Unit</tspan><tspan>;</tspan>
+    <tspan x="10px" y="8866px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8884px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8884px">
 </tspan>
-    <tspan x="10px" y="8902px">
+    <tspan x="10px" y="8902px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="8920px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `tuple` found for enum `Enum`</tspan>
+    <tspan x="10px" y="8920px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:53:11</tspan>
 </tspan>
-    <tspan x="10px" y="8938px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:53:11</tspan>
+    <tspan x="10px" y="8938px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="8956px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="8956px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="8974px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="8974px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="8992px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `tuple` not found here</tspan>
+    <tspan x="10px" y="8992px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="9010px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="9010px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="9028px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::tuple { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="9028px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="9046px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^</tspan>
+    <tspan x="10px" y="9046px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="9064px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="9064px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="9082px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="9082px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="9100px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="9100px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple { x: 0, y: 0 }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="9118px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple { x: 0, y: 0 }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="9118px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="9136px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="9136px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="9154px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="9154px">
 </tspan>
-    <tspan x="10px" y="9172px">
+    <tspan x="10px" y="9172px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
 </tspan>
-    <tspan x="10px" y="9190px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: no variant named `r#struct` found for enum `Enum`</tspan>
+    <tspan x="10px" y="9190px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:54:11</tspan>
 </tspan>
-    <tspan x="10px" y="9208px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/incorrect-variant-literal.rs:54:11</tspan>
+    <tspan x="10px" y="9208px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="9226px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="9226px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
 </tspan>
-    <tspan x="10px" y="9244px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> enum Enum {</tspan>
+    <tspan x="10px" y="9244px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
 </tspan>
-    <tspan x="10px" y="9262px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">---------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">variant `r#struct` not found here</tspan>
+    <tspan x="10px" y="9262px"><tspan class="fg-ansi256-012 bold">...</tspan>
 </tspan>
-    <tspan x="10px" y="9280px"><tspan class="fg-ansi256-012 bold">...</tspan>
+    <tspan x="10px" y="9280px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct { x: 0, y: 0 };</tspan>
 </tspan>
-    <tspan x="10px" y="9298px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Enum::r#struct { x: 0, y: 0 };</tspan>
+    <tspan x="10px" y="9298px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
 </tspan>
-    <tspan x="10px" y="9316px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>           </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^</tspan>
+    <tspan x="10px" y="9316px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="9334px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="9334px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
 </tspan>
-    <tspan x="10px" y="9352px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: there is a variant with a similar name</tspan>
+    <tspan x="10px" y="9352px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="9370px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="9370px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct { x: 0, y: 0 }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="9388px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">r#struct { x: 0, y: 0 }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="9388px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
 </tspan>
-    <tspan x="10px" y="9406px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Struct { x: /* value */ }</tspan><tspan>;</tspan>
+    <tspan x="10px" y="9406px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="9424px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="9424px">
 </tspan>
-    <tspan x="10px" y="9442px">
+    <tspan x="10px" y="9442px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 39 previous errors</tspan>
 </tspan>
-    <tspan x="10px" y="9460px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 39 previous errors</tspan>
+    <tspan x="10px" y="9460px">
 </tspan>
-    <tspan x="10px" y="9478px">
+    <tspan x="10px" y="9478px"><tspan class="bold">Some errors have detailed explanations: E0061, E0063, E0533, E0559, E0599, E0618.</tspan>
 </tspan>
-    <tspan x="10px" y="9496px"><tspan class="bold">Some errors have detailed explanations: E0061, E0063, E0533, E0559, E0599, E0618.</tspan>
+    <tspan x="10px" y="9496px"><tspan class="bold">For more information about an error, try `rustc --explain E0061`.</tspan>
 </tspan>
-    <tspan x="10px" y="9514px"><tspan class="bold">For more information about an error, try `rustc --explain E0061`.</tspan>
-</tspan>
-    <tspan x="10px" y="9532px">
+    <tspan x="10px" y="9514px">
 </tspan>
   </text>
 

--- a/tests/ui/suggestions/incorrect-variant-literal.svg
+++ b/tests/ui/suggestions/incorrect-variant-literal.svg
@@ -103,7 +103,7 @@
 </tspan>
     <tspan x="10px" y="748px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Tuple</tspan><tspan class="fg-ansi256-010">(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="766px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">| </tspan><tspan>    Enum::Tuple(</tspan><tspan class="fg-ansi256-010">/* i32 */</tspan><tspan>);</tspan>
 </tspan>
     <tspan x="10px" y="784px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 </tspan><tspan class="fg-ansi256-010">+++++++++</tspan>
 </tspan>
@@ -581,7 +581,7 @@
 </tspan>
     <tspan x="10px" y="5050px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-009">tuple</tspan><tspan>();</tspan>
 </tspan>
-    <tspan x="10px" y="5068px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple(/* i32 */)</tspan><tspan>;</tspan>
+    <tspan x="10px" y="5068px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>    Enum::</tspan><tspan class="fg-ansi256-010">Tuple</tspan><tspan>(</tspan><tspan class="fg-ansi256-010">/* i32 */</tspan><tspan>);</tspan>
 </tspan>
     <tspan x="10px" y="5086px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>

--- a/tests/ui/suggestions/return-bindings.stderr
+++ b/tests/ui/suggestions/return-bindings.stderr
@@ -22,8 +22,8 @@ LL | |     } else {
    |
 help: consider returning the local binding `s`
    |
-LL ~     let s: String = if let Some(s) = opt_str {
-LL +         s
+LL |     let s: String = if let Some(s) = opt_str {
+LL ~         s
 LL ~
    |
 
@@ -54,8 +54,8 @@ LL | |     } else {
    |
 help: consider returning the local binding `s`
    |
-LL ~     let s: String = if let Some(s) = opt_str {
-LL +         s
+LL |     let s: String = if let Some(s) = opt_str {
+LL ~         s
 LL ~
    |
 
@@ -71,8 +71,8 @@ LL |           String::new()
    |
 help: consider returning the local binding `s`
    |
-LL ~     let s = if let Some(s) = opt_str {
-LL +         s
+LL |     let s = if let Some(s) = opt_str {
+LL ~         s
 LL ~     } else {
    |
 

--- a/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
+++ b/tests/ui/suggestions/suggest-deref-in-match-issue-132784.stderr
@@ -43,9 +43,8 @@ LL |         Some(_) => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match &x {
-LL +     match &*x {
-   |
+LL |     match &*x {
+   |            +
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:18:9
@@ -60,9 +59,8 @@ LL |         None => {}
                 found enum `Option<_>`
 help: consider dereferencing to access the inner value using the Deref trait
    |
-LL -     match &x {
-LL +     match &*x {
-   |
+LL |     match &*x {
+   |            +
 
 error[E0308]: mismatched types
   --> $DIR/suggest-deref-in-match-issue-132784.rs:26:9

--- a/tests/ui/suggestions/suggest-field-through-deref.stderr
+++ b/tests/ui/suggestions/suggest-field-through-deref.stderr
@@ -6,9 +6,8 @@ LL |     let _ = x.longname;
    |
 help: a field with a similar name exists
    |
-LL -     let _ = x.longname;
-LL +     let _ = x.long_name;
-   |
+LL |     let _ = x.long_name;
+   |                   +
 
 error[E0609]: no field `longname` on type `S`
   --> $DIR/suggest-field-through-deref.rs:12:15
@@ -18,9 +17,8 @@ LL |     let _ = y.longname;
    |
 help: a field with a similar name exists
    |
-LL -     let _ = y.longname;
-LL +     let _ = y.long_name;
-   |
+LL |     let _ = y.long_name;
+   |                   +
 
 error[E0609]: no field `longname` on type `Option<Arc<S>>`
   --> $DIR/suggest-field-through-deref.rs:14:15

--- a/tests/ui/suggestions/suggest-let-for-assignment.stderr
+++ b/tests/ui/suggestions/suggest-let-for-assignment.stderr
@@ -58,9 +58,8 @@ LL |     letother_variable = 6;
    |
 help: you might have meant to introduce a new binding
    |
-LL -     letother_variable = 6;
-LL +     let other_variable = 6;
-   |
+LL |     let other_variable = 6;
+   |        +
 
 error[E0425]: cannot find value `other_variable` in this scope
   --> $DIR/suggest-let-for-assignment.rs:14:36

--- a/tests/ui/suggestions/suggest-trait-in-ufcs-in-hrtb.stderr
+++ b/tests/ui/suggestions/suggest-trait-in-ufcs-in-hrtb.stderr
@@ -6,12 +6,10 @@ LL | impl<S> Foo for Bar<S> where for<'a> <&'a S>::Item: Foo {}
    |
 help: use fully-qualified syntax
    |
-LL - impl<S> Foo for Bar<S> where for<'a> <&'a S>::Item: Foo {}
-LL + impl<S> Foo for Bar<S> where for<'a> <&'a S as IntoAsyncIterator>::Item: Foo {}
-   |
-LL - impl<S> Foo for Bar<S> where for<'a> <&'a S>::Item: Foo {}
-LL + impl<S> Foo for Bar<S> where for<'a> <&'a S as IntoIterator>::Item: Foo {}
-   |
+LL | impl<S> Foo for Bar<S> where for<'a> <&'a S as IntoAsyncIterator>::Item: Foo {}
+   |                                             ++++++++++++++++++++
+LL | impl<S> Foo for Bar<S> where for<'a> <&'a S as IntoIterator>::Item: Foo {}
+   |                                             +++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/test-attrs/inaccessible-test-modules.stderr
+++ b/tests/ui/test-attrs/inaccessible-test-modules.stderr
@@ -13,7 +13,7 @@ LL | use test as y;
 help: consider importing this module instead
    |
 LL | use test::test as y;
-   |     ++++++
+   |         ++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
+++ b/tests/ui/type-alias-enum-variants/enum-variant-priority-higher-than-other-inherent.stderr
@@ -11,9 +11,8 @@ LL |     V(u8)
    |     ^
 help: provide the argument
    |
-LL -     <E>::V();
-LL +     <E>::V(/* u8 */);
-   |
+LL |     <E>::V(/* u8 */);
+   |            ++++++++
 
 error[E0308]: mismatched types
   --> $DIR/enum-variant-priority-higher-than-other-inherent.rs:22:17

--- a/tests/ui/type-alias-impl-trait/bad-tait-no-substs.stderr
+++ b/tests/ui/type-alias-impl-trait/bad-tait-no-substs.stderr
@@ -69,7 +69,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~     match x {
 LL +         UninhabitedVariants::Tuple(_) => todo!(),
-LL +     }
+LL ~     }
    |
 
 error: aborting due to 5 previous errors

--- a/tests/ui/type-alias-impl-trait/unconstrained-due-to-bad-pattern.stderr
+++ b/tests/ui/type-alias-impl-trait/unconstrained-due-to-bad-pattern.stderr
@@ -9,7 +9,7 @@ help: ensure that all possible cases are being handled by adding a match arm wit
    |
 LL ~         match empty_opaque() {
 LL +             _ => todo!(),
-LL +         }
+LL ~         }
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/type/type-check/point-at-inference-4.stderr
+++ b/tests/ui/type/type-check/point-at-inference-4.stderr
@@ -11,9 +11,8 @@ LL |     fn infer(&self, a: A, b: B) {}
    |        ^^^^^              ----
 help: provide the argument
    |
-LL -     s.infer(0i32);
-LL +     s.infer(0i32, /* b */);
-   |
+LL |     s.infer(0i32, /* b */);
+   |                 +++++++++
 
 error[E0308]: mismatched types
   --> $DIR/point-at-inference-4.rs:18:24

--- a/tests/ui/typeck/issue-110052.stderr
+++ b/tests/ui/typeck/issue-110052.stderr
@@ -6,12 +6,10 @@ LL |     for<'iter> dyn Validator<<&'iter I>::Item>:,
    |
 help: use fully-qualified syntax
    |
-LL -     for<'iter> dyn Validator<<&'iter I>::Item>:,
-LL +     for<'iter> dyn Validator<<&'iter I as IntoAsyncIterator>::Item>:,
-   |
-LL -     for<'iter> dyn Validator<<&'iter I>::Item>:,
-LL +     for<'iter> dyn Validator<<&'iter I as IntoIterator>::Item>:,
-   |
+LL |     for<'iter> dyn Validator<<&'iter I as IntoAsyncIterator>::Item>:,
+   |                                        ++++++++++++++++++++
+LL |     for<'iter> dyn Validator<<&'iter I as IntoIterator>::Item>:,
+   |                                        +++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-13853-5.stderr
+++ b/tests/ui/typeck/issue-13853-5.stderr
@@ -14,8 +14,8 @@ LL |     fn deserialize_token<D: Deserializer<'a>>(_x: D, _y: &'a str) -> &'a st
    |
 help: consider returning the local binding `_y`
    |
-LL ~     fn deserialize_token<D: Deserializer<'a>>(_x: D, _y: &'a str) -> &'a str {
-LL +         _y
+LL |     fn deserialize_token<D: Deserializer<'a>>(_x: D, _y: &'a str) -> &'a str {
+LL ~         _y
 LL ~
    |
 

--- a/tests/ui/typeck/issue-87872-missing-inaccessible-field-pattern.stderr
+++ b/tests/ui/typeck/issue-87872-missing-inaccessible-field-pattern.stderr
@@ -6,19 +6,16 @@ LL |     let foo::Foo {} = foo::Foo::default();
    |
 help: include the missing field in the pattern and ignore the inaccessible fields
    |
-LL -     let foo::Foo {} = foo::Foo::default();
-LL +     let foo::Foo { visible, .. } = foo::Foo::default();
-   |
+LL |     let foo::Foo { visible, .. } = foo::Foo::default();
+   |                    +++++++++++
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL -     let foo::Foo {} = foo::Foo::default();
-LL +     let foo::Foo { visible: _, .. } = foo::Foo::default();
-   |
+LL |     let foo::Foo { visible: _, .. } = foo::Foo::default();
+   |                    ++++++++++++++
 help: or always ignore missing fields here
    |
-LL -     let foo::Foo {} = foo::Foo::default();
-LL +     let foo::Foo { .. } = foo::Foo::default();
-   |
+LL |     let foo::Foo { .. } = foo::Foo::default();
+   |                    ++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/struct-enum-wrong-args.stderr
+++ b/tests/ui/typeck/struct-enum-wrong-args.stderr
@@ -38,9 +38,8 @@ note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
 help: provide the argument
    |
-LL -     let _ = Ok();
-LL +     let _ = Ok(/* value */);
-   |
+LL |     let _ = Ok(/* value */);
+   |                +++++++++++
 
 error[E0061]: this struct takes 1 argument but 0 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:9:13
@@ -55,9 +54,8 @@ LL | struct Wrapper(i32);
    |        ^^^^^^^
 help: provide the argument
    |
-LL -     let _ = Wrapper();
-LL +     let _ = Wrapper(/* i32 */);
-   |
+LL |     let _ = Wrapper(/* i32 */);
+   |                     +++++++++
 
 error[E0061]: this struct takes 1 argument but 2 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:10:13
@@ -89,9 +87,8 @@ LL | struct DoubleWrapper(i32, i32);
    |        ^^^^^^^^^^^^^
 help: provide the arguments
    |
-LL -     let _ = DoubleWrapper();
-LL +     let _ = DoubleWrapper(/* i32 */, /* i32 */);
-   |
+LL |     let _ = DoubleWrapper(/* i32 */, /* i32 */);
+   |                           ++++++++++++++++++++
 
 error[E0061]: this struct takes 2 arguments but 1 argument was supplied
   --> $DIR/struct-enum-wrong-args.rs:12:13
@@ -106,9 +103,8 @@ LL | struct DoubleWrapper(i32, i32);
    |        ^^^^^^^^^^^^^
 help: provide the argument
    |
-LL -     let _ = DoubleWrapper(5);
-LL +     let _ = DoubleWrapper(5, /* i32 */);
-   |
+LL |     let _ = DoubleWrapper(5, /* i32 */);
+   |                            +++++++++++
 
 error[E0061]: this struct takes 2 arguments but 3 arguments were supplied
   --> $DIR/struct-enum-wrong-args.rs:13:13


### PR DESCRIPTION
Previously #136958 only cared about prefixes or suffixes. Now it detects more cases where a suggestion is "sandwiched" by unchanged code on the left or the right. Would be cool if we could detect several insertions, like `ACE` going to `ABCDE`, extracting `B` and `D`, but that seems unwieldy.

r? @estebank 
