### PR TITLE
lexer: Disallow some leading underscores in float exponents

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -964,6 +964,13 @@ impl Cursor<'_> {
         debug_assert!(self.prev() == 'e' || self.prev() == 'E');
         if self.first() == '-' || self.first() == '+' {
             self.bump();
+            // Reject floats like `1e+_2` and `1.2e+_3` to avoid introducing identifier
+            // tokens into the possible "fine-grained" tokenization of floats.
+            // (Note that `1e_2` and `1.2e_3` are still accepted below because
+            // they don't introduce identifiers, only suffixed integers.)
+            if self.first() == '_' {
+                return false;
+            }
         }
         self.eat_decimal_digits()
     }

--- a/tests/ui/lexer/lex-bad-numeric-literals.rs
+++ b/tests/ui/lexer/lex-bad-numeric-literals.rs
@@ -32,4 +32,11 @@ fn main() {
     0o123.456; //~ ERROR: octal float literal is not supported
     0b101f64; //~ ERROR: binary float literal is not supported
     0b111.101; //~ ERROR: binary float literal is not supported
+    1e_2; // OK for now
+    1.2e_3; // OK for now
+    1e+_2; //~ ERROR expected at least one digit in exponent
+    1e-_2; //~ ERROR expected at least one digit in exponent
+    1.2e+_3; //~ ERROR expected at least one digit in exponent
+    1.2e-_3; //~ ERROR expected at least one digit in exponent
+    0x539.0; //~ ERROR: hexadecimal float literal is not supported
 }

--- a/tests/ui/lexer/lex-bad-numeric-literals.stderr
+++ b/tests/ui/lexer/lex-bad-numeric-literals.stderr
@@ -106,6 +106,36 @@ error: binary float literal is not supported
 LL |     0b111.101;
    |     ^^^^^^^^^
 
+error: expected at least one digit in exponent
+  --> $DIR/lex-bad-numeric-literals.rs:37:5
+   |
+LL |     1e+_2;
+   |     ^^^^^
+
+error: expected at least one digit in exponent
+  --> $DIR/lex-bad-numeric-literals.rs:38:5
+   |
+LL |     1e-_2;
+   |     ^^^^^
+
+error: expected at least one digit in exponent
+  --> $DIR/lex-bad-numeric-literals.rs:39:5
+   |
+LL |     1.2e+_3;
+   |     ^^^^^^^
+
+error: expected at least one digit in exponent
+  --> $DIR/lex-bad-numeric-literals.rs:40:5
+   |
+LL |     1.2e-_3;
+   |     ^^^^^^^
+
+error: hexadecimal float literal is not supported
+  --> $DIR/lex-bad-numeric-literals.rs:41:5
+   |
+LL |     0x539.0;
+   |     ^^^^^^^
+
 error: octal float literal is not supported
   --> $DIR/lex-bad-numeric-literals.rs:5:5
    |
@@ -164,6 +194,6 @@ error: binary float literal is not supported
 LL |     0b101f64;
    |     ^^^^^^^^ not supported
 
-error: aborting due to 26 previous errors
+error: aborting due to 31 previous errors
 
 For more information about this error, try `rustc --explain E0768`.


### PR DESCRIPTION
A second, scaled down, attempt at https://github.com/rust-lang/rust/pull/114567.
cc https://github.com/rust-lang/rust/pull/111628#issuecomment-1569258630