### PR TITLE
Tweak incorrect ABI suggestion and make suggestion verbose

### DIFF
--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -88,7 +88,7 @@ ast_lowering_invalid_abi_clobber_abi =
     invalid ABI for `clobber_abi`
     .note = the following ABIs are supported on this target: {$supported_abis}
 
-ast_lowering_invalid_abi_suggestion = did you mean
+ast_lowering_invalid_abi_suggestion = there's a similarly named valid ABI `{$suggestion}`
 
 ast_lowering_invalid_asm_template_modifier_const =
     asm template modifiers are not allowed for `const` arguments

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -46,8 +46,9 @@ pub(crate) struct TupleStructWithDefault {
 #[derive(Subdiagnostic)]
 #[suggestion(
     ast_lowering_invalid_abi_suggestion,
-    code = "{suggestion}",
-    applicability = "maybe-incorrect"
+    code = "\"{suggestion}\"",
+    applicability = "maybe-incorrect",
+    style = "verbose"
 )]
 pub(crate) struct InvalidAbiSuggestion {
     #[primary_span]

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1510,7 +1510,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             span: abi.span,
             suggestion: suggested_name.map(|suggested_name| InvalidAbiSuggestion {
                 span: abi.span,
-                suggestion: format!("\"{suggested_name}\""),
+                suggestion: suggested_name.to_string(),
             }),
             command: "rustc --print=calling-conventions".to_string(),
         });

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv32.stderr
@@ -2,23 +2,26 @@ error[E0703]: invalid ABI: found `riscv-interrupt`
   --> $DIR/riscv-discoverability-guidance.rs:17:8
    |
 LL | extern "riscv-interrupt" fn isr() {}
-   |        ^^^^^^^^^^^^^^^^^
-   |        |
-   |        invalid ABI
-   |        help: did you mean: `"riscv-interrupt-m"`
+   |        ^^^^^^^^^^^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: there's a similarly named valid ABI `riscv-interrupt-m`
+   |
+LL | extern "riscv-interrupt-m" fn isr() {}
+   |                        ++
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
   --> $DIR/riscv-discoverability-guidance.rs:22:8
    |
 LL | extern "riscv-interrupt-u" fn isr_U() {}
-   |        ^^^^^^^^^^^^^^^^^^^
-   |        |
-   |        invalid ABI
-   |        help: did you mean: `"riscv-interrupt-m"`
+   |        ^^^^^^^^^^^^^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: there's a similarly named valid ABI `riscv-interrupt-m`
+   |
+LL - extern "riscv-interrupt-u" fn isr_U() {}
+LL + extern "riscv-interrupt-m" fn isr_U() {}
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
+++ b/tests/ui/abi/riscv-discoverability-guidance.riscv64.stderr
@@ -2,23 +2,26 @@ error[E0703]: invalid ABI: found `riscv-interrupt`
   --> $DIR/riscv-discoverability-guidance.rs:17:8
    |
 LL | extern "riscv-interrupt" fn isr() {}
-   |        ^^^^^^^^^^^^^^^^^
-   |        |
-   |        invalid ABI
-   |        help: did you mean: `"riscv-interrupt-m"`
+   |        ^^^^^^^^^^^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: there's a similarly named valid ABI `riscv-interrupt-m`
+   |
+LL | extern "riscv-interrupt-m" fn isr() {}
+   |                        ++
 
 error[E0703]: invalid ABI: found `riscv-interrupt-u`
   --> $DIR/riscv-discoverability-guidance.rs:22:8
    |
 LL | extern "riscv-interrupt-u" fn isr_U() {}
-   |        ^^^^^^^^^^^^^^^^^^^
-   |        |
-   |        invalid ABI
-   |        help: did you mean: `"riscv-interrupt-m"`
+   |        ^^^^^^^^^^^^^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: there's a similarly named valid ABI `riscv-interrupt-m`
+   |
+LL - extern "riscv-interrupt-u" fn isr_U() {}
+LL + extern "riscv-interrupt-m" fn isr_U() {}
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/abi-typo.stderr
+++ b/tests/ui/suggestions/abi-typo.stderr
@@ -2,12 +2,14 @@ error[E0703]: invalid ABI: found `cdedl`
   --> $DIR/abi-typo.rs:2:8
    |
 LL | extern "cdedl" fn cdedl() {}
-   |        ^^^^^^^
-   |        |
-   |        invalid ABI
-   |        help: did you mean: `"cdecl"`
+   |        ^^^^^^^ invalid ABI
    |
    = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
+help: there's a similarly named valid ABI `cdecl`
+   |
+LL - extern "cdedl" fn cdedl() {}
+LL + extern "cdecl" fn cdedl() {}
+   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Provide a better suggestion message, and make the suggestion verbose.

```
error[E0703]: invalid ABI: found `riscv-interrupt`
  --> $DIR/riscv-discoverability-guidance.rs:17:8
   |
LL | extern "riscv-interrupt" fn isr() {}
   |        ^^^^^^^^^^^^^^^^^ invalid ABI
   |
   = note: invoke `rustc --print=calling-conventions` for a full list of supported calling conventions
help: there's a similarly named valid ABI `riscv-interrupt-m`
   |
LL | extern "riscv-interrupt-m" fn isr() {}
   |                        ++
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
