### PR TITLE
Check built-in operator obligation before the method's WF obligations so as to not incompletely guide inference

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0284.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0284.md
@@ -1,10 +1,12 @@
+#### Note: this error code is no longer emitted by the compiler.
+
 This error occurs when the compiler is unable to unambiguously infer the
 return type of a function or method which is generic on return type, such
 as the `collect` method for `Iterator`s.
 
 For example:
 
-```compile_fail,E0284
+```compile_fail
 fn main() {
     let n: u32 = 1;
     let mut d: u64 = 2;

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -24,8 +24,8 @@ use tracing::{debug, instrument, warn};
 use super::nice_region_error::placeholder_error::Highlighted;
 use crate::error_reporting::TypeErrCtxt;
 use crate::errors::{
-    AmbiguousImpl, AmbiguousReturn, AnnotationRequired, InferenceBadError,
-    SourceKindMultiSuggestion, SourceKindSubdiag,
+    AmbiguousImpl, AnnotationRequired, InferenceBadError, SourceKindMultiSuggestion,
+    SourceKindSubdiag,
 };
 use crate::infer::InferCtxt;
 
@@ -39,11 +39,6 @@ pub enum TypeAnnotationNeeded {
     /// let _ = Default::default();
     /// ```
     E0283,
-    /// ```compile_fail,E0284
-    /// let mut d: u64 = 2;
-    /// d = d % 1u32.into();
-    /// ```
-    E0284,
 }
 
 impl From<TypeAnnotationNeeded> for ErrCode {
@@ -51,7 +46,6 @@ impl From<TypeAnnotationNeeded> for ErrCode {
         match val {
             TypeAnnotationNeeded::E0282 => E0282,
             TypeAnnotationNeeded::E0283 => E0283,
-            TypeAnnotationNeeded::E0284 => E0284,
         }
     }
 }
@@ -453,17 +447,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 was_written: false,
                 path: Default::default(),
             }),
-            TypeAnnotationNeeded::E0284 => self.dcx().create_err(AmbiguousReturn {
-                span,
-                source_kind,
-                source_name,
-                failure_span,
-                infer_subdiags,
-                multi_suggestions,
-                bad_label,
-                was_written: false,
-                path: Default::default(),
-            }),
         }
     }
 
@@ -650,17 +633,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 time_version,
             }),
             TypeAnnotationNeeded::E0283 => self.dcx().create_err(AmbiguousImpl {
-                span,
-                source_kind,
-                source_name: &name,
-                failure_span,
-                infer_subdiags,
-                multi_suggestions,
-                bad_label: None,
-                was_written: path.is_some(),
-                path: path.unwrap_or_default(),
-            }),
-            TypeAnnotationNeeded::E0284 => self.dcx().create_err(AmbiguousReturn {
                 span,
                 source_kind,
                 source_name: &name,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
@@ -1,8 +1,6 @@
 use std::ops::ControlFlow;
 
-use rustc_errors::{
-    Applicability, Diag, E0283, E0284, E0790, MultiSpan, StashKey, struct_span_code_err,
-};
+use rustc_errors::{Applicability, Diag, E0283, E0790, MultiSpan, StashKey, struct_span_code_err};
 use rustc_hir as hir;
 use rustc_hir::LangItem;
 use rustc_hir::def::{DefKind, Res};
@@ -534,7 +532,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         obligation.cause.body_id,
                         span,
                         arg,
-                        TypeAnnotationNeeded::E0284,
+                        TypeAnnotationNeeded::E0283,
                         true,
                     )
                     .with_note(format!("cannot satisfy `{predicate}`"))
@@ -543,7 +541,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     struct_span_code_err!(
                         self.dcx(),
                         span,
-                        E0284,
+                        E0283,
                         "type annotations needed: cannot satisfy `{predicate}`",
                     )
                     .with_span_label(span, format!("cannot satisfy `{predicate}`"))
@@ -563,7 +561,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         obligation.cause.body_id,
                         span,
                         arg,
-                        TypeAnnotationNeeded::E0284,
+                        TypeAnnotationNeeded::E0283,
                         true,
                     );
                     err
@@ -573,7 +571,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     struct_span_code_err!(
                         self.dcx(),
                         span,
-                        E0284,
+                        E0283,
                         "type annotations needed: cannot satisfy `{predicate}`",
                     )
                     .with_span_label(span, format!("cannot satisfy `{predicate}`"))
