### PR TITLE
Tweak auto trait errors

### DIFF
--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -40,7 +40,7 @@ ast_passes_auto_generic = auto traits cannot have generic parameters
 
 ast_passes_auto_items = auto traits cannot have associated items
     .label = {ast_passes_auto_items}
-    .suggestion = remove these associated items
+    .suggestion = remove the associated items
 
 ast_passes_auto_super_lifetime = auto traits cannot have super traits or lifetime bounds
     .label = {ast_passes_auto_super_lifetime}

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -699,19 +699,23 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn deny_super_traits(&self, bounds: &GenericBounds, ident_span: Span) {
+    fn deny_super_traits(&self, bounds: &GenericBounds, ident: Span) {
         if let [.., last] = &bounds[..] {
-            let span = ident_span.shrink_to_hi().to(last.span());
-            self.dcx().emit_err(errors::AutoTraitBounds { span, ident: ident_span });
+            let span = bounds.iter().map(|b| b.span()).collect();
+            let removal = ident.shrink_to_hi().to(last.span());
+            self.dcx().emit_err(errors::AutoTraitBounds { span, removal, ident });
         }
     }
 
-    fn deny_where_clause(&self, where_clause: &WhereClause, ident_span: Span) {
+    fn deny_where_clause(&self, where_clause: &WhereClause, ident: Span) {
         if !where_clause.predicates.is_empty() {
             // FIXME: The current diagnostic is misleading since it only talks about
             // super trait and lifetime bounds while we should just say “bounds”.
-            self.dcx()
-                .emit_err(errors::AutoTraitBounds { span: where_clause.span, ident: ident_span });
+            self.dcx().emit_err(errors::AutoTraitBounds {
+                span: vec![where_clause.span],
+                removal: where_clause.span,
+                ident,
+            });
         }
     }
 

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -344,7 +344,7 @@ pub(crate) struct ModuleNonAscii {
 #[diag(ast_passes_auto_generic, code = E0567)]
 pub(crate) struct AutoTraitGeneric {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
     pub span: Span,
     #[label]
     pub ident: Span,
@@ -354,8 +354,9 @@ pub(crate) struct AutoTraitGeneric {
 #[diag(ast_passes_auto_super_lifetime, code = E0568)]
 pub(crate) struct AutoTraitBounds {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable")]
-    pub span: Span,
+    pub span: Vec<Span>,
+    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
+    pub removal: Span,
     #[label]
     pub ident: Span,
 }
@@ -365,7 +366,7 @@ pub(crate) struct AutoTraitBounds {
 pub(crate) struct AutoTraitItems {
     #[primary_span]
     pub spans: Vec<Span>,
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
     pub total: Span,
     #[label]
     pub ident: Span,

--- a/tests/ui/auto-traits/assoc-ty.current.stderr
+++ b/tests/ui/auto-traits/assoc-ty.current.stderr
@@ -5,7 +5,7 @@ LL | auto trait Trait {
    |            ----- auto traits cannot have associated items
 LL |
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
 
 error[E0658]: auto traits are experimental and possibly buggy
   --> $DIR/assoc-ty.rs:8:1

--- a/tests/ui/auto-traits/assoc-ty.next.stderr
+++ b/tests/ui/auto-traits/assoc-ty.next.stderr
@@ -5,7 +5,7 @@ LL | auto trait Trait {
    |            ----- auto traits cannot have associated items
 LL |
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
 
 error[E0658]: auto traits are experimental and possibly buggy
   --> $DIR/assoc-ty.rs:8:1

--- a/tests/ui/auto-traits/auto-trait-validation.fixed
+++ b/tests/ui/auto-traits/auto-trait-validation.fixed
@@ -11,4 +11,15 @@ auto trait LifetimeBound {}
 //~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
 auto trait MyTrait {  }
 //~^ ERROR auto traits cannot have associated items [E0380]
+auto trait AssocTy {  }
+//~^ ERROR auto traits cannot have associated items [E0380]
+auto trait All {
+    //~^ ERROR auto traits cannot have generic parameters [E0567]
+    
+}
+// We can't test both generic params and super-traits because the suggestion span overlaps.
+auto trait All2 {
+    //~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
+    
+}
 fn main() {}

--- a/tests/ui/auto-traits/auto-trait-validation.rs
+++ b/tests/ui/auto-traits/auto-trait-validation.rs
@@ -11,4 +11,19 @@ auto trait LifetimeBound : 'static {}
 //~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
 auto trait MyTrait { fn foo() {} }
 //~^ ERROR auto traits cannot have associated items [E0380]
+auto trait AssocTy { type Bar; }
+//~^ ERROR auto traits cannot have associated items [E0380]
+auto trait All<'a, T> {
+    //~^ ERROR auto traits cannot have generic parameters [E0567]
+    type Bar;
+    //~^ ERROR auto traits cannot have associated items [E0380]
+    fn foo() {}
+}
+// We can't test both generic params and super-traits because the suggestion span overlaps.
+auto trait All2: Copy + 'static {
+    //~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
+    type Bar;
+    //~^ ERROR auto traits cannot have associated items [E0380]
+    fn foo() {}
+}
 fn main() {}

--- a/tests/ui/auto-traits/auto-trait-validation.stderr
+++ b/tests/ui/auto-traits/auto-trait-validation.stderr
@@ -2,23 +2,23 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/auto-trait-validation.rs:6:19
    |
 LL | auto trait Generic<T> {}
-   |            -------^^^ help: remove the parameters
+   |            -------^^^
    |            |
    |            auto trait cannot have generic parameters
 
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/auto-trait-validation.rs:8:17
+  --> $DIR/auto-trait-validation.rs:8:20
    |
 LL | auto trait Bound : Copy {}
-   |            -----^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----   ^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/auto-trait-validation.rs:10:25
+  --> $DIR/auto-trait-validation.rs:10:28
    |
 LL | auto trait LifetimeBound : 'static {}
-   |            -------------^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -------------   ^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 
@@ -26,12 +26,59 @@ error[E0380]: auto traits cannot have associated items
   --> $DIR/auto-trait-validation.rs:12:25
    |
 LL | auto trait MyTrait { fn foo() {} }
-   |            -------   ---^^^-----
-   |            |         |
-   |            |         help: remove these associated items
+   |            -------      ^^^
+   |            |
    |            auto traits cannot have associated items
 
-error: aborting due to 4 previous errors
+error[E0380]: auto traits cannot have associated items
+  --> $DIR/auto-trait-validation.rs:14:27
+   |
+LL | auto trait AssocTy { type Bar; }
+   |            -------        ^^^
+   |            |
+   |            auto traits cannot have associated items
+
+error[E0567]: auto traits cannot have generic parameters
+  --> $DIR/auto-trait-validation.rs:16:15
+   |
+LL | auto trait All<'a, T> {
+   |            ---^^^^^^^
+   |            |
+   |            auto trait cannot have generic parameters
+
+error[E0380]: auto traits cannot have associated items
+  --> $DIR/auto-trait-validation.rs:18:10
+   |
+LL | auto trait All<'a, T> {
+   |            --- auto traits cannot have associated items
+LL |
+LL |     type Bar;
+   |          ^^^
+LL |
+LL |     fn foo() {}
+   |        ^^^
+
+error[E0568]: auto traits cannot have super traits or lifetime bounds
+  --> $DIR/auto-trait-validation.rs:23:18
+   |
+LL | auto trait All2: Copy + 'static {
+   |            ----  ^^^^   ^^^^^^^
+   |            |
+   |            auto traits cannot have super traits or lifetime bounds
+
+error[E0380]: auto traits cannot have associated items
+  --> $DIR/auto-trait-validation.rs:25:10
+   |
+LL | auto trait All2: Copy + 'static {
+   |            ---- auto traits cannot have associated items
+LL |
+LL |     type Bar;
+   |          ^^^
+LL |
+LL |     fn foo() {}
+   |        ^^^
+
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0380, E0567, E0568.
 For more information about an error, try `rustc --explain E0380`.

--- a/tests/ui/auto-traits/bad-generics-on-dyn.stderr
+++ b/tests/ui/auto-traits/bad-generics-on-dyn.stderr
@@ -2,7 +2,7 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/bad-generics-on-dyn.rs:3:18
    |
 LL | auto trait Trait1<'a> {}
-   |            ------^^^^ help: remove the parameters
+   |            ------^^^^
    |            |
    |            auto trait cannot have generic parameters
 

--- a/tests/ui/auto-traits/has-arguments.stderr
+++ b/tests/ui/auto-traits/has-arguments.stderr
@@ -2,7 +2,7 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/has-arguments.rs:3:18
    |
 LL | auto trait Trait1<'outer> {}
-   |            ------^^^^^^^^ help: remove the parameters
+   |            ------^^^^^^^^
    |            |
    |            auto trait cannot have generic parameters
 

--- a/tests/ui/auto-traits/issue-117789.stderr
+++ b/tests/ui/auto-traits/issue-117789.stderr
@@ -2,7 +2,7 @@ error[E0567]: auto traits cannot have generic parameters
   --> $DIR/issue-117789.rs:1:17
    |
 LL | auto trait Trait<P> {}
-   |            -----^^^ help: remove the parameters
+   |            -----^^^
    |            |
    |            auto trait cannot have generic parameters
 

--- a/tests/ui/auto-traits/issue-23080-2.current.stderr
+++ b/tests/ui/auto-traits/issue-23080-2.current.stderr
@@ -4,7 +4,7 @@ error[E0380]: auto traits cannot have associated items
 LL | unsafe auto trait Trait {
    |                   ----- auto traits cannot have associated items
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/issue-23080-2.next.stderr
+++ b/tests/ui/auto-traits/issue-23080-2.next.stderr
@@ -4,7 +4,7 @@ error[E0380]: auto traits cannot have associated items
 LL | unsafe auto trait Trait {
    |                   ----- auto traits cannot have associated items
 LL |     type Output;
-   |     -----^^^^^^- help: remove these associated items
+   |          ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/issue-23080.stderr
+++ b/tests/ui/auto-traits/issue-23080.stderr
@@ -1,13 +1,10 @@
 error[E0380]: auto traits cannot have associated items
   --> $DIR/issue-23080.rs:5:8
    |
-LL |   unsafe auto trait Trait {
-   |                     ----- auto traits cannot have associated items
-LL |       fn method(&self) {
-   |  _____-  ^^^^^^
-LL | |         println!("Hello");
-LL | |     }
-   | |_____- help: remove these associated items
+LL | unsafe auto trait Trait {
+   |                   ----- auto traits cannot have associated items
+LL |     fn method(&self) {
+   |        ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/auto-traits/issue-84075.stderr
+++ b/tests/ui/auto-traits/issue-84075.stderr
@@ -2,7 +2,7 @@ error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/issue-84075.rs:5:18
    |
 LL | auto trait Magic where Self: Copy {}
-   |            ----- ^^^^^^^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            ----- ^^^^^^^^^^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
@@ -1,8 +1,8 @@
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:17
+  --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:20
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   |            -----^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----   ^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 
@@ -10,7 +10,7 @@ error[E0568]: auto traits cannot have super traits or lifetime bounds
   --> $DIR/typeck-auto-trait-no-supertraits-2.rs:4:26
    |
 LL | auto trait Magic : Sized where Option<Self> : Magic {}
-   |            -----         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits.stderr
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits.stderr
@@ -1,8 +1,8 @@
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/typeck-auto-trait-no-supertraits.rs:28:17
+  --> $DIR/typeck-auto-trait-no-supertraits.rs:28:19
    |
 LL | auto trait Magic: Copy {}
-   |            -----^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----  ^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 

--- a/tests/ui/methods/issues/issue-105732.stderr
+++ b/tests/ui/methods/issues/issue-105732.stderr
@@ -4,7 +4,7 @@ error[E0380]: auto traits cannot have associated items
 LL | auto trait Foo {
    |            --- auto traits cannot have associated items
 LL |     fn g(&self);
-   |     ---^-------- help: remove these associated items
+   |        ^
 
 error[E0599]: no method named `g` found for reference `&Self` in the current scope
   --> $DIR/issue-105732.rs:10:14

--- a/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
+++ b/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
@@ -1,8 +1,8 @@
 error[E0568]: auto traits cannot have super traits or lifetime bounds
-  --> $DIR/supertrait-auto-trait.rs:8:17
+  --> $DIR/supertrait-auto-trait.rs:8:19
    |
 LL | auto trait Magic: Copy {}
-   |            -----^^^^^^ help: remove the super traits or lifetime bounds
+   |            -----  ^^^^
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 


### PR DESCRIPTION
Make suggestions to remove params and super traits verbose and make spans more accurate.

```
error[E0567]: auto traits cannot have generic parameters
  --> $DIR/auto-trait-validation.rs:6:19
   |
LL | auto trait Generic<T> {}
   |            -------^^^
   |            |
   |            auto trait cannot have generic parameters

error[E0568]: auto traits cannot have super traits or lifetime bounds
  --> $DIR/auto-trait-validation.rs:8:20
   |
LL | auto trait Bound : Copy {}
   |            -----   ^^^^
   |            |
   |            auto traits cannot have super traits or lifetime bounds
```

```
error[E0380]: auto traits cannot have associated items
  --> $DIR/issue-23080.rs:5:8
   |
LL | unsafe auto trait Trait {
   |                   ----- auto traits cannot have associated items
LL |     fn method(&self) {
   |        ^^^^^^
```