### PR TITLE
Provide helpful diagnostics for shebang lookalikes

### DIFF
--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -127,12 +127,29 @@ impl<'a> Parser<'a> {
         let lo = self.token.span;
         // Attributes can't have attributes of their own [Editor's note: not with that attitude]
         self.collect_tokens_no_attrs(|this| {
+            let pound_hi = this.token.span.hi();
             assert!(this.eat(exp!(Pound)), "parse_attribute called in non-attribute position");
 
+            let not_lo = this.token.span.lo();
             let style =
                 if this.eat(exp!(Bang)) { ast::AttrStyle::Inner } else { ast::AttrStyle::Outer };
 
-            this.expect(exp!(OpenBracket))?;
+            let mut bracket_res = this.expect(exp!(OpenBracket));
+            // If `#!` is not followed by `[`
+            if let Err(err) = &mut bracket_res
+                && style == ast::AttrStyle::Inner
+                && pound_hi == not_lo
+            {
+                err.note(
+                    "the token sequence `#!` here looks like the start of \
+                    a shebang interpreter directive but it is not",
+                );
+                err.help(
+                    "if you meant this to be a shebang interpreter directive, \
+                    move it to the very start of the file",
+                );
+            }
+            bracket_res?;
             let item = this.parse_attr_item(ForceCollect::No)?;
             this.expect(exp!(CloseBracket))?;
             let attr_sp = lo.to(this.prev_token.span);

--- a/tests/ui/parser/shebang/issue-71471-ignore-tidy.stderr
+++ b/tests/ui/parser/shebang/issue-71471-ignore-tidy.stderr
@@ -3,6 +3,9 @@ error: expected `[`, found `B`
    |
 LL | #!B
    |   ^ expected `[`
+   |
+   = note: the token sequence `#!` here looks like the start of a shebang interpreter directive but it is not
+   = help: if you meant this to be a shebang interpreter directive, move it to the very start of the file
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/shebang/shebang-must-start-file.stderr
+++ b/tests/ui/parser/shebang/shebang-must-start-file.stderr
@@ -3,6 +3,9 @@ error: expected `[`, found `/`
    |
 LL | #!/bin/bash
    |   ^ expected `[`
+   |
+   = note: the token sequence `#!` here looks like the start of a shebang interpreter directive but it is not
+   = help: if you meant this to be a shebang interpreter directive, move it to the very start of the file
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/shebang/shebang-split.rs
+++ b/tests/ui/parser/shebang/shebang-split.rs
@@ -1,0 +1,5 @@
+// empty line
+# !/bin/env
+
+// checks that diagnostics for shebang lookalikes is not present
+//@ error-pattern: expected `[`\n\n

--- a/tests/ui/parser/shebang/shebang-split.stderr
+++ b/tests/ui/parser/shebang/shebang-split.stderr
@@ -1,0 +1,8 @@
+error: expected `[`, found `/`
+  --> $DIR/shebang-split.rs:2:4
+   |
+LL | # !/bin/env
+   |    ^ expected `[`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
When `[` is not found after a `#!`, a note will be added to the exisiting error

```
error: expected `[`, found `/`
 --> src/main.rs:2:3
  |
2 | #!/usr/bin/env -S cargo +nightly -Zscript
  |   ^ expected `[`
  |
  = note: the token sequence `#!` here looks like the start of a shebang interpreter directive but it is not
  = help: if you meant this to be a shebang interpreter directive, move it to the very start of the file
```

Fixes #137249 

r? @fmease 