### PR TITLE
fix usage of ty decl macro fragments in attributes

### DIFF
--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -473,6 +473,15 @@ impl<'a> MetaItemListParserContext<'a> {
         {
             self.inside_delimiters.next();
             return Some(MetaItemOrLitParser::Lit(lit));
+        } else if let Some(TokenTree::Delimited(.., Delimiter::Invisible(_), inner_tokens)) =
+            self.inside_delimiters.peek()
+        {
+            self.inside_delimiters.next();
+            return MetaItemListParserContext {
+                inside_delimiters: inner_tokens.iter().peekable(),
+                dcx: self.dcx,
+            }
+            .next();
         }
 
         // or a path.

--- a/tests/ui/attributes/decl_macro_ty_in_attr_macro.rs
+++ b/tests/ui/attributes/decl_macro_ty_in_attr_macro.rs
@@ -1,0 +1,20 @@
+// tests for #137662: using a ty or (or most other) fragment inside an attr macro wouldn't work
+// because of a missing code path. With $repr: tt it did work.
+//@ check-pass
+
+macro_rules! foo {
+    {
+        $repr:ty
+    } => {
+        #[repr($repr)]
+        pub enum Foo {
+            Bar = 0i32,
+        }
+    }
+}
+
+foo! {
+    i32
+}
+
+fn main() {}


### PR DESCRIPTION
See the test case. Due to one missing code path (and also the changes in #137517), using $ty or other specific fragments as part of an attr wouldn't work. $tt used to work since it wouldn't be parsed anywhere along the way.

Closes #137662