### PR TITLE
Prevent `rmake.rs` from using unstable features, and fix 3 run-make tests that currently do

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,6 +2527,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "os_pipe"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,6 +3060,7 @@ dependencies = [
  "gimli 0.31.1",
  "libc",
  "object 0.36.7",
+ "os_pipe",
  "regex",
  "serde_json",
  "similar",

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -597,7 +597,7 @@ impl Builder<'_> {
         // sysroot. Passing this cfg enables raw-dylib support instead, which makes the native
         // library unnecessary. This can be removed when windows-rs enables raw-dylib
         // unconditionally.
-        if let Mode::Rustc | Mode::ToolRustc = mode {
+        if let Mode::Rustc | Mode::ToolRustc | Mode::ToolBootstrap = mode {
             rustflags.arg("--cfg=windows_raw_dylib");
         }
 

--- a/src/doc/rustc-dev-guide/src/tests/compiletest.md
+++ b/src/doc/rustc-dev-guide/src/tests/compiletest.md
@@ -415,6 +415,10 @@ Compiletest directives like `//@ only-<target>` or `//@ ignore-<target>` are
 supported in `rmake.rs`, like in UI tests. However, revisions or building
 auxiliary via directives are not currently supported.
 
+`rmake.rs` and `run-make-support` may *not* use any nightly/unstable features,
+as they must be compilable by a stage 0 rustc that may be a beta or even stable
+rustc.
+
 #### Quickly check if `rmake.rs` tests can be compiled
 
 You can quickly check if `rmake.rs` tests can be compiled without having to

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -105,6 +105,11 @@ impl TestCx<'_> {
             .expect("stage0 rustc is required to run run-make tests");
         let mut rustc = Command::new(&stage0_rustc);
         rustc
+            // `rmake.rs` **must** be buildable by a stable compiler, it may not use *any* unstable
+            // library or compiler features. Here, we force the stage 0 rustc to consider itself as
+            // a stable-channel compiler via `RUSTC_BOOTSTRAP=-1` to prevent *any* unstable
+            // library/compiler usages, even if stage 0 rustc is *actually* a nightly rustc.
+            .env("RUSTC_BOOTSTRAP", "-1")
             .arg("-o")
             .arg(&recipe_bin)
             // Specify library search paths for `run_make_support`.

--- a/src/tools/run-make-support/Cargo.toml
+++ b/src/tools/run-make-support/Cargo.toml
@@ -14,5 +14,9 @@ build_helper = { path = "../../build_helper" }
 serde_json = "1.0"
 libc = "0.2"
 
+# FIXME(#137532): replace `os_pipe` with `anonymous_pipe` once it stabilizes and
+# reaches beta.
+os_pipe = "1.2.1"
+
 [lib]
 crate-type = ["lib", "dylib"]

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -40,6 +40,8 @@ pub use bstr;
 pub use gimli;
 pub use libc;
 pub use object;
+// FIXME(#137532): replace with std `anonymous_pipe` once it stabilizes and reaches beta.
+pub use os_pipe;
 pub use regex;
 pub use serde_json;
 pub use similar;

--- a/tests/run-make/broken-pipe-no-ice/rmake.rs
+++ b/tests/run-make/broken-pipe-no-ice/rmake.rs
@@ -11,12 +11,12 @@
 // Internal Compiler Error strangely, but it doesn't even go through normal diagnostic infra. Very
 // strange.
 
-#![feature(anonymous_pipe)]
-
 use std::io::Read;
 use std::process::{Command, Stdio};
 
-use run_make_support::env_var;
+// FIXME(#137532): replace `os_pipe` dependency with std `anonymous_pipe` once that stabilizes and
+// reaches beta.
+use run_make_support::{env_var, os_pipe};
 
 #[derive(Debug, PartialEq)]
 enum Binary {
@@ -25,7 +25,7 @@ enum Binary {
 }
 
 fn check_broken_pipe_handled_gracefully(bin: Binary, mut cmd: Command) {
-    let (reader, writer) = std::io::pipe().unwrap();
+    let (reader, writer) = os_pipe::pipe().unwrap();
     drop(reader); // close read-end
     cmd.stdout(writer).stderr(Stdio::piped());
 

--- a/tests/run-make/issue-107495-archive-permissions/rmake.rs
+++ b/tests/run-make/issue-107495-archive-permissions/rmake.rs
@@ -1,7 +1,5 @@
-#![feature(rustc_private)]
-
 #[cfg(unix)]
-extern crate libc;
+use run_make_support::libc;
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;

--- a/tests/run-make/issue-107495-archive-permissions/rmake.rs
+++ b/tests/run-make/issue-107495-archive-permissions/rmake.rs
@@ -1,10 +1,9 @@
 #[cfg(unix)]
-use run_make_support::libc;
-
-#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
+#[cfg(unix)]
+use run_make_support::libc;
 use run_make_support::{aux_build, rfs};
 
 fn main() {


### PR DESCRIPTION
Addresses (mostly) #137532.
Follow-up to #137373.

### Summary

- Fix 3 run-make tests that currently use unstable features:
    1. `tests/run-make/issue-107495-archive-permissions/rmake.rs` uses `#![feature(rustc_private)]` for `libc` on `unix`, but `run_make_support` already exports `libc`, so just use that.
    2. `tests/run-make/cross-lang-lto/rmake.rs` uses `#![feature(path_file_prefix)]` for convenience, replaced with similar filename prefix logic.
    3. `tests/run-make/broken-pipe-no-ice/rmake.rs` uses `#![feature(anonymous_pipe)]` for anonymous pipes. This is more complicated[^race-condition], and I decided to temporarily introduce a dependency on [`os_pipe`] before std's `anonymous_pipe` library feature is stabilized[^pipe-stab]. I left a FIXME tracked by #137532 to make the switch once `anonymous_pipe` stabilizes and reaches beta.
- Use `RUSTC_BOOTSTRAP=-1` when building `rmake.rs` to have the stage 0 rustc reject any unstable features used in `rmake.rs`.

- The requirement that `rmake.rs` may not use any unstable features is now documented in rustc-dev-guide.
- This PR does not impose `RUSTC_BOOTSTRAP=-1` when building `run-make-support`, but I suppose we could.

r? @Kobzol

try-job: x86_64-msvc-1
try-job: x86_64-mingw-1

[`os_pipe`]: https://github.com/oconnor663/os_pipe.rs

[^race-condition]: We can't just try to spawn `rustc` and immediate close the stderr handle because of race condition, as there's no guarantee `rustc` will not try to print to stderr before the handle gets closed.
[^pipe-stab]: In-progress stabilization PR over at https://github.com/rust-lang/rust/pull/135822.