### PR TITLE
remove some unnecessary rustc_const_unstable

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -1041,7 +1041,6 @@ impl<T> MaybeUninit<T> {
 
     /// Deprecated version of [`slice::assume_init_ref`].
     #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[rustc_const_unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[deprecated(
         note = "replaced by inherent assume_init_ref method; will eventually be removed",
         since = "1.83.0"
@@ -1053,7 +1052,6 @@ impl<T> MaybeUninit<T> {
 
     /// Deprecated version of [`slice::assume_init_mut`].
     #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[rustc_const_unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[deprecated(
         note = "replaced by inherent assume_init_mut method; will eventually be removed",
         since = "1.83.0"
@@ -1326,7 +1324,6 @@ impl<T> [MaybeUninit<T>] {
     ///
     /// [`write_clone_of_slice`]: slice::write_clone_of_slice
     #[unstable(feature = "maybe_uninit_write_slice", issue = "79995")]
-    #[rustc_const_unstable(feature = "maybe_uninit_write_slice", issue = "79995")]
     pub const fn write_copy_of_slice(&mut self, src: &[T]) -> &mut [T]
     where
         T: Copy,

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -956,7 +956,6 @@ impl<T> [T] {
     /// [`swap`]: slice::swap
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     #[unstable(feature = "slice_swap_unchecked", issue = "88539")]
-    #[rustc_const_unstable(feature = "slice_swap_unchecked", issue = "88539")]
     pub const unsafe fn swap_unchecked(&mut self, a: usize, b: usize) {
         assert_unsafe_precondition!(
             check_library_ub,
@@ -3716,6 +3715,7 @@ impl<T> [T] {
     #[inline]
     #[stable(feature = "copy_from_slice", since = "1.9.0")]
     #[rustc_const_unstable(feature = "const_copy_from_slice", issue = "131415")]
+    #[rustc_const_stable_indirect]
     #[track_caller]
     pub const fn copy_from_slice(&mut self, src: &[T])
     where


### PR DESCRIPTION
If the function is anyway unstable, it doesn't need to be `rustc_const_unstable`.

`copy_from_slice` turns out to not do anything const-unstable itself, we just haven't stably committed to it being available in const yet. See [here](https://rustc-dev-guide.rust-lang.org/stability.html?highlight=rustc_const_stable_indirect) for more details on the `rustc_const_stable_indirect` attribute.