### PR TITLE
Use correct error message casing for `io::const_error`s

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -83,7 +83,7 @@ impl Error {
 
     pub(crate) const UNKNOWN_THREAD_COUNT: Self = const_error!(
         ErrorKind::NotFound,
-        "The number of hardware threads is not known for the target platform",
+        "the number of hardware threads is not known for the target platform",
     );
 
     pub(crate) const UNSUPPORTED_PLATFORM: Self =

--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -90,7 +90,7 @@ impl OwnedSocket {
 
     #[cfg(target_vendor = "uwp")]
     pub(crate) fn set_no_inherit(&self) -> io::Result<()> {
-        Err(io::const_error!(io::ErrorKind::Unsupported, "Unavailable on UWP"))
+        Err(io::const_error!(io::ErrorKind::Unsupported, "unavailable on UWP"))
     }
 }
 

--- a/library/std/src/sys/net/connection/xous/tcplistener.rs
+++ b/library/std/src/sys/net/connection/xous/tcplistener.rs
@@ -11,7 +11,7 @@ macro_rules! unimpl {
     () => {
         return Err(io::const_error!(
             io::ErrorKind::Unsupported,
-            "This function is not yet implemented",
+            "this function is not yet implemented",
         ));
     };
 }
@@ -71,7 +71,7 @@ impl TcpListener {
             0,
             4096,
         ) else {
-            return Err(io::const_error!(io::ErrorKind::InvalidInput, "Invalid response"));
+            return Err(io::const_error!(io::ErrorKind::InvalidInput, "invalid response"));
         };
 
         // The first four bytes should be zero upon success, and will be nonzero
@@ -80,15 +80,15 @@ impl TcpListener {
         if response[0] != 0 || valid == 0 {
             let errcode = response[1];
             if errcode == NetError::SocketInUse as u8 {
-                return Err(io::const_error!(io::ErrorKind::ResourceBusy, "Socket in use"));
+                return Err(io::const_error!(io::ErrorKind::ResourceBusy, "socket in use"));
             } else if errcode == NetError::Invalid as u8 {
-                return Err(io::const_error!(io::ErrorKind::AddrNotAvailable, "Invalid address"));
+                return Err(io::const_error!(io::ErrorKind::AddrNotAvailable, "invalid address"));
             } else if errcode == NetError::LibraryError as u8 {
-                return Err(io::const_error!(io::ErrorKind::Other, "Library error"));
+                return Err(io::const_error!(io::ErrorKind::Other, "library error"));
             } else {
                 return Err(io::const_error!(
                     io::ErrorKind::Other,
-                    "Unable to connect or internal error",
+                    "unable to connect or internal error",
                 ));
             }
         }
@@ -131,7 +131,7 @@ impl TcpListener {
                 } else if receive_request.raw[1] == NetError::WouldBlock as u8 {
                     return Err(io::const_error!(io::ErrorKind::WouldBlock, "accept would block"));
                 } else if receive_request.raw[1] == NetError::LibraryError as u8 {
-                    return Err(io::const_error!(io::ErrorKind::Other, "Library error"));
+                    return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 } else {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 }
@@ -169,7 +169,7 @@ impl TcpListener {
                 Ok((TcpStream::from_listener(stream_fd, self.local.port(), port, addr), addr))
             }
         } else {
-            Err(io::const_error!(io::ErrorKind::InvalidInput, "Unable to accept"))
+            Err(io::const_error!(io::ErrorKind::InvalidInput, "unable to accept"))
         }
     }
 
@@ -186,7 +186,7 @@ impl TcpListener {
             services::net_server(),
             services::NetBlockingScalar::StdSetTtlTcp(self.fd.load(Ordering::Relaxed), ttl).into(),
         )
-        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "Unexpected return value")))
+        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "unexpected return value")))
         .map(|_| ())
     }
 
@@ -195,7 +195,7 @@ impl TcpListener {
             services::net_server(),
             services::NetBlockingScalar::StdGetTtlTcp(self.fd.load(Ordering::Relaxed)).into(),
         )
-        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "Unexpected return value")))
+        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "unexpected return value")))
         .map(|res| res[0] as _)?)
     }
 

