### PR TITLE
Tweak comma handling of "missing match arm" suggestion and fix "remove this arm" suggestion, and make suggestion verbose

### DIFF
--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -133,11 +133,11 @@ ast_lowering_misplaced_relax_trait_bound =
 ast_lowering_never_pattern_with_body =
     a never pattern is always unreachable
     .label = this will never be executed
-    .suggestion = remove this expression
+    .suggestion = remove the match arm expression
 
 ast_lowering_never_pattern_with_guard =
     a guard on a never pattern will never be run
-    .suggestion = remove this guard
+    .suggestion = remove the match arm guard
 
 ast_lowering_no_precise_captures_on_apit = `use<...>` precise capturing syntax not allowed in argument-position `impl Trait`
 

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -336,7 +336,7 @@ pub(crate) struct MisplacedRelaxTraitBound {
 pub(crate) struct MatchArmWithNoBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " => todo!(),", applicability = "has-placeholders")]
+    #[suggestion(code = " => todo!(),", applicability = "has-placeholders", style = "verbose")]
     pub suggestion: Span,
 }
 
@@ -345,16 +345,18 @@ pub(crate) struct MatchArmWithNoBody {
 pub(crate) struct NeverPatternWithBody {
     #[primary_span]
     #[label]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
     pub span: Span,
+    #[suggestion(code = ",", applicability = "maybe-incorrect", style = "verbose")]
+    pub removal_span: Span,
 }
 
 #[derive(Diagnostic)]
 #[diag(ast_lowering_never_pattern_with_guard)]
 pub(crate) struct NeverPatternWithGuard {
     #[primary_span]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
     pub span: Span,
+    #[suggestion(code = ",", applicability = "maybe-incorrect", style = "verbose")]
+    pub removal_span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -346,7 +346,7 @@ pub(crate) struct NeverPatternWithBody {
     #[primary_span]
     #[label]
     pub span: Span,
-    #[suggestion(code = ",", applicability = "maybe-incorrect", style = "verbose")]
+    #[suggestion(code = ",", applicability = "maybe-incorrect", style = "hidden")]
     pub removal_span: Span,
 }
 
@@ -355,7 +355,7 @@ pub(crate) struct NeverPatternWithBody {
 pub(crate) struct NeverPatternWithGuard {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = ",", applicability = "maybe-incorrect", style = "verbose")]
+    #[suggestion(code = ",", applicability = "maybe-incorrect", style = "hidden")]
     pub removal_span: Span,
 }
 

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -679,6 +679,16 @@ impl<'hir> LoweringContext<'_, 'hir> {
         {
             body
         } else {
+            let removal_span = |removal_span: Span| {
+                // Seek upwards in the macro call sites to see if we find the place where
+                // `pat!()` was called so that we can get the right span to remove.
+                let Some(pat_span) = pat.span.find_ancestor_in_same_ctxt(arm.span) else {
+                    return removal_span;
+                };
+                // - pat!() => {}
+                // + pat!(),
+                pat_span.shrink_to_hi().with_hi(arm.span.hi())
+            };
             // Either `body.is_none()` or `is_never_pattern` here.
             if !is_never_pattern {
                 if self.tcx.features().never_patterns() {
@@ -689,29 +699,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
             } else if let Some(body) = &arm.body {
                 self.dcx().emit_err(NeverPatternWithBody {
                     span: body.span,
-                    removal_span: if pat.span.eq_ctxt(arm.span) {
-                        // - ! => {}
-                        // + !,
-                        pat.span.shrink_to_hi().with_hi(arm.span.hi())
-                    } else {
-                        // Subtly incorrect, but close enough if macros are involved.
-                        // - ! => {}
-                        // + ! => ,
-                        body.span
-                    },
+                    removal_span: removal_span(body.span),
                 });
             } else if let Some(g) = &arm.guard {
                 self.dcx().emit_err(NeverPatternWithGuard {
                     span: g.span,
-                    removal_span: if pat.span.eq_ctxt(arm.span) {
-                        // - ! if cond,
-                        // + !,
-                        pat.span.shrink_to_hi().with_hi(arm.span.hi())
-                    } else {
-                        // We have something like `never!() if cond =>`
-                        //                      We just remove ^^^^ which isn't entirely correct.
-                        g.span
-                    },
+                    removal_span: removal_span(g.span),
                 });
             }
 

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -687,9 +687,33 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     self.dcx().emit_err(MatchArmWithNoBody { span, suggestion });
                 }
             } else if let Some(body) = &arm.body {
-                self.dcx().emit_err(NeverPatternWithBody { span: body.span });
+                self.dcx().emit_err(NeverPatternWithBody {
+                    span: body.span,
+                    removal_span: if pat.span.eq_ctxt(arm.span) {
+                        // - ! => {}
+                        // + !,
+                        // FIXME: account for `(!|!)`, as pat.span ends *within* the parentheses.
+                        pat.span.shrink_to_hi().with_hi(arm.span.hi())
+                    } else {
+                        // Subtly incorrect, but close enough if macros are involved.
+                        // - ! => {}
+                        // + ! => ,
+                        body.span
+                    },
+                });
             } else if let Some(g) = &arm.guard {
-                self.dcx().emit_err(NeverPatternWithGuard { span: g.span });
+                self.dcx().emit_err(NeverPatternWithGuard {
+                    span: g.span,
+                    removal_span: if pat.span.eq_ctxt(arm.span) {
+                        // - ! if cond,
+                        // + !,
+                        pat.span.shrink_to_hi().with_hi(arm.span.hi())
+                    } else {
+                        // We have something like `never!() if cond =>`
+                        //                      We just remove ^^^^ which isn't entirely correct.
+                        g.span
+                    },
+                });
             }
 
             // We add a fake `loop {}` arm body so that it typecks to `!`. The mir lowering of never

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -692,7 +692,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     removal_span: if pat.span.eq_ctxt(arm.span) {
                         // - ! => {}
                         // + !,
-                        // FIXME: account for `(!|!)`, as pat.span ends *within* the parentheses.
                         pat.span.shrink_to_hi().with_hi(arm.span.hi())
                     } else {
                         // Subtly incorrect, but close enough if macros are involved.

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -20,7 +20,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         self.arena.alloc(self.lower_pat_mut(pattern))
     }
 
-    fn lower_pat_mut(&mut self, mut pattern: &Pat) -> hir::Pat<'hir> {
+    fn lower_pat_mut(&mut self, outer_pattern: &Pat) -> hir::Pat<'hir> {
+        let mut pattern = outer_pattern;
         ensure_sufficient_stack(|| {
             // loop here to avoid recursion
             let pat_hir_id = self.lower_node_id(pattern.id);
@@ -147,7 +148,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 }
             };
 
-            self.pat_with_node_id_of(pattern, node, pat_hir_id)
+            self.pat_with_node_id_of(outer_pattern, node, pat_hir_id)
         })
     }
 

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3138,13 +3138,13 @@ impl<'a> Parser<'a> {
                     arm_body = Some(expr);
                     // Eat a comma if it exists, though.
                     let _ = this.eat(exp!(Comma));
-                    comma = Some(this.prev_token.span);
                     Ok(Recovered::No)
                 } else if let Some((span, guar)) =
                     this.parse_arm_body_missing_braces(&expr, arrow_span)
                 {
                     let body = this.mk_expr_err(span, guar);
                     arm_body = Some(body);
+                    let _ = this.eat(exp!(Comma));
                     Ok(Recovered::Yes(guar))
                 } else {
                     let expr_span = expr.span;
@@ -3185,6 +3185,9 @@ impl<'a> Parser<'a> {
                     })
                 }
             };
+            if let TokenKind::Comma = this.prev_token.kind {
+                comma = Some(this.prev_token.span);
+            }
 
             let hi_span =
                 comma.unwrap_or(arm_body.as_ref().map_or(span_before_body, |body| body.span));

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3074,6 +3074,7 @@ impl<'a> Parser<'a> {
             let (pat, guard) = this.parse_match_arm_pat_and_guard()?;
 
             let span_before_body = this.prev_token.span;
+            let mut comma = None;
             let arm_body;
             let is_fat_arrow = this.check(exp!(FatArrow));
             let is_almost_fat_arrow =
@@ -3137,6 +3138,7 @@ impl<'a> Parser<'a> {
                     arm_body = Some(expr);
                     // Eat a comma if it exists, though.
                     let _ = this.eat(exp!(Comma));
+                    comma = Some(this.prev_token.span);
                     Ok(Recovered::No)
                 } else if let Some((span, guar)) =
                     this.parse_arm_body_missing_braces(&expr, arrow_span)
@@ -3184,7 +3186,8 @@ impl<'a> Parser<'a> {
                 }
             };
 
-            let hi_span = arm_body.as_ref().map_or(span_before_body, |body| body.span);
+            let hi_span =
+                comma.unwrap_or(arm_body.as_ref().map_or(span_before_body, |body| body.span));
             let arm_span = lo.to(hi_span);
 
             // We want to recover:

--- a/src/tools/clippy/clippy_lints/src/loops/single_element_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/single_element_loop.rs
@@ -71,7 +71,7 @@ pub(super) fn check<'tcx>(
     {
         let mut applicability = Applicability::MachineApplicable;
         let mut pat_snip = snippet_with_applicability(cx, pat.span, "..", &mut applicability);
-        if matches!(pat.kind, PatKind::Or(..)) {
+        if matches!(pat.kind, PatKind::Or(..)) && !pat_snip.starts_with("(") {
             pat_snip = format!("({pat_snip})").into();
         }
         let mut arg_snip = snippet_with_applicability(cx, arg_expression.span, "..", &mut applicability);

--- a/src/tools/clippy/tests/ui/match_same_arms.stderr
+++ b/src/tools/clippy/tests/ui/match_same_arms.stderr
@@ -9,7 +9,7 @@ note: `_` wildcard arm here
   --> tests/ui/match_same_arms.rs:14:9
    |
 LL |         _ => 0,
-   |         ^^^^^^
+   |         ^^^^^^^
    = note: `-D clippy::match-same-arms` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::match_same_arms)]`
 
@@ -17,7 +17,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:18:9
    |
 LL |         (1, .., 3) => 42,
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -30,7 +30,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:25:9
    |
 LL |         51 => 1,
-   |         ^^^^^^^
+   |         ^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -44,7 +44,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:26:9
    |
 LL |         41 => 2,
-   |         ^^^^^^^
+   |         ^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -57,7 +57,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:33:9
    |
 LL |         2 => 2,
-   |         ^^^^^^
+   |         ^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -71,7 +71,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:35:9
    |
 LL |         3 => 2,
-   |         ^^^^^^
+   |         ^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -85,7 +85,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:33:9
    |
 LL |         2 => 2,
-   |         ^^^^^^
+   |         ^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -99,7 +99,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:52:17
    |
 LL |                 CommandInfo::External { name, .. } => name.to_string(),
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm

--- a/src/tools/clippy/tests/ui/match_same_arms2.stderr
+++ b/src/tools/clippy/tests/ui/match_same_arms2.stderr
@@ -21,7 +21,7 @@ LL | |             if true {
 ...  |
 LL | |             a
 LL | |         },
-   | |_________^
+   | |__________^
    = note: `-D clippy::match-same-arms` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::match_same_arms)]`
 
@@ -29,7 +29,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:40:9
    |
 LL |         51 => foo(),
-   |         ^^^^^^^^^^^
+   |         ^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -43,7 +43,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:46:9
    |
 LL |         None => 24,
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -57,7 +57,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:68:9
    |
 LL |         (None, Some(a)) => bar(a),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -71,7 +71,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:82:9
    |
 LL |         (None, Some(a)) if a == 42 => a,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -85,7 +85,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:87:9
    |
 LL |         (Some(a), ..) => bar(a),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -98,7 +98,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:121:9
    |
 LL |         (Ok(x), Some(_)) => println!("ok {}", x),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -111,7 +111,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:137:9
    |
 LL |         Ok(_) => println!("ok"),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -127,7 +127,7 @@ error: this match arm has an identical body to another arm
 LL | /         1 => {
 LL | |             empty!(0);
 LL | |         },
-   | |_________^
+   | |__________^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -143,7 +143,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:215:9
    |
 LL |         Foo::X(0) => 1,
-   |         ^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -157,7 +157,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:225:9
    |
 LL |         Foo::Z(_) => 1,
-   |         ^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -170,7 +170,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:248:9
    |
 LL |         Some(Bar { y: 0, x: 5, .. }) => 1,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -184,7 +184,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:262:9
    |
 LL |         1 => cfg!(not_enable),
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -198,7 +198,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:278:17
    |
 LL |                 MaybeStaticStr::Borrowed(s) => s,
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm

--- a/src/tools/clippy/tests/ui/match_same_arms_non_exhaustive.stderr
+++ b/src/tools/clippy/tests/ui/match_same_arms_non_exhaustive.stderr
@@ -10,7 +10,7 @@ note: `_` wildcard arm here
   --> tests/ui/match_same_arms_non_exhaustive.rs:46:9
    |
 LL |         _ => repeat(),
-   |         ^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^
    = note: `-D clippy::match-same-arms` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::match_same_arms)]`
 
@@ -26,7 +26,7 @@ note: `_` wildcard arm here
   --> tests/ui/match_same_arms_non_exhaustive.rs:60:13
    |
 LL |             _ => repeat(),
-   |             ^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/asm/naked-functions.stderr
+++ b/tests/ui/asm/naked-functions.stderr
@@ -89,10 +89,10 @@ LL |     &b: &i32,
    |     ^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:29:6
+  --> $DIR/naked-functions.rs:29:5
    |
 LL |     (None | Some(_)): Option<std::ptr::NonNull<u8>>,
-   |      ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
   --> $DIR/naked-functions.rs:31:5

--- a/tests/ui/attributes/collapse-debuginfo-invalid.stderr
+++ b/tests/ui/attributes/collapse-debuginfo-invalid.stderr
@@ -76,7 +76,7 @@ LL |         #[collapse_debuginfo(yes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |         _ => (),
-   |         ------- not a macro definition
+   |         -------- not a macro definition
 
 error: `collapse_debuginfo` attribute should be applied to macro definitions
   --> $DIR/collapse-debuginfo-invalid.rs:40:1

--- a/tests/ui/closures/2229_closure_analysis/bad-pattern.stderr
+++ b/tests/ui/closures/2229_closure_analysis/bad-pattern.stderr
@@ -17,10 +17,10 @@ LL |         let _0 = v1;
    |             +
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/bad-pattern.rs:14:14
+  --> $DIR/bad-pattern.rs:14:13
    |
 LL |         let (0 | 1) = v1;
-   |              ^^^^^ pattern `2_u32..=u32::MAX` not covered
+   |             ^^^^^^^ pattern `2_u32..=u32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html