@@ -585,7 +583,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     obligation.cause.body_id,
                     span,
                     ct.into(),
-                    TypeAnnotationNeeded::E0284,
+                    TypeAnnotationNeeded::E0283,
                     true,
                 ),
             ty::PredicateKind::NormalizesTo(ty::NormalizesTo { alias, term })
@@ -598,7 +596,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 struct_span_code_err!(
                     self.dcx(),
                     span,
-                    E0284,
+                    E0283,
                     "type annotations needed: cannot normalize `{alias}`",
                 )
                 .with_span_label(span, format!("cannot normalize `{alias}`"))
@@ -612,7 +610,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 struct_span_code_err!(
                     self.dcx(),
                     span,
-                    E0284,
+                    E0283,
                     "type annotations needed: cannot satisfy `{predicate}`",
                 )
                 .with_span_label(span, format!("cannot satisfy `{predicate}`"))

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -220,27 +220,6 @@ pub struct AmbiguousImpl<'a> {
     pub path: PathBuf,
 }
 
-// Copy of `AnnotationRequired` for E0284
-#[derive(Diagnostic)]
-#[diag(trait_selection_type_annotations_needed, code = E0284)]
-pub struct AmbiguousReturn<'a> {
-    #[primary_span]
-    pub span: Span,
-    pub source_kind: &'static str,
-    pub source_name: &'a str,
-    #[label]
-    pub failure_span: Option<Span>,
-    #[subdiagnostic]
-    pub bad_label: Option<InferenceBadError<'a>>,
-    #[subdiagnostic]
-    pub infer_subdiags: Vec<SourceKindSubdiag<'a>>,
-    #[subdiagnostic]
-    pub multi_suggestions: Vec<SourceKindMultiSuggestion<'a>>,
-    #[note(trait_selection_full_type_written)]
-    pub was_written: bool,
-    pub path: PathBuf,
-}
-
 // Used when a better one isn't available
 #[derive(Subdiagnostic)]
 #[label(trait_selection_label_bad)]

--- a/tests/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/tests/ui/associated-types/associated-types-overridden-binding.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot satisfy `<Self as Iterator>::Item == i32`
+error[E0283]: type annotations needed: cannot satisfy `<Self as Iterator>::Item == i32`
   --> $DIR/associated-types-overridden-binding.rs:4:12
    |
 LL | trait Bar: Foo<Item = u32> {}
@@ -10,7 +10,7 @@ note: required by a bound in `Foo`
 LL | trait Foo: Iterator<Item = i32> {}
    |                     ^^^^^^^^^^ required by this bound in `Foo`
 
-error[E0284]: type annotations needed: cannot satisfy `<Self as Iterator>::Item == i32`
+error[E0283]: type annotations needed: cannot satisfy `<Self as Iterator>::Item == i32`
   --> $DIR/associated-types-overridden-binding.rs:7:21
    |
 LL | trait U32Iterator = I32Iterator<Item = u32>;
@@ -35,4 +35,4 @@ LL |     let _: &dyn I32Iterator<Item = u32>;
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/async-await/async-fn/incomplete-constrain-builtin.rs
+++ b/tests/ui/async-await/async-fn/incomplete-constrain-builtin.rs
@@ -1,0 +1,23 @@
+//@ check-pass
+
+// Ensure that a param-env predicate like `(T,): Sized` doesn't get in the way of us
+// confirming the built-in call operator for `AsyncFnOnce`. This happens because we
+// end up with a signature like:
+//
+// `<F as AsyncFnOnce<(?0,)>>::async_call_once(self) -> <F as AsyncFnOnce<(?0,)>>::CallOnceFuture`
+//
+// (where we use fresh infer vars for each arg since we haven't actually typeck'd the args yet).
+// But normalizing that signature keeps the associated type rigid, so we don't end up
+// constraining `?0` like we would if we were normalizing the analogous `FnOnce` call...
+// Then we were checking that the method signature was WF, which would incompletely constrain
+// `(?0,) == (T,)` via the param-env, leading to us later failing on `F: AsyncFnOnce<(T,)>`.
+
+fn run<F, T>(f: F)
+where
+    F: AsyncFnOnce(i32),
+    (T,): Sized,
+{
+    f(1i32);
+}
+
+fn main() {}

