### PR TITLE
Remove deserializing/reserializing toml from configure.py

### DIFF
--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -193,14 +193,24 @@ class GenerateAndParseConfig(unittest.TestCase):
         )
 
     def test_set_target_option(self):
-        build = serialize_and_parse(["--build=x86_64-unknown-linux-gnu", "--llvm-config=/usr/bin/llvm-config"])
+        build = serialize_and_parse(
+            ["--build=x86_64-unknown-linux-gnu", "--llvm-config=/usr/bin/llvm-config"]
+        )
         self.assertEqual(
-            build.get_toml("llvm-config", section="target.x86_64-unknown-linux-gnu"), "/usr/bin/llvm-config"
+            build.get_toml("llvm-config", section="target.x86_64-unknown-linux-gnu"),
+            "/usr/bin/llvm-config",
         )
 
     def test_set_targets(self):
         # Multiple targets can be set
-        build = serialize_and_parse(["--set", "target.x86_64-unknown-linux-gnu.cc=gcc", "--set", "target.aarch64-apple-darwin.cc=clang"])
+        build = serialize_and_parse(
+            [
+                "--set",
+                "target.x86_64-unknown-linux-gnu.cc=gcc",
+                "--set",
+                "target.aarch64-apple-darwin.cc=clang",
+            ]
+        )
         self.assertEqual(
             build.get_toml("cc", section="target.x86_64-unknown-linux-gnu"), "gcc"
         )
@@ -208,10 +218,10 @@ class GenerateAndParseConfig(unittest.TestCase):
             build.get_toml("cc", section="target.aarch64-apple-darwin"), "clang"
         )
 
-        build = serialize_and_parse(["--target", "x86_64-unknown-linux-gnu,aarch64-apple-darwin"])
-        self.assertNotEqual(
-            build.config_toml.find("target.aarch64-apple-darwin"), -1
+        build = serialize_and_parse(
+            ["--target", "x86_64-unknown-linux-gnu,aarch64-apple-darwin"]
         )
+        self.assertNotEqual(build.config_toml.find("target.aarch64-apple-darwin"), -1)
         self.assertNotEqual(
             build.config_toml.find("target.x86_64-unknown-linux-gnu"), -1
         )

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -374,6 +374,7 @@ if "--help" in sys.argv or "-h" in sys.argv:
 
 VERBOSE = False
 
+
 # Parse command line arguments into a valid build configuration.
 def parse_args(args):
     known_args = validate_args(args)
@@ -382,6 +383,7 @@ def parse_args(args):
         _set("profile", "dist", config)
     _set("build.configure-args", args, config)
     return config
+
 
 # Validate command line arguments, throwing an error if there are any unknown
 # arguments, missing values or duplicate arguments when option-checking is also
@@ -434,7 +436,7 @@ def validate_args(args):
                 known_args[option.name] = []
             elif option.name in known_args and option.name != "set":
                 duplicate_args.append(option.name)
-                
+
             known_args[option.name].append((option, value))
             break
 
@@ -595,7 +597,7 @@ def get_configured_targets(config):
 
 def write_block(f, config, block):
     last_line = block[-1]
-    key = last_line.split("=")[0].strip(' #')
+    key = last_line.split("=")[0].strip(" #")
     value = config[key] if key in config else None
     if value is not None:
         for ln in block[:-1]:
@@ -624,10 +626,12 @@ def write_config_toml(f, config):
     section = []
     block = []
 
+    i = 0
     # Drop the initial comment block
-    for i, line in enumerate(lines):
+    for line in lines:
         if not line.startswith("#"):
             break
+        i += 1
 
     for line in lines[i:]:
         if line.startswith("["):


### PR DESCRIPTION
Instead, creates the toml line by line without deserializing/deserializing and replacing the values.

https://github.com/rust-lang/rust/issues/112445

r? jyn514