--- a/tests/ui/closures/2229_closure_analysis/match/issue-88331.stderr
+++ b/tests/ui/closures/2229_closure_analysis/match/issue-88331.stderr
@@ -13,7 +13,7 @@ LL | pub struct Opcode(pub u8);
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Opcode::OP1 => unimplemented!(),
-LL ~         Opcode(0_u8) | Opcode(2_u8..=u8::MAX) => todo!(),
+LL +         Opcode(0_u8) | Opcode(2_u8..=u8::MAX) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Opcode2(Opcode(0_u8))` and `Opcode2(Opcode(2_u8..=u8::MAX))` not covered
@@ -31,7 +31,7 @@ LL | pub struct Opcode2(Opcode);
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Opcode2::OP2=> unimplemented!(),
-LL ~         Opcode2(Opcode(0_u8)) | Opcode2(Opcode(2_u8..=u8::MAX)) => todo!(),
+LL +         Opcode2(Opcode(0_u8)) | Opcode2(Opcode(2_u8..=u8::MAX)) => todo!()
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/consts/const_in_pattern/incomplete-slice.stderr
+++ b/tests/ui/consts/const_in_pattern/incomplete-slice.stderr
@@ -19,7 +19,7 @@ LL |         E_SL_var => {}
    |             ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         E_SL => {},
+LL ~         E_SL => {}
 LL +         &[] | &[_, _, ..] => todo!()
    |
 

--- a/tests/ui/coverage-attr/allowed-positions.stderr
+++ b/tests/ui/coverage-attr/allowed-positions.stderr
@@ -82,7 +82,7 @@ error[E0788]: coverage attribute not allowed here
 LL |         #[coverage(off)]
    |         ^^^^^^^^^^^^^^^^
 LL |         () => (),
-   |         -------- not a function, impl block, or module
+   |         --------- not a function, impl block, or module
    |
    = help: coverage attribute can be applied to a function (with body), impl block, or module
 

--- a/tests/ui/error-codes/E0004.stderr
+++ b/tests/ui/error-codes/E0004.stderr
@@ -14,7 +14,7 @@ LL |     HastaLaVistaBaby,
    = note: the matched value is of type `Terminator`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Terminator::TalkToMyHand => {},
+LL ~         Terminator::TalkToMyHand => {}
 LL +         Terminator::HastaLaVistaBaby => todo!()
    |
 

--- a/tests/ui/feature-gates/feature-gate-never_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_patterns.stderr
@@ -135,11 +135,7 @@ error: a guard on a never pattern will never be run
 LL |         Err(!) if false,
    |                   ^^^^^
    |
-help: remove the match arm guard
-   |
-LL -         Err(!) if false,
-LL +         Err(!),
-   |
+   = help: remove the match arm guard
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-never_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_patterns.stderr
@@ -133,7 +133,13 @@ error: a guard on a never pattern will never be run
   --> $DIR/feature-gate-never_patterns.rs:54:19
    |
 LL |         Err(!) if false,
-   |                   ^^^^^ help: remove this guard
+   |                   ^^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         Err(!) if false,
+LL +         Err(!),
+   |
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
+++ b/tests/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
@@ -84,7 +84,7 @@ LL |         C,
    = note: the matched value is of type `Foo`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Foo::B => {},
+LL ~         Foo::B => {}
 LL +         Foo::C => todo!()
    |
 

--- a/tests/ui/feature-gates/feature-gate-precise_pointer_size_matching.stderr
+++ b/tests/ui/feature-gates/feature-gate-precise_pointer_size_matching.stderr
@@ -8,7 +8,7 @@ LL |     match 0usize {
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         0..=usize::MAX => {},
+LL ~         0..=usize::MAX => {}
 LL +         usize::MAX.. => todo!()
    |
 
@@ -22,7 +22,7 @@ LL |     match 0isize {
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         isize::MIN..=isize::MAX => {},
+LL ~         isize::MIN..=isize::MAX => {}
 LL +         ..isize::MIN | isize::MAX.. => todo!()
    |
 

--- a/tests/ui/force-inlining/invalid.stderr
+++ b/tests/ui/force-inlining/invalid.stderr
@@ -316,7 +316,7 @@ LL |         #[rustc_force_inline]
    |         ^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |         1 => (),
-   |         ------- not a function definition
+   |         -------- not a function definition
 
 error: attribute should be applied to a function
   --> $DIR/invalid.rs:98:5

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
@@ -5,10 +5,17 @@ LL |     m!(0f32, f32::NEG_INFINITY..);
    |        ^^^^ pattern `_` not covered
    |
    = note: the matched value is of type `f32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, _ => todo!() }
-   |                                ++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:15:8
@@ -17,10 +24,17 @@ LL |     m!(0f32, ..f32::INFINITY);
    |        ^^^^ pattern `_` not covered
    |
    = note: the matched value is of type `f32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, _ => todo!() }
-   |                                ++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:24:8
@@ -29,10 +43,17 @@ LL |     m!('a', ..core::char::MAX);
    |        ^^^ pattern `'\u{10ffff}'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, '\u{10ffff}' => todo!() }
-   |                                +++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'\u{10fffe}'..='\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:25:8
@@ -41,10 +62,17 @@ LL |     m!('a', ..ALMOST_MAX);
    |        ^^^ pattern `'\u{10fffe}'..='\u{10ffff}'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, '\u{10fffe}'..='\u{10ffff}' => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'\0'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:26:8
@@ -53,10 +81,17 @@ LL |     m!('a', ALMOST_MIN..);
    |        ^^^ pattern `'\0'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, '\0' => todo!() }
-   |                                +++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:27:8
@@ -65,10 +100,17 @@ LL |     m!('a', ..=ALMOST_MAX);
    |        ^^^ pattern `'\u{10ffff}'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, '\u{10ffff}' => todo!() }
-   |                                +++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'b'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:28:8
@@ -77,10 +119,17 @@ LL |     m!('a', ..=VAL | VAL_2..);
    |        ^^^ pattern `'b'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 'b' => todo!() }
-   |                                ++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'b'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:29:8
@@ -89,10 +138,17 @@ LL |     m!('a', ..VAL_1 | VAL_2..);
    |        ^^^ pattern `'b'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 'b' => todo!() }
-   |                                ++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:39:12
@@ -101,10 +157,17 @@ LL |         m!(0, ..u8::MAX);
    |            ^ pattern `u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `254_u8..=u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:40:12
@@ -113,10 +176,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `254_u8..=u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 254_u8..=u8::MAX => todo!() }
-   |                                +++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:41:12
@@ -125,10 +195,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0_u8` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 0_u8 => todo!() }
-   |                                +++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:42:12
@@ -137,10 +214,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:43:12
@@ -149,10 +233,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_u8` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u8 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:44:12
@@ -161,10 +252,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_u8` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u8 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:52:12
@@ -173,10 +271,17 @@ LL |         m!(0, ..u16::MAX);
    |            ^ pattern `u16::MAX` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u16::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `65534_u16..=u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:53:12
@@ -185,10 +290,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `65534_u16..=u16::MAX` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 65534_u16..=u16::MAX => todo!() }
-   |                                +++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:54:12
@@ -197,10 +309,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0_u16` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 0_u16 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:55:12
@@ -209,10 +328,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `u16::MAX` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u16::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:56:12
@@ -221,10 +347,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_u16` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u16 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:57:12
@@ -233,10 +366,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_u16` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u16 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:65:12
@@ -245,10 +385,17 @@ LL |         m!(0, ..u32::MAX);
    |            ^ pattern `u32::MAX` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u32::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `4294967294_u32..=u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:66:12
@@ -257,10 +404,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `4294967294_u32..=u32::MAX` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 4294967294_u32..=u32::MAX => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:67:12
@@ -269,10 +423,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0_u32` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 0_u32 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:68:12
@@ -281,10 +442,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `u32::MAX` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u32::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:69:12
@@ -293,10 +461,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_u32` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u32 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:70:12
@@ -305,10 +480,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_u32` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u32 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:78:12
@@ -317,10 +499,17 @@ LL |         m!(0, ..u64::MAX);
    |            ^ pattern `u64::MAX` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u64::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `18446744073709551614_u64..=u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:79:12
@@ -329,10 +518,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `18446744073709551614_u64..=u64::MAX` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 18446744073709551614_u64..=u64::MAX => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:80:12
@@ -341,10 +537,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0_u64` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 0_u64 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:81:12
@@ -353,10 +556,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `u64::MAX` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u64::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:82:12
@@ -365,10 +575,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_u64` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u64 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:83:12
@@ -377,10 +594,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_u64` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u64 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:91:12
@@ -389,10 +613,17 @@ LL |         m!(0, ..u128::MAX);
    |            ^ pattern `u128::MAX` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u128::MAX => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `340282366920938463463374607431768211454_u128..` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:92:12
@@ -401,10 +632,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `340282366920938463463374607431768211454_u128..` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 340282366920938463463374607431768211454_u128.. => todo!() }
-   |                                +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:93:12
@@ -413,10 +651,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0_u128` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 0_u128 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:94:12
@@ -425,10 +670,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `u128::MAX` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u128::MAX => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:95:12
@@ -437,10 +689,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_u128` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u128 => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:96:12
@@ -449,10 +708,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_u128` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u128 => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:107:12
@@ -461,10 +727,17 @@ LL |         m!(0, ..i8::MAX);
    |            ^ pattern `i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `126_i8..=i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:108:12
@@ -473,10 +746,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `126_i8..=i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 126_i8..=i8::MAX => todo!() }
-   |                                +++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:109:12
@@ -485,10 +765,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `i8::MIN` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i8::MIN => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:110:12
@@ -497,10 +784,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:111:12
@@ -509,10 +803,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_i8` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i8 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:112:12
@@ -521,10 +822,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_i8` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i8 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:120:12
@@ -533,10 +841,17 @@ LL |         m!(0, ..i16::MAX);
    |            ^ pattern `i16::MAX` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i16::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `32766_i16..=i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:121:12
@@ -545,10 +860,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `32766_i16..=i16::MAX` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 32766_i16..=i16::MAX => todo!() }
-   |                                +++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i16::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:122:12
@@ -557,10 +879,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `i16::MIN` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i16::MIN => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:123:12
@@ -569,10 +898,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `i16::MAX` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i16::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:124:12
@@ -581,10 +917,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_i16` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i16 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:125:12
@@ -593,10 +936,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_i16` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i16 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:133:12
@@ -605,10 +955,17 @@ LL |         m!(0, ..i32::MAX);
    |            ^ pattern `i32::MAX` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i32::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `2147483646_i32..=i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:134:12
@@ -617,10 +974,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `2147483646_i32..=i32::MAX` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 2147483646_i32..=i32::MAX => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i32::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:135:12
@@ -629,10 +993,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `i32::MIN` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i32::MIN => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:136:12
@@ -641,10 +1012,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `i32::MAX` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i32::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:137:12
@@ -653,10 +1031,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_i32` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i32 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:138:12
@@ -665,10 +1050,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_i32` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i32 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:146:12
@@ -677,10 +1069,17 @@ LL |         m!(0, ..i64::MAX);
    |            ^ pattern `i64::MAX` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i64::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `9223372036854775806_i64..=i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:147:12
@@ -689,10 +1088,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `9223372036854775806_i64..=i64::MAX` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 9223372036854775806_i64..=i64::MAX => todo!() }
-   |                                +++++++++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i64::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:148:12
@@ -701,10 +1107,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `i64::MIN` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i64::MIN => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:149:12
@@ -713,10 +1126,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `i64::MAX` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i64::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:150:12
@@ -725,10 +1145,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_i64` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i64 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:151:12
@@ -737,10 +1164,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_i64` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i64 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:159:12
@@ -749,10 +1183,17 @@ LL |         m!(0, ..i128::MAX);
    |            ^ pattern `i128::MAX` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i128::MAX => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `170141183460469231731687303715884105726_i128..` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:160:12
