### PR TITLE
Optimize `CharIndices::advance_by`

### DIFF
--- a/library/alloctests/tests/str.rs
+++ b/library/alloctests/tests/str.rs
@@ -2357,10 +2357,26 @@ fn utf8_char_counts() {
 
                     assert!(!target.starts_with(" ") && !target.ends_with(" "));
                     let expected_count = tmpl_char_count * repeat;
+
                     assert_eq!(
                         expected_count,
                         target.chars().count(),
-                        "wrong count for `{:?}.repeat({})` (padding: `{:?}`)",
+                        "wrong count for `{:?}.repeat({}).count()` (padding: `{:?}`)",
+                        tmpl_str,
+                        repeat,
+                        (pad_start.len(), pad_end.len()),
+                    );
+
+                    // `.advance_by(n)` can also be used to count chars.
+                    let mut iter = target.chars();
+                    let remaining = match iter.advance_by(usize::MAX) {
+                        Ok(()) => 0,
+                        Err(remaining) => remaining.get(),
+                    };
+                    assert_eq!(
+                        expected_count,
+                        usize::MAX - remaining,
+                        "wrong count for `{:?}.repeat({}).advance_by(usize::MAX)` (padding: `{:?}`)",
                         tmpl_str,
                         repeat,
                         (pad_start.len(), pad_end.len()),

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -201,6 +201,15 @@ impl<'a> Iterator for CharIndices<'a> {
     }
 
     #[inline]
+    fn advance_by(&mut self, remainder: usize) -> Result<(), NonZero<usize>> {
+        let pre_len = self.iter.iter.len();
+        let res = self.iter.advance_by(remainder);
+        let len = self.iter.iter.len();
+        self.front_offset += pre_len - len;
+        res
+    }
+
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }

--- a/library/coretests/benches/str/char_count.rs
+++ b/library/coretests/benches/str/char_count.rs
@@ -48,25 +48,38 @@ macro_rules! define_benches {
 }
 
 define_benches! {
-    fn case00_libcore(s: &str) {
-        libcore(s)
+    fn case00_chars_count(s: &str) {
+        chars_count(s)
     }
 
-    fn case01_filter_count_cont_bytes(s: &str) {
+    fn case01_chars_advance_by(s: &str) {
+        chars_advance_by(s)
+    }
+
+    fn case02_filter_count_cont_bytes(s: &str) {
         filter_count_cont_bytes(s)
     }
 
-    fn case02_iter_increment(s: &str) {
-        iterator_increment(s)
+    fn case03_iter_chars_increment(s: &str) {
+        iter_chars_increment(s)
     }
 
-    fn case03_manual_char_len(s: &str) {
+    fn case04_manual_char_len(s: &str) {
         manual_char_len(s)
     }
 }
 
-fn libcore(s: &str) -> usize {
+fn chars_count(s: &str) -> usize {
     s.chars().count()
+}
+
+fn chars_advance_by(s: &str) -> usize {
+    let mut iter = s.chars();
+    let remaining = match iter.advance_by(usize::MAX) {
+        Ok(()) => 0,
+        Err(remaining) => remaining.get(),
+    };
+    usize::MAX - remaining
 }
 
 #[inline]
@@ -78,7 +91,7 @@ fn filter_count_cont_bytes(s: &str) -> usize {
     s.as_bytes().iter().filter(|&&byte| !utf8_is_cont_byte(byte)).count()
 }
 
-fn iterator_increment(s: &str) -> usize {
+fn iter_chars_increment(s: &str) -> usize {
     let mut c = 0;
     for _ in s.chars() {
         c += 1;


### PR DESCRIPTION
Optimize `CharIndices::advance_by` by delegating to the optimized `Chars::advance_by`. Since this can also be used to count chars, add a benchmark for it.

(`Interator::nth` uses `Iterator::advance_by`.)

cc @orlp