### PR TITLE
DWARF mixed versions with LTO on MIPS

### DIFF
--- a/tests/assembly/dwarf-mixed-versions-lto.rs
+++ b/tests/assembly/dwarf-mixed-versions-lto.rs
@@ -1,5 +1,6 @@
 // This test ensures that if LTO occurs between crates with different DWARF versions, we
 // will choose the highest DWARF version for the final binary. This matches Clang's behavior.
+// Note: `.2byte` directive is used on MIPS.
 
 //@ only-linux
 //@ aux-build:dwarf-mixed-versions-lto-aux.rs
@@ -14,6 +15,6 @@ fn main() {
 }
 
 // CHECK: .section .debug_info
-// CHECK-NOT: {{\.(short|hword)}} 2
-// CHECK-NOT: {{\.(short|hword)}} 4
-// CHECK: {{\.(short|hword)}} 5
+// CHECK-NOT: {{\.(short|hword|2byte)}} 2
+// CHECK-NOT: {{\.(short|hword|2byte)}} 4
+// CHECK: {{\.(short|hword|2byte)}} 5


### PR DESCRIPTION
On MIPS the DWARF version is stored in 2 bytes with the `.2byte` assembler directive.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
