### PR TITLE
Try to point of macro expansion from resolver and method errors if it involves macro var

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -620,6 +620,8 @@ hir_analysis_variances_of = {$variances}
 hir_analysis_where_clause_on_main = `main` function is not allowed to have a `where` clause
     .label = `main` cannot have a `where` clause
 
+hir_analysis_within_macro = due to this macro variable
+
 hir_analysis_wrong_number_of_generic_arguments_to_intrinsic =
     intrinsic has wrong number of {$descr} parameters: found {$found}, expected {$expected}
     .label = expected {$expected} {$descr} {$expected ->

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -84,6 +84,8 @@ pub(crate) struct AssocItemNotFound<'a> {
     pub label: Option<AssocItemNotFoundLabel<'a>>,
     #[subdiagnostic]
     pub sugg: Option<AssocItemNotFoundSugg<'a>>,
+    #[label(hir_analysis_within_macro)]
+    pub within_macro_span: Option<Span>,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -153,7 +153,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             sugg: None,
             // Try to get the span of the identifier within the path's syntax context
             // (if that's different).
-            within_macro_span: assoc_name.span.within_macro(span),
+            within_macro_span: assoc_name.span.within_macro(span, tcx.sess.source_map()),
         };
 
         if is_dummy {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -151,6 +151,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             qself: &qself_str,
             label: None,
             sugg: None,
+            // Try to get the span of the identifier within the path's syntax context
+            // (if that's different).
+            within_macro_span: assoc_name.span.within_macro(span),
         };
 
         if is_dummy {

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -158,7 +158,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.typeck_results.borrow_mut().used_trait_imports.insert(import_id);
         }
 
