### PR TITLE
Implement `read_buf` for zkVM stdin

### DIFF
--- a/library/std/src/sys/pal/zkvm/stdio.rs
+++ b/library/std/src/sys/pal/zkvm/stdio.rs
@@ -1,6 +1,6 @@
 use super::abi;
 use super::abi::fileno;
-use crate::io;
+use crate::io::{self, BorrowedCursor};
 
 pub struct Stdin;
 pub struct Stdout;
@@ -15,6 +15,14 @@ impl Stdin {
 impl io::Read for Stdin {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         Ok(unsafe { abi::sys_read(fileno::STDIN, buf.as_mut_ptr(), buf.len()) })
+    }
+
+    fn read_buf(&mut self, mut buf: BorrowedCursor<'_>) -> io::Result<()> {
+        unsafe {
+            let n = abi::sys_read(fileno::STDIN, buf.as_mut().as_mut_ptr().cast(), buf.capacity());
+            buf.advance_unchecked(n);
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
For the zkVM, even when a guest buffer is uninitialized, from the host's perspective it is just a normal piece of memory which was initialized before letting the guest write into it. This makes `sys_read` safe to use with an uninitialized buffer. See https://github.com/risc0/risc0/issues/2853.

cc @bobbobbio, @flaub

r? @Noratrieb

Tracked in https://github.com/rust-lang/rust/issues/136756