### PR TITLE
Suggest using dotdot for ignoring pat fields

### DIFF
--- a/compiler/rustc_privacy/messages.ftl
+++ b/compiler/rustc_privacy/messages.ftl
@@ -25,7 +25,7 @@ privacy_in_public_interface = {$vis_descr} {$kind} `{$descr}` in public interfac
 
 privacy_item_is_private = {$kind} `{$descr}` is private
     .label = private {$kind}
-    .suggestion = consider using `..` to ignore fields with private types
+    .suggestion = consider using `..` to ignore the field with private type
 
 privacy_private_interface_or_bounds_lint = {$ty_kind} `{$ty_descr}` is more private than the item `{$item_descr}`
     .item_label = {$item_kind} `{$item_descr}` is reachable at visibility `{$item_vis_descr}`

--- a/compiler/rustc_privacy/messages.ftl
+++ b/compiler/rustc_privacy/messages.ftl
@@ -25,6 +25,7 @@ privacy_in_public_interface = {$vis_descr} {$kind} `{$descr}` in public interfac
 
 privacy_item_is_private = {$kind} `{$descr}` is private
     .label = private {$kind}
+    .suggestion = consider using `..` to ignore fields with private types
 
 privacy_private_interface_or_bounds_lint = {$ty_kind} `{$ty_descr}` is more private than the item `{$item_descr}`
     .item_label = {$item_kind} `{$item_descr}` is reachable at visibility `{$item_vis_descr}`

--- a/compiler/rustc_privacy/src/errors.rs
+++ b/compiler/rustc_privacy/src/errors.rs
@@ -42,6 +42,8 @@ pub(crate) struct ItemIsPrivate<'a> {
     pub span: Span,
     pub kind: &'a str,
     pub descr: DiagArgFromDisplay<'a>,
+    #[suggestion(style = "verbose", code = "..", applicability = "maybe-incorrect")]
+    pub pat_span: Option<Span>,
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/privacy/private-pat-field-types.rs
+++ b/tests/ui/privacy/private-pat-field-types.rs
@@ -1,0 +1,14 @@
+mod foo {
+    struct Bar;
+    pub enum Foo {
+        #[allow(private_interfaces)]
+        A(Bar),
+    }
+}
+fn foo_bar(v: foo::Foo) {
+    match v {
+        foo::Foo::A(_) => {} //~ ERROR type `Bar` is private
+    }
+}
+
+fn main() {}

--- a/tests/ui/privacy/private-pat-field-types.stderr
+++ b/tests/ui/privacy/private-pat-field-types.stderr
@@ -1,0 +1,14 @@
+error: type `Bar` is private
+  --> $DIR/private-pat-field-types.rs:10:21
+   |
+LL |         foo::Foo::A(_) => {}
+   |                     ^ private type
+   |
+help: consider using `..` to ignore the field with private type
+   |
+LL -         foo::Foo::A(_) => {}
+LL +         foo::Foo::A(..) => {}
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes a part of #135903

The following case where multiple fields are ignored, as shown below, has been excluded from this implementation. In such cases, all underscores should be replaced with `..`. However, in the current implementation of the ItemIsPrivate error, errors for different fields are output as completely separate errors. To fix this, a somewhat substantial change to the TypePrivacyVisitor is necessary. 

Also, a similar suggestion for struct patterns has not been implemented in this pull request.

```rust
match v {
    foo::Foo::A(_, _) => {}
}
```