### PR TITLE
FIx `sym` -> `syn` typo in tail-expr-drop-order type opt-out

### DIFF
--- a/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
+++ b/compiler/rustc_mir_transform/src/lint_tail_expr_drop_order.rs
@@ -186,7 +186,7 @@ fn true_significant_drop_ty<'tcx>(
         debug!(?name_str);
         match name_str[..] {
             // These are the types from Rust core ecosystem
-            ["sym" | "proc_macro2", ..]
+            ["syn" | "proc_macro2", ..]
             | ["core" | "std", "task", "LocalWaker" | "Waker"]
             | ["core" | "std", "task", "wake", "LocalWaker" | "Waker"] => Some(smallvec![]),
             // These are important types from Rust ecosystem


### PR DESCRIPTION
The #131326 PR attempts to reduce some false positives for the `tail_expr_drop_order` lint by hard-coding some common ecosystem crate names. Specifically, I believe it attempts to opt out the drop impls from `syn` which only exist as optimizations.

However, this was typo'd like "sym", which is a crate that has been [yanked](https://crates.io/crates/sym) (lol). This PR fixes that.

cc @dingxiangfei2009 @nikomatsakis -- did I mistake this? Was this meant to be a different crate?

@bors rollup