### PR TITLE
Add build step log for `run-make-support`

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1234,6 +1234,14 @@ impl Step for RunMakeSupport {
             &[],
         );
 
+        let _guard = builder.msg_tool(
+            Kind::Build,
+            Mode::ToolStd,
+            "run-make-support",
+            self.compiler.stage,
+            &self.compiler.host,
+            &self.target,
+        );
         cargo.into_cmd().run(builder);
 
         let lib_name = "librun_make_support.rlib";


### PR DESCRIPTION
I was always confused about what is being built, since nothing was printed in the log :)

r? @jieyouxu