### PR TITLE
Fix `attr` cast for espidf

### DIFF
--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -59,7 +59,7 @@ impl Thread {
             assert_eq!(
                 libc::pthread_attr_setstacksize(
                     attr.as_mut_ptr(),
-                    cmp::max(stack, min_stack_size(&attr))
+                    cmp::max(stack, min_stack_size(attr.as_ptr()))
                 ),
                 0
             );


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/136826 broke ESP-IDF builds with: https://github.com/esp-rs/esp-idf-template/actions/runs/13516221587/job/37765336588.

This PR fixes it.

cc: @ivmarkov @xizheyin