@@ -761,10 +1202,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `170141183460469231731687303715884105726_i128..` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 170141183460469231731687303715884105726_i128.. => todo!() }
-   |                                +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i128::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:161:12
@@ -773,10 +1221,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `i128::MIN` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i128::MIN => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:162:12
@@ -785,10 +1240,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `i128::MAX` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i128::MAX => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:163:12
@@ -797,10 +1259,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_i128` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i128 => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:164:12
@@ -809,10 +1278,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_i128` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i128 => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error: aborting due to 68 previous errors
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.stderr
@@ -21,7 +21,7 @@ LL |     match x {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         74..=> {},
-LL ~         i32::MIN..=-1_i32 => todo!(),
+LL +         i32::MIN..=-1_i32 => todo!()
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/match/intended-binding-pattern-is-const.stderr
+++ b/tests/ui/match/intended-binding-pattern-is-const.stderr
@@ -19,8 +19,9 @@ LL |         x_var => {}
    |          ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL |         x => {}, i32::MIN..=3_i32 | 5_i32..=i32::MAX => todo!()
-   |                ++++++++++++++++++++++++++++++++++++++++++++++++
+LL ~         x => {}
+LL ~         i32::MIN..=3_i32 | 5_i32..=i32::MAX => todo!()
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/match/postfix-match/pf-match-exhaustiveness.stderr
+++ b/tests/ui/match/postfix-match/pf-match-exhaustiveness.stderr
@@ -13,7 +13,7 @@ note: `Option<i32>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => {},
-LL ~         Some(_) => todo!(),
+LL +         Some(_) => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/match/validate-range-endpoints.stderr
+++ b/tests/ui/match/validate-range-endpoints.stderr
@@ -61,7 +61,7 @@ LL |     match 0i8 {
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         -10000..=0 => {},
+LL ~         -10000..=0 => {}
 LL +         i8::MIN..=-17_i8 | 1_i8..=i8::MAX => todo!()
    |
 
@@ -74,7 +74,7 @@ LL |     match 0i8 {
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         -10000.. => {},
+LL ~         -10000.. => {}
 LL +         i8::MIN..=-17_i8 => todo!()
    |
 

--- a/tests/ui/never_type/unused_trait_in_never_pattern_body.stderr
+++ b/tests/ui/never_type/unused_trait_in_never_pattern_body.stderr
@@ -18,10 +18,18 @@ LL | |
 LL | |             use std::ops::Add;
 LL | |             0.add(1)
 LL | |         },
-   | |         ^
-   | |         |
-   | |_________this will never be executed
-   |           help: remove this expression
+   | |_________^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         ! => || {
+LL -
+LL -
+LL -             use std::ops::Add;
+LL -             0.add(1)
+LL -         },
+LL +         !,
+   |
 
 error: mismatched types
   --> $DIR/unused_trait_in_never_pattern_body.rs:3:9

--- a/tests/ui/never_type/unused_trait_in_never_pattern_body.stderr
+++ b/tests/ui/never_type/unused_trait_in_never_pattern_body.stderr
@@ -20,16 +20,7 @@ LL | |             0.add(1)
 LL | |         },
    | |_________^ this will never be executed
    |
-help: remove the match arm expression
-   |
-LL -         ! => || {
-LL -
-LL -
-LL -             use std::ops::Add;
-LL -             0.add(1)
-LL -         },
-LL +         !,
-   |
+   = help: remove the match arm expression
 
 error: mismatched types
   --> $DIR/unused_trait_in_never_pattern_body.rs:3:9

--- a/tests/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
+++ b/tests/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
@@ -7,7 +7,7 @@ LL |     match (0u8, 0u8) {
    = note: the matched value is of type `(u8, u8)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         (0 | 1, 2 | 3) => {},
+LL ~         (0 | 1, 2 | 3) => {}
 LL +         (2_u8..=u8::MAX, _) => todo!()
    |
 
@@ -20,7 +20,7 @@ LL |     match ((0u8,),) {
    = note: the matched value is of type `((u8,),)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         ((0 | 1,) | (2 | 3,),) => {},
+LL ~         ((0 | 1,) | (2 | 3,),) => {}
 LL +         ((4_u8..=u8::MAX)) => todo!()
    |
 
@@ -33,7 +33,7 @@ LL |     match (Some(0u8),) {
    = note: the matched value is of type `(Option<u8>,)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         (None | Some(0 | 1),) => {},
+LL ~         (None | Some(0 | 1),) => {}
 LL +         (Some(2_u8..=u8::MAX)) => todo!()
    |
 

--- a/tests/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
+++ b/tests/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
@@ -1,8 +1,8 @@
 error[E0005]: refutable pattern in local binding
-  --> $DIR/issue-69875-should-have-been-expanded-earlier-non-exhaustive.rs:2:10
+  --> $DIR/issue-69875-should-have-been-expanded-earlier-non-exhaustive.rs:2:9
    |
 LL |     let (0 | (1 | 2)) = 0;
-   |          ^^^^^^^^^^^ patterns `i32::MIN..=-1_i32` and `3_i32..=i32::MAX` not covered
+   |         ^^^^^^^^^^^^^ patterns `i32::MIN..=-1_i32` and `3_i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html

--- a/tests/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
+++ b/tests/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
@@ -21,7 +21,7 @@ LL |     match 0 {
    = note: the matched value is of type `i32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         0 | (1 | 2) => {},
+LL ~         0 | (1 | 2) => {}
 LL +         i32::MIN..=-1_i32 | 3_i32..=i32::MAX => todo!()
    |
 

--- a/tests/ui/or-patterns/missing-bindings.stderr
+++ b/tests/ui/or-patterns/missing-bindings.stderr
@@ -264,8 +264,9 @@ note: `Option<foo>` defined here
    = note: the matched value is of type `Option<foo>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL |         Some(alpha | beta) => {}, None => todo!()
-   |                                 +++++++++++++++++
+LL ~         Some(alpha | beta) => {}
+LL ~         None => todo!()
+   |
 
 error: aborting due to 29 previous errors
 

--- a/tests/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-and-ref.stderr
+++ b/tests/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-and-ref.stderr
@@ -10,18 +10,18 @@ error: cannot borrow value as mutable more than once at a time
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:33:9
    |
 LL |     let ref mut a @ (ref b @ ref mut c) = u(); // sub-in-sub
-   |         ^^^^^^^^^    -----   --------- value is mutably borrowed by `c` here
-   |         |            |
-   |         |            value is borrowed by `b` here
+   |         ^^^^^^^^^   ------   --------- value is mutably borrowed by `c` here
+   |         |           |
+   |         |           value is borrowed by `b` here
    |         value is mutably borrowed by `a` here
 
 error: cannot borrow value as mutable because it is also borrowed as immutable
-  --> $DIR/borrowck-pat-ref-mut-and-ref.rs:33:22
+  --> $DIR/borrowck-pat-ref-mut-and-ref.rs:33:21
    |
 LL |     let ref mut a @ (ref b @ ref mut c) = u(); // sub-in-sub
-   |                      ^^^^^   --------- value is mutably borrowed by `c` here
-   |                      |
-   |                      value is borrowed by `b` here
+   |                     ^^^^^^   --------- value is mutably borrowed by `c` here
+   |                     |
+   |                     value is borrowed by `b` here
 
 error: cannot borrow value as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:37:9

--- a/tests/ui/pattern/pattern-binding-disambiguation.stderr
+++ b/tests/ui/pattern/pattern-binding-disambiguation.stderr
@@ -77,8 +77,9 @@ LL |     BracedVariant{},
    = note: the matched value is of type `E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL |         UnitVariant => {}, E::TupleVariant | E::BracedVariant {  } => todo!() // OK, `UnitVariant` is a unit variant pattern
-   |                          ++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL ~         UnitVariant => {}
+LL ~         E::TupleVariant | E::BracedVariant {  } => todo!() // OK, `UnitVariant` is a unit variant pattern
+   |
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/pattern-binding-disambiguation.rs:51:9

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.classic2021.stderr
@@ -211,7 +211,7 @@ LL |     let [&mut &(mut x)] = &[&mut 0];
 help: consider removing `&` from the pattern
    |
 LL -     let [&mut &(mut x)] = &[&mut 0];
-LL +     let [&mut mut x)] = &[&mut 0];
+LL +     let [&mut (mut x)] = &[&mut 0];
    |
 
 error: aborting due to 14 previous errors

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.stable2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.stable2021.stderr
@@ -276,7 +276,7 @@ LL |     let [&mut &(mut x)] = &[&mut 0];
 help: consider removing `&` from the pattern
    |
 LL -     let [&mut &(mut x)] = &[&mut 0];
-LL +     let [&mut mut x)] = &[&mut 0];
+LL +     let [&mut (mut x)] = &[&mut 0];
    |
 
 error: aborting due to 21 previous errors

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2021.stderr
@@ -302,7 +302,7 @@ LL |     let [&mut &(mut x)] = &[&mut 0];
 help: consider removing `&` from the pattern
    |
 LL -     let [&mut &(mut x)] = &[&mut 0];
-LL +     let [&mut mut x)] = &[&mut 0];
+LL +     let [&mut (mut x)] = &[&mut 0];
    |
 
 error: aborting due to 21 previous errors

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2024.stderr
@@ -142,20 +142,20 @@ LL +     let &[&mut x] = &mut &mut [0];
    |
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/pattern-errors.rs:102:12
+  --> $DIR/pattern-errors.rs:102:11
    |
 LL |     let [&(mut x)] = &[&0];
-   |            ^^^^
+   |           ^^^^^
    |
    = note: see issue #123076 <https://github.com/rust-lang/rust/issues/123076> for more information
    = help: add `#![feature(mut_ref)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/pattern-errors.rs:107:12
+  --> $DIR/pattern-errors.rs:107:11
    |
 LL |     let [&(mut x)] = &mut [&0];
-   |            ^^^^
+   |           ^^^^^
    |
    = note: see issue #123076 <https://github.com/rust-lang/rust/issues/123076> for more information
    = help: add `#![feature(mut_ref)]` to the crate attributes to enable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.classic2021.stderr
@@ -107,7 +107,7 @@ LL |     let [&mut &(mut x)] = &mut [&0];
 help: consider removing `&` from the pattern
    |
 LL -     let [&mut &(mut x)] = &mut [&0];
-LL +     let [&mut mut x)] = &mut [&0];
+LL +     let [&mut (mut x)] = &mut [&0];
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.structural2021.stderr
@@ -107,7 +107,7 @@ LL |     let [&mut &(mut x)] = &mut [&0];
 help: consider removing `&` from the pattern
    |
 LL -     let [&mut &(mut x)] = &mut [&0];
-LL +     let [&mut mut x)] = &mut [&0];
+LL +     let [&mut (mut x)] = &mut [&0];
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable

--- a/tests/ui/pattern/suggest-adding-appropriate-missing-pattern-excluding-comments.fixed
+++ b/tests/ui/pattern/suggest-adding-appropriate-missing-pattern-excluding-comments.fixed
@@ -4,7 +4,7 @@ fn main() {
     match Some(1) { //~ ERROR non-exhaustive patterns: `None` not covered
         Some(1) => {}
         // hello
-        Some(_) => {},
+        Some(_) => {}
         None => todo!()
     }
 }

--- a/tests/ui/pattern/suggest-adding-appropriate-missing-pattern-excluding-comments.stderr
+++ b/tests/ui/pattern/suggest-adding-appropriate-missing-pattern-excluding-comments.stderr
@@ -12,7 +12,7 @@ note: `Option<i32>` defined here
    = note: the matched value is of type `Option<i32>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Some(_) => {},
+LL ~         Some(_) => {}
 LL +         None => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/doc-hidden-non-exhaustive.stderr
+++ b/tests/ui/pattern/usefulness/doc-hidden-non-exhaustive.stderr
@@ -12,7 +12,7 @@ LL | pub enum HiddenEnum {
    = note: the matched value is of type `HiddenEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         HiddenEnum::B => {},
+LL ~         HiddenEnum::B => {}
 LL +         _ => todo!()
    |
 
@@ -33,7 +33,7 @@ LL |     B,
    = note: the matched value is of type `HiddenEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         HiddenEnum::C => {},
+LL ~         HiddenEnum::C => {}
 LL +         HiddenEnum::B => todo!()
    |
 
@@ -54,7 +54,7 @@ LL |     B,
    = note: the matched value is of type `HiddenEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         HiddenEnum::A => {},
+LL ~         HiddenEnum::A => {}
 LL +         HiddenEnum::B | _ => todo!()
    |
 
@@ -72,7 +72,7 @@ note: `Option<HiddenEnum>` defined here
    = note: the matched value is of type `Option<HiddenEnum>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         Some(HiddenEnum::A) => {},
+LL ~         Some(HiddenEnum::A) => {}
 LL +         Some(HiddenEnum::B) | Some(_) => todo!()
    |
 
@@ -93,7 +93,7 @@ LL |     C,
    = note: the matched value is of type `InCrate`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         InCrate::B => {},
+LL ~         InCrate::B => {}
 LL +         InCrate::C => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
@@ -72,7 +72,7 @@ LL |     match 0u8 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         _ if false => {},
+LL ~         _ if false => {}
 LL +         0_u8..=u8::MAX => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
@@ -72,7 +72,7 @@ LL |     match 0u8 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         _ if false => {},
+LL ~         _ if false => {}
 LL +         0_u8..=u8::MAX => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/empty-match.rs:47:20
+  --> $DIR/empty-match.rs:53:20
    |
 LL |     match_no_arms!(0u8);
    |                    ^^^
@@ -8,7 +8,7 @@ LL |     match_no_arms!(0u8);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `i8` is non-empty
-  --> $DIR/empty-match.rs:48:20
+  --> $DIR/empty-match.rs:54:20
    |
 LL |     match_no_arms!(0i8);
    |                    ^^^
@@ -17,7 +17,7 @@ LL |     match_no_arms!(0i8);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `usize` is non-empty
-  --> $DIR/empty-match.rs:49:20
+  --> $DIR/empty-match.rs:55:20
    |
 LL |     match_no_arms!(0usize);
    |                    ^^^^^^
@@ -26,7 +26,7 @@ LL |     match_no_arms!(0usize);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `isize` is non-empty
-  --> $DIR/empty-match.rs:50:20
+  --> $DIR/empty-match.rs:56:20
    |
 LL |     match_no_arms!(0isize);
    |                    ^^^^^^
@@ -35,13 +35,13 @@ LL |     match_no_arms!(0isize);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct1` is non-empty
-  --> $DIR/empty-match.rs:51:20
+  --> $DIR/empty-match.rs:57:20
    |
 LL |     match_no_arms!(NonEmptyStruct1);
    |                    ^^^^^^^^^^^^^^^
    |
 note: `NonEmptyStruct1` defined here
-  --> $DIR/empty-match.rs:22:12
+  --> $DIR/empty-match.rs:28:12
    |
 LL |     struct NonEmptyStruct1;
    |            ^^^^^^^^^^^^^^^
@@ -49,13 +49,13 @@ LL |     struct NonEmptyStruct1;
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct2` is non-empty
-  --> $DIR/empty-match.rs:52:20
+  --> $DIR/empty-match.rs:58:20
    |
 LL |     match_no_arms!(NonEmptyStruct2(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyStruct2` defined here
-  --> $DIR/empty-match.rs:23:12
+  --> $DIR/empty-match.rs:29:12
    |
 LL |     struct NonEmptyStruct2(bool);
    |            ^^^^^^^^^^^^^^^
