### PR TITLE
add a "future" edition

### DIFF
--- a/compiler/rustc_builtin_macros/src/standard_library_imports.rs
+++ b/compiler/rustc_builtin_macros/src/standard_library_imports.rs
@@ -60,6 +60,7 @@ pub fn inject(
             Edition2018 => sym::rust_2018,
             Edition2021 => sym::rust_2021,
             Edition2024 => sym::rust_2024,
+            EditionFuture => sym::rust_future,
         }])
         .map(|&symbol| Ident::new(symbol, span))
         .collect();

--- a/compiler/rustc_span/src/edition.rs
+++ b/compiler/rustc_span/src/edition.rs
@@ -23,11 +23,27 @@ pub enum Edition {
     Edition2021,
     /// The 2024 edition
     Edition2024,
+    /// The future edition - this variant will always exist and features associated with this
+    /// edition can be moved to the next 20XX edition when it is established and it is confirmed
+    /// that those features will be part of that edition.
+    ///
+    /// This variant allows edition changes to be implemented before being assigned to a concrete
+    /// edition - primarily when there are two different unstable behaviours that need tested across
+    /// an edition boundary.
+    ///
+    /// This edition will be permanently unstable and any features associated with this edition
+    /// must also be behind a feature gate.
+    EditionFuture,
 }
 
 // Must be in order from oldest to newest.
-pub const ALL_EDITIONS: &[Edition] =
-    &[Edition::Edition2015, Edition::Edition2018, Edition::Edition2021, Edition::Edition2024];
+pub const ALL_EDITIONS: &[Edition] = &[
+    Edition::Edition2015,
+    Edition::Edition2018,
+    Edition::Edition2021,
+    Edition::Edition2024,
+    Edition::EditionFuture,
+];
 
 pub const EDITION_NAME_LIST: &str = "2015|2018|2021|2024";
 
@@ -42,6 +58,7 @@ impl fmt::Display for Edition {
             Edition::Edition2018 => "2018",
             Edition::Edition2021 => "2021",
             Edition::Edition2024 => "2024",
+            Edition::EditionFuture => "future",
         };
         write!(f, "{s}")
     }
@@ -54,6 +71,7 @@ impl Edition {
             Edition::Edition2018 => "rust_2018_compatibility",
             Edition::Edition2021 => "rust_2021_compatibility",
             Edition::Edition2024 => "rust_2024_compatibility",
+            Edition::EditionFuture => "edition_future_compatibility",
         }
     }
 
@@ -63,6 +81,7 @@ impl Edition {
             Edition::Edition2018 => true,
             Edition::Edition2021 => true,
             Edition::Edition2024 => true,
+            Edition::EditionFuture => false,
         }
     }
 
@@ -85,6 +104,11 @@ impl Edition {
     pub fn at_least_rust_2024(self) -> bool {
         self >= Edition::Edition2024
     }
+
+    /// Are we allowed to use features from the future edition?
+    pub fn at_least_edition_future(self) -> bool {
+        self >= Edition::EditionFuture
+    }
 }
 
 impl FromStr for Edition {
@@ -95,6 +119,7 @@ impl FromStr for Edition {
             "2018" => Ok(Edition::Edition2018),
             "2021" => Ok(Edition::Edition2021),
             "2024" => Ok(Edition::Edition2024),
+            "future" => Ok(Edition::EditionFuture),
             _ => Err(()),
         }
     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1711,6 +1711,7 @@ symbols! {
         rust_cold_cc,
         rust_eh_catch_typeinfo,
         rust_eh_personality,
+        rust_future,
         rust_logo,
         rust_out,
         rustc,

--- a/library/core/src/prelude/mod.rs
+++ b/library/core/src/prelude/mod.rs
@@ -70,3 +70,26 @@ pub mod rust_2024 {
     #[doc(no_inline)]
     pub use crate::future::{Future, IntoFuture};
 }
+
+/// The Future version of the core prelude.
+///
+/// See the [module-level documentation](self) for more.
+#[doc(hidden)]
+#[unstable(feature = "prelude_future", issue = "none")]
+pub mod rust_future {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(no_inline)]
+    pub use super::v1::*;
+
+    #[stable(feature = "prelude_2021", since = "1.55.0")]
+    #[doc(no_inline)]
+    pub use crate::iter::FromIterator;
+
+    #[stable(feature = "prelude_2021", since = "1.55.0")]
+    #[doc(no_inline)]
+    pub use crate::convert::{TryFrom, TryInto};
+
+    #[stable(feature = "prelude_2024", since = "1.85.0")]
+    #[doc(no_inline)]
+    pub use crate::future::{Future, IntoFuture};
+}

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -160,3 +160,18 @@ pub mod rust_2024 {
     #[doc(no_inline)]
     pub use core::prelude::rust_2024::*;
 }
+
+/// The Future version of the prelude of The Rust Standard Library.
+///
+/// See the [module-level documentation](self) for more.
+#[doc(hidden)]
+#[unstable(feature = "prelude_future", issue = "none")]
+pub mod rust_future {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(no_inline)]
+    pub use super::v1::*;
+
+    #[unstable(feature = "prelude_next", issue = "none")]
+    #[doc(no_inline)]
+    pub use core::prelude::rust_future::*;
+}


### PR DESCRIPTION
This idea has been discussed previously [on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Continuous.20edition-like.20changes.3F/near/432559262) (though what I've implemented isn't exactly the "next"/"future" editions proposed in that message, just the "future" edition). I've found myself prototyping changes that involve edition migrations and wanting to target an upcoming edition for those migrations, but none exists. This should be permanently unstable and not removed.