### PR TITLE
stabilize `unsigned_is_multiple_of`

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -3274,14 +3274,14 @@ macro_rules! uint_impl {
         /// Basic usage:
         ///
         /// ```
-        /// #![feature(unsigned_is_multiple_of)]
         #[doc = concat!("assert!(6_", stringify!($SelfT), ".is_multiple_of(2));")]
         #[doc = concat!("assert!(!5_", stringify!($SelfT), ".is_multiple_of(2));")]
         ///
         #[doc = concat!("assert!(0_", stringify!($SelfT), ".is_multiple_of(0));")]
         #[doc = concat!("assert!(!6_", stringify!($SelfT), ".is_multiple_of(0));")]
         /// ```
-        #[unstable(feature = "unsigned_is_multiple_of", issue = "128101")]
+        #[stable(feature = "unsigned_is_multiple_of", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_const_stable(feature = "unsigned_is_multiple_of", since = "CURRENT_RUSTC_VERSION")]
         #[must_use]
         #[inline]
         #[rustc_inherit_overflow_checks]

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -87,7 +87,6 @@
 #![feature(try_blocks)]
 #![feature(try_find)]
 #![feature(try_trait_v2)]
-#![feature(unsigned_is_multiple_of)]
 #![feature(unsize)]
 #![feature(unsized_tuple_coercion)]
 #![feature(unwrap_infallible)]

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -16,7 +16,6 @@
 #![feature(unqualified_local_imports)]
 #![feature(derive_coerce_pointee)]
 #![feature(arbitrary_self_types)]
-#![feature(unsigned_is_multiple_of)]
 #![feature(extract_if)]
 // Configure clippy and other lints
 #![allow(


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/128101
fcp completed in: https://github.com/rust-lang/rust/issues/128101#issuecomment-2674880635

### Public API

A version of this for all the unsigned types 

```rust
fn is_multiple_of(lhs: u64, rhs: u64) -> bool {
    match rhs {
        // prevent division by zero
        0 => lhs == 0,
        _ => lhs % rhs == 0,
    }
}
```