### PR TITLE
Check dyn flavor before registering upcast goal on wide pointer cast in MIR typeck

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2120,8 +2120,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                                 //
                                 // Note that other checks (such as denying `dyn Send` -> `dyn
                                 // Debug`) are in `rustc_hir_typeck`.
-                                if let ty::Dynamic(src_tty, _src_lt, _) = *src_tail.kind()
-                                    && let ty::Dynamic(dst_tty, dst_lt, _) = *dst_tail.kind()
+                                if let ty::Dynamic(src_tty, _src_lt, ty::Dyn) = *src_tail.kind()
+                                    && let ty::Dynamic(dst_tty, dst_lt, ty::Dyn) = *dst_tail.kind()
                                     && src_tty.principal().is_some()
                                     && dst_tty.principal().is_some()
                                 {

--- a/tests/ui/traits/trait-upcasting/dyn-to-dyn-star.rs
+++ b/tests/ui/traits/trait-upcasting/dyn-to-dyn-star.rs
@@ -1,0 +1,19 @@
+// While somewhat nonsensical, this is a cast from a wide pointer to a thin pointer.
+// Thus, we don't need to check an unsize goal here; there isn't any vtable casting
+// happening at all.
+
+// Regression test for <https://github.com/rust-lang/rust/issues/137579>.
+
+//@ check-pass
+
+#![allow(incomplete_features)]
+#![feature(dyn_star)]
+
+trait Foo {}
+trait Bar {}
+
+fn cast(x: *const dyn Foo) {
+    x as *const dyn* Bar;
+}
+
+fn main() {}


### PR DESCRIPTION
See the comment on the test :)

Fixes #137579