### PR TITLE
Introduce `feature(generic_const_parameter_types)`

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -508,6 +508,8 @@ declare_features! (
     (incomplete, generic_const_exprs, "1.56.0", Some(76560)),
     /// Allows generic parameters and where-clauses on free & associated const items.
     (incomplete, generic_const_items, "1.73.0", Some(113521)),
+    /// Allows the type of const generics to depend on generic parameters
+    (incomplete, generic_const_parameter_types, "CURRENT_RUSTC_VERSION", Some(137626)),
     /// Allows any generic constants being used as pattern type range ends
     (incomplete, generic_pattern_types, "1.86.0", Some(136574)),
     /// Allows registering static items globally, possibly across crates, to iterate over at runtime.

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -966,7 +966,7 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) -> Result<(), 
             let ty = tcx.type_of(param.def_id).instantiate_identity();
 
             if tcx.features().unsized_const_params() {
-                enter_wf_checking_ctxt(tcx, hir_ty.span, param.def_id, |wfcx| {
+                enter_wf_checking_ctxt(tcx, hir_ty.span, tcx.local_parent(param.def_id), |wfcx| {
                     wfcx.register_bound(
                         ObligationCause::new(
                             hir_ty.span,
@@ -980,7 +980,7 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) -> Result<(), 
                     Ok(())
                 })
             } else if tcx.features().adt_const_params() {
-                enter_wf_checking_ctxt(tcx, hir_ty.span, param.def_id, |wfcx| {
+                enter_wf_checking_ctxt(tcx, hir_ty.span, tcx.local_parent(param.def_id), |wfcx| {
                     wfcx.register_bound(
                         ObligationCause::new(
                             hir_ty.span,

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1822,6 +1822,9 @@ fn const_param_default<'tcx>(
         ),
     };
     let icx = ItemCtxt::new(tcx, def_id);
-    let ct = icx.lowerer().lower_const_arg(default_ct, FeedConstTy::Param(def_id.to_def_id()));
+    let identity_args = ty::GenericArgs::identity_for_item(tcx, def_id);
+    let ct = icx
+        .lowerer()
+        .lower_const_arg(default_ct, FeedConstTy::Param(def_id.to_def_id(), identity_args));
     ty::EarlyBinder::bind(ct)
 }

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -223,10 +223,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
             }
             hir::GenericParamKind::Const { .. } => {
                 let param_def_id = param.def_id.to_def_id();
-                let ct_ty = tcx
-                    .type_of(param_def_id)
-                    .no_bound_vars()
-                    .expect("const parameters cannot be generic");
+                let ct_ty = tcx.type_of(param_def_id).instantiate_identity();
                 let ct = icx.lowerer().lower_const_param(param_def_id, param.hir_id);
                 predicates
                     .insert((ty::ClauseKind::ConstArgHasType(ct, ct_ty).upcast(tcx), param.span));

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -273,7 +273,7 @@ pub fn lower_generic_args<'tcx: 'a, 'a>(
 
                             // We lower to an infer even when the feature gate is not enabled
                             // as it is useful for diagnostics to be able to see a `ConstKind::Infer`
-                            args.push(ctx.provided_kind(param, arg));
+                            args.push(ctx.provided_kind(&args, param, arg));
                             args_iter.next();
                             params.next();
                         }

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -260,7 +260,7 @@ pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
 pub fn lower_const_arg_for_rustdoc<'tcx>(
     tcx: TyCtxt<'tcx>,
     hir_ct: &hir::ConstArg<'tcx>,
-    feed: FeedConstTy,
+    feed: FeedConstTy<'_, 'tcx>,
 ) -> Const<'tcx> {
     let env_def_id = tcx.hir_get_parent_item(hir_ct.hir_id);
     collect::ItemCtxt::new(tcx, env_def_id.def_id).lowerer().lower_const_arg(hir_ct, feed)

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -519,7 +519,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn lower_const_arg(
         &self,
         const_arg: &'tcx hir::ConstArg<'tcx>,
-        feed: FeedConstTy,
+        feed: FeedConstTy<'_, 'tcx>,
     ) -> ty::Const<'tcx> {
         let ct = self.lowerer().lower_const_arg(const_arg, feed);
         self.register_wf_obligation(
@@ -1135,7 +1135,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .last()
             .is_some_and(|GenericPathSegment(def_id, _)| tcx.generics_of(*def_id).has_self);
 
-        let (res, self_ctor_args) = if let Res::SelfCtor(impl_def_id) = res {
+        let (res, implicit_args) = if let Res::Def(DefKind::ConstParam, def) = res {
+            // types of const parameters are somewhat special as they are part of
+            // the same environment as the const parameter itself. this means that
+            // unlike most paths `type-of(N)` can return a type naming parameters
+            // introduced by the containing item, rather than provided through `N`.
+            //
+            // for example given `<T, const M: usize, const N: [T; M]>` and some
+            // `let a = N;` expression. The path to `N` would wind up with no args
+            // (as it has no args), but instantiating the early binder on `typeof(N)`
+            // requires providing generic arguments for `[T, M, N]`.
+            (res, Some(ty::GenericArgs::identity_for_item(tcx, tcx.parent(def))))
+        } else if let Res::SelfCtor(impl_def_id) = res {
             let ty = LoweredTy::from_raw(
                 self,
                 span,
@@ -1261,6 +1272,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             fn provided_kind(
                 &mut self,
+                preceding_args: &[ty::GenericArg<'tcx>],
                 param: &ty::GenericParamDef,
                 arg: &GenericArg<'tcx>,
             ) -> ty::GenericArg<'tcx> {
@@ -1280,7 +1292,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     (GenericParamDefKind::Const { .. }, GenericArg::Const(ct)) => self
                         .fcx
                         // Ambiguous parts of `ConstArg` are handled in the match arms below
-                        .lower_const_arg(ct.as_unambig_ct(), FeedConstTy::Param(param.def_id))
+                        .lower_const_arg(
+                            ct.as_unambig_ct(),
+                            FeedConstTy::Param(param.def_id, preceding_args),
+                        )
                         .into(),
                     (&GenericParamDefKind::Const { .. }, GenericArg::Infer(inf)) => {
                         self.fcx.ct_infer(Some(param), inf.span).into()
@@ -1320,7 +1335,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
-        let args_raw = self_ctor_args.unwrap_or_else(|| {
+        let args_raw = implicit_args.unwrap_or_else(|| {
             lower_generic_args(
                 self,
                 def_id,

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -426,6 +426,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
 
             fn provided_kind(
                 &mut self,
+                preceding_args: &[ty::GenericArg<'tcx>],
                 param: &ty::GenericParamDef,
                 arg: &GenericArg<'tcx>,
             ) -> ty::GenericArg<'tcx> {
@@ -446,7 +447,10 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                     (GenericParamDefKind::Const { .. }, GenericArg::Const(ct)) => self
                         .cfcx
                         // We handle the ambig portions of `ConstArg` in the match arms below
-                        .lower_const_arg(ct.as_unambig_ct(), FeedConstTy::Param(param.def_id))
+                        .lower_const_arg(
+                            ct.as_unambig_ct(),
+                            FeedConstTy::Param(param.def_id, preceding_args),
+                        )
                         .into(),
                     (GenericParamDefKind::Const { .. }, GenericArg::Infer(inf)) => {
                         self.cfcx.ct_infer(Some(param), inf.span).into()

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -342,6 +342,7 @@ impl ParamConst {
         ParamConst::new(def.index, def.name)
     }
 
+    #[instrument(level = "debug")]
     pub fn find_ty_from_env<'tcx>(self, env: ParamEnv<'tcx>) -> Ty<'tcx> {
         let mut candidates = env.caller_bounds().iter().filter_map(|clause| {
             // `ConstArgHasType` are never desugared to be higher ranked.

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -125,9 +125,6 @@ resolve_const_param_in_enum_discriminant =
 resolve_const_param_in_non_trivial_anon_const =
     const parameters may only be used as standalone arguments, i.e. `{$name}`
 
-resolve_const_param_in_ty_of_const_param =
-    const parameters may not be used in the type of const parameters
-
 resolve_constructor_private_if_any_field_private =
     a constructor is private if any of the fields is private
 
@@ -249,9 +246,6 @@ resolve_lifetime_param_in_enum_discriminant =
 
 resolve_lifetime_param_in_non_trivial_anon_const =
     lifetime parameters may not be used in const expressions
-
-resolve_lifetime_param_in_ty_of_const_param =
-    lifetime parameters may not be used in the type of const parameters
 
 resolve_lowercase_self =
     attempt to use a non-constant value in a constant
@@ -436,9 +430,6 @@ resolve_type_param_in_enum_discriminant =
 
 resolve_type_param_in_non_trivial_anon_const =
     type parameters may not be used in const expressions
-
-resolve_type_param_in_ty_of_const_param =
-    type parameters may not be used in the type of const parameters
 
 resolve_undeclared_label =
     use of undeclared label `{$name}`

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -890,9 +890,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ResolutionError::ForwardDeclaredGenericParam => {
                 self.dcx().create_err(errs::ForwardDeclaredGenericParam { span })
             }
-            ResolutionError::ParamInTyOfConstParam { name, param_kind: is_type } => self
-                .dcx()
-                .create_err(errs::ParamInTyOfConstParam { span, name, param_kind: is_type }),
+            ResolutionError::ParamInTyOfConstParam { name } => {
+                self.dcx().create_err(errs::ParamInTyOfConstParam { span, name })
+            }
             ResolutionError::ParamInNonTrivialAnonConst { name, param_kind: is_type } => {
                 self.dcx().create_err(errs::ParamInNonTrivialAnonConst {
                     span,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -347,19 +347,6 @@ pub(crate) struct ParamInTyOfConstParam {
     #[label]
     pub(crate) span: Span,
     pub(crate) name: Symbol,
-    #[subdiagnostic]
-    pub(crate) param_kind: Option<ParamKindInTyOfConstParam>,
-}
-
-#[derive(Debug)]
-#[derive(Subdiagnostic)]
-pub(crate) enum ParamKindInTyOfConstParam {
-    #[note(resolve_type_param_in_ty_of_const_param)]
-    Type,
-    #[note(resolve_const_param_in_ty_of_const_param)]
-    Const,
-    #[note(resolve_lifetime_param_in_ty_of_const_param)]
-    Lifetime,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3052,7 +3052,6 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             .create_err(errors::ParamInTyOfConstParam {
                 span: lifetime_ref.ident.span,
                 name: lifetime_ref.ident.name,
-                param_kind: Some(errors::ParamKindInTyOfConstParam::Lifetime),
             })
             .emit();
     }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -30,9 +30,7 @@ use std::sync::Arc;
 
 use diagnostics::{ImportSuggestion, LabelSuggestion, Suggestion};
 use effective_visibilities::EffectiveVisibilitiesVisitor;
-use errors::{
-    ParamKindInEnumDiscriminant, ParamKindInNonTrivialAnonConst, ParamKindInTyOfConstParam,
-};
+use errors::{ParamKindInEnumDiscriminant, ParamKindInNonTrivialAnonConst};
 use imports::{Import, ImportData, ImportKind, NameResolution};
 use late::{HasGenericParams, PathSource, PatternSource, UnnecessaryQualification};
 use macros::{MacroRulesBinding, MacroRulesScope, MacroRulesScopeRef};
@@ -276,8 +274,10 @@ enum ResolutionError<'ra> {
     },
     /// Error E0128: generic parameters with a default cannot use forward-declared identifiers.
     ForwardDeclaredGenericParam,
+    // FIXME(generic_const_parameter_types): This should give custom output specifying it's only
+    // problematic to use *forward declared* parameters when the feature is enabled.
     /// ERROR E0770: the type of const parameters must not depend on other generic parameters.
-    ParamInTyOfConstParam { name: Symbol, param_kind: Option<ParamKindInTyOfConstParam> },
+    ParamInTyOfConstParam { name: Symbol },
     /// generic parameters must not be used inside const evaluations.
     ///
     /// This error is only emitted when using `min_const_generics`.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1037,6 +1037,7 @@ symbols! {
         generic_associated_types_extended,
         generic_const_exprs,
         generic_const_items,
+        generic_const_parameter_types,
         generic_param_attrs,
         generic_pattern_types,
         get_context,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1189,9 +1189,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let span = obligation.cause.span;
 
         let mut diag = match ty.kind() {
-            _ if ty.has_param() => {
-                span_bug!(span, "const param tys cannot mention other generic parameters");
-            }
             ty::Float(_) => {
                 struct_span_code_err!(
                     self.dcx(),

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.full.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.full.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
    |                                                    ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/const-param-type-depends-on-const-param.rs:15:40
    |
 LL | pub struct SelfDependent<const N: [u8; N]>;
    |                                        ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
    |                                                    ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/const-param-type-depends-on-const-param.rs:15:40
    |
 LL | pub struct SelfDependent<const N: [u8; N]>;
    |                                        ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: `[u8; N]` is forbidden as the type of a const generic parameter
   --> $DIR/const-param-type-depends-on-const-param.rs:11:47

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct B<T, const N: T>(PhantomData<[T; N]>);
    |                      ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param.full.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                                  ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/const-param-type-depends-on-type-param.rs:11:22

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param.min.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                                  ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/const-param-type-depends-on-type-param.rs:11:22

--- a/tests/ui/const-generics/generic_const_parameter_types/bad_inference.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/bad_inference.rs
@@ -1,0 +1,23 @@
+#![feature(
+    adt_const_params,
+    unsized_const_params,
+    generic_const_parameter_types,
+    generic_arg_infer
+)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<T: ConstParamTy_, const N: usize, const M: [T; N]>() -> [T; N] {
+    loop {}
+}
+
+fn main() {
+    // Requires inferring `T`/`N` from `12_u8` and `2` respectively.
+    let a = foo::<_, _, { [12_u8; 2] }>();
+    //~^ ERROR: anonymous constants with inferred types are not yet supported
+
+    // Requires inferring `T`/`N`/`12_?i`/`_` from `[u8; 2]`
+    let b: [u8; 2] = foo::<_, _, { [12; _] }>();
+    //~^ ERROR: anonymous constants with inferred types are not yet supported
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/bad_inference.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/bad_inference.stderr
@@ -1,0 +1,14 @@
+error: anonymous constants with inferred types are not yet supported
+  --> $DIR/bad_inference.rs:17:25
+   |
+LL |     let a = foo::<_, _, { [12_u8; 2] }>();
+   |                         ^^^^^^^^^^^^^^
+
+error: anonymous constants with inferred types are not yet supported
+  --> $DIR/bad_inference.rs:21:34
+   |
+LL |     let b: [u8; 2] = foo::<_, _, { [12; _] }>();
+   |                                  ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/const-generics/generic_const_parameter_types/evaluate_const_parameter_in_mir.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/evaluate_const_parameter_in_mir.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+
+#![feature(
+    adt_const_params,
+    unsized_const_params,
+    generic_const_parameter_types,
+    generic_arg_infer
+)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<T: ConstParamTy_, const N: usize, const M: [T; N]>() -> [T; N] {
+    M
+}
+
+fn main() {
+    let a: [u8; 2] = foo::<u8, 2, { [12; _] }>();
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.rs
@@ -1,0 +1,11 @@
+#![feature(adt_const_params, generic_const_parameter_types)]
+#![expect(incomplete_features)]
+
+use std::marker::PhantomData;
+
+struct UsesConst<const N: [u8; M], const M: usize>;
+//~^ ERROR: the type of const parameters must not depend on other generic parameters
+struct UsesType<const N: [T; 2], T>(PhantomData<T>);
+//~^ ERROR: the type of const parameters must not depend on other generic parameters
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.stderr
@@ -1,0 +1,15 @@
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/forward_declared_type.rs:6:32
+   |
+LL | struct UsesConst<const N: [u8; M], const M: usize>;
+   |                                ^ the type must not depend on the parameter `M`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/forward_declared_type.rs:8:27
+   |
+LL | struct UsesType<const N: [T; 2], T>(PhantomData<T>);
+   |                           ^ the type must not depend on the parameter `T`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/generic_const_parameter_types/inferred_from_arg.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/inferred_from_arg.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+
+#![feature(adt_const_params, generic_arg_infer, generic_const_parameter_types)]
+#![expect(incomplete_features)]
+
+struct Bar<const N: usize, const M: [u8; N]>;
+
+fn foo<const N: usize, const M: [u8; N]>(_: Bar<N, M>) {}
+
+fn main() {
+    foo(Bar::<2, { [1; 2] }>);
+    foo::<_, _>(Bar::<2, { [1; 2] }>);
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.rs
@@ -1,0 +1,20 @@
+#![feature(generic_const_parameter_types, adt_const_params, unsized_const_params)]
+#![expect(incomplete_features)]
+
+fn foo<'a, const N: &'a u32>() {}
+
+fn bar() {
+    foo::<'static, { &1_u32 }>();
+    //~^ ERROR: anonymous constants with lifetimes in their type are not yet supported
+    foo::<'_, { &1_u32 }>();
+    //~^ ERROR: anonymous constants with lifetimes in their type are not yet supported
+}
+
+fn borrowck<'a, const N: &'static u32, const M: &'a u32>() {
+    foo::<'a, M>();
+    foo::<'static, M>();
+    //~^ ERROR: lifetime may not live long enough
+    foo::<'static, N>();
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.stderr
@@ -1,0 +1,23 @@
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/lifetime_dependent_const_param.rs:7:20
+   |
+LL |     foo::<'static, { &1_u32 }>();
+   |                    ^^^^^^^^^^
+
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/lifetime_dependent_const_param.rs:9:15
+   |
+LL |     foo::<'_, { &1_u32 }>();
+   |               ^^^^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/lifetime_dependent_const_param.rs:15:5
+   |
+LL | fn borrowck<'a, const N: &'static u32, const M: &'a u32>() {
+   |             -- lifetime `'a` defined here
+LL |     foo::<'a, M>();
+LL |     foo::<'static, M>();
+   |     ^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.rs
@@ -1,0 +1,15 @@
+#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<const N: usize, const M: [u8; N]>() {}
+fn bar<T: ConstParamTy_, const M: [T; 2]>() {}
+
+fn main() {
+    foo::<3, { [1; 2] }>();
+    //~^ ERROR: mismatched type
+
+    bar::<u8, { [2_u16; 2] }>();
+    //~^ ERROR: mismatched type
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/mismatched_args_with_value.rs:10:16
+   |
+LL |     foo::<3, { [1; 2] }>();
+   |                ^^^^^^ expected an array with a size of 3, found one with a size of 2
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched_args_with_value.rs:13:18
+   |
+LL |     bar::<u8, { [2_u16; 2] }>();
+   |                  ^^^^^ expected `u8`, found `u16`
+   |
+help: change the type of the numeric literal from `u16` to `u8`
+   |
+LL -     bar::<u8, { [2_u16; 2] }>();
+LL +     bar::<u8, { [2_u8; 2] }>();
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.rs
@@ -1,0 +1,9 @@
+#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![expect(incomplete_features)]
+
+use std::marker::{ConstParamTy_, PhantomData};
+
+struct UsesType<T, const N: usize, const M: [T; N]>(PhantomData<T>);
+//~^ ERROR: `[T; N]` can't be used as a const parameter type
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.stderr
@@ -1,0 +1,11 @@
+error[E0741]: `[T; N]` can't be used as a const parameter type
+  --> $DIR/no_const_param_ty_bound.rs:6:45
+   |
+LL | struct UsesType<T, const N: usize, const M: [T; N]>(PhantomData<T>);
+   |                                             ^^^^^^
+   |
+   = note: `T` must implement `UnsizedConstParamTy`, but it does not
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0741`.

--- a/tests/ui/const-generics/generic_const_parameter_types/unrelated_inferred_arg.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/unrelated_inferred_arg.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+
+#![feature(
+    adt_const_params,
+    unsized_const_params,
+    generic_const_parameter_types,
+    generic_arg_infer
+)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<U, T: ConstParamTy_, const N: usize, const M: [T; N]>(_: U) -> [T; N] {
+    loop {}
+}
+
+fn main() {
+    // Check that `_` doesnt cause a "Type of const argument is uninferred" error
+    // as it is not actually used by the type of `M`.
+    let a = foo::<_, u8, 2, { [12; _] }>(true);
+}

--- a/tests/ui/const-generics/issues/issue-56445-1.full.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-1.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
    |                          ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-56445-1.min.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-1.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
    |                          ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-62878.full.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |                                      ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-62878.min.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |                                      ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: `[u8; N]` is forbidden as the type of a const generic parameter
   --> $DIR/issue-62878.rs:5:33

--- a/tests/ui/const-generics/issues/issue-71169.full.stderr
+++ b/tests/ui/const-generics/issues/issue-71169.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
    |                                           ^^^ the type must not depend on the parameter `LEN`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-71381.full.stderr
+++ b/tests/ui/const-generics/issues/issue-71381.full.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                                                  ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/issue-71381.rs:23:40
    |
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-71381.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71381.min.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                                                  ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/issue-71381.rs:23:40
    |
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71381.rs:14:61

--- a/tests/ui/const-generics/issues/issue-71611.full.stderr
+++ b/tests/ui/const-generics/issues/issue-71611.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                               ^ the type must not depend on the parameter `A`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-71611.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71611.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                               ^ the type must not depend on the parameter `A`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71611.rs:5:21

--- a/tests/ui/const-generics/issues/issue-88997.stderr
+++ b/tests/ui/const-generics/issues/issue-88997.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Range<T: PartialOrd, const MIN: T, const MAX: T>(T)
    |                                        ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/issue-88997.rs:8:54
    |
 LL | struct Range<T: PartialOrd, const MIN: T, const MAX: T>(T)
    |                                                      ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-90364.stderr
+++ b/tests/ui/const-generics/issues/issue-90364.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Foo<T, const H: T>(T)
    |                            ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0771.stderr
+++ b/tests/ui/error-codes/E0771.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn function_with_str<'a, const STRING: &'a str>() {}
    |                                         ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 warning: the feature `unsized_const_params` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/E0771.rs:1:30

--- a/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.normal.stderr
+++ b/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.normal.stderr
@@ -1,14 +1,14 @@
 error[E0770]: the type of const parameters must not depend on other generic parameters
-  --> $DIR/issue-71169.rs:5:43
+  --> $DIR/feature-gate-generic-const-parameter-types.rs:7:50
    |
-LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
-   |                                           ^^^ the type must not depend on the parameter `LEN`
+LL | struct MyADT<const LEN: usize, const ARRAY: [u8; LEN]>;
+   |                                                  ^^^ the type must not depend on the parameter `LEN`
 
 error: `[u8; LEN]` is forbidden as the type of a const generic parameter
-  --> $DIR/issue-71169.rs:5:38
+  --> $DIR/feature-gate-generic-const-parameter-types.rs:7:45
    |
-LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
-   |                                      ^^^^^^^^^
+LL | struct MyADT<const LEN: usize, const ARRAY: [u8; LEN]>;
+   |                                             ^^^^^^^^^
    |
    = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types

--- a/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.rs
+++ b/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.rs
@@ -1,0 +1,11 @@
+//@ [feature] check-pass
+//@ revisions: normal feature
+
+#![cfg_attr(feature, feature(adt_const_params, generic_const_parameter_types))]
+#![cfg_attr(feature, expect(incomplete_features))]
+
+struct MyADT<const LEN: usize, const ARRAY: [u8; LEN]>;
+//[normal]~^ ERROR: the type of const parameters must not depend on other generic parameters
+//[normal]~| ERROR: `[u8; LEN]` is forbidden as the type of a const generic parameter
+
+fn main() {}

--- a/tests/ui/generic-const-items/wfcheck_err_leak_issue_118179.stderr
+++ b/tests/ui/generic-const-items/wfcheck_err_leak_issue_118179.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct G<T, const N: Vec<T>>(T);
    |                          ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -9,8 +9,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
    |                      ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unusual-rib-combinations.rs:11:15

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.rs
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.rs
@@ -3,6 +3,7 @@ trait Foo<const N: Bar<2>> {
     //~^ WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| ERROR cycle detected when computing type of `Foo::N`
+    //~| ERROR cycle detected when computing type of `Foo::N`
     fn func() {}
 }
 

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -13,7 +13,7 @@ LL | trait Foo<const N: dyn Bar<2>> {
    |                    +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:9:20
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:20
    |
 LL | trait Bar<const M: Foo<2>> {}
    |                    ^^^^^^
@@ -32,7 +32,7 @@ LL | trait Foo<const N: Bar<2>> {
    |           ^^^^^^^^^^^^^^^
    |
 note: ...which requires computing type of `Bar::M`...
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:9:11
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:11
    |
 LL | trait Bar<const M: Foo<2>> {}
    |           ^^^^^^^^^^^^^^^
@@ -44,6 +44,26 @@ LL | trait Foo<const N: Bar<2>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 1 previous error; 2 warnings emitted
+error[E0391]: cycle detected when computing type of `Foo::N`
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:2:11
+   |
+LL | trait Foo<const N: Bar<2>> {
+   |           ^^^^^^^^^^^^^^^
+   |
+note: ...which requires computing type of `Bar::M`...
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:11
+   |
+LL | trait Bar<const M: Foo<2>> {}
+   |           ^^^^^^^^^^^^^^^
+   = note: ...which again requires computing type of `Foo::N`, completing the cycle
+note: cycle used when computing explicit predicates of trait `Foo`
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:2:1
+   |
+LL | trait Foo<const N: Bar<2>> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Allows to define const generic parameters whose type depends on other generic parameters, e.g. `Foo<const N: usize, const ARR: [u8; N]>;`

Wasn't going to implement for this for a while until we could implement it with `bad_inference.rs` resolved but apparently the project simd folks would like to be able to use this for some intrinsics and the inference issue isn't really a huge problem there aiui. (cc @workingjubilee )