### PR TITLE
Add option to include submodules from vendoring

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -981,3 +981,6 @@
 
 # Whether to vendor dependencies for the dist tarball.
 #vendor = if "is a tarball source" || "is a git repository" { true } else { false }
+
+# Exclude these submodules from vendoring.
+# exclude-submodules-from-vendoring = []

--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -209,7 +209,11 @@ impl Step for GenerateCopyright {
         let dest = builder.out.join("COPYRIGHT.html");
         let dest_libstd = builder.out.join("COPYRIGHT-library.html");
 
-        let paths_to_vendor = default_paths_to_vendor(builder);
+        let paths_to_vendor = default_paths_to_vendor(
+            builder,
+            &builder.config.dist_exclude_submodules_from_vendoring,
+        );
+
         for (_, submodules) in &paths_to_vendor {
             for submodule in submodules {
                 builder.build.require_submodule(submodule, None);

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -339,6 +339,7 @@ pub struct Config {
     pub dist_compression_profile: String,
     pub dist_include_mingw_linker: bool,
     pub dist_vendor: bool,
+    pub dist_exclude_submodules_from_vendoring: BTreeSet<String>,
 
     // libstd features
     pub backtrace: bool, // support for RUST_BACKTRACE
@@ -1001,6 +1002,7 @@ define_config! {
         compression_profile: Option<String> = "compression-profile",
         include_mingw_linker: Option<bool> = "include-mingw-linker",
         vendor: Option<bool> = "vendor",
+        exclude_submodules_from_vendoring: Option<BTreeSet<String>> = "exclude-submodules-from-vendoring",
     }
 }
 
@@ -2227,10 +2229,13 @@ impl Config {
                 compression_profile,
                 include_mingw_linker,
                 vendor,
+                exclude_submodules_from_vendoring,
             } = dist;
             config.dist_sign_folder = sign_folder.map(PathBuf::from);
             config.dist_upload_addr = upload_addr;
             config.dist_compression_formats = compression_formats;
+            config.dist_exclude_submodules_from_vendoring =
+                exclude_submodules_from_vendoring.unwrap_or_else(BTreeSet::new);
             set(&mut config.dist_compression_profile, compression_profile);
             set(&mut config.rust_dist_src, src_tarball);
             set(&mut config.dist_include_mingw_linker, include_mingw_linker);

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -360,4 +360,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "Added `build.test-stage = 2` to 'tools' profile defaults",
     },
+    ChangeInfo {
+        change_id: 137583,
+        severity: ChangeSeverity::Info,
+        summary: "It is now possible to filter out submodules from vendoring with `dist.exclude-submodules-from-vendoring`",
+    },
 ];


### PR DESCRIPTION
This adds a config option `exclude-submodules-from-vendoring` that explicitly filters out listed submodules from vendoring. This allows us to exclude submodules like `rustc-perf`, which vendors a number of libraries for benchmarking, and has a complicated licensing story.

Closes #137272

cc @Kobzol @pietroalbini @jieyouxu