### PR TITLE
rustdoc: improve the summary icon

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2040,8 +2040,7 @@ button#toggle-all-docs:before {
 	/* Custom arrow icon */
 	content: url('data:image/svg+xml,<svg width="18" height="18" viewBox="0 0 12 12" \
 	enable-background="new 0 0 12 12" xmlns="http://www.w3.org/2000/svg">\
-	<path d="M2,7l4,-4l4,4" stroke="black" fill="none" stroke-width="2px"/>\
-	<path d="M2,11l4,-4l4,4" stroke="black" fill="none" stroke-width="2px" stroke-opacity="0.5"/></svg>');
+	<path d="M2,1l4,3l4,-3M2,11l4,-3l4,3" stroke="black" fill="none" stroke-width="2px"/></svg>');
 	width: 18px;
 	height: 18px;
 	filter: var(--settings-menu-filter);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2040,7 +2040,8 @@ button#toggle-all-docs:before {
 	/* Custom arrow icon */
 	content: url('data:image/svg+xml,<svg width="18" height="18" viewBox="0 0 12 12" \
 	enable-background="new 0 0 12 12" xmlns="http://www.w3.org/2000/svg">\
-	<path d="M2,2l4,4l4,-4M2,6l4,4l4,-4" stroke="black" fill="none" stroke-width="2px"/></svg>');
+	<path d="M2,7l4,-4l4,4" stroke="black" fill="none" stroke-width="2px"/>\
+	<path d="M2,11l4,-4l4,4" stroke="black" fill="none" stroke-width="2px" stroke-opacity="0.5"/></svg>');
 	width: 18px;
 	height: 18px;
 	filter: var(--settings-menu-filter);


### PR DESCRIPTION
I changed the summary icon, from double-down-arrows to ~~double-up-arrows, and the new icon also has a grey part that can be used to hint users 'part of docs will be hidden', or 'less docs will be shown', when clicked~~ two arrows pointing at each other. The old icon with double-down-arrow maybe has the meaning 'show more docs' which always confused me.

old:
![image](https://github.com/user-attachments/assets/f6bdceee-3cef-43e1-af1a-12f55d009991)

~~new:~~
![image](https://github.com/user-attachments/assets/b48ec984-d0b0-4fa7-be6d-f62d1e99e274)

new new:

![image](https://github.com/user-attachments/assets/236b8e11-02c4-4aa5-b5ed-1e2d7a6984d0)



<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
