### PR TITLE
import `simd_` intrinsics

### DIFF
--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -11,7 +11,7 @@
 /// `idx` must be in-bounds of the vector.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_insert<T, U>(_x: T, _idx: u32, _val: U) -> T;
+pub const unsafe fn simd_insert<T, U>(_x: T, _idx: u32, _val: U) -> T;
 
 /// Extracts an element from a vector.
 ///
@@ -22,7 +22,7 @@ pub unsafe fn simd_insert<T, U>(_x: T, _idx: u32, _val: U) -> T;
 /// `idx` must be in-bounds of the vector.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_extract<T, U>(_x: T, _idx: u32) -> U;
+pub const unsafe fn simd_extract<T, U>(_x: T, _idx: u32) -> U;
 
 /// Adds two simd vectors elementwise.
 ///

--- a/tests/codegen/issues/issue-84268.rs
+++ b/tests/codegen/issues/issue-84268.rs
@@ -1,5 +1,5 @@
 //@ compile-flags: -Copt-level=3 --crate-type=rlib
-#![feature(intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
 use std::intrinsics::simd::{simd_eq, simd_fabs};
 

--- a/tests/codegen/issues/issue-84268.rs
+++ b/tests/codegen/issues/issue-84268.rs
@@ -1,10 +1,7 @@
 //@ compile-flags: -Copt-level=3 --crate-type=rlib
 #![feature(intrinsics, repr_simd)]
 
-extern "rust-intrinsic" {
-    fn simd_fabs<T>(x: T) -> T;
-    fn simd_eq<T, U>(x: T, y: T) -> U;
-}
+use std::intrinsics::simd::{simd_eq, simd_fabs};
 
 #[repr(simd)]
 pub struct V([f32; 4]);

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-abs.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-abs.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_fabs;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_fabs<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @fabs_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-ceil.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-ceil.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_ceil;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_ceil<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @ceil_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-cos.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-cos.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_fcos;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_fcos<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @fcos_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_fexp;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_fexp<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @exp_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp2.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp2.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_fexp2;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_fexp2<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @exp2_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-floor.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-floor.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_floor;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_floor<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @floor_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-fma.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-fma.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_fma;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_fma<T>(x: T, b: T, c: T) -> T;
-}
 
 // CHECK-LABEL: @fma_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-fsqrt.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-fsqrt.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_fsqrt;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_fsqrt<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @fsqrt_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-log.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-log.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_flog;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_flog<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @log_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-log10.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-log10.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_flog10;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_flog10<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @log10_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-log2.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-log2.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_flog2;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_flog2<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @log2_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-minmax.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-minmax.rs
