### PR TITLE
Update safety documentation for `CString::from_ptr` and `str::from_boxed_utf8_unchecked`

### DIFF
--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -352,9 +352,14 @@ impl CString {
     /// # Safety
     ///
     /// This should only ever be called with a pointer that was earlier
-    /// obtained by calling [`CString::into_raw`]. Other usage (e.g., trying to take
-    /// ownership of a string that was allocated by foreign code) is likely to lead
-    /// to undefined behavior or allocator corruption.
+    /// obtained by calling [`CString::into_raw`], and the memory it points to must not be accessed
+    /// through any other pointer during the lifetime of reconstructed `CString`.
+    /// Other usage (e.g., trying to take ownership of a string that was allocated by foreign code)
+    /// is likely to lead to undefined behavior or allocator corruption.
+    ///
+    /// This function does not validate ownership of the raw pointer's memory.
+    /// A double-free may occur if the function is called twice on the same raw pointer.
+    /// Additionally, the caller must ensure the pointer is not dangling.
     ///
     /// It should be noted that the length isn't just "recomputed," but that
     /// the recomputed length must match the original length from the

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -604,6 +604,10 @@ impl str {
 /// Converts a boxed slice of bytes to a boxed string slice without checking
 /// that the string contains valid UTF-8.
 ///
+/// # Safety
+///
+/// * The provided bytes must contain a valid UTF-8 sequence.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
## PR Description​
This PR addresses missing safety documentation for two APIs:

​**1. alloc::ffi::CStr::from_raw**​

- ​`Alias`: The pointer ​must not be aliased​ (accessed via other pointers) during the reconstructed CString's lifetime.
- `Owning`: Calling this function twice on the same pointer and creating two objects with overlapping lifetimes, introduces two alive owners of the same memory. This may result in a double-free.
- `Dangling`: The prior documentation required the pointer to originate from CString::into_raw, but this constraint is incomplete. A validly sourced pointer can also cause undefined behavior (UB) if it becomes dangling. A simple Poc for this situation:
```
use std::ffi::CString;
use std::os::raw::c_char;

fn create_dangling() -> *mut c_char {
    let local_ptr: *mut c_char = {
        let valid_data = CString::new("valid").unwrap();
        valid_data.into_raw() 
    }; 

    unsafe { 
        let _x = CString::from_raw(local_ptr); 
    } 
    local_ptr
}

fn main() {
    let dangling = create_dangling();
    unsafe {let _y = CString::from_raw(dangling);} // Cause UB!
}
```

​**2. alloc::str::from_boxed_utf8_unchecked**​

- `ValidStr`: Bytes must contain a ​valid UTF-8 sequence.