### PR TITLE
hir_analysis: skip self type of host effect preds in variances_of

### DIFF
--- a/compiler/rustc_hir_analysis/src/variance/mod.rs
+++ b/compiler/rustc_hir_analysis/src/variance/mod.rs
@@ -198,6 +198,10 @@ fn variance_of_opaque(
             ty::ClauseKind::Trait(ty::TraitPredicate {
                 trait_ref: ty::TraitRef { def_id: _, args, .. },
                 polarity: _,
+            })
+            | ty::ClauseKind::HostEffect(ty::HostEffectPredicate {
+                trait_ref: ty::TraitRef { def_id: _, args, .. },
+                constness: _,
             }) => {
                 for arg in &args[1..] {
                     arg.visit_with(&mut collector);

--- a/tests/ui/traits/const-traits/variance.rs
+++ b/tests/ui/traits/const-traits/variance.rs
@@ -1,0 +1,14 @@
+#![feature(rustc_attrs, const_trait_impl)]
+#![allow(internal_features)]
+#![rustc_variance_of_opaques]
+
+#[const_trait]
+trait Foo {}
+
+impl const Foo for () {}
+
+fn foo<'a: 'a>() -> impl const Foo {}
+//~^ ERROR ['a: o]
+
+fn main() {}
+

--- a/tests/ui/traits/const-traits/variance.rs
+++ b/tests/ui/traits/const-traits/variance.rs
@@ -8,7 +8,6 @@ trait Foo {}
 impl const Foo for () {}
 
 fn foo<'a: 'a>() -> impl const Foo {}
-//~^ ERROR ['a: o]
+//~^ ERROR ['a: *]
 
 fn main() {}
-

--- a/tests/ui/traits/const-traits/variance.stderr
+++ b/tests/ui/traits/const-traits/variance.stderr
@@ -1,0 +1,8 @@
+error: ['a: o]
+  --> $DIR/variance.rs:10:21
+   |
+LL | fn foo<'a: 'a>() -> impl const Foo {}
+   |                     ^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/traits/const-traits/variance.stderr
+++ b/tests/ui/traits/const-traits/variance.stderr
@@ -1,4 +1,4 @@
-error: ['a: o]
+error: ['a: *]
   --> $DIR/variance.rs:10:21
    |
 LL | fn foo<'a: 'a>() -> impl const Foo {}


### PR DESCRIPTION
Discovered as part of an implementation of rust-lang/rfcs#3729 - w/out this then when introducing const trait bounds: many more interesting tests change with different output, missing errors, new errors, etc related to this but they all depend on feature flags and are much more complex than this test.

r? @oli-obk