### PR TITLE
delay the bug when read immediate

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -658,7 +658,10 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                     abi::Scalar::Initialized { .. }
                 )
         ) {
-            span_bug!(self.cur_span(), "primitive read not possible for type: {}", op.layout().ty);
+            self.tcx().dcx().span_delayed_bug(
+                self.cur_span(),
+                format!("primitive read not possible for type: {}", op.layout().ty),
+            );
         }
         let imm = self.read_immediate_raw(op)?.right().unwrap();
         if matches!(*imm, Immediate::Uninit) {

--- a/tests/ui/const-generics/eval_fn_item_in_const_arg.rs
+++ b/tests/ui/const-generics/eval_fn_item_in_const_arg.rs
@@ -1,0 +1,12 @@
+#![feature(generic_const_exprs)]
+//~^ WARN the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+#![feature(min_generic_const_args)]
+//~^ WARN the feature `min_generic_const_args` is incomplete and may not be safe to use and/or cause compiler crashes
+
+struct Checked<const N: usize, const M: usize = { N + 1 }>;
+//~^ ERROR evaluation of `Checked::{constant#0}` failed
+
+fn main() {
+    let _: Checked<main>;
+    //~^ ERROR the constant `main` is not of type `usize`
+}

--- a/tests/ui/const-generics/eval_fn_item_in_const_arg.stderr
+++ b/tests/ui/const-generics/eval_fn_item_in_const_arg.stderr
@@ -1,0 +1,38 @@
+warning: the feature `generic_const_exprs` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/eval_fn_item_in_const_arg.rs:1:12
+   |
+LL | #![feature(generic_const_exprs)]
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: the feature `min_generic_const_args` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/eval_fn_item_in_const_arg.rs:3:12
+   |
+LL | #![feature(min_generic_const_args)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #132980 <https://github.com/rust-lang/rust/issues/132980> for more information
+
+error[E0080]: evaluation of `Checked::{constant#0}` failed
+  --> $DIR/eval_fn_item_in_const_arg.rs:6:51
+   |
+LL | struct Checked<const N: usize, const M: usize = { N + 1 }>;
+   |                                                   ^^^^^ using uninitialized data, but this operation requires initialized memory
+
+error: the constant `main` is not of type `usize`
+  --> $DIR/eval_fn_item_in_const_arg.rs:10:12
+   |
+LL |     let _: Checked<main>;
+   |            ^^^^^^^^^^^^^ expected `usize`, found fn item
+   |
+note: required by a const generic parameter in `Checked`
+  --> $DIR/eval_fn_item_in_const_arg.rs:6:16
+   |
+LL | struct Checked<const N: usize, const M: usize = { N + 1 }>;
+   |                ^^^^^^^^^^^^^^ required by this const generic parameter in `Checked`
+
+error: aborting due to 2 previous errors; 2 warnings emitted
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
Fixes #137656

Fixes ICE during the const evaluation after `SelectionError::ConstArgHasWrongType` was already captured.
Delays the bug to prioritize emitting the caught type error, preventing the crash.