### PR TITLE
type_ir: remove redundant part of comment

### DIFF
--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -131,8 +131,6 @@ pub struct TraitPredicate<I: Interner> {
     /// If polarity is Negative: we are proving that a negative impl of this trait
     /// exists. (Note that coherence also checks whether negative impls of supertraits
     /// exist via a series of predicates.)
-    ///
-    /// If polarity is Reserved: that's a bug.
     pub polarity: PredicatePolarity,
 }
 


### PR DESCRIPTION
This comment refers to a `PredicatePolarity::Reserved` which no longer exists.
