### PR TITLE
Enable `f16` for LoongArch

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -106,7 +106,6 @@ fn main() {
         // Infinite recursion <https://github.com/llvm/llvm-project/issues/97981>
         ("csky", _) => false,
         ("hexagon", _) => false,
-        ("loongarch64", _) => false,
         ("powerpc" | "powerpc64", _) => false,
         ("sparc" | "sparc64", _) => false,
         ("wasm32" | "wasm64", _) => false,


### PR DESCRIPTION
Blocked on https://github.com/rust-lang/compiler-builtins/pull/770

r? @tgross35

Tracking issue for f16: https://github.com/rust-lang/rust/issues/116909

try-job: dist-loongarch64-linux
try-job: dist-loongarch64-musl