--- a/library/std/src/sys/net/connection/xous/tcpstream.rs
+++ b/library/std/src/sys/net/connection/xous/tcpstream.rs
@@ -12,7 +12,7 @@ macro_rules! unimpl {
     () => {
         return Err(io::const_error!(
             io::ErrorKind::Unsupported,
-            "This function is not yet implemented",
+            "this function is not yet implemented",
         ));
     };
 }
@@ -96,7 +96,7 @@ impl TcpStream {
             0,
             4096,
         ) else {
-            return Err(io::const_error!(io::ErrorKind::InvalidInput, "Invalid response"));
+            return Err(io::const_error!(io::ErrorKind::InvalidInput, "invalid response"));
         };
 
         // The first four bytes should be zero upon success, and will be nonzero
@@ -106,13 +106,13 @@ impl TcpStream {
             // errcode is a u8 but stuck in a u16 where the upper byte is invalid. Mask & decode accordingly.
             let errcode = response[0];
             if errcode == NetError::SocketInUse as u8 {
-                return Err(io::const_error!(io::ErrorKind::ResourceBusy, "Socket in use"));
+                return Err(io::const_error!(io::ErrorKind::ResourceBusy, "socket in use"));
             } else if errcode == NetError::Unaddressable as u8 {
-                return Err(io::const_error!(io::ErrorKind::AddrNotAvailable, "Invalid address"));
+                return Err(io::const_error!(io::ErrorKind::AddrNotAvailable, "invalid address"));
             } else {
                 return Err(io::const_error!(
                     io::ErrorKind::InvalidInput,
-                    "Unable to connect or internal error",
+                    "unable to connect or internal error",
                 ));
             }
         }
@@ -198,7 +198,7 @@ impl TcpStream {
         ) else {
             return Err(io::const_error!(
                 io::ErrorKind::InvalidInput,
-                "Library failure: wrong message type or messaging error",
+                "library failure: wrong message type or messaging error",
             ));
         };
 
@@ -212,11 +212,11 @@ impl TcpStream {
             if result[0] != 0 {
                 if result[1] == 8 {
                     // timed out
-                    return Err(io::const_error!(io::ErrorKind::TimedOut, "Timeout"));
+                    return Err(io::const_error!(io::ErrorKind::TimedOut, "timeout"));
                 }
                 if result[1] == 9 {
                     // would block
-                    return Err(io::const_error!(io::ErrorKind::WouldBlock, "Would block"));
+                    return Err(io::const_error!(io::ErrorKind::WouldBlock, "would block"));
                 }
             }
             Err(io::const_error!(io::ErrorKind::Other, "recv_slice failure"))
@@ -258,20 +258,20 @@ impl TcpStream {
             self.write_timeout.load(Ordering::Relaxed) as usize,
             buf_len,
         )
-        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "Internal error")))?;
+        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "internal error")))?;
 
         if send_request.raw[0] != 0 {
             if send_request.raw[4] == 8 {
                 // timed out
                 return Err(io::const_error!(
                     io::ErrorKind::BrokenPipe,
-                    "Timeout or connection closed",
+                    "timeout or connection closed",
                 ));
             } else if send_request.raw[4] == 9 {
                 // would block
-                return Err(io::const_error!(io::ErrorKind::WouldBlock, "Would block"));
+                return Err(io::const_error!(io::ErrorKind::WouldBlock, "would block"));
             } else {
-                return Err(io::const_error!(io::ErrorKind::InvalidInput, "Error when sending"));
+                return Err(io::const_error!(io::ErrorKind::InvalidInput, "error when sending"));
             }
         }
         Ok(u32::from_le_bytes([
@@ -304,7 +304,7 @@ impl TcpStream {
             0,
             0,
         ) else {
-            return Err(io::const_error!(io::ErrorKind::InvalidInput, "Internal error"));
+            return Err(io::const_error!(io::ErrorKind::InvalidInput, "internal error"));
         };
         let mut i = get_addr.raw.iter();
         match *i.next().unwrap() {
@@ -324,7 +324,7 @@ impl TcpStream {
                 }
                 Ok(SocketAddr::V6(SocketAddrV6::new(new_addr.into(), self.local_port, 0, 0)))
             }
-            _ => Err(io::const_error!(io::ErrorKind::InvalidInput, "Internal error")),
+            _ => Err(io::const_error!(io::ErrorKind::InvalidInput, "tnternal error")),
         }
     }
 
@@ -333,7 +333,7 @@ impl TcpStream {
             services::net_server(),
             services::NetBlockingScalar::StdTcpStreamShutdown(self.fd, how).into(),
         )
-        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "Unexpected return value")))
+        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "unexpected return value")))
         .map(|_| ())
     }
 
