### PR TITLE
feature: fix typo in attribute description

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -1011,7 +1011,7 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     rustc_attr!(
         rustc_force_inline, Normal, template!(Word, NameValueStr: "reason"), WarnFollowing, EncodeCrossCrate::Yes,
-        "#![rustc_force_inline] forces a free function to be inlined"
+        "#[rustc_force_inline] forces a free function to be inlined"
     ),
 
     // ==========================================================================

--- a/tests/ui/force-inlining/gate.rs
+++ b/tests/ui/force-inlining/gate.rs
@@ -2,11 +2,11 @@
 #![allow(internal_features)]
 
 #[rustc_force_inline]
-//~^ ERROR #![rustc_force_inline] forces a free function to be inlined
+//~^ ERROR #[rustc_force_inline] forces a free function to be inlined
 pub fn bare() {
 }
 
 #[rustc_force_inline = "the test requires it"]
-//~^ ERROR #![rustc_force_inline] forces a free function to be inlined
+//~^ ERROR #[rustc_force_inline] forces a free function to be inlined
 pub fn justified() {
 }

--- a/tests/ui/force-inlining/gate.stderr
+++ b/tests/ui/force-inlining/gate.stderr
@@ -1,4 +1,4 @@
-error[E0658]: #![rustc_force_inline] forces a free function to be inlined
+error[E0658]: #[rustc_force_inline] forces a free function to be inlined
   --> $DIR/gate.rs:4:1
    |
 LL | #[rustc_force_inline]
@@ -7,7 +7,7 @@ LL | #[rustc_force_inline]
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: #![rustc_force_inline] forces a free function to be inlined
+error[E0658]: #[rustc_force_inline] forces a free function to be inlined
   --> $DIR/gate.rs:9:1
    |
 LL | #[rustc_force_inline = "the test requires it"]


### PR DESCRIPTION
The force inlining attribute isn't is never used with `#![..]` attribute syntax, only `#[..]` syntax.
