### PR TITLE
Update `compiler-builtins` to 0.1.149

### DIFF
--- a/compiler/rustc_codegen_cranelift/patches/0029-stdlib-Disable-f16-and-f128-in-compiler-builtins.patch
+++ b/compiler/rustc_codegen_cranelift/patches/0029-stdlib-Disable-f16-and-f128-in-compiler-builtins.patch
@@ -16,8 +16,8 @@ index 7165c3e48af..968552ad435 100644
  
  [dependencies]
  core = { path = "../core", public = true }
--compiler_builtins = { version = "=0.1.148", features = ['rustc-dep-of-std'] }
-+compiler_builtins = { version = "=0.1.148", features = ['rustc-dep-of-std', 'no-f16-f128'] }
+-compiler_builtins = { version = "=0.1.150", features = ['rustc-dep-of-std'] }
++compiler_builtins = { version = "=0.1.150", features = ['rustc-dep-of-std', 'no-f16-f128'] }
  
  [dev-dependencies]
  rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.148"
+version = "0.1.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26137996631d90d2727b905b480fdcf8c4479fdbce7afd7f8e3796d689b33cc2"
+checksum = "5c42734e0ccf0d9f953165770593a75306f0b24dda1aa03f115c70748726dbca"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.148", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "=0.1.150", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.9.0", default-features = false, features = ["alloc"] }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.148" }
+compiler_builtins = { version = "=0.1.150" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',


### PR DESCRIPTION
Includes a change to make a subset of math symbols available on all platforms [1], and disables `f16` on aarch64 without neon [2].

[1]: https://github.com/rust-lang/compiler-builtins/pull/763
[2]: https://github.com/rust-lang/compiler-builtins/pull/775

try-job: aarch64-gnu
try-job: aarch64-gnu-debug
try-job: armhf-gnu
try-job: dist-various-1
try-job: dist-various-2
try-job: dist-aarch64-linux
try-job: dist-arm-linux
try-job: dist-armv7-linux
try-job: dist-x86_64-linux
try-job: test-various

<!-- homu-ignore:start -->
r? @ghost
<!-- homu-ignore:end -->