@@ -355,7 +355,7 @@ impl TcpStream {
             services::net_server(),
             services::NetBlockingScalar::StdSetNodelay(self.fd, enabled).into(),
         )
-        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "Unexpected return value")))
+        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "unexpected return value")))
         .map(|_| ())
     }
 
@@ -364,7 +364,7 @@ impl TcpStream {
             services::net_server(),
             services::NetBlockingScalar::StdGetNodelay(self.fd).into(),
         )
-        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "Unexpected return value")))
+        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "unexpected return value")))
         .map(|res| res[0] != 0)?)
     }
 
@@ -376,7 +376,7 @@ impl TcpStream {
             services::net_server(),
             services::NetBlockingScalar::StdSetTtlTcp(self.fd, ttl).into(),
         )
-        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "Unexpected return value")))
+        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "unexpected return value")))
         .map(|_| ())
     }
 
@@ -385,7 +385,7 @@ impl TcpStream {
             services::net_server(),
             services::NetBlockingScalar::StdGetTtlTcp(self.fd).into(),
         )
-        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "Unexpected return value")))
+        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "unexpected return value")))
         .map(|res| res[0] as _)?)
     }
 

--- a/library/std/src/sys/net/connection/xous/udp.rs
+++ b/library/std/src/sys/net/connection/xous/udp.rs
@@ -13,7 +13,7 @@ macro_rules! unimpl {
     () => {
         return Err(io::const_error!(
             io::ErrorKind::Unsupported,
-            "This function is not yet implemented",
+            "this function is not yet implemented",
         ));
     };
 }
@@ -72,18 +72,18 @@ impl UdpSocket {
             if response[0] != 0 || valid == 0 {
                 let errcode = response[1];
                 if errcode == NetError::SocketInUse as u8 {
-                    return Err(io::const_error!(io::ErrorKind::ResourceBusy, "Socket in use"));
+                    return Err(io::const_error!(io::ErrorKind::ResourceBusy, "socket in use"));
                 } else if errcode == NetError::Invalid as u8 {
                     return Err(io::const_error!(
                         io::ErrorKind::InvalidInput,
-                        "Port can't be 0 or invalid address",
+                        "port can't be 0 or invalid address",
                     ));
                 } else if errcode == NetError::LibraryError as u8 {
-                    return Err(io::const_error!(io::ErrorKind::Other, "Library error"));
+                    return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 } else {
                     return Err(io::const_error!(
                         io::ErrorKind::Other,
-                        "Unable to connect or internal error",
+                        "unable to connect or internal error",
                     ));
                 }
             }
@@ -98,13 +98,13 @@ impl UdpSocket {
                 nonblocking: Cell::new(false),
             });
         }
-        Err(io::const_error!(io::ErrorKind::InvalidInput, "Invalid response"))
+        Err(io::const_error!(io::ErrorKind::InvalidInput, "invalid response"))
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         match self.remote.get() {
             Some(dest) => Ok(dest),
-            None => Err(io::const_error!(io::ErrorKind::NotConnected, "No peer specified")),
+            None => Err(io::const_error!(io::ErrorKind::NotConnected, "no peer specified")),
         }
     }
 
@@ -145,7 +145,7 @@ impl UdpSocket {
                 } else if receive_request.raw[1] == NetError::WouldBlock as u8 {
                     return Err(io::const_error!(io::ErrorKind::WouldBlock, "recv would block"));
                 } else if receive_request.raw[1] == NetError::LibraryError as u8 {
-                    return Err(io::const_error!(io::ErrorKind::Other, "Library error"));
+                    return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 } else {
                     return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                 }
