### PR TITLE
Re-enable `--generate-link-to-defintion` for tools internal rustdoc

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -987,9 +987,7 @@ macro_rules! tool_doc {
                 cargo.rustdocflag("-Arustdoc::private-intra-doc-links");
                 cargo.rustdocflag("--enable-index-page");
                 cargo.rustdocflag("--show-type-layout");
-                // FIXME: `--generate-link-to-definition` tries to resolve cfged out code
-                // see https://github.com/rust-lang/rust/pull/122066#issuecomment-1983049222
-                // cargo.rustdocflag("--generate-link-to-definition");
+                cargo.rustdocflag("--generate-link-to-definition");
 
                 let out_dir = builder.stage_out(compiler, Mode::ToolRustc).join(target).join("doc");
                 $(for krate in $crates {


### PR DESCRIPTION
~~These were removed because they used to break the build: https://github.com/rust-lang/rust/pull/122066#issuecomment-1983049222, but testing locally it seems to work now.~~

This was re enabled in #136589, but only for rustc, not tools.

The FIXME that prompted removing this is still present. Do we have an issue with an MCVE for this? CC @GuillaumeGomez 

https://github.com/rust-lang/rust/blob/ac91805f3179fc2225c60e8ccf5a1daa09d43f3d/src/librustdoc/html/render/span_map.rs#L178-L182

try-job: aarch64-apple