### PR TITLE
Fix 32-bit MSVC CI

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -474,13 +474,13 @@ auto:
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc  --enable-sanitizers
       SCRIPT: make ci-msvc-py
-    <<: *job-windows
+    <<: *job-windows-8c
 
   - name: i686-msvc-2
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc --enable-sanitizers
       SCRIPT: make ci-msvc-ps1
-    <<: *job-windows
+    <<: *job-windows-8c
 
   # x86_64-msvc-ext is split into multiple jobs to run tests in parallel.
   - name: x86_64-msvc-ext1
@@ -595,7 +595,7 @@ auto:
       SCRIPT: python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-windows
+    <<: *job-windows-8c
 
   - name: dist-aarch64-msvc
     env:


### PR DESCRIPTION
By throwing more hardware at it. The large runners should still use the old image. This could buy us a couple of... hours? Days? Who knows.

See https://github.com/rust-lang/rust/issues/137733 for context.

r? @ghost

try-job: i686-msvc-1
try-job: i686-msvc-2
try-job: dist-i686-msvc