### PR TITLE
Update E0133 docs for 2024 edition

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0133.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0133.md
@@ -45,6 +45,7 @@ unsafe fn g() {
 ```
 
 Linting against this is controlled via the `unsafe_op_in_unsafe_fn` lint, which
-is `allow` by default but will be upgraded to `warn` in a future edition.
+is `warn` by default in the 2024 edition and `allow` by default in earlier
+editions.
 
 [unsafe-section]: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html


### PR DESCRIPTION
The behavior of unsafe_op_in_unsafe_fn was changed in the 2024 edition. This updates this note in the E0133 docs to reflect that change.