### PR TITLE
Recover `param: Ty = EXPR`

### DIFF
--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -137,14 +137,37 @@ impl<'a> Parser<'a> {
     /// The difference from `parse_ty` is that this version allows `...`
     /// (`CVarArgs`) at the top level of the type.
     pub(super) fn parse_ty_for_param(&mut self) -> PResult<'a, Box<Ty>> {
-        self.parse_ty_common(
+        let ty = self.parse_ty_common(
             AllowPlus::Yes,
             AllowCVariadic::Yes,
             RecoverQPath::Yes,
             RecoverReturnSign::Yes,
             None,
             RecoverQuestionMark::Yes,
-        )
+        )?;
+
+        // Recover a trailing `= EXPR` if present.
+        if self.may_recover()
+            && self.check_noexpect(&token::Eq)
+            && self.look_ahead(1, |tok| tok.can_begin_expr())
+        {
+            let snapshot = self.create_snapshot_for_diagnostic();
+            self.bump();
+            let eq_span = self.prev_token.span;
+            match self.parse_expr() {
+                Ok(e) => {
+                    self.dcx()
+                        .struct_span_err(eq_span.to(e.span), "parameter defaults are not supported")
+                        .emit();
+                }
+                Err(diag) => {
+                    diag.cancel();
+                    self.restore_snapshot(snapshot);
+                }
+            }
+        }
+
+        Ok(ty)
     }
 
     /// Parses a type in restricted contexts where `+` is not permitted.

--- a/tests/ui/parser/recover/param-default.rs
+++ b/tests/ui/parser/recover/param-default.rs
@@ -1,0 +1,5 @@
+fn foo(x: i32 = 1) {} //~ ERROR parameter defaults are not supported
+
+type Foo = fn(i32 = 0); //~ ERROR parameter defaults are not supported
+
+fn main() {}

--- a/tests/ui/parser/recover/param-default.stderr
+++ b/tests/ui/parser/recover/param-default.stderr
@@ -1,0 +1,14 @@
+error: parameter defaults are not supported
+  --> $DIR/param-default.rs:1:15
+   |
+LL | fn foo(x: i32 = 1) {}
+   |               ^^^
+
+error: parameter defaults are not supported
+  --> $DIR/param-default.rs:3:19
+   |
+LL | type Foo = fn(i32 = 0);
+   |                   ^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #137310

Pretty basic recovery here, but better than giving an unexpected token error.