-        let (span, sugg_span, source, item_name, args) = match self.tcx.hir_node(call_id) {
+        let (span, expr_span, source, item_name, args) = match self.tcx.hir_node(call_id) {
             hir::Node::Expr(&hir::Expr {
                 kind: hir::ExprKind::MethodCall(segment, rcvr, args, _),
                 span,
@@ -194,6 +194,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             node => unreachable!("{node:?}"),
         };
 
+        // Try to get the span of the identifier within the expression's syntax context (if that's different).
+        let within_macro_span = span.within_macro(expr_span);
+
         // Avoid suggestions when we don't know what's going on.
         if let Err(guar) = rcvr_ty.error_reported() {
             return guar;
@@ -207,10 +210,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 call_id,
                 source,
                 args,
-                sugg_span,
+                expr_span,
                 &mut no_match_data,
                 expected,
                 trait_missing_method,
+                within_macro_span,
             ),
 
             MethodError::Ambiguity(mut sources) => {
@@ -221,6 +225,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     "multiple applicable items in scope"
                 );
                 err.span_label(item_name.span, format!("multiple `{item_name}` found"));
+                if let Some(within_macro_span) = within_macro_span {
+                    err.span_label(within_macro_span, "due to this macro variable");
+                }
 
                 self.note_candidates_on_method_error(
                     rcvr_ty,
@@ -230,7 +237,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     span,
                     &mut err,
                     &mut sources,
-                    Some(sugg_span),
+                    Some(expr_span),
                 );
                 err.emit()
             }
@@ -252,6 +259,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .span_if_local(def_id)
                     .unwrap_or_else(|| self.tcx.def_span(def_id));
                 err.span_label(sp, format!("private {kind} defined here"));
+                if let Some(within_macro_span) = within_macro_span {
+                    err.span_label(within_macro_span, "due to this macro variable");
+                }
                 self.suggest_valid_traits(&mut err, item_name, out_of_scope_traits, true);
                 err.emit()
             }
@@ -267,6 +277,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let mut err = self.dcx().struct_span_err(span, msg);
                 if !needs_mut {
                     err.span_label(bound_span, "this has a `Sized` requirement");
+                }
+                if let Some(within_macro_span) = within_macro_span {
+                    err.span_label(within_macro_span, "due to this macro variable");
                 }
                 if !candidates.is_empty() {
                     let help = format!(
@@ -581,6 +594,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         no_match_data: &mut NoMatchData<'tcx>,
         expected: Expectation<'tcx>,
         trait_missing_method: bool,
+        within_macro_span: Option<Span>,
     ) -> ErrorGuaranteed {
         let mode = no_match_data.mode;
         let tcx = self.tcx;
@@ -720,6 +734,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         if tcx.sess.source_map().is_multiline(sugg_span) {
             err.span_label(sugg_span.with_hi(span.lo()), "");
+        }
+        if let Some(within_macro_span) = within_macro_span {
+            err.span_label(within_macro_span, "due to this macro variable");
         }
 
         if short_ty_str.len() < ty_str.len() && ty_str.len() > 10 {

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -196,7 +196,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Try to get the span of the identifier within the expression's syntax context
         // (if that's different).
-        let within_macro_span = span.within_macro(expr_span);
+        let within_macro_span = span.within_macro(expr_span, self.tcx.sess.source_map());
 
         // Avoid suggestions when we don't know what's going on.
         if let Err(guar) = rcvr_ty.error_reported() {

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -194,7 +194,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             node => unreachable!("{node:?}"),
         };
 
-        // Try to get the span of the identifier within the expression's syntax context (if that's different).
+        // Try to get the span of the identifier within the expression's syntax context
+        // (if that's different).
         let within_macro_span = span.within_macro(expr_span);
 
         // Avoid suggestions when we don't know what's going on.

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -431,8 +431,10 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
         // Try to get the span of the identifier within the path's syntax context
         // (if that's different).
-        if let Some(within_macro_span) = base_error.span.within_macro(span) {
-            err.span_label(within_macro_span, "within this macro");
+        if let Some(within_macro_span) =
+            base_error.span.within_macro(span, self.r.tcx.sess.source_map())
+        {
+            err.span_label(within_macro_span, "due to this macro variable");
         }
 
         self.detect_missing_binding_available_from_pattern(&mut err, path, following_seg);

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -429,6 +429,12 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         let mut err = self.r.dcx().struct_span_err(base_error.span, base_error.msg.clone());
         err.code(code);
 
+        // Try to get the span of the identifier within the path's syntax context
+        // (if that's different).
+        if let Some(within_macro_span) = base_error.span.within_macro(span) {
+            err.span_label(within_macro_span, "within this macro");
+        }
+
         self.detect_missing_binding_available_from_pattern(&mut err, path, following_seg);
         self.suggest_at_operator_in_slice_pat_with_range(&mut err, path);
         self.suggest_swapping_misplaced_self_ty_and_trait(&mut err, source, res, base_error.span);

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1071,9 +1071,17 @@ impl Span {
     ///
     /// If "self" is the span of the outer_ident, and "within" is the span of the `($ident,)`
     /// expr, then this will return the span of the `$ident` macro variable.
-    pub fn within_macro(self, within: Span) -> Option<Span> {
+    pub fn within_macro(self, within: Span, sm: &SourceMap) -> Option<Span> {
         match Span::prepare_to_combine(self, within) {
-            Ok((self_, _, parent)) if self_.lo != self.lo() && self.hi() != self_.hi => {
+            // Only return something if it doesn't overlap with the original span,
+            // and the span isn't "imported" (i.e. from unavailable sources).
+            // FIXME: This does limit the usefulness of the error when the macro is
+            // from a foreign crate; we could also take into account `-Zmacro-backtrace`,
+            // which doesn't redact this span (but that would mean passing in even more
+            // args to this function, lol).
+            Ok((self_, _, parent))
+                if self_.hi < self.lo() || self.hi() < self_.lo && !sm.is_imported(within) =>
+            {
                 Some(Span::new(self_.lo, self_.hi, self_.ctxt, parent))
             }
             _ => None,

--- a/tests/ui/associated-types/ident-from-macro-expansion.rs
+++ b/tests/ui/associated-types/ident-from-macro-expansion.rs
@@ -1,0 +1,23 @@
+trait Trait {}
+impl Trait for () {}
+
+macro_rules! fully_qualified {
+    ($id:ident) => {
+        <() as Trait>::$id
+    }
+}
+
+macro_rules! type_dependent {
+    ($t:ident, $id:ident) => {
+        T::$id
+    }
+}
+
+fn t<T: Trait>() {
+    let x: fully_qualified!(Assoc);
+    //~^ ERROR cannot find associated type `Assoc` in trait `Trait`
+    let x: type_dependent!(T, Assoc);
+    //~^ ERROR associated type `Assoc` not found for `T`
+}
+
+fn main() {}

--- a/tests/ui/associated-types/ident-from-macro-expansion.stderr
+++ b/tests/ui/associated-types/ident-from-macro-expansion.stderr
@@ -1,0 +1,22 @@
+error[E0576]: cannot find associated type `Assoc` in trait `Trait`
+  --> $DIR/ident-from-macro-expansion.rs:17:29
+   |
+LL |         <() as Trait>::$id
+   |                        --- due to this macro variable
+...
+LL |     let x: fully_qualified!(Assoc);
+   |                             ^^^^^ not found in `Trait`
+
+error[E0220]: associated type `Assoc` not found for `T`
+  --> $DIR/ident-from-macro-expansion.rs:19:31
+   |
+LL |         T::$id
+   |            --- due to this macro variable
+...
+LL |     let x: type_dependent!(T, Assoc);
+   |                               ^^^^^ associated type `Assoc` not found
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0220, E0576.
+For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/hygiene/generate-mod.stderr
+++ b/tests/ui/hygiene/generate-mod.stderr
@@ -1,12 +1,18 @@
 error[E0412]: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:35:13
    |
+LL |     type A = $FromOutside;
+   |              ------------ due to this macro variable
+...
 LL |     genmod!(FromOutside, Outer);
    |             ^^^^^^^^^^^ not found in this scope
 
 error[E0412]: cannot find type `Outer` in this scope
   --> $DIR/generate-mod.rs:35:26
    |
+LL |     struct $Outer;
+   |            ------ due to this macro variable
+...
 LL |     genmod!(FromOutside, Outer);
    |                          ^^^^^ not found in this scope
 

--- a/tests/ui/hygiene/globs.stderr
+++ b/tests/ui/hygiene/globs.stderr
@@ -50,6 +50,9 @@ error[E0425]: cannot find function `f` in this scope
 LL | n!(f);
    | ----- in this macro invocation
 ...
+LL |                     $j();
+   |                     -- due to this macro variable
+...
 LL |         n!(f);
    |            ^ not found in this scope
    |
@@ -62,6 +65,9 @@ error[E0425]: cannot find function `f` in this scope
    |
 LL | n!(f);
    | ----- in this macro invocation
+...
+LL |                     $j();
+   |                     -- due to this macro variable
 ...
 LL |                 f
    |                 ^ not found in this scope

--- a/tests/ui/macros/macro-parameter-span.stderr
+++ b/tests/ui/macros/macro-parameter-span.stderr
@@ -1,6 +1,9 @@
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/macro-parameter-span.rs:11:9
    |
+LL |         $id
+   |         --- due to this macro variable
+...
 LL |         x
    |         ^ not found in this scope
 

--- a/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
@@ -338,6 +338,9 @@ LL |     no_curly__no_rhs_dollar__no_round!(a);
 error[E0425]: cannot find value `a` in this scope
   --> $DIR/syntax-errors.rs:152:37
    |
+LL |     ( $i:ident ) => { count($i) };
+   |                             -- due to this macro variable
+...
 LL |     no_curly__rhs_dollar__no_round!(a);
    |                                     ^ not found in this scope
 

--- a/tests/ui/methods/ident-from-macro-expansion.rs
+++ b/tests/ui/methods/ident-from-macro-expansion.rs
@@ -1,0 +1,18 @@
+macro_rules! dot {
+    ($id:ident) => {
+        ().$id();
+    }
+}
+
+macro_rules! dispatch {
+    ($id:ident) => {
+        <()>::$id();
+    }
+}
+
+fn main() {
+    dot!(hello);
+    //~^ ERROR no method named `hello` found for unit type `()` in the current scope
+    dispatch!(hello);
+    //~^ ERROR no function or associated item named `hello` found for unit type `()` in the current scope
+}

--- a/tests/ui/methods/ident-from-macro-expansion.stderr
+++ b/tests/ui/methods/ident-from-macro-expansion.stderr
@@ -1,0 +1,21 @@
+error[E0599]: no method named `hello` found for unit type `()` in the current scope
+  --> $DIR/ident-from-macro-expansion.rs:14:10
+   |
+LL |         ().$id();
+   |            --- due to this macro variable
+...
+LL |     dot!(hello);
+   |          ^^^^^ method not found in `()`
+
+error[E0599]: no function or associated item named `hello` found for unit type `()` in the current scope
+  --> $DIR/ident-from-macro-expansion.rs:16:15
+   |
+LL |         <()>::$id();
+   |               --- due to this macro variable
+...
+LL |     dispatch!(hello);
+   |               ^^^^^ function or associated item not found in `()`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/structs/ident-from-macro-expansion.rs
+++ b/tests/ui/structs/ident-from-macro-expansion.rs
@@ -1,0 +1,19 @@
+struct Foo {
+    inner: Inner,
+}
+
+struct Inner {
+    y: i32,
+}
+
+macro_rules! access {
+    ($expr:expr, $ident:ident) => {
+        $expr.$ident
+    }
+}
+
+fn main() {
+    let k = Foo { inner: Inner { y: 0 } };
+    access!(k, y);
+    //~^ ERROR no field `y` on type `Foo`
+}

--- a/tests/ui/structs/ident-from-macro-expansion.stderr
+++ b/tests/ui/structs/ident-from-macro-expansion.stderr
@@ -1,0 +1,14 @@
+error[E0609]: no field `y` on type `Foo`
+  --> $DIR/ident-from-macro-expansion.rs:17:16
+   |
+LL |         $expr.$ident
+   |               ------ due to this macro variable
+...
+LL |     access!(k, y);
+   |                ^ unknown field
+   |
+   = note: available field is: `inner`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0609`.


### PR DESCRIPTION
In the case that a macro caller passes an identifier into a macro generating a path or method expression, point out that identifier in the context of the *macro* so it's a bit more clear how the macro is involved in causing the error.

r? @estebank or reassign