### PR TITLE
Return unexpected termination error instead of panicing in `Thread::join`

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1739,7 +1739,11 @@ struct JoinInner<'scope, T> {
 impl<'scope, T> JoinInner<'scope, T> {
     fn join(mut self) -> Result<T> {
         self.native.join();
-        Arc::get_mut(&mut self.packet).unwrap().result.get_mut().take().unwrap()
+        if let Some(packet) = Arc::get_mut(&mut self.packet) {
+            packet.result.get_mut().take().unwrap()
+        } else {
+            Err(Box::new("thread terminated unexpectedly (e.g. due to OS intervention)"))
+        }
     }
 }
 

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1742,7 +1742,7 @@ impl<'scope, T> JoinInner<'scope, T> {
         if let Some(packet) = Arc::get_mut(&mut self.packet) {
             packet.result.get_mut().take().unwrap()
         } else {
-            Err(Box::new("thread terminated unexpectedly (e.g. due to OS intervention)"))
+            Err(Box::new("thread terminated unexpectedly"))
         }
     }
 }

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1739,11 +1739,16 @@ struct JoinInner<'scope, T> {
 impl<'scope, T> JoinInner<'scope, T> {
     fn join(mut self) -> Result<T> {
         self.native.join();
-        if let Some(packet) = Arc::get_mut(&mut self.packet) {
-            packet.result.get_mut().take().unwrap()
-        } else {
-            Err(Box::new("thread terminated unexpectedly"))
-        }
+        Arc::get_mut(&mut self.packet)
+            // FIXME(fuzzypixelz): returning an error instead of panicking here
+            // would require updating the documentation of
+            // `std::thread::Result`; currently we can return `Err` if and only
+            // if the thread had panicked.
+            .expect("threads should not terminate unexpectedly")
+            .result
+            .get_mut()
+            .take()
+            .unwrap()
     }
 }
 


### PR DESCRIPTION
There is a time window during which the OS can terminate a thread before stdlib can retreive its `Packet`. Currently the `Thread::join` panics with no message in such an event, which makes debugging difficult; fixes #124466.