@@ -178,7 +178,7 @@ impl UdpSocket {
                 Ok((rxlen as usize, addr))
             }
         } else {
-            Err(io::const_error!(io::ErrorKind::InvalidInput, "Unable to recv"))
+            Err(io::const_error!(io::ErrorKind::InvalidInput, "unable to recv"))
         }
     }
 
@@ -281,19 +281,19 @@ impl UdpSocket {
                         if errcode == NetError::SocketInUse as u8 {
                             return Err(io::const_error!(
                                 io::ErrorKind::ResourceBusy,
-                                "Socket in use",
+                                "socket in use",
                             ));
                         } else if errcode == NetError::Invalid as u8 {
                             return Err(io::const_error!(
                                 io::ErrorKind::InvalidInput,
-                                "Socket not valid",
+                                "socket not valid",
                             ));
                         } else if errcode == NetError::LibraryError as u8 {
-                            return Err(io::const_error!(io::ErrorKind::Other, "Library error"));
+                            return Err(io::const_error!(io::ErrorKind::Other, "library error"));
                         } else {
                             return Err(io::const_error!(
                                 io::ErrorKind::Other,
-                                "Unable to connect",
+                                "unable to connect",
                             ));
                         }
                     } else {
@@ -303,13 +303,13 @@ impl UdpSocket {
                 }
                 Err(crate::os::xous::ffi::Error::ServerQueueFull) => {
                     if now.elapsed() >= write_timeout {
-                        return Err(io::const_error!(io::ErrorKind::WouldBlock, "Write timed out"));
+                        return Err(io::const_error!(io::ErrorKind::WouldBlock, "write timed out"));
                     } else {
                         // question: do we want to do something a bit more gentle than immediately retrying?
                         crate::thread::yield_now();
                     }
                 }
-                _ => return Err(io::const_error!(io::ErrorKind::Other, "Library error")),
+                _ => return Err(io::const_error!(io::ErrorKind::Other, "library error")),
             }
         }
     }
@@ -363,7 +363,7 @@ impl UdpSocket {
             services::net_server(),
             services::NetBlockingScalar::StdSetTtlUdp(self.fd, ttl).into(),
         )
-        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "Unexpected return value")))
+        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "unexpected return value")))
         .map(|_| ())
     }
 
@@ -372,7 +372,7 @@ impl UdpSocket {
             services::net_server(),
             services::NetBlockingScalar::StdGetTtlUdp(self.fd).into(),
         )
-        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "Unexpected return value")))
+        .or(Err(io::const_error!(io::ErrorKind::InvalidInput, "unexpected return value")))
         .map(|res| res[0] as _)?)
     }
 

--- a/library/std/src/sys/pal/hermit/thread.rs
+++ b/library/std/src/sys/pal/hermit/thread.rs
@@ -41,7 +41,7 @@ impl Thread {
             unsafe {
                 drop(Box::from_raw(p));
             }
-            Err(io::const_error!(io::ErrorKind::Uncategorized, "Unable to create thread!"))
+            Err(io::const_error!(io::ErrorKind::Uncategorized, "unable to create thread!"))
         } else {
             Ok(Thread { tid })
         };

--- a/library/std/src/sys/pal/uefi/helpers.rs
+++ b/library/std/src/sys/pal/uefi/helpers.rs
@@ -158,7 +158,7 @@ pub(crate) unsafe fn close_event(evt: NonNull<crate::ffi::c_void>) -> io::Result
 /// Note: Some protocols need to be manually freed. It is the caller's responsibility to do so.
 pub(crate) fn image_handle_protocol<T>(protocol_guid: Guid) -> io::Result<NonNull<T>> {
     let system_handle = uefi::env::try_image_handle()
-        .ok_or(io::const_error!(io::ErrorKind::NotFound, "Protocol not found in Image handle"))?;
+        .ok_or(io::const_error!(io::ErrorKind::NotFound, "protocol not found in Image handle"))?;
     open_protocol(system_handle, protocol_guid)
 }
 
