### PR TITLE
Use original command for showing sccache stats

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -279,5 +279,5 @@ if [ "$RUN_CHECK_WITH_PARALLEL_QUERIES" != "" ]; then
 fi
 
 echo "::group::sccache stats"
-sccache --show-adv-stats || true
+sccache --show-stats || true
 echo "::endgroup::"


### PR DESCRIPTION
I used the newer advanced command after bumping Linux sccache to 0.9. However, Windows and macOS still use older sccache, so the command didn't work for them (the error was masked on CI though). It sucks that we don't see the Windows/macOS sccache stats, so until we update both of them, just use the older flag with slightly less information.