### PR TITLE
tests: use minicore more

### DIFF
--- a/tests/assembly/aarch64-pointer-auth.rs
+++ b/tests/assembly/aarch64-pointer-auth.rs
@@ -1,5 +1,6 @@
 // Test that PAC instructions are emitted when branch-protection is specified.
 
+//@ add-core-stubs
 //@ revisions: PACRET PAUTHLR_NOP PAUTHLR
 //@ assembly-output: emit-asm
 //@ needs-llvm-components: aarch64
@@ -14,8 +15,8 @@
 #![no_core]
 #![crate_type = "lib"]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // PACRET: hint #25
 // PACRET: hint #29

--- a/tests/assembly/cmse.rs
+++ b/tests/assembly/cmse.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: hard soft
 //@ assembly-output: emit-asm
 //@ [hard] compile-flags: --target thumbv8m.main-none-eabihf --crate-type lib -Copt-level=1
@@ -7,10 +8,9 @@
 #![crate_type = "lib"]
 #![feature(abi_c_cmse_nonsecure_call, cmse_nonsecure_entry, no_core, lang_items)]
 #![no_core]
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
+
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: __acle_se_entry_point:
 // CHECK-NEXT: entry_point:

--- a/tests/assembly/dwarf4.rs
+++ b/tests/assembly/dwarf4.rs
@@ -1,5 +1,6 @@
 // Makes sure that `-Z dwarf-version=4` causes `rustc` to emit DWARF version 4.
 //@ assembly-output: emit-asm
+//@ add-core-stubs
 //@ compile-flags: -g --target x86_64-unknown-linux-gnu -Z dwarf-version=4 -Copt-level=0
 //@ needs-llvm-components: x86
 
@@ -7,10 +8,8 @@
 #![crate_type = "rlib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 pub fn wibble() {}
 

--- a/tests/assembly/dwarf5.rs
+++ b/tests/assembly/dwarf5.rs
@@ -1,4 +1,5 @@
 // Makes sure that `-Z dwarf-version=5` causes `rustc` to emit DWARF version 5.
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 //@ compile-flags: -g --target x86_64-unknown-linux-gnu -Z dwarf-version=5 -Copt-level=0
 //@ needs-llvm-components: x86
@@ -7,10 +8,8 @@
 #![crate_type = "rlib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 pub fn wibble() {}
 

--- a/tests/assembly/pic-relocation-model.rs
+++ b/tests/assembly/pic-relocation-model.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x64
 //@ assembly-output: emit-asm
 //@ [x64] compile-flags: --target x86_64-unknown-linux-gnu -Crelocation-model=pic
@@ -7,10 +8,8 @@
 #![no_core]
 #![crate_type = "rlib"]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: call_other_fn:
 // CHECK:       {{(jmpq|callq)}} *other_fn@GOTPCREL(%rip)

--- a/tests/assembly/pie-relocation-model.rs
+++ b/tests/assembly/pie-relocation-model.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x64
 //@ assembly-output: emit-asm
 //@ [x64] compile-flags: --target x86_64-unknown-linux-gnu -Crelocation-model=pie
@@ -7,10 +8,8 @@
 #![no_core]
 #![crate_type = "rlib"]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: call_other_fn:
 // With PIE local functions are called "directly".

--- a/tests/assembly/powerpc64-struct-abi.rs
+++ b/tests/assembly/powerpc64-struct-abi.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: elfv1-be elfv2-be elfv2-le aix
 //@ assembly-output: emit-asm
 //@ compile-flags: -Copt-level=3
@@ -20,21 +21,9 @@
 #![no_core]
 #![crate_type = "lib"]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
-#[lang = "copy"]
-trait Copy {}
-
-#[lang = "freeze"]
-trait Freeze {}
-
-#[lang = "unpin"]
-trait Unpin {}
-
-impl Copy for u8 {}
-impl Copy for u16 {}
-impl Copy for u32 {}
 impl Copy for FiveU32s {}
 impl Copy for FiveU16s {}
 impl Copy for ThreeU8s {}

--- a/tests/assembly/riscv-soft-abi-with-float-features.rs
+++ b/tests/assembly/riscv-soft-abi-with-float-features.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 //@ compile-flags: --target riscv64imac-unknown-none-elf -Ctarget-feature=+f,+d
 //@ needs-llvm-components: riscv
@@ -9,15 +10,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for f16 {}
-impl Copy for f32 {}
-impl Copy for f64 {}
+extern crate minicore;
+use minicore::*;
 
 // This test checks that the floats are all returned in `a0` as required by the `lp64` ABI.
 

--- a/tests/assembly/s390x-backchain-toggle.rs
+++ b/tests/assembly/s390x-backchain-toggle.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: enable-backchain disable-backchain
 //@ assembly-output: emit-asm
 //@ compile-flags: -Copt-level=3 --crate-type=lib --target=s390x-unknown-linux-gnu
@@ -8,8 +9,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 extern "C" {
     fn extern_func();

--- a/tests/assembly/simd-bitmask.rs
+++ b/tests/assembly/simd-bitmask.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x86 x86-avx2 x86-avx512 aarch64
 //@ [x86] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86] needs-llvm-components: x86
@@ -16,12 +17,8 @@
 #![no_core]
 #![allow(non_camel_case_types)]
 
-// Because we don't have core yet.
-#[lang = "sized"]
-pub trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(simd)]
 pub struct m8x16([i8; 16]);

--- a/tests/assembly/simd-intrinsic-gather.rs
+++ b/tests/assembly/simd-intrinsic-gather.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x86-avx512
 //@ [x86-avx512] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
@@ -9,12 +10,8 @@
 #![no_core]
 #![allow(non_camel_case_types)]
 
-// Because we don't have core yet.
-#[lang = "sized"]
-pub trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(simd)]
 pub struct f64x4([f64; 4]);

--- a/tests/assembly/simd-intrinsic-mask-load.rs
+++ b/tests/assembly/simd-intrinsic-mask-load.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x86-avx2 x86-avx512
 //@ [x86-avx2] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx2] compile-flags: -C target-feature=+avx2
@@ -12,13 +13,8 @@
 #![no_core]
 #![allow(non_camel_case_types)]
 
-// Because we don't have core yet.
-#[lang = "sized"]
-pub trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
-impl<T: ?Sized> Copy for *const T {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(simd)]
 pub struct i8x16([i8; 16]);

--- a/tests/assembly/simd-intrinsic-mask-reduce.rs
+++ b/tests/assembly/simd-intrinsic-mask-reduce.rs
@@ -1,4 +1,5 @@
 // verify that simd mask reductions do not introduce additional bit shift operations
+//@ add-core-stubs
 //@ revisions: x86 aarch64
 //@ [x86] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 // Set the base cpu explicitly, in case the default has been changed.
@@ -13,12 +14,8 @@
 #![no_core]
 #![allow(non_camel_case_types)]
 
-// Because we don't have core yet.
-#[lang = "sized"]
-pub trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(simd)]
 pub struct mask8x16([i8; 16]);

--- a/tests/assembly/simd-intrinsic-mask-store.rs
+++ b/tests/assembly/simd-intrinsic-mask-store.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x86-avx2 x86-avx512
 //@ [x86-avx2] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx2] compile-flags: -C target-feature=+avx2
@@ -12,13 +13,8 @@
 #![no_core]
 #![allow(non_camel_case_types)]
 
-// Because we don't have core yet.
-#[lang = "sized"]
-pub trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
-impl<T: ?Sized> Copy for *mut T {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(simd)]
 pub struct i8x16([i8; 16]);

--- a/tests/assembly/simd-intrinsic-scatter.rs
+++ b/tests/assembly/simd-intrinsic-scatter.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x86-avx512
 //@ [x86-avx512] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx512] compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512dq
@@ -9,12 +10,8 @@
 #![no_core]
 #![allow(non_camel_case_types)]
 
-// Because we don't have core yet.
-#[lang = "sized"]
-pub trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(simd)]
 pub struct f64x4([f64; 4]);

--- a/tests/assembly/simd-intrinsic-select.rs
+++ b/tests/assembly/simd-intrinsic-select.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x86-avx2 x86-avx512 aarch64
 //@ [x86-avx2] compile-flags: --target=x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
 //@ [x86-avx2] compile-flags: -C target-feature=+avx2
@@ -14,12 +15,8 @@
 #![no_core]
 #![allow(non_camel_case_types)]
 
-// Because we don't have core yet.
-#[lang = "sized"]
-pub trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(simd)]
 pub struct i8x16([i8; 16]);

--- a/tests/assembly/sparc-struct-abi.rs
+++ b/tests/assembly/sparc-struct-abi.rs
@@ -2,6 +2,7 @@
 // - float structure members are passes in floating point registers
 // (#86163)
 
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 //@ needs-llvm-components: sparc
 //@ compile-flags: --target=sparcv9-sun-solaris -Copt-level=3
