### PR TITLE
Do not yeet `unsafe<>` from type when formatting unsafe binder

### DIFF
--- a/src/tools/rustfmt/src/types.rs
+++ b/src/tools/rustfmt/src/types.rs
@@ -1019,7 +1019,11 @@ impl Rewrite for ast::Ty {
             }
             ast::TyKind::UnsafeBinder(ref binder) => {
                 let mut result = String::new();
-                if let Some(ref lifetime_str) =
+                if binder.generic_params.is_empty() {
+                    // We always want to write `unsafe<>` since `unsafe<> Ty`
+                    // and `Ty` are distinct types.
+                    result.push_str("unsafe<> ")
+                } else if let Some(ref lifetime_str) =
                     rewrite_bound_params(context, shape, &binder.generic_params)
                 {
                     result.push_str("unsafe<");

--- a/src/tools/rustfmt/tests/source/unsafe-binders.rs
+++ b/src/tools/rustfmt/tests/source/unsafe-binders.rs
@@ -9,3 +9,6 @@ struct Foo {
 struct Bar(unsafe<'a> &'a ());
 
 impl Trait for unsafe<'a> &'a () {}
+
+fn empty()
+-> unsafe<> () {}

--- a/src/tools/rustfmt/tests/target/unsafe-binders.rs
+++ b/src/tools/rustfmt/tests/target/unsafe-binders.rs
@@ -7,3 +7,5 @@ struct Foo {
 struct Bar(unsafe<'a> &'a ());
 
 impl Trait for unsafe<'a> &'a () {}
+
+fn empty() -> unsafe<> () {}


### PR DESCRIPTION
Unsafe binders are types like `unsafe<'a, 'b> Ty<'a, 'b>`. However, users can also specify unsafe binder types with no bound vars, like `unsafe<> Ty`. 

When I added nightly formatting for unsafe binders, I didn't consider this, so on nightly we are stripping the `unsafe<>` part, which gives us back `Ty` which is a different type!

This PR fixes that.

r? @ytmimi