### PR TITLE
test(codegen): add looping_over_ne_bytes test for #133528

### DIFF
--- a/tests/codegen/issues/looping-over-ne-bytes-133528.rs
+++ b/tests/codegen/issues/looping-over-ne-bytes-133528.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -Copt-level=3
+//@ min-llvm-version: 20
+#![crate_type = "lib"]
+
+/// Ensure the function is properly optimized
+/// In the issue #133528, the function was not getting optimized
+/// whereas, a version with `bytes` wrapped into a `black_box` was optimized
+/// It was probably a LLVM bug that was fixed in LLVM 20
+
+// CHECK-LABEL: @looping_over_ne_bytes
+// CHECK: icmp eq i64 %input, -1
+// CHECK-NEXT: ret i1
+#[no_mangle]
+fn looping_over_ne_bytes(input: u64) -> bool {
+    let bytes = input.to_ne_bytes();
+    bytes.iter().all(|x| *x == !0)
+}


### PR DESCRIPTION
Adds test for #133528.
I renamed the function to `looping_over_ne_bytes` to better reflect that it is doing.
I also set the min llvm version to 20 as this was presumably a llvm bug that was fixed in version 20.
I didn't tie the test to any specific architecture, as we are testing llvm output.


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
