### PR TITLE
Fix crash in BufReader::peek()

### DIFF
--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -118,16 +118,16 @@ impl<R: Read + ?Sized> BufReader<R> {
     /// #![feature(bufreader_peek)]
     /// use std::io::{Read, BufReader};
     ///
-    /// let mut bytes = &b"oh, hello"[..];
+    /// let mut bytes = &b"oh, hello there"[..];
     /// let mut rdr = BufReader::with_capacity(6, &mut bytes);
     /// assert_eq!(rdr.peek(2).unwrap(), b"oh");
     /// let mut buf = [0; 4];
     /// rdr.read(&mut buf[..]).unwrap();
     /// assert_eq!(&buf, b"oh, ");
-    /// assert_eq!(rdr.peek(2).unwrap(), b"he");
+    /// assert_eq!(rdr.peek(5).unwrap(), b"hello");
     /// let mut s = String::new();
     /// rdr.read_to_string(&mut s).unwrap();
-    /// assert_eq!(&s, "hello");
+    /// assert_eq!(&s, "hello there");
     /// assert_eq!(rdr.peek(1).unwrap().len(), 0);
     /// ```
     #[unstable(feature = "bufreader_peek", issue = "128405")]

--- a/library/std/src/io/buffered/bufreader/buffer.rs
+++ b/library/std/src/io/buffered/bufreader/buffer.rs
@@ -109,8 +109,8 @@ impl Buffer {
 
     /// Read more bytes into the buffer without discarding any of its contents
     pub fn read_more(&mut self, mut reader: impl Read) -> io::Result<usize> {
-        let mut buf = BorrowedBuf::from(&mut self.buf[self.pos..]);
-        let old_init = self.initialized - self.pos;
+        let mut buf = BorrowedBuf::from(&mut self.buf[self.filled..]);
+        let old_init = self.initialized - self.filled;
         unsafe {
             buf.set_init(old_init);
         }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

`bufreader_peek` tracking issue: #128405

This fixes a logic error in `Buffer::read_more()` that would make `BufReader::peek()` expose uninitialized data and/or segfault if `read_more()` was called with a partially-full buffer and a non-empty inner reader.