### PR TITLE
Downgrade 32-bit Windows SDK to 10.0.22621.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,21 @@ jobs:
       - name: ensure the stable version number is correct
         run: src/ci/scripts/verify-stable-version-number.sh
 
+      # Temporary fix to unblock CI
+      # We revert to an older Windows SDK for 32-bit Windows MSVC builds.
+      # See issue https://github.com/rust-lang/rust/issues/137733 for more details.
+      - name: downgrade Windows SDK
+        shell: pwsh
+        if: ${{ matrix.name == 'i686-msvc-1' || matrix.name == 'i686-msvc-2' || matrix.name == 'dist-i686-msvc' }}
+        run: |
+          $sdk_dir = (Get-ItemProperty -path 'HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots').KitsRoot10
+          $sdk_version = "10.0.22621.0"
+
+          # Override the SDK used by cc-rs by setting the SDK environment variables
+          "WindowsSdkDir=$sdk_dir" >> $env:GITHUB_ENV
+          "WindowsSDKVersion=$sdk_version\" >> $env:GITHUB_ENV
+
+
       # Show the environment just before we run the build
       # This makes it easier to diagnose problems with the above install scripts.
       - name: show the current environment

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -474,13 +474,13 @@ auto:
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc  --enable-sanitizers
       SCRIPT: make ci-msvc-py
-    <<: *job-windows-8c
+    <<: *job-windows
 
   - name: i686-msvc-2
     env:
       RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc --enable-sanitizers
       SCRIPT: make ci-msvc-ps1
-    <<: *job-windows-8c
+    <<: *job-windows
 
   # x86_64-msvc-ext is split into multiple jobs to run tests in parallel.
   - name: x86_64-msvc-ext1
@@ -595,7 +595,7 @@ auto:
       SCRIPT: python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-windows-8c
+    <<: *job-windows
 
   - name: dist-aarch64-msvc
     env:


### PR DESCRIPTION
Reverts 6ea4823733254432aee255465177b8e53f01a79d and worksaround https://github.com/rust-lang/rust/issues/137733

try-job: i686-msvc-1
try-job: i686-msvc-2
try-job: dist-i686-msvc