### PR TITLE
tests: Unignore target modifier tests on all platforms

### DIFF
--- a/tests/ui/target_modifiers/auxiliary/default_reg_struct_return.rs
+++ b/tests/ui/target_modifiers/auxiliary/default_reg_struct_return.rs
@@ -1,20 +1,7 @@
-//@ compile-flags: --target i686-unknown-linux-gnu -Cpanic=abort
-// Auxiliary build problems with aarch64-apple:
-// Shared library linking cc seems to convert "-m32" flag into -arch armv4t
-// Auxiliary build problems with i686-mingw: linker `cc` not found
-//@ only-x86
-//@ ignore-windows
-//@ ignore-apple
+//@ no-prefer-dynamic
+//@ compile-flags: --target i686-unknown-linux-gnu
 //@ needs-llvm-components: x86
+
+#![feature(no_core)]
 #![crate_type = "rlib"]
 #![no_core]
-#![feature(no_core, lang_items, repr_simd)]
-
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-pub fn somefun() {}
-
-pub struct S;

--- a/tests/ui/target_modifiers/auxiliary/wrong_regparm.rs
+++ b/tests/ui/target_modifiers/auxiliary/wrong_regparm.rs
@@ -1,20 +1,7 @@
-//@ compile-flags: --target i686-unknown-linux-gnu -Zregparm=2 -Cpanic=abort
-// Auxiliary build problems with aarch64-apple:
-// Shared library linking cc seems to convert "-m32" flag into -arch armv4t
-// Auxiliary build problems with i686-mingw: linker `cc` not found
-//@ only-x86
-//@ ignore-windows
-//@ ignore-apple
+//@ no-prefer-dynamic
+//@ compile-flags: --target i686-unknown-linux-gnu -Zregparm=2
 //@ needs-llvm-components: x86
+
+#![feature(no_core)]
 #![crate_type = "rlib"]
 #![no_core]
-#![feature(no_core, lang_items, repr_simd)]
-
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-pub fn somefun() {}
-
-pub struct S;

--- a/tests/ui/target_modifiers/auxiliary/wrong_regparm_and_ret.rs
+++ b/tests/ui/target_modifiers/auxiliary/wrong_regparm_and_ret.rs
@@ -1,20 +1,7 @@
-//@ compile-flags: --target i686-unknown-linux-gnu -Zregparm=2 -Zreg-struct-return=true -Cpanic=abort
-// Auxiliary build problems with aarch64-apple:
-// Shared library linking cc seems to convert "-m32" flag into -arch armv4t
-// Auxiliary build problems with i686-mingw: linker `cc` not found
-//@ only-x86
-//@ ignore-windows
-//@ ignore-apple
+//@ no-prefer-dynamic
+//@ compile-flags: --target i686-unknown-linux-gnu -Zregparm=2 -Zreg-struct-return=true
 //@ needs-llvm-components: x86
+
+#![feature(no_core)]
 #![crate_type = "rlib"]
 #![no_core]
-#![feature(no_core, lang_items, repr_simd)]
-
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-pub fn somefun() {}
-
-pub struct S;

--- a/tests/ui/target_modifiers/defaults_check.error.stderr
+++ b/tests/ui/target_modifiers/defaults_check.error.stderr
@@ -1,7 +1,7 @@
 error: mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `defaults_check`
-  --> $DIR/defaults_check.rs:20:1
+  --> $DIR/defaults_check.rs:15:1
    |
-LL | #![crate_type = "rlib"]
+LL | #![feature(no_core)]
    | ^
    |
    = help: the `-Zreg-struct-return` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely

--- a/tests/ui/target_modifiers/defaults_check.rs
+++ b/tests/ui/target_modifiers/defaults_check.rs
@@ -1,27 +1,20 @@
 // Tests that default unspecified target modifier value in dependency crate is ok linked
 // with the same value, explicitly specified
-//@ aux-crate:default_reg_struct_return=default_reg_struct_return.rs
+
+//@ aux-build:default_reg_struct_return.rs
 //@ compile-flags: --target i686-unknown-linux-gnu -Cpanic=abort
-//@ revisions:error ok ok_explicit
+//@ needs-llvm-components: x86
+
+//@ revisions: ok ok_explicit error
 //@[ok] compile-flags:
 //@[ok_explicit] compile-flags: -Zreg-struct-return=false
 //@[error] compile-flags: -Zreg-struct-return=true
+//@[ok] check-pass
+//@[ok_explicit] check-pass
 
-// Auxiliary build problems with aarch64-apple:
-// Shared library linking cc seems to convert "-m32" flag into -arch armv4t
-// Auxiliary build problems with i686-mingw: linker `cc` not found
-//@ only-x86
-//@ ignore-windows
-//@ ignore-apple
-//@ needs-llvm-components: x86
-//@[ok] build-pass
-//@[ok_explicit] build-pass
-
-#![crate_type = "rlib"]
+#![feature(no_core)]
 //[error]~^ ERROR mixing `-Zreg-struct-return` will cause an ABI mismatch in crate `defaults_check`