@@ -1,18 +1,14 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{simd_fmax, simd_fmin};
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x4(pub [f32; 4]);
-
-extern "rust-intrinsic" {
-    fn simd_fmin<T>(x: T, y: T) -> T;
-    fn simd_fmax<T>(x: T, y: T) -> T;
-}
 
 // CHECK-LABEL: @fmin
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-sin.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-sin.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_fsin;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,10 +21,6 @@ pub struct f32x8(pub [f32; 8]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct f32x16(pub [f32; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_fsin<T>(x: T) -> T;
-}
 
 // CHECK-LABEL: @fsin_32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-arithmetic-saturating.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-arithmetic-saturating.rs
@@ -1,70 +1,70 @@
 //@ compile-flags: -C no-prepopulate-passes
-//
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 #![deny(unused)]
 
-// signed integer types
+use std::intrinsics::simd::{simd_saturating_add, simd_saturating_sub};
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x2([i8; 2]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x4([i8; 4]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x8([i8; 8]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x16([i8; 16]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x32([i8; 32]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x64([i8; 64]);
+#[rustfmt::skip]
+mod types {
+    // signed integer types
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x2([i16; 2]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x4([i16; 4]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x8([i16; 8]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x16([i16; 16]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x32([i16; 32]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i8x2([i8; 2]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i8x4([i8; 4]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i8x8([i8; 8]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i8x16([i8; 16]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i8x32([i8; 32]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i8x64([i8; 64]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x2([i32; 2]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x4([i32; 4]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x8([i32; 8]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x16([i32; 16]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i16x2([i16; 2]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i16x4([i16; 4]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i16x8([i16; 8]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i16x16([i16; 16]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i16x32([i16; 32]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i64x2([i64; 2]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i64x4([i64; 4]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i64x8([i64; 8]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i32x2([i32; 2]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i32x4([i32; 4]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i32x8([i32; 8]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i32x16([i32; 16]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i128x2([i128; 2]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i128x4([i128; 4]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i64x2([i64; 2]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i64x4([i64; 4]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i64x8([i64; 8]);
 
-// unsigned integer types
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i128x2([i128; 2]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct i128x4([i128; 4]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x2([u8; 2]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x4([u8; 4]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x8([u8; 8]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x16([u8; 16]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x32([u8; 32]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x64([u8; 64]);
+    // unsigned integer types
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x2([u16; 2]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x4([u16; 4]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x8([u16; 8]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x16([u16; 16]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x32([u16; 32]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u8x2([u8; 2]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u8x4([u8; 4]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u8x8([u8; 8]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u8x16([u8; 16]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u8x32([u8; 32]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u8x64([u8; 64]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x2([u32; 2]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x4([u32; 4]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x8([u32; 8]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x16([u32; 16]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u16x2([u16; 2]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u16x4([u16; 4]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u16x8([u16; 8]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u16x16([u16; 16]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u16x32([u16; 32]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u64x2([u64; 2]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u64x4([u64; 4]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u64x8([u64; 8]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u32x2([u32; 2]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u32x4([u32; 4]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u32x8([u32; 8]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u32x16([u32; 16]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u128x2([u128; 2]);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u128x4([u128; 4]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u64x2([u64; 2]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u64x4([u64; 4]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u64x8([u64; 8]);
 
-extern "rust-intrinsic" {
-    fn simd_saturating_add<T>(x: T, y: T) -> T;
-    fn simd_saturating_sub<T>(x: T, y: T) -> T;
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u128x2([u128; 2]);
+    #[repr(simd)] #[derive(Copy, Clone)] pub struct u128x4([u128; 4]);
 }
+
+use types::*;
 
 // NOTE(eddyb) `%{{x|0}}` is used because on some targets (e.g. WASM)
 // SIMD vectors are passed directly, resulting in `%x` being a vector,
@@ -213,8 +213,6 @@ pub unsafe fn sadd_i128x4(x: i128x4, y: i128x4) -> i128x4 {
     simd_saturating_add(x, y)
 }
 
-
-
 // CHECK-LABEL: @uadd_u8x2
 #[no_mangle]
 pub unsafe fn uadd_u8x2(x: u8x2, y: u8x2) -> u8x2 {
@@ -355,10 +353,6 @@ pub unsafe fn uadd_u128x4(x: u128x4, y: u128x4) -> u128x4 {
     simd_saturating_add(x, y)
 }
 
-
-
-
-
 // CHECK-LABEL: @ssub_i8x2
 #[no_mangle]
 pub unsafe fn ssub_i8x2(x: i8x2, y: i8x2) -> i8x2 {
@@ -498,8 +492,6 @@ pub unsafe fn ssub_i128x4(x: i128x4, y: i128x4) -> i128x4 {
     // CHECK: %{{[0-9]+}} = call <4 x i128> @llvm.ssub.sat.v4i128(<4 x i128> %{{x|0}}, <4 x i128> %{{y|1}})
     simd_saturating_sub(x, y)
 }
-
-
 
 // CHECK-LABEL: @usub_u8x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-bitmask.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-bitmask.rs
@@ -2,9 +2,10 @@
 //
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_bitmask;
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -17,10 +18,6 @@ pub struct i32x2([i32; 2]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 pub struct i8x16([i8; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_bitmask<T, U>(x: T) -> U;
-}
 
 // NOTE(eddyb) `%{{x|1}}` is used because on some targets (e.g. WASM)
 // SIMD vectors are passed directly, resulting in `%x` being a vector,

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-gather.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-gather.rs
@@ -3,9 +3,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_gather;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -15,14 +16,13 @@ pub struct Vec2<T>(pub [T; 2]);
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Vec4<T>(pub [T; 4]);
 
-extern "rust-intrinsic" {
-    fn simd_gather<T, P, M>(value: T, pointers: P, mask: M) -> T;
-}
-
 // CHECK-LABEL: @gather_f32x2
 #[no_mangle]
-pub unsafe fn gather_f32x2(pointers: Vec2<*const f32>, mask: Vec2<i32>,
-                           values: Vec2<f32>) -> Vec2<f32> {
+pub unsafe fn gather_f32x2(
+    pointers: Vec2<*const f32>,
+    mask: Vec2<i32>,
+    values: Vec2<f32>,
+) -> Vec2<f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
     // CHECK: call <2 x float> @llvm.masked.gather.v2f32.v2p0(<2 x ptr> {{.*}}, i32 {{.*}}, <2 x i1> [[B]], <2 x float> {{.*}})
@@ -31,8 +31,11 @@ pub unsafe fn gather_f32x2(pointers: Vec2<*const f32>, mask: Vec2<i32>,
 
 // CHECK-LABEL: @gather_pf32x2
 #[no_mangle]
-pub unsafe fn gather_pf32x2(pointers: Vec2<*const *const f32>, mask: Vec2<i32>,
-                           values: Vec2<*const f32>) -> Vec2<*const f32> {
+pub unsafe fn gather_pf32x2(
+    pointers: Vec2<*const *const f32>,
+    mask: Vec2<i32>,
+    values: Vec2<*const f32>,
+) -> Vec2<*const f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
     // CHECK: call <2 x ptr> @llvm.masked.gather.v2p0.v2p0(<2 x ptr> {{.*}}, i32 {{.*}}, <2 x i1> [[B]], <2 x ptr> {{.*}})

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-load.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-load.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_masked_load;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -13,14 +14,9 @@ pub struct Vec2<T>(pub [T; 2]);
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Vec4<T>(pub [T; 4]);
 
-extern "rust-intrinsic" {
-    fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;
-}
-
 // CHECK-LABEL: @load_f32x2
 #[no_mangle]
-pub unsafe fn load_f32x2(mask: Vec2<i32>, pointer: *const f32,
-                         values: Vec2<f32>) -> Vec2<f32> {
+pub unsafe fn load_f32x2(mask: Vec2<i32>, pointer: *const f32, values: Vec2<f32>) -> Vec2<f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
     // CHECK: call <2 x float> @llvm.masked.load.v2f32.p0(ptr {{.*}}, i32 4, <2 x i1> [[B]], <2 x float> {{.*}})
@@ -29,8 +25,11 @@ pub unsafe fn load_f32x2(mask: Vec2<i32>, pointer: *const f32,
 
 // CHECK-LABEL: @load_pf32x4
 #[no_mangle]
-pub unsafe fn load_pf32x4(mask: Vec4<i32>, pointer: *const *const f32,
-                          values: Vec4<*const f32>) -> Vec4<*const f32> {
+pub unsafe fn load_pf32x4(
+    mask: Vec4<i32>,
+    pointer: *const *const f32,
+    values: Vec4<*const f32>,
+) -> Vec4<*const f32> {
     // CHECK: [[A:%[0-9]+]] = lshr <4 x i32> {{.*}}, {{<i32 31, i32 31, i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <4 x i32> [[A]] to <4 x i1>
     // CHECK: call <4 x ptr> @llvm.masked.load.v4p0.p0(ptr {{.*}}, i32 {{.*}}, <4 x i1> [[B]], <4 x ptr> {{.*}})

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-store.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-store.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_masked_store;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -12,10 +13,6 @@ pub struct Vec2<T>(pub [T; 2]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Vec4<T>(pub [T; 4]);
-
-extern "rust-intrinsic" {
-    fn simd_masked_store<M, P, T>(mask: M, pointer: P, values: T) -> ();
-}
 
 // CHECK-LABEL: @store_f32x2
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-scatter.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-scatter.rs
@@ -3,9 +3,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_scatter;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -15,25 +16,22 @@ pub struct Vec2<T>(pub [T; 2]);
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Vec4<T>(pub [T; 4]);
 
-extern "rust-intrinsic" {
-    fn simd_scatter<T, P, M>(value: T, pointers: P, mask: M);
-}
-
 // CHECK-LABEL: @scatter_f32x2
 #[no_mangle]
-pub unsafe fn scatter_f32x2(pointers: Vec2<*mut f32>, mask: Vec2<i32>,
-                            values: Vec2<f32>) {
+pub unsafe fn scatter_f32x2(pointers: Vec2<*mut f32>, mask: Vec2<i32>, values: Vec2<f32>) {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
     // CHECK: call void @llvm.masked.scatter.v2f32.v2p0(<2 x float> {{.*}}, <2 x ptr> {{.*}}, i32 {{.*}}, <2 x i1> [[B]]
     simd_scatter(values, pointers, mask)
 }
 
-
 // CHECK-LABEL: @scatter_pf32x2
 #[no_mangle]
-pub unsafe fn scatter_pf32x2(pointers: Vec2<*mut *const f32>, mask: Vec2<i32>,
-                             values: Vec2<*const f32>) {
+pub unsafe fn scatter_pf32x2(
+    pointers: Vec2<*mut *const f32>,
+    mask: Vec2<i32>,
+    values: Vec2<*const f32>,
+) {
     // CHECK: [[A:%[0-9]+]] = lshr <2 x i32> {{.*}}, {{<i32 31, i32 31>|splat \(i32 31\)}}
     // CHECK: [[B:%[0-9]+]] = trunc <2 x i32> [[A]] to <2 x i1>
     // CHECK: call void @llvm.masked.scatter.v2p0.v2p0(<2 x ptr> {{.*}}, <2 x ptr> {{.*}}, i32 {{.*}}, <2 x i1> [[B]]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-select.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-select.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{simd_select, simd_select_bitmask};
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,11 +21,6 @@ pub struct b8x4(pub [i8; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct i32x4([i32; 4]);
-
-extern "rust-intrinsic" {
-    fn simd_select<T, U>(x: T, a: U, b: U) -> U;
-    fn simd_select_bitmask<T, U>(x: T, a: U, b: U) -> U;
-}
 
 // CHECK-LABEL: @select_m8
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-mask-reduce.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-mask-reduce.rs
@@ -1,9 +1,10 @@
 //@ compile-flags: -C no-prepopulate-passes
-//
 
 #![crate_type = "lib"]
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{simd_reduce_all, simd_reduce_any};
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -12,11 +13,6 @@ pub struct mask32x2([i32; 2]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 pub struct mask8x16([i8; 16]);
-
-extern "rust-intrinsic" {
-    fn simd_reduce_all<T>(x: T) -> bool;
-    fn simd_reduce_any<T>(x: T) -> bool;
-}
 
 // NOTE(eddyb) `%{{x|1}}` is used because on some targets (e.g. WASM)
 // SIMD vectors are passed directly, resulting in `%x` being a vector,

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
@@ -12,7 +12,7 @@
 
 #![crate_type = "lib"]
 #![allow(non_camel_case_types)]
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone)]

--- a/tests/codegen/simd/simd_arith_offset.rs
+++ b/tests/codegen/simd/simd_arith_offset.rs
@@ -3,7 +3,7 @@
 //
 
 #![crate_type = "lib"]
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
 use std::intrinsics::simd::simd_arith_offset;
 

--- a/tests/codegen/simd/simd_arith_offset.rs
+++ b/tests/codegen/simd/simd_arith_offset.rs
@@ -5,9 +5,7 @@
 #![crate_type = "lib"]
 #![feature(repr_simd, intrinsics)]
 
-extern "rust-intrinsic" {
-    pub(crate) fn simd_arith_offset<T, U>(ptrs: T, offsets: U) -> T;
-}
+use std::intrinsics::simd::simd_arith_offset;
 
 /// A vector of *const T.
 #[derive(Debug, Copy, Clone)]

--- a/tests/incremental/issue-61530.rs
+++ b/tests/incremental/issue-61530.rs
@@ -1,13 +1,11 @@
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
 //@ revisions:rpass1 rpass2
 
+use std::intrinsics::simd::simd_shuffle;
+
 #[repr(simd)]
 struct I32x2([i32; 2]);
-
-extern "rust-intrinsic" {
-    fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
-}
 
 #[repr(simd)]
 struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);

--- a/tests/ui/consts/const-eval/simd/insert_extract.rs
+++ b/tests/ui/consts/const-eval/simd/insert_extract.rs
@@ -1,14 +1,12 @@
 //@ run-pass
 #![feature(repr_simd)]
-#![feature(intrinsics, rustc_attrs)]
+#![feature(intrinsics, core_intrinsics, rustc_attrs)]
 #![feature(staged_api)]
 #![stable(feature = "foo", since = "1.3.37")]
 #![allow(non_camel_case_types)]
 
-// repr(simd) now only supports array types
-#[repr(simd)] struct i8x1([i8; 1]);
-#[repr(simd)] struct u16x2([u16; 2]);
-#[repr(simd)] struct f32x4([f32; 4]);
+// FIXME these intrinsics are not marked as const fn
+// use std::intrinsics::simd::{simd_extract, simd_insert};
 
 #[stable(feature = "foo", since = "1.3.37")]
 #[rustc_const_stable(feature = "foo", since = "1.3.37")]
@@ -23,6 +21,14 @@ const unsafe fn simd_insert<T, U>(_x: T, _idx: u32, _val: U) -> T {
 const unsafe fn simd_extract<T, U>(_x: T, _idx: u32) -> U {
     unimplemented!()
 }
+
+// repr(simd) now only supports array types
+#[repr(simd)]
+struct i8x1([i8; 1]);
+#[repr(simd)]
+struct u16x2([u16; 2]);
+#[repr(simd)]
+struct f32x4([f32; 4]);
 
 fn main() {
     {

--- a/tests/ui/consts/const-eval/simd/insert_extract.rs
+++ b/tests/ui/consts/const-eval/simd/insert_extract.rs
@@ -5,22 +5,7 @@
 #![stable(feature = "foo", since = "1.3.37")]
 #![allow(non_camel_case_types)]
 
-// FIXME these intrinsics are not marked as const fn
-// use std::intrinsics::simd::{simd_extract, simd_insert};
-
-#[stable(feature = "foo", since = "1.3.37")]
-#[rustc_const_stable(feature = "foo", since = "1.3.37")]
-#[rustc_intrinsic]
-const unsafe fn simd_insert<T, U>(_x: T, _idx: u32, _val: U) -> T {
-    unimplemented!()
-}
-
-#[stable(feature = "foo", since = "1.3.37")]
-#[rustc_const_stable(feature = "foo", since = "1.3.37")]
-#[rustc_intrinsic]
-const unsafe fn simd_extract<T, U>(_x: T, _idx: u32) -> U {
-    unimplemented!()
-}
+use std::intrinsics::simd::{simd_extract, simd_insert};
 
 // repr(simd) now only supports array types
 #[repr(simd)]

--- a/tests/ui/error-codes/E0511.rs
+++ b/tests/ui/error-codes/E0511.rs
@@ -1,11 +1,11 @@
 //@ build-fail
 
-#![feature(intrinsics)]
+#![feature(core_intrinsics)]
 
-extern "rust-intrinsic" {
-    fn simd_add<T>(a: T, b: T) -> T;
-}
+use std::intrinsics::simd::simd_add;
 
 fn main() {
-    unsafe { simd_add(0, 1); } //~ ERROR E0511
+    unsafe {
+        simd_add(0, 1) //~ ERROR E0511
+    };
 }

--- a/tests/ui/error-codes/E0511.stderr
+++ b/tests/ui/error-codes/E0511.stderr
@@ -1,8 +1,8 @@
 error[E0511]: invalid monomorphization of `simd_add` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/E0511.rs:10:14
+  --> $DIR/E0511.rs:9:9
    |
-LL |     unsafe { simd_add(0, 1); }
-   |              ^^^^^^^^^^^^^^
+LL |         simd_add(0, 1)
+   |         ^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/intrinsics/bad-intrinsic-monomorphization.rs
+++ b/tests/ui/intrinsics/bad-intrinsic-monomorphization.rs
@@ -7,10 +7,6 @@
 // Bad monomorphizations could previously cause LLVM asserts even though the
 // error was caught in the compiler.
 
-extern "rust-intrinsic" {
-    fn simd_add<T>(x: T, y: T) -> T;
-}
-
 use std::intrinsics;
 
 #[derive(Copy, Clone)]
@@ -27,6 +23,6 @@ pub unsafe fn test_fadd_fast(a: Foo, b: Foo) -> Foo {
 }
 
 pub unsafe fn test_simd_add(a: Foo, b: Foo) -> Foo {
-    simd_add(a, b)
+    intrinsics::simd::simd_add(a, b)
     //~^ ERROR `simd_add` intrinsic: expected SIMD input type, found non-SIMD `Foo`
 }

--- a/tests/ui/intrinsics/bad-intrinsic-monomorphization.stderr
+++ b/tests/ui/intrinsics/bad-intrinsic-monomorphization.stderr
@@ -1,20 +1,20 @@
 error[E0511]: invalid monomorphization of `cttz` intrinsic: expected basic integer type, found `Foo`
-  --> $DIR/bad-intrinsic-monomorphization.rs:20:5
+  --> $DIR/bad-intrinsic-monomorphization.rs:16:5
    |
 LL |     intrinsics::cttz(v)
    |     ^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `fadd_fast` intrinsic: expected basic float type, found `Foo`
-  --> $DIR/bad-intrinsic-monomorphization.rs:25:5
+  --> $DIR/bad-intrinsic-monomorphization.rs:21:5
    |
 LL |     intrinsics::fadd_fast(a, b)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_add` intrinsic: expected SIMD input type, found non-SIMD `Foo`
-  --> $DIR/bad-intrinsic-monomorphization.rs:30:5
+  --> $DIR/bad-intrinsic-monomorphization.rs:26:5
    |
-LL |     simd_add(a, b)
-   |     ^^^^^^^^^^^^^^
+LL |     intrinsics::simd::simd_add(a, b)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/simd/array-trait.rs
+++ b/tests/ui/simd/array-trait.rs
@@ -1,10 +1,10 @@
 // Figuring out the size of a vector type that depends on traits doesn't ICE
 
 #![allow(dead_code)]
-
-
-#![feature(repr_simd, intrinsics, generic_const_exprs)]
+#![feature(repr_simd, core_intrinsics, generic_const_exprs)]
 #![allow(non_camel_case_types, incomplete_features)]
+
+use std::intrinsics::simd::{simd_extract, simd_insert};
 
 pub trait Simd {
     type Lane: Clone + Copy;
@@ -23,13 +23,6 @@ pub struct T<S: Simd>([S::Lane; S::SIZE]);
 //~^ ERROR unconstrained generic constant
 //~| ERROR SIMD vector element type should be a primitive scalar
 //~| ERROR unconstrained generic constant
-
-#[rustc_intrinsic]
-unsafe fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_extract<T, E>(x: T, idx: u32) -> E;
-
 
 pub fn main() {
     let mut t = T::<i32x4>([0; 4]);

--- a/tests/ui/simd/array-type.rs
+++ b/tests/ui/simd/array-type.rs
@@ -1,8 +1,8 @@
 //@ run-pass
 #![allow(dead_code)]
+#![feature(repr_simd, core_intrinsics)]
 
-
-#![feature(repr_simd, intrinsics)]
+use std::intrinsics::simd::{simd_extract, simd_insert};
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -11,13 +11,6 @@ struct S([i32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct T<const N: usize>([i32; N]);
-
-#[rustc_intrinsic]
-unsafe fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_extract<T, E>(x: T, idx: u32) -> E;
-
 
 pub fn main() {
     let mut s = S([0; 4]);

--- a/tests/ui/simd/generics.rs
+++ b/tests/ui/simd/generics.rs
@@ -1,7 +1,8 @@
 //@ run-pass
 #![allow(non_camel_case_types)]
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
+use std::intrinsics::simd::simd_add;
 use std::ops;
 
 #[repr(simd)]
@@ -20,11 +21,7 @@ struct B<T>([T; 4]);
 #[derive(Copy, Clone)]
 struct C<T, const N: usize>([T; N]);
 
-
-#[rustc_intrinsic]
-unsafe fn simd_add<T>(x: T, y: T) -> T;
-
-fn add<T: ops::Add<Output=T>>(lhs: T, rhs: T) -> T {
+fn add<T: ops::Add<Output = T>>(lhs: T, rhs: T) -> T {
     lhs + rhs
 }
 
@@ -59,7 +56,6 @@ impl ops::Add for C<f32, 4> {
         unsafe { simd_add(self, rhs) }
     }
 }
-
 
 pub fn main() {
     let x = [1.0f32, 2.0f32, 3.0f32, 4.0f32];

--- a/tests/ui/simd/intrinsic/float-math-pass.rs
+++ b/tests/ui/simd/intrinsic/float-math-pass.rs
@@ -8,58 +8,14 @@
 
 // Test that the simd floating-point math intrinsics produce correct results.
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, intrinsics, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct f32x4(pub [f32; 4]);
 
-#[rustc_intrinsic]
-unsafe fn simd_fsqrt<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_fabs<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_fsin<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_fcos<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_fexp<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_fexp2<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_fma<T>(x: T, y: T, z: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_relaxed_fma<T>(x: T, y: T, z: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_flog<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_flog10<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_flog2<T>(x: T) -> T;
-
-// rounding functions
-#[rustc_intrinsic]
-unsafe fn simd_ceil<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_floor<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_round<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_trunc<T>(x: T) -> T;
+use std::intrinsics::simd::*;
 
 macro_rules! assert_approx_eq_f32 {
     ($a:expr, $b:expr) => {{

--- a/tests/ui/simd/intrinsic/generic-arithmetic-2.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-2.rs
@@ -1,7 +1,10 @@
 //@ build-fail
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::*;
+
 #[repr(simd)]
 #[derive(Copy, Clone)]
 pub struct i32x4(pub [i32; 4]);
@@ -13,55 +16,6 @@ pub struct u32x4(pub [u32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 pub struct f32x4(pub [f32; 4]);
-
-#[rustc_intrinsic]
-unsafe fn simd_add<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_sub<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_mul<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_div<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_rem<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_shl<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_shr<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_and<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_or<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_xor<T>(x: T, y: T) -> T;
-
-
-#[rustc_intrinsic]
-unsafe fn simd_neg<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_bswap<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_bitreverse<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_ctlz<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_ctpop<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_cttz<T>(x: T) -> T;
 
 fn main() {
     let x = i32x4([0, 0, 0, 0]);

--- a/tests/ui/simd/intrinsic/generic-arithmetic-2.stderr
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-2.stderr
@@ -1,143 +1,143 @@
 error[E0511]: invalid monomorphization of `simd_add` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:110:9
+  --> $DIR/generic-arithmetic-2.rs:64:9
    |
 LL |         simd_add(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_sub` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:112:9
+  --> $DIR/generic-arithmetic-2.rs:66:9
    |
 LL |         simd_sub(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_mul` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:114:9
+  --> $DIR/generic-arithmetic-2.rs:68:9
    |
 LL |         simd_mul(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_div` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:116:9
+  --> $DIR/generic-arithmetic-2.rs:70:9
    |
 LL |         simd_div(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shl` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:118:9
+  --> $DIR/generic-arithmetic-2.rs:72:9
    |
 LL |         simd_shl(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shr` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:120:9
+  --> $DIR/generic-arithmetic-2.rs:74:9
    |
 LL |         simd_shr(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_and` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:122:9
+  --> $DIR/generic-arithmetic-2.rs:76:9
    |
 LL |         simd_and(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_or` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:124:9
+  --> $DIR/generic-arithmetic-2.rs:78:9
    |
 LL |         simd_or(0, 0);
    |         ^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_xor` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:126:9
+  --> $DIR/generic-arithmetic-2.rs:80:9
    |
 LL |         simd_xor(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_neg` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:129:9
+  --> $DIR/generic-arithmetic-2.rs:83:9
    |
 LL |         simd_neg(0);
    |         ^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_bswap` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:131:9
+  --> $DIR/generic-arithmetic-2.rs:85:9
    |
 LL |         simd_bswap(0);
    |         ^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_bitreverse` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:133:9
+  --> $DIR/generic-arithmetic-2.rs:87:9
    |
 LL |         simd_bitreverse(0);
    |         ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ctlz` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:135:9
+  --> $DIR/generic-arithmetic-2.rs:89:9
    |
 LL |         simd_ctlz(0);
    |         ^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_cttz` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-arithmetic-2.rs:137:9
+  --> $DIR/generic-arithmetic-2.rs:91:9
    |
 LL |         simd_cttz(0);
    |         ^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shl` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/generic-arithmetic-2.rs:140:9
+  --> $DIR/generic-arithmetic-2.rs:94:9
    |
 LL |         simd_shl(z, z);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shr` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/generic-arithmetic-2.rs:142:9
+  --> $DIR/generic-arithmetic-2.rs:96:9
    |
 LL |         simd_shr(z, z);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_and` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/generic-arithmetic-2.rs:144:9
+  --> $DIR/generic-arithmetic-2.rs:98:9
    |
 LL |         simd_and(z, z);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_or` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/generic-arithmetic-2.rs:146:9
+  --> $DIR/generic-arithmetic-2.rs:100:9
    |
 LL |         simd_or(z, z);
    |         ^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_xor` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/generic-arithmetic-2.rs:148:9
+  --> $DIR/generic-arithmetic-2.rs:102:9
    |
 LL |         simd_xor(z, z);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_bswap` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/generic-arithmetic-2.rs:150:9
+  --> $DIR/generic-arithmetic-2.rs:104:9
    |
 LL |         simd_bswap(z);
    |         ^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_bitreverse` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/generic-arithmetic-2.rs:152:9
+  --> $DIR/generic-arithmetic-2.rs:106:9
    |
 LL |         simd_bitreverse(z);
    |         ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ctlz` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/generic-arithmetic-2.rs:154:9
+  --> $DIR/generic-arithmetic-2.rs:108:9
    |
 LL |         simd_ctlz(z);
    |         ^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ctpop` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/generic-arithmetic-2.rs:156:9
+  --> $DIR/generic-arithmetic-2.rs:110:9
    |
 LL |         simd_ctpop(z);
    |         ^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_cttz` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/generic-arithmetic-2.rs:158:9
+  --> $DIR/generic-arithmetic-2.rs:112:9
    |
 LL |         simd_cttz(z);
    |         ^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-arithmetic-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-pass.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 #![allow(non_camel_case_types)]
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -22,53 +22,7 @@ macro_rules! all_eq {
     }};
 }
 
-#[rustc_intrinsic]
-unsafe fn simd_add<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_sub<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_mul<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_div<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_rem<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_shl<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_shr<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_and<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_or<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_xor<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_neg<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_bswap<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_bitreverse<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_ctlz<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_ctpop<T>(x: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_cttz<T>(x: T) -> T;
+use std::intrinsics::simd::*;
 
 fn main() {
     let x1 = i32x4([1, 2, 3, 4]);

--- a/tests/ui/simd/intrinsic/generic-arithmetic-saturating-2.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-saturating-2.rs
@@ -1,7 +1,10 @@
 //@ build-fail
 //@ ignore-emscripten
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{simd_saturating_add, simd_saturating_sub};
+
 #[repr(simd)]
 #[derive(Copy, Clone)]
 pub struct i32x4(pub [i32; 4]);
@@ -13,13 +16,6 @@ pub struct x4<T>(pub [T; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 pub struct f32x4(pub [f32; 4]);
-
-#[rustc_intrinsic]
-unsafe fn simd_saturating_add<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_saturating_sub<T>(x: T, y: T) -> T;
-
 
 fn main() {
     let x = i32x4([0, 0, 0, 0]);

--- a/tests/ui/simd/intrinsic/generic-arithmetic-saturating-2.stderr
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-saturating-2.stderr
@@ -1,11 +1,11 @@
 error[E0511]: invalid monomorphization of `simd_saturating_add` intrinsic: expected element type `f32` of vector type `f32x4` to be a signed or unsigned integer type
-  --> $DIR/generic-arithmetic-saturating-2.rs:35:9
+  --> $DIR/generic-arithmetic-saturating-2.rs:31:9
    |
 LL |         simd_saturating_add(z, z);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_saturating_sub` intrinsic: expected element type `f32` of vector type `f32x4` to be a signed or unsigned integer type
-  --> $DIR/generic-arithmetic-saturating-2.rs:37:9
+  --> $DIR/generic-arithmetic-saturating-2.rs:33:9
    |
 LL |         simd_saturating_sub(z, z);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
@@ -2,7 +2,9 @@
 //@ ignore-emscripten
 
 #![allow(non_camel_case_types)]
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+
+use std::intrinsics::simd::{simd_saturating_add, simd_saturating_sub};
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -11,13 +13,6 @@ struct u32x4(pub [u32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct I32<const N: usize>([i32; N]);
-
-#[rustc_intrinsic]
-unsafe fn simd_saturating_add<T>(x: T, y: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_saturating_sub<T>(x: T, y: T) -> T;
-
 
 fn main() {
     // unsigned

--- a/tests/ui/simd/intrinsic/generic-as.rs
+++ b/tests/ui/simd/intrinsic/generic-as.rs
@@ -1,10 +1,8 @@
 //@ run-pass
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
-
-#[rustc_intrinsic]
-unsafe fn simd_as<T, U>(x: T) -> U;
+use std::intrinsics::simd::simd_as;
 
 #[derive(Copy, Clone)]
 #[repr(simd)]

--- a/tests/ui/simd/intrinsic/generic-bitmask-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-bitmask-pass.rs
@@ -1,13 +1,12 @@
 //@ run-pass
 #![allow(non_camel_case_types)]
-
 //@ ignore-emscripten
 //@ ignore-endian-big behavior of simd_bitmask is endian-specific
 
 // Test that the simd_bitmask intrinsic produces correct results.
+#![feature(repr_simd, core_intrinsics)]
 
-#![feature(repr_simd, intrinsics)]
-#[allow(non_camel_case_types)]
+use std::intrinsics::simd::simd_bitmask;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -20,9 +19,6 @@ struct u8x4(pub [u8; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct Tx4<T>(pub [T; 4]);
-
-#[rustc_intrinsic]
-unsafe fn simd_bitmask<T, U>(x: T) -> U;
 
 fn main() {
     let z = u32x4([0, 0, 0, 0]);
@@ -56,6 +52,5 @@ fn main() {
 
         let r: u8 = simd_bitmask(msize);
         assert_eq!(r, e);
-
     }
 }

--- a/tests/ui/simd/intrinsic/generic-bitmask.rs
+++ b/tests/ui/simd/intrinsic/generic-bitmask.rs
@@ -3,8 +3,10 @@
 // Test that the simd_bitmask intrinsic produces ok-ish error
 // messages when misused.
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_bitmask;
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -29,9 +31,6 @@ struct u8x32([u8; 32]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct u8x64([u8; 64]);
-
-#[rustc_intrinsic]
-unsafe fn simd_bitmask<T, U>(x: T) -> U;
 
 fn main() {
     let m2 = u32x2([0; 2]);
@@ -63,6 +62,5 @@ fn main() {
 
         let _: u128 = simd_bitmask(m64);
         //~^ ERROR invalid monomorphization of `simd_bitmask` intrinsic
-
-   }
+    }
 }

--- a/tests/ui/simd/intrinsic/generic-bitmask.stderr
+++ b/tests/ui/simd/intrinsic/generic-bitmask.stderr
@@ -1,29 +1,29 @@
 error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u16`, expected `u8` or `[u8; 1]`
-  --> $DIR/generic-bitmask.rs:52:22
+  --> $DIR/generic-bitmask.rs:51:22
    |
 LL |         let _: u16 = simd_bitmask(m2);
    |                      ^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u16`, expected `u8` or `[u8; 1]`
-  --> $DIR/generic-bitmask.rs:55:22
+  --> $DIR/generic-bitmask.rs:54:22
    |
 LL |         let _: u16 = simd_bitmask(m8);
    |                      ^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u32`, expected `u16` or `[u8; 2]`
-  --> $DIR/generic-bitmask.rs:58:22
+  --> $DIR/generic-bitmask.rs:57:22
    |
 LL |         let _: u32 = simd_bitmask(m16);
    |                      ^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u64`, expected `u32` or `[u8; 4]`
-  --> $DIR/generic-bitmask.rs:61:22
+  --> $DIR/generic-bitmask.rs:60:22
    |
 LL |         let _: u64 = simd_bitmask(m32);
    |                      ^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_bitmask` intrinsic: cannot return `u128`, expected `u64` or `[u8; 8]`
-  --> $DIR/generic-bitmask.rs:64:23
+  --> $DIR/generic-bitmask.rs:63:23
    |
 LL |         let _: u128 = simd_bitmask(m64);
    |                       ^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-bswap-byte.rs
+++ b/tests/ui/simd/intrinsic/generic-bswap-byte.rs
@@ -1,6 +1,8 @@
 //@ run-pass
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_bswap;
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -9,9 +11,6 @@ struct i8x4([i8; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct u8x4([u8; 4]);
-
-#[rustc_intrinsic]
-unsafe fn simd_bswap<T>(x: T) -> T;
 
 fn main() {
     unsafe {

--- a/tests/ui/simd/intrinsic/generic-cast-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-cast-pass.rs
@@ -1,9 +1,8 @@
 //@ run-pass
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
-#[rustc_intrinsic]
-unsafe fn simd_cast<T, U>(x: T) -> U;
+use std::intrinsics::simd::simd_cast;
 
 use std::cmp::{max, min};
 

--- a/tests/ui/simd/intrinsic/generic-cast-pointer-width.rs
+++ b/tests/ui/simd/intrinsic/generic-cast-pointer-width.rs
@@ -1,8 +1,7 @@
 //@ run-pass
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
-#[rustc_intrinsic]
-unsafe fn simd_cast<T, U>(x: T) -> U;
+use std::intrinsics::simd::simd_cast;
 
 #[derive(Copy, Clone)]
 #[repr(simd)]

--- a/tests/ui/simd/intrinsic/generic-cast.rs
+++ b/tests/ui/simd/intrinsic/generic-cast.rs
@@ -1,6 +1,8 @@
 //@ build-fail
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+
+use std::intrinsics::simd::simd_cast;
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -20,10 +22,6 @@ struct f32x4([f32; 4]);
 #[allow(non_camel_case_types)]
 struct f32x8([f32; 8]);
 
-
-#[rustc_intrinsic]
-unsafe fn simd_cast<T, U>(x: T) -> U;
-
 fn main() {
     let x = i32x4([0, 0, 0, 0]);
 
@@ -35,6 +33,6 @@ fn main() {
         simd_cast::<i32x4, i32>(x);
         //~^ ERROR expected SIMD return type, found non-SIMD `i32`
         simd_cast::<_, i32x8>(x);
-//~^ ERROR return type with length 4 (same as input type `i32x4`), found `i32x8` with length 8
+        //~^ ERROR return type with length 4 (same as input type `i32x4`), found `i32x8` with length 8
     }
 }

--- a/tests/ui/simd/intrinsic/generic-cast.stderr
+++ b/tests/ui/simd/intrinsic/generic-cast.stderr
@@ -1,23 +1,23 @@
 error[E0511]: invalid monomorphization of `simd_cast` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-cast.rs:31:9
+  --> $DIR/generic-cast.rs:29:9
    |
 LL |         simd_cast::<i32, i32>(0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_cast` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-cast.rs:33:9
+  --> $DIR/generic-cast.rs:31:9
    |
 LL |         simd_cast::<i32, i32x4>(0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_cast` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-cast.rs:35:9
+  --> $DIR/generic-cast.rs:33:9
    |
 LL |         simd_cast::<i32x4, i32>(x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_cast` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i32x8` with length 8
-  --> $DIR/generic-cast.rs:37:9
+  --> $DIR/generic-cast.rs:35:9
    |
 LL |         simd_cast::<_, i32x8>(x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-comparison-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-comparison-pass.rs
@@ -1,7 +1,9 @@
 //@ run-pass
 
-#![feature(repr_simd, intrinsics, concat_idents)]
+#![feature(repr_simd, core_intrinsics, concat_idents)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{simd_eq, simd_ge, simd_gt, simd_le, simd_lt, simd_ne};
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -12,24 +14,6 @@ struct u32x4(pub [u32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct f32x4(pub [f32; 4]);
-
-#[rustc_intrinsic]
-unsafe fn simd_eq<T, U>(x: T, y: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_ne<T, U>(x: T, y: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_lt<T, U>(x: T, y: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_le<T, U>(x: T, y: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_gt<T, U>(x: T, y: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_ge<T, U>(x: T, y: T) -> U;
 
 macro_rules! cmp {
     ($method: ident($lhs: expr, $rhs: expr)) => {{

--- a/tests/ui/simd/intrinsic/generic-comparison.rs
+++ b/tests/ui/simd/intrinsic/generic-comparison.rs
@@ -1,6 +1,6 @@
 //@ build-fail
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -11,24 +11,7 @@ struct i32x4([i32; 4]);
 #[allow(non_camel_case_types)]
 struct i16x8([i16; 8]);
 
-
-#[rustc_intrinsic]
-unsafe fn simd_eq<T, U>(x: T, y: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_ne<T, U>(x: T, y: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_lt<T, U>(x: T, y: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_le<T, U>(x: T, y: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_gt<T, U>(x: T, y: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_ge<T, U>(x: T, y: T) -> U;
+use std::intrinsics::simd::{simd_eq, simd_ge, simd_gt, simd_le, simd_lt, simd_ne};
 
 fn main() {
     let x = i32x4([0, 0, 0, 0]);
@@ -61,16 +44,16 @@ fn main() {
         //~^ ERROR expected SIMD return type, found non-SIMD `i32`
 
         simd_eq::<_, i16x8>(x, x);
-//~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
+        //~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
         simd_ne::<_, i16x8>(x, x);
-//~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
+        //~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
         simd_lt::<_, i16x8>(x, x);
-//~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
+        //~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
         simd_le::<_, i16x8>(x, x);
-//~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
+        //~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
         simd_gt::<_, i16x8>(x, x);
-//~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
+        //~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
         simd_ge::<_, i16x8>(x, x);
-//~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
+        //~^ ERROR return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
     }
 }

--- a/tests/ui/simd/intrinsic/generic-comparison.stderr
+++ b/tests/ui/simd/intrinsic/generic-comparison.stderr
@@ -1,107 +1,107 @@
 error[E0511]: invalid monomorphization of `simd_eq` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:37:9
+  --> $DIR/generic-comparison.rs:20:9
    |
 LL |         simd_eq::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ne` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:39:9
+  --> $DIR/generic-comparison.rs:22:9
    |
 LL |         simd_ne::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_lt` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:41:9
+  --> $DIR/generic-comparison.rs:24:9
    |
 LL |         simd_lt::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_le` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:43:9
+  --> $DIR/generic-comparison.rs:26:9
    |
 LL |         simd_le::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_gt` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:45:9
+  --> $DIR/generic-comparison.rs:28:9
    |
 LL |         simd_gt::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ge` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:47:9
+  --> $DIR/generic-comparison.rs:30:9
    |
 LL |         simd_ge::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_eq` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:50:9
+  --> $DIR/generic-comparison.rs:33:9
    |
 LL |         simd_eq::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ne` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:52:9
+  --> $DIR/generic-comparison.rs:35:9
    |
 LL |         simd_ne::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_lt` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:54:9
+  --> $DIR/generic-comparison.rs:37:9
    |
 LL |         simd_lt::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_le` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:56:9
+  --> $DIR/generic-comparison.rs:39:9
    |
 LL |         simd_le::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_gt` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:58:9
+  --> $DIR/generic-comparison.rs:41:9
    |
 LL |         simd_gt::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ge` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:60:9
+  --> $DIR/generic-comparison.rs:43:9
    |
 LL |         simd_ge::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_eq` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:63:9
+  --> $DIR/generic-comparison.rs:46:9
    |
 LL |         simd_eq::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ne` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:65:9
+  --> $DIR/generic-comparison.rs:48:9
    |
 LL |         simd_ne::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_lt` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:67:9
+  --> $DIR/generic-comparison.rs:50:9
    |
 LL |         simd_lt::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_le` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:69:9
+  --> $DIR/generic-comparison.rs:52:9
    |
 LL |         simd_le::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_gt` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:71:9
+  --> $DIR/generic-comparison.rs:54:9
    |
 LL |         simd_gt::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ge` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:73:9
+  --> $DIR/generic-comparison.rs:56:9
    |
 LL |         simd_ge::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-elements-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-elements-pass.rs
@@ -1,6 +1,8 @@
 //@ run-pass
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+
+use std::intrinsics::simd::{simd_extract, simd_insert, simd_shuffle};
 
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -14,15 +16,6 @@ struct i32x4([i32; 4]);
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 struct i32x8([i32; 8]);
-
-#[rustc_intrinsic]
-unsafe fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_extract<T, E>(x: T, idx: u32) -> E;
-
-#[rustc_intrinsic]
-unsafe fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 
 #[repr(simd)]
 struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);

--- a/tests/ui/simd/intrinsic/generic-elements.rs
+++ b/tests/ui/simd/intrinsic/generic-elements.rs
@@ -1,7 +1,19 @@
 //@ build-fail
 
-#![feature(repr_simd, intrinsics, rustc_attrs, adt_const_params, unsized_const_params)]
+#![feature(
+    repr_simd,
+    intrinsics,
+    core_intrinsics,
+    rustc_attrs,
+    adt_const_params,
+    unsized_const_params
+)]
 #![allow(incomplete_features)]
+
+use std::intrinsics::simd::{simd_extract, simd_insert, simd_shuffle};
+
+#[rustc_intrinsic]
+unsafe fn simd_shuffle_const_generic<T, U, const IDX: &'static [u32]>(x: T, y: T) -> U;
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -28,21 +40,6 @@ struct f32x4([f32; 4]);
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
 struct f32x8([f32; 8]);
-
-
-#[rustc_intrinsic]
-unsafe fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_extract<T, E>(x: T, idx: u32) -> E;
-
-
-#[rustc_intrinsic]
-unsafe fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_shuffle_const_generic<T, U, const IDX: &'static [u32]>(x: T, y: T) -> U;
-
 
 #[repr(simd)]
 struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);

--- a/tests/ui/simd/intrinsic/generic-elements.stderr
+++ b/tests/ui/simd/intrinsic/generic-elements.stderr
@@ -1,125 +1,125 @@
 error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:54:9
+  --> $DIR/generic-elements.rs:51:9
    |
 LL |         simd_insert(0, 0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected inserted type `i32` (element of input `i32x4`), found `f64`
-  --> $DIR/generic-elements.rs:56:9
+  --> $DIR/generic-elements.rs:53:9
    |
 LL |         simd_insert(x, 0, 1.0);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_extract` intrinsic: expected return type `i32` (element of input `i32x4`), found `f32`
-  --> $DIR/generic-elements.rs:58:9
+  --> $DIR/generic-elements.rs:55:9
    |
 LL |         simd_extract::<_, f32>(x, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:62:9
+  --> $DIR/generic-elements.rs:59:9
    |
 LL |         simd_shuffle::<i32, _, i32>(0, 0, IDX2);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:65:9
+  --> $DIR/generic-elements.rs:62:9
    |
 LL |         simd_shuffle::<i32, _, i32>(0, 0, IDX4);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:68:9
+  --> $DIR/generic-elements.rs:65:9
    |
 LL |         simd_shuffle::<i32, _, i32>(0, 0, IDX8);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x2` with element type `f32`
-  --> $DIR/generic-elements.rs:71:9
+  --> $DIR/generic-elements.rs:68:9
    |
 LL |         simd_shuffle::<_, _, f32x2>(x, x, IDX2);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x4` with element type `f32`
-  --> $DIR/generic-elements.rs:73:9
+  --> $DIR/generic-elements.rs:70:9
    |
 LL |         simd_shuffle::<_, _, f32x4>(x, x, IDX4);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x8` with element type `f32`
-  --> $DIR/generic-elements.rs:75:9
+  --> $DIR/generic-elements.rs:72:9
    |
 LL |         simd_shuffle::<_, _, f32x8>(x, x, IDX8);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 2, found `i32x8` with length 8
-  --> $DIR/generic-elements.rs:78:9
+  --> $DIR/generic-elements.rs:75:9
    |
 LL |         simd_shuffle::<_, _, i32x8>(x, x, IDX2);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 4, found `i32x8` with length 8
-  --> $DIR/generic-elements.rs:80:9
+  --> $DIR/generic-elements.rs:77:9
    |
 LL |         simd_shuffle::<_, _, i32x8>(x, x, IDX4);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 8, found `i32x2` with length 2
-  --> $DIR/generic-elements.rs:82:9
+  --> $DIR/generic-elements.rs:79:9
    |
 LL |         simd_shuffle::<_, _, i32x2>(x, x, IDX8);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_const_generic` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:86:9
+  --> $DIR/generic-elements.rs:83:9
    |
 LL |         simd_shuffle_const_generic::<i32, i32, I2>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_const_generic` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:89:9
+  --> $DIR/generic-elements.rs:86:9
    |
 LL |         simd_shuffle_const_generic::<i32, i32, I4>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_const_generic` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:92:9
+  --> $DIR/generic-elements.rs:89:9
    |
 LL |         simd_shuffle_const_generic::<i32, i32, I8>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_const_generic` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x2` with element type `f32`
-  --> $DIR/generic-elements.rs:95:9
+  --> $DIR/generic-elements.rs:92:9
    |
 LL |         simd_shuffle_const_generic::<_, f32x2, I2>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_const_generic` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x4` with element type `f32`
-  --> $DIR/generic-elements.rs:97:9
+  --> $DIR/generic-elements.rs:94:9
    |
 LL |         simd_shuffle_const_generic::<_, f32x4, I4>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_const_generic` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x8` with element type `f32`
-  --> $DIR/generic-elements.rs:99:9
+  --> $DIR/generic-elements.rs:96:9
    |
 LL |         simd_shuffle_const_generic::<_, f32x8, I8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_const_generic` intrinsic: expected return type of length 2, found `i32x8` with length 8
-  --> $DIR/generic-elements.rs:102:9
+  --> $DIR/generic-elements.rs:99:9
    |
 LL |         simd_shuffle_const_generic::<_, i32x8, I2>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_const_generic` intrinsic: expected return type of length 4, found `i32x8` with length 8
-  --> $DIR/generic-elements.rs:104:9
+  --> $DIR/generic-elements.rs:101:9
    |
 LL |         simd_shuffle_const_generic::<_, i32x8, I4>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_const_generic` intrinsic: expected return type of length 8, found `i32x2` with length 2
-  --> $DIR/generic-elements.rs:106:9
+  --> $DIR/generic-elements.rs:103:9
    |
 LL |         simd_shuffle_const_generic::<_, i32x2, I8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-gather-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-gather-pass.rs
@@ -3,18 +3,14 @@
 
 // Test that the simd_{gather,scatter} intrinsics produce the correct results.
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{simd_gather, simd_scatter};
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct x4<T>(pub [T; 4]);
-
-#[rustc_intrinsic]
-unsafe fn simd_gather<T, U, V>(x: T, y: U, z: V) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_scatter<T, U, V>(x: T, y: U, z: V) -> ();
 
 fn main() {
     let mut x = [0_f32, 1., 2., 3., 4., 5., 6., 7.];
@@ -26,12 +22,8 @@ fn main() {
     // reading from *const
     unsafe {
         let pointer = x.as_ptr();
-        let pointers =  x4([
-            pointer.offset(0),
-            pointer.offset(2),
-            pointer.offset(4),
-            pointer.offset(6)
-        ]);
+        let pointers =
+            x4([pointer.offset(0), pointer.offset(2), pointer.offset(4), pointer.offset(6)]);
 
         let r_strided = simd_gather(default, pointers, mask);
 
@@ -41,12 +33,8 @@ fn main() {
     // reading from *mut
     unsafe {
         let pointer = x.as_mut_ptr();
-        let pointers = x4([
-            pointer.offset(0),
-            pointer.offset(2),
-            pointer.offset(4),
-            pointer.offset(6)
-        ]);
+        let pointers =
+            x4([pointer.offset(0), pointer.offset(2), pointer.offset(4), pointer.offset(6)]);
 
         let r_strided = simd_gather(default, pointers, mask);
 
@@ -56,12 +44,8 @@ fn main() {
     // writing to *mut
     unsafe {
         let pointer = x.as_mut_ptr();
-        let pointers = x4([
-            pointer.offset(0),
-            pointer.offset(2),
-            pointer.offset(4),
-            pointer.offset(6)
-        ]);
+        let pointers =
+            x4([pointer.offset(0), pointer.offset(2), pointer.offset(4), pointer.offset(6)]);
 
         let values = x4([42_f32, 43_f32, 44_f32, 45_f32]);
         simd_scatter(values, pointers, mask);
@@ -78,7 +62,7 @@ fn main() {
         &x[4] as *const f32,
         &x[5] as *const f32,
         &x[6] as *const f32,
-        &x[7] as *const f32
+        &x[7] as *const f32,
     ];
 
     let default = x4([y[0], y[0], y[0], y[0]]);
@@ -87,12 +71,8 @@ fn main() {
     // reading from *const
     unsafe {
         let pointer = y.as_ptr();
-        let pointers = x4([
-            pointer.offset(0),
-            pointer.offset(2),
-            pointer.offset(4),
-            pointer.offset(6)
-        ]);
+        let pointers =
+            x4([pointer.offset(0), pointer.offset(2), pointer.offset(4), pointer.offset(6)]);
 
         let r_strided = simd_gather(default, pointers, mask);
 
@@ -102,12 +82,8 @@ fn main() {
     // reading from *mut
     unsafe {
         let pointer = y.as_mut_ptr();
-        let pointers = x4([
-            pointer.offset(0),
-            pointer.offset(2),
-            pointer.offset(4),
-            pointer.offset(6)
-        ]);
+        let pointers =
+            x4([pointer.offset(0), pointer.offset(2), pointer.offset(4), pointer.offset(6)]);
 
         let r_strided = simd_gather(default, pointers, mask);
 
@@ -117,12 +93,8 @@ fn main() {
     // writing to *mut
     unsafe {
         let pointer = y.as_mut_ptr();
-        let pointers = x4([
-            pointer.offset(0),
-            pointer.offset(2),
-            pointer.offset(4),
-            pointer.offset(6)
-        ]);
+        let pointers =
+            x4([pointer.offset(0), pointer.offset(2), pointer.offset(4), pointer.offset(6)]);
 
         let values = x4([y[7], y[6], y[5], y[1]]);
         simd_scatter(values, pointers, mask);
@@ -135,7 +107,7 @@ fn main() {
             &x[4] as *const f32,
             &x[5] as *const f32,
             &x[1] as *const f32,
-            &x[7] as *const f32
+            &x[7] as *const f32,
         ];
         assert_eq!(y, s);
     }

--- a/tests/ui/simd/intrinsic/generic-reduction-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-reduction-pass.rs
@@ -1,12 +1,15 @@
 //@ run-pass
 #![allow(non_camel_case_types)]
-
 //@ ignore-emscripten
 
 // Test that the simd_reduce_{op} intrinsics produce the correct results.
+#![feature(repr_simd, core_intrinsics)]
 
-#![feature(repr_simd, intrinsics)]
-#[allow(non_camel_case_types)]
+use std::intrinsics::simd::{
+    simd_reduce_add_ordered, simd_reduce_add_unordered, simd_reduce_all, simd_reduce_and,
+    simd_reduce_any, simd_reduce_max, simd_reduce_min, simd_reduce_mul_ordered,
+    simd_reduce_mul_unordered, simd_reduce_or, simd_reduce_xor,
+};
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -23,39 +26,6 @@ struct f32x4(pub [f32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct b8x4(pub [i8; 4]);
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_add_unordered<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_mul_unordered<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_add_ordered<T, U>(x: T, acc: U) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_mul_ordered<T, U>(x: T, acc: U) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_min<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_max<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_and<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_or<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_xor<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_all<T>(x: T) -> bool;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_any<T>(x: T) -> bool;
 
 fn main() {
     unsafe {

--- a/tests/ui/simd/intrinsic/generic-reduction-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-reduction-pass.rs
@@ -5,11 +5,7 @@
 // Test that the simd_reduce_{op} intrinsics produce the correct results.
 #![feature(repr_simd, core_intrinsics)]
 
-use std::intrinsics::simd::{
-    simd_reduce_add_ordered, simd_reduce_add_unordered, simd_reduce_all, simd_reduce_and,
-    simd_reduce_any, simd_reduce_max, simd_reduce_min, simd_reduce_mul_ordered,
-    simd_reduce_mul_unordered, simd_reduce_or, simd_reduce_xor,
-};
+use std::intrinsics::simd::*;
 
 #[repr(simd)]
 #[derive(Copy, Clone)]

--- a/tests/ui/simd/intrinsic/generic-reduction.rs
+++ b/tests/ui/simd/intrinsic/generic-reduction.rs
@@ -4,8 +4,13 @@
 // Test that the simd_reduce_{op} intrinsics produce ok-ish error
 // messages when misused.
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{
+    simd_reduce_add_ordered, simd_reduce_all, simd_reduce_and, simd_reduce_any,
+    simd_reduce_mul_ordered, simd_reduce_or, simd_reduce_xor,
+};
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -14,27 +19,6 @@ pub struct f32x4(pub [f32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 pub struct u32x4(pub [u32; 4]);
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_add_ordered<T, U>(x: T, y: U) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_mul_ordered<T, U>(x: T, y: U) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_and<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_or<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_xor<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_all<T>(x: T) -> bool;
-
-#[rustc_intrinsic]
-unsafe fn simd_reduce_any<T>(x: T) -> bool;
 
 fn main() {
     let x = u32x4([0, 0, 0, 0]);

--- a/tests/ui/simd/intrinsic/generic-reduction.rs
+++ b/tests/ui/simd/intrinsic/generic-reduction.rs
@@ -7,10 +7,7 @@
 #![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
 
-use std::intrinsics::simd::{
-    simd_reduce_add_ordered, simd_reduce_all, simd_reduce_and, simd_reduce_any,
-    simd_reduce_mul_ordered, simd_reduce_or, simd_reduce_xor,
-};
+use std::intrinsics::simd::*;
 
 #[repr(simd)]
 #[derive(Copy, Clone)]

--- a/tests/ui/simd/intrinsic/generic-reduction.stderr
+++ b/tests/ui/simd/intrinsic/generic-reduction.stderr
@@ -1,59 +1,59 @@
 error[E0511]: invalid monomorphization of `simd_reduce_add_ordered` intrinsic: expected return type `f32` (element of input `f32x4`), found `i32`
-  --> $DIR/generic-reduction.rs:28:9
+  --> $DIR/generic-reduction.rs:25:9
    |
 LL |         simd_reduce_add_ordered(z, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_mul_ordered` intrinsic: expected return type `f32` (element of input `f32x4`), found `i32`
-  --> $DIR/generic-reduction.rs:30:9
+  --> $DIR/generic-reduction.rs:27:9
    |
 LL |         simd_reduce_mul_ordered(z, 1);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_and` intrinsic: expected return type `u32` (element of input `u32x4`), found `f32`
-  --> $DIR/generic-reduction.rs:33:22
+  --> $DIR/generic-reduction.rs:30:22
    |
 LL |         let _: f32 = simd_reduce_and(x);
    |                      ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_or` intrinsic: expected return type `u32` (element of input `u32x4`), found `f32`
-  --> $DIR/generic-reduction.rs:35:22
+  --> $DIR/generic-reduction.rs:32:22
    |
 LL |         let _: f32 = simd_reduce_or(x);
    |                      ^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_xor` intrinsic: expected return type `u32` (element of input `u32x4`), found `f32`
-  --> $DIR/generic-reduction.rs:37:22
+  --> $DIR/generic-reduction.rs:34:22
    |
 LL |         let _: f32 = simd_reduce_xor(x);
    |                      ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_and` intrinsic: unsupported simd_reduce_and from `f32x4` with element `f32` to `f32`
-  --> $DIR/generic-reduction.rs:40:22
+  --> $DIR/generic-reduction.rs:37:22
    |
 LL |         let _: f32 = simd_reduce_and(z);
    |                      ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_or` intrinsic: unsupported simd_reduce_or from `f32x4` with element `f32` to `f32`
-  --> $DIR/generic-reduction.rs:42:22
+  --> $DIR/generic-reduction.rs:39:22
    |
 LL |         let _: f32 = simd_reduce_or(z);
    |                      ^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_xor` intrinsic: unsupported simd_reduce_xor from `f32x4` with element `f32` to `f32`
-  --> $DIR/generic-reduction.rs:44:22
+  --> $DIR/generic-reduction.rs:41:22
    |
 LL |         let _: f32 = simd_reduce_xor(z);
    |                      ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_all` intrinsic: unsupported simd_reduce_all from `f32x4` with element `f32` to `bool`
-  --> $DIR/generic-reduction.rs:47:23
+  --> $DIR/generic-reduction.rs:44:23
    |
 LL |         let _: bool = simd_reduce_all(z);
    |                       ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_any` intrinsic: unsupported simd_reduce_any from `f32x4` with element `f32` to `bool`
-  --> $DIR/generic-reduction.rs:49:23
+  --> $DIR/generic-reduction.rs:46:23
    |
 LL |         let _: bool = simd_reduce_any(z);
    |                       ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-reduction.stderr
+++ b/tests/ui/simd/intrinsic/generic-reduction.stderr
@@ -1,59 +1,59 @@
 error[E0511]: invalid monomorphization of `simd_reduce_add_ordered` intrinsic: expected return type `f32` (element of input `f32x4`), found `i32`
-  --> $DIR/generic-reduction.rs:44:9
+  --> $DIR/generic-reduction.rs:28:9
    |
 LL |         simd_reduce_add_ordered(z, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_mul_ordered` intrinsic: expected return type `f32` (element of input `f32x4`), found `i32`
-  --> $DIR/generic-reduction.rs:46:9
+  --> $DIR/generic-reduction.rs:30:9
    |
 LL |         simd_reduce_mul_ordered(z, 1);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_and` intrinsic: expected return type `u32` (element of input `u32x4`), found `f32`
-  --> $DIR/generic-reduction.rs:49:22
+  --> $DIR/generic-reduction.rs:33:22
    |
 LL |         let _: f32 = simd_reduce_and(x);
    |                      ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_or` intrinsic: expected return type `u32` (element of input `u32x4`), found `f32`
-  --> $DIR/generic-reduction.rs:51:22
+  --> $DIR/generic-reduction.rs:35:22
    |
 LL |         let _: f32 = simd_reduce_or(x);
    |                      ^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_xor` intrinsic: expected return type `u32` (element of input `u32x4`), found `f32`
-  --> $DIR/generic-reduction.rs:53:22
+  --> $DIR/generic-reduction.rs:37:22
    |
 LL |         let _: f32 = simd_reduce_xor(x);
    |                      ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_and` intrinsic: unsupported simd_reduce_and from `f32x4` with element `f32` to `f32`
-  --> $DIR/generic-reduction.rs:56:22
+  --> $DIR/generic-reduction.rs:40:22
    |
 LL |         let _: f32 = simd_reduce_and(z);
    |                      ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_or` intrinsic: unsupported simd_reduce_or from `f32x4` with element `f32` to `f32`
-  --> $DIR/generic-reduction.rs:58:22
+  --> $DIR/generic-reduction.rs:42:22
    |
 LL |         let _: f32 = simd_reduce_or(z);
    |                      ^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_xor` intrinsic: unsupported simd_reduce_xor from `f32x4` with element `f32` to `f32`
-  --> $DIR/generic-reduction.rs:60:22
+  --> $DIR/generic-reduction.rs:44:22
    |
 LL |         let _: f32 = simd_reduce_xor(z);
    |                      ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_all` intrinsic: unsupported simd_reduce_all from `f32x4` with element `f32` to `bool`
-  --> $DIR/generic-reduction.rs:63:23
+  --> $DIR/generic-reduction.rs:47:23
    |
 LL |         let _: bool = simd_reduce_all(z);
    |                       ^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_reduce_any` intrinsic: unsupported simd_reduce_any from `f32x4` with element `f32` to `bool`
-  --> $DIR/generic-reduction.rs:65:23
+  --> $DIR/generic-reduction.rs:49:23
    |
 LL |         let _: bool = simd_reduce_any(z);
    |                       ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-select-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-select-pass.rs
@@ -1,13 +1,12 @@
 //@ run-pass
 #![allow(non_camel_case_types)]
-
 //@ ignore-emscripten
 //@ ignore-endian-big behavior of simd_select_bitmask is endian-specific
 
 // Test that the simd_select intrinsics produces correct results.
+#![feature(repr_simd, core_intrinsics)]
 
-#![feature(repr_simd, intrinsics)]
-#[allow(non_camel_case_types)]
+use std::intrinsics::simd::{simd_select, simd_select_bitmask};
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -28,13 +27,6 @@ struct f32x4(pub [f32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct b8x4(pub [i8; 4]);
-
-#[rustc_intrinsic]
-unsafe fn simd_select<T, U>(x: T, a: U, b: U) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_select_bitmask<T, U>(x: T, a: U, b: U) -> U;
-
 
 fn main() {
     let m0 = b8x4([!0, !0, !0, !0]);

--- a/tests/ui/simd/intrinsic/generic-select.rs
+++ b/tests/ui/simd/intrinsic/generic-select.rs
@@ -3,8 +3,10 @@
 // Test that the simd_select intrinsic produces ok-ish error
 // messages when misused.
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{simd_select, simd_select_bitmask};
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -21,14 +23,6 @@ struct b8x4(pub [i8; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq)]
 struct b8x8(pub [i8; 8]);
-
-
-#[rustc_intrinsic]
-unsafe fn simd_select<T, U>(x: T, a: U, b: U) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_select_bitmask<T, U>(x: T, a: U, b: U) -> U;
-
 
 fn main() {
     let m4 = b8x4([0, 0, 0, 0]);

--- a/tests/ui/simd/intrinsic/generic-select.stderr
+++ b/tests/ui/simd/intrinsic/generic-select.stderr
@@ -1,47 +1,47 @@
 error[E0511]: invalid monomorphization of `simd_select` intrinsic: mismatched lengths: mask length `8` != other vector length `4`
-  --> $DIR/generic-select.rs:42:9
+  --> $DIR/generic-select.rs:36:9
    |
 LL |         simd_select(m8, x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_select` intrinsic: mask element type is `u32`, expected `i_`
-  --> $DIR/generic-select.rs:45:9
+  --> $DIR/generic-select.rs:39:9
    |
 LL |         simd_select(x, x, x);
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_select` intrinsic: mask element type is `f32`, expected `i_`
-  --> $DIR/generic-select.rs:48:9
+  --> $DIR/generic-select.rs:42:9
    |
 LL |         simd_select(z, z, z);
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_select` intrinsic: expected SIMD argument type, found non-SIMD `u32`
-  --> $DIR/generic-select.rs:51:9
+  --> $DIR/generic-select.rs:45:9
    |
 LL |         simd_select(m4, 0u32, 1u32);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_select_bitmask` intrinsic: invalid bitmask `u16`, expected `u8` or `[u8; 1]`
-  --> $DIR/generic-select.rs:54:9
+  --> $DIR/generic-select.rs:48:9
    |
 LL |         simd_select_bitmask(0u16, x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_select_bitmask` intrinsic: expected SIMD argument type, found non-SIMD `u32`
-  --> $DIR/generic-select.rs:57:9
+  --> $DIR/generic-select.rs:51:9
    |
 LL |         simd_select_bitmask(0u8, 1u32, 2u32);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_select_bitmask` intrinsic: invalid bitmask `f32`, expected `u8` or `[u8; 1]`
-  --> $DIR/generic-select.rs:60:9
+  --> $DIR/generic-select.rs:54:9
    |
 LL |         simd_select_bitmask(0.0f32, x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_select_bitmask` intrinsic: invalid bitmask `&str`, expected `u8` or `[u8; 1]`
-  --> $DIR/generic-select.rs:63:9
+  --> $DIR/generic-select.rs:57:9
    |
 LL |         simd_select_bitmask("x", x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-shuffle.rs
+++ b/tests/ui/simd/intrinsic/generic-shuffle.rs
@@ -3,15 +3,13 @@
 // Test that the simd_shuffle intrinsic produces ok-ish error
 // messages when misused.
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
+
+use std::intrinsics::simd::simd_shuffle;
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 pub struct Simd<T, const N: usize>([T; N]);
-
-#[rustc_intrinsic]
-unsafe fn simd_shuffle<T, I, U>(a: T, b: T, i: I) -> U;
-
 
 fn main() {
     const I: Simd<u32, 2> = Simd([0; 2]);

--- a/tests/ui/simd/intrinsic/generic-shuffle.stderr
+++ b/tests/ui/simd/intrinsic/generic-shuffle.stderr
@@ -1,23 +1,23 @@
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: simd_shuffle index must be a SIMD vector of `u32`, got `[u32; 2]`
-  --> $DIR/generic-shuffle.rs:24:31
+  --> $DIR/generic-shuffle.rs:22:31
    |
 LL |         let _: Simd<u32, 2> = simd_shuffle(v, v, const { [0u32; 2] });
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 2, found `Simd<u32, 4>` with length 4
-  --> $DIR/generic-shuffle.rs:27:31
+  --> $DIR/generic-shuffle.rs:25:31
    |
 LL |         let _: Simd<u32, 4> = simd_shuffle(v, v, I);
    |                               ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `u32` (element of input `Simd<u32, 4>`), found `Simd<f32, 2>` with element type `f32`
-  --> $DIR/generic-shuffle.rs:30:31
+  --> $DIR/generic-shuffle.rs:28:31
    |
 LL |         let _: Simd<f32, 2> = simd_shuffle(v, v, I);
    |                               ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: simd_shuffle index must be a SIMD vector of `u32`, got `Simd<f32, 2>`
-  --> $DIR/generic-shuffle.rs:33:31
+  --> $DIR/generic-shuffle.rs:31:31
    |
 LL |         let _: Simd<u32, 2> = simd_shuffle(v, v, I2);
    |                               ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/inlining-issue67557-ice.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557-ice.rs
@@ -3,10 +3,9 @@
 //
 //@ run-pass
 //@ compile-flags: -Zmir-opt-level=4
-#![feature(intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
-#[rustc_intrinsic]
-unsafe fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
+use std::intrinsics::simd::simd_shuffle;
 
 #[repr(simd)]
 #[derive(Debug, PartialEq)]

--- a/tests/ui/simd/intrinsic/inlining-issue67557.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557.rs
@@ -3,10 +3,9 @@
 //
 //@ run-pass
 //@ compile-flags: -Zmir-opt-level=4
-#![feature(intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd)]
 
-#[rustc_intrinsic]
-unsafe fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
+use std::intrinsics::simd::simd_shuffle;
 
 #[repr(simd)]
 #[derive(Debug, PartialEq)]
@@ -35,7 +34,6 @@ fn assert_10_11(x: Simd2) {
 fn assert_10_13(x: Simd2) {
     assert_eq!(x, Simd2([10, 13]));
 }
-
 
 #[inline(always)]
 unsafe fn inline_me() -> Simd2 {

--- a/tests/ui/simd/intrinsic/issue-85855.rs
+++ b/tests/ui/simd/intrinsic/issue-85855.rs
@@ -3,8 +3,7 @@
 // that no ICE occurs in these cases.
 
 #![feature(intrinsics)]
-#![crate_type="lib"]
-
+#![crate_type = "lib"]
 
 #[rustc_intrinsic]
 unsafe fn simd_saturating_add<'a, T: 'a>(x: T, y: T);

--- a/tests/ui/simd/intrinsic/issue-85855.stderr
+++ b/tests/ui/simd/intrinsic/issue-85855.stderr
@@ -1,17 +1,17 @@
 error[E0094]: intrinsic has wrong number of lifetime parameters: found 1, expected 0
-  --> $DIR/issue-85855.rs:10:30
+  --> $DIR/issue-85855.rs:9:30
    |
 LL | unsafe fn simd_saturating_add<'a, T: 'a>(x: T, y: T);
    |                              ^^^^^^^^^^^ expected 0 lifetime parameters
 
 error[E0094]: intrinsic has wrong number of type parameters: found 2, expected 1
-  --> $DIR/issue-85855.rs:17:19
+  --> $DIR/issue-85855.rs:16:19
    |
 LL | unsafe fn simd_sub<T, U>(x: T, y: U);
    |                   ^^^^^^ expected 1 type parameter
 
 error[E0094]: intrinsic has wrong number of const parameters: found 1, expected 0
-  --> $DIR/issue-85855.rs:21:19
+  --> $DIR/issue-85855.rs:20:19
    |
 LL | unsafe fn simd_mul<T, const N: usize>(x: T, y: T);
    |                   ^^^^^^^^^^^^^^^^^^^ expected 0 const parameters

--- a/tests/ui/simd/intrinsic/ptr-cast.rs
+++ b/tests/ui/simd/intrinsic/ptr-cast.rs
@@ -1,16 +1,8 @@
 //@ run-pass
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
-
-#[rustc_intrinsic]
-unsafe fn simd_cast_ptr<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_expose_provenance<T, U>(x: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_with_exposed_provenance<T, U>(x: T) -> U;
+use std::intrinsics::simd::{simd_cast_ptr, simd_expose_provenance, simd_with_exposed_provenance};
 
 #[derive(Copy, Clone)]
 #[repr(simd)]

--- a/tests/ui/simd/issue-105439.rs
+++ b/tests/ui/simd/issue-105439.rs
@@ -1,16 +1,12 @@
 //@ run-pass
 //@ compile-flags: -O -Zverify-llvm-ir
 
-#![feature(repr_simd)]
-#![feature(intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy)]
 #[repr(simd)]
 struct i32x4([i32; 4]);
-
-#[rustc_intrinsic]
-pub(crate) unsafe fn simd_add<T>(x: T, y: T) -> T;
 
 #[inline(always)]
 fn to_array(a: i32x4) -> [i32; 4] {
@@ -19,6 +15,6 @@ fn to_array(a: i32x4) -> [i32; 4] {
 
 fn main() {
     let a = i32x4([1, 2, 3, 4]);
-    let b = unsafe { simd_add(a, a) };
+    let b = unsafe { std::intrinsics::simd::simd_add(a, a) };
     assert_eq!(to_array(b), [2, 4, 6, 8]);
 }

--- a/tests/ui/simd/issue-39720.rs
+++ b/tests/ui/simd/issue-39720.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, Debug)]
@@ -10,11 +10,8 @@ pub struct Char3(pub [i8; 3]);
 #[derive(Copy, Clone, Debug)]
 pub struct Short3(pub [i16; 3]);
 
-#[rustc_intrinsic]
-unsafe fn simd_cast<T, U>(x: T) -> U;
-
 fn main() {
-    let cast: Short3 = unsafe { simd_cast(Char3([10, -3, -9])) };
+    let cast: Short3 = unsafe { std::intrinsics::simd::simd_cast(Char3([10, -3, -9])) };
 
     println!("{:?}", cast);
 }

--- a/tests/ui/simd/issue-85915-simd-ptrs.rs
+++ b/tests/ui/simd/issue-85915-simd-ptrs.rs
@@ -3,8 +3,10 @@
 
 // Short form of the generic gather/scatter tests,
 // verifying simd([*const T; N]) and simd([*mut T; N]) pass typeck and work.
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{simd_gather, simd_scatter};
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -22,13 +24,6 @@ struct f32x4([f32; 4]);
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct i32x4([i32; 4]);
 
-
-#[rustc_intrinsic]
-unsafe fn simd_gather<T, U, V>(x: T, y: U, z: V) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_scatter<T, U, V>(x: T, y: U, z: V) -> ();
-
 fn main() {
     let mut x = [0_f32, 1., 2., 3., 4., 5., 6., 7.];
 
@@ -39,11 +34,11 @@ fn main() {
     // reading from *const
     unsafe {
         let pointer = &x as *const f32;
-        let pointers =  cptrx4([
+        let pointers = cptrx4([
             pointer.offset(0) as *const f32,
             pointer.offset(2),
             pointer.offset(4),
-            pointer.offset(6)
+            pointer.offset(6),
         ]);
 
         let r_strided = simd_gather(default, pointers, mask);
@@ -58,7 +53,7 @@ fn main() {
             pointer.offset(0) as *mut f32,
             pointer.offset(2),
             pointer.offset(4),
-            pointer.offset(6)
+            pointer.offset(6),
         ]);
 
         let values = f32x4([42_f32, 43_f32, 44_f32, 45_f32]);

--- a/tests/ui/simd/issue-89193.rs
+++ b/tests/ui/simd/issue-89193.rs
@@ -3,15 +3,14 @@
 // Test that simd gather instructions on slice of usize don't cause crash
 // See issue #89183 - https://github.com/rust-lang/rust/issues/89193
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_gather;
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct x4<T>(pub [T; 4]);
-
-#[rustc_intrinsic]
-unsafe fn simd_gather<T, U, V>(x: T, y: U, z: V) -> T;
 
 fn main() {
     let x: [usize; 4] = [10, 11, 12, 13];
@@ -22,12 +21,8 @@ fn main() {
 
     unsafe {
         let pointer = x.as_ptr();
-        let pointers =  x4([
-            pointer.offset(0),
-            pointer.offset(1),
-            pointer.offset(2),
-            pointer.offset(3)
-        ]);
+        let pointers =
+            x4([pointer.offset(0), pointer.offset(1), pointer.offset(2), pointer.offset(3)]);
         let result = simd_gather(default, pointers, mask);
         assert_eq!(result, expected);
     }
@@ -39,12 +34,8 @@ fn main() {
 
     unsafe {
         let pointer = x.as_ptr();
-        let pointers =  x4([
-            pointer.offset(0),
-            pointer.offset(1),
-            pointer.offset(2),
-            pointer.offset(3)
-        ]);
+        let pointers =
+            x4([pointer.offset(0), pointer.offset(1), pointer.offset(2), pointer.offset(3)]);
         let result = simd_gather(default, pointers, mask);
         assert_eq!(result, expected);
     }

--- a/tests/ui/simd/masked-load-store-build-fail.rs
+++ b/tests/ui/simd/masked-load-store-build-fail.rs
@@ -1,12 +1,7 @@
 //@ build-fail
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
-
-#[rustc_intrinsic]
-unsafe fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_masked_store<M, P, T>(mask: M, pointer: P, values: T) -> ();
+use std::intrinsics::simd::{simd_masked_load, simd_masked_store};
 
 #[derive(Copy, Clone)]
 #[repr(simd)]
@@ -17,60 +12,28 @@ fn main() {
         let mut arr = [4u8, 5, 6, 7];
         let default = Simd::<u8, 4>([9; 4]);
 
-        simd_masked_load(
-            Simd::<i8, 8>([-1, 0, -1, -1, 0, 0, 0, 0]),
-            arr.as_ptr(),
-            default
-        );
-        //~^^^^^ ERROR expected third argument with length 8 (same as input type `Simd<i8, 8>`), found `Simd<u8, 4>` with length 4
+        simd_masked_load(Simd::<i8, 8>([-1, 0, -1, -1, 0, 0, 0, 0]), arr.as_ptr(), default);
+        //~^ ERROR expected third argument with length 8 (same as input type `Simd<i8, 8>`), found `Simd<u8, 4>` with length 4
 
-        simd_masked_load(
-            Simd::<i8, 4>([-1, 0, -1, -1]),
-            arr.as_ptr() as *const i8,
-            default
-        );
-        //~^^^^^ ERROR expected element type `u8` of second argument `*const i8` to be a pointer to the element type `u8` of the first argument `Simd<u8, 4>`, found `u8` != `*_ u8`
+        simd_masked_load(Simd::<i8, 4>([-1, 0, -1, -1]), arr.as_ptr() as *const i8, default);
+        //~^ ERROR expected element type `u8` of second argument `*const i8` to be a pointer to the element type `u8` of the first argument `Simd<u8, 4>`, found `u8` != `*_ u8`
 
-        simd_masked_load(
-            Simd::<i8, 4>([-1, 0, -1, -1]),
-            arr.as_ptr(),
-            Simd::<u32, 4>([9; 4])
-        );
-        //~^^^^^ ERROR expected element type `u32` of second argument `*const u8` to be a pointer to the element type `u32` of the first argument `Simd<u32, 4>`, found `u32` != `*_ u32`
+        simd_masked_load(Simd::<i8, 4>([-1, 0, -1, -1]), arr.as_ptr(), Simd::<u32, 4>([9; 4]));
+        //~^ ERROR expected element type `u32` of second argument `*const u8` to be a pointer to the element type `u32` of the first argument `Simd<u32, 4>`, found `u32` != `*_ u32`
 
-        simd_masked_load(
-            Simd::<u8, 4>([1, 0, 1, 1]),
-            arr.as_ptr(),
-            default
-        );
-        //~^^^^^ ERROR expected element type `u8` of third argument `Simd<u8, 4>` to be a signed integer type
+        simd_masked_load(Simd::<u8, 4>([1, 0, 1, 1]), arr.as_ptr(), default);
+        //~^ ERROR expected element type `u8` of third argument `Simd<u8, 4>` to be a signed integer type
 
-        simd_masked_store(
-            Simd([-1i8; 4]),
-            arr.as_ptr(),
-            Simd([5u32; 4])
-        );
-        //~^^^^^ ERROR expected element type `u32` of second argument `*const u8` to be a pointer to the element type `u32` of the first argument `Simd<u32, 4>`, found `u32` != `*mut u32`
+        simd_masked_store(Simd([-1i8; 4]), arr.as_ptr(), Simd([5u32; 4]));
+        //~^ ERROR expected element type `u32` of second argument `*const u8` to be a pointer to the element type `u32` of the first argument `Simd<u32, 4>`, found `u32` != `*mut u32`
 
-        simd_masked_store(
-            Simd([-1i8; 4]),
-            arr.as_ptr(),
-            Simd([5u8; 4])
-        );
-        //~^^^^^ ERROR expected element type `u8` of second argument `*const u8` to be a pointer to the element type `u8` of the first argument `Simd<u8, 4>`, found `u8` != `*mut u8`
+        simd_masked_store(Simd([-1i8; 4]), arr.as_ptr(), Simd([5u8; 4]));
+        //~^ ERROR expected element type `u8` of second argument `*const u8` to be a pointer to the element type `u8` of the first argument `Simd<u8, 4>`, found `u8` != `*mut u8`
 
-        simd_masked_store(
-            Simd([-1i8; 4]),
-            arr.as_mut_ptr(),
-            Simd([5u8; 2])
-        );
-        //~^^^^^ ERROR expected third argument with length 4 (same as input type `Simd<i8, 4>`), found `Simd<u8, 2>` with length 2
+        simd_masked_store(Simd([-1i8; 4]), arr.as_mut_ptr(), Simd([5u8; 2]));
+        //~^ ERROR expected third argument with length 4 (same as input type `Simd<i8, 4>`), found `Simd<u8, 2>` with length 2
 
-        simd_masked_store(
-            Simd([1u32; 4]),
-            arr.as_mut_ptr(),
-            Simd([5u8; 4])
-        );
-        //~^^^^^ ERROR expected element type `u8` of third argument `Simd<u32, 4>` to be a signed integer type
+        simd_masked_store(Simd([1u32; 4]), arr.as_mut_ptr(), Simd([5u8; 4]));
+        //~^ ERROR expected element type `u8` of third argument `Simd<u32, 4>` to be a signed integer type
     }
 }

--- a/tests/ui/simd/masked-load-store-build-fail.stderr
+++ b/tests/ui/simd/masked-load-store-build-fail.stderr
@@ -1,82 +1,50 @@
 error[E0511]: invalid monomorphization of `simd_masked_load` intrinsic: expected third argument with length 8 (same as input type `Simd<i8, 8>`), found `Simd<u8, 4>` with length 4
-  --> $DIR/masked-load-store-build-fail.rs:20:9
+  --> $DIR/masked-load-store-build-fail.rs:15:9
    |
-LL | /         simd_masked_load(
-LL | |             Simd::<i8, 8>([-1, 0, -1, -1, 0, 0, 0, 0]),
-LL | |             arr.as_ptr(),
-LL | |             default
-LL | |         );
-   | |_________^
+LL |         simd_masked_load(Simd::<i8, 8>([-1, 0, -1, -1, 0, 0, 0, 0]), arr.as_ptr(), default);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_masked_load` intrinsic: expected element type `u8` of second argument `*const i8` to be a pointer to the element type `u8` of the first argument `Simd<u8, 4>`, found `u8` != `*_ u8`
-  --> $DIR/masked-load-store-build-fail.rs:27:9
+  --> $DIR/masked-load-store-build-fail.rs:18:9
    |
-LL | /         simd_masked_load(
-LL | |             Simd::<i8, 4>([-1, 0, -1, -1]),
-LL | |             arr.as_ptr() as *const i8,
-LL | |             default
-LL | |         );
-   | |_________^
+LL |         simd_masked_load(Simd::<i8, 4>([-1, 0, -1, -1]), arr.as_ptr() as *const i8, default);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_masked_load` intrinsic: expected element type `u32` of second argument `*const u8` to be a pointer to the element type `u32` of the first argument `Simd<u32, 4>`, found `u32` != `*_ u32`
-  --> $DIR/masked-load-store-build-fail.rs:34:9
+  --> $DIR/masked-load-store-build-fail.rs:21:9
    |
-LL | /         simd_masked_load(
-LL | |             Simd::<i8, 4>([-1, 0, -1, -1]),
-LL | |             arr.as_ptr(),
-LL | |             Simd::<u32, 4>([9; 4])
-LL | |         );
-   | |_________^
+LL |         simd_masked_load(Simd::<i8, 4>([-1, 0, -1, -1]), arr.as_ptr(), Simd::<u32, 4>([9; 4]));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_masked_load` intrinsic: expected element type `u8` of third argument `Simd<u8, 4>` to be a signed integer type
-  --> $DIR/masked-load-store-build-fail.rs:41:9
+  --> $DIR/masked-load-store-build-fail.rs:24:9
    |
-LL | /         simd_masked_load(
-LL | |             Simd::<u8, 4>([1, 0, 1, 1]),
-LL | |             arr.as_ptr(),
-LL | |             default
-LL | |         );
-   | |_________^
+LL |         simd_masked_load(Simd::<u8, 4>([1, 0, 1, 1]), arr.as_ptr(), default);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_masked_store` intrinsic: expected element type `u32` of second argument `*const u8` to be a pointer to the element type `u32` of the first argument `Simd<u32, 4>`, found `u32` != `*mut u32`
-  --> $DIR/masked-load-store-build-fail.rs:48:9
+  --> $DIR/masked-load-store-build-fail.rs:27:9
    |
-LL | /         simd_masked_store(
-LL | |             Simd([-1i8; 4]),
-LL | |             arr.as_ptr(),
-LL | |             Simd([5u32; 4])
-LL | |         );
-   | |_________^
+LL |         simd_masked_store(Simd([-1i8; 4]), arr.as_ptr(), Simd([5u32; 4]));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_masked_store` intrinsic: expected element type `u8` of second argument `*const u8` to be a pointer to the element type `u8` of the first argument `Simd<u8, 4>`, found `u8` != `*mut u8`
-  --> $DIR/masked-load-store-build-fail.rs:55:9
+  --> $DIR/masked-load-store-build-fail.rs:30:9
    |
-LL | /         simd_masked_store(
-LL | |             Simd([-1i8; 4]),
-LL | |             arr.as_ptr(),
-LL | |             Simd([5u8; 4])
-LL | |         );
-   | |_________^
+LL |         simd_masked_store(Simd([-1i8; 4]), arr.as_ptr(), Simd([5u8; 4]));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_masked_store` intrinsic: expected third argument with length 4 (same as input type `Simd<i8, 4>`), found `Simd<u8, 2>` with length 2
-  --> $DIR/masked-load-store-build-fail.rs:62:9
+  --> $DIR/masked-load-store-build-fail.rs:33:9
    |
-LL | /         simd_masked_store(
-LL | |             Simd([-1i8; 4]),
-LL | |             arr.as_mut_ptr(),
-LL | |             Simd([5u8; 2])
-LL | |         );
-   | |_________^
+LL |         simd_masked_store(Simd([-1i8; 4]), arr.as_mut_ptr(), Simd([5u8; 2]));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_masked_store` intrinsic: expected element type `u8` of third argument `Simd<u32, 4>` to be a signed integer type
-  --> $DIR/masked-load-store-build-fail.rs:69:9
+  --> $DIR/masked-load-store-build-fail.rs:36:9
    |
-LL | /         simd_masked_store(
-LL | |             Simd([1u32; 4]),
-LL | |             arr.as_mut_ptr(),
-LL | |             Simd([5u8; 4])
-LL | |         );
-   | |_________^
+LL |         simd_masked_store(Simd([1u32; 4]), arr.as_mut_ptr(), Simd([5u8; 4]));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/simd/masked-load-store-check-fail.rs
+++ b/tests/ui/simd/masked-load-store-check-fail.rs
@@ -1,11 +1,7 @@
 //@ check-fail
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
-#[rustc_intrinsic]
-unsafe fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_masked_store<M, P, T>(mask: M, pointer: P, values: T) -> ();
+use std::intrinsics::simd::{simd_masked_load, simd_masked_store};
 
 #[derive(Copy, Clone)]
 #[repr(simd)]
@@ -16,18 +12,11 @@ fn main() {
         let mut arr = [4u8, 5, 6, 7];
         let default = Simd::<u8, 4>([9; 4]);
 
-        let _x: Simd<u8, 2> = simd_masked_load(
-            Simd::<i8, 4>([-1, 0, -1, -1]),
-            arr.as_ptr(),
-            Simd::<u8, 4>([9; 4])
-        );
-        //~^^ ERROR mismatched types
+        let _x: Simd<u8, 2> =
+            simd_masked_load(Simd::<i8, 4>([-1, 0, -1, -1]), arr.as_ptr(), Simd::<u8, 4>([9; 4]));
+        //~^ ERROR mismatched types
 
-        let _x: Simd<u32, 4> = simd_masked_load(
-            Simd::<u8, 4>([1, 0, 1, 1]),
-            arr.as_ptr(),
-            default
-        );
-        //~^^ ERROR mismatched types
+        let _x: Simd<u32, 4> = simd_masked_load(Simd::<u8, 4>([1, 0, 1, 1]), arr.as_ptr(), default);
+        //~^ ERROR mismatched types
     }
 }

--- a/tests/ui/simd/masked-load-store-check-fail.stderr
+++ b/tests/ui/simd/masked-load-store-check-fail.stderr
@@ -1,58 +1,38 @@
 error[E0308]: mismatched types
-  --> $DIR/masked-load-store-check-fail.rs:22:13
+  --> $DIR/masked-load-store-check-fail.rs:16:76
    |
-LL |         let _x: Simd<u8, 2> = simd_masked_load(
-   |                               ---------------- arguments to this function are incorrect
-...
-LL |             Simd::<u8, 4>([9; 4])
-   |             ^^^^^^^^^^^^^^^^^^^^^ expected `2`, found `4`
+LL |             simd_masked_load(Simd::<i8, 4>([-1, 0, -1, -1]), arr.as_ptr(), Simd::<u8, 4>([9; 4]));
+   |             ---------------- arguments to this function are incorrect      ^^^^^^^^^^^^^^^^^^^^^ expected `2`, found `4`
    |
    = note: expected struct `Simd<_, 2>`
               found struct `Simd<_, 4>`
 help: the return type of this call is `Simd<u8, 4>` due to the type of the argument passed
-  --> $DIR/masked-load-store-check-fail.rs:19:31
+  --> $DIR/masked-load-store-check-fail.rs:16:13
    |
-LL |           let _x: Simd<u8, 2> = simd_masked_load(
-   |  _______________________________^
-LL | |             Simd::<i8, 4>([-1, 0, -1, -1]),
-LL | |             arr.as_ptr(),
-LL | |             Simd::<u8, 4>([9; 4])
-   | |             --------------------- this argument influences the return type of `simd_masked_load`
-LL | |         );
-   | |_________^
+LL |             simd_masked_load(Simd::<i8, 4>([-1, 0, -1, -1]), arr.as_ptr(), Simd::<u8, 4>([9; 4]));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---------------------^
+   |                                                                            |
+   |                                                                            this argument influences the return type of `simd_masked_load`
 note: function defined here
-  --> $DIR/masked-load-store-check-fail.rs:5:11
-   |
-LL | unsafe fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;
-   |           ^^^^^^^^^^^^^^^^                               ---------
+  --> $SRC_DIR/core/src/intrinsics/simd.rs:LL:COL
 
 error[E0308]: mismatched types
-  --> $DIR/masked-load-store-check-fail.rs:29:13
+  --> $DIR/masked-load-store-check-fail.rs:19:92
    |
-LL |         let _x: Simd<u32, 4> = simd_masked_load(
-   |                                ---------------- arguments to this function are incorrect
-...
-LL |             default
-   |             ^^^^^^^ expected `Simd<u32, 4>`, found `Simd<u8, 4>`
+LL |         let _x: Simd<u32, 4> = simd_masked_load(Simd::<u8, 4>([1, 0, 1, 1]), arr.as_ptr(), default);
+   |                                ---------------- arguments to this function are incorrect   ^^^^^^^ expected `Simd<u32, 4>`, found `Simd<u8, 4>`
    |
    = note: expected struct `Simd<u32, _>`
               found struct `Simd<u8, _>`
 help: the return type of this call is `Simd<u8, 4>` due to the type of the argument passed
-  --> $DIR/masked-load-store-check-fail.rs:26:32
+  --> $DIR/masked-load-store-check-fail.rs:19:32
    |
-LL |           let _x: Simd<u32, 4> = simd_masked_load(
-   |  ________________________________^
-LL | |             Simd::<u8, 4>([1, 0, 1, 1]),
-LL | |             arr.as_ptr(),
-LL | |             default
-   | |             ------- this argument influences the return type of `simd_masked_load`
-LL | |         );
-   | |_________^
+LL |         let _x: Simd<u32, 4> = simd_masked_load(Simd::<u8, 4>([1, 0, 1, 1]), arr.as_ptr(), default);
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-------^
+   |                                                                                            |
+   |                                                                                            this argument influences the return type of `simd_masked_load`
 note: function defined here
-  --> $DIR/masked-load-store-check-fail.rs:5:11
-   |
-LL | unsafe fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;
-   |           ^^^^^^^^^^^^^^^^                               ---------
+  --> $SRC_DIR/core/src/intrinsics/simd.rs:LL:COL
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/simd/masked-load-store.rs
+++ b/tests/ui/simd/masked-load-store.rs
@@ -1,11 +1,7 @@
 //@ run-pass
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
-#[rustc_intrinsic]
-unsafe fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;
-
-#[rustc_intrinsic]
-unsafe fn simd_masked_store<M, P, T>(mask: M, pointer: P, values: T) -> ();
+use std::intrinsics::simd::{simd_masked_load, simd_masked_store};
 
 #[derive(Copy, Clone)]
 #[repr(simd)]
@@ -16,11 +12,8 @@ fn main() {
         let a = Simd::<u8, 4>([0, 1, 2, 3]);
         let b_src = [4u8, 5, 6, 7];
         let b_default = Simd::<u8, 4>([9; 4]);
-        let b: Simd::<u8, 4> = simd_masked_load(
-            Simd::<i8, 4>([-1, 0, -1, -1]),
-            b_src.as_ptr(),
-            b_default
-        );
+        let b: Simd<u8, 4> =
+            simd_masked_load(Simd::<i8, 4>([-1, 0, -1, -1]), b_src.as_ptr(), b_default);
 
         assert_eq!(&b.0, &[4, 9, 6, 7]);
 

--- a/tests/ui/simd/monomorphize-shuffle-index.generic.stderr
+++ b/tests/ui/simd/monomorphize-shuffle-index.generic.stderr
@@ -1,5 +1,5 @@
 error: overly complex generic constant
-  --> $DIR/monomorphize-shuffle-index.rs:32:51
+  --> $DIR/monomorphize-shuffle-index.rs:36:51
    |
 LL |         return simd_shuffle_const_generic::<_, _, { &Self::I.0 }>(a, b);
    |                                                   ^^----------^^

--- a/tests/ui/simd/monomorphize-shuffle-index.rs
+++ b/tests/ui/simd/monomorphize-shuffle-index.rs
@@ -1,18 +1,22 @@
+//@ revisions: old generic generic_with_fn
 //@[old]run-pass
 //@[generic_with_fn]run-pass
-//@ revisions: old generic generic_with_fn
-#![feature(repr_simd, intrinsics, adt_const_params, unsized_const_params, generic_const_exprs)]
+#![feature(
+    repr_simd,
+    core_intrinsics,
+    intrinsics,
+    adt_const_params,
+    unsized_const_params,
+    generic_const_exprs
+)]
 #![allow(incomplete_features)]
 
-
-#[rustc_intrinsic]
 #[cfg(old)]
-unsafe fn simd_shuffle<T, I, U>(a: T, b: T, i: I) -> U;
+use std::intrinsics::simd::simd_shuffle;
 
-#[rustc_intrinsic]
 #[cfg(any(generic, generic_with_fn))]
+#[rustc_intrinsic]
 unsafe fn simd_shuffle_const_generic<T, U, const I: &'static [u32]>(a: T, b: T) -> U;
-
 
 #[derive(Copy, Clone)]
 #[repr(simd)]

--- a/tests/ui/simd/repr_packed.rs
+++ b/tests/ui/simd/repr_packed.rs
@@ -1,7 +1,9 @@
 //@ run-pass
 
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::simd_add;
 
 #[repr(simd, packed)]
 struct Simd<T, const N: usize>([T; N]);
@@ -21,9 +23,6 @@ fn check_ty<T>() {
     check_size_align::<T, 9>();
     check_size_align::<T, 15>();
 }
-
-#[rustc_intrinsic]
-unsafe fn simd_add<T>(a: T, b: T) -> T;
 
 fn main() {
     check_ty::<u8>();

--- a/tests/ui/simd/shuffle.rs
+++ b/tests/ui/simd/shuffle.rs
@@ -2,14 +2,13 @@
 //@ revisions: opt noopt
 //@[noopt] compile-flags: -Copt-level=0
 //@[opt] compile-flags: -O
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 #![allow(incomplete_features)]
 #![feature(adt_const_params)]
 
 use std::marker::ConstParamTy;
 
-#[rustc_intrinsic]
-unsafe fn simd_shuffle<T, I, U>(a: T, b: T, i: I) -> U;
+use std::intrinsics::simd::simd_shuffle;
 
 #[derive(Copy, Clone, ConstParamTy, PartialEq, Eq)]
 #[repr(simd)]

--- a/tests/ui/simd/simd-bitmask-notpow2.rs
+++ b/tests/ui/simd/simd-bitmask-notpow2.rs
@@ -2,14 +2,9 @@
 // FIXME: broken codegen on big-endian (https://github.com/rust-lang/rust/issues/127205)
 // This should be merged into `simd-bitmask` once that's fixed.
 //@ ignore-endian-big
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
-#[rustc_intrinsic]
-unsafe fn simd_bitmask<T, U>(v: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_select_bitmask<T, U>(m: T, a: U, b: U) -> U;
-
+use std::intrinsics::simd::{simd_bitmask, simd_select_bitmask};
 
 fn main() {
     // Non-power-of-2 multi-byte mask.

--- a/tests/ui/simd/simd-bitmask.rs
+++ b/tests/ui/simd/simd-bitmask.rs
@@ -1,12 +1,7 @@
 //@run-pass
-#![feature(repr_simd, intrinsics)]
+#![feature(repr_simd, core_intrinsics)]
 
-#[rustc_intrinsic]
-unsafe fn simd_bitmask<T, U>(v: T) -> U;
-
-#[rustc_intrinsic]
-unsafe fn simd_select_bitmask<T, U>(m: T, a: U, b: U) -> U;
-
+use std::intrinsics::simd::{simd_bitmask, simd_select_bitmask};
 
 #[derive(Copy, Clone)]
 #[repr(simd)]


### PR DESCRIPTION
In most cases, we can import the simd intrinsics rather than redeclare them. Apparently, most of these tests were written before `std::intrinsics::simd` existed.

There are a couple of exceptions where we can't yet import:

- the intrinsics are not declared as `const fn` in the standard library, causing issues in the `const-eval` tests
- the `simd_shuffle_generic` function is not exposed from `std::intrinsics`
- the `simd_fpow` and `simd_fpowi` functions are not exposed from `std::intrinsics` (removed in https://github.com/rust-lang/rust/pull/137595)
- some tests use `no_core`, and therefore cannot use `std::intrinsics`

r? @RalfJung 

cc @workingjubilee do you have context on why some intrinsics are not exposed?