### PR TITLE
Change TaskDeps to start preallocated with 128 capacity

### DIFF
--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -1299,12 +1299,11 @@ impl Default for TaskDeps {
             #[cfg(debug_assertions)]
             node: None,
             reads: EdgesVec::new(),
-            read_set: FxHashSet::default(),
+            read_set: FxHashSet::with_capacity_and_hasher(128, Default::default()),
             phantom_data: PhantomData,
         }
     }
 }
-
 // A data structure that stores Option<DepNodeColor> values as a contiguous
 // array, using one u32 per entry.
 struct DepNodeColorMap {


### PR DESCRIPTION
This is a tiny change that makes `TaskDeps::read_set` start preallocated with capacity for 128 elements. 

From local profiling, it looks like `TaskDeps::read_set`  is one of the most-often resized hash-sets in `rustc`. 