### PR TITLE
Don't re-`assume` in `transmute`s that don't change niches

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -386,6 +386,13 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     ) -> Bx::Value {
         assert_eq!(from_scalar.size(self.cx), to_scalar.size(self.cx));
 
+        // While optimizations will remove no-op transmutes, they might still be
+        // there in debug or things that aren't no-op in MIR because they change
+        // the Rust type but not the underlying layout/niche.
+        if from_scalar == to_scalar && from_backend_ty == to_backend_ty {
+            return imm;
+        }
+
         use abi::Primitive::*;
         imm = bx.from_immediate(imm);
 


### PR DESCRIPTION
I noticed in nightly 2025-02-21 that `transmute` is emitting way more `assume`s than necessary for newtypes.

For example, the three transmutes in <https://rust.godbolt.org/z/fW1KaTc4o> emits
```rust
define noundef range(i32 1, 0) i32 @repeatedly_transparent_transmute(i32 noundef range(i32 1, 0) %_1) unnamed_addr {
start:
  %0 = sub i32 %_1, 1
  %1 = icmp ule i32 %0, -2
  call void @llvm.assume(i1 %1)
  %2 = sub i32 %_1, 1
  %3 = icmp ule i32 %2, -2
  call void @llvm.assume(i1 %3)
  %4 = sub i32 %_1, 1
  %5 = icmp ule i32 %4, -2
  call void @llvm.assume(i1 %5)
  %6 = sub i32 %_1, 1
  %7 = icmp ule i32 %6, -2
  call void @llvm.assume(i1 %7)
  %8 = sub i32 %_1, 1
  %9 = icmp ule i32 %8, -2
  call void @llvm.assume(i1 %9)
  %10 = sub i32 %_1, 1
  %11 = icmp ule i32 %10, -2
  call void @llvm.assume(i1 %11)
  ret i32 %_1
}
```

But those are all just newtypes that don't change size or niches, so none of it's needed.

After this PR it's down to just
```rust
define noundef range(i32 1, 0) i32 @repeatedly_transparent_transmute(i32 noundef range(i32 1, 0) %_1) unnamed_addr {
start:
  ret i32 %_1
}
```
because none of those `assume`s in the original actually did anything.

(Transmuting to something with a difference niche, though, still has the assumes -- the other tests continue to pass checking that.)
