### PR TITLE
fix doc path in std::fmt macro

### DIFF
--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -41,7 +41,7 @@ macro_rules! panic {
 /// Use `print!` only for the primary output of your program. Use
 /// [`eprint!`] instead to print error and progress messages.
 ///
-/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// See the formatting documentation in [`std::fmt`](crate::fmt)
 /// for details of the macro argument syntax.
 ///
 /// [flush]: crate::io::Write::flush
@@ -106,7 +106,7 @@ macro_rules! print {
 /// Use `println!` only for the primary output of your program. Use
 /// [`eprintln!`] instead to print error and progress messages.
 ///
-/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// See the formatting documentation in [`std::fmt`](crate::fmt)
 /// for details of the macro argument syntax.
 ///
 /// [`std::fmt`]: crate::fmt
@@ -156,7 +156,7 @@ macro_rules! println {
 /// [`io::stderr`]: crate::io::stderr
 /// [`io::stdout`]: crate::io::stdout
 ///
-/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// See the formatting documentation in [`std::fmt`](crate::fmt)
 /// for details of the macro argument syntax.
 ///
 /// # Panics
@@ -190,7 +190,7 @@ macro_rules! eprint {
 /// Use `eprintln!` only for error and progress messages. Use `println!`
 /// instead for the primary output of your program.
 ///
-/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// See the formatting documentation in [`std::fmt`](crate::fmt)
 /// for details of the macro argument syntax.
 ///
 /// [`io::stderr`]: crate::io::stderr


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/137519
