### PR TITLE
Pass correct `TypingEnv` to `InlineAsmCtxt`

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsicck.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsicck.rs
@@ -33,14 +33,12 @@ impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
     pub fn new(
         tcx: TyCtxt<'tcx>,
         def_id: LocalDefId,
+        typing_env: ty::TypingEnv<'tcx>,
         get_operand_ty: impl Fn(&hir::Expr<'tcx>) -> Ty<'tcx> + 'a,
     ) -> Self {
         InlineAsmCtxt {
             tcx,
-            typing_env: ty::TypingEnv {
-                typing_mode: ty::TypingMode::non_body_analysis(),
-                param_env: ty::ParamEnv::empty(),
-            },
+            typing_env,
             target_features: tcx.asm_target_features(def_id),
             expr_ty: Box::new(get_operand_ty),
         }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -110,7 +110,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.tcx.erase_regions(ty)
                 }
             };
-            InlineAsmCtxt::new(self.tcx, enclosing_id, expr_ty).check_asm(asm);
+            InlineAsmCtxt::new(self.tcx, enclosing_id, self.typing_env(self.param_env), expr_ty)
+                .check_asm(asm);
         }
     }
 

--- a/tests/ui/asm/conditionally-sized-ptr-fail.rs
+++ b/tests/ui/asm/conditionally-sized-ptr-fail.rs
@@ -1,0 +1,19 @@
+//@ needs-asm-support
+
+use std::arch::asm;
+
+fn _f<T: ?Sized>(p: *mut T) {
+    unsafe {
+        asm!("/* {} */", in(reg) p);
+        //~^ ERROR cannot use value of unsized pointer type `*mut T` for inline assembly
+    }
+}
+
+fn _g(p: *mut [u8]) {
+    unsafe {
+        asm!("/* {} */", in(reg) p);
+        //~^ ERROR cannot use value of unsized pointer type `*mut [u8]` for inline assembly
+    }
+}
+
+fn main() {}

--- a/tests/ui/asm/conditionally-sized-ptr-fail.stderr
+++ b/tests/ui/asm/conditionally-sized-ptr-fail.stderr
@@ -1,0 +1,18 @@
+error: cannot use value of unsized pointer type `*mut T` for inline assembly
+  --> $DIR/conditionally-sized-ptr-fail.rs:7:34
+   |
+LL |         asm!("/* {} */", in(reg) p);
+   |                                  ^
+   |
+   = note: only sized pointers can be used in inline assembly
+
+error: cannot use value of unsized pointer type `*mut [u8]` for inline assembly
+  --> $DIR/conditionally-sized-ptr-fail.rs:14:34
+   |
+LL |         asm!("/* {} */", in(reg) p);
+   |                                  ^
+   |
+   = note: only sized pointers can be used in inline assembly
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/asm/conditionally-sized-ptr.rs
+++ b/tests/ui/asm/conditionally-sized-ptr.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+//@ needs-asm-support
+
+use std::arch::asm;
+
+fn _f<T>(p: *mut T) {
+    unsafe {
+        asm!("/* {} */", in(reg) p);
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #137512

r? oli-obk