### PR TITLE
More aggressive inlining in the `fast_reject` code.

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -100,7 +100,10 @@ pub fn overlapping_impls(
     let impl1_ref = tcx.impl_trait_ref(impl1_def_id);
     let impl2_ref = tcx.impl_trait_ref(impl2_def_id);
     let may_overlap = match (impl1_ref, impl2_ref) {
-        (Some(a), Some(b)) => drcx.args_may_unify(a.skip_binder().args, b.skip_binder().args),
+        (Some(a), Some(b)) => {
+            // This call site can be hot.
+            drcx.inlined_args_may_unify(a.skip_binder().args, b.skip_binder().args)
+        }
         (None, None) => {
             let self_ty1 = tcx.type_of(impl1_def_id).skip_binder();
             let self_ty2 = tcx.type_of(impl2_def_id).skip_binder();

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -561,9 +561,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // consider a "quick reject". This avoids creating more types
                 // and so forth that we need to.
                 let impl_trait_header = self.tcx().impl_trait_header(impl_def_id).unwrap();
-                if !drcx
-                    .args_may_unify(obligation_args, impl_trait_header.trait_ref.skip_binder().args)
-                {
+                // This call site can be hot.
+                if !drcx.inlined_args_may_unify(
+                    obligation_args,
+                    impl_trait_header.trait_ref.skip_binder().args,
+                ) {
                     return;
                 }
 


### PR DESCRIPTION
This code is very hot in a couple of benchmarks.

r? @lcnr