### PR TITLE
Added `unchecked_div` and `unchecked_rem` to signed and unsigned numerical types

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -898,6 +898,39 @@ macro_rules! int_impl {
             }
         }
 
+        /// Unchecked integer division. Computes `self / rhs`, assuming `rhs != 0` and
+        /// overflow cannot occur.
+        ///
+        /// Calling `x.unchecked_div(y)` is semantically equivalent to calling
+        /// `x.`[`checked_div`]`(y).`[`unwrap_unchecked`]`()`.
+        ///
+        /// # Safety
+        ///
+        /// This results in undefined behavior when `rhs == 0` or
+        #[doc = concat!("(`self == ", stringify!($SelfT), "::MIN` and `rhs == -1`),")]
+        /// i.e. when [`checked_div`] would return `None`.
+        ///
+        /// [`unwrap_unchecked`]: option/enum.Option.html#method.unwrap_unchecked
+        #[doc = concat!("[`checked_div`]: ", stringify!($SelfT), "::checked_div")]
+        #[doc = concat!("[`wrapping_div`]: ", stringify!($SelfT), "::wrapping_div")]
+        #[unstable(feature = "unchecked_div_rem", issue = "136716")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        pub const unsafe fn unchecked_div(self, rhs: Self) -> Self {
+            assert_unsafe_precondition!(
+                check_language_ub,
+                concat!(stringify!($SelfT), "::unchecked_div cannot overflow or divide by zero"),
+                (
+                    lhs: $SelfT = self,
+                    rhs: $SelfT = rhs
+                ) => rhs != 0 && !lhs.overflowing_div(rhs).1,
+            );
+
+            // SAFETY: this is guaranteed to be safe by the caller.
+            unsafe { intrinsics::unchecked_div(self, rhs) }
+        }
+
         /// Strict integer division. Computes `self / rhs`, panicking
         /// if overflow occurred.
         ///

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1017,6 +1017,36 @@ macro_rules! uint_impl {
             }
         }
 
+        /// Unchecked integer division. Computes `self / rhs`, assuming `rhs` is not zero.
+        ///
+        /// Calling `x.unchecked_div(y)` is semantically equivalent to calling
+        /// `x.`[`checked_div`]`(y).`[`unwrap_unchecked`]`()`.
+        ///
+        /// # Safety
+        ///
+        /// This results in undefined behavior when `rhs == 0`
+        /// i.e. when [`checked_div`] would return `None`.
+        ///
+        /// [`unwrap_unchecked`]: option/enum.Option.html#method.unwrap_unchecked
+        #[doc = concat!("[`checked_div`]: ", stringify!($SelfT), "::checked_div")]
+        #[doc = concat!("[`wrapping_div`]: ", stringify!($SelfT), "::wrapping_div")]
+        #[unstable(feature = "unchecked_div_rem", issue = "136716")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        pub const unsafe fn unchecked_div(self, rhs: Self) -> Self {
+            assert_unsafe_precondition!(
+                check_language_ub,
+                concat!(stringify!($SelfT), "::unchecked_div cannot divide by zero"),
+                (
+                    rhs: $SelfT = rhs
+                ) => rhs != 0,
+            );
+
+            // SAFETY: this is guaranteed to be safe by the caller.
+            unsafe { intrinsics::unchecked_div(self, rhs) }
+        }
+
         /// Strict integer division. Computes `self / rhs`.
         ///
         /// Strict division on unsigned types is just normal division. There's no

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1024,7 +1024,7 @@ macro_rules! uint_impl {
         ///
         /// # Safety
         ///
-        /// This results in undefined behavior when `rhs == 0`
+        /// This results in undefined behavior when `rhs == 0`,
         /// i.e. when [`checked_div`] would return `None`.
         ///
         /// [`unwrap_unchecked`]: option/enum.Option.html#method.unwrap_unchecked
@@ -1163,6 +1163,33 @@ macro_rules! uint_impl {
                 // SAFETY: div by zero has been checked above and unsigned types have no other
                 // failure modes for division
                 Some(unsafe { intrinsics::unchecked_rem(self, rhs) })
+            }
+        }
+
+        /// Unchecked integer remainder. Computes `self % rhs`, assuming `rhs` is not zero.
+        ///
+        /// # Safety
+        ///
+        /// This results in undefined behavior when `rhs == 0`,
+        /// i.e. when [`checked_rem`] would return `None`.
+        ///
+        #[doc = concat!("[`checked_rem`]: ", stringify!($SelfT), "::checked_rem")]
+        #[unstable(feature = "unchecked_div_rem", issue = "136716")]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
+        pub const unsafe fn unchecked_rem(self, rhs: Self) -> Self {
+            assert_unsafe_precondition!(
+                check_language_ub,
+                concat!(stringify!($SelfT), "::unchecked_rem cannot divide by zero"),
+                (
+                    rhs: $SelfT = rhs
+                ) => rhs != 0,
+            );
+
+            // SAFETY: this is guaranteed to be safe by the caller.
+            unsafe {
+                intrinsics::unchecked_rem(self, rhs)
             }
         }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/137598)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->

## Context

Adds `unchecked_div` and `unchecked_rem` to signed and unsigned numerical types in `core`.
This is an unstable addition.

## Related Issue
- https://github.com/rust-lang/rust/issues/136716

<!-- homu-ignore:end -->
