### PR TITLE
trait_sel: resolve vars in host effects

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -31,6 +31,8 @@ pub fn evaluate_host_effect_obligation<'tcx>(
         );
     }
 
+    let ref obligation = selcx.infcx.resolve_vars_if_possible(obligation.clone());
+
     // Force ambiguity for infer self ty.
     if obligation.predicate.self_ty().is_ty_var() {
         return Err(EvaluationFailure::Ambiguous);

--- a/tests/ui/traits/const-traits/unconstrained-var-specialization.rs
+++ b/tests/ui/traits/const-traits/unconstrained-var-specialization.rs
@@ -1,0 +1,36 @@
+//@ check-pass
+//@ compile-flags: --crate-type=lib
+#![no_std]
+#![allow(internal_features)]
+#![feature(rustc_attrs, min_specialization, const_trait_impl)]
+
+// In the default impl below, `A` is constrained by the projection predicate, and if the host effect
+// predicate for `const Foo` doesn't resolve vars, then specialization will fail.
+
+#[const_trait]
+trait Foo {}
+
+pub trait Iterator {
+    type Item;
+}
+
+#[rustc_unsafe_specialization_marker]
+pub trait MoreSpecificThanIterator: Iterator {}
+
+pub trait Tr {
+    fn foo();
+}
+
+impl<A: const Foo, Iter> Tr for Iter
+    where
+        Iter: Iterator<Item = A>,
+{
+    default fn foo() {}
+}
+
+impl<A: const Foo, Iter> Tr for Iter
+    where
+        Iter: MoreSpecificThanIterator<Item = A>,
+{
+    fn foo() {}
+}


### PR DESCRIPTION
In the standard library, the `Extend` impl for `Iterator` (specialised with `TrustedLen`) has a parameter which is constrained by a projection predicate. This projection predicate provides a value for an inference variable but - if the default bound is `const Sized` instead of `Sized` - host effect evaluation wasn't resolving variables first. Added a test that doesn't depend on a rust-lang/rfcs#3729 implementation.

Adding the extra resolve can the number of errors in some tests when they gain host effect predicates, but this is not unexpected as calls to `resolve_vars_if_possible` can cause more error tainting to happen.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
