### PR TITLE
Add rustdoc support for `--emit=dep-info[=path]`

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -315,23 +315,30 @@ pub(crate) enum ModuleSorting {
     Alphabetical,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum EmitType {
     Unversioned,
     Toolchain,
     InvocationSpecific,
+    DepInfo(Option<PathBuf>),
 }
 
 impl FromStr for EmitType {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use EmitType::*;
         match s {
-            "unversioned-shared-resources" => Ok(Unversioned),
-            "toolchain-shared-resources" => Ok(Toolchain),
-            "invocation-specific" => Ok(InvocationSpecific),
-            _ => Err(()),
+            "unversioned-shared-resources" => Ok(Self::Unversioned),
+            "toolchain-shared-resources" => Ok(Self::Toolchain),
+            "invocation-specific" => Ok(Self::InvocationSpecific),
+            "dep-info" => Ok(Self::DepInfo(None)),
+            option => {
+                if let Some(file) = option.strip_prefix("dep-info=") {
+                    Ok(Self::DepInfo(Some(Path::new(file).into())))
+                } else {
+                    Err(())
+                }
+            }
         }
     }
 }
@@ -339,6 +346,15 @@ impl FromStr for EmitType {
 impl RenderOptions {
     pub(crate) fn should_emit_crate(&self) -> bool {
         self.emit.is_empty() || self.emit.contains(&EmitType::InvocationSpecific)
+    }
+
+    pub(crate) fn dep_info(&self) -> Option<Option<&Path>> {
+        for emit in &self.emit {
+            if let EmitType::DepInfo(file) = emit {
+                return Some(file.as_deref());
+            }
+        }
+        None
     }
 }
 

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -153,7 +153,7 @@ fn write_rendered_cross_crate_info(
     include_sources: bool,
 ) -> Result<(), Error> {
     let m = &opt.should_merge;
-    if opt.emit.is_empty() || opt.emit.contains(&EmitType::InvocationSpecific) {
+    if opt.should_emit_crate() {
         if include_sources {
             write_rendered_cci::<SourcesPart, _>(SourcesPart::blank, dst, crates, m)?;
         }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -561,7 +561,7 @@ fn opts() -> Vec<RustcOptGroup> {
             "",
             "emit",
             "Comma separated list of types of output for rustdoc to emit",
-            "[unversioned-shared-resources,toolchain-shared-resources,invocation-specific]",
+            "[unversioned-shared-resources,toolchain-shared-resources,invocation-specific,dep-info]",
         ),
         opt(Unstable, FlagMulti, "", "no-run", "Compile doctests without running them", ""),
         opt(
@@ -890,7 +890,13 @@ fn main_args(early_dcx: &mut EarlyDiagCtxt, at_args: &[String]) {
                 // if we ran coverage, bail early, we don't need to also generate docs at this point
                 // (also we didn't load in any of the useful passes)
                 return;
-            } else if run_check {
+            }
+
+            if render_opts.dep_info().is_some() {
+                rustc_interface::passes::write_dep_info(tcx);
+            }
+
+            if run_check {
                 // Since we're in "check" mode, no need to generate anything beyond this point.
                 return;
             }

--- a/src/tools/run-make-support/src/external_deps/rustdoc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustdoc.rs
@@ -132,4 +132,11 @@ impl Rustdoc {
         self.cmd.arg(format);
         self
     }
+
+    /// Specify type(s) of output files to generate.
+    pub fn emit<S: AsRef<str>>(&mut self, kinds: S) -> &mut Self {
+        let kinds = kinds.as_ref();
+        self.cmd.arg(format!("--emit={kinds}"));
+        self
+    }
 }

--- a/tests/run-make/rustdoc-default-output/output-default.stdout
+++ b/tests/run-make/rustdoc-default-output/output-default.stdout
@@ -153,7 +153,7 @@ Options:
         --generate-redirect-map 
                         Generate JSON file at the top level instead of
                         generating HTML redirection files
-        --emit [unversioned-shared-resources,toolchain-shared-resources,invocation-specific]
+        --emit [unversioned-shared-resources,toolchain-shared-resources,invocation-specific,dep-info]
                         Comma separated list of types of output for rustdoc to
                         emit
         --no-run        Compile doctests without running them

--- a/tests/run-make/rustdoc-dep-info/bar.rs
+++ b/tests/run-make/rustdoc-dep-info/bar.rs
@@ -1,0 +1,1 @@
+include!("foo.rs");

--- a/tests/run-make/rustdoc-dep-info/doc.md
+++ b/tests/run-make/rustdoc-dep-info/doc.md
@@ -1,0 +1,1 @@
+blablabla

--- a/tests/run-make/rustdoc-dep-info/foo.rs
+++ b/tests/run-make/rustdoc-dep-info/foo.rs
@@ -1,0 +1,1 @@
+pub fn foo() {}

--- a/tests/run-make/rustdoc-dep-info/lib.rs
+++ b/tests/run-make/rustdoc-dep-info/lib.rs
@@ -1,0 +1,6 @@
+#![crate_name = "foo"]
+
+#[cfg_attr(doc, doc = include_str!("doc.md"))]
+pub struct Bar;
+
+mod bar;

--- a/tests/run-make/rustdoc-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-dep-info/rmake.rs
@@ -1,0 +1,21 @@
+// This is a simple smoke test for rustdoc's `--emit dep-info` feature. It prints out
+// information about dependencies in a Makefile-compatible format, as a `.d` file.
+
+use run_make_support::assertion_helpers::assert_contains;
+use run_make_support::{path, rfs, rustdoc};
+
+fn main() {
+    // We're only emitting dep info, so we shouldn't be running static analysis to
+    // figure out that this program is erroneous.
+    rustdoc().input("lib.rs").arg("-Zunstable-options").emit("dep-info").run();
+
+    let content = rfs::read_to_string("foo.d");
+    assert_contains(&content, "lib.rs:");
+    assert_contains(&content, "foo.rs:");
+    assert_contains(&content, "bar.rs:");
+    assert_contains(&content, "doc.md:");
+
+    // Now we check that we can provide a file name to the `dep-info` argument.
+    rustdoc().input("lib.rs").arg("-Zunstable-options").emit("dep-info=bla.d").run();
+    assert!(path("bla.d").exists());
+}


### PR DESCRIPTION
Fixes #91982.

This PR adds the `--emit=dep-info` command line flag support. It will be helpful for `cargo` development.

cc @epage

r? @notriddle 