### PR TITLE
Various coretests improvements

### DIFF
--- a/library/coretests/tests/slice.rs
+++ b/library/coretests/tests/slice.rs
@@ -5,8 +5,6 @@ use core::num::NonZero;
 use core::ops::{Range, RangeInclusive};
 use core::slice;
 
-use rand::seq::IndexedRandom;
-
 #[test]
 fn test_position() {
     let b = [1, 2, 3, 5, 5];
@@ -1810,6 +1808,7 @@ fn select_nth_unstable() {
     use core::cmp::Ordering::{Equal, Greater, Less};
 
     use rand::Rng;
+    use rand::seq::IndexedRandom;
 
     let mut rng = crate::test_rng();
 

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2785,14 +2785,15 @@ impl Step for Crate {
             _ => panic!("can only test libraries"),
         };
 
-        run_cargo_test(
-            cargo,
-            &[],
-            &self.crates,
-            &*crate_description(&self.crates),
-            target,
-            builder,
-        );
+        let mut crates = self.crates.clone();
+        // The core crate can't directly be tested. We could silently
+        // ignore it, but adding it's own test crate is less confusing
+        // for users. We still keep core itself for doctests.
+        if crates.iter().any(|crate_| crate_ == "core") {
+            crates.push("coretests".to_owned());
+        }
+
+        run_cargo_test(cargo, &[], &crates, &*crate_description(&self.crates), target, builder);
     }
 }
 

--- a/src/bootstrap/src/core/metadata.rs
+++ b/src/bootstrap/src/core/metadata.rs
@@ -28,7 +28,6 @@ struct Package {
     source: Option<String>,
     manifest_path: String,
     dependencies: Vec<Dependency>,
-    targets: Vec<Target>,
     features: BTreeMap<String, Vec<String>>,
 }
 
@@ -38,11 +37,6 @@ struct Package {
 struct Dependency {
     name: String,
     source: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct Target {
-    kind: Vec<String>,
 }
 
 /// Collects and stores package metadata of each workspace members into `build`,
@@ -59,12 +53,10 @@ pub fn build(build: &mut Build) {
                 .filter(|dep| dep.source.is_none())
                 .map(|dep| dep.name)
                 .collect();
-            let has_lib = package.targets.iter().any(|t| t.kind.iter().any(|k| k == "lib"));
             let krate = Crate {
                 name: name.clone(),
                 deps,
                 path,
-                has_lib,
                 features: package.features.keys().cloned().collect(),
             };
             let relative_path = krate.local_path(build);

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -185,7 +185,6 @@ struct Crate {
     name: String,
     deps: HashSet<String>,
     path: PathBuf,
-    has_lib: bool,
     features: Vec<String>,
 }
 


### PR DESCRIPTION
The first commit is not yet strictly necessary as directly testing libcore works though useless work, but will be necessary once https://github.com/rust-lang/rust/pull/136642 migrates the liballoc tests into a separate package. The second commit fixes https://github.com/rust-lang/rust/issues/137478 and ensures that coretests actually gets tested on all CI job. The third commit fixes an error that didn't get caught because coretests doesn't run on the wasm32 CI job.