### PR TITLE
Remove latest Windows SDK from 32-bit CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,20 @@ jobs:
       - name: show the current environment
         run: src/ci/scripts/dump-environment.sh
 
+      # Temporary fix to unblock CI
+      # Remove the latest Windows SDK for 32-bit Windows MSVC builds.
+      # See issue https://github.com/rust-lang/rust/issues/137733 for more details.
+      - name: Remove Windows SDK 10.0.26100.0
+        shell: powershell
+        if: ${{ matrix.name == 'i686-msvc-1' || matrix.name == 'i686-msvc-2' || matrix.name == 'dist-i686-msvc' }}
+        run: |
+          $kits = (Get-ItemProperty -path 'HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots').KitsRoot10
+          $sdk_version = "10.0.26100.0"
+
+          foreach ($kind in 'Bin', 'Lib', 'Include') {
+            Remove-Item -Force -Recurse $kits\$kind\$sdk_version -ErrorAction Continue
+          }
+
       - name: run the build
         # Redirect stderr to stdout to avoid reordering the two streams in the GHA logs.
         run: src/ci/scripts/run-build-from-ci.sh 2>&1

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -474,13 +474,13 @@ auto:
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc  --enable-sanitizers
       SCRIPT: make ci-msvc-py
-    <<: *job-windows-8c
+    <<: *job-windows
 
   - name: i686-msvc-2
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc --enable-sanitizers
       SCRIPT: make ci-msvc-ps1
-    <<: *job-windows-8c
+    <<: *job-windows
 
   # x86_64-msvc-ext is split into multiple jobs to run tests in parallel.
   - name: x86_64-msvc-ext1
@@ -595,7 +595,7 @@ auto:
       SCRIPT: python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-windows-8c
+    <<: *job-windows
 
   - name: dist-aarch64-msvc
     env:


### PR DESCRIPTION
This is an alternative to #137766, in case that doesn't work. It is in some ways simpler but is less principled and may be more flaky (as it involves deleting stuff).

try-job: i686-msvc-1
try-job: i686-msvc-2
try-job: dist-i686-msvc