### PR TITLE
Ferris 🦀 Identifier naming conventions

### DIFF
--- a/compiler/rustc_interface/src/errors.rs
+++ b/compiler/rustc_interface/src/errors.rs
@@ -24,8 +24,9 @@ pub(crate) struct CrateNameInvalid<'a> {
 pub struct FerrisIdentifier {
     #[primary_span]
     pub spans: Vec<Span>,
-    #[suggestion(code = "ferris", applicability = "maybe-incorrect")]
+    #[suggestion(code = "{ferris_fix}", applicability = "maybe-incorrect")]
     pub first_span: Span,
+    pub ferris_fix: &'static str,
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/parser/ferris-static-mut.rs
+++ b/tests/ui/parser/ferris-static-mut.rs
@@ -1,0 +1,3 @@
+static mut 🦀: &str = "ferris!";//~ ERROR Ferris cannot be used as an identifier
+
+fn main() {}

--- a/tests/ui/parser/ferris-static-mut.stderr
+++ b/tests/ui/parser/ferris-static-mut.stderr
@@ -1,0 +1,8 @@
+error: Ferris cannot be used as an identifier
+  --> $DIR/ferris-static-mut.rs:1:12
+   |
+LL | static mut 🦀: &str = "ferris!";
+   |            ^^ help: try using their name instead: `FERRIS`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/ferris-struct.rs
+++ b/tests/ui/parser/ferris-struct.rs
@@ -1,0 +1,3 @@
+struct 🦀 {}//~ ERROR Ferris cannot be used as an identifier
+
+fn main() {}

--- a/tests/ui/parser/ferris-struct.stderr
+++ b/tests/ui/parser/ferris-struct.stderr
@@ -1,0 +1,8 @@
+error: Ferris cannot be used as an identifier
+  --> $DIR/ferris-struct.rs:1:8
+   |
+LL | struct 🦀 {}
+   |        ^^ help: try using their name instead: `Ferris`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

You cannot use Ferris as an identifier in Rust, this code will suggest to correct the  🦀 to `ferris`:

```rs
fn main() {
  let  🦀 = 4;
}
``` 

But it also suggests to correct to `ferris` in these cases, too:

```rs
struct  🦀 {}
fn main() {}
```

^ suggests: `ferris`
~ with this PR: `Ferris`

```rs
static 🦀: &str = "ferris!";
fn main() {}
```

^ suggests: `ferris`
~ with this PR: `FERRIS`

This is my first pull requests here!