### PR TITLE
revert accidental change in get_closest_merge_commit

### DIFF
--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -154,6 +154,7 @@ pub fn get_closest_merge_commit(
         "rev-list",
         &format!("--author={}", config.git_merge_commit_email),
         "-n1",
+        "--first-parent",
         &merge_base,
     ]);
 


### PR DESCRIPTION
This was accidentally merged as part of https://github.com/rust-lang/rust/pull/137594. I need this local diff to be able to debug miri syncs, and then typed `git commit -a` too fast and didn't realize it includes this change... sorry for that.

r? @Kobzol 