--- a/tests/ui/coherence/indirect-impl-for-trait-obj-coherence.next.stderr
+++ b/tests/ui/coherence/indirect-impl-for-trait-obj-coherence.next.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot normalize `<dyn Object<U, Output = T> as Object<U>>::Output`
+error[E0283]: type annotations needed: cannot normalize `<dyn Object<U, Output = T> as Object<U>>::Output`
   --> $DIR/indirect-impl-for-trait-obj-coherence.rs:25:41
    |
 LL |     foo::<dyn Object<U, Output = T>, U>(x)
@@ -6,4 +6,4 @@ LL |     foo::<dyn Object<U, Output = T>, U>(x)
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/coherence/occurs-check/associated-type.next.stderr
+++ b/tests/ui/coherence/occurs-check/associated-type.next.stderr
@@ -14,7 +14,7 @@ LL | |     for<'a> *const T: ToUnit<'a>,
    |
    = note: this behavior recently changed as a result of a bug fix; see rust-lang/rust#56105 for details
 
-error[E0284]: type annotations needed: cannot normalize `<for<'a> fn(&'a (), ()) as Overlap<for<'a> fn(&'a (), ())>>::Assoc`
+error[E0283]: type annotations needed: cannot normalize `<for<'a> fn(&'a (), ()) as Overlap<for<'a> fn(&'a (), ())>>::Assoc`
   --> $DIR/associated-type.rs:45:59
    |
 LL |     foo::<for<'a> fn(&'a (), ()), for<'a> fn(&'a (), ())>(3usize);
@@ -22,5 +22,5 @@ LL |     foo::<for<'a> fn(&'a (), ()), for<'a> fn(&'a (), ())>(3usize);
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0119, E0284.
+Some errors have detailed explanations: E0119, E0283.
 For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/const-generics/defaults/doesnt_infer.stderr
+++ b/tests/ui/const-generics/defaults/doesnt_infer.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed for `Foo<_>`
+error[E0283]: type annotations needed for `Foo<_>`
   --> $DIR/doesnt_infer.rs:13:9
    |
 LL |     let foo = Foo::foo();
@@ -14,7 +14,7 @@ help: consider giving `foo` an explicit type, where the value of const parameter
 LL |     let foo: Foo<N> = Foo::foo();
    |            ++++++++
 
-error[E0284]: type annotations needed for `Foo<_>`
+error[E0283]: type annotations needed for `Foo<_>`
   --> $DIR/doesnt_infer.rs:13:9
    |
 LL |     let foo = Foo::foo();
@@ -34,4 +34,4 @@ LL |     let foo: Foo<N> = Foo::foo();
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -33,7 +33,7 @@ LL |     1_u64
    = help: the trait `Traitor<1, 1>` is not implemented for `u64`
            but trait `Traitor<1, 2>` is implemented for it
 
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/rp_impl_trait_fail.rs:28:5
    |
 LL |     uwu();
@@ -51,5 +51,5 @@ LL |     uwu::<N>();
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0277, E0284.
+Some errors have detailed explanations: E0277, E0283.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/const-generics/generic_arg_infer/issue-91614.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/issue-91614.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed for `Mask<_, _>`
+error[E0283]: type annotations needed for `Mask<_, _>`
   --> $DIR/issue-91614.rs:6:9
    |
 LL |     let y = Mask::<_, _>::splat(false);
