### PR TITLE
Fix "missing match arm body" suggestion involving `!`

### DIFF
--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -804,7 +804,14 @@ pub(crate) struct NegativeBoundWithParentheticalNotation {
 pub(crate) struct MatchArmWithNoBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " => todo!(),", applicability = "has-placeholders")]
+    // We include the braces around `todo!()` so that a comma is optional, and we don't have to have
+    // any logic looking at the arm being replaced if there was a comma already or not for the
+    // resulting code to be correct.
+    #[suggestion(
+        code = " => {{ todo!() }}",
+        applicability = "has-placeholders",
+        style = "verbose"
+    )]
     pub suggestion: Span,
 }
 

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3125,10 +3125,11 @@ impl<'a> Parser<'a> {
             let mut result = if armless {
                 // A pattern without a body, allowed for never patterns.
                 arm_body = None;
+                let span = lo.to(this.prev_token.span);
                 this.expect_one_of(&[exp!(Comma)], &[exp!(CloseBrace)]).map(|x| {
                     // Don't gate twice
                     if !pat.contains_never_pattern() {
-                        this.psess.gated_spans.gate(sym::never_patterns, pat.span);
+                        this.psess.gated_spans.gate(sym::never_patterns, span);
                     }
                     x
                 })

--- a/tests/ui/feature-gates/feature-gate-never_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_patterns.stderr
@@ -58,19 +58,34 @@ error: `match` arm with no body
   --> $DIR/feature-gate-never_patterns.rs:38:9
    |
 LL |         Some(_)
-   |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         Some(_) => { todo!() }
+   |                 ++++++++++++++
 
 error: `match` arm with no body
   --> $DIR/feature-gate-never_patterns.rs:43:9
    |
 LL |         Some(_) if false,
-   |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^^^^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         Some(_) if false => { todo!() },
+   |                          ++++++++++++++
 
 error: `match` arm with no body
   --> $DIR/feature-gate-never_patterns.rs:45:9
    |
 LL |         Some(_) if false
-   |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^^^^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         Some(_) if false => { todo!() }
+   |                          ++++++++++++++
 
 error[E0658]: `!` patterns are experimental
   --> $DIR/feature-gate-never_patterns.rs:50:13
@@ -96,13 +111,23 @@ error: `match` arm with no body
   --> $DIR/feature-gate-never_patterns.rs:64:9
    |
 LL |         Some(_)
-   |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         Some(_) => { todo!() }
+   |                 ++++++++++++++
 
 error: `match` arm with no body
   --> $DIR/feature-gate-never_patterns.rs:70:9
    |
 LL |         Some(_) if false
-   |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^^^^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         Some(_) if false => { todo!() }
+   |                          ++++++++++++++
 
 error: a guard on a never pattern will never be run
   --> $DIR/feature-gate-never_patterns.rs:54:19

--- a/tests/ui/parser/macro/macro-expand-to-match-arm.stderr
+++ b/tests/ui/parser/macro/macro-expand-to-match-arm.stderr
@@ -14,7 +14,12 @@ error: `match` arm with no body
   --> $DIR/macro-expand-to-match-arm.rs:14:9
    |
 LL |         arm!(None => {}),
-   |         ^^^^^^^^^^^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^^^^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         arm!(None => {}) => { todo!() },
+   |                          ++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/match-arm-without-body.stderr
+++ b/tests/ui/parser/match-arm-without-body.stderr
@@ -68,49 +68,89 @@ error: `match` arm with no body
   --> $DIR/match-arm-without-body.rs:7:9
    |
 LL |         Some(_)
-   |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         Some(_) => { todo!() }
+   |                 ++++++++++++++
 
 error: `match` arm with no body
   --> $DIR/match-arm-without-body.rs:30:9
    |
 LL |         Some(_) if true
-   |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^^^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         Some(_) if true => { todo!() }
+   |                         ++++++++++++++
 
 error: `match` arm with no body
   --> $DIR/match-arm-without-body.rs:40:9
    |
 LL |         Some(_) if true,
-   |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^^^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         Some(_) if true => { todo!() },
+   |                         ++++++++++++++
 
 error: `match` arm with no body
   --> $DIR/match-arm-without-body.rs:45:9
    |
 LL |         Some(_) if true,
-   |         ^^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^^^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         Some(_) if true => { todo!() },
+   |                         ++++++++++++++
 
 error: `match` arm with no body
   --> $DIR/match-arm-without-body.rs:51:9
    |
 LL |         pat!()
-   |         ^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         pat!() => { todo!() }
+   |                ++++++++++++++
 
 error: `match` arm with no body
   --> $DIR/match-arm-without-body.rs:56:9
    |
 LL |         pat!(),
-   |         ^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         pat!() => { todo!() },
+   |                ++++++++++++++
 
 error: `match` arm with no body
   --> $DIR/match-arm-without-body.rs:61:9
    |
 LL |         pat!() if true,
-   |         ^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^^^^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         pat!() if true => { todo!() },
+   |                        ++++++++++++++
 
 error: `match` arm with no body
   --> $DIR/match-arm-without-body.rs:72:9
    |
 LL |         pat!(),
-   |         ^^^^^^- help: add a body after the pattern: `=> todo!(),`
+   |         ^^^^^^
+   |
+help: add a body after the pattern
+   |
+LL |         pat!() => { todo!() },
+   |                ++++++++++++++
 
 error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Include the match arm guard in the gated span, so that the suggestion to add a body is correct instead of inserting the body before the guard.

Make the suggestion verbose.

```
error: `match` arm with no body
  --> $DIR/feature-gate-never_patterns.rs:43:9
   |
LL |         Some(_) if false,
   |         ^^^^^^^^^^^^^^^^
   |
help: add a body after the pattern
   |
LL |         Some(_) if false => { todo!() },
   |                          ++++++++++++++
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? @compiler-errors