### PR TITLE
Tag all format-like macros with `#[clippy::format_args]`

### DIFF
--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -120,7 +120,7 @@ macro_rules! vec {
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow_internal_unstable(hint_must_use, liballoc_internals)]
-#[cfg_attr(not(test), rustc_diagnostic_item = "format_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "format_macro", clippy::format_args)]
 macro_rules! format {
     ($($arg:tt)*) => {
         $crate::__export::must_use({

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -37,7 +37,7 @@ macro_rules! panic {
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "assert_eq_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "assert_eq_macro", clippy::format_args)]
 #[allow_internal_unstable(panic_internals)]
 macro_rules! assert_eq {
     ($left:expr, $right:expr $(,)?) => {
@@ -93,7 +93,7 @@ macro_rules! assert_eq {
 /// ```
 #[macro_export]
 #[stable(feature = "assert_ne", since = "1.13.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "assert_ne_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "assert_ne_macro", clippy::format_args)]
 #[allow_internal_unstable(panic_internals)]
 macro_rules! assert_ne {
     ($left:expr, $right:expr $(,)?) => {
@@ -169,6 +169,7 @@ macro_rules! assert_ne {
 #[unstable(feature = "assert_matches", issue = "82775")]
 #[allow_internal_unstable(panic_internals)]
 #[rustc_macro_transparency = "semitransparent"]
+#[cfg_attr(not(test), clippy::format_args)]
 pub macro assert_matches {
     ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => {
         match $left {
@@ -392,6 +393,7 @@ pub macro cfg_match {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "debug_assert_macro"]
 #[allow_internal_unstable(edition_panic)]
+#[cfg_attr(not(test), clippy::format_args)]
 macro_rules! debug_assert {
     ($($arg:tt)*) => {
         if $crate::cfg!(debug_assertions) {
@@ -421,7 +423,7 @@ macro_rules! debug_assert {
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "debug_assert_eq_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "debug_assert_eq_macro", clippy::format_args)]
 macro_rules! debug_assert_eq {
     ($($arg:tt)*) => {
         if $crate::cfg!(debug_assertions) {
@@ -451,7 +453,7 @@ macro_rules! debug_assert_eq {
 /// ```
 #[macro_export]
 #[stable(feature = "assert_ne", since = "1.13.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "debug_assert_ne_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "debug_assert_ne_macro", clippy::format_args)]
 macro_rules! debug_assert_ne {
     ($($arg:tt)*) => {
         if $crate::cfg!(debug_assertions) {
@@ -707,7 +709,7 @@ macro_rules! r#try {
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "write_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "write_macro", clippy::format_args)]
 macro_rules! write {
     ($dst:expr, $($arg:tt)*) => {
         $dst.write_fmt($crate::format_args!($($arg)*))
@@ -741,7 +743,7 @@ macro_rules! write {
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "writeln_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "writeln_macro", clippy::format_args)]
 #[allow_internal_unstable(format_args_nl)]
 macro_rules! writeln {
     ($dst:expr $(,)?) => {
@@ -895,6 +897,7 @@ macro_rules! unreachable {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "unimplemented_macro")]
 #[allow_internal_unstable(panic_internals)]
+#[clippy::format_args]
 macro_rules! unimplemented {
     () => {
         $crate::panicking::panic("not implemented")
@@ -973,7 +976,7 @@ macro_rules! unimplemented {
 /// ```
 #[macro_export]
 #[stable(feature = "todo_macro", since = "1.40.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "todo_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "todo_macro", clippy::format_args)]
 #[allow_internal_unstable(panic_internals)]
 macro_rules! todo {
     () => {
@@ -1085,7 +1088,7 @@ pub(crate) mod builtin {
     /// and cannot be stored for later use.
     /// This is a known limitation, see [#92698](https://github.com/rust-lang/rust/issues/92698).
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[cfg_attr(not(test), rustc_diagnostic_item = "format_args_macro")]
+    #[cfg_attr(not(test), rustc_diagnostic_item = "format_args_macro", clippy::format_args)]
     #[allow_internal_unsafe]
     #[allow_internal_unstable(fmt_internals)]
     #[rustc_builtin_macro]
@@ -1675,6 +1678,7 @@ pub(crate) mod builtin {
         edition_panic,
         generic_assert_internals
     )]
+    #[cfg_attr(not(test), clippy::format_args)]
     macro_rules! assert {
         ($cond:expr $(,)?) => {{ /* compiler built-in */ }};
         ($cond:expr, $($arg:tt)+) => {{ /* compiler built-in */ }};

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -49,6 +49,7 @@ pub macro panic_2015 {
 #[rustc_diagnostic_item = "core_panic_2021_macro"]
 #[rustc_macro_transparency = "semitransparent"]
 #[cfg(feature = "panic_immediate_abort")]
+#[cfg_attr(not(test), clippy::format_args)]
 pub macro panic_2021 {
     () => (
         $crate::panicking::panic("explicit panic")
@@ -77,6 +78,7 @@ pub macro panic_2021 {
 #[rustc_diagnostic_item = "core_panic_2021_macro"]
 #[rustc_macro_transparency = "semitransparent"]
 #[cfg(not(feature = "panic_immediate_abort"))]
+#[cfg_attr(not(test), clippy::format_args)]
 pub macro panic_2021 {
     () => ({
         // Create a function so that the argument for `track_caller`
@@ -131,6 +133,7 @@ pub macro unreachable_2015 {
 #[unstable(feature = "edition_panic", issue = "none", reason = "use unreachable!() instead")]
 #[allow_internal_unstable(panic_internals)]
 #[rustc_macro_transparency = "semitransparent"]
+#[cfg_attr(not(test), clippy::format_args)]
 pub macro unreachable_2021 {
     () => (
         $crate::panicking::panic("internal error: entered unreachable code")

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -77,7 +77,7 @@ macro_rules! panic {
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "print_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "print_macro", clippy::format_args)]
 #[allow_internal_unstable(print_internals)]
 macro_rules! print {
     ($($arg:tt)*) => {{
@@ -133,7 +133,7 @@ macro_rules! print {
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "println_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "println_macro", clippy::format_args)]
 #[allow_internal_unstable(print_internals, format_args_nl)]
 macro_rules! println {
     () => {
@@ -173,7 +173,7 @@ macro_rules! println {
 /// ```
 #[macro_export]
 #[stable(feature = "eprint", since = "1.19.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "eprint_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "eprint_macro", clippy::format_args)]
 #[allow_internal_unstable(print_internals)]
 macro_rules! eprint {
     ($($arg:tt)*) => {{
@@ -211,7 +211,7 @@ macro_rules! eprint {
 /// ```
 #[macro_export]
 #[stable(feature = "eprint", since = "1.19.0")]
-#[cfg_attr(not(test), rustc_diagnostic_item = "eprintln_macro")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "eprintln_macro", clippy::format_args)]
 #[allow_internal_unstable(print_internals, format_args_nl)]
 macro_rules! eprintln {
     () => {

--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -30,6 +30,7 @@ use crate::{mem, panic, sys};
 // - the standard error output
 // - some dedicated platform specific output
 // - nothing (so this macro is a no-op)
+#[cfg_attr(not(test), clippy::format_args)]
 macro_rules! rtprintpanic {
     ($($t:tt)*) => {
         #[cfg(not(feature = "panic_immediate_abort"))]
@@ -43,6 +44,7 @@ macro_rules! rtprintpanic {
     }
 }
 
+#[cfg_attr(not(test), clippy::format_args)]
 macro_rules! rtabort {
     ($($t:tt)*) => {
         {


### PR DESCRIPTION
### Help needed
Is there a workaround for #98291 ?  The build errors here seem to be triggered by that issue.

### Description
Since 1.85, Clippy [supports](https://doc.rust-lang.org/nightly/clippy/attribs.html#clippyformat_args) attribute-based discovery of the `format!`-compatible macros, i.e. macros whose trailing arguments can be passed to `format_args!` as is.

Tagging core library with the same attribute will allow clippy to stop maintaining a separate list of format-like macros - allowing Clippy to validate macro usage for all lints that work on format arguments. See also https://github.com/rust-lang/rust-clippy/issues/14267