### PR TITLE
Fix invalid suggestion from type error for derive macro

### DIFF
--- a/tests/ui/typeck/auxiliary/derive-demo-issue-136343.rs
+++ b/tests/ui/typeck/auxiliary/derive-demo-issue-136343.rs
@@ -1,0 +1,7 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_derive(Sample)]
+pub fn sample(_: TokenStream) -> TokenStream {
+    "fn bad<T: Into<U>, U>(a: T) -> U { a }".parse().unwrap()
+}

--- a/tests/ui/typeck/invalid-sugg-for-derive-macro-issue-136343.rs
+++ b/tests/ui/typeck/invalid-sugg-for-derive-macro-issue-136343.rs
@@ -1,0 +1,9 @@
+//@ proc-macro: derive-demo-issue-136343.rs
+
+#[macro_use]
+extern crate derive_demo_issue_136343;
+
+#[derive(Sample)] //~ ERROR mismatched types
+struct Test;
+
+fn main() {}

--- a/tests/ui/typeck/invalid-sugg-for-derive-macro-issue-136343.stderr
+++ b/tests/ui/typeck/invalid-sugg-for-derive-macro-issue-136343.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> $DIR/invalid-sugg-for-derive-macro-issue-136343.rs:6:10
+   |
+LL | #[derive(Sample)]
+   |          ^^^^^^
+   |          |
+   |          expected type parameter `U`, found type parameter `T`
+   |          expected `U` because of return type
+   |
+   = note: expected type parameter `U`
+              found type parameter `T`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+   = note: the caller chooses a type for `U` which can be different from `T`
+   = note: this error originates in the derive macro `Sample` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #136343

r? @estebank 

I didn't use `from_expansion` to avoid it because of testcase 
`tests/ui/typeck/issue-110017-format-into-help-deletes-macro.rs`:

https://github.com/chenyukang/rust/blob/11959a8b6e75d2c55500a703070a248342d29549/tests/ui/typeck/issue-110017-format-into-help-deletes-macro.rs#L34-L37

This type error could come up with a proper fix.
