### PR TITLE
Complete the list of resources used in rustdoc output

### DIFF
--- a/src/librustdoc/html/static/COPYRIGHT.txt
+++ b/src/librustdoc/html/static/COPYRIGHT.txt
@@ -45,6 +45,17 @@ included, and carry their own copyright notices and license terms:
     Licensed under the SIL Open Font License, Version 1.1.
     See SourceSerif4-LICENSE.md.
 
+* Nanum Barun Gothic Font (NanumBarunGothic.woff2)
+
+    Copyright 2017 NAVER, free for personal and commercial use.
+    https://hangeul.naver.com/2017/nanum
+
+* Rust logos (rust-logo.svg, favicon.svg, favicon-32x32.png)
+
+    Copyright 2025 Rust Foundation.
+    Licensed under the Creative Commons Attribution license (CC-BY).
+    https://rustfoundation.org/policy/rust-trademark-policy/
+
 This copyright file is intended to be distributed with rustdoc output.
 
 # REUSE-IgnoreEnd

--- a/src/librustdoc/html/static/COPYRIGHT.txt
+++ b/src/librustdoc/html/static/COPYRIGHT.txt
@@ -47,8 +47,18 @@ included, and carry their own copyright notices and license terms:
 
 * Nanum Barun Gothic Font (NanumBarunGothic.woff2)
 
-    Copyright 2017 NAVER, free for personal and commercial use.
+    Copyright 2010, NAVER Corporation (http://www.nhncorp.com)
+    with Reserved Font Name Nanum, Naver Nanum, NanumGothic, Naver NanumGothic,
+    NanumMyeongjo, Naver NanumMyeongjo, NanumBrush, Naver NanumBrush, NanumPen,
+    Naver NanumPen, Naver NanumGothicEco, NanumGothicEco,
+    Naver NanumMyeongjoEco, NanumMyeongjoEco, Naver NanumGothicLight,
+    NanumGothicLight, NanumBarunGothic, Naver NanumBarunGothic.
+
     https://hangeul.naver.com/2017/nanum
+    https://github.com/hiun/NanumBarunGothic
+
+    Licensed under the SIL Open Font License, Version 1.1.
+    See NanumBarunGothic-LICENSE.txt.
 
 * Rust logos (rust-logo.svg, favicon.svg, favicon-32x32.png)
 


### PR DESCRIPTION
The Nanum Barun Gothic Font was missing in the list and should clearly be mentionned.

Arguably referencing the Rust logos is not really necessary as the file mentions "third party resources" but it doesn't hurt and should make things clearer for anybody who wants to publish their Rust doc.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
