### PR TITLE
Don't doc-comment BTreeMap<K, SetValZST, A>

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -289,7 +289,7 @@ impl<K: Clone, V: Clone, A: Allocator + Clone> Clone for BTreeMap<K, V, A> {
     }
 }
 
-/// Internal functionality for `BTreeSet`.
+// Internal functionality for `BTreeSet`.
 impl<K, A: Allocator + Clone> BTreeMap<K, SetValZST, A> {
     pub(super) fn replace(&mut self, key: K) -> Option<K>
     where


### PR DESCRIPTION
This otherwise shows up in documentation as an empty impl block (worse, at the *top* of the docs above the public impls).