@@ -11,7 +11,7 @@ help: consider giving `y` an explicit type, where the value of const parameter `
 LL |     let y: Mask<_, N> = Mask::<_, _>::splat(false);
    |          ++++++++++++
 
-error[E0284]: type annotations needed for `Mask<_, _>`
+error[E0283]: type annotations needed for `Mask<_, _>`
   --> $DIR/issue-91614.rs:6:9
    |
 LL |     let y = Mask::<_, _>::splat(false);
@@ -26,4 +26,4 @@ LL |     let y: Mask<_, N> = Mask::<_, _>::splat(false);
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-ok-infer-err.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-ok-infer-err.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/dyn-compatibility-ok-infer-err.rs:19:5
    |
 LL |     use_dyn(&());
@@ -14,7 +14,7 @@ help: consider specifying the generic argument
 LL |     use_dyn::<N>(&());
    |            +++++
 
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/dyn-compatibility-ok-infer-err.rs:19:5
    |
 LL |     use_dyn(&());
@@ -37,4 +37,4 @@ LL |     use_dyn::<N>(&());
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-62504.full.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-62504.full.stderr
@@ -18,7 +18,7 @@ help: try adding a `where` bound
 LL |     pub const fn new() -> Self where [(); Self::SIZE]: {
    |                                +++++++++++++++++++++++
 
-error[E0284]: type annotations needed for `ArrayHolder<_>`
+error[E0283]: type annotations needed for `ArrayHolder<_>`
   --> $DIR/issue-62504.rs:26:9
    |
 LL |     let mut array = ArrayHolder::new();
@@ -34,7 +34,7 @@ help: consider giving `array` an explicit type, where the value of const paramet
 LL |     let mut array: ArrayHolder<X> = ArrayHolder::new();
    |                  ++++++++++++++++
 
-error[E0284]: type annotations needed for `ArrayHolder<_>`
+error[E0283]: type annotations needed for `ArrayHolder<_>`
   --> $DIR/issue-62504.rs:26:9
    |
 LL |     let mut array = ArrayHolder::new();
@@ -54,5 +54,5 @@ LL |     let mut array: ArrayHolder<X> = ArrayHolder::new();
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0284, E0308.
-For more information about an error, try `rustc --explain E0284`.
+Some errors have detailed explanations: E0283, E0308.
+For more information about an error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/generic_const_exprs/issue-62504.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-62504.min.stderr
@@ -20,7 +20,7 @@ note: tuple struct defined here
 LL | struct ArrayHolder<const X: usize>([u32; X]);
    |        ^^^^^^^^^^^
 
-error[E0284]: type annotations needed for `ArrayHolder<_>`
+error[E0283]: type annotations needed for `ArrayHolder<_>`
   --> $DIR/issue-62504.rs:26:9
    |
 LL |     let mut array = ArrayHolder::new();
@@ -36,7 +36,7 @@ help: consider giving `array` an explicit type, where the value of const paramet
 LL |     let mut array: ArrayHolder<X> = ArrayHolder::new();
    |                  ++++++++++++++++
 
-error[E0284]: type annotations needed for `ArrayHolder<_>`
+error[E0283]: type annotations needed for `ArrayHolder<_>`
   --> $DIR/issue-62504.rs:26:9
    |
 LL |     let mut array = ArrayHolder::new();
@@ -56,5 +56,5 @@ LL |     let mut array: ArrayHolder<X> = ArrayHolder::new();
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0284, E0308.
-For more information about an error, try `rustc --explain E0284`.
+Some errors have detailed explanations: E0283, E0308.
+For more information about an error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/generic_const_exprs/post-analysis-user-facing-param-env.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/post-analysis-user-facing-param-env.stderr
@@ -26,7 +26,7 @@ LL | impl<'a, const NUM: usize> std::ops::Add<&'a Foo> for Foo
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/post-analysis-user-facing-param-env.rs:11:40
    |
 LL |     fn unimplemented(self, _: &Foo) -> Self::Output {
@@ -42,5 +42,5 @@ LL | impl<'a, const NUM: usize> std::ops::Add<&'a Foo> for Foo
 
 error: aborting due to 3 previous errors; 1 warning emitted
 
-Some errors have detailed explanations: E0207, E0284, E0407.
+Some errors have detailed explanations: E0207, E0283, E0407.
 For more information about an error, try `rustc --explain E0207`.

--- a/tests/ui/const-generics/infer/cannot-infer-const-args.stderr
+++ b/tests/ui/const-generics/infer/cannot-infer-const-args.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/cannot-infer-const-args.rs:6:5
    |
 LL |     foo();
@@ -16,4 +16,4 @@ LL |     foo::<X>();
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/infer/issue-77092.stderr
+++ b/tests/ui/const-generics/infer/issue-77092.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/issue-77092.rs:11:26
    |
 LL |         println!("{:?}", take_array_from_mut(&mut arr, i));
@@ -14,7 +14,7 @@ help: consider specifying the generic arguments
 LL |         println!("{:?}", take_array_from_mut::<i32, N>(&mut arr, i));
    |                                             ++++++++++
 
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/issue-77092.rs:11:26
    |
 LL |         println!("{:?}", take_array_from_mut(&mut arr, i));
@@ -34,4 +34,4 @@ LL |         println!("{:?}", take_array_from_mut::<i32, N>(&mut arr, i));
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/infer/method-chain.stderr
+++ b/tests/ui/const-generics/infer/method-chain.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/method-chain.rs:15:33
    |
 LL |     Foo.bar().bar().bar().bar().baz();
@@ -16,4 +16,4 @@ LL |     Foo.bar().bar().bar().bar().baz::<N>();
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/infer/one-param-uninferred.stderr
+++ b/tests/ui/const-generics/infer/one-param-uninferred.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/one-param-uninferred.rs:9:23
    |
 LL |     let _: [u8; 17] = foo();
@@ -16,4 +16,4 @@ LL |     let _: [u8; 17] = foo::<17, M>();
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/infer/uninferred-consts.stderr
+++ b/tests/ui/const-generics/infer/uninferred-consts.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/uninferred-consts.rs:9:9
    |
 LL |     Foo.foo();
@@ -14,7 +14,7 @@ help: consider specifying the generic arguments
 LL |     Foo.foo::<A, B>();
    |            ++++++++
 
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/uninferred-consts.rs:9:9
    |
 LL |     Foo.foo();
@@ -32,4 +32,4 @@ LL |     Foo.foo::<A, B>();
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
+++ b/tests/ui/const-generics/parent_generics_of_encoding_impl_trait.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/parent_generics_of_encoding_impl_trait.rs:9:5
    |
 LL |     generics_of_parent_impl_trait::foo([()]);
@@ -12,4 +12,4 @@ LL | pub fn foo<const N: usize>(foo: impl Into<[(); N + 1]>) {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/const-generics/unify_with_nested_expr.stderr
+++ b/tests/ui/const-generics/unify_with_nested_expr.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/unify_with_nested_expr.rs:8:5
    |
 LL |     bar();
@@ -16,4 +16,4 @@ LL |     bar::<N>();
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/delegation/generics/free-fn-to-free-fn.stderr
+++ b/tests/ui/delegation/generics/free-fn-to-free-fn.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/free-fn-to-free-fn.rs:15:17
    |
 LL | reuse to_reuse::consts;
@@ -50,5 +50,5 @@ LL |     struct S;
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0277, E0284, E0794.
+Some errors have detailed explanations: E0277, E0283, E0794.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/dropck/dropck-only-error-ambiguity.stderr
+++ b/tests/ui/dropck/dropck-only-error-ambiguity.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/dropck-only-error-ambiguity.rs:19:23
    |
 LL |     pub fn MOVES_SELF(self) {}
@@ -8,4 +8,4 @@ LL |     pub fn MOVES_SELF(self) {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/generic-associated-types/bugs/issue-91762.stderr
+++ b/tests/ui/generic-associated-types/bugs/issue-91762.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/issue-91762.rs:24:15
    |
 LL |         ret = <Self::Base as Functor>::fmap(arg);
@@ -12,4 +12,4 @@ LL |         ret = <Self::Base as Functor>::fmap::<T, U>(arg);
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/higher-ranked/trait-bounds/rigid-equate-projections-in-higher-ranked-fn-signature.next.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/rigid-equate-projections-in-higher-ranked-fn-signature.next.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot satisfy `for<'a> <_ as Trait<'a>>::Assoc normalizes-to <T as Trait<'_>>::Assoc`
+error[E0283]: type annotations needed: cannot satisfy `for<'a> <_ as Trait<'a>>::Assoc normalizes-to <T as Trait<'_>>::Assoc`
   --> $DIR/rigid-equate-projections-in-higher-ranked-fn-signature.rs:27:50
    |
 LL |     let _: for<'a> fn(<_ as Trait<'a>>::Assoc) = foo::<T>();
