### PR TITLE
Inline the closure in `assemble_candidates_from_impls`.

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -556,6 +556,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         self.tcx().for_each_relevant_impl(
             obligation.predicate.def_id(),
             obligation.predicate.skip_binder().trait_ref.self_ty(),
+            #[inline(always)]
             |impl_def_id| {
                 // Before we create the generic parameters and everything, first
                 // consider a "quick reject". This avoids creating more types


### PR DESCRIPTION
It's really hot on some benchmarks, e.g. `bitmaps-3.1.0`.

r? @ghost