### PR TITLE
Fix code suggestion for local enum patterns in non-exhaustive matches

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -538,8 +538,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
                 self.error = Err(report_non_exhaustive_match(
                     &cx,
                     self.thir,
-                    scrut.ty,
-                    scrut.span,
+                    scrut,
                     witnesses,
                     arms,
                     braces_span,
@@ -1205,12 +1204,13 @@ fn pat_is_catchall(pat: &DeconstructedPat<'_, '_>) -> bool {
 fn report_non_exhaustive_match<'p, 'tcx>(
     cx: &PatCtxt<'p, 'tcx>,
     thir: &Thir<'tcx>,
-    scrut_ty: Ty<'tcx>,
-    sp: Span,
+    scrut: &Expr<'tcx>,
     witnesses: Vec<WitnessPat<'p, 'tcx>>,
     arms: &[ArmId],
     braces_span: Option<Span>,
 ) -> ErrorGuaranteed {
+    let scrut_ty = scrut.ty;
+    let sp = scrut.span;
     let is_empty_match = arms.is_empty();
     let non_empty_enum = match scrut_ty.kind() {
         ty::Adt(def, _) => def.is_enum() && !def.variants().is_empty(),
@@ -1323,7 +1323,7 @@ fn report_non_exhaustive_match<'p, 'tcx>(
     let suggested_arm = if suggest_the_witnesses {
         let pattern = witnesses
             .iter()
-            .map(|witness| cx.print_witness_pat(witness))
+            .map(|witness| cx.print_witness_pat_with_scrut(witness, Some(scrut)))
             .collect::<Vec<String>>()
             .join(" | ");
         if witnesses.iter().all(|p| p.is_never_pattern()) && cx.tcx.features().never_patterns() {

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -805,10 +805,18 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
         }
     }
 
+    pub fn print_witness_pat(&self, pat: &WitnessPat<'p, 'tcx>) -> String {
+        self.print_witness_pat_with_scrut(pat, None)
+    }
+
     /// Prints a [`WitnessPat`] to an owned string, for diagnostic purposes.
     ///
     /// This panics for patterns that don't appear in diagnostics, like float ranges.
-    pub fn print_witness_pat(&self, pat: &WitnessPat<'p, 'tcx>) -> String {
+    pub fn print_witness_pat_with_scrut(
+        &self,
+        pat: &WitnessPat<'p, 'tcx>,
+        scrut: Option<&thir::Expr<'tcx>>,
+    ) -> String {
         let cx = self;
         let print = |p| cx.print_witness_pat(p);
         match pat.ctor() {
@@ -847,6 +855,7 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                     pat.ty().inner(),
                     &enum_info,
                     &subpatterns,
+                    scrut,
                 )
                 .unwrap();
                 s

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/shadowed-non-exhaustive.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/shadowed-non-exhaustive.rs
@@ -1,0 +1,13 @@
+struct Shadowed {}
+
+fn main() {
+    let v = Shadowed::Foo;
+
+    match v {
+        //~^ non-exhaustive patterns: `main::Shadowed::Foo` not covered [E0004]
+    }
+
+    enum Shadowed {
+        Foo,
+    }
+}

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/shadowed-non-exhaustive.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/shadowed-non-exhaustive.stderr
@@ -1,0 +1,24 @@
+error[E0004]: non-exhaustive patterns: `main::Shadowed::Foo` not covered
+  --> $DIR/shadowed-non-exhaustive.rs:6:11
+   |
+LL |     match v {
+   |           ^ pattern `main::Shadowed::Foo` not covered
+   |
+note: `main::Shadowed` defined here
+  --> $DIR/shadowed-non-exhaustive.rs:10:10
+   |
+LL |     enum Shadowed {
+   |          ^^^^^^^^
+LL |         Foo,
+   |         --- not covered
+   = note: the matched value is of type `main::Shadowed`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~     match v {
+LL +         Shadowed::Foo => todo!(),
+LL +     }
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/137783)*
<!-- homu-ignore:end -->

Fixes: rust-lang/rust#137682 .

The fixed version of the output be like:
```shell
error[E0004]: non-exhaustive patterns: `make_index::Shadowed::Foo` not covered
 --> reprod.rs:6:11
  |
6 |     match v {}
  |           ^ pattern `make_index::Shadowed::Foo` not covered
  |
note: `make_index::Shadowed` defined here
 --> reprod.rs:8:10
  |
8 |     enum Shadowed {
  |          ^^^^^^^^
9 |         Foo,
  |         --- not covered
  = note: the matched value is of type `make_index::Shadowed`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
  |
6 ~     match v {
7 +         Shadowed::Foo => todo!(),
8 ~     }
  |

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0004`.
```

I guess only adjusting the code suggestion is better because `make_index::Shadowed::Foo` is more specific than `Shadowed::Foo` in this case.