### PR TITLE
miri native-call support: all previously exposed provenance is accessible to the callee

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -955,18 +955,13 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
     /// Handle the effect an FFI call might have on the state of allocations.
     /// This overapproximates the modifications which external code might make to memory:
-    /// We set all reachable allocations as initialized, mark all provenances as exposed
+    /// We set all reachable allocations as initialized, mark all reachable provenances as exposed
     /// and overwrite them with `Provenance::WILDCARD`.
-    pub fn prepare_for_native_call(
-        &mut self,
-        id: AllocId,
-        initial_prov: M::Provenance,
-    ) -> InterpResult<'tcx> {
-        // Expose provenance of the root allocation.
-        M::expose_provenance(self, initial_prov)?;
-
+    ///
+    /// The allocations in `ids` are assumed to be already exposed.
+    pub fn prepare_for_native_call(&mut self, ids: Vec<AllocId>) -> InterpResult<'tcx> {
         let mut done = FxHashSet::default();
-        let mut todo = vec![id];
+        let mut todo = ids;
         while let Some(id) = todo.pop() {
             if !done.insert(id) {
                 // We already saw this allocation before, don't process it again.

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -1291,18 +1291,12 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
     /// Called on `ptr as usize` casts.
     /// (Actually computing the resulting `usize` doesn't need machine help,
     /// that's just `Scalar::try_to_int`.)
+    #[inline(always)]
     fn expose_provenance(
         ecx: &InterpCx<'tcx, Self>,
         provenance: Self::Provenance,
     ) -> InterpResult<'tcx> {
-        match provenance {
-            Provenance::Concrete { alloc_id, tag } => ecx.expose_ptr(alloc_id, tag),
-            Provenance::Wildcard => {
-                // No need to do anything for wildcard pointers as
-                // their provenances have already been previously exposed.
-                interp_ok(())
-            }
-        }
+        ecx.expose_provenance(provenance)
     }
 
     /// Convert a pointer with provenance into an allocation-offset pair and extra provenance info.

--- a/src/tools/miri/tests/native-lib/ptr_read_access.c
+++ b/src/tools/miri/tests/native-lib/ptr_read_access.c
@@ -1,33 +1,34 @@
 #include <stdio.h>
+#include <stdint.h>
 
 // See comments in build_native_lib()
 #define EXPORT __attribute__((visibility("default")))
 
 /* Test: test_access_pointer */
 
-EXPORT void print_pointer(const int *ptr) {
+EXPORT void print_pointer(const int32_t *ptr) {
   printf("printing pointer dereference from C: %d\n", *ptr);
 }
 
 /* Test: test_access_simple */
 
 typedef struct Simple {
-  int field;
+  int32_t field;
 } Simple;
 
-EXPORT int access_simple(const Simple *s_ptr) {
+EXPORT int32_t access_simple(const Simple *s_ptr) {
   return s_ptr->field;
 }
 
 /* Test: test_access_nested */
 
 typedef struct Nested {
-  int value;
+  int32_t value;
   struct Nested *next;
 } Nested;
 
 // Returns the innermost/last value of a Nested pointer chain.
-EXPORT int access_nested(const Nested *n_ptr) {
+EXPORT int32_t access_nested(const Nested *n_ptr) {
   // Edge case: `n_ptr == NULL` (i.e. first Nested is None).
   if (!n_ptr) { return 0; }
 
@@ -41,10 +42,10 @@ EXPORT int access_nested(const Nested *n_ptr) {
 /* Test: test_access_static */
 
 typedef struct Static {
-    int value;
+    int32_t value;
     struct Static *recurse;
 } Static;
 
-EXPORT int access_static(const Static *s_ptr) {
+EXPORT int32_t access_static(const Static *s_ptr) {
   return s_ptr->recurse->recurse->value;
 }

--- a/src/tools/miri/tests/native-lib/ptr_write_access.c
+++ b/src/tools/miri/tests/native-lib/ptr_write_access.c
@@ -1,4 +1,5 @@
 #include <stddef.h>
+#include <stdint.h>
 
 // See comments in build_native_lib()
 #define EXPORT __attribute__((visibility("default")))
@@ -87,4 +88,22 @@ EXPORT void swap_ptr_triple_dangling(Triple *t_ptr) {
 
 EXPORT const int *return_ptr(const int *ptr) {
   return ptr;
+}
+
+/* Test: test_pass_ptr_as_int */
+
+EXPORT void pass_ptr_as_int(uintptr_t ptr, int set_to_val) {
+  *(int*)ptr = set_to_val;
+}
+
+/* Test: test_pass_ptr_via_previously_shared_mem */
+
+int** shared_place;
+
+EXPORT void set_shared_mem(int** ptr) {
+  shared_place = ptr;
+}
+
+EXPORT void init_ptr_stored_in_shared_mem(int val) {
+  **shared_place = val;
 }

--- a/src/tools/miri/tests/native-lib/ptr_write_access.c
+++ b/src/tools/miri/tests/native-lib/ptr_write_access.c
@@ -6,19 +6,19 @@
 
 /* Test: test_increment_int */
 
-EXPORT void increment_int(int *ptr) {
+EXPORT void increment_int(int32_t *ptr) {
   *ptr += 1;
 }
 
 /* Test: test_init_int */
 
-EXPORT void init_int(int *ptr, int val) {
+EXPORT void init_int(int32_t *ptr, int32_t val) {
   *ptr = val;
 }
 
 /* Test: test_init_array */
 
-EXPORT void init_array(int *array, size_t len, int val) {
+EXPORT void init_array(int32_t *array, size_t len, int32_t val) {
   for (size_t i = 0; i < len; i++) {
     array[i] = val;
   }
@@ -27,28 +27,28 @@ EXPORT void init_array(int *array, size_t len, int val) {
 /* Test: test_init_static_inner */
 
 typedef struct SyncPtr {
-    int *ptr;
+    int32_t *ptr;
 } SyncPtr;
 
-EXPORT void init_static_inner(const SyncPtr *s_ptr, int val) {
+EXPORT void init_static_inner(const SyncPtr *s_ptr, int32_t val) {
   *(s_ptr->ptr) = val;
 }
 
 /* Tests: test_exposed, test_pass_dangling */
 
-EXPORT void ignore_ptr(__attribute__((unused)) const int *ptr) {
+EXPORT void ignore_ptr(__attribute__((unused)) const int32_t *ptr) {
   return;
 }
 
 /* Test: test_expose_int */
-EXPORT void expose_int(const int *int_ptr, const int **pptr) {
+EXPORT void expose_int(const int32_t *int_ptr, const int32_t **pptr) {
   *pptr = int_ptr;
 }
 
 /* Test: test_swap_ptr */
 
-EXPORT void swap_ptr(const int **pptr0, const int **pptr1) {
-  const int *tmp = *pptr0;
+EXPORT void swap_ptr(const int32_t **pptr0, const int32_t **pptr1) {
+  const int32_t *tmp = *pptr0;
   *pptr0 = *pptr1;
   *pptr1 = tmp;
 }
@@ -56,54 +56,54 @@ EXPORT void swap_ptr(const int **pptr0, const int **pptr1) {
 /* Test: test_swap_ptr_tuple */
 
 typedef struct Tuple {
-    int *ptr0;
-    int *ptr1;
+    int32_t *ptr0;
+    int32_t *ptr1;
 } Tuple;
 
 EXPORT void swap_ptr_tuple(Tuple *t_ptr) {
-  int *tmp = t_ptr->ptr0;
+  int32_t *tmp = t_ptr->ptr0;
   t_ptr->ptr0 = t_ptr->ptr1;
   t_ptr->ptr1 = tmp;
 }
 
 /* Test: test_overwrite_dangling */
 
-EXPORT void overwrite_ptr(const int **pptr) {
+EXPORT void overwrite_ptr(const int32_t **pptr) {
   *pptr = NULL;
 }
 
 /* Test: test_swap_ptr_triple_dangling */
 
 typedef struct Triple {
-    int *ptr0;
-    int *ptr1;
-    int *ptr2;
+    int32_t *ptr0;
+    int32_t *ptr1;
+    int32_t *ptr2;
 } Triple;
 
 EXPORT void swap_ptr_triple_dangling(Triple *t_ptr) {
-  int *tmp = t_ptr->ptr0;
+  int32_t *tmp = t_ptr->ptr0;
   t_ptr->ptr0 = t_ptr->ptr2;
   t_ptr->ptr2 = tmp;
 }
 
-EXPORT const int *return_ptr(const int *ptr) {
+EXPORT const int32_t *return_ptr(const int32_t *ptr) {
   return ptr;
 }
 
 /* Test: test_pass_ptr_as_int */
 
-EXPORT void pass_ptr_as_int(uintptr_t ptr, int set_to_val) {
-  *(int*)ptr = set_to_val;
+EXPORT void pass_ptr_as_int(uintptr_t ptr, int32_t set_to_val) {
+  *(int32_t*)ptr = set_to_val;
 }
 
 /* Test: test_pass_ptr_via_previously_shared_mem */
 
-int** shared_place;
+int32_t** shared_place;
 
-EXPORT void set_shared_mem(int** ptr) {
+EXPORT void set_shared_mem(int32_t** ptr) {
   shared_place = ptr;
 }
 
-EXPORT void init_ptr_stored_in_shared_mem(int val) {
+EXPORT void init_ptr_stored_in_shared_mem(int32_t val) {
   **shared_place = val;
 }

--- a/src/tools/miri/tests/native-lib/scalar_arguments.c
+++ b/src/tools/miri/tests/native-lib/scalar_arguments.c
@@ -1,9 +1,10 @@
 #include <stdio.h>
+#include <stdint.h>
 
 // See comments in build_native_lib()
 #define EXPORT __attribute__((visibility("default")))
 
-EXPORT int add_one_int(int x) {
+EXPORT int32_t add_one_int(int32_t x) {
   return 2 + x;
 }
 
@@ -13,23 +14,23 @@ EXPORT void printer(void) {
 
 // function with many arguments, to test functionality when some args are stored
 // on the stack
-EXPORT int test_stack_spill(int a, int b, int c, int d, int e, int f, int g, int h, int i, int j, int k, int l) {
+EXPORT int32_t test_stack_spill(int32_t a, int32_t b, int32_t c, int32_t d, int32_t e, int32_t f, int32_t g, int32_t h, int32_t i, int32_t j, int32_t k, int32_t l) {
   return a+b+c+d+e+f+g+h+i+j+k+l;
 }
 
-EXPORT unsigned int get_unsigned_int(void) {
+EXPORT uint32_t get_unsigned_int(void) {
   return -10;
 }
 
-EXPORT short add_int16(short x) {
+EXPORT short add_int16(int16_t x) {
   return x + 3;
 }
 
-EXPORT long add_short_to_long(short x, long y) {
+EXPORT long add_short_to_long(int16_t x, int64_t y) {
   return x + y;
 }
 
 // To test that functions not marked with EXPORT cannot be called by Miri.
-int not_exported(void) {
+int32_t not_exported(void) {
   return 0;
 }


### PR DESCRIPTION
When Miri invokes a native C function, the memory C can access needs to be "prepared": to avoid false positives, we need to consider all that memory initialized, and we need to consider it to have arbitrary provenance. So far we did this for all pointers passed to C, but not for pointers that were exposed already before the native call. This PR adjusts the logic so that we now "prepare" all memory that has ever been exposed.

This fixes cases such as:
- cast a pointer to integer, send that integer to C, and access the memory there (`test_pass_ptr_as_int`)
- send a pointer to some memory to C, which stores it somewhere; then in Rust store another pointer in that memory, and access that via C (`test_pass_ptr_via_previously_shared_mem`)

r? @oli-obk 