### PR TITLE
[illumos] attempt to use posix_spawn to spawn processes

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -35,7 +35,7 @@ miniz_oxide = { version = "0.8.0", optional = true, default-features = false }
 addr2line = { version = "0.24.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
-libc = { version = "0.2.169", default-features = false, features = [
+libc = { version = "0.2.170", default-features = false, features = [
     'rustc-dep-of-std',
 ], public = true }
 


### PR DESCRIPTION
illumos has `posix_spawn`, and the very newest versions also have `_addchdir`, so use that. POSIX standardized this function so I also added a weak symbol lookup for the non `_np` version. (illumos has both.)

This probably also works on Solaris, but I don't have access to an installation to validate this so I decided to focus on illumos instead.

This is a nice ~4x performance improvement for process creation. My go-to as usual is nextest against the clap repo, which acts as a stress test for process creation -- with [this commit]:

```console
$ cargo nextest run -E 'not test(ui_tests) and not test(example_tests)'
before: Summary [   1.747s] 879 tests run: 879 passed, 2 skipped
after:  Summary [   0.445s] 879 tests run: 879 passed, 2 skipped
```

[this commit]: https://github.com/clap-rs/clap/commit/fde45f9aea766fb8de46e3d46e6575f393c3b6b9