### PR TITLE
not lint break with label and unsafe block

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1859,13 +1859,15 @@ impl<'a> Parser<'a> {
             let mut expr = self.parse_expr_opt()?;
             if let Some(expr) = &mut expr {
                 if label.is_some()
-                    && matches!(
-                        expr.kind,
+                    && match &expr.kind {
                         ExprKind::While(_, _, None)
-                            | ExprKind::ForLoop { label: None, .. }
-                            | ExprKind::Loop(_, None, _)
-                            | ExprKind::Block(_, None)
-                    )
+                        | ExprKind::ForLoop { label: None, .. }
+                        | ExprKind::Loop(_, None, _) => true,
+                        ExprKind::Block(block, None) => {
+                            matches!(block.rules, BlockCheckMode::Default)
+                        }
+                        _ => false,
+                    }
                 {
                     self.psess.buffer_lint(
                         BREAK_WITH_LABEL_AND_LOOP,

--- a/tests/ui/lint/break-with-label-and-unsafe-block.rs
+++ b/tests/ui/lint/break-with-label-and-unsafe-block.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+
+#![deny(break_with_label_and_loop)]
+
+unsafe fn foo() -> i32 { 42 }
+
+fn main () {
+    'label: loop {
+        break 'label unsafe { foo() }
+    };
+}


### PR DESCRIPTION
fixes #137414

we can't label unsafe blocks, so that we can do not lint them