### PR TITLE
Use `as_chunks` in `analyze_source_file_sse2`

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -31,6 +31,7 @@
 #![feature(round_char_boundary)]
 #![feature(rustc_attrs)]
 #![feature(rustdoc_internals)]
+#![feature(slice_as_chunks)]
 #![warn(unreachable_pub)]
 // tidy-alphabetical-end
 


### PR DESCRIPTION
Follow-up to #136460. Uses a slightly cleaner method of iterating over chunks of bytes.