### PR TITLE
[Perf experiment] Inline hints on some small, hot functions

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2425,6 +2425,7 @@ impl<'tcx, T: 'tcx + ?Sized> IntoPointer for InternedInSet<'tcx, T> {
 
 #[allow(rustc::usage_of_ty_tykind)]
 impl<'tcx, T> Borrow<T> for InternedInSet<'tcx, WithCachedTypeInfo<T>> {
+    #[inline]
     fn borrow(&self) -> &T {
         &self.0.internee
     }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -440,10 +440,11 @@ impl<'tcx> rustc_type_ir::inherent::IntoKind for Ty<'tcx> {
 }
 
 impl<'tcx> rustc_type_ir::visit::Flags for Ty<'tcx> {
+    #[inline]
     fn flags(&self) -> TypeFlags {
         self.0.flags
     }
-
+    #[inline]
     fn outer_exclusive_binder(&self) -> DebruijnIndex {
         self.0.outer_exclusive_binder
     }


### PR DESCRIPTION
During some local profiling, I identified a few tiny hot functions which did not get inlined. 

From some local perf runs, it looks like adding inline hints to them is beneficial. 

![image](https://github.com/user-attachments/assets/22e58ab0-d6a4-46fe-9cd2-dee23d2027a5)


I have checked this change both with and without LTO,  and I still see a perf difference between the version with and without inline hints. So, this *may* be a good change. 

However, since I can't run the compiler PGO setup locally, I'll need a perf run to see if this  improvement will be seen in the CI build of `rustc`.

There is a chance this optimization is already done by PGO(in which case this PR is less useful), but I still want to see if this can have any real effect.  