@@ -178,7 +178,7 @@ pub(crate) fn device_path_to_text(path: NonNull<device_path::Protocol>) -> io::R
         };
 
         let path = os_string_from_raw(path_ptr)
-            .ok_or(io::const_error!(io::ErrorKind::InvalidData, "Invalid path"))?;
+            .ok_or(io::const_error!(io::ErrorKind::InvalidData, "invalid path"))?;
 
         if let Some(boot_services) = crate::os::uefi::env::boot_services() {
             let boot_services: NonNull<r_efi::efi::BootServices> = boot_services.cast();
@@ -213,7 +213,7 @@ pub(crate) fn device_path_to_text(path: NonNull<device_path::Protocol>) -> io::R
         }
     }
 
-    Err(io::const_error!(io::ErrorKind::NotFound, "No device path to text protocol found"))
+    Err(io::const_error!(io::ErrorKind::NotFound, "no device path to text protocol found"))
 }
 
 /// Gets RuntimeServices.
@@ -245,7 +245,7 @@ impl OwnedDevicePath {
 
             NonNull::new(path)
                 .map(OwnedDevicePath)
-                .ok_or_else(|| const_error!(io::ErrorKind::InvalidFilename, "Invalid Device Path"))
+                .ok_or_else(|| const_error!(io::ErrorKind::InvalidFilename, "invalid Device Path"))
         }
 
         static LAST_VALID_HANDLE: AtomicPtr<crate::ffi::c_void> =
@@ -490,7 +490,7 @@ pub(crate) fn get_device_path_from_map(map: &Path) -> io::Result<BorrowedDeviceP
     let shell =
         open_shell().ok_or(io::const_error!(io::ErrorKind::NotFound, "UEFI Shell not found"))?;
     let mut path = os_string_to_raw(map.as_os_str())
-        .ok_or(io::const_error!(io::ErrorKind::InvalidFilename, "Invalid UEFI shell mapping"))?;
+        .ok_or(io::const_error!(io::ErrorKind::InvalidFilename, "invalid UEFI shell mapping"))?;
 
     // The Device Path Protocol pointer returned by UEFI shell is owned by the shell and is not
     // freed throughout it's lifetime. So it has a 'static lifetime.

