### PR TITLE
Use Windows 2019 for 32-bit MSVC CI jobs

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -35,6 +35,13 @@ runners:
     os: windows-2022
     <<: *base-job
 
+  # Temporarily use old Windows 2019 because of an issue with Windows 2022 GHA runner images.
+  # See https://github.com/rust-lang/rust/issues/137733 for more details.
+  # FIXME(#137733): go back to Windows 2022 once this is resolved
+  - &job-windows-19
+    os: windows-2019
+    <<: *base-job
+
   - &job-windows-25
     os: windows-2025
     <<: *base-job
@@ -474,13 +481,13 @@ auto:
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc  --enable-sanitizers
       SCRIPT: make ci-msvc-py
-    <<: *job-windows
+    <<: *job-windows-19
 
   - name: i686-msvc-2
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc --enable-sanitizers
       SCRIPT: make ci-msvc-ps1
-    <<: *job-windows
+    <<: *job-windows-19
 
   # x86_64-msvc-ext is split into multiple jobs to run tests in parallel.
   - name: x86_64-msvc-ext1
@@ -595,7 +602,7 @@ auto:
       SCRIPT: python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-windows
+    <<: *job-windows-19
 
   - name: dist-aarch64-msvc
     env:

--- a/tests/ui/parser/deep-unmatched-angle-brackets.rs
+++ b/tests/ui/parser/deep-unmatched-angle-brackets.rs
@@ -1,3 +1,5 @@
+//@ ignore-i686-pc-windows-msvc (#137733; exit status 0xc0000005, maybe memory usage?)
+
 trait Mul<T> {
     type Output;
 }

--- a/tests/ui/parser/deep-unmatched-angle-brackets.stderr
+++ b/tests/ui/parser/deep-unmatched-angle-brackets.stderr
@@ -1,5 +1,5 @@
 error: expected one of `!`, `+`, `,`, `::`, or `>`, found `(`
-  --> $DIR/deep-unmatched-angle-brackets.rs:14:63
+  --> $DIR/deep-unmatched-angle-brackets.rs:16:63
    |
 LL |         <f::<f::<f::<f::<f::<f::<f::<f::<f::<f::<f::<f::<f::<>();
    |                                                               ^ expected one of `!`, `+`, `,`, `::`, or `>`


### PR DESCRIPTION
Windows 2022 runner images have been updated today, which brought with itself an unfortunate problem with compiling C code (see https://github.com/rust-lang/cc-rs/pull/1425 or https://github.com/rust-lang/rust/issues/137733 for more details).

This is a temporary hotfix to try to unblock our CI.

r? @jieyouxu

try-job: i686-msvc-1
try-job: i686-msvc-2
try-job: dist-i686-msvc