### PR TITLE
Improve a bit HIR pretty printer

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -424,20 +424,23 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
         self.ann_post(ident)
     }
 
-    fn strsep<T, F>(
+    fn strsep<'x, T: 'x, F, I>(
         &mut self,
         sep: &'static str,
         space_before: bool,
         b: Breaks,
-        elts: &[T],
+        elts: I,
         mut op: F,
     ) where
         F: FnMut(&mut Self, &T),
+        I: IntoIterator<Item = &'x T>,
     {
+        let mut it = elts.into_iter();
+
         self.rbox(0, b);
-        if let Some((first, rest)) = elts.split_first() {
+        if let Some(first) = it.next() {
             op(self, first);
-            for elt in rest {
+            for elt in it {
                 if space_before {
                     self.space();
                 }
@@ -448,9 +451,10 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
         self.end();
     }
 
-    fn commasep<T, F>(&mut self, b: Breaks, elts: &[T], op: F)
+    fn commasep<'x, T: 'x, F, I>(&mut self, b: Breaks, elts: I, op: F)
     where
         F: FnMut(&mut Self, &T),
+        I: IntoIterator<Item = &'x T>,
     {
         self.strsep(",", false, b, elts, op)
     }

--- a/tests/ui/unpretty/debug-fmt-hir.rs
+++ b/tests/ui/unpretty/debug-fmt-hir.rs
@@ -1,0 +1,26 @@
+//@ compile-flags: -Zunpretty=hir
+//@ check-pass
+
+use std::fmt;
+
+pub struct Bar {
+    a: String,
+    b: u8,
+}
+
+impl fmt::Debug for Bar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        debug_struct_field2_finish(f, "Bar", "a", &self.a, "b", &&self.b)
+    }
+}
+
+fn debug_struct_field2_finish<'a>(
+    name: &str,
+    name1: &str,
+    value1: &'a dyn fmt::Debug,
+    name2: &str,
+    value2: &'a dyn fmt::Debug,
+) -> fmt::Result
+{
+    loop {}
+}

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -1,0 +1,25 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+//@ compile-flags: -Zunpretty=hir
+//@ check-pass
+
+use std::fmt;
+
+struct Bar {
+    a: String,
+    b: u8,
+}
+
+impl fmt::Debug for Bar {
+    fn fmt<'_, '_, '_>(self: &'_ Self, f: &'_ mut fmt::Formatter<'_>)
+        ->
+            fmt::Result {
+        debug_struct_field2_finish(f, "Bar", "a", &self.a, "b", &&self.b)
+    }
+}
+
+fn debug_struct_field2_finish<'a, '_, '_,
+    '_>(name: &'_ str, name1: &'_ str, value1: &'a dyn fmt::Debug,
+    name2: &'_ str, value2: &'a dyn fmt::Debug) -> fmt::Result { loop { } }

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -13,7 +13,7 @@ struct Bar {
 }
 
 impl fmt::Debug for Bar {
-    fn fmt(self: &'_ Self, f: &'_ mut fmt::Formatter<'_>)
+    fn fmt(&self, f: &'_ mut fmt::Formatter<'_>)
         ->
             fmt::Result {
         debug_struct_field2_finish(f, "Bar", "a", &self.a, "b", &&self.b)

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -13,13 +13,13 @@ struct Bar {
 }
 
 impl fmt::Debug for Bar {
-    fn fmt<'_, '_, '_>(self: &'_ Self, f: &'_ mut fmt::Formatter<'_>)
+    fn fmt(self: &'_ Self, f: &'_ mut fmt::Formatter<'_>)
         ->
             fmt::Result {
         debug_struct_field2_finish(f, "Bar", "a", &self.a, "b", &&self.b)
     }
 }
 
-fn debug_struct_field2_finish<'a, '_, '_,
-    '_>(name: &'_ str, name1: &'_ str, value1: &'a dyn fmt::Debug,
-    name2: &'_ str, value2: &'a dyn fmt::Debug) -> fmt::Result { loop { } }
+fn debug_struct_field2_finish<'a>(name: &'_ str, name1: &'_ str,
+    value1: &'a dyn fmt::Debug, name2: &'_ str, value2: &'a dyn fmt::Debug)
+    -> fmt::Result { loop { } }

--- a/tests/ui/unpretty/self-hir.rs
+++ b/tests/ui/unpretty/self-hir.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: -Zunpretty=hir
+//@ check-pass
+
+pub struct Bar {
+    a: String,
+    b: u8,
+}
+
+impl Bar {
+    fn imm_self(self) {}
+    fn mut_self(mut self) {}
+    fn refimm_self(&self) {}
+    fn refmut_self(&mut self) {}
+}

--- a/tests/ui/unpretty/self-hir.stdout
+++ b/tests/ui/unpretty/self-hir.stdout
@@ -1,0 +1,18 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+//@ compile-flags: -Zunpretty=hir
+//@ check-pass
+
+struct Bar {
+    a: String,
+    b: u8,
+}
+
+impl Bar {
+    fn imm_self(self) { }
+    fn mut_self(mut self) { }
+    fn refimm_self(&self) { }
+    fn refmut_self(&mut self) { }
+}


### PR DESCRIPTION
This PR improve (a bit) the HIR pretty printer.

It does so by:
 - Not printing elided lifetimes (those are not expressible in surface Rust anyway)
 - And by rendering implicit self with the shorthand syntax

I also tried fixing some indentation and other things but gave up for now.

Best reviewed commit by commit.