### PR TITLE
Fully qualify `Result` in generated doctest code

### DIFF
--- a/src/librustdoc/doctest/make.rs
+++ b/src/librustdoc/doctest/make.rs
@@ -208,7 +208,7 @@ impl DocTestBuilder {
             let (main_pre, main_post) = if returns_result {
                 (
                     format!(
-                        "fn main() {{ {inner_attr}fn {inner_fn_name}() -> Result<(), impl core::fmt::Debug> {{\n",
+                        "fn main() {{ {inner_attr}fn {inner_fn_name}() -> core::result::Result<(), impl core::fmt::Debug> {{\n",
                     ),
                     format!("\n}} {inner_fn_name}().unwrap() }}"),
                 )

--- a/src/librustdoc/doctest/tests.rs
+++ b/src/librustdoc/doctest/tests.rs
@@ -316,7 +316,7 @@ let mut input = String::new();
 io::stdin().read_line(&mut input)?;
 Ok::<(), io:Error>(())";
     let expected = "#![allow(unused)]
-fn main() { fn _inner() -> Result<(), impl core::fmt::Debug> {
+fn main() { fn _inner() -> core::result::Result<(), impl core::fmt::Debug> {
 use std::io;
 let mut input = String::new();
 io::stdin().read_line(&mut input)?;


### PR DESCRIPTION
As discussed in https://lore.kernel.org/rust-for-linux/20250228132553.880126-1-guillaume1.gomez@gmail.com/T/#u, it would require less code for RfL to be able to reach the same result (pun unintended).

cc @ojeda 

r? @notriddle 