### PR TITLE
bootstrap: allow to set clippy.toml for x.py clippy

### DIFF
--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -385,7 +385,7 @@ lint_any!(
     RemoteTestServer, "src/tools/remote-test-server", "remote-test-server";
     Rls, "src/tools/rls", "rls";
     RustAnalyzer, "src/tools/rust-analyzer", "rust-analyzer";
-    Rustdoc, "src/librustdoc", "clippy";
+    Rustdoc, "src/librustdoc", "rustdoc";
     Rustfmt, "src/tools/rustfmt", "rustfmt";
     RustInstaller, "src/tools/rust-installer", "rust-installer";
     Tidy, "src/tools/tidy", "tidy";

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -95,7 +95,7 @@ pub struct LintConfig {
     pub deny: Vec<String>,
     pub forbid: Vec<String>,
     // Path to folder containing clippy.toml, if any
-    clippy_cfg_path: Option<PathBuf>,
+    pub clippy_cfg_path: Option<PathBuf>,
 }
 
 impl LintConfig {

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -318,7 +318,7 @@ fn order_of_clippy_rules() {
 
     let actual = match config.cmd.clone() {
         crate::Subcommand::Clippy { allow, deny, warn, forbid, .. } => {
-            let cfg = LintConfig { allow, deny, warn, forbid };
+            let cfg = LintConfig { allow, deny, warn, forbid, clippy_cfg_path: None };
             get_clippy_rules_in_order(&args, &cfg)
         }
         _ => panic!("invalid subcommand"),
@@ -342,7 +342,7 @@ fn clippy_rule_separate_prefix() {
 
     let actual = match config.cmd.clone() {
         crate::Subcommand::Clippy { allow, deny, warn, forbid, .. } => {
-            let cfg = LintConfig { allow, deny, warn, forbid };
+            let cfg = LintConfig { allow, deny, warn, forbid, clippy_cfg_path: None };
             get_clippy_rules_in_order(&args, &cfg)
         }
         _ => panic!("invalid subcommand"),

--- a/src/etc/clippy_configs/bootstrap/clippy.toml
+++ b/src/etc/clippy_configs/bootstrap/clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/src/etc/clippy_configs/compiler/clippy.toml
+++ b/src/etc/clippy_configs/compiler/clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false


### PR DESCRIPTION
First two commits adds ability to set `clippy.toml` for `x.py clippy`, to be able to tune clippy lints, and set `avoid-breaking-exported-api = false` for bootstrap and compiler as example.
3rd commit fixes wrong displayed name for rustdoc - now it will be named `rustdoc` when running `python x.py clippy librustdoc`, not `clippy`.

I don't like copypasted paths for lint targets in CI, but can't find better way for it.