### PR TITLE
Don't immediately panic if dropck fails without returning errors

### DIFF
--- a/tests/ui/dropck/dropck-after-failed-type-lowering.rs
+++ b/tests/ui/dropck/dropck-after-failed-type-lowering.rs
@@ -1,0 +1,14 @@
+// Regression test for #137329
+
+trait B {
+    type C<'a>;
+    fn d<E>() -> F<E> {
+        todo!()
+    }
+}
+struct F<G> {
+    h: Option<<G as B>::C>,
+    //~^ ERROR missing generics for associated type `B::C`
+}
+
+fn main() {}

--- a/tests/ui/dropck/dropck-after-failed-type-lowering.stderr
+++ b/tests/ui/dropck/dropck-after-failed-type-lowering.stderr
@@ -1,0 +1,19 @@
+error[E0107]: missing generics for associated type `B::C`
+  --> $DIR/dropck-after-failed-type-lowering.rs:10:25
+   |
+LL |     h: Option<<G as B>::C>,
+   |                         ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/dropck-after-failed-type-lowering.rs:4:10
+   |
+LL |     type C<'a>;
+   |          ^ --
+help: add missing lifetime argument
+   |
+LL |     h: Option<<G as B>::C<'a>>,
+   |                          ++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
This span_bug was a little too optimistic. I've decided that matching on the ErrorGuaranteed is a little more sensible than a delay bug that will always be ignored.

closes #137329 
r? @compiler-errors
