### PR TITLE
make qnx pass a test

### DIFF
--- a/tests/ui/attributes/auxiliary/used_pre_main_constructor.rs
+++ b/tests/ui/attributes/auxiliary/used_pre_main_constructor.rs
@@ -10,14 +10,14 @@
 
 #[cfg_attr(
     any(
-        target_os = "linux",
         target_os = "android",
+        target_os = "dragonfly",
         target_os = "freebsd",
+        target_os = "haiku",
+        target_os = "illumos",
+        target_os = "linux",
         target_os = "netbsd",
         target_os = "openbsd",
-        target_os = "dragonfly",
-        target_os = "illumos",
-        target_os = "haiku"
     ),
     link_section = ".init_array"
 )]

--- a/tests/ui/attributes/auxiliary/used_pre_main_constructor.rs
+++ b/tests/ui/attributes/auxiliary/used_pre_main_constructor.rs
@@ -17,6 +17,7 @@
         target_os = "illumos",
         target_os = "linux",
         target_os = "netbsd",
+        target_os = "nto",
         target_os = "openbsd",
     ),
     link_section = ".init_array"


### PR DESCRIPTION
[tests/ui/attributes/used_with_archive.rs](https://github.com/rust-lang/rust/blob/b2024300840c3ef94a97273531bdb37d56d50fb5/tests/ui/attributes/used_with_archive.rs) fails when executed for QNX targets, because its stdout does not match [this content](https://github.com/rust-lang/rust/blob/b2024300840c3ef94a97273531bdb37d56d50fb5/tests/ui/attributes/used_with_archive.run.stdout)