### PR TITLE
Add `std::os::unix::process::CommandExt::chroot` to safely chroot a child process

### DIFF
--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -203,9 +203,11 @@ pub trait CommandExt: Sealed {
     /// the command.
     ///
     /// This happens before changing to the directory specified with `Command::current_dir`, and
-    /// that directory will be relative to the new root. If no directory has been specified with
-    /// `Command::current_dir`, this will set the directory to `/`, to avoid leaving the current
-    /// directory outside the chroot.
+    /// that directory will be relative to the new root.
+    ///
+    /// If no directory has been specified with `Command::current_dir`, this will set the directory
+    /// to `/`, to avoid leaving the current directory outside the chroot. (This is an intentional
+    /// difference from the underlying `chroot` system call.)
     #[unstable(feature = "process_chroot", issue = "none")]
     fn chroot<P: AsRef<Path>>(&mut self, dir: P) -> &mut process::Command;
 }

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -8,6 +8,7 @@ use cfg_if::cfg_if;
 
 use crate::ffi::OsStr;
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use crate::path::Path;
 use crate::sealed::Sealed;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 use crate::{io, process, sys};
@@ -197,6 +198,16 @@ pub trait CommandExt: Sealed {
     /// ```
     #[stable(feature = "process_set_process_group", since = "1.64.0")]
     fn process_group(&mut self, pgroup: i32) -> &mut process::Command;
+
+    /// Set the root of the child process. This calls `chroot` in the child process before executing
+    /// the command.
+    ///
+    /// This happens before changing to the directory specified with `Command::current_dir`, and
+    /// that directory will be relative to the new root. If no directory has been specified with
+    /// `Command::current_dir`, this will set the directory to `/`, to avoid leaving the current
+    /// directory outside the chroot.
+    #[unstable(feature = "process_chroot", issue = "none")]
+    fn chroot<P: AsRef<Path>>(&mut self, dir: P) -> &mut process::Command;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -240,6 +251,11 @@ impl CommandExt for process::Command {
 
     fn process_group(&mut self, pgroup: i32) -> &mut process::Command {
         self.as_inner_mut().pgroup(pgroup);
+        self
+    }
+
+    fn chroot<P: AsRef<Path>>(&mut self, dir: P) -> &mut process::Command {
+        self.as_inner_mut().chroot(dir.as_ref());
         self
     }
 }

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -208,7 +208,7 @@ pub trait CommandExt: Sealed {
     /// If no directory has been specified with `Command::current_dir`, this will set the directory
     /// to `/`, to avoid leaving the current directory outside the chroot. (This is an intentional
     /// difference from the underlying `chroot` system call.)
-    #[unstable(feature = "process_chroot", issue = "none")]
+    #[unstable(feature = "process_chroot", issue = "141298")]
     fn chroot<P: AsRef<Path>>(&mut self, dir: P) -> &mut process::Command;
 }
 

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -202,12 +202,12 @@ pub trait CommandExt: Sealed {
     /// Set the root of the child process. This calls `chroot` in the child process before executing
     /// the command.
     ///
-    /// This happens before changing to the directory specified with `Command::current_dir`, and
-    /// that directory will be relative to the new root.
+    /// This happens before changing to the directory specified with
+    /// [`process::Command::current_dir`], and that directory will be relative to the new root.
     ///
-    /// If no directory has been specified with `Command::current_dir`, this will set the directory
-    /// to `/`, to avoid leaving the current directory outside the chroot. (This is an intentional
-    /// difference from the underlying `chroot` system call.)
+    /// If no directory has been specified with [`process::Command::current_dir`], this will set the
+    /// directory to `/`, to avoid leaving the current directory outside the chroot. (This is an
+    /// intentional difference from the underlying `chroot` system call.)
     #[unstable(feature = "process_chroot", issue = "141298")]
     fn chroot<P: AsRef<Path>>(&mut self, dir: P) -> &mut process::Command;
 }

--- a/library/std/src/sys/process/unix/common.rs
+++ b/library/std/src/sys/process/unix/common.rs
@@ -88,6 +88,7 @@ pub struct Command {
 
     program_kind: ProgramKind,
     cwd: Option<CString>,
+    chroot: Option<CString>,
     uid: Option<uid_t>,
     gid: Option<gid_t>,
     saw_nul: bool,
@@ -182,6 +183,7 @@ impl Command {
             program_kind,
             env: Default::default(),
             cwd: None,
+            chroot: None,
             uid: None,
             gid: None,
             saw_nul,
@@ -206,6 +208,7 @@ impl Command {
             program_kind,
             env: Default::default(),
             cwd: None,
+            chroot: None,
             uid: None,
             gid: None,
             saw_nul,
@@ -253,6 +256,12 @@ impl Command {
     }
     pub fn pgroup(&mut self, pgroup: pid_t) {
         self.pgroup = Some(pgroup);
+    }
+    pub fn chroot(&mut self, dir: &Path) {
+        self.chroot = Some(os2c(dir.as_os_str(), &mut self.saw_nul));
+        if self.cwd.is_none() {
+            self.cwd(&OsStr::new("/"));
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -325,6 +334,10 @@ impl Command {
     #[allow(dead_code)]
     pub fn get_pgroup(&self) -> Option<pid_t> {
         self.pgroup
+    }
+    #[allow(dead_code)]
+    pub fn get_chroot(&self) -> Option<&CStr> {
+        self.chroot.as_deref()
     }
 
     pub fn get_closures(&mut self) -> &mut Vec<Box<dyn FnMut() -> io::Result<()> + Send + Sync>> {

--- a/library/std/src/sys/process/unix/vxworks.rs
+++ b/library/std/src/sys/process/unix/vxworks.rs
@@ -27,6 +27,12 @@ impl Command {
                 "nul byte found in provided data",
             ));
         }
+        if self.get_chroot().is_some() {
+            return Err(io::const_error!(
+                ErrorKind::Unsupported,
+                "chroot not supported by vxworks",
+            ));
+        }
         let (ours, theirs) = self.setup_io(default, needs_stdin)?;
         let mut p = Process { pid: 0, status: None };
 


### PR DESCRIPTION
This adds a `chroot` method to the `CommandExt` extension trait for the
`Command` builder, to set a directory to chroot into. This will chroot
the child process into that directory right before calling chdir for the
`Command`'s working directory.

To avoid allowing a process to have a working directory outside of the
chroot, if the `Command` does not yet have a working directory set,
`chroot` will set its working directory to "/".

---

ACP: https://github.com/rust-lang/libs-team/issues/551

This PR currently has the tracking issue set to "none"; if the ACP is approved,
I'll file a tracking issue and update the PR.