--- a/library/std/src/sys/pal/uefi/os.rs
+++ b/library/std/src/sys/pal/uefi/os.rs
@@ -70,7 +70,7 @@ pub fn getcwd() -> io::Result<PathBuf> {
             let path_ptr = unsafe { ((*shell.as_ptr()).get_cur_dir)(crate::ptr::null_mut()) };
             helpers::os_string_from_raw(path_ptr)
                 .map(PathBuf::from)
-                .ok_or(io::const_error!(io::ErrorKind::InvalidData, "Invalid path"))
+                .ok_or(io::const_error!(io::ErrorKind::InvalidData, "invalid path"))
         }
         None => {
             let mut t = current_exe()?;
@@ -86,7 +86,7 @@ pub fn chdir(p: &path::Path) -> io::Result<()> {
     let shell = helpers::open_shell().ok_or(unsupported_err())?;
 
     let mut p = helpers::os_string_to_raw(p.as_os_str())
-        .ok_or(io::const_error!(io::ErrorKind::InvalidData, "Invalid path"))?;
+        .ok_or(io::const_error!(io::ErrorKind::InvalidData, "invalid path"))?;
 
     let r = unsafe { ((*shell.as_ptr()).set_cur_dir)(crate::ptr::null_mut(), p.as_mut_ptr()) };
     if r.is_error() { Err(io::Error::from_raw_os_error(r.as_usize())) } else { Ok(()) }
@@ -229,15 +229,15 @@ mod uefi_env {
 
     pub(crate) fn set(key: &OsStr, val: &OsStr) -> io::Result<()> {
         let mut key_ptr = helpers::os_string_to_raw(key)
-            .ok_or(io::const_error!(io::ErrorKind::InvalidInput, "Invalid Key"))?;
+            .ok_or(io::const_error!(io::ErrorKind::InvalidInput, "invalid key"))?;
         let mut val_ptr = helpers::os_string_to_raw(val)
-            .ok_or(io::const_error!(io::ErrorKind::InvalidInput, "Invalid Value"))?;
+            .ok_or(io::const_error!(io::ErrorKind::InvalidInput, "invalid value"))?;
         unsafe { set_raw(key_ptr.as_mut_ptr(), val_ptr.as_mut_ptr()) }
     }
 
     pub(crate) fn unset(key: &OsStr) -> io::Result<()> {
         let mut key_ptr = helpers::os_string_to_raw(key)
-            .ok_or(io::const_error!(io::ErrorKind::InvalidInput, "Invalid Key"))?;
+            .ok_or(io::const_error!(io::ErrorKind::InvalidInput, "invalid key"))?;
         unsafe { set_raw(key_ptr.as_mut_ptr(), crate::ptr::null_mut()) }
     }
 
@@ -267,7 +267,7 @@ mod uefi_env {
                 });
                 // SAFETY: val.add(start) is always NULL terminated
                 let val = unsafe { get_raw(shell, val.add(start)) }
-                    .ok_or(io::const_error!(io::ErrorKind::InvalidInput, "Invalid Value"))?;
+                    .ok_or(io::const_error!(io::ErrorKind::InvalidInput, "invalid value"))?;
 
                 vars.push((key, val));
                 start = i + 1;

--- a/library/std/src/sys/pal/uefi/process.rs
+++ b/library/std/src/sys/pal/uefi/process.rs
@@ -613,7 +613,7 @@ mod uefi_command_internal {
             OsString::from_wide(&self._buffer)
                 .into_string()
                 .map(Into::into)
-                .map_err(|_| const_error!(io::ErrorKind::Other, "utf8 conversion failed"))
+                .map_err(|_| const_error!(io::ErrorKind::Other, "UTF-8 conversion failed"))
         }
 
         extern "efiapi" fn reset(

--- a/library/std/src/sys/pal/uefi/stdio.rs
+++ b/library/std/src/sys/pal/uefi/stdio.rs
@@ -71,7 +71,7 @@ impl io::Read for Stdin {
             };
 
         if ch.len() > 1 {
-            return Err(io::const_error!(io::ErrorKind::InvalidData, "invalid utf-16 sequence"));
+            return Err(io::const_error!(io::ErrorKind::InvalidData, "invalid UTF-16 sequence"));
         }
 
         match ch.pop().unwrap() {

--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -475,7 +475,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
         );
         if result != libc::B_OK {
             use crate::io::ErrorKind;
-            Err(io::const_error!(ErrorKind::Uncategorized, "Error getting executable path"))
+            Err(io::const_error!(ErrorKind::Uncategorized, "error getting executable path"))
         } else {
             // find_path adds the null terminator.
             let name = CStr::from_ptr(name.as_ptr()).to_bytes();
@@ -492,7 +492,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
 #[cfg(target_os = "l4re")]
 pub fn current_exe() -> io::Result<PathBuf> {
     use crate::io::ErrorKind;
-    Err(io::const_error!(ErrorKind::Unsupported, "Not yet implemented!"))
+    Err(io::const_error!(ErrorKind::Unsupported, "not yet implemented!"))
 }
 
 #[cfg(target_os = "vxworks")]

--- a/library/std/src/sys/pal/unix/process/process_fuchsia.rs
+++ b/library/std/src/sys/pal/unix/process/process_fuchsia.rs
@@ -187,7 +187,7 @@ impl Process {
         if actual != 1 {
             return Err(io::const_error!(
                 io::ErrorKind::InvalidData,
-                "Failed to get exit status of process",
+                "failed to get exit status of process",
             ));
         }
         Ok(ExitStatus(proc_info.return_code))
@@ -224,7 +224,7 @@ impl Process {
         if actual != 1 {
             return Err(io::const_error!(
                 io::ErrorKind::InvalidData,
-                "Failed to get exit status of process",
+                "failed to get exit status of process",
             ));
         }
         Ok(Some(ExitStatus(proc_info.return_code)))

--- a/library/std/src/sys/pal/unix/process/process_unix.rs
+++ b/library/std/src/sys/pal/unix/process/process_unix.rs
@@ -1228,7 +1228,7 @@ mod linux_child_ext {
                 .as_ref()
                 // SAFETY: The os type is a transparent wrapper, therefore we can transmute references
                 .map(|fd| unsafe { mem::transmute::<&imp::PidFd, &os::PidFd>(fd) })
-                .ok_or_else(|| io::const_error!(ErrorKind::Uncategorized, "No pidfd was created."))
+                .ok_or_else(|| io::const_error!(ErrorKind::Uncategorized, "no pidfd was created."))
         }
 
         fn into_pidfd(mut self) -> Result<os::PidFd, Self> {

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -480,7 +480,7 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             unsafe {
                 use libc::_syspage_ptr;
                 if _syspage_ptr.is_null() {
-                    Err(io::const_error!(io::ErrorKind::NotFound, "No syspage available"))
+                    Err(io::const_error!(io::ErrorKind::NotFound, "no syspage available"))
                 } else {
                     let cpus = (*_syspage_ptr).num_cpu;
                     NonZero::new(cpus as usize)
@@ -520,7 +520,7 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
             }
         } else {
             // FIXME: implement on Redox, l4re
-            Err(io::const_error!(io::ErrorKind::Unsupported, "Getting the number of hardware threads is not supported on the target platform"))
+            Err(io::const_error!(io::ErrorKind::Unsupported, "getting the number of hardware threads is not supported on the target platform"))
         }
     }
 }

--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -92,7 +92,7 @@ impl Timespec {
         if tv_nsec >= 0 && tv_nsec < NSEC_PER_SEC as i64 {
             Ok(unsafe { Self::new_unchecked(tv_sec, tv_nsec) })
         } else {
-            Err(io::const_error!(io::ErrorKind::InvalidData, "Invalid timestamp"))
+            Err(io::const_error!(io::ErrorKind::InvalidData, "invalid timestamp"))
         }
     }
 

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -724,7 +724,7 @@ impl File {
         {
             return Err(io::const_error!(
                 io::ErrorKind::InvalidInput,
-                "Cannot set file timestamp to 0",
+                "cannot set file timestamp to 0",
             ));
         }
         let is_max = |t: c::FILETIME| t.dwLowDateTime == u32::MAX && t.dwHighDateTime == u32::MAX;
@@ -734,7 +734,7 @@ impl File {
         {
             return Err(io::const_error!(
                 io::ErrorKind::InvalidInput,
-                "Cannot set file timestamp to 0xFFFF_FFFF_FFFF_FFFF",
+                "cannot set file timestamp to 0xFFFF_FFFF_FFFF_FFFF",
             ));
         }
         cvt(unsafe {

--- a/library/test/src/formatters/junit.rs
+++ b/library/test/src/formatters/junit.rs
@@ -39,15 +39,15 @@ fn str_to_cdata(s: &str) -> String {
 
 impl<T: Write> OutputFormatter for JunitFormatter<T> {
     fn write_discovery_start(&mut self) -> io::Result<()> {
-        Err(io::const_error!(io::ErrorKind::NotFound, "Not yet implemented!"))
+        Err(io::const_error!(io::ErrorKind::NotFound, "not yet implemented!"))
     }
 
     fn write_test_discovered(&mut self, _desc: &TestDesc, _test_type: &str) -> io::Result<()> {
-        Err(io::const_error!(io::ErrorKind::NotFound, "Not yet implemented!"))
+        Err(io::const_error!(io::ErrorKind::NotFound, "not yet implemented!"))
     }
 
     fn write_discovery_finish(&mut self, _state: &ConsoleTestDiscoveryState) -> io::Result<()> {
-        Err(io::const_error!(io::ErrorKind::NotFound, "Not yet implemented!"))
+        Err(io::const_error!(io::ErrorKind::NotFound, "not yet implemented!"))
     }
 
     fn write_run_start(


### PR DESCRIPTION
Error messages are supposed to start with lowercase letters, but a lot of `io::const_error` messages did not. This fixes them to start with a lowercase letter.
I did consider adding a const check for this to the macro, but some of them start with proper nouns that make sense to uppercase them.

See https://doc.rust-lang.org/1.85.0/std/error/trait.Error.html

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
