### PR TITLE
Do not exempt nonexistent platforms from platform policy

### DIFF
--- a/src/tools/tidy/src/target_policy.rs
+++ b/src/tools/tidy/src/target_policy.rs
@@ -21,7 +21,6 @@ const EXCEPTIONS: &[&str] = &[
     "xtensa_esp32s2_espidf",
     "xtensa_esp32s3_none_elf",
     "xtensa_esp32s3_espidf",
-    "i586_pc_nto_qnx700", // Renamed to i686-pc-nto-qnx700, see https://github.com/rust-lang/rust/issues/136495
 ];
 
 pub fn check(root_path: &Path, bad: &mut bool) {


### PR DESCRIPTION
In #137324 I approved the change of the i586-pc-qnx platform to i686 with this extra line included. I noticed it but thought it was a bootstrap problem of some sort. Nonetheless, removing this line doesn't seem to change anything.

r? @Noratrieb