@@ -9,11 +10,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
-impl Copy for f32 {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 pub struct Franta {

--- a/tests/assembly/stack-probes.rs
+++ b/tests/assembly/stack-probes.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x86_64 i686 aarch64
 //@ assembly-output: emit-asm
 //@[x86_64] compile-flags: --target x86_64-unknown-linux-gnu -C llvm-args=-x86-asm-syntax=intel
@@ -11,12 +12,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for u8 {}
+extern crate minicore;
+use minicore::*;
 
 // Check that inline-asm stack probes are generated correctly.
 // To avoid making this test fragile to slight asm changes,

--- a/tests/assembly/stack-protector/stack-protector-target-support.rs
+++ b/tests/assembly/stack-protector/stack-protector-target-support.rs
@@ -1,6 +1,7 @@
 // Test that stack smash protection code is emitted for all tier1 and tier2
 // targets, with the exception of nvptx64-nvidia-cuda
 //
+//@ add-core-stubs
 //@ revisions: r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 r15 r16 r17 r18 r19 r20 r21 r22 r23
 //@ revisions: r24 r25 r26 r27 r28 r29 r30 r31 r32 r33     r35 r36 r37 r38 r39 r40 r41 r42 r43 r44
 //@ revisions: r45 r46 r47 r48 r49 r50 r51 r52 r53 r54 r55 r56 r57 r58 r59 r60 r61 r62 r63 r64 r65
@@ -183,10 +184,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 pub fn foo() {

--- a/tests/assembly/static-relocation-model.rs
+++ b/tests/assembly/static-relocation-model.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x64 A64 ppc64le
 //@ assembly-output: emit-asm
 //@ [x64] compile-flags: --target x86_64-unknown-linux-gnu -Crelocation-model=static
@@ -11,20 +12,8 @@
 #![no_core]
 #![crate_type = "rlib"]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
-
-#[lang = "sync"]
-trait Sync {}
-
-#[lang = "drop_in_place"]
-fn drop_in_place<T>(_: *mut T) {}
-
-impl Copy for u8 {}
-impl Sync for u8 {}
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 pub static PIERIS: u8 = 42;

--- a/tests/assembly/target-feature-multiple.rs
+++ b/tests/assembly/target-feature-multiple.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 //@ needs-llvm-components: x86
 //@ revisions: TWOFLAGS SINGLEFLAG
@@ -19,11 +20,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-impl Copy for u32 {}
+extern crate minicore;
+use minicore::*;
 
 // Use of these requires target features to be enabled
 extern "unadjusted" {

--- a/tests/assembly/targets/targets-amdgpu.rs
+++ b/tests/assembly/targets/targets-amdgpu.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 // ignore-tidy-linelength
 //@ revisions: amdgcn_amd_amdhsa
@@ -11,8 +12,8 @@
 #![no_core]
 #![crate_type = "lib"]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 pub fn test() -> u8 {
     42

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 // ignore-tidy-linelength
 //@ revisions: aarch64_be_unknown_linux_gnu
@@ -709,8 +710,8 @@
 #![no_core]
 #![crate_type = "lib"]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // Force linkage to ensure code is actually generated
 #[no_mangle]

--- a/tests/assembly/targets/targets-macho.rs
+++ b/tests/assembly/targets/targets-macho.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 // ignore-tidy-linelength
 //@ revisions: aarch64_apple_darwin
@@ -80,8 +81,8 @@
 #![no_core]
 #![crate_type = "lib"]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // Force linkage to ensure code is actually generated
 #[no_mangle]

--- a/tests/assembly/targets/targets-nvptx.rs
+++ b/tests/assembly/targets/targets-nvptx.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 // ignore-tidy-linelength
 //@ revisions: nvptx64_nvidia_cuda
@@ -11,8 +12,8 @@
 #![no_core]
 #![crate_type = "lib"]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 pub fn test() -> u8 {
     42

--- a/tests/assembly/targets/targets-pe.rs
+++ b/tests/assembly/targets/targets-pe.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 // ignore-tidy-linelength
 //@ revisions: aarch64_pc_windows_msvc
@@ -95,8 +96,8 @@
 #![no_core]
 #![crate_type = "lib"]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 pub fn test() -> u8 {
     42

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -25,7 +25,8 @@
     naked_functions,
     f16,
     f128,
-    asm_experimental_arch
+    asm_experimental_arch,
+    unboxed_closures
 )]
 #![allow(unused, improper_ctypes_definitions, internal_features)]
 #![no_std]
@@ -61,7 +62,7 @@ pub auto trait Unpin {}
 
 impl_marker_trait!(
     Copy => [
-        bool, char,
+        char, bool,
         isize, i8, i16, i32, i64, i128,
         usize, u8, u16, u32, u64, u128,
         f16, f32, f64, f128,
@@ -102,6 +103,9 @@ pub struct UnsafeCell<T: ?Sized> {
 }
 impl<T: ?Sized> !Freeze for UnsafeCell<T> {}
 
+#[lang = "tuple_trait"]
+pub trait Tuple {}
+
 #[rustc_builtin_macro]
 pub macro asm("assembly template", $(operands,)* $(options($(option),*))?) {
     /* compiler built-in */
@@ -128,4 +132,62 @@ macro_rules! stringify {
     ($($t:tt)*) => {
         /* compiler built-in */
     };
+}
+
+#[lang = "add"]
+pub trait Add<Rhs = Self> {
+    type Output;
+
+    fn add(self, _: Rhs) -> Self::Output;
+}
+
+impl Add<isize> for isize {
+    type Output = isize;
+
+    fn add(self, other: isize) -> isize {
+        7 // avoid needing to add all of the overflow handling and panic language items
+    }
+}
+
+#[lang = "sync"]
+trait Sync {}
+impl Sync for u8 {}
+
+#[lang = "drop_in_place"]
+fn drop_in_place<T>(_: *mut T) {}
+
+#[lang = "fn_once"]
+pub trait FnOnce<Args: Tuple> {
+    #[lang = "fn_once_output"]
+    type Output;
+
+    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
+}
+
+#[lang = "fn_mut"]
+pub trait FnMut<Args: Tuple>: FnOnce<Args> {
+    extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
+}
+
+#[lang = "fn"]
+pub trait Fn<Args: Tuple>: FnMut<Args> {
+    extern "rust-call" fn call(&self, args: Args) -> Self::Output;
+}
+
+#[lang = "dispatch_from_dyn"]
+trait DispatchFromDyn<T> {}
+
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<&'a U> for &'a T {}
+
+#[lang = "unsize"]
+trait Unsize<T: ?Sized> {}
+
+#[lang = "coerce_unsized"]
+pub trait CoerceUnsized<T: ?Sized> {}
+
+impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b T {}
+
+#[lang = "drop"]
+trait Drop {
+    fn drop(&mut self);
 }

--- a/tests/codegen/aarch64-softfloat.rs
+++ b/tests/codegen/aarch64-softfloat.rs
@@ -1,15 +1,12 @@
+//@ add-core-stubs
 //@ compile-flags: --target aarch64-unknown-none-softfloat -Zmerge-functions=disabled
 //@ needs-llvm-components: aarch64
 #![crate_type = "lib"]
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-impl Copy for f32 {}
-impl Copy for f64 {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK: i64 @pass_f64_C(i64 {{[^,]*}})
 #[no_mangle]

--- a/tests/codegen/aarch64-struct-align-128.rs
+++ b/tests/codegen/aarch64-struct-align-128.rs
@@ -1,5 +1,6 @@
 // Test that structs aligned to 128 bits are passed with the correct ABI on aarch64.
 
+//@ add-core-stubs
 //@ revisions: linux darwin win
 //@[linux] compile-flags: --target aarch64-unknown-linux-gnu
 //@[darwin] compile-flags: --target aarch64-apple-darwin
@@ -12,12 +13,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // Passed as `[i64 x 2]`, since it's an aggregate with size <= 128 bits, align < 128 bits.
 #[repr(C)]

--- a/tests/codegen/abi-efiapi.rs
+++ b/tests/codegen/abi-efiapi.rs
@@ -1,5 +1,6 @@
 // Checks if the correct annotation for the efiapi ABI is passed to llvm.
 
+//@ add-core-stubs
 //@ revisions:x86_64 i686 aarch64 arm riscv
 //@[x86_64] compile-flags: --target x86_64-unknown-uefi
 //@[x86_64] needs-llvm-components: aarch64 arm riscv
@@ -17,12 +18,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 //x86_64: define win64cc void @has_efiapi
 //i686: define void @has_efiapi

--- a/tests/codegen/abi-repr-ext.rs
+++ b/tests/codegen/abi-repr-ext.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3
 
 //@ revisions:x86_64 i686 aarch64-apple aarch64-windows aarch64-linux arm riscv
@@ -24,12 +25,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(i8)]
 pub enum Type {

--- a/tests/codegen/abi-sysv64.rs
+++ b/tests/codegen/abi-sysv64.rs
@@ -2,6 +2,7 @@
 // llvm. Also checks that the abi-sysv64 feature gate allows usage
 // of the sysv64 abi.
 //
+//@ add-core-stubs
 //@ needs-llvm-components: x86
 //@ compile-flags: -C no-prepopulate-passes --target=x86_64-unknown-linux-gnu -Copt-level=0
 
@@ -9,11 +10,8 @@
 #![no_core]
 #![feature(abi_x86_interrupt, no_core, lang_items)]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-impl Copy for i64 {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK: define x86_64_sysvcc i64 @has_sysv64_abi
 #[no_mangle]

--- a/tests/codegen/abi-win64-zst.rs
+++ b/tests/codegen/abi-win64-zst.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: -Z merge-functions=disabled
 //@ add-core-stubs
 

--- a/tests/codegen/abi-x86-interrupt.rs
+++ b/tests/codegen/abi-x86-interrupt.rs
@@ -2,6 +2,7 @@
 // llvm. Also checks that the abi_x86_interrupt feature gate allows usage
 // of the x86-interrupt abi.
 
+//@ add-core-stubs
 //@ needs-llvm-components: x86
 //@ compile-flags: -C no-prepopulate-passes --target=x86_64-unknown-linux-gnu -Copt-level=0
 
@@ -9,11 +10,8 @@
 #![no_core]
 #![feature(abi_x86_interrupt, no_core, lang_items)]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-impl Copy for i64 {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK: define x86_intrcc i64 @has_x86_interrupt_abi
 #[no_mangle]

--- a/tests/codegen/avr/avr-func-addrspace.rs
+++ b/tests/codegen/avr/avr-func-addrspace.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3 --target=avr-none -C target-cpu=atmega328p --crate-type=rlib -C panic=abort
 //@ needs-llvm-components: avr
 
@@ -13,45 +14,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
-impl<T: ?Sized> Copy for *const T {}
-#[lang = "legacy_receiver"]
-pub trait LegacyReceiver {}
-#[lang = "tuple_trait"]
-pub trait Tuple {}
-
-pub struct Result<T, E> {
-    _a: T,
-    _b: E,
-}
-
-impl Copy for usize {}
-impl Copy for &usize {}
-
-#[lang = "drop_in_place"]
-pub unsafe fn drop_in_place<T: ?Sized>(_: *mut T) {}
-
-#[lang = "fn_once"]
-pub trait FnOnce<Args: Tuple> {
-    #[lang = "fn_once_output"]
-    type Output;
-
-    extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
-}
-
-#[lang = "fn_mut"]
-pub trait FnMut<Args: Tuple>: FnOnce<Args> {
-    extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
-}
-
-#[lang = "fn"]
-pub trait Fn<Args: Tuple>: FnOnce<Args> {
-    /// Performs the call operation.
-    extern "rust-call" fn call(&self, args: Args) -> Self::Output;
-}
+extern crate minicore;
+use minicore::*;
 
 extern "rust-intrinsic" {
     pub fn transmute<Src, Dst>(src: Src) -> Dst;

--- a/tests/codegen/branch-protection-old-llvm.rs
+++ b/tests/codegen/branch-protection-old-llvm.rs
@@ -1,5 +1,6 @@
 // Test that the correct module flags are emitted with different branch protection flags.
 
+//@ add-core-stubs
 //@ revisions: BTI PACRET LEAF BKEY NONE
 //@ needs-llvm-components: aarch64
 //@ [BTI] compile-flags: -Z branch-protection=bti
@@ -13,8 +14,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // A basic test function.
 pub fn test() {}

--- a/tests/codegen/branch-protection.rs
+++ b/tests/codegen/branch-protection.rs
@@ -1,5 +1,6 @@
 // Test that the correct module flags are emitted with different branch protection flags.
 
+//@ add-core-stubs
 //@ revisions: BTI PACRET LEAF BKEY PAUTHLR PAUTHLR_BKEY PAUTHLR_LEAF PAUTHLR_BTI NONE
 //@ needs-llvm-components: aarch64
 //@ [BTI] compile-flags: -Z branch-protection=bti
@@ -17,8 +18,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // A basic test function.
 // CHECK: @test(){{.*}} [[ATTR:#[0-9]+]] {

--- a/tests/codegen/cast-target-abi.rs
+++ b/tests/codegen/cast-target-abi.rs
@@ -1,4 +1,5 @@
 // ignore-tidy-linelength
+//@ add-core-stubs
 //@ revisions:aarch64 loongarch64 powerpc64 sparc64 x86_64
 //@ min-llvm-version: 19
 //@ compile-flags: -Copt-level=3 -Cno-prepopulate-passes -Zlint-llvm-ir -Cllvm-args=-lint-abort-on-error
@@ -21,12 +22,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // This struct will be passed as a single `i64` or `i32`.
 // This may be (if `i64)) larger than the Rust layout, which is just `{ i16, i16 }`.

--- a/tests/codegen/cf-protection.rs
+++ b/tests/codegen/cf-protection.rs
@@ -1,5 +1,6 @@
 // Test that the correct module flags are emitted with different control-flow protection flags.
 
+//@ add-core-stubs
 //@ revisions: undefined none branch return full
 //@ needs-llvm-components: x86
 //@ [undefined] compile-flags:
@@ -13,8 +14,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // A basic test function.
 pub fn test() {}

--- a/tests/codegen/cffi/ffi-out-of-bounds-loads.rs
+++ b/tests/codegen/cffi/ffi-out-of-bounds-loads.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: linux apple
 //@ min-llvm-version: 19
 //@ compile-flags: -Copt-level=0 -Cno-prepopulate-passes -Zlint-llvm-ir -Cllvm-args=-lint-abort-on-error
@@ -14,12 +15,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 struct S {

--- a/tests/codegen/default-requires-uwtable.rs
+++ b/tests/codegen/default-requires-uwtable.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: WINDOWS_ ANDROID_
 //@ compile-flags: -C panic=abort -Copt-level=0
 //@ [WINDOWS_] compile-flags: --target=x86_64-pc-windows-msvc
@@ -9,8 +10,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK: attributes #{{.*}} uwtable
 pub fn foo() {}

--- a/tests/codegen/fastcall-inreg.rs
+++ b/tests/codegen/fastcall-inreg.rs
@@ -2,6 +2,7 @@
 // as "inreg" like the C/C++ compilers for the platforms.
 // x86 only.
 
+//@ add-core-stubs
 //@ compile-flags: --target i686-unknown-linux-gnu -Cno-prepopulate-passes -Copt-level=3
 //@ needs-llvm-components: x86
 
@@ -9,10 +10,8 @@
 #![no_core]
 #![feature(no_core, lang_items)]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 pub mod tests {
     // CHECK: @f1(i32 inreg noundef %_1, i32 inreg noundef %_2, i32 noundef %_3)

--- a/tests/codegen/fixed-x18.rs
+++ b/tests/codegen/fixed-x18.rs
@@ -1,6 +1,7 @@
 // Test that the `reserve-x18` target feature is (not) emitted when
 // the `-Zfixed-x18` flag is (not) set.
 
+//@ add-core-stubs
 //@ revisions: unset set
 //@ needs-llvm-components: aarch64
 //@ compile-flags: --target aarch64-unknown-none
@@ -10,8 +11,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 pub fn foo() {

--- a/tests/codegen/frame-pointer.rs
+++ b/tests/codegen/frame-pointer.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: --crate-type=rlib -Copt-level=0
 //@ revisions: aarch64-apple aarch64-linux force x64-apple x64-linux
 //@ [aarch64-apple] needs-llvm-components: aarch64
@@ -13,11 +14,9 @@
 
 #![feature(no_core, lang_items)]
 #![no_core]
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-impl Copy for u32 {}
+
+extern crate minicore;
+use minicore::*;
 
 // CHECK: define i32 @peach{{.*}}[[PEACH_ATTRS:\#[0-9]+]] {
 #[no_mangle]

--- a/tests/codegen/function-return.rs
+++ b/tests/codegen/function-return.rs
@@ -1,6 +1,7 @@
 // Test that the `fn_ret_thunk_extern` function attribute is (not) emitted when
 // the `-Zfunction-return={keep,thunk-extern}` flag is (not) set.
 
+//@ add-core-stubs
 //@ revisions: unset keep thunk-extern keep-thunk-extern thunk-extern-keep
 //@ needs-llvm-components: x86
 //@ compile-flags: --target x86_64-unknown-linux-gnu
@@ -13,8 +14,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 pub fn foo() {

--- a/tests/codegen/gpu-kernel-abi.rs
+++ b/tests/codegen/gpu-kernel-abi.rs
@@ -1,17 +1,14 @@
 // Checks that the gpu-kernel calling convention correctly translates to LLVM calling conventions.
 
+//@ add-core-stubs
 //@ revisions: nvptx
 //@ [nvptx] compile-flags: --crate-type=rlib --target=nvptx64-nvidia-cuda
 //@ [nvptx] needs-llvm-components: nvptx
 #![feature(no_core, lang_items, abi_gpu_kernel)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // nvptx: define ptx_kernel void @fun(i32
 #[no_mangle]

--- a/tests/codegen/intrinsics/nontemporal.rs
+++ b/tests/codegen/intrinsics/nontemporal.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3
 //@revisions: with_nontemporal without_nontemporal
 //@[with_nontemporal] compile-flags: --target aarch64-unknown-linux-gnu
@@ -14,13 +15,8 @@
 #![no_core]
 #![crate_type = "lib"]
 
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
-
-impl Copy for u32 {}
-impl<T> Copy for *mut T {}
+extern crate minicore;
+use minicore::*;
 
 extern "rust-intrinsic" {
     pub fn nontemporal_store<T>(ptr: *mut T, val: T);

--- a/tests/codegen/loongarch-abi/loongarch64-lp64d-abi.rs
+++ b/tests/codegen/loongarch-abi/loongarch64-lp64d-abi.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes --target loongarch64-unknown-linux-gnu
 //@ needs-llvm-components: loongarch
 
@@ -6,12 +7,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK: define void @f_fpr_tracking(double %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, i8 noundef zeroext %i)
 #[no_mangle]

--- a/tests/codegen/macos/i686-macosx-deployment-target.rs
+++ b/tests/codegen/macos/i686-macosx-deployment-target.rs
@@ -1,19 +1,15 @@
-//
 // Checks that we correctly modify the target when MACOSX_DEPLOYMENT_TARGET is set.
 // See issue #60235.
 
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3 --target=i686-apple-darwin --crate-type=rlib
 //@ needs-llvm-components: x86
 //@ rustc-env:MACOSX_DEPLOYMENT_TARGET=10.14
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 pub struct Bool {

--- a/tests/codegen/macos/i686-no-macosx-deployment-target.rs
+++ b/tests/codegen/macos/i686-no-macosx-deployment-target.rs
@@ -1,19 +1,15 @@
-//
 // Checks that we leave the target alone MACOSX_DEPLOYMENT_TARGET is unset.
 // See issue #60235.
 
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3 --target=i686-apple-darwin --crate-type=rlib
 //@ needs-llvm-components: x86
 //@ unset-rustc-env:MACOSX_DEPLOYMENT_TARGET
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 pub struct Bool {

--- a/tests/codegen/macos/x86_64-macosx-deployment-target.rs
+++ b/tests/codegen/macos/x86_64-macosx-deployment-target.rs
@@ -1,19 +1,15 @@
-//
 // Checks that we correctly modify the target when MACOSX_DEPLOYMENT_TARGET is set.
 // See issue #60235.
 
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3 --target=x86_64-apple-darwin --crate-type=rlib
 //@ needs-llvm-components: x86
 //@ rustc-env:MACOSX_DEPLOYMENT_TARGET=10.14
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 pub struct Bool {

--- a/tests/codegen/macos/x86_64-no-macosx-deployment-target.rs
+++ b/tests/codegen/macos/x86_64-no-macosx-deployment-target.rs
@@ -1,19 +1,15 @@
-//
 // Checks that we leave the target alone when MACOSX_DEPLOYMENT_TARGET is unset.
 // See issue #60235.
 
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3 --target=x86_64-apple-darwin --crate-type=rlib
 //@ needs-llvm-components: x86
 //@ unset-rustc-env:MACOSX_DEPLOYMENT_TARGET
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 pub struct Bool {

--- a/tests/codegen/naked-fn/instruction-set.rs
+++ b/tests/codegen/naked-fn/instruction-set.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: arm-mode thumb-mode
 //@ [arm-mode] compile-flags: --target armv5te-none-eabi
 //@ [thumb-mode] compile-flags: --target thumbv5te-none-eabi
@@ -8,15 +9,8 @@
 #![feature(no_core, lang_items, rustc_attrs, naked_functions)]
 #![no_core]
 
-#[rustc_builtin_macro]
-macro_rules! naked_asm {
-    () => {};
-}
-
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // arm-mode: .arm
 // thumb-mode: .thumb

--- a/tests/codegen/naked-fn/naked-functions.rs
+++ b/tests/codegen/naked-fn/naked-functions.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: linux win macos thumb
 //
 //@[linux] compile-flags: --target x86_64-unknown-linux-gnu
@@ -13,15 +14,8 @@
 #![feature(no_core, lang_items, rustc_attrs, naked_functions)]
 #![no_core]
 
-#[rustc_builtin_macro]
-macro_rules! naked_asm {
-    () => {};
-}
-
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // linux,win: .intel_syntax
 //

--- a/tests/codegen/no-jump-tables.rs
+++ b/tests/codegen/no-jump-tables.rs
@@ -1,6 +1,7 @@
 // Test that the `no-jump-tables` function attribute are (not) emitted when
 // the `-Zno-jump-tables` flag is (not) set.
 
+//@ add-core-stubs
 //@ revisions: unset set
 //@ needs-llvm-components: x86
 //@ compile-flags: --target x86_64-unknown-linux-gnu
@@ -10,8 +11,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 pub fn foo() {

--- a/tests/codegen/powerpc64le-struct-align-128.rs
+++ b/tests/codegen/powerpc64le-struct-align-128.rs
@@ -1,6 +1,7 @@
 // Test that structs aligned to 128 bits are passed with the correct ABI on powerpc64le.
 // This is similar to aarch64-struct-align-128.rs, but for ppc.
 
+//@ add-core-stubs
 //@ compile-flags: --target powerpc64le-unknown-linux-gnu
 //@ needs-llvm-components: powerpc
 
@@ -8,12 +9,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 pub struct Align8 {

--- a/tests/codegen/regparm-inreg.rs
+++ b/tests/codegen/regparm-inreg.rs
@@ -2,6 +2,7 @@
 // marks function arguments as "inreg" like the C/C++ compilers for the platforms.
 // x86 only.
 
+//@ add-core-stubs
 //@ compile-flags: --target i686-unknown-linux-gnu -Cno-prepopulate-passes -Copt-level=3
 //@ needs-llvm-components: x86
 
@@ -14,10 +15,9 @@
 #![crate_type = "lib"]
 #![no_core]
 #![feature(no_core, lang_items, repr_simd)]
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+
+extern crate minicore;
+use minicore::*;
 
 pub mod tests {
     // regparm doesn't work for "fastcall" calling conv (only 2 inregs)

--- a/tests/codegen/repr/transparent-byval-struct-ptr.rs
+++ b/tests/codegen/repr/transparent-byval-struct-ptr.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: i686-linux i686-freebsd x64-linux x64-apple
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
 
@@ -21,14 +22,9 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
-impl Copy for [u32; 16] {}
 impl Copy for BigS {}
 impl Copy for BigU {}
 

--- a/tests/codegen/repr/transparent-imm-array.rs
+++ b/tests/codegen/repr/transparent-imm-array.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: arm-linux arm-android armv7-linux armv7-android mips thumb sparc
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
 
@@ -27,14 +28,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for [u32; 16] {}
+extern crate minicore;
+use minicore::*;
 impl Copy for BigS {}
 impl Copy for BigU {}
 

--- a/tests/codegen/repr/transparent-mips64.rs
+++ b/tests/codegen/repr/transparent-mips64.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: mips64 mips64el
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
 
@@ -13,14 +14,9 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
-impl Copy for [u32; 16] {}
 impl Copy for BigS {}
 impl Copy for BigU {}
 

--- a/tests/codegen/repr/transparent-opaque-ptr.rs
+++ b/tests/codegen/repr/transparent-opaque-ptr.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: aarch64-linux aarch64-darwin wasm32-wasip1
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
 
@@ -19,14 +20,9 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
-impl Copy for [u32; 16] {}
 impl Copy for BigS {}
 impl Copy for BigU {}
 

--- a/tests/codegen/repr/transparent-sparc64.rs
+++ b/tests/codegen/repr/transparent-sparc64.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes --target sparc64-unknown-linux-gnu
 //@ needs-llvm-components: sparc
 
@@ -8,14 +9,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for [u32; 16] {}
+extern crate minicore;
+use minicore::*;
 impl Copy for BigS {}
 impl Copy for BigU {}
 

--- a/tests/codegen/repr/transparent-sysv64.rs
+++ b/tests/codegen/repr/transparent-sysv64.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: linux apple win
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes
 
@@ -13,12 +14,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 pub struct Rgb8 {

--- a/tests/codegen/riscv-abi/riscv64-lp64-lp64f-lp64d-abi.rs
+++ b/tests/codegen/riscv-abi/riscv64-lp64-lp64f-lp64d-abi.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: --target riscv64gc-unknown-linux-gnu -Copt-level=3 -C no-prepopulate-passes -C panic=abort
 //@ needs-llvm-components: riscv
 
@@ -6,19 +7,8 @@
 #![feature(no_core, lang_items)]
 #![allow(improper_ctypes)]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-impl Copy for bool {}
-impl Copy for i8 {}
-impl Copy for u8 {}
-impl Copy for i32 {}
-impl Copy for i64 {}
-impl Copy for u64 {}
-impl Copy for f32 {}
-impl Copy for f64 {}
-impl<T> Copy for *mut T {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK: define void @f_void()
 #[no_mangle]

--- a/tests/codegen/riscv-abi/riscv64-lp64d-abi.rs
+++ b/tests/codegen/riscv-abi/riscv64-lp64d-abi.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes --target riscv64gc-unknown-linux-gnu
 //@ needs-llvm-components: riscv
 
@@ -6,12 +7,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK: define void @f_fpr_tracking(double %0, double %1, double %2, double %3, double %4, double %5, double %6, double %7, i8 noundef zeroext %i)
 #[no_mangle]

--- a/tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs
+++ b/tests/codegen/riscv-abi/riscv64-lp64f-lp64d-abi.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3 -C no-prepopulate-passes --target riscv64gc-unknown-linux-gnu
 //@ needs-llvm-components: riscv
 
@@ -6,12 +7,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK: define void @f_fpr_tracking(float %0, float %1, float %2, float %3, float %4, float %5, float %6, float %7, i8 noundef zeroext %i)
 #[no_mangle]

--- a/tests/codegen/riscv-target-abi.rs
+++ b/tests/codegen/riscv-target-abi.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions:riscv64gc riscv32gc riscv32imac
 
 //@[riscv64gc] compile-flags: --target=riscv64gc-unknown-linux-gnu
@@ -16,5 +17,5 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;

--- a/tests/codegen/sanitizer/aarch64-shadow-call-stack-with-fixed-x18.rs
+++ b/tests/codegen/sanitizer/aarch64-shadow-call-stack-with-fixed-x18.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: aarch64 android
 //@[aarch64] compile-flags: --target aarch64-unknown-none -Zfixed-x18 -Zsanitizer=shadow-call-stack
 //@[aarch64] needs-llvm-components: aarch64
@@ -9,8 +10,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK: ; Function Attrs:{{.*}}shadowcallstack
 #[no_mangle]

--- a/tests/codegen/sanitizer/kasan-emits-instrumentation.rs
+++ b/tests/codegen/sanitizer/kasan-emits-instrumentation.rs
@@ -1,5 +1,6 @@
 // Verifies that `-Zsanitizer=kernel-address` emits sanitizer instrumentation.
 
+//@ add-core-stubs
 //@ compile-flags: -Zsanitizer=kernel-address -Copt-level=0
 //@ revisions: aarch64 riscv64imac riscv64gc x86_64
 //@[aarch64] compile-flags: --target aarch64-unknown-none
@@ -15,13 +16,8 @@
 #![feature(no_core, no_sanitize, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for u8 {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: ; kasan_emits_instrumentation::unsanitized
 // CHECK-NEXT:  ; Function Attrs:

--- a/tests/codegen/sanitizer/kcfi/add-cfi-normalize-integers-flag.rs
+++ b/tests/codegen/sanitizer/kcfi/add-cfi-normalize-integers-flag.rs
@@ -1,5 +1,6 @@
 // Verifies that "cfi-normalize-integers" module flag is added.
 //
+//@ add-core-stubs
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
@@ -11,10 +12,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 pub fn foo() {}
 

--- a/tests/codegen/sanitizer/kcfi/add-kcfi-flag.rs
+++ b/tests/codegen/sanitizer/kcfi/add-kcfi-flag.rs
@@ -1,5 +1,6 @@
 // Verifies that "kcfi" module flag is added.
 //
+//@ add-core-stubs
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
@@ -11,10 +12,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 pub fn foo() {}
 

--- a/tests/codegen/sanitizer/kcfi/add-kcfi-offset-flag.rs
+++ b/tests/codegen/sanitizer/kcfi/add-kcfi-offset-flag.rs
@@ -1,5 +1,6 @@
 // Verifies that "kcfi-offset" module flag is added.
 //
+//@ add-core-stubs
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
@@ -11,10 +12,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 pub fn foo() {}
 

--- a/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle-attr-no-sanitize.rs
+++ b/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle-attr-no-sanitize.rs
@@ -1,5 +1,6 @@
 // Verifies that KCFI operand bundles are omitted.
 //
+//@ add-core-stubs
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
@@ -11,12 +12,8 @@
 #![feature(no_core, no_sanitize, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i32 {}
+extern crate minicore;
+use minicore::*;
 
 #[no_sanitize(kcfi)]
 pub fn foo(f: fn(i32) -> i32, arg: i32) -> i32 {

--- a/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-generalized.rs
+++ b/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-generalized.rs
@@ -1,5 +1,6 @@
 // Verifies that generalized KCFI type metadata for functions are emitted.
 //
+//@ add-core-stubs
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
@@ -11,12 +12,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i32 {}
+extern crate minicore;
+use minicore::*;
 
 pub fn foo(f: fn(i32) -> i32, arg: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}foo

--- a/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-normalized-generalized.rs
+++ b/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-normalized-generalized.rs
@@ -1,5 +1,6 @@
 // Verifies that normalized and generalized KCFI type metadata for functions are emitted.
 //
+//@ add-core-stubs
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
@@ -11,12 +12,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i32 {}
+extern crate minicore;
+use minicore::*;
 
 pub fn foo(f: fn(i32) -> i32, arg: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}foo

--- a/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-normalized.rs
+++ b/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi-normalized.rs
@@ -1,5 +1,6 @@
 // Verifies that normalized KCFI type metadata for functions are emitted.
 //
+//@ add-core-stubs
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
@@ -11,12 +12,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i32 {}
+extern crate minicore;
+use minicore::*;
 
 pub fn foo(f: fn(i32) -> i32, arg: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}foo

--- a/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi.rs
+++ b/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle-itanium-cxx-abi.rs
@@ -1,5 +1,6 @@
 // Verifies that KCFI type metadata for functions are emitted.
 //
+//@ add-core-stubs
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
@@ -11,12 +12,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i32 {}
+extern crate minicore;
+use minicore::*;
 
 pub fn foo(f: fn(i32) -> i32, arg: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}foo

--- a/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle.rs
+++ b/tests/codegen/sanitizer/kcfi/emit-kcfi-operand-bundle.rs
@@ -1,5 +1,6 @@
 // Verifies that KCFI operand bundles are emitted.
 //
+//@ add-core-stubs
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
@@ -11,12 +12,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i32 {}
+extern crate minicore;
+use minicore::*;
 
 pub fn foo(f: fn(i32) -> i32, arg: i32) -> i32 {
     // CHECK-LABEL: define{{.*}}foo{{.*}}!{{<unknown kind #36>|kcfi_type}} !{{[0-9]+}}

--- a/tests/codegen/sanitizer/kcfi/emit-type-metadata-trait-objects.rs
+++ b/tests/codegen/sanitizer/kcfi/emit-type-metadata-trait-objects.rs
@@ -1,5 +1,6 @@
 // Verifies that type metadata identifiers for trait objects are emitted correctly.
 //
+//@ add-core-stubs
 //@ revisions: aarch64 x86_64
 //@ [aarch64] compile-flags: --target aarch64-unknown-none
 //@ [aarch64] needs-llvm-components: aarch64
@@ -11,29 +12,8 @@
 #![feature(arbitrary_self_types, no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-impl<T: ?Sized> Copy for &T {}
-#[lang = "legacy_receiver"]
-trait LegacyReceiver {}
-#[lang = "dispatch_from_dyn"]
-trait DispatchFromDyn<T> {}
-impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<&'a U> for &'a T {}
-#[lang = "unsize"]
-trait Unsize<T: ?Sized> {}
-#[lang = "coerce_unsized"]
-pub trait CoerceUnsized<T: ?Sized> {}
-impl<'a, 'b: 'a, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<&'a U> for &'b T {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "drop_in_place"]
-fn drop_in_place_fn<T>() {}
-#[lang = "drop"]
-trait Drop {
-    fn drop(&mut self);
-}
+extern crate minicore;
+use minicore::*;
 
 pub trait Trait1 {
     fn foo(&self);

--- a/tests/codegen/sanitizer/riscv64-shadow-call-stack.rs
+++ b/tests/codegen/sanitizer/riscv64-shadow-call-stack.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: --target riscv64imac-unknown-none-elf -Zsanitizer=shadow-call-stack
 //@ needs-llvm-components: riscv
 
@@ -6,8 +7,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // CHECK: ; Function Attrs:{{.*}}shadowcallstack
 // CHECK: define dso_local void @foo() unnamed_addr #0

--- a/tests/codegen/some-abis-do-extend-params-to-32-bits.rs
+++ b/tests/codegen/some-abis-do-extend-params-to-32-bits.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: -Cno-prepopulate-passes -Copt-level=0
 
 //@ revisions:x86_64 i686 aarch64-apple aarch64-windows aarch64-linux arm riscv
@@ -24,12 +25,8 @@
 #![no_std]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 // The patterns in this file are written in the style of a table to make the
 // uniformities and distinctions more apparent.

--- a/tests/codegen/sparc-struct-abi.rs
+++ b/tests/codegen/sparc-struct-abi.rs
@@ -1,17 +1,14 @@
 // Checks that we correctly codegen extern "C" functions returning structs.
 // See issues #52638 and #86163.
 
+//@ add-core-stubs
 //@ compile-flags: -Copt-level=3 --target=sparc64-unknown-linux-gnu --crate-type=rlib
 //@ needs-llvm-components: sparc
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "freeze"]
-trait Freeze {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 pub struct Bool {

--- a/tests/codegen/stack-probes-inline.rs
+++ b/tests/codegen/stack-probes-inline.rs
@@ -1,6 +1,7 @@
 // Check the "probe-stack" attribute for targets with `StackProbeType::Inline`,
 // or `StackProbeType::InlineOrCall` when running on newer LLVM.
 
+//@ add-core-stubs
 //@ compile-flags: -C no-prepopulate-passes
 //@ revisions: aarch64 powerpc powerpc64 powerpc64le s390x i686 x86_64
 //@[aarch64] compile-flags: --target aarch64-unknown-linux-gnu
@@ -22,8 +23,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 pub fn foo() {

--- a/tests/codegen/target-feature-overrides.rs
+++ b/tests/codegen/target-feature-overrides.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: COMPAT INCOMPAT
 //@ needs-llvm-components: x86
 //@ compile-flags: --target=x86_64-unknown-linux-gnu -Copt-level=3
@@ -9,10 +10,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 extern "C" {
     fn peach() -> u32;

--- a/tests/codegen/tied-features-strength.rs
+++ b/tests/codegen/tied-features-strength.rs
@@ -1,4 +1,5 @@
 // ignore-tidy-linelength
+//@ add-core-stubs
 //@ revisions: ENABLE_SVE DISABLE_SVE DISABLE_NEON ENABLE_NEON
 //@ compile-flags: --crate-type=rlib --target=aarch64-unknown-linux-gnu
 //@ needs-llvm-components: aarch64
@@ -22,7 +23,7 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 pub fn test() {}

--- a/tests/ui/abi/arm-unadjusted-intrinsic.rs
+++ b/tests/ui/abi/arm-unadjusted-intrinsic.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ build-pass
 //@ revisions: arm
 //@[arm] compile-flags: --target arm-unknown-linux-gnueabi
@@ -14,19 +15,8 @@
 #![crate_type = "lib"]
 #![allow(non_camel_case_types)]
 
-/// To work cross-target this test must be no_core.
-/// This little prelude supplies what we need.
-#[lang = "sized"]
-pub trait Sized {}
-
-#[lang = "copy"]
-pub trait Copy: Sized {}
-impl Copy for i8 {}
-impl<T: ?Sized> Copy for *const T {}
-impl<T: ?Sized> Copy for *mut T {}
-
-// I hate no_core tests!
-impl<T: Copy, const N: usize> Copy for [T; N] {}
+extern crate minicore;
+use minicore::*;
 
 // Regression test for https://github.com/rust-lang/rust/issues/118124.
 

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
@@ -1,5 +1,5 @@
 error[E0703]: invalid ABI: found `riscv-interrupt`
-  --> $DIR/riscv-discoverability-guidance.rs:17:8
+  --> $DIR/riscv-discoverability-guidance.rs:15:8
    |
 LL | extern "riscv-interrupt" fn isr() {}
    |        ^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | extern "riscv-interrupt" fn isr() {}
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
-  --> $DIR/riscv-discoverability-guidance.rs:22:8
+  --> $DIR/riscv-discoverability-guidance.rs:20:8
    |
 LL | extern "riscv-interrupt-u" fn isr_U() {}
    |        ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
@@ -1,5 +1,5 @@
 error[E0703]: invalid ABI: found `riscv-interrupt`
-  --> $DIR/riscv-discoverability-guidance.rs:17:8
+  --> $DIR/riscv-discoverability-guidance.rs:15:8
    |
 LL | extern "riscv-interrupt" fn isr() {}
    |        ^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | extern "riscv-interrupt" fn isr() {}
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
-  --> $DIR/riscv-discoverability-guidance.rs:22:8
+  --> $DIR/riscv-discoverability-guidance.rs:20:8
    |
 LL | extern "riscv-interrupt-u" fn isr_U() {}
    |        ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/riscv-discoverability-guidance.rs
+++ b/tests/ui/abi/riscv-discoverability-guidance.rs
@@ -1,4 +1,5 @@
 // ignore-tidy-linelength
+//@ add-core-stubs
 //@ revisions: riscv32 riscv64
 //
 //@ [riscv32] needs-llvm-components: riscv
@@ -6,13 +7,10 @@
 //@ [riscv64] needs-llvm-components: riscv
 //@ [riscv64] compile-flags: --target=riscv64gc-unknown-none-elf -C target-feature=-unaligned-scalar-mem --crate-type=rlib
 #![no_core]
-#![feature(
-    no_core,
-    lang_items,
-    abi_riscv_interrupt
-)]
-#[lang = "sized"]
-trait Sized {}
+#![feature(no_core, lang_items, abi_riscv_interrupt)]
+
+extern crate minicore;
+use minicore::*;
 
 extern "riscv-interrupt" fn isr() {}
 //~^ ERROR invalid ABI

--- a/tests/ui/abi/sparcv8plus-llvm19.rs
+++ b/tests/ui/abi/sparcv8plus-llvm19.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: sparc sparcv8plus sparc_cpu_v9 sparc_feature_v8plus sparc_cpu_v9_feature_v8plus
 //@[sparc] compile-flags: --target sparc-unknown-none-elf
 //@[sparc] needs-llvm-components: sparc
@@ -15,10 +16,8 @@
 #![feature(no_core, rustc_attrs, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[rustc_builtin_macro]
 macro_rules! compile_error {

--- a/tests/ui/abi/sparcv8plus-llvm19.sparc.stderr
+++ b/tests/ui/abi/sparcv8plus-llvm19.sparc.stderr
@@ -1,5 +1,5 @@
 error: -v8plus,-v9
-  --> $DIR/sparcv8plus-llvm19.rs:29:1
+  --> $DIR/sparcv8plus-llvm19.rs:28:1
    |
 LL | compile_error!("-v8plus,-v9");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/sparcv8plus-llvm19.sparc_cpu_v9.stderr
+++ b/tests/ui/abi/sparcv8plus-llvm19.sparc_cpu_v9.stderr
@@ -1,5 +1,5 @@
 error: +v8plus,+v9
-  --> $DIR/sparcv8plus-llvm19.rs:34:1
+  --> $DIR/sparcv8plus-llvm19.rs:33:1
    |
 LL | compile_error!("+v8plus,+v9");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/sparcv8plus-llvm19.sparc_cpu_v9_feature_v8plus.stderr
+++ b/tests/ui/abi/sparcv8plus-llvm19.sparc_cpu_v9_feature_v8plus.stderr
@@ -1,5 +1,5 @@
 error: +v8plus,+v9
-  --> $DIR/sparcv8plus-llvm19.rs:34:1
+  --> $DIR/sparcv8plus-llvm19.rs:33:1
    |
 LL | compile_error!("+v8plus,+v9");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/sparcv8plus-llvm19.sparc_feature_v8plus.stderr
+++ b/tests/ui/abi/sparcv8plus-llvm19.sparc_feature_v8plus.stderr
@@ -1,5 +1,5 @@
 error: +v8plus,-v9 (FIXME)
-  --> $DIR/sparcv8plus-llvm19.rs:39:1
+  --> $DIR/sparcv8plus-llvm19.rs:38:1
    |
 LL | compile_error!("+v8plus,-v9 (FIXME)");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/sparcv8plus-llvm19.sparcv8plus.stderr
+++ b/tests/ui/abi/sparcv8plus-llvm19.sparcv8plus.stderr
@@ -1,5 +1,5 @@
 error: +v8plus,+v9
-  --> $DIR/sparcv8plus-llvm19.rs:34:1
+  --> $DIR/sparcv8plus-llvm19.rs:33:1
    |
 LL | compile_error!("+v8plus,+v9");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/sparcv8plus.rs
+++ b/tests/ui/abi/sparcv8plus.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: sparc sparcv8plus sparc_cpu_v9 sparc_feature_v8plus sparc_cpu_v9_feature_v8plus
 //@[sparc] compile-flags: --target sparc-unknown-none-elf
 //@[sparc] needs-llvm-components: sparc
@@ -15,10 +16,8 @@
 #![feature(no_core, rustc_attrs, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[rustc_builtin_macro]
 macro_rules! compile_error {

--- a/tests/ui/abi/sparcv8plus.sparc.stderr
+++ b/tests/ui/abi/sparcv8plus.sparc.stderr
@@ -1,5 +1,5 @@
 error: -v8plus,-v9
-  --> $DIR/sparcv8plus.rs:29:1
+  --> $DIR/sparcv8plus.rs:28:1
    |
 LL | compile_error!("-v8plus,-v9");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/sparcv8plus.sparc_cpu_v9.stderr
+++ b/tests/ui/abi/sparcv8plus.sparc_cpu_v9.stderr
@@ -1,5 +1,5 @@
 error: -v8plus,+v9
-  --> $DIR/sparcv8plus.rs:42:1
+  --> $DIR/sparcv8plus.rs:41:1
    |
 LL | compile_error!("-v8plus,+v9");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/sparcv8plus.sparc_cpu_v9_feature_v8plus.stderr
+++ b/tests/ui/abi/sparcv8plus.sparc_cpu_v9_feature_v8plus.stderr
@@ -1,5 +1,5 @@
 error: +v8plus,+v9
-  --> $DIR/sparcv8plus.rs:33:1
+  --> $DIR/sparcv8plus.rs:32:1
    |
 LL | compile_error!("+v8plus,+v9");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/sparcv8plus.sparc_feature_v8plus.stderr
+++ b/tests/ui/abi/sparcv8plus.sparc_feature_v8plus.stderr
@@ -1,5 +1,5 @@
 error: +v8plus,-v9 (FIXME)
-  --> $DIR/sparcv8plus.rs:38:1
+  --> $DIR/sparcv8plus.rs:37:1
    |
 LL | compile_error!("+v8plus,-v9 (FIXME)");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/sparcv8plus.sparcv8plus.stderr
+++ b/tests/ui/abi/sparcv8plus.sparcv8plus.stderr
@@ -1,5 +1,5 @@
 error: +v8plus,+v9
-  --> $DIR/sparcv8plus.rs:33:1
+  --> $DIR/sparcv8plus.rs:32:1
    |
 LL | compile_error!("+v8plus,+v9");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.aarch64.stderr
+++ b/tests/ui/abi/unsupported.aarch64.stderr
@@ -1,5 +1,5 @@
 warning: the calling convention "ptx-kernel" is not supported on this target
-  --> $DIR/unsupported.rs:36:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "aapcs" is not supported on this target
-  --> $DIR/unsupported.rs:52:17
+  --> $DIR/unsupported.rs:51:17
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:65:1
+  --> $DIR/unsupported.rs:64:1
    |
 LL | extern "aapcs" {}
    | ^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "msp430-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:74:18
+  --> $DIR/unsupported.rs:73:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "avr-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:84:15
+  --> $DIR/unsupported.rs:83:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:89:1
+  --> $DIR/unsupported.rs:88:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "riscv-interrupt-m" is not supported on this target
-  --> $DIR/unsupported.rs:97:17
+  --> $DIR/unsupported.rs:96:17
    |
 LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:108:1
+  --> $DIR/unsupported.rs:107:1
    |
 LL | extern "riscv-interrupt-m" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "x86-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:119:15
+  --> $DIR/unsupported.rs:118:15
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:130:1
+  --> $DIR/unsupported.rs:129:1
    |
 LL | extern "x86-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "thiscall" is not supported on this target
-  --> $DIR/unsupported.rs:142:20
+  --> $DIR/unsupported.rs:141:20
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -99,13 +99,13 @@ LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:155:1
+  --> $DIR/unsupported.rs:154:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "stdcall" is not supported on this target
-  --> $DIR/unsupported.rs:168:19
+  --> $DIR/unsupported.rs:167:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -114,13 +114,13 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"stdcall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:181:1
+  --> $DIR/unsupported.rs:180:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "C-cmse-nonsecure-call" is not supported on this target
-  --> $DIR/unsupported.rs:188:21
+  --> $DIR/unsupported.rs:187:21
    |
 LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,7 +129,7 @@ LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: the calling convention "C-cmse-nonsecure-entry" is not supported on this target
-  --> $DIR/unsupported.rs:196:22
+  --> $DIR/unsupported.rs:195:22
    |
 LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,67 +138,67 @@ LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:201:1
+  --> $DIR/unsupported.rs:200:1
    |
 LL | extern "C-cmse-nonsecure-entry" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:34:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "gpu-kernel" fn gpu() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:46:1
+  --> $DIR/unsupported.rs:45:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:72:1
+  --> $DIR/unsupported.rs:71:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:1
+  --> $DIR/unsupported.rs:81:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:1
+  --> $DIR/unsupported.rs:91:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:114:1
+  --> $DIR/unsupported.rs:113:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:1
+  --> $DIR/unsupported.rs:135:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"stdcall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:162:1
+  --> $DIR/unsupported.rs:161:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:194:1
+  --> $DIR/unsupported.rs:193:1
    |
 LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.arm.stderr
+++ b/tests/ui/abi/unsupported.arm.stderr
@@ -1,5 +1,5 @@
 warning: the calling convention "ptx-kernel" is not supported on this target
-  --> $DIR/unsupported.rs:36:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "msp430-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:74:18
+  --> $DIR/unsupported.rs:73:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "avr-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:84:15
+  --> $DIR/unsupported.rs:83:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:89:1
+  --> $DIR/unsupported.rs:88:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "riscv-interrupt-m" is not supported on this target
-  --> $DIR/unsupported.rs:97:17
+  --> $DIR/unsupported.rs:96:17
    |
 LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:108:1
+  --> $DIR/unsupported.rs:107:1
    |
 LL | extern "riscv-interrupt-m" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "x86-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:119:15
+  --> $DIR/unsupported.rs:118:15
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:130:1
+  --> $DIR/unsupported.rs:129:1
    |
 LL | extern "x86-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "thiscall" is not supported on this target
-  --> $DIR/unsupported.rs:142:20
+  --> $DIR/unsupported.rs:141:20
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:155:1
+  --> $DIR/unsupported.rs:154:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "stdcall" is not supported on this target
-  --> $DIR/unsupported.rs:168:19
+  --> $DIR/unsupported.rs:167:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -99,13 +99,13 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"stdcall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:181:1
+  --> $DIR/unsupported.rs:180:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "C-cmse-nonsecure-call" is not supported on this target
-  --> $DIR/unsupported.rs:188:21
+  --> $DIR/unsupported.rs:187:21
    |
 LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: the calling convention "C-cmse-nonsecure-entry" is not supported on this target
-  --> $DIR/unsupported.rs:196:22
+  --> $DIR/unsupported.rs:195:22
    |
 LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,61 +123,61 @@ LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:201:1
+  --> $DIR/unsupported.rs:200:1
    |
 LL | extern "C-cmse-nonsecure-entry" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:34:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "gpu-kernel" fn gpu() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:72:1
+  --> $DIR/unsupported.rs:71:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:1
+  --> $DIR/unsupported.rs:81:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:1
+  --> $DIR/unsupported.rs:91:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:114:1
+  --> $DIR/unsupported.rs:113:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:1
+  --> $DIR/unsupported.rs:135:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"stdcall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:162:1
+  --> $DIR/unsupported.rs:161:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:194:1
+  --> $DIR/unsupported.rs:193:1
    |
 LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.i686.stderr
+++ b/tests/ui/abi/unsupported.i686.stderr
@@ -1,5 +1,5 @@
 warning: the calling convention "ptx-kernel" is not supported on this target
-  --> $DIR/unsupported.rs:36:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "aapcs" is not supported on this target
-  --> $DIR/unsupported.rs:52:17
+  --> $DIR/unsupported.rs:51:17
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:65:1
+  --> $DIR/unsupported.rs:64:1
    |
 LL | extern "aapcs" {}
    | ^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "msp430-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:74:18
+  --> $DIR/unsupported.rs:73:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "avr-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:84:15
+  --> $DIR/unsupported.rs:83:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:89:1
+  --> $DIR/unsupported.rs:88:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "riscv-interrupt-m" is not supported on this target
-  --> $DIR/unsupported.rs:97:17
+  --> $DIR/unsupported.rs:96:17
    |
 LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:108:1
+  --> $DIR/unsupported.rs:107:1
    |
 LL | extern "riscv-interrupt-m" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "C-cmse-nonsecure-call" is not supported on this target
-  --> $DIR/unsupported.rs:188:21
+  --> $DIR/unsupported.rs:187:21
    |
 LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: the calling convention "C-cmse-nonsecure-entry" is not supported on this target
-  --> $DIR/unsupported.rs:196:22
+  --> $DIR/unsupported.rs:195:22
    |
 LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,49 +93,49 @@ LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:201:1
+  --> $DIR/unsupported.rs:200:1
    |
 LL | extern "C-cmse-nonsecure-entry" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:34:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "gpu-kernel" fn gpu() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:46:1
+  --> $DIR/unsupported.rs:45:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:72:1
+  --> $DIR/unsupported.rs:71:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:1
+  --> $DIR/unsupported.rs:81:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:1
+  --> $DIR/unsupported.rs:91:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:194:1
+  --> $DIR/unsupported.rs:193:1
    |
 LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.riscv32.stderr
+++ b/tests/ui/abi/unsupported.riscv32.stderr
@@ -1,5 +1,5 @@
 warning: the calling convention "ptx-kernel" is not supported on this target
-  --> $DIR/unsupported.rs:36:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "aapcs" is not supported on this target
-  --> $DIR/unsupported.rs:52:17
+  --> $DIR/unsupported.rs:51:17
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:65:1
+  --> $DIR/unsupported.rs:64:1
    |
 LL | extern "aapcs" {}
    | ^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "msp430-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:74:18
+  --> $DIR/unsupported.rs:73:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "avr-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:84:15
+  --> $DIR/unsupported.rs:83:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:89:1
+  --> $DIR/unsupported.rs:88:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "x86-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:119:15
+  --> $DIR/unsupported.rs:118:15
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:130:1
+  --> $DIR/unsupported.rs:129:1
    |
 LL | extern "x86-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "thiscall" is not supported on this target
-  --> $DIR/unsupported.rs:142:20
+  --> $DIR/unsupported.rs:141:20
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:155:1
+  --> $DIR/unsupported.rs:154:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "stdcall" is not supported on this target
-  --> $DIR/unsupported.rs:168:19
+  --> $DIR/unsupported.rs:167:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -99,13 +99,13 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"stdcall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:181:1
+  --> $DIR/unsupported.rs:180:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "C-cmse-nonsecure-call" is not supported on this target
-  --> $DIR/unsupported.rs:188:21
+  --> $DIR/unsupported.rs:187:21
    |
 LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: the calling convention "C-cmse-nonsecure-entry" is not supported on this target
-  --> $DIR/unsupported.rs:196:22
+  --> $DIR/unsupported.rs:195:22
    |
 LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,61 +123,61 @@ LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:201:1
+  --> $DIR/unsupported.rs:200:1
    |
 LL | extern "C-cmse-nonsecure-entry" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:34:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "gpu-kernel" fn gpu() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:46:1
+  --> $DIR/unsupported.rs:45:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:72:1
+  --> $DIR/unsupported.rs:71:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:1
+  --> $DIR/unsupported.rs:81:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:114:1
+  --> $DIR/unsupported.rs:113:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:1
+  --> $DIR/unsupported.rs:135:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"stdcall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:162:1
+  --> $DIR/unsupported.rs:161:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:194:1
+  --> $DIR/unsupported.rs:193:1
    |
 LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.riscv64.stderr
+++ b/tests/ui/abi/unsupported.riscv64.stderr
@@ -1,5 +1,5 @@
 warning: the calling convention "ptx-kernel" is not supported on this target
-  --> $DIR/unsupported.rs:36:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "aapcs" is not supported on this target
-  --> $DIR/unsupported.rs:52:17
+  --> $DIR/unsupported.rs:51:17
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:65:1
+  --> $DIR/unsupported.rs:64:1
    |
 LL | extern "aapcs" {}
    | ^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "msp430-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:74:18
+  --> $DIR/unsupported.rs:73:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "avr-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:84:15
+  --> $DIR/unsupported.rs:83:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:89:1
+  --> $DIR/unsupported.rs:88:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "x86-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:119:15
+  --> $DIR/unsupported.rs:118:15
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:130:1
+  --> $DIR/unsupported.rs:129:1
    |
 LL | extern "x86-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "thiscall" is not supported on this target
-  --> $DIR/unsupported.rs:142:20
+  --> $DIR/unsupported.rs:141:20
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:155:1
+  --> $DIR/unsupported.rs:154:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "stdcall" is not supported on this target
-  --> $DIR/unsupported.rs:168:19
+  --> $DIR/unsupported.rs:167:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -99,13 +99,13 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"stdcall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:181:1
+  --> $DIR/unsupported.rs:180:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "C-cmse-nonsecure-call" is not supported on this target
-  --> $DIR/unsupported.rs:188:21
+  --> $DIR/unsupported.rs:187:21
    |
 LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: the calling convention "C-cmse-nonsecure-entry" is not supported on this target
-  --> $DIR/unsupported.rs:196:22
+  --> $DIR/unsupported.rs:195:22
    |
 LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,61 +123,61 @@ LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:201:1
+  --> $DIR/unsupported.rs:200:1
    |
 LL | extern "C-cmse-nonsecure-entry" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:34:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "gpu-kernel" fn gpu() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:46:1
+  --> $DIR/unsupported.rs:45:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:72:1
+  --> $DIR/unsupported.rs:71:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:1
+  --> $DIR/unsupported.rs:81:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:114:1
+  --> $DIR/unsupported.rs:113:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:1
+  --> $DIR/unsupported.rs:135:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"stdcall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:162:1
+  --> $DIR/unsupported.rs:161:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:194:1
+  --> $DIR/unsupported.rs:193:1
    |
 LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/abi/unsupported.rs
+++ b/tests/ui/abi/unsupported.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x64 i686 aarch64 arm riscv32 riscv64
 //
 //@ [x64] needs-llvm-components: x86
@@ -25,11 +26,9 @@
     abi_c_cmse_nonsecure_call,
     cmse_nonsecure_entry
 )]
-#[lang = "sized"]
-trait Sized {}
 
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 extern "ptx-kernel" fn ptx() {}
 //~^ ERROR is not a supported ABI

--- a/tests/ui/abi/unsupported.x64.stderr
+++ b/tests/ui/abi/unsupported.x64.stderr
@@ -1,5 +1,5 @@
 warning: the calling convention "ptx-kernel" is not supported on this target
-  --> $DIR/unsupported.rs:36:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:41:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "aapcs" is not supported on this target
-  --> $DIR/unsupported.rs:52:17
+  --> $DIR/unsupported.rs:51:17
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:65:1
+  --> $DIR/unsupported.rs:64:1
    |
 LL | extern "aapcs" {}
    | ^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "msp430-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:74:18
+  --> $DIR/unsupported.rs:73:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:79:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "avr-interrupt" is not supported on this target
-  --> $DIR/unsupported.rs:84:15
+  --> $DIR/unsupported.rs:83:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:89:1
+  --> $DIR/unsupported.rs:88:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "riscv-interrupt-m" is not supported on this target
-  --> $DIR/unsupported.rs:97:17
+  --> $DIR/unsupported.rs:96:17
    |
 LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:108:1
+  --> $DIR/unsupported.rs:107:1
    |
 LL | extern "riscv-interrupt-m" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "thiscall" is not supported on this target
-  --> $DIR/unsupported.rs:142:20
+  --> $DIR/unsupported.rs:141:20
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:155:1
+  --> $DIR/unsupported.rs:154:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "stdcall" is not supported on this target
-  --> $DIR/unsupported.rs:168:19
+  --> $DIR/unsupported.rs:167:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -99,13 +99,13 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"stdcall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:181:1
+  --> $DIR/unsupported.rs:180:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
 
 warning: the calling convention "C-cmse-nonsecure-call" is not supported on this target
-  --> $DIR/unsupported.rs:188:21
+  --> $DIR/unsupported.rs:187:21
    |
 LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: the calling convention "C-cmse-nonsecure-entry" is not supported on this target
-  --> $DIR/unsupported.rs:196:22
+  --> $DIR/unsupported.rs:195:22
    |
 LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,61 +123,61 @@ LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:201:1
+  --> $DIR/unsupported.rs:200:1
    |
 LL | extern "C-cmse-nonsecure-entry" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:34:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:43:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "gpu-kernel" fn gpu() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:46:1
+  --> $DIR/unsupported.rs:45:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:72:1
+  --> $DIR/unsupported.rs:71:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:82:1
+  --> $DIR/unsupported.rs:81:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:92:1
+  --> $DIR/unsupported.rs:91:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:136:1
+  --> $DIR/unsupported.rs:135:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"stdcall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:162:1
+  --> $DIR/unsupported.rs:161:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:194:1
+  --> $DIR/unsupported.rs:193:1
    |
 LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/associated-types/associated-types-ICE-when-projecting-out-of-err.rs
+++ b/tests/ui/associated-types/associated-types-ICE-when-projecting-out-of-err.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 // Test that we do not ICE when the self type is `ty::err`, but rather
 // just propagate the error.
 
@@ -6,17 +7,8 @@
 #![feature(no_core)]
 #![no_core]
 
-#[lang="sized"]
-pub trait Sized {
-    // Empty.
-}
-
-#[lang = "add"]
-trait Add<RHS=Self> {
-    type Output;
-
-    fn add(self, _: RHS) -> Self::Output;
-}
+extern crate minicore;
+use minicore::*;
 
 fn ice<A>(a: A) {
     let r = loop {};

--- a/tests/ui/associated-types/associated-types-ICE-when-projecting-out-of-err.stderr
+++ b/tests/ui/associated-types/associated-types-ICE-when-projecting-out-of-err.stderr
@@ -1,14 +1,8 @@
 error[E0277]: the trait bound `(): Add<A>` is not satisfied
-  --> $DIR/associated-types-ICE-when-projecting-out-of-err.rs:23:11
+  --> $DIR/associated-types-ICE-when-projecting-out-of-err.rs:15:11
    |
 LL |     r = r + a;
    |           ^ the trait `Add<A>` is not implemented for `()`
-   |
-help: this trait has no implementations, consider adding one
-  --> $DIR/associated-types-ICE-when-projecting-out-of-err.rs:15:1
-   |
-LL | trait Add<RHS=Self> {
-   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-92157.rs
+++ b/tests/ui/borrowck/issue-92157.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 #![feature(no_core)]
 #![feature(lang_items)]
 
@@ -13,28 +14,7 @@ fn start<T>(_main: fn() -> T, _argc: isize, _argv: *const *const u8) -> isize {
     40+2
 }
 
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
-
-#[lang = "drop_in_place"]
-#[allow(unconditional_recursion)]
-pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
-    drop_in_place(to_drop)
-}
-
-#[lang = "add"]
-trait Add<RHS> {
-    type Output;
-    fn add(self, other: RHS) -> Self::Output;
-}
-
-impl Add<isize> for isize {
-    type Output = isize;
-    fn add(self, other: isize) -> isize {
-        self + other
-    }
-}
+extern crate minicore;
+use minicore::*;
 
 fn main() {}

--- a/tests/ui/borrowck/issue-92157.stderr
+++ b/tests/ui/borrowck/issue-92157.stderr
@@ -1,5 +1,5 @@
 error[E0308]: lang item `start` function has wrong type
-  --> $DIR/issue-92157.rs:11:1
+  --> $DIR/issue-92157.rs:12:1
    |
 LL | fn start<T>(_main: fn() -> T, _argc: isize, _argv: *const *const u8) -> isize {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters

--- a/tests/ui/c-variadic/variadic-ffi-1.rs
+++ b/tests/ui/c-variadic/variadic-ffi-1.rs
@@ -1,9 +1,11 @@
+//@ add-core-stubs
 //@ needs-llvm-components: x86
 //@ compile-flags: --target=i686-pc-windows-msvc --crate-type=rlib
 #![no_core]
 #![feature(no_core, lang_items)]
-#[lang="sized"]
-trait Sized { }
+
+extern crate minicore;
+use minicore::*;
 
 extern "stdcall" {
     fn printf(_: *const u8, ...);

--- a/tests/ui/c-variadic/variadic-ffi-1.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-1.stderr
@@ -1,17 +1,17 @@
 error[E0045]: C-variadic function must have a compatible calling convention, like `C`, `cdecl`, `system`, `aapcs`, `win64`, `sysv64` or `efiapi`
-  --> $DIR/variadic-ffi-1.rs:9:5
+  --> $DIR/variadic-ffi-1.rs:11:5
    |
 LL |     fn printf(_: *const u8, ...);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention
 
 error[E0060]: this function takes at least 2 arguments but 0 arguments were supplied
-  --> $DIR/variadic-ffi-1.rs:22:9
+  --> $DIR/variadic-ffi-1.rs:24:9
    |
 LL |         foo();
    |         ^^^-- two arguments of type `isize` and `u8` are missing
    |
 note: function defined here
-  --> $DIR/variadic-ffi-1.rs:15:8
+  --> $DIR/variadic-ffi-1.rs:17:8
    |
 LL |     fn foo(f: isize, x: u8, ...);
    |        ^^^ -         -
@@ -21,13 +21,13 @@ LL |         foo(/* isize */, /* u8 */);
    |             +++++++++++++++++++++
 
 error[E0060]: this function takes at least 2 arguments but 1 argument was supplied
-  --> $DIR/variadic-ffi-1.rs:23:9
+  --> $DIR/variadic-ffi-1.rs:25:9
    |
 LL |         foo(1);
    |         ^^^--- argument #2 of type `u8` is missing
    |
 note: function defined here
-  --> $DIR/variadic-ffi-1.rs:15:8
+  --> $DIR/variadic-ffi-1.rs:17:8
    |
 LL |     fn foo(f: isize, x: u8, ...);
    |        ^^^           -
@@ -37,7 +37,7 @@ LL |         foo(1, /* u8 */);
    |              ++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/variadic-ffi-1.rs:25:56
+  --> $DIR/variadic-ffi-1.rs:27:56
    |
 LL |         let x: unsafe extern "C" fn(f: isize, x: u8) = foo;
    |                -------------------------------------   ^^^ expected non-variadic fn, found variadic function
@@ -48,7 +48,7 @@ LL |         let x: unsafe extern "C" fn(f: isize, x: u8) = foo;
                  found fn item `unsafe extern "C" fn(_, _, ...) {foo}`
 
 error[E0308]: mismatched types
-  --> $DIR/variadic-ffi-1.rs:26:54
+  --> $DIR/variadic-ffi-1.rs:28:54
    |
 LL |         let y: extern "C" fn(f: isize, x: u8, ...) = bar;
    |                -----------------------------------   ^^^ expected variadic fn, found non-variadic function
@@ -59,7 +59,7 @@ LL |         let y: extern "C" fn(f: isize, x: u8, ...) = bar;
                  found fn item `extern "C" fn(_, _) {bar}`
 
 error[E0617]: can't pass `f32` to variadic function
-  --> $DIR/variadic-ffi-1.rs:28:19
+  --> $DIR/variadic-ffi-1.rs:30:19
    |
 LL |         foo(1, 2, 3f32);
    |                   ^^^^
@@ -70,7 +70,7 @@ LL |         foo(1, 2, 3f32 as c_double);
    |                        +++++++++++
 
 error[E0617]: can't pass `bool` to variadic function
-  --> $DIR/variadic-ffi-1.rs:29:19
+  --> $DIR/variadic-ffi-1.rs:31:19
    |
 LL |         foo(1, 2, true);
    |                   ^^^^
@@ -81,7 +81,7 @@ LL |         foo(1, 2, true as c_int);
    |                        ++++++++
 
 error[E0617]: can't pass `i8` to variadic function
-  --> $DIR/variadic-ffi-1.rs:30:19
+  --> $DIR/variadic-ffi-1.rs:32:19
    |
 LL |         foo(1, 2, 1i8);
    |                   ^^^
@@ -92,7 +92,7 @@ LL |         foo(1, 2, 1i8 as c_int);
    |                       ++++++++
 
 error[E0617]: can't pass `u8` to variadic function
-  --> $DIR/variadic-ffi-1.rs:31:19
+  --> $DIR/variadic-ffi-1.rs:33:19
    |
 LL |         foo(1, 2, 1u8);
    |                   ^^^
@@ -103,7 +103,7 @@ LL |         foo(1, 2, 1u8 as c_uint);
    |                       +++++++++
 
 error[E0617]: can't pass `i16` to variadic function
-  --> $DIR/variadic-ffi-1.rs:32:19
+  --> $DIR/variadic-ffi-1.rs:34:19
    |
 LL |         foo(1, 2, 1i16);
    |                   ^^^^
@@ -114,7 +114,7 @@ LL |         foo(1, 2, 1i16 as c_int);
    |                        ++++++++
 
 error[E0617]: can't pass `u16` to variadic function
-  --> $DIR/variadic-ffi-1.rs:33:19
+  --> $DIR/variadic-ffi-1.rs:35:19
    |
 LL |         foo(1, 2, 1u16);
    |                   ^^^^

--- a/tests/ui/check-cfg/my-awesome-platform.json
+++ b/tests/ui/check-cfg/my-awesome-platform.json
@@ -1,6 +1,6 @@
 {
     "llvm-target": "x86_64-unknown-none-gnu",
-    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",

--- a/tests/ui/check-cfg/values-target-json.rs
+++ b/tests/ui/check-cfg/values-target-json.rs
@@ -1,5 +1,6 @@
 // This test checks that we don't lint values defined by a custom target (target json)
 //
+//@ add-core-stubs
 //@ check-pass
 //@ no-auto-check-cfg
 //@ needs-llvm-components: x86
@@ -8,8 +9,8 @@
 #![feature(lang_items, no_core, auto_traits)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[cfg(target_os = "linux")]
 fn target_os_linux() {}

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/callback-as-argument.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/callback-as-argument.rs
@@ -1,13 +1,12 @@
+//@ add-core-stubs
 //@ build-pass
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 #![feature(abi_c_cmse_nonsecure_call, cmse_nonsecure_entry, no_core, lang_items, intrinsics)]
 #![no_core]
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
-impl Copy for u32 {}
+
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 pub extern "C-cmse-nonsecure-entry" fn test(

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.rs
@@ -1,12 +1,11 @@
+//@ add-core-stubs
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 #![feature(abi_c_cmse_nonsecure_call, no_core, lang_items)]
 #![no_core]
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
-impl Copy for u32 {}
+
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 struct Wrapper<T>(T);

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/generics.stderr
@@ -1,11 +1,11 @@
 error: function pointer types may not have generic parameters
-  --> $DIR/generics.rs:15:42
+  --> $DIR/generics.rs:14:42
    |
 LL |     f1: extern "C-cmse-nonsecure-call" fn<U: Copy>(U, u32, u32, u32) -> u64,
    |                                          ^^^^^^^^^
 
 error[E0412]: cannot find type `U` in this scope
-  --> $DIR/generics.rs:15:52
+  --> $DIR/generics.rs:14:52
    |
 LL | struct Test<T: Copy> {
    |             - similarly named type parameter `T` defined here
@@ -23,7 +23,7 @@ LL | struct Test<T: Copy, U> {
    |                    +++
 
 error[E0562]: `impl Trait` is not allowed in `fn` pointer parameters
-  --> $DIR/generics.rs:18:43
+  --> $DIR/generics.rs:17:43
    |
 LL |     f2: extern "C-cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> u64,
    |                                           ^^^^^^^^^
@@ -31,19 +31,19 @@ LL |     f2: extern "C-cmse-nonsecure-call" fn(impl Copy, u32, u32, u32) -> u64,
    = note: `impl Trait` is only allowed in arguments and return types of functions and methods
 
 error[E0798]: function pointers with the `"C-cmse-nonsecure-call"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:20:9
+  --> $DIR/generics.rs:19:9
    |
 LL |     f3: extern "C-cmse-nonsecure-call" fn(T, u32, u32, u32) -> u64,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: function pointers with the `"C-cmse-nonsecure-call"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:21:9
+  --> $DIR/generics.rs:20:9
    |
 LL |     f4: extern "C-cmse-nonsecure-call" fn(Wrapper<T>, u32, u32, u32) -> u64,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:27:73
+  --> $DIR/generics.rs:26:73
    |
 LL | type WithTraitObject = extern "C-cmse-nonsecure-call" fn(&dyn Trait) -> &dyn Trait;
    |                                                                         ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -52,7 +52,7 @@ LL | type WithTraitObject = extern "C-cmse-nonsecure-call" fn(&dyn Trait) -> &dy
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:31:62
+  --> $DIR/generics.rs:30:62
    |
 LL |     extern "C-cmse-nonsecure-call" fn(&'static dyn Trait) -> &'static dyn Trait;
    |                                                              ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -61,7 +61,7 @@ LL |     extern "C-cmse-nonsecure-call" fn(&'static dyn Trait) -> &'static dyn T
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/generics.rs:38:62
+  --> $DIR/generics.rs:37:62
    |
 LL |     extern "C-cmse-nonsecure-call" fn(WrapperTransparent) -> WrapperTransparent;
    |                                                              ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -70,7 +70,7 @@ LL |     extern "C-cmse-nonsecure-call" fn(WrapperTransparent) -> WrapperTranspa
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0045]: C-variadic function must have a compatible calling convention, like `C`, `cdecl`, `system`, `aapcs`, `win64`, `sysv64` or `efiapi`
-  --> $DIR/generics.rs:41:20
+  --> $DIR/generics.rs:40:20
    |
 LL | type WithVarArgs = extern "C-cmse-nonsecure-call" fn(u32, ...);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.rs
@@ -1,12 +1,11 @@
+//@ add-core-stubs
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 #![feature(abi_c_cmse_nonsecure_call, no_core, lang_items)]
 #![no_core]
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
-impl Copy for u32 {}
+
+extern crate minicore;
+use minicore::*;
 
 #[repr(C, align(16))]
 #[allow(unused)]

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/params-via-stack.stderr
@@ -1,5 +1,5 @@
 error[E0798]: arguments for `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:17:63
+  --> $DIR/params-via-stack.rs:16:63
    |
 LL |     f1: extern "C-cmse-nonsecure-call" fn(u32, u32, u32, u32, x: u32, y: u32),
    |                                                               ^^^^^^^^^^^^^^ these arguments don't fit in the available registers
@@ -7,7 +7,7 @@ LL |     f1: extern "C-cmse-nonsecure-call" fn(u32, u32, u32, u32, x: u32, y: u3
    = note: functions with the `"C-cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit available argument registers
 
 error[E0798]: arguments for `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:18:63
+  --> $DIR/params-via-stack.rs:17:63
    |
 LL |     f2: extern "C-cmse-nonsecure-call" fn(u32, u32, u32, u16, u16),
    |                                                               ^^^ this argument doesn't fit in the available registers
@@ -15,7 +15,7 @@ LL |     f2: extern "C-cmse-nonsecure-call" fn(u32, u32, u32, u16, u16),
    = note: functions with the `"C-cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit available argument registers
 
 error[E0798]: arguments for `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:19:53
+  --> $DIR/params-via-stack.rs:18:53
    |
 LL |     f3: extern "C-cmse-nonsecure-call" fn(u32, u64, u32),
    |                                                     ^^^ this argument doesn't fit in the available registers
@@ -23,7 +23,7 @@ LL |     f3: extern "C-cmse-nonsecure-call" fn(u32, u64, u32),
    = note: functions with the `"C-cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit available argument registers
 
 error[E0798]: arguments for `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:20:58
+  --> $DIR/params-via-stack.rs:19:58
    |
 LL |     f4: extern "C-cmse-nonsecure-call" fn(AlignRelevant, u32),
    |                                                          ^^^ this argument doesn't fit in the available registers
@@ -31,7 +31,7 @@ LL |     f4: extern "C-cmse-nonsecure-call" fn(AlignRelevant, u32),
    = note: functions with the `"C-cmse-nonsecure-call"` ABI must pass all their arguments via the 4 32-bit available argument registers
 
 error[E0798]: arguments for `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:21:43
+  --> $DIR/params-via-stack.rs:20:43
    |
 LL |     f5: extern "C-cmse-nonsecure-call" fn([u32; 5]),
    |                                           ^^^^^^^^ this argument doesn't fit in the available registers

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 //@ add-core-stubs

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/return-via-stack.stderr
@@ -1,5 +1,5 @@
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:35:50
+  --> $DIR/return-via-stack.rs:36:50
    |
 LL |     u128: extern "C-cmse-nonsecure-call" fn() -> u128,
    |                                                  ^^^^ this type doesn't fit in the available registers
@@ -8,7 +8,7 @@ LL |     u128: extern "C-cmse-nonsecure-call" fn() -> u128,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:36:50
+  --> $DIR/return-via-stack.rs:37:50
    |
 LL |     i128: extern "C-cmse-nonsecure-call" fn() -> i128,
    |                                                  ^^^^ this type doesn't fit in the available registers
@@ -17,7 +17,7 @@ LL |     i128: extern "C-cmse-nonsecure-call" fn() -> i128,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:25:48
+  --> $DIR/return-via-stack.rs:26:48
    |
 LL |     f1: extern "C-cmse-nonsecure-call" fn() -> ReprCU64,
    |                                                ^^^^^^^^ this type doesn't fit in the available registers
@@ -26,7 +26,7 @@ LL |     f1: extern "C-cmse-nonsecure-call" fn() -> ReprCU64,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:26:48
+  --> $DIR/return-via-stack.rs:27:48
    |
 LL |     f2: extern "C-cmse-nonsecure-call" fn() -> ReprCBytes,
    |                                                ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -35,7 +35,7 @@ LL |     f2: extern "C-cmse-nonsecure-call" fn() -> ReprCBytes,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:27:48
+  --> $DIR/return-via-stack.rs:28:48
    |
 LL |     f3: extern "C-cmse-nonsecure-call" fn() -> U64Compound,
    |                                                ^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -44,7 +44,7 @@ LL |     f3: extern "C-cmse-nonsecure-call" fn() -> U64Compound,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:28:48
+  --> $DIR/return-via-stack.rs:29:48
    |
 LL |     f4: extern "C-cmse-nonsecure-call" fn() -> ReprCAlign16,
    |                                                ^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -53,7 +53,7 @@ LL |     f4: extern "C-cmse-nonsecure-call" fn() -> ReprCAlign16,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:29:48
+  --> $DIR/return-via-stack.rs:30:48
    |
 LL |     f5: extern "C-cmse-nonsecure-call" fn() -> [u8; 5],
    |                                                ^^^^^^^ this type doesn't fit in the available registers
@@ -62,7 +62,7 @@ LL |     f5: extern "C-cmse-nonsecure-call" fn() -> [u8; 5],
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:51:48
+  --> $DIR/return-via-stack.rs:52:48
    |
 LL |     f1: extern "C-cmse-nonsecure-call" fn() -> ReprRustUnionU64,
    |                                                ^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -71,7 +71,7 @@ LL |     f1: extern "C-cmse-nonsecure-call" fn() -> ReprRustUnionU64,
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-call"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:52:48
+  --> $DIR/return-via-stack.rs:53:48
    |
 LL |     f2: extern "C-cmse-nonsecure-call" fn() -> ReprCUnionU64,
    |                                                ^^^^^^^^^^^^^ this type doesn't fit in the available registers

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/via-registers.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/via-registers.rs
@@ -1,13 +1,12 @@
+//@ add-core-stubs
 //@ build-pass
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 #![feature(abi_c_cmse_nonsecure_call, no_core, lang_items, intrinsics)]
 #![no_core]
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
-impl Copy for u32 {}
+
+extern crate minicore;
+use minicore::*;
 
 #[repr(transparent)]
 pub struct ReprTransparentStruct<T> {

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-1.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-1.rs
@@ -1,8 +1,10 @@
+//@ add-core-stubs
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 #![feature(abi_c_cmse_nonsecure_call, lang_items, no_core)]
 #![no_core]
-#[lang="sized"]
-trait Sized { }
+
+extern crate minicore;
+use minicore::*;
 
 pub extern "C-cmse-nonsecure-call" fn test() {} //~ ERROR [E0781]

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-1.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-1.stderr
@@ -1,5 +1,5 @@
 error[E0781]: the `"C-cmse-nonsecure-call"` ABI is only allowed on function pointers
-  --> $DIR/wrong-abi-location-1.rs:8:1
+  --> $DIR/wrong-abi-location-1.rs:10:1
    |
 LL | pub extern "C-cmse-nonsecure-call" fn test() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-2.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-2.rs
@@ -1,9 +1,11 @@
+//@ add-core-stubs
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 #![feature(abi_c_cmse_nonsecure_call, lang_items, no_core)]
 #![no_core]
-#[lang="sized"]
-trait Sized { }
+
+extern crate minicore;
+use minicore::*;
 
 extern "C-cmse-nonsecure-call" { //~ ERROR [E0781]
     fn test();

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-2.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/wrong-abi-location-2.stderr
@@ -1,5 +1,5 @@
 error[E0781]: the `"C-cmse-nonsecure-call"` ABI is only allowed on function pointers
-  --> $DIR/wrong-abi-location-2.rs:8:1
+  --> $DIR/wrong-abi-location-2.rs:10:1
    |
 LL | / extern "C-cmse-nonsecure-call" {
 LL | |     fn test();

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.rs
@@ -1,12 +1,11 @@
+//@ add-core-stubs
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 #![feature(cmse_nonsecure_entry, c_variadic, no_core, lang_items)]
 #![no_core]
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
-impl Copy for u32 {}
+
+extern crate minicore;
+use minicore::*;
 
 #[repr(C)]
 struct Wrapper<T>(T);

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/generics.stderr
@@ -1,11 +1,11 @@
 error: only foreign, `unsafe extern "C"`, or `unsafe extern "C-unwind"` functions may have a C-variadic arg
-  --> $DIR/generics.rs:74:55
+  --> $DIR/generics.rs:73:55
    |
 LL | extern "C-cmse-nonsecure-entry" fn c_variadic(_: u32, _: ...) {
    |                                                       ^^^^^^
 
 error[E0798]: functions with the `"C-cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:31:1
+  --> $DIR/generics.rs:30:1
    |
 LL | / extern "C-cmse-nonsecure-entry" fn introduced_generic<U: Copy>(
 LL | |
@@ -17,19 +17,19 @@ LL | | ) -> u64 {
    | |________^
 
 error[E0798]: functions with the `"C-cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:41:1
+  --> $DIR/generics.rs:40:1
    |
 LL | extern "C-cmse-nonsecure-entry" fn impl_trait(_: impl Copy, _: u32, _: u32, _: u32) -> u64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: functions with the `"C-cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:15:5
+  --> $DIR/generics.rs:14:5
    |
 LL |     extern "C-cmse-nonsecure-entry" fn ambient_generic(_: T, _: u32, _: u32, _: u32) -> u64 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0798]: functions with the `"C-cmse-nonsecure-entry"` ABI cannot contain generics in their type
-  --> $DIR/generics.rs:20:5
+  --> $DIR/generics.rs:19:5
    |
 LL | /     extern "C-cmse-nonsecure-entry" fn ambient_generic_nested(
 LL | |
@@ -41,7 +41,7 @@ LL | |     ) -> u64 {
    | |____________^
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/generics.rs:52:67
+  --> $DIR/generics.rs:51:67
    |
 LL | extern "C-cmse-nonsecure-entry" fn trait_object(x: &dyn Trait) -> &dyn Trait {
    |                                                                   ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -50,7 +50,7 @@ LL | extern "C-cmse-nonsecure-entry" fn trait_object(x: &dyn Trait) -> &dyn Trai
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/generics.rs:59:6
+  --> $DIR/generics.rs:58:6
    |
 LL | ) -> &'static dyn Trait {
    |      ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -59,7 +59,7 @@ LL | ) -> &'static dyn Trait {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/generics.rs:69:6
+  --> $DIR/generics.rs:68:6
    |
 LL | ) -> WrapperTransparent {
    |      ^^^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -68,7 +68,7 @@ LL | ) -> WrapperTransparent {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error: requires `va_list` lang_item
-  --> $DIR/generics.rs:74:55
+  --> $DIR/generics.rs:73:55
    |
 LL | extern "C-cmse-nonsecure-entry" fn c_variadic(_: u32, _: ...) {
    |                                                       ^^^^^^

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.rs
@@ -1,12 +1,11 @@
+//@ add-core-stubs
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 #![feature(cmse_nonsecure_entry, no_core, lang_items)]
 #![no_core]
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-impl Copy for u32 {}
+
+extern crate minicore;
+use minicore::*;
 
 #[repr(C, align(16))]
 #[allow(unused)]

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/params-via-stack.stderr
@@ -1,5 +1,5 @@
 error[E0798]: arguments for `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:16:78
+  --> $DIR/params-via-stack.rs:15:78
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn f1(_: u32, _: u32, _: u32, _: u32, _: u32, _: u32) {}
    |                                                                              ^^^^^^^^^^^ these arguments don't fit in the available registers
@@ -7,7 +7,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn f1(_: u32, _: u32, _: u32, _: u32, _
    = note: functions with the `"C-cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit available argument registers
 
 error[E0798]: arguments for `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:18:78
+  --> $DIR/params-via-stack.rs:17:78
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn f2(_: u32, _: u32, _: u32, _: u16, _: u16) {}
    |                                                                              ^^^ this argument doesn't fit in the available registers
@@ -15,7 +15,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn f2(_: u32, _: u32, _: u32, _: u16, _
    = note: functions with the `"C-cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit available argument registers
 
 error[E0798]: arguments for `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:20:62
+  --> $DIR/params-via-stack.rs:19:62
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn f3(_: u32, _: u64, _: u32) {}
    |                                                              ^^^ this argument doesn't fit in the available registers
@@ -23,7 +23,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn f3(_: u32, _: u64, _: u32) {}
    = note: functions with the `"C-cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit available argument registers
 
 error[E0798]: arguments for `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:22:64
+  --> $DIR/params-via-stack.rs:21:64
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn f4(_: AlignRelevant, _: u32) {}
    |                                                                ^^^ this argument doesn't fit in the available registers
@@ -31,7 +31,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn f4(_: AlignRelevant, _: u32) {}
    = note: functions with the `"C-cmse-nonsecure-entry"` ABI must pass all their arguments via the 4 32-bit available argument registers
 
 error[E0798]: arguments for `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/params-via-stack.rs:26:46
+  --> $DIR/params-via-stack.rs:25:46
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn f5(_: [u32; 5]) {}
    |                                              ^^^^^^^^ this argument doesn't fit in the available registers

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/return-via-stack.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/return-via-stack.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 //@ add-core-stubs

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/return-via-stack.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/return-via-stack.stderr
@@ -1,5 +1,5 @@
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:24:48
+  --> $DIR/return-via-stack.rs:25:48
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn f1() -> ReprCU64 {
    |                                                ^^^^^^^^ this type doesn't fit in the available registers
@@ -8,7 +8,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn f1() -> ReprCU64 {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:29:48
+  --> $DIR/return-via-stack.rs:30:48
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn f2() -> ReprCBytes {
    |                                                ^^^^^^^^^^ this type doesn't fit in the available registers
@@ -17,7 +17,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn f2() -> ReprCBytes {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:34:48
+  --> $DIR/return-via-stack.rs:35:48
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn f3() -> U64Compound {
    |                                                ^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -26,7 +26,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn f3() -> U64Compound {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:39:48
+  --> $DIR/return-via-stack.rs:40:48
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn f4() -> ReprCAlign16 {
    |                                                ^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -35,7 +35,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn f4() -> ReprCAlign16 {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:46:48
+  --> $DIR/return-via-stack.rs:47:48
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn f5() -> [u8; 5] {
    |                                                ^^^^^^^ this type doesn't fit in the available registers
@@ -44,7 +44,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn f5() -> [u8; 5] {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:52:50
+  --> $DIR/return-via-stack.rs:53:50
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn u128() -> u128 {
    |                                                  ^^^^ this type doesn't fit in the available registers
@@ -53,7 +53,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn u128() -> u128 {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:58:50
+  --> $DIR/return-via-stack.rs:59:50
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn i128() -> i128 {
    |                                                  ^^^^ this type doesn't fit in the available registers
@@ -62,7 +62,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn i128() -> i128 {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:75:56
+  --> $DIR/return-via-stack.rs:76:56
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn union_rust() -> ReprRustUnionU64 {
    |                                                        ^^^^^^^^^^^^^^^^ this type doesn't fit in the available registers
@@ -71,7 +71,7 @@ LL | pub extern "C-cmse-nonsecure-entry" fn union_rust() -> ReprRustUnionU64 {
    = note: the result must either be a (transparently wrapped) i64, u64 or f64, or be at most 4 bytes in size
 
 error[E0798]: return value of `"C-cmse-nonsecure-entry"` function too large to pass via registers
-  --> $DIR/return-via-stack.rs:80:53
+  --> $DIR/return-via-stack.rs:81:53
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn union_c() -> ReprCUnionU64 {
    |                                                     ^^^^^^^^^^^^^ this type doesn't fit in the available registers

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/trustzone-only.aarch64.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/trustzone-only.aarch64.stderr
@@ -1,5 +1,5 @@
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/trustzone-only.rs:20:1
+  --> $DIR/trustzone-only.rs:17:1
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn entry_function(input: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/trustzone-only.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/trustzone-only.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x86 aarch64 thumb7
 //
 //@[x86] compile-flags: --target x86_64-unknown-linux-gnu
@@ -9,12 +10,8 @@
 #![feature(no_core, lang_items, rustc_attrs, cmse_nonsecure_entry)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for u32 {}
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 pub extern "C-cmse-nonsecure-entry" fn entry_function(input: u32) -> u32 {

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/trustzone-only.thumb7.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/trustzone-only.thumb7.stderr
@@ -1,5 +1,5 @@
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/trustzone-only.rs:20:1
+  --> $DIR/trustzone-only.rs:17:1
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn entry_function(input: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/trustzone-only.x86.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/trustzone-only.x86.stderr
@@ -1,5 +1,5 @@
 error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
-  --> $DIR/trustzone-only.rs:20:1
+  --> $DIR/trustzone-only.rs:17:1
    |
 LL | pub extern "C-cmse-nonsecure-entry" fn entry_function(input: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/via-registers.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-entry/via-registers.rs
@@ -1,15 +1,13 @@
+//@ add-core-stubs
 //@ build-pass
 //@ compile-flags: --target thumbv8m.main-none-eabi --crate-type lib
 //@ needs-llvm-components: arm
 #![feature(cmse_nonsecure_entry, no_core, lang_items)]
 #![no_core]
 #![crate_type = "lib"]
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-impl Copy for u32 {}
-impl Copy for u8 {}
+
+extern crate minicore;
+use minicore::*;
 
 #[repr(transparent)]
 pub struct ReprTransparentStruct<T> {

--- a/tests/ui/deriving/deriving-with-helper.rs
+++ b/tests/ui/deriving/deriving-with-helper.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ check-pass
 //@ compile-flags: --crate-type=lib
 
@@ -7,6 +8,9 @@
 #![feature(rustc_attrs)]
 
 #![no_core]
+
+extern crate minicore;
+use minicore::*;
 
 #[rustc_builtin_macro]
 macro derive() {}
@@ -25,9 +29,6 @@ mod default {
         }
     }
 }
-
-#[lang = "sized"]
-trait Sized {}
 
 #[derive(Default)]
 enum S {

--- a/tests/ui/feature-gates/feature-gate-abi-avr-interrupt.rs
+++ b/tests/ui/feature-gates/feature-gate-abi-avr-interrupt.rs
@@ -1,9 +1,11 @@
+//@ add-core-stubs
 //@ needs-llvm-components: avr
 //@ compile-flags: --target=avr-none -C target-cpu=atmega328p --crate-type=rlib
 #![no_core]
 #![feature(no_core, lang_items)]
-#[lang="sized"]
-trait Sized { }
+
+extern crate minicore;
+use minicore::*;
 
 // Test that the AVR interrupt ABI cannot be used when avr_interrupt
 // feature gate is not used.

--- a/tests/ui/feature-gates/feature-gate-abi-avr-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-avr-interrupt.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the extern "avr-non-blocking-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:11:8
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:13:8
    |
 LL | extern "avr-non-blocking-interrupt" fn fu() {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | extern "avr-non-blocking-interrupt" fn fu() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:13:8
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:15:8
    |
 LL | extern "avr-interrupt" fn f() {}
    |        ^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL | extern "avr-interrupt" fn f() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:17:12
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:19:12
    |
 LL |     extern "avr-interrupt" fn m();
    |            ^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     extern "avr-interrupt" fn m();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-non-blocking-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:19:12
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:21:12
    |
 LL |     extern "avr-non-blocking-interrupt" fn mu();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     extern "avr-non-blocking-interrupt" fn mu();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:22:12
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:24:12
    |
 LL |     extern "avr-interrupt" fn dm() {}
    |            ^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     extern "avr-interrupt" fn dm() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-non-blocking-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:24:12
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:26:12
    |
 LL |     extern "avr-non-blocking-interrupt" fn dmu() {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     extern "avr-non-blocking-interrupt" fn dmu() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:30:12
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:32:12
    |
 LL |     extern "avr-interrupt" fn m() {}
    |            ^^^^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL |     extern "avr-interrupt" fn m() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-non-blocking-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:32:12
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:34:12
    |
 LL |     extern "avr-non-blocking-interrupt" fn mu() {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,7 +79,7 @@ LL |     extern "avr-non-blocking-interrupt" fn mu() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:37:12
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:39:12
    |
 LL |     extern "avr-interrupt" fn im() {}
    |            ^^^^^^^^^^^^^^^
@@ -89,7 +89,7 @@ LL |     extern "avr-interrupt" fn im() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-non-blocking-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:39:12
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:41:12
    |
 LL |     extern "avr-non-blocking-interrupt" fn imu() {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL |     extern "avr-non-blocking-interrupt" fn imu() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:43:18
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:45:18
    |
 LL | type TA = extern "avr-interrupt" fn();
    |                  ^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL | type TA = extern "avr-interrupt" fn();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-non-blocking-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:45:19
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:47:19
    |
 LL | type TAU = extern "avr-non-blocking-interrupt" fn();
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -119,7 +119,7 @@ LL | type TAU = extern "avr-non-blocking-interrupt" fn();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:48:8
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:50:8
    |
 LL | extern "avr-interrupt" {}
    |        ^^^^^^^^^^^^^^^
@@ -129,7 +129,7 @@ LL | extern "avr-interrupt" {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "avr-non-blocking-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-avr-interrupt.rs:50:8
+  --> $DIR/feature-gate-abi-avr-interrupt.rs:52:8
    |
 LL | extern "avr-non-blocking-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-abi-msp430-interrupt.rs
+++ b/tests/ui/feature-gates/feature-gate-abi-msp430-interrupt.rs
@@ -1,9 +1,11 @@
+//@ add-core-stubs
 //@ needs-llvm-components: msp430
 //@ compile-flags: --target=msp430-none-elf --crate-type=rlib
 #![no_core]
 #![feature(no_core, lang_items)]
-#[lang="sized"]
-trait Sized { }
+
+extern crate minicore;
+use minicore::*;
 
 extern "msp430-interrupt" fn f() {}
 //~^ ERROR "msp430-interrupt" ABI is experimental

--- a/tests/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:8:8
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:10:8
    |
 LL | extern "msp430-interrupt" fn f() {}
    |        ^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | extern "msp430-interrupt" fn f() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:12:12
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:14:12
    |
 LL |     extern "msp430-interrupt" fn m();
    |            ^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     extern "msp430-interrupt" fn m();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:15:12
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:17:12
    |
 LL |     extern "msp430-interrupt" fn dm() {}
    |            ^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     extern "msp430-interrupt" fn dm() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:21:12
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:23:12
    |
 LL |     extern "msp430-interrupt" fn m() {}
    |            ^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     extern "msp430-interrupt" fn m() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:26:12
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:28:12
    |
 LL |     extern "msp430-interrupt" fn im() {}
    |            ^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     extern "msp430-interrupt" fn im() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:30:18
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:32:18
    |
 LL | type TA = extern "msp430-interrupt" fn();
    |                  ^^^^^^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL | type TA = extern "msp430-interrupt" fn();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-msp430-interrupt.rs:33:8
+  --> $DIR/feature-gate-abi-msp430-interrupt.rs:35:8
    |
 LL | extern "msp430-interrupt" {}
    |        ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-abi-riscv-interrupt.rs
+++ b/tests/ui/feature-gates/feature-gate-abi-riscv-interrupt.rs
@@ -1,9 +1,11 @@
+//@ add-core-stubs
 //@ needs-llvm-components: riscv
 //@ compile-flags: --target=riscv32imc-unknown-none-elf --crate-type=rlib
 #![no_core]
 #![feature(no_core, lang_items)]
-#[lang = "sized"]
-trait Sized {}
+
+extern crate minicore;
+use minicore::*;
 
 // Test that the riscv interrupt ABIs cannot be used when riscv_interrupt
 // feature gate is not used.

--- a/tests/ui/feature-gates/feature-gate-abi-riscv-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-riscv-interrupt.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the extern "riscv-interrupt-m" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-riscv-interrupt.rs:11:8
+  --> $DIR/feature-gate-abi-riscv-interrupt.rs:13:8
    |
 LL | extern "riscv-interrupt-m" fn f() {}
    |        ^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | extern "riscv-interrupt-m" fn f() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "riscv-interrupt-s" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-riscv-interrupt.rs:13:8
+  --> $DIR/feature-gate-abi-riscv-interrupt.rs:15:8
    |
 LL | extern "riscv-interrupt-s" fn f_s() {}
    |        ^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL | extern "riscv-interrupt-s" fn f_s() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "riscv-interrupt-m" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-riscv-interrupt.rs:17:12
+  --> $DIR/feature-gate-abi-riscv-interrupt.rs:19:12
    |
 LL |     extern "riscv-interrupt-m" fn m();
    |            ^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     extern "riscv-interrupt-m" fn m();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "riscv-interrupt-m" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-riscv-interrupt.rs:23:12
+  --> $DIR/feature-gate-abi-riscv-interrupt.rs:25:12
    |
 LL |     extern "riscv-interrupt-m" fn m() {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     extern "riscv-interrupt-m" fn m() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "riscv-interrupt-m" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-riscv-interrupt.rs:28:12
+  --> $DIR/feature-gate-abi-riscv-interrupt.rs:30:12
    |
 LL |     extern "riscv-interrupt-m" fn im() {}
    |            ^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     extern "riscv-interrupt-m" fn im() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "riscv-interrupt-m" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-riscv-interrupt.rs:32:18
+  --> $DIR/feature-gate-abi-riscv-interrupt.rs:34:18
    |
 LL | type TA = extern "riscv-interrupt-m" fn();
    |                  ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.rs
+++ b/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.rs
@@ -1,9 +1,11 @@
+//@ add-core-stubs
 //@ needs-llvm-components: x86
 //@ compile-flags: --target=x86_64-unknown-linux-gnu --crate-type=rlib
 #![no_core]
 #![feature(no_core, lang_items)]
-#[lang="sized"]
-trait Sized { }
+
+extern crate minicore;
+use minicore::*;
 
 extern "x86-interrupt" fn f7() {} //~ ERROR "x86-interrupt" ABI is experimental
 trait Tr {

--- a/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi-x86-interrupt.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-x86-interrupt.rs:8:8
+  --> $DIR/feature-gate-abi-x86-interrupt.rs:10:8
    |
 LL | extern "x86-interrupt" fn f7() {}
    |        ^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | extern "x86-interrupt" fn f7() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-x86-interrupt.rs:10:12
+  --> $DIR/feature-gate-abi-x86-interrupt.rs:12:12
    |
 LL |     extern "x86-interrupt" fn m7();
    |            ^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     extern "x86-interrupt" fn m7();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-x86-interrupt.rs:11:12
+  --> $DIR/feature-gate-abi-x86-interrupt.rs:13:12
    |
 LL |     extern "x86-interrupt" fn dm7() {}
    |            ^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     extern "x86-interrupt" fn dm7() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-x86-interrupt.rs:18:12
+  --> $DIR/feature-gate-abi-x86-interrupt.rs:20:12
    |
 LL |     extern "x86-interrupt" fn m7() {}
    |            ^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     extern "x86-interrupt" fn m7() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-x86-interrupt.rs:23:12
+  --> $DIR/feature-gate-abi-x86-interrupt.rs:25:12
    |
 LL |     extern "x86-interrupt" fn im7() {}
    |            ^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     extern "x86-interrupt" fn im7() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-x86-interrupt.rs:26:18
+  --> $DIR/feature-gate-abi-x86-interrupt.rs:28:18
    |
 LL | type A7 = extern "x86-interrupt" fn();
    |                  ^^^^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL | type A7 = extern "x86-interrupt" fn();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "x86-interrupt" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi-x86-interrupt.rs:28:8
+  --> $DIR/feature-gate-abi-x86-interrupt.rs:30:8
    |
 LL | extern "x86-interrupt" {}
    |        ^^^^^^^^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-abi.rs
+++ b/tests/ui/feature-gates/feature-gate-abi.rs
@@ -1,14 +1,12 @@
 // gate-test-intrinsics
+//@ add-core-stubs
 //@ compile-flags: --crate-type=rlib
 
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang="sized"]
-trait Sized { }
-
-#[lang="tuple_trait"]
-trait Tuple { }
+extern crate minicore;
+use minicore::*;
 
 // Functions
 extern "rust-intrinsic" fn f1() {} //~ ERROR extern "rust-intrinsic" ABI is an implementation detail

--- a/tests/ui/feature-gates/feature-gate-abi.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:14:8
+  --> $DIR/feature-gate-abi.rs:12:8
    |
 LL | extern "rust-intrinsic" fn f1() {}
    |        ^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | extern "rust-intrinsic" fn f1() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:16:8
+  --> $DIR/feature-gate-abi.rs:14:8
    |
 LL | extern "rust-intrinsic" fn f2() {}
    |        ^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | extern "rust-intrinsic" fn f2() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-call" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:18:8
+  --> $DIR/feature-gate-abi.rs:16:8
    |
 LL | extern "rust-call" fn f4(_: ()) {}
    |        ^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL | extern "rust-call" fn f4(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:22:12
+  --> $DIR/feature-gate-abi.rs:20:12
    |
 LL |     extern "rust-intrinsic" fn m1();
    |            ^^^^^^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL |     extern "rust-intrinsic" fn m1();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:24:12
+  --> $DIR/feature-gate-abi.rs:22:12
    |
 LL |     extern "rust-intrinsic" fn m2();
    |            ^^^^^^^^^^^^^^^^
@@ -45,7 +45,7 @@ LL |     extern "rust-intrinsic" fn m2();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-call" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:26:12
+  --> $DIR/feature-gate-abi.rs:24:12
    |
 LL |     extern "rust-call" fn m4(_: ());
    |            ^^^^^^^^^^^
@@ -55,7 +55,7 @@ LL |     extern "rust-call" fn m4(_: ());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-call" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:28:12
+  --> $DIR/feature-gate-abi.rs:26:12
    |
 LL |     extern "rust-call" fn dm4(_: ()) {}
    |            ^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |     extern "rust-call" fn dm4(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:35:12
+  --> $DIR/feature-gate-abi.rs:33:12
    |
 LL |     extern "rust-intrinsic" fn m1() {}
    |            ^^^^^^^^^^^^^^^^
@@ -74,7 +74,7 @@ LL |     extern "rust-intrinsic" fn m1() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:37:12
+  --> $DIR/feature-gate-abi.rs:35:12
    |
 LL |     extern "rust-intrinsic" fn m2() {}
    |            ^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL |     extern "rust-intrinsic" fn m2() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-call" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:39:12
+  --> $DIR/feature-gate-abi.rs:37:12
    |
 LL |     extern "rust-call" fn m4(_: ()) {}
    |            ^^^^^^^^^^^
@@ -93,7 +93,7 @@ LL |     extern "rust-call" fn m4(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:44:12
+  --> $DIR/feature-gate-abi.rs:42:12
    |
 LL |     extern "rust-intrinsic" fn im1() {}
    |            ^^^^^^^^^^^^^^^^
@@ -102,7 +102,7 @@ LL |     extern "rust-intrinsic" fn im1() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:46:12
+  --> $DIR/feature-gate-abi.rs:44:12
    |
 LL |     extern "rust-intrinsic" fn im2() {}
    |            ^^^^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL |     extern "rust-intrinsic" fn im2() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-call" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:48:12
+  --> $DIR/feature-gate-abi.rs:46:12
    |
 LL |     extern "rust-call" fn im4(_: ()) {}
    |            ^^^^^^^^^^^
@@ -121,7 +121,7 @@ LL |     extern "rust-call" fn im4(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:52:18
+  --> $DIR/feature-gate-abi.rs:50:18
    |
 LL | type A1 = extern "rust-intrinsic" fn();
    |                  ^^^^^^^^^^^^^^^^
@@ -130,7 +130,7 @@ LL | type A1 = extern "rust-intrinsic" fn();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:53:18
+  --> $DIR/feature-gate-abi.rs:51:18
    |
 LL | type A2 = extern "rust-intrinsic" fn();
    |                  ^^^^^^^^^^^^^^^^
@@ -139,7 +139,7 @@ LL | type A2 = extern "rust-intrinsic" fn();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-call" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:54:18
+  --> $DIR/feature-gate-abi.rs:52:18
    |
 LL | type A4 = extern "rust-call" fn(_: ());
    |                  ^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL | type A4 = extern "rust-call" fn(_: ());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:57:8
+  --> $DIR/feature-gate-abi.rs:55:8
    |
 LL | extern "rust-intrinsic" {}
    |        ^^^^^^^^^^^^^^^^
@@ -158,7 +158,7 @@ LL | extern "rust-intrinsic" {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-intrinsic" ABI is an implementation detail and perma-unstable
-  --> $DIR/feature-gate-abi.rs:58:8
+  --> $DIR/feature-gate-abi.rs:56:8
    |
 LL | extern "rust-intrinsic" {}
    |        ^^^^^^^^^^^^^^^^
@@ -167,7 +167,7 @@ LL | extern "rust-intrinsic" {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "rust-call" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:59:8
+  --> $DIR/feature-gate-abi.rs:57:8
    |
 LL | extern "rust-call" {}
    |        ^^^^^^^^^^^
@@ -177,49 +177,49 @@ LL | extern "rust-call" {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:22:32
+  --> $DIR/feature-gate-abi.rs:20:32
    |
 LL |     extern "rust-intrinsic" fn m1();
    |                                ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:24:32
+  --> $DIR/feature-gate-abi.rs:22:32
    |
 LL |     extern "rust-intrinsic" fn m2();
    |                                ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:14:33
+  --> $DIR/feature-gate-abi.rs:12:33
    |
 LL | extern "rust-intrinsic" fn f1() {}
    |                                 ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:16:33
+  --> $DIR/feature-gate-abi.rs:14:33
    |
 LL | extern "rust-intrinsic" fn f2() {}
    |                                 ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:35:37
+  --> $DIR/feature-gate-abi.rs:33:37
    |
 LL |     extern "rust-intrinsic" fn m1() {}
    |                                     ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:37:37
+  --> $DIR/feature-gate-abi.rs:35:37
    |
 LL |     extern "rust-intrinsic" fn m2() {}
    |                                     ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:44:38
+  --> $DIR/feature-gate-abi.rs:42:38
    |
 LL |     extern "rust-intrinsic" fn im1() {}
    |                                      ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:46:38
+  --> $DIR/feature-gate-abi.rs:44:38
    |
 LL |     extern "rust-intrinsic" fn im2() {}
    |                                      ^^

--- a/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.rs
+++ b/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.rs
@@ -1,13 +1,11 @@
+//@ add-core-stubs
 //@ compile-flags: --crate-type=rlib
 
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang="sized"]
-trait Sized { }
-
-#[lang="tuple_trait"]
-trait Tuple { }
+extern crate minicore;
+use minicore::*;
 
 // Functions
 extern "gpu-kernel" fn f1(_: ()) {} //~ ERROR "gpu-kernel" ABI is experimental and subject to change

--- a/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi_gpu_kernel.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:13:8
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:11:8
    |
 LL | extern "gpu-kernel" fn f1(_: ()) {}
    |        ^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | extern "gpu-kernel" fn f1(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:18:12
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:16:12
    |
 LL |     extern "gpu-kernel" fn m1(_: ());
    |            ^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     extern "gpu-kernel" fn m1(_: ());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:20:12
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:18:12
    |
 LL |     extern "gpu-kernel" fn dm1(_: ()) {}
    |            ^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     extern "gpu-kernel" fn dm1(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:28:12
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:26:12
    |
 LL |     extern "gpu-kernel" fn m1(_: ()) {}
    |            ^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     extern "gpu-kernel" fn m1(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:34:12
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:32:12
    |
 LL |     extern "gpu-kernel" fn im1(_: ()) {}
    |            ^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     extern "gpu-kernel" fn im1(_: ()) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:39:18
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:37:18
    |
 LL | type A1 = extern "gpu-kernel" fn(_: ());
    |                  ^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL | type A1 = extern "gpu-kernel" fn(_: ());
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "gpu-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:44:8
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:42:8
    |
 LL | extern "gpu-kernel" {}
    |        ^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL | extern "gpu-kernel" {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 warning: the calling convention "gpu-kernel" is not supported on this target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:39:11
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:37:11
    |
 LL | type A1 = extern "gpu-kernel" fn(_: ());
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -79,31 +79,31 @@ LL | type A1 = extern "gpu-kernel" fn(_: ());
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:44:1
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:42:1
    |
 LL | extern "gpu-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:13:1
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:11:1
    |
 LL | extern "gpu-kernel" fn f1(_: ()) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:20:5
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:18:5
    |
 LL |     extern "gpu-kernel" fn dm1(_: ()) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:28:5
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:26:5
    |
 LL |     extern "gpu-kernel" fn m1(_: ()) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"gpu-kernel"` is not a supported ABI for the current target
-  --> $DIR/feature-gate-abi_gpu_kernel.rs:34:5
+  --> $DIR/feature-gate-abi_gpu_kernel.rs:32:5
    |
 LL |     extern "gpu-kernel" fn im1(_: ()) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-abi_ptx.rs
+++ b/tests/ui/feature-gates/feature-gate-abi_ptx.rs
@@ -1,9 +1,11 @@
+//@ add-core-stubs
 //@ needs-llvm-components: nvptx
 //@ compile-flags: --target=nvptx64-nvidia-cuda --crate-type=rlib
 #![no_core]
 #![feature(no_core, lang_items)]
-#[lang="sized"]
-trait Sized { }
+
+extern crate minicore;
+use minicore::*;
 
 extern "ptx-kernel" fn fu() {} //~ ERROR extern "ptx-kernel" ABI is experimental
 

--- a/tests/ui/feature-gates/feature-gate-abi_ptx.stderr
+++ b/tests/ui/feature-gates/feature-gate-abi_ptx.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the extern "ptx-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_ptx.rs:8:8
+  --> $DIR/feature-gate-abi_ptx.rs:10:8
    |
 LL | extern "ptx-kernel" fn fu() {}
    |        ^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | extern "ptx-kernel" fn fu() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "ptx-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_ptx.rs:11:12
+  --> $DIR/feature-gate-abi_ptx.rs:13:12
    |
 LL |     extern "ptx-kernel" fn mu();
    |            ^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     extern "ptx-kernel" fn mu();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "ptx-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_ptx.rs:12:12
+  --> $DIR/feature-gate-abi_ptx.rs:14:12
    |
 LL |     extern "ptx-kernel" fn dmu() {}
    |            ^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     extern "ptx-kernel" fn dmu() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "ptx-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_ptx.rs:17:12
+  --> $DIR/feature-gate-abi_ptx.rs:19:12
    |
 LL |     extern "ptx-kernel" fn mu() {}
    |            ^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     extern "ptx-kernel" fn mu() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "ptx-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_ptx.rs:21:12
+  --> $DIR/feature-gate-abi_ptx.rs:23:12
    |
 LL |     extern "ptx-kernel" fn imu() {}
    |            ^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     extern "ptx-kernel" fn imu() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "ptx-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_ptx.rs:24:19
+  --> $DIR/feature-gate-abi_ptx.rs:26:19
    |
 LL | type TAU = extern "ptx-kernel" fn();
    |                   ^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL | type TAU = extern "ptx-kernel" fn();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "ptx-kernel" ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi_ptx.rs:26:8
+  --> $DIR/feature-gate-abi_ptx.rs:28:8
    |
 LL | extern "ptx-kernel" {}
    |        ^^^^^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-asm_experimental_arch.rs
+++ b/tests/ui/feature-gates/feature-gate-asm_experimental_arch.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: --target mips-unknown-linux-gnu
 //@ needs-llvm-components: mips
 
@@ -5,15 +6,8 @@
 #![crate_type = "rlib"]
 #![no_core]
 
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
-
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 unsafe fn main() {
     asm!("");

--- a/tests/ui/feature-gates/feature-gate-asm_experimental_arch.stderr
+++ b/tests/ui/feature-gates/feature-gate-asm_experimental_arch.stderr
@@ -1,5 +1,5 @@
 error[E0658]: inline assembly is not stable yet on this architecture
-  --> $DIR/feature-gate-asm_experimental_arch.rs:19:5
+  --> $DIR/feature-gate-asm_experimental_arch.rs:13:5
    |
 LL |     asm!("");
    |     ^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-asm_experimental_reg.rs
+++ b/tests/ui/feature-gates/feature-gate-asm_experimental_reg.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ needs-asm-support
 //@ compile-flags: --target s390x-unknown-linux-gnu
 //@ needs-llvm-components: systemz
@@ -6,15 +7,8 @@
 #![crate_type = "rlib"]
 #![no_core]
 
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
-
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 unsafe fn main() {
     asm!("", in("v0") 0);

--- a/tests/ui/feature-gates/feature-gate-asm_experimental_reg.stderr
+++ b/tests/ui/feature-gates/feature-gate-asm_experimental_reg.stderr
@@ -1,5 +1,5 @@
 error[E0658]: register class `vreg` can only be used as a clobber in stable
-  --> $DIR/feature-gate-asm_experimental_reg.rs:20:14
+  --> $DIR/feature-gate-asm_experimental_reg.rs:14:14
    |
 LL |     asm!("", in("v0") 0);
    |              ^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     asm!("", in("v0") 0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: type `i32` cannot be used with this register class in stable
-  --> $DIR/feature-gate-asm_experimental_reg.rs:20:23
+  --> $DIR/feature-gate-asm_experimental_reg.rs:14:23
    |
 LL |     asm!("", in("v0") 0);
    |                       ^

--- a/tests/ui/feature-gates/feature-gate-vectorcall.rs
+++ b/tests/ui/feature-gates/feature-gate-vectorcall.rs
@@ -1,10 +1,12 @@
 // gate-test-abi_vectorcall
+//@ add-core-stubs
 //@ needs-llvm-components: x86
 //@ compile-flags: --target=i686-pc-windows-msvc --crate-type=rlib
 #![no_core]
 #![feature(no_core, lang_items)]
-#[lang="sized"]
-trait Sized { }
+
+extern crate minicore;
+use minicore::*;
 
 // Test that the "vectorcall" ABI is feature-gated, and cannot be used when
 // the `vectorcall` feature gate is not used.

--- a/tests/ui/feature-gates/feature-gate-vectorcall.stderr
+++ b/tests/ui/feature-gates/feature-gate-vectorcall.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the extern "vectorcall" ABI is experimental and subject to change
-  --> $DIR/feature-gate-vectorcall.rs:12:8
+  --> $DIR/feature-gate-vectorcall.rs:14:8
    |
 LL | extern "vectorcall" fn f() {}
    |        ^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | extern "vectorcall" fn f() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "vectorcall" ABI is experimental and subject to change
-  --> $DIR/feature-gate-vectorcall.rs:15:12
+  --> $DIR/feature-gate-vectorcall.rs:17:12
    |
 LL |     extern "vectorcall" fn m();
    |            ^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     extern "vectorcall" fn m();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "vectorcall" ABI is experimental and subject to change
-  --> $DIR/feature-gate-vectorcall.rs:17:12
+  --> $DIR/feature-gate-vectorcall.rs:19:12
    |
 LL |     extern "vectorcall" fn dm() {}
    |            ^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     extern "vectorcall" fn dm() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "vectorcall" ABI is experimental and subject to change
-  --> $DIR/feature-gate-vectorcall.rs:22:12
+  --> $DIR/feature-gate-vectorcall.rs:24:12
    |
 LL |     extern "vectorcall" fn m() {}
    |            ^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     extern "vectorcall" fn m() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "vectorcall" ABI is experimental and subject to change
-  --> $DIR/feature-gate-vectorcall.rs:26:12
+  --> $DIR/feature-gate-vectorcall.rs:28:12
    |
 LL |     extern "vectorcall" fn im() {}
    |            ^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     extern "vectorcall" fn im() {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "vectorcall" ABI is experimental and subject to change
-  --> $DIR/feature-gate-vectorcall.rs:29:18
+  --> $DIR/feature-gate-vectorcall.rs:31:18
    |
 LL | type TA = extern "vectorcall" fn();
    |                  ^^^^^^^^^^^^
@@ -59,7 +59,7 @@ LL | type TA = extern "vectorcall" fn();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the extern "vectorcall" ABI is experimental and subject to change
-  --> $DIR/feature-gate-vectorcall.rs:31:8
+  --> $DIR/feature-gate-vectorcall.rs:33:8
    |
 LL | extern "vectorcall" {}
    |        ^^^^^^^^^^^^

--- a/tests/ui/force-inlining/asm.rs
+++ b/tests/ui/force-inlining/asm.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ build-fail
 //@ compile-flags: --crate-type=lib --target thumbv4t-none-eabi
 //@ needs-llvm-components: arm
@@ -9,17 +10,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy {}
-#[lang = "freeze"]
-pub unsafe trait Freeze {}
-
-#[lang = "start"]
-fn start<T>(_main: fn() -> T, _argc: isize, _argv: *const *const u8, _sigpipe: u8) -> isize {
-    0
-}
+extern crate minicore;
+use minicore::*;
 
 #[rustc_builtin_macro]
 #[macro_export]

--- a/tests/ui/force-inlining/asm.stderr
+++ b/tests/ui/force-inlining/asm.stderr
@@ -1,5 +1,5 @@
 error: `instruction_set_a32` could not be inlined into `t32` but is required to be inlined
-  --> $DIR/asm.rs:53:5
+  --> $DIR/asm.rs:45:5
    |
 LL |     instruction_set_a32();
    |     ^^^^^^^^^^^^^^^^^^^^^ ...`instruction_set_a32` called here
@@ -7,7 +7,7 @@ LL |     instruction_set_a32();
    = note: could not be inlined due to: incompatible instruction set
 
 error: `inline_always_and_using_inline_asm` could not be inlined into `t32` but is required to be inlined
-  --> $DIR/asm.rs:57:5
+  --> $DIR/asm.rs:49:5
    |
 LL |     inline_always_and_using_inline_asm();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...`inline_always_and_using_inline_asm` called here
@@ -15,7 +15,7 @@ LL |     inline_always_and_using_inline_asm();
    = note: could not be inlined due to: cannot move inline-asm across instruction sets
 
 error: `instruction_set_a32` could not be inlined into `default` but is required to be inlined
-  --> $DIR/asm.rs:62:5
+  --> $DIR/asm.rs:54:5
    |
 LL |     instruction_set_a32();
    |     ^^^^^^^^^^^^^^^^^^^^^ ...`instruction_set_a32` called here
@@ -23,7 +23,7 @@ LL |     instruction_set_a32();
    = note: could not be inlined due to: incompatible instruction set
 
 error: `instruction_set_t32` could not be inlined into `default` but is required to be inlined
-  --> $DIR/asm.rs:64:5
+  --> $DIR/asm.rs:56:5
    |
 LL |     instruction_set_t32();
    |     ^^^^^^^^^^^^^^^^^^^^^ ...`instruction_set_t32` called here

--- a/tests/ui/layout/hexagon-enum.rs
+++ b/tests/ui/layout/hexagon-enum.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: --target hexagon-unknown-linux-musl
 //@ normalize-stderr: "randomization_seed: \d+" -> "randomization_seed: $$SEED"
 //@ needs-llvm-components: hexagon
@@ -9,8 +10,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang="sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[rustc_layout(debug)]
 #[repr(C)]

--- a/tests/ui/layout/hexagon-enum.stderr
+++ b/tests/ui/layout/hexagon-enum.stderr
@@ -71,7 +71,7 @@ error: layout_of(A) = Layout {
            unadjusted_abi_align: Align(1 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/hexagon-enum.rs:17:1
+  --> $DIR/hexagon-enum.rs:18:1
    |
 LL | enum A { Apple }
    | ^^^^^^
@@ -149,7 +149,7 @@ error: layout_of(B) = Layout {
            unadjusted_abi_align: Align(1 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/hexagon-enum.rs:21:1
+  --> $DIR/hexagon-enum.rs:22:1
    |
 LL | enum B { Banana = 255, }
    | ^^^^^^
@@ -227,7 +227,7 @@ error: layout_of(C) = Layout {
            unadjusted_abi_align: Align(2 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/hexagon-enum.rs:25:1
+  --> $DIR/hexagon-enum.rs:26:1
    |
 LL | enum C { Chaenomeles = 256, }
    | ^^^^^^
@@ -305,7 +305,7 @@ error: layout_of(P) = Layout {
            unadjusted_abi_align: Align(4 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/hexagon-enum.rs:29:1
+  --> $DIR/hexagon-enum.rs:30:1
    |
 LL | enum P { Peach = 0x1000_0000isize, }
    | ^^^^^^
@@ -383,7 +383,7 @@ error: layout_of(T) = Layout {
            unadjusted_abi_align: Align(4 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/hexagon-enum.rs:35:1
+  --> $DIR/hexagon-enum.rs:36:1
    |
 LL | enum T { Tangerine = TANGERINE as isize }
    | ^^^^^^

--- a/tests/ui/layout/thumb-enum.rs
+++ b/tests/ui/layout/thumb-enum.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ compile-flags: --target thumbv8m.main-none-eabihf
 //@ normalize-stderr: "randomization_seed: \d+" -> "randomization_seed: $$SEED"
 //@ needs-llvm-components: arm
@@ -9,8 +10,8 @@
 #![crate_type = "lib"]
 #![no_core]
 
-#[lang="sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[rustc_layout(debug)]
 #[repr(C)]

--- a/tests/ui/layout/thumb-enum.stderr
+++ b/tests/ui/layout/thumb-enum.stderr
@@ -71,7 +71,7 @@ error: layout_of(A) = Layout {
            unadjusted_abi_align: Align(1 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/thumb-enum.rs:17:1
+  --> $DIR/thumb-enum.rs:18:1
    |
 LL | enum A { Apple }
    | ^^^^^^
@@ -149,7 +149,7 @@ error: layout_of(B) = Layout {
            unadjusted_abi_align: Align(1 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/thumb-enum.rs:21:1
+  --> $DIR/thumb-enum.rs:22:1
    |
 LL | enum B { Banana = 255, }
    | ^^^^^^
@@ -227,7 +227,7 @@ error: layout_of(C) = Layout {
            unadjusted_abi_align: Align(2 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/thumb-enum.rs:25:1
+  --> $DIR/thumb-enum.rs:26:1
    |
 LL | enum C { Chaenomeles = 256, }
    | ^^^^^^
@@ -305,7 +305,7 @@ error: layout_of(P) = Layout {
            unadjusted_abi_align: Align(4 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/thumb-enum.rs:29:1
+  --> $DIR/thumb-enum.rs:30:1
    |
 LL | enum P { Peach = 0x1000_0000isize, }
    | ^^^^^^
@@ -383,7 +383,7 @@ error: layout_of(T) = Layout {
            unadjusted_abi_align: Align(4 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/thumb-enum.rs:35:1
+  --> $DIR/thumb-enum.rs:36:1
    |
 LL | enum T { Tangerine = TANGERINE as isize }
    | ^^^^^^

--- a/tests/ui/layout/too-big-with-padding.rs
+++ b/tests/ui/layout/too-big-with-padding.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ build-fail
 //@ compile-flags: --target i686-unknown-linux-gnu --crate-type lib
 //@ needs-llvm-components: x86
@@ -6,13 +7,11 @@
 #![no_std]
 #![no_core]
 
+extern crate minicore;
+use minicore::*;
+
 // 0x7fffffff is fine, but after rounding up it becomes too big
 #[repr(C, align(2))]
 pub struct Example([u8; 0x7fffffff]);
 
 pub fn lib(_x: Example) {} //~ERROR: too big for the target architecture
-
-#[lang = "sized"]
-pub trait Sized {}
-#[lang = "copy"]
-pub trait Copy: Sized {}

--- a/tests/ui/layout/too-big-with-padding.stderr
+++ b/tests/ui/layout/too-big-with-padding.stderr
@@ -1,5 +1,5 @@
 error: values of the type `Example` are too big for the target architecture
-  --> $DIR/too-big-with-padding.rs:13:1
+  --> $DIR/too-big-with-padding.rs:17:1
    |
 LL | pub fn lib(_x: Example) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/mir/checks_without_panic_impl.rs
+++ b/tests/ui/mir/checks_without_panic_impl.rs
@@ -2,6 +2,7 @@
 // does not prevent crates without a panic_impl from compiling.
 // See rust-lang/rust#109996
 
+//@ add-core-stubs
 //@ build-pass
 //@ compile-flags: -Cdebug-assertions=yes
 
@@ -11,7 +12,7 @@
 #![feature(no_core)]
 #![no_core]
 
-#[lang = "sized"]
-trait Foo {}
+extern crate minicore;
+use minicore::*;
 
 pub unsafe fn foo(x: *const i32) -> &'static i32 { unsafe { &*x } }

--- a/tests/ui/repr/16-bit-repr-c-enum.rs
+++ b/tests/ui/repr/16-bit-repr-c-enum.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ build-pass
 //@ revisions: avr msp430
 //
@@ -10,6 +11,9 @@
 #![crate_type = "lib"]
 #![stable(feature = "intrinsics_for_test", since = "3.3.3")]
 #![allow(dead_code)]
+
+extern crate minicore;
+use minicore::*;
 
 // Test that the repr(C) attribute doesn't break compilation
 // Previous bad assumption was that 32-bit enum default width is fine on msp430, avr
@@ -25,11 +29,6 @@ enum Foo {
 #[rustc_const_stable(feature = "intrinsics_for_test", since = "3.3.3")]
 #[rustc_intrinsic]
 const fn size_of<T>() -> usize;
-
-#[lang="sized"]
-trait Sized {}
-#[lang="copy"]
-trait Copy {}
 
 const EXPECTED: usize = 2;
 const ACTUAL: usize = size_of::<Foo>();

--- a/tests/ui/repr/repr-c-dead-variants.aarch64-unknown-linux-gnu.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.aarch64-unknown-linux-gnu.stderr
@@ -81,7 +81,7 @@ error: layout_of(Univariant) = Layout {
            unadjusted_abi_align: Align(4 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:39:1
+  --> $DIR/repr-c-dead-variants.rs:43:1
    |
 LL | enum Univariant {
    | ^^^^^^^^^^^^^^^
@@ -219,7 +219,7 @@ error: layout_of(TwoVariants) = Layout {
            unadjusted_abi_align: Align(4 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:46:1
+  --> $DIR/repr-c-dead-variants.rs:50:1
    |
 LL | enum TwoVariants {
    | ^^^^^^^^^^^^^^^^
@@ -327,7 +327,7 @@ error: layout_of(DeadBranchHasOtherField) = Layout {
            unadjusted_abi_align: Align(8 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:58:1
+  --> $DIR/repr-c-dead-variants.rs:62:1
    |
 LL | enum DeadBranchHasOtherField {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/repr/repr-c-dead-variants.armebv7r-none-eabi.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.armebv7r-none-eabi.stderr
@@ -81,7 +81,7 @@ error: layout_of(Univariant) = Layout {
            unadjusted_abi_align: Align(1 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:39:1
+  --> $DIR/repr-c-dead-variants.rs:43:1
    |
 LL | enum Univariant {
    | ^^^^^^^^^^^^^^^
@@ -219,7 +219,7 @@ error: layout_of(TwoVariants) = Layout {
            unadjusted_abi_align: Align(1 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:46:1
+  --> $DIR/repr-c-dead-variants.rs:50:1
    |
 LL | enum TwoVariants {
    | ^^^^^^^^^^^^^^^^
@@ -327,7 +327,7 @@ error: layout_of(DeadBranchHasOtherField) = Layout {
            unadjusted_abi_align: Align(8 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:58:1
+  --> $DIR/repr-c-dead-variants.rs:62:1
    |
 LL | enum DeadBranchHasOtherField {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/repr/repr-c-dead-variants.i686-pc-windows-msvc.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.i686-pc-windows-msvc.stderr
@@ -81,7 +81,7 @@ error: layout_of(Univariant) = Layout {
            unadjusted_abi_align: Align(4 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:39:1
+  --> $DIR/repr-c-dead-variants.rs:43:1
    |
 LL | enum Univariant {
    | ^^^^^^^^^^^^^^^
@@ -219,7 +219,7 @@ error: layout_of(TwoVariants) = Layout {
            unadjusted_abi_align: Align(4 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:46:1
+  --> $DIR/repr-c-dead-variants.rs:50:1
    |
 LL | enum TwoVariants {
    | ^^^^^^^^^^^^^^^^
@@ -327,7 +327,7 @@ error: layout_of(DeadBranchHasOtherField) = Layout {
            unadjusted_abi_align: Align(8 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:58:1
+  --> $DIR/repr-c-dead-variants.rs:62:1
    |
 LL | enum DeadBranchHasOtherField {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/repr/repr-c-dead-variants.rs
+++ b/tests/ui/repr/repr-c-dead-variants.rs
@@ -4,8 +4,12 @@
 #![no_std]
 #![no_core]
 
+extern crate minicore;
+use minicore::*;
+
 // See also: repr-c-int-dead-variants.rs
 
+//@ add-core-stubs
 //@ normalize-stderr: "pref: Align\([1-8] bytes\)" -> "pref: $$SOME_ALIGN"
 //@ normalize-stderr: "randomization_seed: \d+" -> "randomization_seed: $$SEED"
 
@@ -59,6 +63,3 @@ enum DeadBranchHasOtherField { //~ ERROR layout_of
     Variant1(Void, Align8U64),
     Variant2(u8),
 }
-
-#[lang = "sized"]
-trait Sized {}

--- a/tests/ui/repr/repr-c-dead-variants.x86_64-unknown-linux-gnu.stderr
+++ b/tests/ui/repr/repr-c-dead-variants.x86_64-unknown-linux-gnu.stderr
@@ -81,7 +81,7 @@ error: layout_of(Univariant) = Layout {
            unadjusted_abi_align: Align(4 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:39:1
+  --> $DIR/repr-c-dead-variants.rs:43:1
    |
 LL | enum Univariant {
    | ^^^^^^^^^^^^^^^
@@ -219,7 +219,7 @@ error: layout_of(TwoVariants) = Layout {
            unadjusted_abi_align: Align(4 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:46:1
+  --> $DIR/repr-c-dead-variants.rs:50:1
    |
 LL | enum TwoVariants {
    | ^^^^^^^^^^^^^^^^
@@ -327,7 +327,7 @@ error: layout_of(DeadBranchHasOtherField) = Layout {
            unadjusted_abi_align: Align(8 bytes),
            randomization_seed: $SEED,
        }
-  --> $DIR/repr-c-dead-variants.rs:58:1
+  --> $DIR/repr-c-dead-variants.rs:62:1
    |
 LL | enum DeadBranchHasOtherField {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/repr/repr_align_greater_usize.msp430.stderr
+++ b/tests/ui/repr/repr_align_greater_usize.msp430.stderr
@@ -1,5 +1,5 @@
 error[E0589]: alignment must not be greater than `isize::MAX` bytes
-  --> $DIR/repr_align_greater_usize.rs:21:8
+  --> $DIR/repr_align_greater_usize.rs:22:8
    |
 LL | #[repr(align(32768))]
    |        ^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | #[repr(align(32768))]
    = note: `isize::MAX` is 32767 for the current target
 
 error[E0589]: alignment must not be greater than `isize::MAX` bytes
-  --> $DIR/repr_align_greater_usize.rs:24:8
+  --> $DIR/repr_align_greater_usize.rs:25:8
    |
 LL | #[repr(align(65536))]
    |        ^^^^^^^^^^^^

--- a/tests/ui/repr/repr_align_greater_usize.rs
+++ b/tests/ui/repr/repr_align_greater_usize.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: msp430 aarch32
 //@[msp430] needs-llvm-components: msp430
 //@[msp430] compile-flags: --target=msp430-none-elf
@@ -12,8 +13,8 @@
 #![no_core]
 #![crate_type = "lib"]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(align(16384))]
 struct Kitten;

--- a/tests/ui/sanitizer/cfg-kasan.rs
+++ b/tests/ui/sanitizer/cfg-kasan.rs
@@ -1,6 +1,7 @@
 // Verifies that when compiling with -Zsanitizer=kernel-address,
 // the `#[cfg(sanitize = "address")]` attribute is configured.
 
+//@ add-core-stubs
 //@ check-pass
 //@ compile-flags: -Zsanitizer=kernel-address
 //@ revisions: aarch64 riscv64imac riscv64gc x86_64
@@ -17,8 +18,8 @@
 #![feature(cfg_sanitize, no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 const _: fn() -> () = main;
 

--- a/tests/ui/sanitizer/cfg.rs
+++ b/tests/ui/sanitizer/cfg.rs
@@ -1,6 +1,7 @@
 // Verifies that when compiling with -Zsanitizer=option,
 // the `#[cfg(sanitize = "option")]` attribute is configured.
 
+//@ add-core-stubs
 //@ check-pass
 //@ revisions: address cfi kcfi leak memory thread
 //@compile-flags: -Ctarget-feature=-crt-static
@@ -23,10 +24,8 @@
 #![crate_type="lib"]
 #![no_core]
 
-#[lang="sized"]
-trait Sized { }
-#[lang="copy"]
-trait Copy { }
+extern crate minicore;
+use minicore::*;
 
 #[cfg(all(sanitize = "address", address))]
 fn main() {}

--- a/tests/ui/static/static_sized_requirement.rs
+++ b/tests/ui/static/static_sized_requirement.rs
@@ -1,11 +1,12 @@
-//@ build-pass (FIXME(62277): could be check-pass?)
+//@ add-core-stubs
+//@ check-pass
 
 #![feature(no_core, lang_items)]
 #![no_core]
 #![crate_type = "lib"]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 extern "C" {
     pub static A: u32;

--- a/tests/ui/target-feature/no-llvm-leaks.rs
+++ b/tests/ui/target-feature/no-llvm-leaks.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: aarch64 x86-64
 //@ [aarch64] compile-flags: -Ctarget-feature=+neon,+fp16,+fhm --target=aarch64-unknown-linux-gnu
 //@ [aarch64] needs-llvm-components: aarch64
@@ -9,12 +10,8 @@
 #![feature(intrinsics, rustc_attrs, no_core, lang_items, staged_api)]
 #![stable(feature = "test", since = "1.0.0")]
 
-// Supporting minimal rust core code
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-impl Copy for bool {}
+extern crate minicore;
+use minicore::*;
 
 #[stable(feature = "test", since = "1.0.0")]
 #[rustc_const_stable(feature = "test", since = "1.0.0")]

--- a/tests/ui/target-feature/tied-features.rs
+++ b/tests/ui/target-feature/tied-features.rs
@@ -1,10 +1,11 @@
+//@ add-core-stubs
 //@ compile-flags: --crate-type=rlib --target=aarch64-unknown-linux-gnu
 //@ needs-llvm-components: aarch64
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang="sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 pub fn main() {
     #[target_feature(enable = "pacg")]

--- a/tests/ui/target-feature/tied-features.stderr
+++ b/tests/ui/target-feature/tied-features.stderr
@@ -1,5 +1,5 @@
 error: the target features paca, pacg must all be either enabled or disabled together
-  --> $DIR/tied-features.rs:10:5
+  --> $DIR/tied-features.rs:11:5
    |
 LL |     #[target_feature(enable = "pacg")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     #[target_feature(enable = "pacg")]
    = help: add the missing features in a `target_feature` attribute
 
 error: the target features paca, pacg must all be either enabled or disabled together
-  --> $DIR/tied-features.rs:22:1
+  --> $DIR/tied-features.rs:23:1
    |
 LL | #[target_feature(enable = "paca")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL | #[target_feature(enable = "paca")]
    = help: add the missing features in a `target_feature` attribute
 
 error: the target features paca, pacg must all be either enabled or disabled together
-  --> $DIR/tied-features.rs:35:1
+  --> $DIR/tied-features.rs:36:1
    |
 LL | #[target_feature(enable = "paca")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
minicore makes it much easier to add new language items to all of the existing `no_core` tests.

Most of the remaining tests that *could* use minicore either fail because..

1. LLVM IR output changes and doesn't pass the test as written. I didn't look into these further.
2. The test has revisions w/ different compilation flags, expecting some to fail, and when using minicore, minicore is compiled with those flags and fails in the expected way because of the flags rather than the test, and that's considered a failure.

But these tests can be changed and make adding new language items a lot easier.

r? @jieyouxu 
