### PR TITLE
tests: adapt for LLVM 21 changes

### DIFF
--- a/tests/codegen/issues/issue-114312.rs
+++ b/tests/codegen/issues/issue-114312.rs
@@ -15,7 +15,6 @@ pub enum Expr {
 #[no_mangle]
 pub extern "C" fn issue_114312(expr: Expr) {
     // CHECK-LABEL: @issue_114312(
-    // CHECK-NOT: readonly
     // CHECK-SAME: byval
     // CHECK-NEXT: start:
     // CHECK-NEXT: ret void


### PR DESCRIPTION
Per discussion in #137799 we don't really need this readonly attribute, so let's just drop it so the test passes on LLVM 21.

Fixes #137799.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
