### PR TITLE
Don't suggest constraining unstable associated types

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -136,7 +136,10 @@ pub fn suggest_restriction<'tcx, G: EmissionGuarantee>(
 ) {
     if hir_generics.where_clause_span.from_expansion()
         || hir_generics.where_clause_span.desugaring_kind().is_some()
-        || projection.is_some_and(|projection| tcx.is_impl_trait_in_trait(projection.def_id))
+        || projection.is_some_and(|projection| {
+            tcx.is_impl_trait_in_trait(projection.def_id)
+                || tcx.lookup_stability(projection.def_id).is_some_and(|stab| stab.is_unstable())
+        })
     {
         return;
     }

--- a/tests/ui/async-await/async-fn/suggest-constrain.rs
+++ b/tests/ui/async-await/async-fn/suggest-constrain.rs
@@ -1,0 +1,11 @@
+// Ensure that we don't suggest constraining `CallRefFuture` here,
+// since that isn't stable.
+
+fn spawn<F: AsyncFn() + Send>(f: F) {
+    check_send(f());
+    //~^ ERROR cannot be sent between threads safely
+}
+
+fn check_send<T: Send>(_: T) {}
+
+fn main() {}

--- a/tests/ui/async-await/async-fn/suggest-constrain.stderr
+++ b/tests/ui/async-await/async-fn/suggest-constrain.stderr
@@ -1,0 +1,18 @@
+error[E0277]: `<F as AsyncFnMut<()>>::CallRefFuture<'_>` cannot be sent between threads safely
+  --> $DIR/suggest-constrain.rs:5:16
+   |
+LL |     check_send(f());
+   |     ---------- ^^^ `<F as AsyncFnMut<()>>::CallRefFuture<'_>` cannot be sent between threads safely
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Send` is not implemented for `<F as AsyncFnMut<()>>::CallRefFuture<'_>`
+note: required by a bound in `check_send`
+  --> $DIR/suggest-constrain.rs:9:18
+   |
+LL | fn check_send<T: Send>(_: T) {}
+   |                  ^^^^ required by this bound in `check_send`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #137624

This could be made a bit more specific, considering the local crate's stability or nightly status or something, but I think in general we should not be suggesting associated type bounds on unstable associated items.