### PR TITLE
Reserve before `write_fmt` for owned buffers

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -645,8 +645,7 @@ pub fn format(args: Arguments<'_>) -> string::String {
     fn format_inner(args: Arguments<'_>) -> string::String {
         let capacity = args.estimated_capacity();
         let mut output = string::String::with_capacity(capacity);
-        output
-            .write_fmt(args)
+        core::fmt::write(&mut output, args)
             .expect("a formatting trait implementation returned an error when the underlying stream did not");
         output
     }

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -3172,6 +3172,15 @@ impl fmt::Write for String {
         self.push(c);
         Ok(())
     }
+
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
+        if let Some(s) = args.as_statically_known_str() {
+            self.write_str(s)
+        } else {
+            self.reserve(args.estimated_capacity());
+            fmt::write(self, args)
+        }
+    }
 }
 
 /// An iterator over the [`char`]s of a string.

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -799,9 +799,19 @@ impl Hash for OsString {
 
 #[stable(feature = "os_string_fmt_write", since = "1.64.0")]
 impl fmt::Write for OsString {
+    #[inline]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.push(s);
         Ok(())
+    }
+
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
+        if let Some(s) = args.as_statically_known_str() {
+            self.write_str(s)
+        } else {
+            self.reserve(args.estimated_capacity());
+            fmt::write(self, args)
+        }
     }
 }
 

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -511,6 +511,15 @@ impl<A: Allocator> Write for Vec<u8, A> {
         Ok(())
     }
 
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
+        if let Some(s) = args.as_statically_known_str() {
+            self.write_all(s.as_bytes())
+        } else {
+            self.reserve(args.estimated_capacity());
+            io::default_write_fmt(self, args)
+        }
+    }
+
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
@@ -660,6 +669,15 @@ impl<A: Allocator> Write for VecDeque<u8, A> {
     fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
         self.write_vectored(bufs)?;
         Ok(())
+    }
+
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
+        if let Some(s) = args.as_statically_known_str() {
+            self.write_all(s.as_bytes())
+        } else {
+            self.reserve(args.estimated_capacity());
+            io::default_write_fmt(self, args)
+        }
     }
 
     #[inline]


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/137762)*
<!-- homu-ignore:end -->

`fmt::Arguments::estimated_capacity()` is currently only used by `fmt::format()` to reserve the initial string capacity. Also use it in `fmt::Write::write_fmt` for `String` and `OsString`; and `io::Write::write_fmt` for `Vec<u8>`, `VecDeque<u8>`, `Cursor<&mut Vec<u8>>`, and `Cursor<Vec<u8>>`.

This may be worth checking perf.