@@ -6,4 +6,4 @@ LL |     let _: for<'a> fn(<_ as Trait<'a>>::Assoc) = foo::<T>();
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/impl-trait/auto-trait-selection-freeze.next.stderr
+++ b/tests/ui/impl-trait/auto-trait-selection-freeze.next.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot satisfy `impl Sized == _`
+error[E0283]: type annotations needed: cannot satisfy `impl Sized == _`
   --> $DIR/auto-trait-selection-freeze.rs:19:5
    |
 LL |     if false { is_trait(foo()) } else { Default::default() }
@@ -6,4 +6,4 @@ LL |     if false { is_trait(foo()) } else { Default::default() }
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/impl-trait/auto-trait-selection.next.stderr
+++ b/tests/ui/impl-trait/auto-trait-selection.next.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot satisfy `impl Sized == _`
+error[E0283]: type annotations needed: cannot satisfy `impl Sized == _`
   --> $DIR/auto-trait-selection.rs:15:5
    |
 LL |     if false { is_trait(foo()) } else { Default::default() }
@@ -6,4 +6,4 @@ LL |     if false { is_trait(foo()) } else { Default::default() }
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/impl-trait/two_tait_defining_each_other2.next.stderr
+++ b/tests/ui/impl-trait/two_tait_defining_each_other2.next.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot satisfy `_ == A`
+error[E0283]: type annotations needed: cannot satisfy `_ == A`
   --> $DIR/two_tait_defining_each_other2.rs:11:8
    |
 LL | fn muh(x: A) -> B {
@@ -6,4 +6,4 @@ LL | fn muh(x: A) -> B {
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/inference/issue-12028.stderr
+++ b/tests/ui/inference/issue-12028.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/issue-12028.rs:27:14
    |
 LL |         self.input_stream(&mut stream);
@@ -13,4 +13,4 @@ LL +         <u8 as StreamHash<H>>::input_stream(self, &mut stream);
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/inference/issue-70082.stderr
+++ b/tests/ui/inference/issue-70082.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/issue-70082.rs:7:33
    |
 LL |     let y: f64 = 0.01f64 * 1i16.into();
@@ -6,7 +6,9 @@ LL |     let y: f64 = 0.01f64 * 1i16.into();
    |                          |
    |                          type must be known at this point
    |
-   = note: cannot satisfy `<f64 as Mul<_>>::Output == f64`
+   = note: multiple `impl`s satisfying `f64: Mul<_>` found in the `core` crate:
+           - impl Mul for f64;
+           - impl Mul<&f64> for f64;
 help: try using a fully qualified path to specify the expected types
    |
 LL -     let y: f64 = 0.01f64 * 1i16.into();
@@ -15,4 +17,4 @@ LL +     let y: f64 = 0.01f64 * <i16 as Into<T>>::into(1i16);
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/inference/issue-71584.stderr
+++ b/tests/ui/inference/issue-71584.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/issue-71584.rs:5:15
    |
 LL |     d = d % n.into();
@@ -6,7 +6,10 @@ LL |     d = d % n.into();
    |           |
    |           type must be known at this point
    |
-   = note: cannot satisfy `<u64 as Rem<_>>::Output == u64`
+   = note: multiple `impl`s satisfying `u64: Rem<_>` found in the `core` crate:
+           - impl Rem for u64;
+           - impl Rem<&u64> for u64;
+           - impl Rem<NonZero<u64>> for u64;
 help: try using a fully qualified path to specify the expected types
    |
 LL -     d = d % n.into();
@@ -15,4 +18,4 @@ LL +     d = d % <u32 as Into<T>>::into(n);
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/inference/issue-83606.stderr
+++ b/tests/ui/inference/issue-83606.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed for `[usize; _]`
+error[E0283]: type annotations needed for `[usize; _]`
   --> $DIR/issue-83606.rs:8:9
    |
 LL |     let _ = foo("foo");
@@ -16,4 +16,4 @@ LL |     let _: [_; N] = foo("foo");
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/issues/issue-24036.stderr
+++ b/tests/ui/issues/issue-24036.stderr
@@ -11,13 +11,15 @@ LL |     x = |c| c + 1;
    = note: no two closures, even if identical, have the same type
    = help: consider boxing your closure and/or using it as a trait object
 
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/issue-24036.rs:9:15
    |
 LL |         1 => |c| c + 1,
    |               ^    - type must be known at this point
    |
-   = note: cannot satisfy `<_ as Add<i32>>::Output == _`
+   = note: multiple `impl`s satisfying `_: Add<i32>` found in the `core` crate:
+           - impl Add for i32;
+           - impl<'a> Add<i32> for &'a i32;
 help: consider giving this closure parameter an explicit type
    |
 LL |         1 => |c: /* Type */| c + 1,
@@ -25,5 +27,5 @@ LL |         1 => |c: /* Type */| c + 1,
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0284, E0308.
-For more information about an error, try `rustc --explain E0284`.
+Some errors have detailed explanations: E0283, E0308.
+For more information about an error, try `rustc --explain E0283`.

--- a/tests/ui/issues/issue-69455.stderr
+++ b/tests/ui/issues/issue-69455.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/issue-69455.rs:29:41
    |
 LL |     println!("{}", 23u64.test(xs.iter().sum()));
@@ -35,5 +35,4 @@ LL |     println!("{}", 23u64.test(xs.iter().sum::<S>()));
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0283, E0284.
-For more information about an error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/issues/issue-69683.stderr
+++ b/tests/ui/issues/issue-69683.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed
+error[E0283]: type annotations needed
   --> $DIR/issue-69683.rs:30:10
    |
 LL |     0u16.foo(b);
@@ -41,5 +41,4 @@ LL +     <u16 as Foo<I>>::foo(0u16, b);
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0283, E0284.
-For more information about an error, try `rustc --explain E0283`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/issues/issue-98299.stderr
+++ b/tests/ui/issues/issue-98299.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed for `SmallCString<_>`
+error[E0283]: type annotations needed for `SmallCString<_>`
   --> $DIR/issue-98299.rs:4:36
    |
 LL |     SmallCString::try_from(p).map(|cstr| cstr);
@@ -16,7 +16,7 @@ help: consider giving this closure parameter an explicit type, where the value o
 LL |     SmallCString::try_from(p).map(|cstr: SmallCString<N>| cstr);
    |                                        +++++++++++++++++
 
-error[E0284]: type annotations needed for `SmallCString<_>`
+error[E0283]: type annotations needed for `SmallCString<_>`
   --> $DIR/issue-98299.rs:4:36
    |
 LL |     SmallCString::try_from(p).map(|cstr| cstr);
@@ -36,7 +36,7 @@ help: consider giving this closure parameter an explicit type, where the value o
 LL |     SmallCString::try_from(p).map(|cstr: SmallCString<N>| cstr);
    |                                        +++++++++++++++++
 
-error[E0284]: type annotations needed for `SmallCString<_>`
+error[E0283]: type annotations needed for `SmallCString<_>`
   --> $DIR/issue-98299.rs:4:36
    |
 LL |     SmallCString::try_from(p).map(|cstr| cstr);
@@ -58,4 +58,4 @@ LL |     SmallCString::try_from(p).map(|cstr: SmallCString<N>| cstr);
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.stderr
+++ b/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot satisfy `the constant `{ || {} }` can be evaluated`
+error[E0283]: type annotations needed: cannot satisfy `the constant `{ || {} }` can be evaluated`
   --> $DIR/const-region-infer-to-static-in-binder.rs:4:10
    |
 LL | struct X<const FN: fn() = { || {} }>;
@@ -23,4 +23,4 @@ LL | struct X<const FN: fn() = { || {} }>;
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/normalize/two-projection-param-candidates-are-ambiguous.stderr
+++ b/tests/ui/traits/next-solver/normalize/two-projection-param-candidates-are-ambiguous.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot normalize `<T as Foo>::Assoc`
+error[E0283]: type annotations needed: cannot normalize `<T as Foo>::Assoc`
   --> $DIR/two-projection-param-candidates-are-ambiguous.rs:26:17
    |
 LL |     needs_bar::<T>();
@@ -17,4 +17,4 @@ LL | fn needs_bar<T: Bar>() {}
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/opaques/dont-type_of-tait-in-defining-scope.is_send.stderr
+++ b/tests/ui/traits/next-solver/opaques/dont-type_of-tait-in-defining-scope.is_send.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot satisfy `Foo == _`
+error[E0283]: type annotations needed: cannot satisfy `Foo == _`
   --> $DIR/dont-type_of-tait-in-defining-scope.rs:15:18
    |
 LL |     needs_send::<Foo>();
@@ -6,4 +6,4 @@ LL |     needs_send::<Foo>();
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/opaques/dont-type_of-tait-in-defining-scope.not_send.stderr
+++ b/tests/ui/traits/next-solver/opaques/dont-type_of-tait-in-defining-scope.not_send.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot satisfy `Foo == _`
+error[E0283]: type annotations needed: cannot satisfy `Foo == _`
   --> $DIR/dont-type_of-tait-in-defining-scope.rs:15:18
    |
 LL |     needs_send::<Foo>();
@@ -6,4 +6,4 @@ LL |     needs_send::<Foo>();
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/traits/next-solver/specialization-transmute.stderr
+++ b/tests/ui/traits/next-solver/specialization-transmute.stderr
@@ -20,13 +20,13 @@ error[E0282]: type annotations needed
 LL |     fn intu(&self) -> &Self::Id {
    |                       ^^^^^^^^^ cannot infer type for reference `&<T as Default>::Id`
 
-error[E0284]: type annotations needed: cannot satisfy `<T as Default>::Id normalizes-to T`
+error[E0283]: type annotations needed: cannot satisfy `<T as Default>::Id normalizes-to T`
   --> $DIR/specialization-transmute.rs:17:9
    |
 LL |         self
    |         ^^^^ cannot satisfy `<T as Default>::Id normalizes-to T`
 
-error[E0284]: type annotations needed: cannot satisfy `<u8 as Default>::Id normalizes-to Option<NonZero<u8>>`
+error[E0283]: type annotations needed: cannot satisfy `<u8 as Default>::Id normalizes-to Option<NonZero<u8>>`
   --> $DIR/specialization-transmute.rs:28:13
    |
 LL |     let s = transmute::<u8, Option<NonZero<u8>>>(0);
@@ -40,5 +40,5 @@ LL | fn transmute<T: Default<Id = U>, U: Copy>(t: T) -> U {
 
 error: aborting due to 4 previous errors; 1 warning emitted
 
-Some errors have detailed explanations: E0282, E0284.
+Some errors have detailed explanations: E0282, E0283.
 For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/traits/next-solver/specialization-unconstrained.stderr
+++ b/tests/ui/traits/next-solver/specialization-unconstrained.stderr
@@ -8,7 +8,7 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0284]: type annotations needed: cannot satisfy `<u32 as Default>::Id normalizes-to ()`
+error[E0283]: type annotations needed: cannot satisfy `<u32 as Default>::Id normalizes-to ()`
   --> $DIR/specialization-unconstrained.rs:20:5
    |
 LL |     test::<u32, ()>();
@@ -22,4 +22,4 @@ LL | fn test<T: Default<Id = U>, U>() {}
 
 error: aborting due to 1 previous error; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.

--- a/tests/ui/type-alias-impl-trait/issue-84660-unsoundness.next.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-84660-unsoundness.next.stderr
@@ -7,7 +7,7 @@ LL | impl<In, Out> Trait<Bar, In> for Out {
 LL | impl<In, Out> Trait<(), In> for Out {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
 
-error[E0284]: type annotations needed: cannot satisfy `Bar == _`
+error[E0283]: type annotations needed: cannot satisfy `Bar == _`
   --> $DIR/issue-84660-unsoundness.rs:22:37
    |
 LL |       fn convert(_i: In) -> Self::Out {
@@ -20,5 +20,5 @@ LL | |     }
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0119, E0284.
+Some errors have detailed explanations: E0119, E0283.
 For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/type-alias-impl-trait/nested-tait-inference2.next.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inference2.next.stderr
@@ -1,4 +1,4 @@
-error[E0284]: type annotations needed: cannot satisfy `impl Foo<FooX> == ()`
+error[E0283]: type annotations needed: cannot satisfy `impl Foo<FooX> == ()`
   --> $DIR/nested-tait-inference2.rs:19:5
    |
 LL |     ()
@@ -6,4 +6,4 @@ LL |     ()
 
 error: aborting due to 1 previous error
 
-For more information about this error, try `rustc --explain E0284`.
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
Fixes #137781

See the test description. Let me know if you want a more detailed step by step explanation for why this is failing.

We could *alternatively* fix this by trying to make `Sized` obligation checking less incomplete in the old solver... but that seems like a much larger change.

r? lcnr