### PR TITLE
ci: use ubuntu 24 on arm large runner

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -54,7 +54,7 @@ runners:
     <<: *base-job
 
   - &job-aarch64-linux-8c
-    os: ubuntu-22.04-arm64-8core-32gb
+    os: ubuntu-24.04-arm64-8core-32gb
     <<: *base-job
 envs:
   env-x86_64-apple-tests: &env-x86_64-apple-tests


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
The free runner is already using ubuntu 24, so we use the same in the large runner.
<!-- homu-ignore:end -->
try-job: dist-aarch64-linux