### PR TITLE
Stacker now handles miri using a noop impl itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
+checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
 dependencies = [
  "cc",
 ]
@@ -4947,9 +4947,9 @@ dependencies = [
 
 [[package]]
 name = "stacker"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799c883d55abdb5e98af1a7b3f23b9b6de8ecada0ecac058672d7635eb48ca7b"
+checksum = "1d08feb8f695b465baed819b03c128dc23f57a694510ab1f06c77f763975685e"
 dependencies = [
  "cc",
  "cfg-if",

--- a/compiler/rustc_data_structures/src/stack.rs
+++ b/compiler/rustc_data_structures/src/stack.rs
@@ -17,18 +17,6 @@ const STACK_PER_RECURSION: usize = 16 * 1024 * 1024; // 16MB
 ///
 /// Should not be sprinkled around carelessly, as it causes a little bit of overhead.
 #[inline]
-#[cfg(not(miri))]
 pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
     stacker::maybe_grow(RED_ZONE, STACK_PER_RECURSION, f)
-}
-
-/// Grows the stack on demand to prevent stack overflow. Call this in strategic locations
-/// to "break up" recursive calls. E.g. almost any call to `visit_expr` or equivalent can benefit
-/// from this.
-///
-/// Should not be sprinkled around carelessly, as it causes a little bit of overhead.
-#[cfg(miri)]
-#[inline]
-pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
-    f()
 }


### PR DESCRIPTION
Reverts a no longer necessary change from https://github.com/rust-lang/rust/pull/136580.