+#![crate_type = "rlib"]
 #![no_core]
-#![feature(no_core, lang_items, repr_simd)]
 
-fn foo() {
-    default_reg_struct_return::somefun();
-}
+extern crate default_reg_struct_return;

--- a/tests/ui/target_modifiers/incompatible_regparm.error_generated.stderr
+++ b/tests/ui/target_modifiers/incompatible_regparm.error_generated.stderr
@@ -1,7 +1,7 @@
 error: mixing `-Zregparm` will cause an ABI mismatch in crate `incompatible_regparm`
-  --> $DIR/incompatible_regparm.rs:16:1
+  --> $DIR/incompatible_regparm.rs:11:1
    |
-LL | #![crate_type = "rlib"]
+LL | #![feature(no_core)]
    | ^
    |
    = help: the `-Zregparm` flag modifies the ABI so Rust crates compiled with different values of this flag cannot be used together safely

--- a/tests/ui/target_modifiers/incompatible_regparm.rs
+++ b/tests/ui/target_modifiers/incompatible_regparm.rs
@@ -1,23 +1,16 @@
-//@ aux-crate:wrong_regparm=wrong_regparm.rs
-//@ compile-flags: --target i686-unknown-linux-gnu -Zregparm=1 -Cpanic=abort
-// Auxiliary build problems with aarch64-apple:
-// Shared library linking cc seems to convert "-m32" flag into -arch armv4t
-// Auxiliary build problems with i686-mingw: linker `cc` not found
-//@ only-x86
-//@ ignore-windows
-//@ ignore-apple
+//@ aux-build:wrong_regparm.rs
+//@ compile-flags: --target i686-unknown-linux-gnu -Zregparm=1
 //@ needs-llvm-components: x86
-//@ revisions:error_generated allow_regparm_mismatch allow_no_value
 
+//@ revisions:allow_regparm_mismatch allow_no_value error_generated
 //@[allow_regparm_mismatch] compile-flags: -Cunsafe-allow-abi-mismatch=regparm
-//@[allow_regparm_mismatch] build-pass
 //@[allow_no_value] compile-flags: -Cunsafe-allow-abi-mismatch
+//@[error_generated] compile-flags:
+//@[allow_regparm_mismatch] check-pass
 
-#![crate_type = "rlib"]
+#![feature(no_core)]
 //[error_generated]~^ ERROR mixing `-Zregparm` will cause an ABI mismatch in crate `incompatible_regparm`
+#![crate_type = "rlib"]
 #![no_core]
-#![feature(no_core, lang_items, repr_simd)]
 
-fn foo() {
-    wrong_regparm::somefun();
-}
+extern crate wrong_regparm;

--- a/tests/ui/target_modifiers/two_flags.rs
+++ b/tests/ui/target_modifiers/two_flags.rs
@@ -1,23 +1,15 @@
-//@ aux-crate:wrong_regparm_and_ret=wrong_regparm_and_ret.rs
-//@ compile-flags: --target i686-unknown-linux-gnu -Cpanic=abort
-// Auxiliary build problems with aarch64-apple:
-// Shared library linking cc seems to convert "-m32" flag into -arch armv4t
-// Auxiliary build problems with i686-mingw: linker `cc` not found
-//@ only-x86
-//@ ignore-windows
-//@ ignore-apple
+//@ aux-build:wrong_regparm_and_ret.rs
+//@ compile-flags: --target i686-unknown-linux-gnu
 //@ needs-llvm-components: x86
+
 //@ revisions:two_allowed unknown_allowed
-
 //@[two_allowed] compile-flags: -Cunsafe-allow-abi-mismatch=regparm,reg-struct-return
-//@[two_allowed] build-pass
 //@[unknown_allowed] compile-flags: -Cunsafe-allow-abi-mismatch=unknown_flag -Zregparm=2 -Zreg-struct-return=true
+//@[two_allowed] check-pass
 
-#![crate_type = "rlib"]
+#![feature(no_core)]
 //[unknown_allowed]~^ ERROR unknown target modifier `unknown_flag`, requested by `-Cunsafe-allow-abi-mismatch=unknown_flag`
+#![crate_type = "rlib"]
 #![no_core]
-#![feature(no_core, lang_items, repr_simd)]
 
-fn foo() {
-    wrong_regparm_and_ret::somefun();
-}
+extern crate wrong_regparm_and_ret;

--- a/tests/ui/target_modifiers/two_flags.unknown_allowed.stderr
+++ b/tests/ui/target_modifiers/two_flags.unknown_allowed.stderr
@@ -1,7 +1,7 @@
 error: unknown target modifier `unknown_flag`, requested by `-Cunsafe-allow-abi-mismatch=unknown_flag`
-  --> $DIR/two_flags.rs:16:1
+  --> $DIR/two_flags.rs:10:1
    |
-LL | #![crate_type = "rlib"]
+LL | #![feature(no_core)]
    | ^
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
These tests can be `check-pass` and do not need dynamic libraries.
Also remove other unnecessary stuff from them.

Follow up to https://github.com/rust-lang/rust/pull/133138.