@@ -63,13 +63,13 @@ LL |     struct NonEmptyStruct2(bool);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/empty-match.rs:53:20
+  --> $DIR/empty-match.rs:59:20
    |
 LL |     match_no_arms!((NonEmptyUnion1 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyUnion1` defined here
-  --> $DIR/empty-match.rs:24:11
+  --> $DIR/empty-match.rs:30:11
    |
 LL |     union NonEmptyUnion1 {
    |           ^^^^^^^^^^^^^^
@@ -77,13 +77,13 @@ LL |     union NonEmptyUnion1 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/empty-match.rs:54:20
+  --> $DIR/empty-match.rs:60:20
    |
 LL |     match_no_arms!((NonEmptyUnion2 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyUnion2` defined here
-  --> $DIR/empty-match.rs:27:11
+  --> $DIR/empty-match.rs:33:11
    |
 LL |     union NonEmptyUnion2 {
    |           ^^^^^^^^^^^^^^
@@ -91,29 +91,39 @@ LL |     union NonEmptyUnion2 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:55:20
+  --> $DIR/empty-match.rs:61:20
    |
 LL |     match_no_arms!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:31:10
+  --> $DIR/empty-match.rs:37:10
    |
 LL |     enum NonEmptyEnum1 {
    |          ^^^^^^^^^^^^^
 LL |         Foo(bool),
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:56:20
+  --> $DIR/empty-match.rs:62:20
    |
 LL |     match_no_arms!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:34:10
+  --> $DIR/empty-match.rs:40:10
    |
 LL |     enum NonEmptyEnum2 {
    |          ^^^^^^^^^^^^^
@@ -122,16 +132,26 @@ LL |         Foo(bool),
 LL |         Bar,
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:57:20
+  --> $DIR/empty-match.rs:63:20
    |
 LL |     match_no_arms!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:38:10
+  --> $DIR/empty-match.rs:44:10
    |
 LL |     enum NonEmptyEnum5 {
    |          ^^^^^^^^^^^^^
@@ -146,10 +166,20 @@ LL |         V4,
 LL |         V5,
    |         -- not covered
    = note: the matched value is of type `NonEmptyEnum5`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
-  --> $DIR/empty-match.rs:58:20
+  --> $DIR/empty-match.rs:64:20
    |
 LL |     match_no_arms!(array0_of_empty);
    |                    ^^^^^^^^^^^^^^^
@@ -158,7 +188,7 @@ LL |     match_no_arms!(array0_of_empty);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `[!; N]` is non-empty
-  --> $DIR/empty-match.rs:59:20
+  --> $DIR/empty-match.rs:65:20
    |
 LL |     match_no_arms!(arrayN_of_empty);
    |                    ^^^^^^^^^^^^^^^
@@ -167,158 +197,239 @@ LL |     match_no_arms!(arrayN_of_empty);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: `0_u8..=u8::MAX` not covered
-  --> $DIR/empty-match.rs:61:24
+  --> $DIR/empty-match.rs:67:24
    |
 LL |     match_guarded_arm!(0u8);
    |                        ^^^ pattern `0_u8..=u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, 0_u8..=u8::MAX => todo!()
-   |                                 +++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=i8::MAX` not covered
-  --> $DIR/empty-match.rs:62:24
+  --> $DIR/empty-match.rs:68:24
    |
 LL |     match_guarded_arm!(0i8);
    |                        ^^^ pattern `i8::MIN..=i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, i8::MIN..=i8::MAX => todo!()
-   |                                 ++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_usize..` not covered
-  --> $DIR/empty-match.rs:63:24
+  --> $DIR/empty-match.rs:69:24
    |
 LL |     match_guarded_arm!(0usize);
    |                        ^^^^^^ pattern `0_usize..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, 0_usize.. => todo!()
-   |                                 ++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/empty-match.rs:64:24
+  --> $DIR/empty-match.rs:70:24
    |
 LL |     match_guarded_arm!(0isize);
    |                        ^^^^^^ pattern `_` not covered
    |
    = note: the matched value is of type `isize`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, _ => todo!()
-   |                                 ++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct1` not covered
-  --> $DIR/empty-match.rs:65:24
+  --> $DIR/empty-match.rs:71:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct1);
    |                        ^^^^^^^^^^^^^^^ pattern `NonEmptyStruct1` not covered
    |
 note: `NonEmptyStruct1` defined here
-  --> $DIR/empty-match.rs:22:12
+  --> $DIR/empty-match.rs:28:12
    |
 LL |     struct NonEmptyStruct1;
    |            ^^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyStruct1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyStruct1 => todo!()
-   |                                 ++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct2(_)` not covered
-  --> $DIR/empty-match.rs:66:24
+  --> $DIR/empty-match.rs:72:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct2(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyStruct2(_)` not covered
    |
 note: `NonEmptyStruct2` defined here
-  --> $DIR/empty-match.rs:23:12
+  --> $DIR/empty-match.rs:29:12
    |
 LL |     struct NonEmptyStruct2(bool);
    |            ^^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyStruct2`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyStruct2(_) => todo!()
-   |                                 +++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/empty-match.rs:67:24
+  --> $DIR/empty-match.rs:73:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion1 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion1 { .. }` not covered
    |
 note: `NonEmptyUnion1` defined here
-  --> $DIR/empty-match.rs:24:11
+  --> $DIR/empty-match.rs:30:11
    |
 LL |     union NonEmptyUnion1 {
    |           ^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyUnion1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyUnion1 { .. } => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/empty-match.rs:68:24
+  --> $DIR/empty-match.rs:74:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion2 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion2 { .. }` not covered
    |
 note: `NonEmptyUnion2` defined here
-  --> $DIR/empty-match.rs:27:11
+  --> $DIR/empty-match.rs:33:11
    |
 LL |     union NonEmptyUnion2 {
    |           ^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyUnion2`
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyUnion2 { .. } => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:69:24
+  --> $DIR/empty-match.rs:75:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum1::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:31:10
+  --> $DIR/empty-match.rs:37:10
    |
 LL |     enum NonEmptyEnum1 {
    |          ^^^^^^^^^^^^^
 LL |         Foo(bool),
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyEnum1::Foo(_) => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:70:24
+  --> $DIR/empty-match.rs:76:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum2::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:34:10
+  --> $DIR/empty-match.rs:40:10
    |
 LL |     enum NonEmptyEnum2 {
    |          ^^^^^^^^^^^^^
@@ -327,20 +438,29 @@ LL |         Foo(bool),
 LL |         Bar,
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
-   |                                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:71:24
+  --> $DIR/empty-match.rs:77:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum5::V1);
    |                        ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:38:10
+  --> $DIR/empty-match.rs:44:10
    |
 LL |     enum NonEmptyEnum5 {
    |          ^^^^^^^^^^^^^
@@ -355,38 +475,91 @@ LL |         V4,
 LL |         V5,
    |         -- not covered
    = note: the matched value is of type `NonEmptyEnum5`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, _ => todo!()
-   |                                 ++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-match.rs:72:24
+  --> $DIR/empty-match.rs:78:24
    |
 LL |     match_guarded_arm!(array0_of_empty);
    |                        ^^^^^^^^^^^^^^^ pattern `[]` not covered
    |
    = note: the matched value is of type `[!; 0]`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, [] => todo!()
-   |                                 +++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-match.rs:73:24
+  --> $DIR/empty-match.rs:79:24
    |
 LL |     match_guarded_arm!(arrayN_of_empty);
    |                        ^^^^^^^^^^^^^^^ pattern `[]` not covered
    |
    = note: the matched value is of type `[!; N]`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, [] => todo!()
-   |                                 +++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
-error: aborting due to 26 previous errors
+error[E0004]: non-exhaustive patterns: `[]` not covered
+  --> $DIR/empty-match.rs:81:15
+   |
+LL |     indirect!(arrayN_of_empty);
+   |               ^^^^^^^^^^^^^^^ pattern `[]` not covered
+   |
+   = note: the matched value is of type `[!; N]`
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
+   |
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+...
+LL |        indirect!(arrayN_of_empty);
+   |        -------------------------- in this macro invocation
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
+   = note: this error originates in the macro `indirect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 27 previous errors
 
 For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
@@ -176,9 +176,8 @@ LL |     match_guarded_arm!(0u8);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 0_u8..=u8::MAX => todo!()
-   |
+LL |                 _ if false => {}, 0_u8..=u8::MAX => todo!()
+   |                                 +++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=i8::MAX` not covered
   --> $DIR/empty-match.rs:62:24
@@ -190,9 +189,8 @@ LL |     match_guarded_arm!(0i8);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 i8::MIN..=i8::MAX => todo!()
-   |
+LL |                 _ if false => {}, i8::MIN..=i8::MAX => todo!()
+   |                                 ++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_usize..` not covered
   --> $DIR/empty-match.rs:63:24
@@ -204,9 +202,8 @@ LL |     match_guarded_arm!(0usize);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 0_usize.. => todo!()
-   |
+LL |                 _ if false => {}, 0_usize.. => todo!()
+   |                                 ++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/empty-match.rs:64:24
@@ -218,9 +215,8 @@ LL |     match_guarded_arm!(0isize);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 _ => todo!()
-   |
+LL |                 _ if false => {}, _ => todo!()
+   |                                 ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct1` not covered
   --> $DIR/empty-match.rs:65:24
@@ -237,9 +233,8 @@ LL |     struct NonEmptyStruct1;
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyStruct1 => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyStruct1 => todo!()
+   |                                 ++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct2(_)` not covered
   --> $DIR/empty-match.rs:66:24
@@ -256,9 +251,8 @@ LL |     struct NonEmptyStruct2(bool);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyStruct2(_) => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyStruct2(_) => todo!()
+   |                                 +++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
   --> $DIR/empty-match.rs:67:24
@@ -275,9 +269,8 @@ LL |     union NonEmptyUnion1 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyUnion1 { .. } => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyUnion1 { .. } => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
   --> $DIR/empty-match.rs:68:24
@@ -295,9 +288,8 @@ LL |     union NonEmptyUnion2 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyUnion2 { .. } => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyUnion2 { .. } => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
   --> $DIR/empty-match.rs:69:24
@@ -316,9 +308,8 @@ LL |         Foo(bool),
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyEnum1::Foo(_) => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyEnum1::Foo(_) => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
   --> $DIR/empty-match.rs:70:24
@@ -339,9 +330,8 @@ LL |         Bar,
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
+   |                                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
   --> $DIR/empty-match.rs:71:24
@@ -368,9 +358,8 @@ LL |         V5,
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~                 _ if false => {},
-LL +                 _ => todo!()
-   |
+LL |                 _ if false => {}, _ => todo!()
+   |                                 ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-match.rs:72:24
@@ -382,9 +371,8 @@ LL |     match_guarded_arm!(array0_of_empty);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 [] => todo!()
-   |
+LL |                 _ if false => {}, [] => todo!()
+   |                                 +++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-match.rs:73:24
@@ -396,9 +384,8 @@ LL |     match_guarded_arm!(arrayN_of_empty);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 [] => todo!()
-   |
+LL |                 _ if false => {}, [] => todo!()
+   |                                 +++++++++++++++
 
 error: aborting due to 26 previous errors
 

--- a/tests/ui/pattern/usefulness/empty-match.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.normal.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/empty-match.rs:47:20
+  --> $DIR/empty-match.rs:53:20
    |
 LL |     match_no_arms!(0u8);
    |                    ^^^
@@ -8,7 +8,7 @@ LL |     match_no_arms!(0u8);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `i8` is non-empty
-  --> $DIR/empty-match.rs:48:20
+  --> $DIR/empty-match.rs:54:20
    |
 LL |     match_no_arms!(0i8);
    |                    ^^^
@@ -17,7 +17,7 @@ LL |     match_no_arms!(0i8);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `usize` is non-empty
-  --> $DIR/empty-match.rs:49:20
+  --> $DIR/empty-match.rs:55:20
    |
 LL |     match_no_arms!(0usize);
    |                    ^^^^^^
@@ -26,7 +26,7 @@ LL |     match_no_arms!(0usize);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `isize` is non-empty
-  --> $DIR/empty-match.rs:50:20
+  --> $DIR/empty-match.rs:56:20
    |
 LL |     match_no_arms!(0isize);
    |                    ^^^^^^
@@ -35,13 +35,13 @@ LL |     match_no_arms!(0isize);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct1` is non-empty
-  --> $DIR/empty-match.rs:51:20
+  --> $DIR/empty-match.rs:57:20
    |
 LL |     match_no_arms!(NonEmptyStruct1);
    |                    ^^^^^^^^^^^^^^^
    |
 note: `NonEmptyStruct1` defined here
-  --> $DIR/empty-match.rs:22:12
+  --> $DIR/empty-match.rs:28:12
    |
 LL |     struct NonEmptyStruct1;
    |            ^^^^^^^^^^^^^^^
@@ -49,13 +49,13 @@ LL |     struct NonEmptyStruct1;
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct2` is non-empty
-  --> $DIR/empty-match.rs:52:20
+  --> $DIR/empty-match.rs:58:20
    |
 LL |     match_no_arms!(NonEmptyStruct2(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyStruct2` defined here
-  --> $DIR/empty-match.rs:23:12
+  --> $DIR/empty-match.rs:29:12
    |
 LL |     struct NonEmptyStruct2(bool);
    |            ^^^^^^^^^^^^^^^
@@ -63,13 +63,13 @@ LL |     struct NonEmptyStruct2(bool);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/empty-match.rs:53:20
+  --> $DIR/empty-match.rs:59:20
    |
 LL |     match_no_arms!((NonEmptyUnion1 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyUnion1` defined here
-  --> $DIR/empty-match.rs:24:11
+  --> $DIR/empty-match.rs:30:11
    |
 LL |     union NonEmptyUnion1 {
    |           ^^^^^^^^^^^^^^
@@ -77,13 +77,13 @@ LL |     union NonEmptyUnion1 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/empty-match.rs:54:20
+  --> $DIR/empty-match.rs:60:20
    |
 LL |     match_no_arms!((NonEmptyUnion2 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyUnion2` defined here
-  --> $DIR/empty-match.rs:27:11
+  --> $DIR/empty-match.rs:33:11
    |
 LL |     union NonEmptyUnion2 {
    |           ^^^^^^^^^^^^^^
@@ -91,29 +91,39 @@ LL |     union NonEmptyUnion2 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:55:20
+  --> $DIR/empty-match.rs:61:20
    |
 LL |     match_no_arms!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:31:10
+  --> $DIR/empty-match.rs:37:10
    |
 LL |     enum NonEmptyEnum1 {
    |          ^^^^^^^^^^^^^
 LL |         Foo(bool),
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:56:20
+  --> $DIR/empty-match.rs:62:20
    |
 LL |     match_no_arms!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:34:10
+  --> $DIR/empty-match.rs:40:10
    |
 LL |     enum NonEmptyEnum2 {
    |          ^^^^^^^^^^^^^
@@ -122,16 +132,26 @@ LL |         Foo(bool),
 LL |         Bar,
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:57:20
+  --> $DIR/empty-match.rs:63:20
    |
 LL |     match_no_arms!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:38:10
+  --> $DIR/empty-match.rs:44:10
    |
 LL |     enum NonEmptyEnum5 {
    |          ^^^^^^^^^^^^^
@@ -146,10 +166,20 @@ LL |         V4,
 LL |         V5,
    |         -- not covered
    = note: the matched value is of type `NonEmptyEnum5`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
-  --> $DIR/empty-match.rs:58:20
+  --> $DIR/empty-match.rs:64:20
    |
 LL |     match_no_arms!(array0_of_empty);
    |                    ^^^^^^^^^^^^^^^
@@ -158,7 +188,7 @@ LL |     match_no_arms!(array0_of_empty);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `[!; N]` is non-empty
-  --> $DIR/empty-match.rs:59:20
+  --> $DIR/empty-match.rs:65:20
    |
 LL |     match_no_arms!(arrayN_of_empty);
    |                    ^^^^^^^^^^^^^^^
@@ -167,158 +197,239 @@ LL |     match_no_arms!(arrayN_of_empty);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: `0_u8..=u8::MAX` not covered
-  --> $DIR/empty-match.rs:61:24
+  --> $DIR/empty-match.rs:67:24
    |
 LL |     match_guarded_arm!(0u8);
    |                        ^^^ pattern `0_u8..=u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, 0_u8..=u8::MAX => todo!()
-   |                                 +++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=i8::MAX` not covered
-  --> $DIR/empty-match.rs:62:24
+  --> $DIR/empty-match.rs:68:24
    |
 LL |     match_guarded_arm!(0i8);
    |                        ^^^ pattern `i8::MIN..=i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, i8::MIN..=i8::MAX => todo!()
-   |                                 ++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_usize..` not covered
-  --> $DIR/empty-match.rs:63:24
+  --> $DIR/empty-match.rs:69:24
    |
 LL |     match_guarded_arm!(0usize);
    |                        ^^^^^^ pattern `0_usize..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, 0_usize.. => todo!()
-   |                                 ++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/empty-match.rs:64:24
+  --> $DIR/empty-match.rs:70:24
    |
 LL |     match_guarded_arm!(0isize);
    |                        ^^^^^^ pattern `_` not covered
    |
    = note: the matched value is of type `isize`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, _ => todo!()
-   |                                 ++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct1` not covered
-  --> $DIR/empty-match.rs:65:24
+  --> $DIR/empty-match.rs:71:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct1);
    |                        ^^^^^^^^^^^^^^^ pattern `NonEmptyStruct1` not covered
    |
 note: `NonEmptyStruct1` defined here
-  --> $DIR/empty-match.rs:22:12
+  --> $DIR/empty-match.rs:28:12
    |
 LL |     struct NonEmptyStruct1;
    |            ^^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyStruct1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyStruct1 => todo!()
-   |                                 ++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct2(_)` not covered
-  --> $DIR/empty-match.rs:66:24
+  --> $DIR/empty-match.rs:72:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct2(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyStruct2(_)` not covered
    |
 note: `NonEmptyStruct2` defined here
-  --> $DIR/empty-match.rs:23:12
+  --> $DIR/empty-match.rs:29:12
    |
 LL |     struct NonEmptyStruct2(bool);
    |            ^^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyStruct2`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyStruct2(_) => todo!()
-   |                                 +++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/empty-match.rs:67:24
+  --> $DIR/empty-match.rs:73:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion1 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion1 { .. }` not covered
    |
 note: `NonEmptyUnion1` defined here
-  --> $DIR/empty-match.rs:24:11
+  --> $DIR/empty-match.rs:30:11
    |
 LL |     union NonEmptyUnion1 {
    |           ^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyUnion1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyUnion1 { .. } => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/empty-match.rs:68:24
+  --> $DIR/empty-match.rs:74:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion2 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion2 { .. }` not covered
    |
 note: `NonEmptyUnion2` defined here
-  --> $DIR/empty-match.rs:27:11
+  --> $DIR/empty-match.rs:33:11
    |
 LL |     union NonEmptyUnion2 {
    |           ^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyUnion2`
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyUnion2 { .. } => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:69:24
+  --> $DIR/empty-match.rs:75:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum1::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:31:10
+  --> $DIR/empty-match.rs:37:10
    |
 LL |     enum NonEmptyEnum1 {
    |          ^^^^^^^^^^^^^
 LL |         Foo(bool),
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyEnum1::Foo(_) => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:70:24
+  --> $DIR/empty-match.rs:76:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum2::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:34:10
+  --> $DIR/empty-match.rs:40:10
    |
 LL |     enum NonEmptyEnum2 {
    |          ^^^^^^^^^^^^^
@@ -327,20 +438,29 @@ LL |         Foo(bool),
 LL |         Bar,
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
-   |                                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:71:24
+  --> $DIR/empty-match.rs:77:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum5::V1);
    |                        ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:38:10
+  --> $DIR/empty-match.rs:44:10
    |
 LL |     enum NonEmptyEnum5 {
    |          ^^^^^^^^^^^^^
@@ -355,38 +475,91 @@ LL |         V4,
 LL |         V5,
    |         -- not covered
    = note: the matched value is of type `NonEmptyEnum5`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, _ => todo!()
-   |                                 ++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-match.rs:72:24
+  --> $DIR/empty-match.rs:78:24
    |
 LL |     match_guarded_arm!(array0_of_empty);
    |                        ^^^^^^^^^^^^^^^ pattern `[]` not covered
    |
    = note: the matched value is of type `[!; 0]`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, [] => todo!()
-   |                                 +++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-match.rs:73:24
+  --> $DIR/empty-match.rs:79:24
    |
 LL |     match_guarded_arm!(arrayN_of_empty);
    |                        ^^^^^^^^^^^^^^^ pattern `[]` not covered
    |
    = note: the matched value is of type `[!; N]`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, [] => todo!()
-   |                                 +++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
-error: aborting due to 26 previous errors
+error[E0004]: non-exhaustive patterns: `[]` not covered
+  --> $DIR/empty-match.rs:81:15
+   |
+LL |     indirect!(arrayN_of_empty);
+   |               ^^^^^^^^^^^^^^^ pattern `[]` not covered
+   |
+   = note: the matched value is of type `[!; N]`
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
+   |
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+...
+LL |        indirect!(arrayN_of_empty);
+   |        -------------------------- in this macro invocation
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
+   = note: this error originates in the macro `indirect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 27 previous errors
 
 For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/pattern/usefulness/empty-match.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.normal.stderr
@@ -176,9 +176,8 @@ LL |     match_guarded_arm!(0u8);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 0_u8..=u8::MAX => todo!()
-   |
+LL |                 _ if false => {}, 0_u8..=u8::MAX => todo!()
+   |                                 +++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=i8::MAX` not covered
   --> $DIR/empty-match.rs:62:24
@@ -190,9 +189,8 @@ LL |     match_guarded_arm!(0i8);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 i8::MIN..=i8::MAX => todo!()
-   |
+LL |                 _ if false => {}, i8::MIN..=i8::MAX => todo!()
+   |                                 ++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_usize..` not covered
   --> $DIR/empty-match.rs:63:24
@@ -204,9 +202,8 @@ LL |     match_guarded_arm!(0usize);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 0_usize.. => todo!()
-   |
+LL |                 _ if false => {}, 0_usize.. => todo!()
+   |                                 ++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/empty-match.rs:64:24
@@ -218,9 +215,8 @@ LL |     match_guarded_arm!(0isize);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 _ => todo!()
-   |
+LL |                 _ if false => {}, _ => todo!()
+   |                                 ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct1` not covered
   --> $DIR/empty-match.rs:65:24
@@ -237,9 +233,8 @@ LL |     struct NonEmptyStruct1;
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyStruct1 => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyStruct1 => todo!()
+   |                                 ++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct2(_)` not covered
   --> $DIR/empty-match.rs:66:24
@@ -256,9 +251,8 @@ LL |     struct NonEmptyStruct2(bool);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyStruct2(_) => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyStruct2(_) => todo!()
+   |                                 +++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
   --> $DIR/empty-match.rs:67:24
@@ -275,9 +269,8 @@ LL |     union NonEmptyUnion1 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyUnion1 { .. } => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyUnion1 { .. } => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
   --> $DIR/empty-match.rs:68:24
@@ -295,9 +288,8 @@ LL |     union NonEmptyUnion2 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyUnion2 { .. } => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyUnion2 { .. } => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
   --> $DIR/empty-match.rs:69:24
@@ -316,9 +308,8 @@ LL |         Foo(bool),
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyEnum1::Foo(_) => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyEnum1::Foo(_) => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
   --> $DIR/empty-match.rs:70:24
@@ -339,9 +330,8 @@ LL |         Bar,
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
+   |                                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
   --> $DIR/empty-match.rs:71:24
@@ -368,9 +358,8 @@ LL |         V5,
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~                 _ if false => {},
-LL +                 _ => todo!()
-   |
+LL |                 _ if false => {}, _ => todo!()
+   |                                 ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-match.rs:72:24
@@ -382,9 +371,8 @@ LL |     match_guarded_arm!(array0_of_empty);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 [] => todo!()
-   |
+LL |                 _ if false => {}, [] => todo!()
+   |                                 +++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-match.rs:73:24
@@ -396,9 +384,8 @@ LL |     match_guarded_arm!(arrayN_of_empty);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 [] => todo!()
-   |
+LL |                 _ if false => {}, [] => todo!()
+   |                                 +++++++++++++++
 
 error: aborting due to 26 previous errors
 

--- a/tests/ui/pattern/usefulness/empty-match.rs
+++ b/tests/ui/pattern/usefulness/empty-match.rs
@@ -19,6 +19,12 @@ fn nonempty<const N: usize>(arrayN_of_empty: [!; N]) {
         };
     }
 
+    macro_rules! indirect {
+        ($e:expr) => {
+            match_guarded_arm!($e)
+        };
+    }
+
     struct NonEmptyStruct1;
     struct NonEmptyStruct2(bool);
     union NonEmptyUnion1 {
@@ -71,6 +77,8 @@ fn nonempty<const N: usize>(arrayN_of_empty: [!; N]) {
     match_guarded_arm!(NonEmptyEnum5::V1); //~ ERROR `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
     match_guarded_arm!(array0_of_empty); //~ ERROR `[]` not covered
     match_guarded_arm!(arrayN_of_empty); //~ ERROR `[]` not covered
+
+    indirect!(arrayN_of_empty); //~ ERROR `[]` not covered
 }
 
 fn main() {}

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -139,7 +139,7 @@ note: `Result<u32, !>` defined here
    = note: the matched value is of type `Result<u32, !>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Err(_) => {},
+LL ~         Err(_) => {}
 LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
@@ -386,7 +386,7 @@ LL |     match slice_never {
    = note: the matched value is of type `&[!]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [_, _, _, ..] => {},
+LL ~         [_, _, _, ..] => {}
 LL +         &[] => todo!()
    |
 
@@ -400,7 +400,7 @@ LL |     match slice_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &[..] if false => {},
+LL ~         &[..] if false => {}
 LL +         &[] => todo!()
    |
 
@@ -483,7 +483,7 @@ LL |     match array_0_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [..] if false => {},
+LL ~         [..] if false => {}
 LL +         [] => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -93,7 +93,7 @@ note: `Result<u32, !>` defined here
    = note: the matched value is of type `Result<u32, !>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Err(_) => {},
+LL ~         Err(_) => {}
 LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
@@ -162,7 +162,7 @@ note: `Option<Void>` defined here
    = note: `Void` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~             None => {},
+LL ~             None => {}
 LL +             Some(!)
    |
 
@@ -334,7 +334,7 @@ LL |     match slice_never {
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [] => {},
+LL ~         [] => {}
 LL +         &[!, ..]
    |
 
@@ -347,7 +347,7 @@ LL |     match slice_never {
    = note: the matched value is of type `&[!]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         [_, _, _, ..] => {},
+LL ~         [_, _, _, ..] => {}
 LL +         &[] | &[!] | &[!, !] => todo!()
    |
 
@@ -361,7 +361,7 @@ LL |     match slice_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         &[..] if false => {},
+LL ~         &[..] if false => {}
 LL +         &[] | &[!, ..] => todo!()
    |
 
@@ -411,7 +411,7 @@ LL |     match array_0_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [..] if false => {},
+LL ~         [..] if false => {}
 LL +         [] => todo!()
    |
 
@@ -430,7 +430,7 @@ note: `Option<!>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &None => {},
+LL ~         &None => {}
 LL +         &Some(!)
    |
 
@@ -449,7 +449,7 @@ note: `Option<!>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(!)
    |
 
@@ -468,7 +468,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Ok(_) => {},
+LL ~         Ok(_) => {}
 LL +         Err(!)
    |
 
@@ -487,7 +487,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Ok(_a) => {},
+LL ~         Ok(_a) => {}
 LL +         Err(!)
    |
 
@@ -561,7 +561,7 @@ LL |     match ref_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &_a if false => {},
+LL ~         &_a if false => {}
 LL +         &!
    |
 
@@ -580,7 +580,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Err(_) => {},
+LL ~         Err(_) => {}
 LL +         Ok(!)
    |
 
@@ -599,7 +599,7 @@ note: `Option<Result<!, !>>` defined here
    = note: `Result<!, !>` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(!)
    |
 

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -84,7 +84,7 @@ note: `Result<u32, !>` defined here
    = note: the matched value is of type `Result<u32, !>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Err(_) => {},
+LL ~         Err(_) => {}
 LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
@@ -153,7 +153,7 @@ note: `Option<Void>` defined here
    = note: `Void` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~             None => {},
+LL ~             None => {}
 LL +             Some(_) => todo!()
    |
 
@@ -325,7 +325,7 @@ LL |     match slice_never {
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [] => {},
+LL ~         [] => {}
 LL +         &[_, ..] => todo!()
    |
 
@@ -338,7 +338,7 @@ LL |     match slice_never {
    = note: the matched value is of type `&[!]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         [_, _, _, ..] => {},
+LL ~         [_, _, _, ..] => {}
 LL +         &[] | &[_] | &[_, _] => todo!()
    |
 
@@ -352,7 +352,7 @@ LL |     match slice_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         &[..] if false => {},
+LL ~         &[..] if false => {}
 LL +         &[] | &[_, ..] => todo!()
    |
 
@@ -402,7 +402,7 @@ LL |     match array_0_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [..] if false => {},
+LL ~         [..] if false => {}
 LL +         [] => todo!()
    |
 
@@ -421,7 +421,7 @@ note: `Option<!>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &None => {},
+LL ~         &None => {}
 LL +         &Some(_) => todo!()
    |
 
@@ -440,7 +440,7 @@ note: `Option<!>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(_) => todo!()
    |
 
@@ -459,7 +459,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Ok(_) => {},
+LL ~         Ok(_) => {}
 LL +         Err(_) => todo!()
    |
 
@@ -478,7 +478,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Ok(_a) => {},
+LL ~         Ok(_a) => {}
 LL +         Err(_) => todo!()
    |
 
@@ -552,7 +552,7 @@ LL |     match ref_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &_a if false => {},
+LL ~         &_a if false => {}
 LL +         &_ => todo!()
    |
 
@@ -571,7 +571,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Err(_) => {},
+LL ~         Err(_) => {}
 LL +         Ok(_) => todo!()
    |
 
@@ -590,7 +590,7 @@ note: `Option<Result<!, !>>` defined here
    = note: `Result<!, !>` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(_) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/floats.stderr
+++ b/tests/ui/pattern/usefulness/floats.stderr
@@ -7,7 +7,7 @@ LL |     match 0.0 {
    = note: the matched value is of type `f64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         0.0..=1.0 => {},
+LL ~         0.0..=1.0 => {}
 LL +         _ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/guards.stderr
+++ b/tests/ui/pattern/usefulness/guards.stderr
@@ -7,7 +7,7 @@ LL |     match 0u8 {
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         128 ..= 255 if true => {},
+LL ~         128 ..= 255 if true => {}
 LL +         128_u8..=u8::MAX => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
@@ -5,10 +5,17 @@ LL |     m!(0u8, 0..255);
    |        ^^^ pattern `u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/exhaustiveness.rs:48:8
@@ -17,10 +24,17 @@ LL |     m!(0u8, 0..=254);
    |        ^^^ pattern `u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u8` not covered
   --> $DIR/exhaustiveness.rs:49:8
@@ -29,10 +43,17 @@ LL |     m!(0u8, 1..=255);
    |        ^^^ pattern `0_u8` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, 0_u8 => todo!() }
-   |                                +++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `42_u8` not covered
   --> $DIR/exhaustiveness.rs:50:8
@@ -41,10 +62,17 @@ LL |     m!(0u8, 0..42 | 43..=255);
    |        ^^^ pattern `42_u8` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, 42_u8 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/exhaustiveness.rs:51:8
@@ -53,10 +81,17 @@ LL |     m!(0i8, -128..127);
    |        ^^^ pattern `i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/exhaustiveness.rs:52:8
@@ -65,10 +100,17 @@ LL |     m!(0i8, -128..=126);
    |        ^^^ pattern `i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
   --> $DIR/exhaustiveness.rs:53:8
@@ -77,10 +119,17 @@ LL |     m!(0i8, -127..=127);
    |        ^^^ pattern `i8::MIN` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, i8::MIN => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_i8` not covered
   --> $DIR/exhaustiveness.rs:54:11
@@ -102,10 +151,17 @@ LL |     m!(0u128, 0..=ALMOST_MAX);
    |        ^^^^^ pattern `u128::MAX` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, u128::MAX => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `5_u128..` not covered
   --> $DIR/exhaustiveness.rs:60:8
@@ -114,10 +170,17 @@ LL |     m!(0u128, 0..=4);
    |        ^^^^^ pattern `5_u128..` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, 5_u128.. => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u128` not covered
   --> $DIR/exhaustiveness.rs:61:8
@@ -126,10 +189,17 @@ LL |     m!(0u128, 1..=u128::MAX);
    |        ^^^^^ pattern `0_u128` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, 0_u128 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `(126_u8..=127_u8, false)` not covered
   --> $DIR/exhaustiveness.rs:69:11

--- a/tests/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
@@ -91,7 +91,7 @@ LL |     match 0i8 {
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         1 ..= i8::MAX => {},
+LL ~         1 ..= i8::MAX => {}
 LL +         0_i8 => todo!()
    |
 
@@ -140,7 +140,7 @@ LL |     match (0u8, true) {
    = note: the matched value is of type `(u8, bool)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         (0 ..= 255, true) => {},
+LL ~         (0 ..= 255, true) => {}
 LL +         (126_u8..=127_u8, false) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
@@ -8,7 +8,7 @@ LL |     match 0usize {
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         0..=usize::MAX => {},
+LL ~         0..=usize::MAX => {}
 LL +         usize::MAX.. => todo!()
    |
 
@@ -22,7 +22,7 @@ LL |     match 0isize {
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         isize::MIN..=isize::MAX => {},
+LL ~         isize::MIN..=isize::MAX => {}
 LL +         ..isize::MIN | isize::MAX.. => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
@@ -34,10 +34,17 @@ LL |     m!(0usize, 0..=usize::MAX);
    |
    = note: the matched value is of type `usize`
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, usize::MAX.. => todo!() }
-   |                                +++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `usize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:24:8
@@ -47,10 +54,17 @@ LL |     m!(0usize, 0..5 | 5..=usize::MAX);
    |
    = note: the matched value is of type `usize`
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, usize::MAX.. => todo!() }
-   |                                +++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `usize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:26:8
@@ -60,10 +74,17 @@ LL |     m!(0usize, 0..usize::MAX | usize::MAX);
    |
    = note: the matched value is of type `usize`
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, usize::MAX.. => todo!() }
-   |                                +++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `(usize::MAX.., _)` not covered
   --> $DIR/pointer-sized-int.rs:28:8
@@ -73,10 +94,17 @@ LL |     m!((0usize, true), (0..5, true) | (5..=usize::MAX, true) | (0..=usize::
    |
    = note: the matched value is of type `(usize, bool)`
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, (usize::MAX.., _) => todo!() }
-   |                                ++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `..isize::MIN` and `isize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:37:8
@@ -86,10 +114,17 @@ LL |     m!(0isize, isize::MIN..=isize::MAX);
    |
    = note: the matched value is of type `isize`
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `..isize::MIN` and `isize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:39:8
@@ -99,10 +134,17 @@ LL |     m!(0isize, isize::MIN..5 | 5..=isize::MAX);
    |
    = note: the matched value is of type `isize`
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `..isize::MIN` and `isize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:41:8
@@ -112,10 +154,17 @@ LL |     m!(0isize, isize::MIN..=-1 | 0 | 1..=isize::MAX);
    |
    = note: the matched value is of type `isize`
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `..isize::MIN` and `isize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:43:8
@@ -125,10 +174,17 @@ LL |     m!(0isize, isize::MIN..isize::MAX | isize::MAX);
    |
    = note: the matched value is of type `isize`
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `(..isize::MIN, _)` and `(isize::MAX.., _)` not covered
   --> $DIR/pointer-sized-int.rs:46:9
@@ -138,10 +194,17 @@ LL |         (0isize, true),
    |
    = note: the matched value is of type `(isize, bool)`
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, (..isize::MIN, _) | (isize::MAX.., _) => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: type `usize` is non-empty
   --> $DIR/pointer-sized-int.rs:57:11

--- a/tests/ui/pattern/usefulness/integer-ranges/precise_pointer_matching-message.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/precise_pointer_matching-message.stderr
@@ -8,7 +8,7 @@ LL |     match 0usize {
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         0..=usize::MAX => {},
+LL ~         0..=usize::MAX => {}
 LL +         usize::MAX.. => todo!()
    |
 
@@ -22,7 +22,7 @@ LL |     match 0isize {
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         isize::MIN..=isize::MAX => {},
+LL ~         isize::MIN..=isize::MAX => {}
 LL +         ..isize::MIN | isize::MAX.. => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-105479-str-non-exhaustiveness.stderr
+++ b/tests/ui/pattern/usefulness/issue-105479-str-non-exhaustiveness.stderr
@@ -8,7 +8,7 @@ LL |     match (a, b) {
    = note: `&str` cannot be matched exhaustively, so a wildcard `_` is necessary
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         ("c", "d") => {},
+LL ~         ("c", "d") => {}
 LL +         (&_, _) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-15129.stderr
+++ b/tests/ui/pattern/usefulness/issue-15129.stderr
@@ -8,7 +8,7 @@ LL |     match (T::T1(()), V::V2(true)) {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         (T::T2(()), V::V2(b)) => (),
-LL ~         (T::T1(()), V::V2(_)) | (T::T2(()), V::V1(_)) => todo!(),
+LL +         (T::T1(()), V::V2(_)) | (T::T2(()), V::V1(_)) => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/issue-2111.stderr
+++ b/tests/ui/pattern/usefulness/issue-2111.stderr
@@ -7,7 +7,7 @@ LL |     match (a, b) {
    = note: the matched value is of type `(Option<usize>, Option<usize>)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         (Some(_), None) | (None, Some(_)) => {},
+LL ~         (Some(_), None) | (None, Some(_)) => {}
 LL +         (None, None) | (Some(_), Some(_)) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-30240.stderr
+++ b/tests/ui/pattern/usefulness/issue-30240.stderr
@@ -8,7 +8,7 @@ LL |     match "world" {
    = note: `&str` cannot be matched exhaustively, so a wildcard `_` is necessary
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         "hello" => {},
+LL ~         "hello" => {}
 LL +         &_ => todo!()
    |
 
@@ -22,7 +22,7 @@ LL |     match "world" {
    = note: `&str` cannot be matched exhaustively, so a wildcard `_` is necessary
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         "hello" => {},
+LL ~         "hello" => {}
 LL +         &_ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-35609.stderr
+++ b/tests/ui/pattern/usefulness/issue-35609.stderr
@@ -7,7 +7,7 @@ LL |     match (A, ()) {
    = note: the matched value is of type `(Enum, ())`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         (A, _) => {},
+LL ~         (A, _) => {}
 LL +         _ => todo!()
    |
 
@@ -20,7 +20,7 @@ LL |     match (A, A) {
    = note: the matched value is of type `(Enum, Enum)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         (_, A) => {},
+LL ~         (_, A) => {}
 LL +         _ => todo!()
    |
 
@@ -33,7 +33,7 @@ LL |     match ((A, ()), ()) {
    = note: the matched value is of type `((Enum, ()), ())`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         ((A, ()), _) => {},
+LL ~         ((A, ()), _) => {}
 LL +         _ => todo!()
    |
 
@@ -46,7 +46,7 @@ LL |     match ((A, ()), A) {
    = note: the matched value is of type `((Enum, ()), Enum)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         ((A, ()), _) => {},
+LL ~         ((A, ()), _) => {}
 LL +         _ => todo!()
    |
 
@@ -59,7 +59,7 @@ LL |     match ((A, ()), ()) {
    = note: the matched value is of type `((Enum, ()), ())`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         ((A, _), _) => {},
+LL ~         ((A, _), _) => {}
 LL +         _ => todo!()
    |
 
@@ -77,7 +77,7 @@ LL | struct S(Enum, ());
    = note: the matched value is of type `S`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         S(A, _) => {},
+LL ~         S(A, _) => {}
 LL +         _ => todo!()
    |
 
@@ -95,7 +95,7 @@ LL | struct Sd { x: Enum, y: () }
    = note: the matched value is of type `Sd`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         Sd { x: A, y: _ } => {},
+LL ~         Sd { x: A, y: _ } => {}
 LL +         _ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-3601.stderr
+++ b/tests/ui/pattern/usefulness/issue-3601.stderr
@@ -11,7 +11,7 @@ note: `Box<ElementKind>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~             box ElementKind::HTMLImageElement(ref d) if d.image.is_some() => true,
-LL ~             box ElementKind::HTMLImageElement(_) => todo!(),
+LL +             box ElementKind::HTMLImageElement(_) => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/issue-39362.stderr
+++ b/tests/ui/pattern/usefulness/issue-39362.stderr
@@ -15,7 +15,7 @@ LL |     Bar { bar: Bar, id: usize }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
 LL ~         Foo::Bar { bar: Bar::B, .. } => (),
-LL ~         _ => todo!(),
+LL +         _ => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/issue-40221.stderr
+++ b/tests/ui/pattern/usefulness/issue-40221.stderr
@@ -15,7 +15,7 @@ LL |     C(PC),
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         P::C(PC::Q) => (),
-LL ~         P::C(PC::QA) => todo!(),
+LL +         P::C(PC::QA) => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/issue-50900.stderr
+++ b/tests/ui/pattern/usefulness/issue-50900.stderr
@@ -12,7 +12,7 @@ LL | pub struct Tag(pub Context, pub u16);
    = note: the matched value is of type `Tag`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Tag::ExifIFDPointer => {},
+LL ~         Tag::ExifIFDPointer => {}
 LL +         Tag(Context::Exif, _) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-56379.stderr
+++ b/tests/ui/pattern/usefulness/issue-56379.stderr
@@ -18,7 +18,7 @@ LL |     C(bool),
    = note: the matched value is of type `Foo`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         Foo::C(true) => {},
+LL ~         Foo::C(true) => {}
 LL +         Foo::A(false) | Foo::B(false) | Foo::C(false) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-72377.stderr
+++ b/tests/ui/pattern/usefulness/issue-72377.stderr
@@ -8,7 +8,7 @@ LL |     match (x, y) {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
 LL ~         (X::A, Some(X::C)) | (X::C, Some(X::A)) => false,
-LL ~         _ => todo!(),
+LL +         _ => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
+++ b/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
@@ -54,7 +54,7 @@ note: `Option<usize>` defined here
    = note: the matched value is of type `Option<usize>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(_) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
+++ b/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
@@ -9,7 +9,7 @@ LL |     match 0 {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         1..=usize::MAX => (),
-LL ~         usize::MAX.. => todo!(),
+LL +         usize::MAX.. => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `(usize::MAX.., _)` not covered
@@ -23,7 +23,7 @@ LL |     match (0usize, 0usize) {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         (1..=usize::MAX, 1..=usize::MAX) => (),
-LL ~         (usize::MAX.., _) => todo!(),
+LL +         (usize::MAX.., _) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `(..isize::MIN, _)` and `(isize::MAX.., _)` not covered
@@ -37,7 +37,7 @@ LL |     match (0isize, 0usize) {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         (isize::MIN..=isize::MAX, 1..=usize::MAX) => (),
-LL ~         (..isize::MIN, _) | (isize::MAX.., _) => todo!(),
+LL +         (..isize::MIN, _) | (isize::MAX.., _) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
@@ -74,7 +74,7 @@ note: `Option<usize>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => (),
-LL ~         Some(usize::MAX..) => todo!(),
+LL +         Some(usize::MAX..) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Some(Some(Some(usize::MAX..)))` not covered
@@ -97,7 +97,7 @@ note: `Option<Option<Option<usize>>>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => (),
-LL ~         Some(Some(Some(usize::MAX..))) => todo!(),
+LL +         Some(Some(Some(usize::MAX..))) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `A { a: usize::MAX.. }` not covered
@@ -116,7 +116,7 @@ LL | struct A<T> {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         A { a: 1..=usize::MAX } => (),
-LL ~         A { a: usize::MAX.. } => todo!(),
+LL +         A { a: usize::MAX.. } => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `B(..isize::MIN, _)` and `B(isize::MAX.., _)` not covered
@@ -135,7 +135,7 @@ LL | struct B<T, U>(T, U);
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         B(isize::MIN..=isize::MAX, 1..=usize::MAX) => (),
-LL ~         B(..isize::MIN, _) | B(isize::MAX.., _) => todo!(),
+LL +         B(..isize::MIN, _) | B(isize::MAX.., _) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `B(_, usize::MAX..)` not covered
@@ -154,7 +154,7 @@ LL | struct B<T, U>(T, U);
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         B(_, 1..=usize::MAX) => (),
-LL ~         B(_, usize::MAX..) => todo!(),
+LL +         B(_, usize::MAX..) => todo!()
    |
 
 error: aborting due to 9 previous errors

--- a/tests/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
+++ b/tests/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
@@ -7,7 +7,7 @@ LL |     match buf {
    = note: the matched value is of type `&[u8; 4]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         b"AAAA" => {},
+LL ~         b"AAAA" => {}
 LL +         &[0_u8..=64_u8, _, _, _] | &[66_u8..=u8::MAX, _, _, _] => todo!()
    |
 
@@ -20,7 +20,7 @@ LL |     match buf {
    = note: the matched value is of type `&[u8]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         b"AAAA" => {},
+LL ~         b"AAAA" => {}
 LL +         _ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/match-privately-empty.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/match-privately-empty.exhaustive_patterns.stderr
@@ -12,7 +12,7 @@ note: `Option<Private>` defined here
    = note: the matched value is of type `Option<Private>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Some(private::Private { misc: false, .. }) => {},
+LL ~         Some(private::Private { misc: false, .. }) => {}
 LL +         Some(Private { misc: true, .. }) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/match-privately-empty.normal.stderr
+++ b/tests/ui/pattern/usefulness/match-privately-empty.normal.stderr
@@ -12,7 +12,7 @@ note: `Option<Private>` defined here
    = note: the matched value is of type `Option<Private>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Some(private::Private { misc: false, .. }) => {},
+LL ~         Some(private::Private { misc: false, .. }) => {}
 LL +         Some(Private { misc: true, .. }) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/match-slice-patterns.stderr
+++ b/tests/ui/pattern/usefulness/match-slice-patterns.stderr
@@ -8,7 +8,7 @@ LL |     match list {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &[.., Some(_), _] => {},
-LL ~         &[_, Some(_), .., None, _] => todo!(),
+LL +         &[_, Some(_), .., None, _] => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/nested-non-exhaustive-enums.stderr
+++ b/tests/ui/pattern/usefulness/nested-non-exhaustive-enums.stderr
@@ -13,7 +13,7 @@ note: `Option<NonExhaustiveEnum>` defined here
    = note: `NonExhaustiveEnum` is marked as non-exhaustive, so a wildcard `_` is necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(_) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
@@ -18,7 +18,7 @@ LL |     C
    = note: the matched value is of type `E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         E::A => {},
+LL ~         E::A => {}
 LL +         E::B | E::C => todo!()
    |
 
@@ -67,7 +67,7 @@ LL |     C
    = note: the matched value is of type `&E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         E::A => {},
+LL ~         E::A => {}
 LL +         &E::B | &E::C => todo!()
    |
 
@@ -116,7 +116,7 @@ LL |     C
    = note: the matched value is of type `&&mut &E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         E::A => {},
+LL ~         E::A => {}
 LL +         &&mut &E::B | &&mut &E::C => todo!()
    |
 
@@ -162,7 +162,7 @@ LL |     None,
    = note: the matched value is of type `Opt`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Opt::Some(ref _x) => {},
+LL ~         Opt::Some(ref _x) => {}
 LL +         Opt::None => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -12,8 +12,8 @@ LL | enum T { A, B }
    = note: the matched value is of type `T`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL |     match x { T::B => { }, T::A => todo!() }
-   |                          +++++++++++++++++
+LL |     match x { T::B => { } T::A => todo!() }
+   |                           +++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `false` not covered
   --> $DIR/non-exhaustive-match.rs:6:11
@@ -24,7 +24,7 @@ LL |     match true {
    = note: the matched value is of type `bool`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~       true => {},
+LL ~       true => {}
 LL +       false => todo!()
    |
 
@@ -42,7 +42,7 @@ note: `Option<i32>` defined here
    = note: the matched value is of type `Option<i32>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~       None => {},
+LL ~       None => {}
 LL +       Some(_) => todo!()
    |
 
@@ -55,7 +55,7 @@ LL |     match (2, 3, 4) {
    = note: the matched value is of type `(i32, i32, i32)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~       (_, _, 4) => {},
+LL ~       (_, _, 4) => {}
 LL +       (_, _, i32::MIN..=3_i32) | (_, _, 5_i32..=i32::MAX) => todo!()
    |
 
@@ -68,7 +68,7 @@ LL |     match (T::A, T::A) {
    = note: the matched value is of type `(T, T)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~       (T::B, T::A) => {},
+LL ~       (T::B, T::A) => {}
 LL +       (T::A, T::A) | (T::B, T::B) => todo!()
    |
 
@@ -86,7 +86,7 @@ LL | enum T { A, B }
    = note: the matched value is of type `T`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~       T::A => {},
+LL ~       T::A => {}
 LL +       T::B => todo!()
    |
 
@@ -99,7 +99,7 @@ LL |     match *vec {
    = note: the matched value is of type `[Option<isize>]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [None] => {},
+LL ~         [None] => {}
 LL +         [] => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
@@ -13,7 +13,7 @@ LL | struct Foo {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Foo { first: false, second: Some([1, 2, 3, 4]) } => (),
-LL ~         Foo { first: false, second: Some([0_usize, _, _, _]) } | Foo { first: false, second: Some([2_usize.., _, _, _]) } => todo!(),
+LL +         Foo { first: false, second: Some([0_usize, _, _, _]) } | Foo { first: false, second: Some([2_usize.., _, _, _]) } => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Color::Red` not covered
@@ -33,7 +33,7 @@ LL |     Red,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Color::Green => (),
-LL ~         Color::Red => todo!(),
+LL +         Color::Red => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Direction::East`, `Direction::South` and `Direction::West` not covered
@@ -58,7 +58,7 @@ LL |     West,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Direction::North => (),
-LL ~         Direction::East | Direction::South | Direction::West => todo!(),
+LL +         Direction::East | Direction::South | Direction::West => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `ExcessiveEnum::Second`, `ExcessiveEnum::Third`, `ExcessiveEnum::Fourth` and 8 more not covered
@@ -87,7 +87,7 @@ LL |     Sixth,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
 LL ~         ExcessiveEnum::First => (),
-LL ~         _ => todo!(),
+LL +         _ => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Color::CustomRGBA { a: true, .. }` not covered
@@ -108,7 +108,7 @@ LL |     CustomRGBA { a: bool, r: u8, g: u8, b: u8 },
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Color::CustomRGBA { a: false, r: _, g: _, b: _ } => (),
-LL ~         Color::CustomRGBA { a: true, .. } => todo!(),
+LL +         Color::CustomRGBA { a: true, .. } => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `[Enum::Second(true), Enum::Second(false)]` not covered
@@ -121,7 +121,7 @@ LL |     match *x {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         [_, _, ref tail @ .., _] => (),
-LL ~         [Enum::Second(true), Enum::Second(false)] => todo!(),
+LL +         [Enum::Second(true), Enum::Second(false)] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `((), false)` not covered
@@ -134,7 +134,7 @@ LL |     match ((), false) {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         ((), true) => (),
-LL ~         ((), false) => todo!(),
+LL +         ((), false) => todo!()
    |
 
 error: aborting due to 7 previous errors

--- a/tests/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
+++ b/tests/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
@@ -7,7 +7,7 @@ LL |     match s2 {
    = note: the matched value is of type `&[bool; 2]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [true, .., true] => {},
+LL ~         [true, .., true] => {}
 LL +         &[false, _] => todo!()
    |
 
@@ -20,7 +20,7 @@ LL |     match s3 {
    = note: the matched value is of type `&[bool; 3]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [true, .., true] => {},
+LL ~         [true, .., true] => {}
 LL +         &[false, ..] => todo!()
    |
 
@@ -33,7 +33,7 @@ LL |     match s10 {
    = note: the matched value is of type `&[bool; 10]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [true, .., true] => {},
+LL ~         [true, .., true] => {}
 LL +         &[false, ..] => todo!()
    |
 
@@ -46,7 +46,7 @@ LL |     match s2 {
    = note: the matched value is of type `&[bool; 2]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [.., false] => {},
+LL ~         [.., false] => {}
 LL +         &[false, true] => todo!()
    |
 
@@ -59,7 +59,7 @@ LL |     match s3 {
    = note: the matched value is of type `&[bool; 3]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [.., false] => {},
+LL ~         [.., false] => {}
 LL +         &[false, .., true] => todo!()
    |
 
@@ -72,7 +72,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [.., false] => {},
+LL ~         [.., false] => {}
 LL +         &[false, .., true] => todo!()
    |
 
@@ -85,7 +85,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [] => {},
+LL ~         [] => {}
 LL +         &[_, ..] => todo!()
    |
 
@@ -99,7 +99,7 @@ LL |     match s {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         [..] if false => {},
+LL ~         [..] if false => {}
 LL +         &[] | &[_, ..] => todo!()
    |
 
@@ -112,7 +112,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [_] => {},
+LL ~         [_] => {}
 LL +         &[_, _, ..] => todo!()
    |
 
@@ -125,7 +125,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [true, ..] => {},
+LL ~         [true, ..] => {}
 LL +         &[false, ..] => todo!()
    |
 
@@ -138,7 +138,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [true, ..] => {},
+LL ~         [true, ..] => {}
 LL +         &[false, _, ..] => todo!()
    |
 
@@ -151,7 +151,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [.., true] => {},
+LL ~         [.., true] => {}
 LL +         &[_, .., false] => todo!()
    |
 
@@ -164,7 +164,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [.., false] => {},
+LL ~         [.., false] => {}
 LL +         &[_, _, .., true] => todo!()
    |
 
@@ -177,7 +177,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [false, .., false] => {},
+LL ~         [false, .., false] => {}
 LL +         &[true, _, .., _] => todo!()
    |
 
@@ -190,7 +190,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         &[true] => {},
+LL ~         &[true] => {}
 LL +         &[] | &[_, _, ..] => todo!()
    |
 
@@ -215,7 +215,7 @@ LL |         CONST_var => {}
    |              ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         CONST => {},
+LL ~         CONST => {}
 LL +         &[] | &[_, _, ..] => todo!()
    |
 
@@ -240,7 +240,7 @@ LL |         CONST_var => {}
    |              ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         &[false] => {},
+LL ~         &[false] => {}
 LL +         &[] | &[_, _, ..] => todo!()
    |
 
@@ -265,7 +265,7 @@ LL |         CONST_var => {}
    |              ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         CONST => {},
+LL ~         CONST => {}
 LL +         &[] | &[_, _, ..] => todo!()
    |
 
@@ -290,7 +290,7 @@ LL |         CONST_var => {}
    |              ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         CONST => {},
+LL ~         CONST => {}
 LL +         &[_, _, ..] => todo!()
    |
 
@@ -315,7 +315,7 @@ LL |         CONST_var => {}
    |              ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &[_, _, ..] => {},
+LL ~         &[_, _, ..] => {}
 LL +         &[false] => todo!()
    |
 
@@ -340,7 +340,7 @@ LL |         CONST1_var => {}
    |               ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         CONST1 => {},
+LL ~         CONST1 => {}
 LL +         &[false] => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/slice_of_empty.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/slice_of_empty.exhaustive_patterns.stderr
@@ -8,7 +8,7 @@ LL |     match nevers {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &[_] => (),
-LL ~         &[] => todo!(),
+LL +         &[] => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/slice_of_empty.normal.stderr
+++ b/tests/ui/pattern/usefulness/slice_of_empty.normal.stderr
@@ -9,7 +9,7 @@ LL |     match nevers {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &[] => (),
-LL ~         &[_, ..] => todo!(),
+LL +         &[_, ..] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]` and `&[_, _, ..]` not covered
@@ -22,7 +22,7 @@ LL |     match nevers {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         &[_] => (),
-LL ~         &[] | &[_, _, ..] => todo!(),
+LL +         &[] | &[_, _, ..] => todo!()
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/pattern/usefulness/stable-gated-patterns.stderr
+++ b/tests/ui/pattern/usefulness/stable-gated-patterns.stderr
@@ -15,7 +15,7 @@ LL |     Stable2,
    = note: the matched value is of type `UnstableEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         UnstableEnum::Stable => {},
+LL ~         UnstableEnum::Stable => {}
 LL +         UnstableEnum::Stable2 | _ => todo!()
    |
 
@@ -33,7 +33,7 @@ LL | pub enum UnstableEnum {
    = note: the matched value is of type `UnstableEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         UnstableEnum::Stable2 => {},
+LL ~         UnstableEnum::Stable2 => {}
 LL +         _ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/struct-like-enum-nonexhaustive.stderr
+++ b/tests/ui/pattern/usefulness/struct-like-enum-nonexhaustive.stderr
@@ -14,7 +14,7 @@ LL |     B { x: Option<isize> },
    = note: the matched value is of type `A`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         A::B { x: None } => {},
+LL ~         A::B { x: None } => {}
 LL +         A::B { x: Some(_) } => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/type_polymorphic_byte_str_literals.stderr
+++ b/tests/ui/pattern/usefulness/type_polymorphic_byte_str_literals.stderr
@@ -8,7 +8,7 @@ LL |     match data {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         b"" => 1,
-LL ~         &[_, ..] => todo!(),
+LL +         &[_, ..] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]`, `&[_]`, `&[_, _]` and 1 more not covered
@@ -21,7 +21,7 @@ LL |     match data {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
 LL ~         [_, _, _] => 1,
-LL ~         _ => todo!(),
+LL +         _ => todo!()
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/pattern/usefulness/unions.stderr
+++ b/tests/ui/pattern/usefulness/unions.stderr
@@ -12,7 +12,7 @@ LL |     union U8AsBool {
    = note: the matched value is of type `U8AsBool`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~             U8AsBool { n: 1.. } => {},
+LL ~             U8AsBool { n: 1.. } => {}
 LL +             U8AsBool { n: 0_u8 } | U8AsBool { b: false } => todo!()
    |
 
@@ -25,7 +25,7 @@ LL |         match (x, true) {
    = note: the matched value is of type `(U8AsBool, bool)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~             (U8AsBool { n: 1.. }, true) => {},
+LL ~             (U8AsBool { n: 1.. }, true) => {}
 LL +             _ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/unstable-gated-patterns.stderr
+++ b/tests/ui/pattern/usefulness/unstable-gated-patterns.stderr
@@ -15,7 +15,7 @@ LL |     Unstable,
    = note: the matched value is of type `UnstableEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         UnstableEnum::Stable2 => {},
+LL ~         UnstableEnum::Stable2 => {}
 LL +         UnstableEnum::Unstable => todo!()
    |
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
@@ -24,14 +24,7 @@ error: a guard on a never pattern will never be run
 LL |             false
    |             ^^^^^
    |
-help: remove the match arm guard
-   |
-LL -         Some(!)
-LL -
-LL -             if #[deny(unused_mut)]
-LL -             false
-LL +         Some(!),
-   |
+   = help: remove the match arm guard
 
 error: mismatched types
   --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:5:14

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
@@ -22,7 +22,16 @@ error: a guard on a never pattern will never be run
   --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:8:13
    |
 LL |             false
-   |             ^^^^^ help: remove this guard
+   |             ^^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         Some(!)
+LL -
+LL -             if #[deny(unused_mut)]
+LL -             false
+LL +         Some(!),
+   |
 
 error: mismatched types
   --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:5:14

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block-fix.fixed
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block-fix.fixed
@@ -1,0 +1,13 @@
+//@ run-rustfix
+#![feature(never_patterns)]
+#![allow(incomplete_features, dead_code, unreachable_patterns)]
+
+enum Void {}
+
+fn foo(v: Void) {
+    match v {
+        ! , //~ ERROR: a never pattern is always unreachable
+    }
+}
+
+fn main() {}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block-fix.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block-fix.rs
@@ -1,0 +1,14 @@
+//@ run-rustfix
+#![feature(never_patterns)]
+#![allow(incomplete_features, dead_code, unreachable_patterns)]
+
+enum Void {}
+
+fn foo(v: Void) {
+    match v {
+        ! | //~ ERROR: a trailing `|` is not allowed in an or-pattern
+        if true => {} //~ ERROR: a never pattern is always unreachable
+    }
+}
+
+fn main() {}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block-fix.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block-fix.stderr
@@ -1,5 +1,5 @@
 error: a trailing `|` is not allowed in an or-pattern
-  --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:8:11
+  --> $DIR/ICE-130779-never-arm-no-oatherwise-block-fix.rs:9:11
    |
 LL |         ! |
    |         - ^
@@ -13,20 +13,12 @@ LL +         !
    |
 
 error: a never pattern is always unreachable
-  --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:10:20
+  --> $DIR/ICE-130779-never-arm-no-oatherwise-block-fix.rs:10:20
    |
 LL |         if true => {}
    |                    ^^ this will never be executed
    |
    = help: remove the match arm expression
 
-error: mismatched types
-  --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:8:9
-   |
-LL |         ! |
-   |         ^ a never pattern must be used on an uninhabited type
-   |
-   = note: the matched value is of type `E`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block.stderr
@@ -16,10 +16,15 @@ error: a never pattern is always unreachable
   --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:10:20
    |
 LL |         if true => {}
-   |                    ^^
-   |                    |
-   |                    this will never be executed
-   |                    help: remove this expression
+   |                    ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         ! |
+LL -
+LL -         if true => {}
+LL +         ! |,
+   |
 
 error: mismatched types
   --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:8:9

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.fixed
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.fixed
@@ -8,7 +8,7 @@ enum Void {}
 fn foo(x: Void) {
     loop {
         match x {
-            (!|!) if false => {} //~ ERROR a never pattern is always unreachable
+            (!|!), //~ ERROR a never pattern is always unreachable
             _ => {}
         }
     }

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
@@ -7,7 +7,7 @@ LL |             (!|!) if false => {}
 help: remove the match arm expression
    |
 LL -             (!|!) if false => {}
-LL +             (!|!,
+LL +             (!|!),
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
@@ -2,10 +2,13 @@ error: a never pattern is always unreachable
   --> $DIR/ICE-133063-never-arm-no-otherwise-block.rs:10:31
    |
 LL |             (!|!) if false => {}
-   |                               ^^
-   |                               |
-   |                               this will never be executed
-   |                               help: remove this expression
+   |                               ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -             (!|!) if false => {}
+LL +             (!|!,
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
@@ -1,14 +1,10 @@
 error: a never pattern is always unreachable
-  --> $DIR/ICE-133063-never-arm-no-otherwise-block.rs:10:31
+  --> $DIR/ICE-133063-never-arm-no-otherwise-block.rs:11:31
    |
 LL |             (!|!) if false => {}
    |                               ^^ this will never be executed
    |
-help: remove the match arm expression
-   |
-LL -             (!|!) if false => {}
-LL +             (!|!),
-   |
+   = help: remove the match arm expression
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.fixed
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.fixed
@@ -6,8 +6,8 @@ enum Void {}
 
 fn foo(x: Void) {
     match x {
-        (!|!) if true => {} //~ ERROR a never pattern is always unreachable
-        (!|!) if true => {} //~ ERROR a never pattern is always unreachable
+        (!|!), //~ ERROR a never pattern is always unreachable
+        (!|!), //~ ERROR a never pattern is always unreachable
     }
 }
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
@@ -7,7 +7,7 @@ LL |         (!|!) if true => {}
 help: remove the match arm expression
    |
 LL -         (!|!) if true => {}
-LL +         (!|!,
+LL +         (!|!),
    |
 
 error: a never pattern is always unreachable
@@ -19,7 +19,7 @@ LL |         (!|!) if true => {}
 help: remove the match arm expression
    |
 LL -         (!|!) if true => {}
-LL +         (!|!,
+LL +         (!|!),
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
@@ -4,11 +4,7 @@ error: a never pattern is always unreachable
 LL |         (!|!) if true => {}
    |                          ^^ this will never be executed
    |
-help: remove the match arm expression
-   |
-LL -         (!|!) if true => {}
-LL +         (!|!),
-   |
+   = help: remove the match arm expression
 
 error: a never pattern is always unreachable
   --> $DIR/ICE-133117-duplicate-never-arm.rs:10:26
@@ -16,11 +12,7 @@ error: a never pattern is always unreachable
 LL |         (!|!) if true => {}
    |                          ^^ this will never be executed
    |
-help: remove the match arm expression
-   |
-LL -         (!|!) if true => {}
-LL +         (!|!),
-   |
+   = help: remove the match arm expression
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
@@ -2,19 +2,25 @@ error: a never pattern is always unreachable
   --> $DIR/ICE-133117-duplicate-never-arm.rs:9:26
    |
 LL |         (!|!) if true => {}
-   |                          ^^
-   |                          |
-   |                          this will never be executed
-   |                          help: remove this expression
+   |                          ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         (!|!) if true => {}
+LL +         (!|!,
+   |
 
 error: a never pattern is always unreachable
   --> $DIR/ICE-133117-duplicate-never-arm.rs:10:26
    |
 LL |         (!|!) if true => {}
-   |                          ^^
-   |                          |
-   |                          this will never be executed
-   |                          help: remove this expression
+   |                          ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         (!|!) if true => {}
+LL +         (!|!,
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.fixed
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.fixed
@@ -13,22 +13,24 @@ macro_rules! never {
 
 fn no_arms_or_guards(x: Void) {
     match &None::<Void> {
-        Some(!) => {}
+        Some(!),
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }
     match &None::<Void> { //~ ERROR: `&Some(!)` not covered
-        Some(!) if true,
+        Some(!),
         //~^ ERROR guard on a never pattern
         None => {}
+        &Some(!)
     }
     match &None::<Void> { //~ ERROR: `&Some(!)` not covered
-        Some(!) if true => {}
+        Some(!),
         //~^ ERROR a never pattern is always unreachable
         None => {}
+        &Some(!)
     }
     match &None::<Void> {
-        Some(never!()) => {}
+        Some(never!()),
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
@@ -1,38 +1,53 @@
 error: a never pattern is always unreachable
-  --> $DIR/check.rs:15:20
+  --> $DIR/check.rs:16:20
    |
 LL |         Some(!) => {}
-   |                    ^^
-   |                    |
-   |                    this will never be executed
-   |                    help: remove this expression
+   |                    ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         Some(!) => {}
+LL +         Some(!),
+   |
 
 error: a guard on a never pattern will never be run
-  --> $DIR/check.rs:20:20
+  --> $DIR/check.rs:21:20
    |
 LL |         Some(!) if true,
-   |                    ^^^^ help: remove this guard
+   |                    ^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         Some(!) if true,
+LL +         Some(!),
+   |
 
 error: a never pattern is always unreachable
-  --> $DIR/check.rs:25:28
+  --> $DIR/check.rs:26:28
    |
 LL |         Some(!) if true => {}
-   |                            ^^
-   |                            |
-   |                            this will never be executed
-   |                            help: remove this expression
+   |                            ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         Some(!) if true => {}
+LL +         Some(!),
+   |
 
 error: a never pattern is always unreachable
-  --> $DIR/check.rs:30:27
+  --> $DIR/check.rs:31:27
    |
 LL |         Some(never!()) => {}
-   |                           ^^
-   |                           |
-   |                           this will never be executed
-   |                           help: remove this expression
+   |                           ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         Some(never!()) => {}
+LL +         Some(never!()),
+   |
 
 error[E0004]: non-exhaustive patterns: `&Some(!)` not covered
-  --> $DIR/check.rs:19:11
+  --> $DIR/check.rs:20:11
    |
 LL |     match &None::<Void> {
    |           ^^^^^^^^^^^^^ pattern `&Some(!)` not covered
@@ -51,7 +66,7 @@ LL +         &Some(!)
    |
 
 error[E0004]: non-exhaustive patterns: `&Some(!)` not covered
-  --> $DIR/check.rs:24:11
+  --> $DIR/check.rs:25:11
    |
 LL |     match &None::<Void> {
    |           ^^^^^^^^^^^^^ pattern `&Some(!)` not covered

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
@@ -46,7 +46,7 @@ note: `Option<Void>` defined here
    = note: `Void` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         &Some(!)
    |
 
@@ -65,7 +65,7 @@ note: `Option<Void>` defined here
    = note: `Void` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         &Some(!)
    |
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
@@ -4,11 +4,7 @@ error: a never pattern is always unreachable
 LL |         Some(!) => {}
    |                    ^^ this will never be executed
    |
-help: remove the match arm expression
-   |
-LL -         Some(!) => {}
-LL +         Some(!),
-   |
+   = help: remove the match arm expression
 
 error: a guard on a never pattern will never be run
   --> $DIR/check.rs:21:20
@@ -16,11 +12,7 @@ error: a guard on a never pattern will never be run
 LL |         Some(!) if true,
    |                    ^^^^
    |
-help: remove the match arm guard
-   |
-LL -         Some(!) if true,
-LL +         Some(!),
-   |
+   = help: remove the match arm guard
 
 error: a never pattern is always unreachable
   --> $DIR/check.rs:26:28
@@ -28,11 +20,7 @@ error: a never pattern is always unreachable
 LL |         Some(!) if true => {}
    |                            ^^ this will never be executed
    |
-help: remove the match arm expression
-   |
-LL -         Some(!) if true => {}
-LL +         Some(!),
-   |
+   = help: remove the match arm expression
 
 error: a never pattern is always unreachable
   --> $DIR/check.rs:31:27
@@ -40,11 +28,7 @@ error: a never pattern is always unreachable
 LL |         Some(never!()) => {}
    |                           ^^ this will never be executed
    |
-help: remove the match arm expression
-   |
-LL -         Some(never!()) => {}
-LL +         Some(never!()),
-   |
+   = help: remove the match arm expression
 
 error[E0004]: non-exhaustive patterns: `&Some(!)` not covered
   --> $DIR/check.rs:20:11

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
@@ -76,7 +76,7 @@ LL |         never!() if true,
 help: remove the match arm guard
    |
 LL -         never!() if true,
-LL +         never!() if ,,
+LL +         never!(),
    |
 
 error: aborting due to 8 previous errors

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
@@ -49,11 +49,7 @@ error: a guard on a never pattern will never be run
 LL |         Some(!) if true
    |                    ^^^^
    |
-help: remove the match arm guard
-   |
-LL -         Some(!) if true
-LL +         Some(!),
-   |
+   = help: remove the match arm guard
 
 error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:37:20
@@ -61,11 +57,7 @@ error: a guard on a never pattern will never be run
 LL |         Some(!) if true,
    |                    ^^^^
    |
-help: remove the match arm guard
-   |
-LL -         Some(!) if true,
-LL +         Some(!),
-   |
+   = help: remove the match arm guard
 
 error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:49:21
@@ -73,11 +65,7 @@ error: a guard on a never pattern will never be run
 LL |         never!() if true,
    |                     ^^^^
    |
-help: remove the match arm guard
-   |
-LL -         never!() if true,
-LL +         never!(),
-   |
+   = help: remove the match arm guard
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
@@ -47,19 +47,37 @@ error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:31:20
    |
 LL |         Some(!) if true
-   |                    ^^^^ help: remove this guard
+   |                    ^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         Some(!) if true
+LL +         Some(!),
+   |
 
 error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:37:20
    |
 LL |         Some(!) if true,
-   |                    ^^^^ help: remove this guard
+   |                    ^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         Some(!) if true,
+LL +         Some(!),
+   |
 
 error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:49:21
    |
 LL |         never!() if true,
-   |                     ^^^^ help: remove this guard
+   |                     ^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         never!() if true,
+LL +         never!() if ,,
+   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/pattern-behind-macro.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/pattern-behind-macro.rs
@@ -1,0 +1,16 @@
+#![feature(never_patterns, never_type)]
+#![allow(incomplete_features)]
+
+enum Void {}
+fn main() {}
+
+macro_rules! never {
+    () => { ! }
+}
+
+fn no_arms_or_guards(x: Void) {
+    match x {
+        never!() => {}
+        //~^ ERROR a never pattern is always unreachable
+    }
+}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/pattern-behind-macro.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/pattern-behind-macro.stderr
@@ -4,11 +4,7 @@ error: a never pattern is always unreachable
 LL |         never!() => {}
    |                     ^^ this will never be executed
    |
-help: remove the match arm expression
-   |
-LL -         never!() => {}
-LL +         never!(),
-   |
+   = help: remove the match arm expression
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/pattern-behind-macro.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/pattern-behind-macro.stderr
@@ -1,0 +1,14 @@
+error: a never pattern is always unreachable
+  --> $DIR/pattern-behind-macro.rs:13:21
+   |
+LL |         never!() => {}
+   |                     ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         never!() => {}
+LL +         never!(),
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/slice.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/slice.stderr
@@ -8,7 +8,7 @@ LL |     match sl {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         [first, remainder @ ..] => {},
-LL ~         &[] => todo!(),
+LL +         &[] => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/exhaustive.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/exhaustive.stderr
@@ -12,7 +12,7 @@ note: `Option<u32>` defined here
    = note: the matched value is of type `Option<u32>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None if let y = x => {},
+LL ~         None if let y = x => {}
 LL +         None => todo!()
    |
 
@@ -26,7 +26,7 @@ LL |     match x {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         y if let z = y => {},
+LL ~         y if let z = y => {}
 LL +         () => todo!()
    |
 

--- a/tests/ui/thir-print/thir-tree-match.stdout
+++ b/tests/ui/thir-print/thir-tree-match.stdout
@@ -142,7 +142,7 @@ body:
                                                                             }
                                                                         lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).14))
                                                                         scope: Node(14)
-                                                                        span: $DIR/thir-tree-match.rs:17:9: 17:40 (#0)
+                                                                        span: $DIR/thir-tree-match.rs:17:9: 17:41 (#0)
                                                                     }
                                                                     Arm {
                                                                         pattern: 
@@ -194,7 +194,7 @@ body:
                                                                             }
                                                                         lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).20))
                                                                         scope: Node(20)
-                                                                        span: $DIR/thir-tree-match.rs:18:9: 18:32 (#0)
+                                                                        span: $DIR/thir-tree-match.rs:18:9: 18:33 (#0)
                                                                     }
                                                                     Arm {
                                                                         pattern: 
@@ -238,7 +238,7 @@ body:
                                                                             }
                                                                         lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).26))
                                                                         scope: Node(26)
-                                                                        span: $DIR/thir-tree-match.rs:19:9: 19:28 (#0)
+                                                                        span: $DIR/thir-tree-match.rs:19:9: 19:29 (#0)
                                                                     }
                                                                 ]
                                                             }

--- a/tests/ui/uninhabited/uninhabited-matches-feature-gated.stderr
+++ b/tests/ui/uninhabited/uninhabited-matches-feature-gated.stderr
@@ -13,7 +13,7 @@ note: `Result<u32, &Void>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Ok(n) => n,
-LL ~         Err(_) => todo!(),
+LL +         Err(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `&Void` is non-empty
@@ -47,7 +47,7 @@ LL |     let _ = match x {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &[] => (),
-LL ~         &[_, ..] => todo!(),
+LL +         &[_, ..] => todo!()
    |
 
 error: aborting due to 3 previous errors

--- a/tests/ui/unsafe/issue-115348-false-positive-warning-of-unnecessary-unsafe.stderr
+++ b/tests/ui/unsafe/issue-115348-false-positive-warning-of-unnecessary-unsafe.stderr
@@ -13,7 +13,7 @@ note: `Option<u32>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Some(_) => unsafe { uwu() },
-LL ~         None => todo!(),
+LL +         None => todo!()
    |
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
Better track trailing commas in match arms. Do not suggest adding trailing comma to match arm with block body. Better heuristic for "is this match in one line".

When encountering an unreachable match arm, (correctly) suggest removing the entire arm:

```
error: a never pattern is always unreachable
  --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:10:20
   |
LL |         ! if true => {}
   |                      ^^ this will never be executed
   |
help: remove the unreachable match arm
   |
LL -         ! if true => {}
   |
```

Noticed in https://github.com/rust-lang/rust/pull/137343#discussion_r1964304010.

r? @compiler-errors

The first commit is independent of the second, but to make the second one produce accurate suggestions the span needs to include the trailing comma, hence the grouping of both changes in this PR.