### PR TITLE
configure.py: don't instruct user to run nonexistent program

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -776,6 +776,6 @@ if __name__ == "__main__":
         f.write(contents)
 
     p("")
-    p("run `python {}/x.py --help`".format(rust_dir))
+    p("run `{} {}/x.py --help`".format(os.path.basename(sys.executable), rust_dir))
     if "GITHUB_ACTIONS" in os.environ:
         print("::endgroup::")


### PR DESCRIPTION
```shell-session
$ ./configure
configure: processing command line
configure:
configure: build.configure-args := []
configure: profile              := dist
configure:
configure: writing `config.toml` in current directory
configure:
configure: run `python /mnt/filling/store/nabijaczleweli/code/rust/x.py --help`
```

This is naturally not valid since I don't have a "python" executable (and this will hopefully become more and more true as Python 2 dies out).

./configure knows this since it does `try python3 "$@"`, then `python2.7` &c.

After, this now says
```
configure: run `python3 /mnt/filling/store/nabijaczleweli/code/rust/x.py --help`
```
which is possible, and corresponds to the interpreter actually running.
