### PR TITLE
Fix(lib/fs/tests): Disable rename POSIX semantics FS tests under Windows 7

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1914,8 +1914,11 @@ fn test_hidden_file_truncation() {
     assert_eq!(metadata.len(), 0);
 }
 
+// See https://github.com/rust-lang/rust/pull/131072 for more details about why
+// these two tests are disabled under Windows 7 here.
 #[cfg(windows)]
 #[test]
+#[cfg_attr(target_vendor = "win7", ignore = "Unsupported under Windows 7.")]
 fn test_rename_file_over_open_file() {
     // Make sure that std::fs::rename works if the target file is already opened with FILE_SHARE_DELETE. See #123985.
     let tmpdir = tmpdir();
@@ -1940,6 +1943,7 @@ fn test_rename_file_over_open_file() {
 
 #[test]
 #[cfg(windows)]
+#[cfg_attr(target_vendor = "win7", ignore = "Unsupported under Windows 7.")]
 fn test_rename_directory_to_non_empty_directory() {
     // Renaming a directory over a non-empty existing directory should fail on Windows.
     let tmpdir: TempDir = tmpdir();


### PR DESCRIPTION
Would otherwise fail there. The Windows7-specific parts were left pretty much untouched by the changes introduced by
51df98ddb094b39b2e17d24f887cd66c52560ef6, so it is expected that these tests fail under Windows 7 as they were probably written to run under Windows 10+ only.