### PR TITLE
Add a tidy check for GCC submodule version

### DIFF
--- a/src/tools/tidy/src/gcc_submodule.rs
+++ b/src/tools/tidy/src/gcc_submodule.rs
@@ -1,0 +1,47 @@
+//! Tidy check to ensure that the commit SHA of the `src/gcc` submodule is the same as the
+//! required GCC version of the GCC codegen backend.
+
+use std::path::Path;
+use std::process::Command;
+
+pub fn check(root_path: &Path, compiler_path: &Path, bad: &mut bool) {
+    let cg_gcc_version_path = compiler_path.join("rustc_codegen_gcc/libgccjit.version");
+    let cg_gcc_version = std::fs::read_to_string(&cg_gcc_version_path)
+        .expect(&format!("Cannot read GCC version from {}", cg_gcc_version_path.display()))
+        .trim()
+        .to_string();
+
+    let git_output = Command::new("git")
+        .current_dir(root_path)
+        .arg("submodule")
+        .arg("status")
+        // --cached asks for the version that is actually committed in the repository, not the one
+        // that is currently checked out.
+        .arg("--cached")
+        .arg("src/gcc")
+        .output()
+        .expect("Cannot determine git SHA of the src/gcc checkout");
+
+    // This can return e.g.
+    // -e607be166673a8de9fc07f6f02c60426e556c5f2 src/gcc
+    //  e607be166673a8de9fc07f6f02c60426e556c5f2 src/gcc (master-e607be166673a8de9fc07f6f02c60426e556c5f2.e607be)
+    // +e607be166673a8de9fc07f6f02c60426e556c5f2 src/gcc (master-e607be166673a8de9fc07f6f02c60426e556c5f2.e607be)
+    let git_output = String::from_utf8_lossy(&git_output.stdout)
+        .trim()
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_string();
+
+    // The SHA can start with + if the submodule is modified or - if it is not checked out.
+    let gcc_submodule_sha = git_output.trim_start_matches(&['+', '-']);
+    if gcc_submodule_sha != cg_gcc_version {
+        *bad = true;
+        eprintln!(
+            r#"Commit SHA of the src/gcc submodule (`{gcc_submodule_sha}`) does not match the required GCC version of the GCC codegen backend (`{cg_gcc_version}`).
+Make sure to set the src/gcc submodule to commit {cg_gcc_version}.
+The GCC codegen backend commit is configured at {}."#,
+            cg_gcc_version_path.display(),
+        );
+    }
+}

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -75,6 +75,7 @@ pub mod features;
 pub mod fluent_alphabetical;
 pub mod fluent_period;
 mod fluent_used;
+pub mod gcc_submodule;
 pub(crate) mod iter_header;
 pub mod known_bug;
 pub mod mir_opt_tests;

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -116,6 +116,7 @@ fn main() {
         check!(fluent_alphabetical, &compiler_path, bless);
         check!(fluent_period, &compiler_path);
         check!(target_policy, &root_path);
+        check!(gcc_submodule, &root_path, &compiler_path);
 
         // Checks that only make sense for the std libs.
         check!(pal, &library_path);


### PR DESCRIPTION
To make sure that it stays in sync with the required GCC version of the GCC codegen backend.

The check should succeed on CI, although it will fail after https://github.com/rust-lang/rust/pull/137660, until the next GCC sync.

r? @GuillaumeGomez
