### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,7 +4500,6 @@ dependencies = [
  "rustc_abi",
  "rustc_data_structures",
  "rustc_hir",
- "rustc_macros",
  "rustc_middle",
  "rustc_span",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,7 +4500,6 @@ dependencies = [
  "rustc_abi",
  "rustc_data_structures",
  "rustc_hir",
- "rustc_infer",
  "rustc_macros",
  "rustc_middle",
  "rustc_span",

--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -133,11 +133,11 @@ ast_lowering_misplaced_relax_trait_bound =
 ast_lowering_never_pattern_with_body =
     a never pattern is always unreachable
     .label = this will never be executed
-    .suggestion = remove this expression
+    .suggestion = remove the match arm expression
 
 ast_lowering_never_pattern_with_guard =
     a guard on a never pattern will never be run
-    .suggestion = remove this guard
+    .suggestion = remove the match arm guard
 
 ast_lowering_no_precise_captures_on_apit = `use<...>` precise capturing syntax not allowed in argument-position `impl Trait`
 

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -335,7 +335,7 @@ pub(crate) struct MisplacedRelaxTraitBound {
 pub(crate) struct MatchArmWithNoBody {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = " => todo!(),", applicability = "has-placeholders")]
+    #[suggestion(code = " => todo!(),", applicability = "has-placeholders", style = "verbose")]
     pub suggestion: Span,
 }
 
@@ -344,16 +344,18 @@ pub(crate) struct MatchArmWithNoBody {
 pub(crate) struct NeverPatternWithBody {
     #[primary_span]
     #[label]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
     pub span: Span,
+    #[suggestion(code = ",", applicability = "maybe-incorrect", style = "verbose")]
+    pub removal_span: Span,
 }
 
 #[derive(Diagnostic)]
 #[diag(ast_lowering_never_pattern_with_guard)]
 pub(crate) struct NeverPatternWithGuard {
     #[primary_span]
-    #[suggestion(code = "", applicability = "maybe-incorrect")]
     pub span: Span,
+    #[suggestion(code = ",", applicability = "maybe-incorrect", style = "verbose")]
+    pub removal_span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -689,7 +689,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     removal_span: if pat.span.eq_ctxt(arm.span) {
                         // - ! => {}
                         // + !,
-                        // FIXME: account for `(!|!)`, as pat.span ends *within* the parentheses.
                         pat.span.shrink_to_hi().with_hi(arm.span.hi())
                     } else {
                         // Subtly incorrect, but close enough if macros are involved.

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -20,7 +20,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         self.arena.alloc(self.lower_pat_mut(pattern))
     }
 
-    fn lower_pat_mut(&mut self, mut pattern: &Pat) -> hir::Pat<'hir> {
+    fn lower_pat_mut(&mut self, outer_pattern: &Pat) -> hir::Pat<'hir> {
+        let mut pattern = outer_pattern;
         ensure_sufficient_stack(|| {
             // loop here to avoid recursion
             let pat_hir_id = self.lower_node_id(pattern.id);
@@ -147,7 +148,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 }
             };
 
-            self.pat_with_node_id_of(pattern, node, pat_hir_id)
+            self.pat_with_node_id_of(outer_pattern, node, pat_hir_id)
         })
     }
 

--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -109,6 +109,8 @@ const_eval_frame_note_inner = inside {$where_ ->
     *[other] {""}
 }
 
+const_eval_frame_note_last = the failure occurred here
+
 const_eval_in_bounds_test = out-of-bounds pointer use
 const_eval_incompatible_calling_conventions =
     calling a function with calling convention {$callee_conv} using calling convention {$caller_conv}
@@ -300,8 +302,7 @@ const_eval_overflow_arith =
 const_eval_overflow_shift =
     overflowing shift by {$shift_amount} in `{$intrinsic}`
 
-const_eval_panic =
-    the evaluated program panicked at '{$msg}', {$file}:{$line}:{$col}
+const_eval_panic = evaluation panicked: {$msg}
 
 const_eval_panic_non_str = argument to `panic!()` in a const context must have type `&str`
 

--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -48,11 +48,8 @@ impl MachineStopType for ConstEvalErrKind {
             | ModifiedGlobal
             | WriteThroughImmutablePointer => {}
             AssertFailure(kind) => kind.add_args(adder),
-            Panic { msg, line, col, file } => {
+            Panic { msg, .. } => {
                 adder("msg".into(), msg.into_diag_arg(&mut None));
-                adder("file".into(), file.into_diag_arg(&mut None));
-                adder("line".into(), line.into_diag_arg(&mut None));
-                adder("col".into(), col.into_diag_arg(&mut None));
             }
         }
     }
@@ -72,7 +69,7 @@ pub fn get_span_and_frames<'tcx>(
     let mut stacktrace = Frame::generate_stacktrace_from_stack(stack);
     // Filter out `requires_caller_location` frames.
     stacktrace.retain(|frame| !frame.instance.def.requires_caller_location(*tcx));
-    let span = stacktrace.first().map(|f| f.span).unwrap_or(tcx.span);
+    let span = stacktrace.last().map(|f| f.span).unwrap_or(tcx.span);
 
     let mut frames = Vec::new();
 
@@ -113,6 +110,20 @@ pub fn get_span_and_frames<'tcx>(
         if let Some(frame) = last_frame {
             add_frame(frame);
         }
+    }
+
+    // In `rustc`, we present const-eval errors from the outer-most place first to the inner-most.
+    // So we reverse the frames here. The first frame will be the same as the span from the current
+    // `TyCtxtAt<'_>`, so we remove it as it would be redundant.
+    frames.reverse();
+    if frames.len() > 0 {
+        frames.remove(0);
+    }
+    if let Some(last) = frames.last_mut()
+        // If the span is not going to be printed, we don't want the span label for `is_last`.
+        && tcx.sess.source_map().span_to_snippet(last.span.source_callsite()).is_ok()
+    {
+        last.has_label = true;
     }
 
     (span, frames)

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -231,13 +231,19 @@ impl<'tcx> FrameInfo<'tcx> {
     pub fn as_note(&self, tcx: TyCtxt<'tcx>) -> errors::FrameNote {
         let span = self.span;
         if tcx.def_key(self.instance.def_id()).disambiguated_data.data == DefPathData::Closure {
-            errors::FrameNote { where_: "closure", span, instance: String::new(), times: 0 }
+            errors::FrameNote {
+                where_: "closure",
+                span,
+                instance: String::new(),
+                times: 0,
+                has_label: false,
+            }
         } else {
             let instance = format!("{}", self.instance);
             // Note: this triggers a `must_produce_diag` state, which means that if we ever get
             // here we must emit a diagnostic. We should never display a `FrameInfo` unless we
             // actually want to emit a warning or error to the user.
-            errors::FrameNote { where_: "instance", span, instance, times: 0 }
+            errors::FrameNote { where_: "instance", span, instance, times: 0, has_label: false }
         }
     }
 }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -508,6 +508,8 @@ declare_features! (
     (incomplete, generic_const_exprs, "1.56.0", Some(76560)),
     /// Allows generic parameters and where-clauses on free & associated const items.
     (incomplete, generic_const_items, "1.73.0", Some(113521)),
+    /// Allows the type of const generics to depend on generic parameters
+    (incomplete, generic_const_parameter_types, "CURRENT_RUSTC_VERSION", Some(137626)),
     /// Allows any generic constants being used as pattern type range ends
     (incomplete, generic_pattern_types, "1.86.0", Some(136574)),
     /// Allows registering static items globally, possibly across crates, to iterate over at runtime.

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -966,7 +966,7 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) -> Result<(), 
             let ty = tcx.type_of(param.def_id).instantiate_identity();
 
             if tcx.features().unsized_const_params() {
-                enter_wf_checking_ctxt(tcx, hir_ty.span, param.def_id, |wfcx| {
+                enter_wf_checking_ctxt(tcx, hir_ty.span, tcx.local_parent(param.def_id), |wfcx| {
                     wfcx.register_bound(
                         ObligationCause::new(
                             hir_ty.span,
@@ -980,7 +980,7 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) -> Result<(), 
                     Ok(())
                 })
             } else if tcx.features().adt_const_params() {
-                enter_wf_checking_ctxt(tcx, hir_ty.span, param.def_id, |wfcx| {
+                enter_wf_checking_ctxt(tcx, hir_ty.span, tcx.local_parent(param.def_id), |wfcx| {
                     wfcx.register_bound(
                         ObligationCause::new(
                             hir_ty.span,

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1822,6 +1822,9 @@ fn const_param_default<'tcx>(
         ),
     };
     let icx = ItemCtxt::new(tcx, def_id);
-    let ct = icx.lowerer().lower_const_arg(default_ct, FeedConstTy::Param(def_id.to_def_id()));
+    let identity_args = ty::GenericArgs::identity_for_item(tcx, def_id);
+    let ct = icx
+        .lowerer()
+        .lower_const_arg(default_ct, FeedConstTy::Param(def_id.to_def_id(), identity_args));
     ty::EarlyBinder::bind(ct)
 }

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -223,10 +223,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
             }
             hir::GenericParamKind::Const { .. } => {
                 let param_def_id = param.def_id.to_def_id();
-                let ct_ty = tcx
-                    .type_of(param_def_id)
-                    .no_bound_vars()
-                    .expect("const parameters cannot be generic");
+                let ct_ty = tcx.type_of(param_def_id).instantiate_identity();
                 let ct = icx.lowerer().lower_const_param(param_def_id, param.hir_id);
                 predicates
                     .insert((ty::ClauseKind::ConstArgHasType(ct, ct_ty).upcast(tcx), param.span));

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -273,7 +273,7 @@ pub fn lower_generic_args<'tcx: 'a, 'a>(
 
                             // We lower to an infer even when the feature gate is not enabled
                             // as it is useful for diagnostics to be able to see a `ConstKind::Infer`
-                            args.push(ctx.provided_kind(param, arg));
+                            args.push(ctx.provided_kind(&args, param, arg));
                             args_iter.next();
                             params.next();
                         }

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -260,7 +260,7 @@ pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
 pub fn lower_const_arg_for_rustdoc<'tcx>(
     tcx: TyCtxt<'tcx>,
     hir_ct: &hir::ConstArg<'tcx>,
-    feed: FeedConstTy,
+    feed: FeedConstTy<'_, 'tcx>,
 ) -> Const<'tcx> {
     let env_def_id = tcx.hir_get_parent_item(hir_ct.hir_id);
     collect::ItemCtxt::new(tcx, env_def_id.def_id).lowerer().lower_const_arg(hir_ct, feed)

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -895,20 +895,22 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                         // e.g. we want to allow `dyn T -> (dyn T,)`, etc.
                         //
                         // We also need to skip auto traits to emit an FCW and not an error.
-                        let src_obj = tcx.mk_ty_from_kind(ty::Dynamic(
+                        let src_obj = Ty::new_dynamic(
+                            tcx,
                             tcx.mk_poly_existential_predicates(
                                 &src_tty.without_auto_traits().collect::<Vec<_>>(),
                             ),
                             tcx.lifetimes.re_erased,
                             ty::Dyn,
-                        ));
-                        let dst_obj = tcx.mk_ty_from_kind(ty::Dynamic(
+                        );
+                        let dst_obj = Ty::new_dynamic(
+                            tcx,
                             tcx.mk_poly_existential_predicates(
                                 &dst_tty.without_auto_traits().collect::<Vec<_>>(),
                             ),
                             tcx.lifetimes.re_erased,
                             ty::Dyn,
-                        ));
+                        );
 
                         // `dyn Src = dyn Dst`, this checks for matching traits/generics/projections
                         // This is `fcx.demand_eqtype`, but inlined to give a better error.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -519,7 +519,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn lower_const_arg(
         &self,
         const_arg: &'tcx hir::ConstArg<'tcx>,
-        feed: FeedConstTy,
+        feed: FeedConstTy<'_, 'tcx>,
     ) -> ty::Const<'tcx> {
         let ct = self.lowerer().lower_const_arg(const_arg, feed);
         self.register_wf_obligation(
@@ -1135,7 +1135,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .last()
             .is_some_and(|GenericPathSegment(def_id, _)| tcx.generics_of(*def_id).has_self);
 
-        let (res, self_ctor_args) = if let Res::SelfCtor(impl_def_id) = res {
+        let (res, implicit_args) = if let Res::Def(DefKind::ConstParam, def) = res {
+            // types of const parameters are somewhat special as they are part of
+            // the same environment as the const parameter itself. this means that
+            // unlike most paths `type-of(N)` can return a type naming parameters
+            // introduced by the containing item, rather than provided through `N`.
+            //
+            // for example given `<T, const M: usize, const N: [T; M]>` and some
+            // `let a = N;` expression. The path to `N` would wind up with no args
+            // (as it has no args), but instantiating the early binder on `typeof(N)`
+            // requires providing generic arguments for `[T, M, N]`.
+            (res, Some(ty::GenericArgs::identity_for_item(tcx, tcx.parent(def))))
+        } else if let Res::SelfCtor(impl_def_id) = res {
             let ty = LoweredTy::from_raw(
                 self,
                 span,
@@ -1261,6 +1272,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             fn provided_kind(
                 &mut self,
+                preceding_args: &[ty::GenericArg<'tcx>],
                 param: &ty::GenericParamDef,
                 arg: &GenericArg<'tcx>,
             ) -> ty::GenericArg<'tcx> {
@@ -1280,7 +1292,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     (GenericParamDefKind::Const { .. }, GenericArg::Const(ct)) => self
                         .fcx
                         // Ambiguous parts of `ConstArg` are handled in the match arms below
-                        .lower_const_arg(ct.as_unambig_ct(), FeedConstTy::Param(param.def_id))
+                        .lower_const_arg(
+                            ct.as_unambig_ct(),
+                            FeedConstTy::Param(param.def_id, preceding_args),
+                        )
                         .into(),
                     (&GenericParamDefKind::Const { .. }, GenericArg::Infer(inf)) => {
                         self.fcx.ct_infer(Some(param), inf.span).into()
@@ -1320,7 +1335,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
-        let args_raw = self_ctor_args.unwrap_or_else(|| {
+        let args_raw = implicit_args.unwrap_or_else(|| {
             lower_generic_args(
                 self,
                 def_id,

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -426,6 +426,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
 
             fn provided_kind(
                 &mut self,
+                preceding_args: &[ty::GenericArg<'tcx>],
                 param: &ty::GenericParamDef,
                 arg: &GenericArg<'tcx>,
             ) -> ty::GenericArg<'tcx> {
@@ -446,7 +447,10 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                     (GenericParamDefKind::Const { .. }, GenericArg::Const(ct)) => self
                         .cfcx
                         // We handle the ambig portions of `ConstArg` in the match arms below
-                        .lower_const_arg(ct.as_unambig_ct(), FeedConstTy::Param(param.def_id))
+                        .lower_const_arg(
+                            ct.as_unambig_ct(),
+                            FeedConstTy::Param(param.def_id, preceding_args),
+                        )
                         .into(),
                     (GenericParamDefKind::Const { .. }, GenericArg::Infer(inf)) => {
                         self.cfcx.ct_infer(Some(param), inf.span).into()

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -224,7 +224,7 @@ impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> Decodable<D> for Ty<'tcx> {
             })
         } else {
             let tcx = decoder.interner();
-            tcx.mk_ty_from_kind(rustc_type_ir::TyKind::decode(decoder))
+            tcx.mk_ty_from_kind(ty::TyKind::decode(decoder))
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -991,12 +991,6 @@ impl<'tcx> ParamEnv<'tcx> {
         ParamEnv { caller_bounds }
     }
 
-    /// Returns this same environment but with no caller bounds.
-    #[inline]
-    pub fn without_caller_bounds(self) -> Self {
-        Self::new(ListWithCachedTypeInfo::empty())
-    }
-
     /// Creates a pair of param-env and value for use in queries.
     pub fn and<T: TypeVisitable<TyCtxt<'tcx>>>(self, value: T) -> ParamEnvAnd<'tcx, T> {
         ParamEnvAnd { param_env: self, value }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -342,6 +342,7 @@ impl ParamConst {
         ParamConst::new(def.index, def.name)
     }
 
+    #[instrument(level = "debug")]
     pub fn find_ty_from_env<'tcx>(self, env: ParamEnv<'tcx>) -> Ty<'tcx> {
         let mut candidates = env.caller_bounds().iter().filter_map(|clause| {
             // `ConstArgHasType` are never desugared to be higher ranked.

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -461,7 +461,7 @@ impl<'tcx> Ty<'tcx> {
 
     #[inline]
     pub fn new_param(tcx: TyCtxt<'tcx>, index: u32, name: Symbol) -> Ty<'tcx> {
-        tcx.mk_ty_from_kind(Param(ParamTy { index, name }))
+        Ty::new(tcx, Param(ParamTy { index, name }))
     }
 
     #[inline]

--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -102,7 +102,6 @@ pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
 
     fn is_transmutable(
         &self,
-        param_env: <Self::Interner as Interner>::ParamEnv,
         dst: <Self::Interner as Interner>::Ty,
         src: <Self::Interner as Interner>::Ty,
         assume: <Self::Interner as Interner>::Const,

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1037,12 +1037,11 @@ where
 
     pub(super) fn is_transmutable(
         &mut self,
-        param_env: I::ParamEnv,
         dst: I::Ty,
         src: I::Ty,
         assume: I::Const,
     ) -> Result<Certainty, NoSolution> {
-        self.delegate.is_transmutable(param_env, dst, src, assume)
+        self.delegate.is_transmutable(dst, src, assume)
     }
 }
 

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -617,7 +617,6 @@ where
             )?;
 
             let certainty = ecx.is_transmutable(
-                goal.param_env,
                 goal.predicate.trait_ref.args.type_at(0),
                 goal.predicate.trait_ref.args.type_at(1),
                 assume,

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3176,13 +3176,13 @@ impl<'a> Parser<'a> {
                     arm_body = Some(expr);
                     // Eat a comma if it exists, though.
                     let _ = this.eat(exp!(Comma));
-                    comma = Some(this.prev_token.span);
                     Ok(Recovered::No)
                 } else if let Some((span, guar)) =
                     this.parse_arm_body_missing_braces(&expr, arrow_span)
                 {
                     let body = this.mk_expr_err(span, guar);
                     arm_body = Some(body);
+                    let _ = this.eat(exp!(Comma));
                     Ok(Recovered::Yes(guar))
                 } else {
                     let expr_span = expr.span;
@@ -3223,6 +3223,9 @@ impl<'a> Parser<'a> {
                     })
                 }
             };
+            if let TokenKind::Comma = this.prev_token.kind {
+                comma = Some(this.prev_token.span);
+            }
 
             let hi_span =
                 comma.unwrap_or(arm_body.as_ref().map_or(span_before_body, |body| body.span));

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -3112,6 +3112,7 @@ impl<'a> Parser<'a> {
             let (pat, guard) = this.parse_match_arm_pat_and_guard()?;
 
             let span_before_body = this.prev_token.span;
+            let mut comma = None;
             let arm_body;
             let is_fat_arrow = this.check(exp!(FatArrow));
             let is_almost_fat_arrow =
@@ -3175,6 +3176,7 @@ impl<'a> Parser<'a> {
                     arm_body = Some(expr);
                     // Eat a comma if it exists, though.
                     let _ = this.eat(exp!(Comma));
+                    comma = Some(this.prev_token.span);
                     Ok(Recovered::No)
                 } else if let Some((span, guar)) =
                     this.parse_arm_body_missing_braces(&expr, arrow_span)
@@ -3222,7 +3224,8 @@ impl<'a> Parser<'a> {
                 }
             };
 
-            let hi_span = arm_body.as_ref().map_or(span_before_body, |body| body.span);
+            let hi_span =
+                comma.unwrap_or(arm_body.as_ref().map_or(span_before_body, |body| body.span));
             let arm_span = lo.to(hi_span);
 
             // We want to recover:

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -125,9 +125,6 @@ resolve_const_param_in_enum_discriminant =
 resolve_const_param_in_non_trivial_anon_const =
     const parameters may only be used as standalone arguments, i.e. `{$name}`
 
-resolve_const_param_in_ty_of_const_param =
-    const parameters may not be used in the type of const parameters
-
 resolve_constructor_private_if_any_field_private =
     a constructor is private if any of the fields is private
 
@@ -249,9 +246,6 @@ resolve_lifetime_param_in_enum_discriminant =
 
 resolve_lifetime_param_in_non_trivial_anon_const =
     lifetime parameters may not be used in const expressions
-
-resolve_lifetime_param_in_ty_of_const_param =
-    lifetime parameters may not be used in the type of const parameters
 
 resolve_lowercase_self =
     attempt to use a non-constant value in a constant
@@ -436,9 +430,6 @@ resolve_type_param_in_enum_discriminant =
 
 resolve_type_param_in_non_trivial_anon_const =
     type parameters may not be used in const expressions
-
-resolve_type_param_in_ty_of_const_param =
-    type parameters may not be used in the type of const parameters
 
 resolve_undeclared_label =
     use of undeclared label `{$name}`

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -890,9 +890,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ResolutionError::ForwardDeclaredGenericParam => {
                 self.dcx().create_err(errs::ForwardDeclaredGenericParam { span })
             }
-            ResolutionError::ParamInTyOfConstParam { name, param_kind: is_type } => self
-                .dcx()
-                .create_err(errs::ParamInTyOfConstParam { span, name, param_kind: is_type }),
+            ResolutionError::ParamInTyOfConstParam { name } => {
+                self.dcx().create_err(errs::ParamInTyOfConstParam { span, name })
+            }
             ResolutionError::ParamInNonTrivialAnonConst { name, param_kind: is_type } => {
                 self.dcx().create_err(errs::ParamInNonTrivialAnonConst {
                     span,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -347,19 +347,6 @@ pub(crate) struct ParamInTyOfConstParam {
     #[label]
     pub(crate) span: Span,
     pub(crate) name: Symbol,
-    #[subdiagnostic]
-    pub(crate) param_kind: Option<ParamKindInTyOfConstParam>,
-}
-
-#[derive(Debug)]
-#[derive(Subdiagnostic)]
-pub(crate) enum ParamKindInTyOfConstParam {
-    #[note(resolve_type_param_in_ty_of_const_param)]
-    Type,
-    #[note(resolve_const_param_in_ty_of_const_param)]
-    Const,
-    #[note(resolve_lifetime_param_in_ty_of_const_param)]
-    Lifetime,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3052,7 +3052,6 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             .create_err(errors::ParamInTyOfConstParam {
                 span: lifetime_ref.ident.span,
                 name: lifetime_ref.ident.name,
-                param_kind: Some(errors::ParamKindInTyOfConstParam::Lifetime),
             })
             .emit();
     }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -30,9 +30,7 @@ use std::sync::Arc;
 
 use diagnostics::{ImportSuggestion, LabelSuggestion, Suggestion};
 use effective_visibilities::EffectiveVisibilitiesVisitor;
-use errors::{
-    ParamKindInEnumDiscriminant, ParamKindInNonTrivialAnonConst, ParamKindInTyOfConstParam,
-};
+use errors::{ParamKindInEnumDiscriminant, ParamKindInNonTrivialAnonConst};
 use imports::{Import, ImportData, ImportKind, NameResolution};
 use late::{HasGenericParams, PathSource, PatternSource, UnnecessaryQualification};
 use macros::{MacroRulesBinding, MacroRulesScope, MacroRulesScopeRef};
@@ -276,8 +274,10 @@ enum ResolutionError<'ra> {
     },
     /// Error E0128: generic parameters with a default cannot use forward-declared identifiers.
     ForwardDeclaredGenericParam,
+    // FIXME(generic_const_parameter_types): This should give custom output specifying it's only
+    // problematic to use *forward declared* parameters when the feature is enabled.
     /// ERROR E0770: the type of const parameters must not depend on other generic parameters.
-    ParamInTyOfConstParam { name: Symbol, param_kind: Option<ParamKindInTyOfConstParam> },
+    ParamInTyOfConstParam { name: Symbol },
     /// generic parameters must not be used inside const evaluations.
     ///
     /// This error is only emitted when using `min_const_generics`.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1037,6 +1037,7 @@ symbols! {
         generic_associated_types_extended,
         generic_const_exprs,
         generic_const_items,
+        generic_const_parameter_types,
         generic_param_attrs,
         generic_pattern_types,
         get_context,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1189,9 +1189,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let span = obligation.cause.span;
 
         let mut diag = match ty.kind() {
-            _ if ty.has_param() => {
-                span_bug!(span, "const param tys cannot mention other generic parameters");
-            }
             ty::Float(_) => {
                 struct_span_code_err!(
                     self.dcx(),

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2544,7 +2544,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             let src = trait_pred.trait_ref.args.type_at(1);
             let err_msg = format!("`{src}` cannot be safely transmuted into `{dst}`");
 
-            match rustc_transmute::TransmuteTypeEnv::new(self.infcx).is_transmutable(
+            match rustc_transmute::TransmuteTypeEnv::new(self.infcx.tcx).is_transmutable(
                 obligation.cause,
                 src_and_dst,
                 assume,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2530,9 +2530,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 return GetSafeTransmuteErrorAndReason::Silent;
             };
 
-            let Some(assume) =
-                rustc_transmute::Assume::from_const(self.infcx.tcx, obligation.param_env, assume)
-            else {
+            let Some(assume) = rustc_transmute::Assume::from_const(self.infcx.tcx, assume) else {
                 self.dcx().span_delayed_bug(
                     span,
                     "Unable to construct rustc_transmute::Assume where it was previously possible",
@@ -2544,11 +2542,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             let src = trait_pred.trait_ref.args.type_at(1);
             let err_msg = format!("`{src}` cannot be safely transmuted into `{dst}`");
 
-            match rustc_transmute::TransmuteTypeEnv::new(self.infcx.tcx).is_transmutable(
-                obligation.cause,
-                src_and_dst,
-                assume,
-            ) {
+            match rustc_transmute::TransmuteTypeEnv::new(self.infcx.tcx)
+                .is_transmutable(src_and_dst, assume)
+            {
                 Answer::No(reason) => {
                     let safe_transmute_explanation = match reason {
                         rustc_transmute::Reason::SrcIsNotYetSupported => {

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -236,7 +236,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
         };
 
         // FIXME(transmutability): This really should be returning nested goals for `Answer::If*`
-        match rustc_transmute::TransmuteTypeEnv::new(&self.0).is_transmutable(
+        match rustc_transmute::TransmuteTypeEnv::new(self.0.tcx).is_transmutable(
             ObligationCause::dummy(),
             rustc_transmute::Types { src, dst },
             assume,

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -7,7 +7,6 @@ use rustc_infer::infer::canonical::{
     Canonical, CanonicalExt as _, CanonicalQueryInput, CanonicalVarInfo, CanonicalVarValues,
 };
 use rustc_infer::infer::{InferCtxt, RegionVariableOrigin, TyCtxtInferExt};
-use rustc_infer::traits::ObligationCause;
 use rustc_infer::traits::solve::Goal;
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt as _};
@@ -222,7 +221,6 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
     // register candidates. We probably need to register >1 since we may have an OR of ANDs.
     fn is_transmutable(
         &self,
-        param_env: ty::ParamEnv<'tcx>,
         dst: Ty<'tcx>,
         src: Ty<'tcx>,
         assume: ty::Const<'tcx>,
@@ -231,16 +229,14 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
         // which will ICE for region vars.
         let (dst, src) = self.tcx.erase_regions((dst, src));
 
-        let Some(assume) = rustc_transmute::Assume::from_const(self.tcx, param_env, assume) else {
+        let Some(assume) = rustc_transmute::Assume::from_const(self.tcx, assume) else {
             return Err(NoSolution);
         };
 
         // FIXME(transmutability): This really should be returning nested goals for `Answer::If*`
-        match rustc_transmute::TransmuteTypeEnv::new(self.0.tcx).is_transmutable(
-            ObligationCause::dummy(),
-            rustc_transmute::Types { src, dst },
-            assume,
-        ) {
+        match rustc_transmute::TransmuteTypeEnv::new(self.0.tcx)
+            .is_transmutable(rustc_transmute::Types { src, dst }, assume)
+        {
             rustc_transmute::Answer::Yes => Ok(Certainty::Yes),
             rustc_transmute::Answer::No(_) | rustc_transmute::Answer::If(_) => Err(NoSolution),
         }

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -424,7 +424,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let src = predicate.trait_ref.args.type_at(1);
 
         debug!(?src, ?dst);
-        let mut transmute_env = rustc_transmute::TransmuteTypeEnv::new(self.infcx);
+        let mut transmute_env = rustc_transmute::TransmuteTypeEnv::new(self.infcx.tcx);
         let maybe_transmutable = transmute_env.is_transmutable(
             obligation.cause.clone(),
             rustc_transmute::Types { dst, src },

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -414,9 +414,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         if self.tcx().features().generic_const_exprs() {
             assume = crate::traits::evaluate_const(self.infcx, assume, obligation.param_env)
         }
-        let Some(assume) =
-            rustc_transmute::Assume::from_const(self.infcx.tcx, obligation.param_env, assume)
-        else {
+        let Some(assume) = rustc_transmute::Assume::from_const(self.infcx.tcx, assume) else {
             return Err(Unimplemented);
         };
 
@@ -425,11 +423,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         debug!(?src, ?dst);
         let mut transmute_env = rustc_transmute::TransmuteTypeEnv::new(self.infcx.tcx);
-        let maybe_transmutable = transmute_env.is_transmutable(
-            obligation.cause.clone(),
-            rustc_transmute::Types { dst, src },
-            assume,
-        );
+        let maybe_transmutable =
+            transmute_env.is_transmutable(rustc_transmute::Types { dst, src }, assume);
 
         let fully_flattened = match maybe_transmutable {
             Answer::No(_) => Err(Unimplemented)?,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1008,7 +1008,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // depend on its particular value in order to work, so we can clear
             // out the param env and get better caching.
             debug!("in global");
-            obligation.param_env = obligation.param_env.without_caller_bounds();
+            obligation.param_env = ty::ParamEnv::empty();
         }
 
         let stack = self.push_stack(previous_stack, &obligation);

--- a/compiler/rustc_transmute/Cargo.toml
+++ b/compiler/rustc_transmute/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 rustc_abi = { path = "../rustc_abi", optional = true }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_hir = { path = "../rustc_hir", optional = true }
-rustc_infer = { path = "../rustc_infer", optional = true }
 rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_middle = { path = "../rustc_middle", optional = true }
 rustc_span = { path = "../rustc_span", optional = true }
@@ -19,7 +18,6 @@ tracing = "0.1"
 rustc = [
     "dep:rustc_abi",
     "dep:rustc_hir",
-    "dep:rustc_infer",
     "dep:rustc_macros",
     "dep:rustc_middle",
     "dep:rustc_span",

--- a/compiler/rustc_transmute/Cargo.toml
+++ b/compiler/rustc_transmute/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 rustc_abi = { path = "../rustc_abi", optional = true }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_hir = { path = "../rustc_hir", optional = true }
-rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_middle = { path = "../rustc_middle", optional = true }
 rustc_span = { path = "../rustc_span", optional = true }
 tracing = "0.1"
@@ -18,7 +17,6 @@ tracing = "0.1"
 rustc = [
     "dep:rustc_abi",
     "dep:rustc_hir",
-    "dep:rustc_macros",
     "dep:rustc_middle",
     "dep:rustc_span",
 ]

--- a/compiler/rustc_transmute/src/layout/dfa.rs
+++ b/compiler/rustc_transmute/src/layout/dfa.rs
@@ -38,7 +38,7 @@ impl<R> Transitions<R>
 where
     R: Ref,
 {
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn insert(&mut self, transition: Transition<R>, state: State) {
         match transition {
             Transition::Byte(b) => {
@@ -86,15 +86,6 @@ impl<R> Dfa<R>
 where
     R: Ref,
 {
-    #[allow(dead_code)]
-    pub(crate) fn unit() -> Self {
-        let transitions: Map<State, Transitions<R>> = Map::default();
-        let start = State::new();
-        let accepting = start;
-
-        Self { transitions, start, accepting }
-    }
-
     #[cfg(test)]
     pub(crate) fn bool() -> Self {
         let mut transitions: Map<State, Transitions<R>> = Map::default();

--- a/compiler/rustc_transmute/src/layout/nfa.rs
+++ b/compiler/rustc_transmute/src/layout/nfa.rs
@@ -159,11 +159,6 @@ where
         }
         Self { transitions, start, accepting }
     }
-
-    #[allow(dead_code)]
-    pub(crate) fn edges_from(&self, start: State) -> Option<&Map<Transition<R>, Set<State>>> {
-        self.transitions.get(&start)
-    }
 }
 
 impl State {

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -104,7 +104,6 @@ mod rustc {
             Self { tcx }
         }
 
-        #[allow(unused)]
         pub fn is_transmutable(
             &mut self,
             cause: ObligationCause<'tcx>,

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -81,14 +81,13 @@ pub enum Reason<T> {
 #[cfg(feature = "rustc")]
 mod rustc {
     use rustc_hir::lang_items::LangItem;
-    use rustc_macros::TypeVisitable;
     use rustc_middle::traits::ObligationCause;
     use rustc_middle::ty::{Const, ParamEnv, Ty, TyCtxt};
 
     use super::*;
 
     /// The source and destination types of a transmutation.
-    #[derive(TypeVisitable, Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy)]
     pub struct Types<'tcx> {
         /// The source type.
         pub src: Ty<'tcx>,

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -1,5 +1,4 @@
 // tidy-alphabetical-start
-#![allow(unused_variables)]
 #![feature(never_type)]
 #![warn(unreachable_pub)]
 // tidy-alphabetical-end
@@ -80,8 +79,7 @@ pub enum Reason<T> {
 #[cfg(feature = "rustc")]
 mod rustc {
     use rustc_hir::lang_items::LangItem;
-    use rustc_middle::traits::ObligationCause;
-    use rustc_middle::ty::{Const, ParamEnv, Ty, TyCtxt};
+    use rustc_middle::ty::{Const, Ty, TyCtxt};
 
     use super::*;
 
@@ -105,15 +103,11 @@ mod rustc {
 
         pub fn is_transmutable(
             &mut self,
-            cause: ObligationCause<'tcx>,
             types: Types<'tcx>,
             assume: crate::Assume,
         ) -> crate::Answer<crate::layout::rustc::Ref<'tcx>> {
             crate::maybe_transmutable::MaybeTransmutableQuery::new(
-                types.src,
-                types.dst,
-                assume,
-                self.tcx,
+                types.src, types.dst, assume, self.tcx,
             )
             .answer()
         }
@@ -121,11 +115,7 @@ mod rustc {
 
     impl Assume {
         /// Constructs an `Assume` from a given const-`Assume`.
-        pub fn from_const<'tcx>(
-            tcx: TyCtxt<'tcx>,
-            param_env: ParamEnv<'tcx>,
-            ct: Const<'tcx>,
-        ) -> Option<Self> {
+        pub fn from_const<'tcx>(tcx: TyCtxt<'tcx>, ct: Const<'tcx>) -> Option<Self> {
             use rustc_middle::ty::ScalarInt;
             use rustc_span::sym;
 

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -81,7 +81,6 @@ pub enum Reason<T> {
 #[cfg(feature = "rustc")]
 mod rustc {
     use rustc_hir::lang_items::LangItem;
-    use rustc_infer::infer::InferCtxt;
     use rustc_macros::TypeVisitable;
     use rustc_middle::traits::ObligationCause;
     use rustc_middle::ty::{Const, ParamEnv, Ty, TyCtxt};
@@ -97,13 +96,13 @@ mod rustc {
         pub dst: Ty<'tcx>,
     }
 
-    pub struct TransmuteTypeEnv<'cx, 'tcx> {
-        infcx: &'cx InferCtxt<'tcx>,
+    pub struct TransmuteTypeEnv<'tcx> {
+        tcx: TyCtxt<'tcx>,
     }
 
-    impl<'cx, 'tcx> TransmuteTypeEnv<'cx, 'tcx> {
-        pub fn new(infcx: &'cx InferCtxt<'tcx>) -> Self {
-            Self { infcx }
+    impl<'tcx> TransmuteTypeEnv<'tcx> {
+        pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+            Self { tcx }
         }
 
         #[allow(unused)]
@@ -117,7 +116,7 @@ mod rustc {
                 types.src,
                 types.dst,
                 assume,
-                self.infcx.tcx,
+                self.tcx,
             )
             .answer()
         }

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -1,6 +1,5 @@
 // tidy-alphabetical-start
 #![allow(unused_variables)]
-#![feature(alloc_layout_extra)]
 #![feature(never_type)]
 #![warn(unreachable_pub)]
 // tidy-alphabetical-end

--- a/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
+++ b/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
@@ -79,12 +79,12 @@ where
     pub(crate) fn answer(self) -> Answer<<C as QueryContext>::Ref> {
         let Self { src, dst, assume, context } = self;
 
-        // Unconditionally all `Def` nodes from `src`, without pruning away the
+        // Unconditionally remove all `Def` nodes from `src`, without pruning away the
         // branches they appear in. This is valid to do for value-to-value
         // transmutations, but not for `&mut T` to `&mut U`; we will need to be
         // more sophisticated to handle transmutations between mutable
         // references.
-        let src = src.prune(&|def| false);
+        let src = src.prune(&|_def| false);
 
         if src.is_inhabited() && !dst.is_inhabited() {
             return Answer::No(Reason::DstUninhabited);
@@ -96,7 +96,7 @@ where
         let dst = if assume.safety {
             // ...if safety is assumed, don't check if they carry safety
             // invariants; retain all paths.
-            dst.prune(&|def| false)
+            dst.prune(&|_def| false)
         } else {
             // ...otherwise, prune away all paths with safety invariants from
             // the `Dst` layout.

--- a/compiler/rustc_transmute/src/maybe_transmutable/tests.rs
+++ b/compiler/rustc_transmute/src/maybe_transmutable/tests.rs
@@ -92,7 +92,6 @@ mod bool {
 
     #[test]
     fn should_permit_validity_expansion_and_reject_contraction() {
-        let un = layout::Tree::<Def, !>::uninhabited();
         let b0 = layout::Tree::<Def, !>::from_bits(0);
         let b1 = layout::Tree::<Def, !>::from_bits(1);
         let b2 = layout::Tree::<Def, !>::from_bits(2);

--- a/src/doc/rustdoc/src/write-documentation/re-exports.md
+++ b/src/doc/rustdoc/src/write-documentation/re-exports.md
@@ -85,7 +85,22 @@ pub struct Hidden;
 pub use self::Hidden as InlinedHidden;
 ```
 
-The same applies on re-exports themselves: if you have multiple re-exports and some of them have
+However, if you still want the re-export itself to be visible, you can add the `#[doc(inline)]`
+attribute on it:
+
+```rust,ignore (inline)
+// This struct won't be visible.
+#[doc(hidden)]
+pub struct Hidden;
+
+#[doc(inline)]
+pub use self::Hidden as InlinedHidden;
+```
+
+In this case, you will have `pub use self::Hidden as InlinedHidden;` in the generated documentation
+but no link to the `Hidden` item.
+
+So back to `#[doc(hidden)]`: if you have multiple re-exports and some of them have
 `#[doc(hidden)]`, then these ones (and only these) won't appear in the documentation:
 
 ```rust,ignore (inline)

--- a/src/tools/clippy/clippy_lints/src/loops/single_element_loop.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/single_element_loop.rs
@@ -71,7 +71,7 @@ pub(super) fn check<'tcx>(
     {
         let mut applicability = Applicability::MachineApplicable;
         let mut pat_snip = snippet_with_applicability(cx, pat.span, "..", &mut applicability);
-        if matches!(pat.kind, PatKind::Or(..)) {
+        if matches!(pat.kind, PatKind::Or(..)) && !pat_snip.starts_with("(") {
             pat_snip = format!("({pat_snip})").into();
         }
         let mut arg_snip = snippet_with_applicability(cx, arg_expression.span, "..", &mut applicability);

--- a/src/tools/clippy/tests/ui/match_same_arms.stderr
+++ b/src/tools/clippy/tests/ui/match_same_arms.stderr
@@ -9,7 +9,7 @@ note: `_` wildcard arm here
   --> tests/ui/match_same_arms.rs:14:9
    |
 LL |         _ => 0,
-   |         ^^^^^^
+   |         ^^^^^^^
    = note: `-D clippy::match-same-arms` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::match_same_arms)]`
 
@@ -17,7 +17,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:18:9
    |
 LL |         (1, .., 3) => 42,
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -30,7 +30,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:25:9
    |
 LL |         51 => 1,
-   |         ^^^^^^^
+   |         ^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -44,7 +44,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:26:9
    |
 LL |         41 => 2,
-   |         ^^^^^^^
+   |         ^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -57,7 +57,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:33:9
    |
 LL |         2 => 2,
-   |         ^^^^^^
+   |         ^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -71,7 +71,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:35:9
    |
 LL |         3 => 2,
-   |         ^^^^^^
+   |         ^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -85,7 +85,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:33:9
    |
 LL |         2 => 2,
-   |         ^^^^^^
+   |         ^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -99,7 +99,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms.rs:52:17
    |
 LL |                 CommandInfo::External { name, .. } => name.to_string(),
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm

--- a/src/tools/clippy/tests/ui/match_same_arms2.stderr
+++ b/src/tools/clippy/tests/ui/match_same_arms2.stderr
@@ -21,7 +21,7 @@ LL | |             if true {
 ...  |
 LL | |             a
 LL | |         },
-   | |_________^
+   | |__________^
    = note: `-D clippy::match-same-arms` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::match_same_arms)]`
 
@@ -29,7 +29,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:40:9
    |
 LL |         51 => foo(),
-   |         ^^^^^^^^^^^
+   |         ^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -43,7 +43,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:46:9
    |
 LL |         None => 24,
-   |         ^^^^^^^^^^
+   |         ^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -57,7 +57,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:68:9
    |
 LL |         (None, Some(a)) => bar(a),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -71,7 +71,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:82:9
    |
 LL |         (None, Some(a)) if a == 42 => a,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -85,7 +85,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:87:9
    |
 LL |         (Some(a), ..) => bar(a),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -98,7 +98,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:121:9
    |
 LL |         (Ok(x), Some(_)) => println!("ok {}", x),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -111,7 +111,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:137:9
    |
 LL |         Ok(_) => println!("ok"),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -127,7 +127,7 @@ error: this match arm has an identical body to another arm
 LL | /         1 => {
 LL | |             empty!(0);
 LL | |         },
-   | |_________^
+   | |__________^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -143,7 +143,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:215:9
    |
 LL |         Foo::X(0) => 1,
-   |         ^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -157,7 +157,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:225:9
    |
 LL |         Foo::Z(_) => 1,
-   |         ^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -170,7 +170,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:248:9
    |
 LL |         Some(Bar { y: 0, x: 5, .. }) => 1,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -184,7 +184,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:262:9
    |
 LL |         1 => cfg!(not_enable),
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm
@@ -198,7 +198,7 @@ error: this match arm has an identical body to another arm
   --> tests/ui/match_same_arms2.rs:278:17
    |
 LL |                 MaybeStaticStr::Borrowed(s) => s,
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try changing either arm body
 help: or try merging the arm patterns and removing the obsolete arm

--- a/src/tools/clippy/tests/ui/match_same_arms_non_exhaustive.stderr
+++ b/src/tools/clippy/tests/ui/match_same_arms_non_exhaustive.stderr
@@ -10,7 +10,7 @@ note: `_` wildcard arm here
   --> tests/ui/match_same_arms_non_exhaustive.rs:46:9
    |
 LL |         _ => repeat(),
-   |         ^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^
    = note: `-D clippy::match-same-arms` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::match_same_arms)]`
 
@@ -26,7 +26,7 @@ note: `_` wildcard arm here
   --> tests/ui/match_same_arms_non_exhaustive.rs:60:13
    |
 LL |             _ => repeat(),
-   |             ^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/tools/miri/tests/fail/erroneous_const.stderr
+++ b/src/tools/miri/tests/fail/erroneous_const.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `PrintName::<i32>::VOID` failed
   --> tests/fail/erroneous_const.rs:LL:CC
    |
 LL |     const VOID: ! = panic!();
-   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', tests/fail/erroneous_const.rs:LL:CC
+   |                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/rustfmt/src/types.rs
+++ b/src/tools/rustfmt/src/types.rs
@@ -1019,7 +1019,11 @@ impl Rewrite for ast::Ty {
             }
             ast::TyKind::UnsafeBinder(ref binder) => {
                 let mut result = String::new();
-                if let Some(ref lifetime_str) =
+                if binder.generic_params.is_empty() {
+                    // We always want to write `unsafe<>` since `unsafe<> Ty`
+                    // and `Ty` are distinct types.
+                    result.push_str("unsafe<> ")
+                } else if let Some(ref lifetime_str) =
                     rewrite_bound_params(context, shape, &binder.generic_params)
                 {
                     result.push_str("unsafe<");

--- a/src/tools/rustfmt/tests/source/unsafe-binders.rs
+++ b/src/tools/rustfmt/tests/source/unsafe-binders.rs
@@ -9,3 +9,6 @@ struct Foo {
 struct Bar(unsafe<'a> &'a ());
 
 impl Trait for unsafe<'a> &'a () {}
+
+fn empty()
+-> unsafe<> () {}

--- a/src/tools/rustfmt/tests/target/unsafe-binders.rs
+++ b/src/tools/rustfmt/tests/target/unsafe-binders.rs
@@ -7,3 +7,5 @@ struct Foo {
 struct Bar(unsafe<'a> &'a ());
 
 impl Trait for unsafe<'a> &'a () {}
+
+fn empty() -> unsafe<> () {}

--- a/tests/codegen/uninhabited-transparent-return-abi.rs
+++ b/tests/codegen/uninhabited-transparent-return-abi.rs
@@ -24,7 +24,7 @@ extern "Rust" {
 pub fn test_uninhabited_ret_by_ref() {
     // CHECK: %_1 = alloca [24 x i8], align {{8|4}}
     // CHECK-NEXT: call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %_1)
-    // CHECK-NEXT: call void @opaque(ptr noalias nocapture noundef nonnull sret([24 x i8]) align {{8|4}} dereferenceable(24) %_1) #2
+    // CHECK-NEXT: call void @opaque({{.*}} sret([24 x i8]) {{.*}} %_1) #2
     // CHECK-NEXT: unreachable
     unsafe {
         opaque();
@@ -36,7 +36,7 @@ pub fn test_uninhabited_ret_by_ref() {
 pub fn test_uninhabited_ret_by_ref_with_arg(rsi: u32) {
     // CHECK: %_2 = alloca [24 x i8], align {{8|4}}
     // CHECK-NEXT: call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %_2)
-    // CHECK-NEXT: call void @opaque_with_arg(ptr noalias nocapture noundef nonnull sret([24 x i8]) align {{8|4}} dereferenceable(24) %_2, i32 noundef %rsi) #2
+    // CHECK-NEXT: call void @opaque_with_arg({{.*}} sret([24 x i8]) {{.*}} %_2, i32 noundef %rsi) #2
     // CHECK-NEXT: unreachable
     unsafe {
         opaque_with_arg(rsi);

--- a/tests/ui/asm/naked-functions.stderr
+++ b/tests/ui/asm/naked-functions.stderr
@@ -89,10 +89,10 @@ LL |     &b: &i32,
    |     ^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:29:6
+  --> $DIR/naked-functions.rs:29:5
    |
 LL |     (None | Some(_)): Option<std::ptr::NonNull<u8>>,
-   |      ^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
   --> $DIR/naked-functions.rs:31:5

--- a/tests/ui/attributes/collapse-debuginfo-invalid.stderr
+++ b/tests/ui/attributes/collapse-debuginfo-invalid.stderr
@@ -76,7 +76,7 @@ LL |         #[collapse_debuginfo(yes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |         _ => (),
-   |         ------- not a macro definition
+   |         -------- not a macro definition
 
 error: `collapse_debuginfo` attribute should be applied to macro definitions
   --> $DIR/collapse-debuginfo-invalid.rs:40:1

--- a/tests/ui/borrowck/issue-81899.rs
+++ b/tests/ui/borrowck/issue-81899.rs
@@ -1,15 +1,14 @@
 // Regression test for #81899.
 // The `panic!()` below is important to trigger the fixed ICE.
 
-const _CONST: &[u8] = &f(&[], |_| {});
+const _CONST: &[u8] = &f(&[], |_| {}); //~ ERROR evaluation of constant value failed
 //~^ constant
 
 const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
-    //~^ panic
+    panic!() //~ inside `f
 }
 
 fn main() {}

--- a/tests/ui/borrowck/issue-81899.stderr
+++ b/tests/ui/borrowck/issue-81899.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-81899.rs:11:5
+  --> $DIR/issue-81899.rs:4:24
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-81899.rs:11:5
+LL | const _CONST: &[u8] = &f(&[], |_| {});
+   |                        ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
 note: inside `f::<{closure@$DIR/issue-81899.rs:4:31: 4:34}>`
   --> $DIR/issue-81899.rs:11:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_CONST`
-  --> $DIR/issue-81899.rs:4:24
-   |
-LL | const _CONST: &[u8] = &f(&[], |_| {});
-   |                        ^^^^^^^^^^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered

--- a/tests/ui/borrowck/issue-88434-minimal-example.rs
+++ b/tests/ui/borrowck/issue-88434-minimal-example.rs
@@ -1,14 +1,13 @@
 // Regression test related to issue 88434
 
-const _CONST: &() = &f(&|_| {});
+const _CONST: &() = &f(&|_| {}); //~ ERROR evaluation of constant value failed
 //~^ constant
 
 const fn f<F>(_: &F)
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
-    //~^ panic
+    panic!() //~ inside `f
 }
 
 fn main() { }

--- a/tests/ui/borrowck/issue-88434-minimal-example.stderr
+++ b/tests/ui/borrowck/issue-88434-minimal-example.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-88434-minimal-example.rs:10:5
+  --> $DIR/issue-88434-minimal-example.rs:3:22
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-88434-minimal-example.rs:10:5
+LL | const _CONST: &() = &f(&|_| {});
+   |                      ^^^^^^^^^^ evaluation panicked: explicit panic
    |
 note: inside `f::<{closure@$DIR/issue-88434-minimal-example.rs:3:25: 3:28}>`
   --> $DIR/issue-88434-minimal-example.rs:10:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_CONST`
-  --> $DIR/issue-88434-minimal-example.rs:3:22
-   |
-LL | const _CONST: &() = &f(&|_| {});
-   |                      ^^^^^^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.rs
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.rs
@@ -1,14 +1,13 @@
 // Regression test for issue 88434
 
-const _CONST: &[u8] = &f(&[], |_| {});
+const _CONST: &[u8] = &f(&[], |_| {}); //~ ERROR evaluation of constant value failed
 //~^ constant
 
 const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
-    //~^ panic
+    panic!() //~ inside `f
 }
 
 fn main() { }

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
+  --> $DIR/issue-88434-removal-index-should-be-less.rs:3:24
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-88434-removal-index-should-be-less.rs:10:5
+LL | const _CONST: &[u8] = &f(&[], |_| {});
+   |                        ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
 note: inside `f::<{closure@$DIR/issue-88434-removal-index-should-be-less.rs:3:31: 3:34}>`
   --> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_CONST`
-  --> $DIR/issue-88434-removal-index-should-be-less.rs:3:24
-   |
-LL | const _CONST: &[u8] = &f(&[], |_| {});
-   |                        ^^^^^^^^^^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered

--- a/tests/ui/closures/2229_closure_analysis/bad-pattern.stderr
+++ b/tests/ui/closures/2229_closure_analysis/bad-pattern.stderr
@@ -17,10 +17,10 @@ LL |         let _0 = v1;
    |             +
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/bad-pattern.rs:14:14
+  --> $DIR/bad-pattern.rs:14:13
    |
 LL |         let (0 | 1) = v1;
-   |              ^^^^^ pattern `2_u32..=u32::MAX` not covered
+   |             ^^^^^^^ pattern `2_u32..=u32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html

--- a/tests/ui/closures/2229_closure_analysis/match/issue-88331.stderr
+++ b/tests/ui/closures/2229_closure_analysis/match/issue-88331.stderr
@@ -13,7 +13,7 @@ LL | pub struct Opcode(pub u8);
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Opcode::OP1 => unimplemented!(),
-LL ~         Opcode(0_u8) | Opcode(2_u8..=u8::MAX) => todo!(),
+LL +         Opcode(0_u8) | Opcode(2_u8..=u8::MAX) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Opcode2(Opcode(0_u8))` and `Opcode2(Opcode(2_u8..=u8::MAX))` not covered
@@ -31,7 +31,7 @@ LL | pub struct Opcode2(Opcode);
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Opcode2::OP2=> unimplemented!(),
-LL ~         Opcode2(Opcode(0_u8)) | Opcode2(Opcode(2_u8..=u8::MAX)) => todo!(),
+LL +         Opcode2(Opcode(0_u8)) | Opcode2(Opcode(2_u8..=u8::MAX)) => todo!()
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/coherence/const-errs-dont-conflict-103369.rs
+++ b/tests/ui/coherence/const-errs-dont-conflict-103369.rs
@@ -2,13 +2,12 @@
 
 pub trait ConstGenericTrait<const N: u32> {}
 
-impl ConstGenericTrait<{my_fn(1)}> for () {}
+impl ConstGenericTrait<{my_fn(1)}> for () {} //~ ERROR E0080
 
-impl ConstGenericTrait<{my_fn(2)}> for () {}
+impl ConstGenericTrait<{my_fn(2)}> for () {} //~ ERROR E0080
 
 const fn my_fn(v: u32) -> u32 {
-    panic!("Some error occurred"); //~ ERROR E0080
-    //~| ERROR E0080
+    panic!("Some error occurred");
 }
 
 fn main() {}

--- a/tests/ui/coherence/const-errs-dont-conflict-103369.stderr
+++ b/tests/ui/coherence/const-errs-dont-conflict-103369.stderr
@@ -1,37 +1,27 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Some error occurred', $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-note: inside `my_fn`
-  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `<() as ConstGenericTrait<{my_fn(1)}>>::{constant#0}`
   --> $DIR/const-errs-dont-conflict-103369.rs:5:25
    |
 LL | impl ConstGenericTrait<{my_fn(1)}> for () {}
-   |                         ^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Some error occurred', $DIR/const-errs-dont-conflict-103369.rs:10:5
+   |                         ^^^^^^^^ evaluation panicked: Some error occurred
    |
 note: inside `my_fn`
   --> $DIR/const-errs-dont-conflict-103369.rs:10:5
    |
 LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `<() as ConstGenericTrait<{my_fn(2)}>>::{constant#0}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/const-errs-dont-conflict-103369.rs:7:25
    |
 LL | impl ConstGenericTrait<{my_fn(2)}> for () {}
-   |                         ^^^^^^^^
+   |                         ^^^^^^^^ evaluation panicked: Some error occurred
+   |
+note: inside `my_fn`
+  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
+   |
+LL |     panic!("Some error occurred");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.full.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.full.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
    |                                                    ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/const-param-type-depends-on-const-param.rs:15:40
    |
 LL | pub struct SelfDependent<const N: [u8; N]>;
    |                                        ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
    |                                                    ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/const-param-type-depends-on-const-param.rs:15:40
    |
 LL | pub struct SelfDependent<const N: [u8; N]>;
    |                                        ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: `[u8; N]` is forbidden as the type of a const generic parameter
   --> $DIR/const-param-type-depends-on-const-param.rs:11:47

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct B<T, const N: T>(PhantomData<[T; N]>);
    |                      ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param.full.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                                  ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/const-param-type-depends-on-type-param.rs:11:22

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param.min.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                                  ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/const-param-type-depends-on-type-param.rs:11:22

--- a/tests/ui/const-generics/generic_const_parameter_types/bad_inference.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/bad_inference.rs
@@ -1,0 +1,23 @@
+#![feature(
+    adt_const_params,
+    unsized_const_params,
+    generic_const_parameter_types,
+    generic_arg_infer
+)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<T: ConstParamTy_, const N: usize, const M: [T; N]>() -> [T; N] {
+    loop {}
+}
+
+fn main() {
+    // Requires inferring `T`/`N` from `12_u8` and `2` respectively.
+    let a = foo::<_, _, { [12_u8; 2] }>();
+    //~^ ERROR: anonymous constants with inferred types are not yet supported
+
+    // Requires inferring `T`/`N`/`12_?i`/`_` from `[u8; 2]`
+    let b: [u8; 2] = foo::<_, _, { [12; _] }>();
+    //~^ ERROR: anonymous constants with inferred types are not yet supported
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/bad_inference.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/bad_inference.stderr
@@ -1,0 +1,14 @@
+error: anonymous constants with inferred types are not yet supported
+  --> $DIR/bad_inference.rs:17:25
+   |
+LL |     let a = foo::<_, _, { [12_u8; 2] }>();
+   |                         ^^^^^^^^^^^^^^
+
+error: anonymous constants with inferred types are not yet supported
+  --> $DIR/bad_inference.rs:21:34
+   |
+LL |     let b: [u8; 2] = foo::<_, _, { [12; _] }>();
+   |                                  ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/const-generics/generic_const_parameter_types/evaluate_const_parameter_in_mir.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/evaluate_const_parameter_in_mir.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+
+#![feature(
+    adt_const_params,
+    unsized_const_params,
+    generic_const_parameter_types,
+    generic_arg_infer
+)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<T: ConstParamTy_, const N: usize, const M: [T; N]>() -> [T; N] {
+    M
+}
+
+fn main() {
+    let a: [u8; 2] = foo::<u8, 2, { [12; _] }>();
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.rs
@@ -1,0 +1,11 @@
+#![feature(adt_const_params, generic_const_parameter_types)]
+#![expect(incomplete_features)]
+
+use std::marker::PhantomData;
+
+struct UsesConst<const N: [u8; M], const M: usize>;
+//~^ ERROR: the type of const parameters must not depend on other generic parameters
+struct UsesType<const N: [T; 2], T>(PhantomData<T>);
+//~^ ERROR: the type of const parameters must not depend on other generic parameters
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.stderr
@@ -1,0 +1,15 @@
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/forward_declared_type.rs:6:32
+   |
+LL | struct UsesConst<const N: [u8; M], const M: usize>;
+   |                                ^ the type must not depend on the parameter `M`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/forward_declared_type.rs:8:27
+   |
+LL | struct UsesType<const N: [T; 2], T>(PhantomData<T>);
+   |                           ^ the type must not depend on the parameter `T`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/generic_const_parameter_types/inferred_from_arg.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/inferred_from_arg.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+
+#![feature(adt_const_params, generic_arg_infer, generic_const_parameter_types)]
+#![expect(incomplete_features)]
+
+struct Bar<const N: usize, const M: [u8; N]>;
+
+fn foo<const N: usize, const M: [u8; N]>(_: Bar<N, M>) {}
+
+fn main() {
+    foo(Bar::<2, { [1; 2] }>);
+    foo::<_, _>(Bar::<2, { [1; 2] }>);
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.rs
@@ -1,0 +1,20 @@
+#![feature(generic_const_parameter_types, adt_const_params, unsized_const_params)]
+#![expect(incomplete_features)]
+
+fn foo<'a, const N: &'a u32>() {}
+
+fn bar() {
+    foo::<'static, { &1_u32 }>();
+    //~^ ERROR: anonymous constants with lifetimes in their type are not yet supported
+    foo::<'_, { &1_u32 }>();
+    //~^ ERROR: anonymous constants with lifetimes in their type are not yet supported
+}
+
+fn borrowck<'a, const N: &'static u32, const M: &'a u32>() {
+    foo::<'a, M>();
+    foo::<'static, M>();
+    //~^ ERROR: lifetime may not live long enough
+    foo::<'static, N>();
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.stderr
@@ -1,0 +1,23 @@
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/lifetime_dependent_const_param.rs:7:20
+   |
+LL |     foo::<'static, { &1_u32 }>();
+   |                    ^^^^^^^^^^
+
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/lifetime_dependent_const_param.rs:9:15
+   |
+LL |     foo::<'_, { &1_u32 }>();
+   |               ^^^^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/lifetime_dependent_const_param.rs:15:5
+   |
+LL | fn borrowck<'a, const N: &'static u32, const M: &'a u32>() {
+   |             -- lifetime `'a` defined here
+LL |     foo::<'a, M>();
+LL |     foo::<'static, M>();
+   |     ^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.rs
@@ -1,0 +1,15 @@
+#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<const N: usize, const M: [u8; N]>() {}
+fn bar<T: ConstParamTy_, const M: [T; 2]>() {}
+
+fn main() {
+    foo::<3, { [1; 2] }>();
+    //~^ ERROR: mismatched type
+
+    bar::<u8, { [2_u16; 2] }>();
+    //~^ ERROR: mismatched type
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/mismatched_args_with_value.rs:10:16
+   |
+LL |     foo::<3, { [1; 2] }>();
+   |                ^^^^^^ expected an array with a size of 3, found one with a size of 2
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched_args_with_value.rs:13:18
+   |
+LL |     bar::<u8, { [2_u16; 2] }>();
+   |                  ^^^^^ expected `u8`, found `u16`
+   |
+help: change the type of the numeric literal from `u16` to `u8`
+   |
+LL -     bar::<u8, { [2_u16; 2] }>();
+LL +     bar::<u8, { [2_u8; 2] }>();
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.rs
@@ -1,0 +1,9 @@
+#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![expect(incomplete_features)]
+
+use std::marker::{ConstParamTy_, PhantomData};
+
+struct UsesType<T, const N: usize, const M: [T; N]>(PhantomData<T>);
+//~^ ERROR: `[T; N]` can't be used as a const parameter type
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.stderr
@@ -1,0 +1,11 @@
+error[E0741]: `[T; N]` can't be used as a const parameter type
+  --> $DIR/no_const_param_ty_bound.rs:6:45
+   |
+LL | struct UsesType<T, const N: usize, const M: [T; N]>(PhantomData<T>);
+   |                                             ^^^^^^
+   |
+   = note: `T` must implement `UnsizedConstParamTy`, but it does not
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0741`.

--- a/tests/ui/const-generics/generic_const_parameter_types/unrelated_inferred_arg.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/unrelated_inferred_arg.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+
+#![feature(
+    adt_const_params,
+    unsized_const_params,
+    generic_const_parameter_types,
+    generic_arg_infer
+)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<U, T: ConstParamTy_, const N: usize, const M: [T; N]>(_: U) -> [T; N] {
+    loop {}
+}
+
+fn main() {
+    // Check that `_` doesnt cause a "Type of const argument is uninferred" error
+    // as it is not actually used by the type of `M`.
+    let a = foo::<_, u8, 2, { [12; _] }>(true);
+}

--- a/tests/ui/const-generics/issues/issue-100313.rs
+++ b/tests/ui/const-generics/issues/issue-100313.rs
@@ -6,15 +6,14 @@ struct T<const B: &'static bool>;
 impl<const B: &'static bool> T<B> {
     const fn set_false(&self) {
         unsafe {
-            *(B as *const bool as *mut bool) = false;
-            //~^ ERROR evaluation of constant value failed [E0080]
+            *(B as *const bool as *mut bool) = false; //~ inside `T
         }
     }
 }
 
 const _: () = {
     let x = T::<{ &true }>;
-    x.set_false();
+    x.set_false(); //~ ERROR evaluation of constant value failed [E0080]
 };
 
 fn main() {}

--- a/tests/ui/const-generics/issues/issue-100313.stderr
+++ b/tests/ui/const-generics/issues/issue-100313.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-100313.rs:9:13
+  --> $DIR/issue-100313.rs:16:5
    |
-LL |             *(B as *const bool as *mut bool) = false;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ writing to ALLOC0 which is read-only
+LL |     x.set_false();
+   |     ^^^^^^^^^^^^^ writing to ALLOC0 which is read-only
    |
 note: inside `T::<&true>::set_false`
   --> $DIR/issue-100313.rs:9:13
    |
 LL |             *(B as *const bool as *mut bool) = false;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `_`
-  --> $DIR/issue-100313.rs:17:5
-   |
-LL |     x.set_false();
-   |     ^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-56445-1.full.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-1.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
    |                          ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-56445-1.min.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-1.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
    |                          ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-62878.full.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |                                      ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-62878.min.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |                                      ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: `[u8; N]` is forbidden as the type of a const generic parameter
   --> $DIR/issue-62878.rs:5:33

--- a/tests/ui/const-generics/issues/issue-71169.full.stderr
+++ b/tests/ui/const-generics/issues/issue-71169.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
    |                                           ^^^ the type must not depend on the parameter `LEN`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-71381.full.stderr
+++ b/tests/ui/const-generics/issues/issue-71381.full.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                                                  ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/issue-71381.rs:23:40
    |
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-71381.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71381.min.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                                                  ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/issue-71381.rs:23:40
    |
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71381.rs:14:61

--- a/tests/ui/const-generics/issues/issue-71611.full.stderr
+++ b/tests/ui/const-generics/issues/issue-71611.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                               ^ the type must not depend on the parameter `A`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-71611.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71611.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                               ^ the type must not depend on the parameter `A`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71611.rs:5:21

--- a/tests/ui/const-generics/issues/issue-88997.stderr
+++ b/tests/ui/const-generics/issues/issue-88997.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Range<T: PartialOrd, const MIN: T, const MAX: T>(T)
    |                                        ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/issue-88997.rs:8:54
    |
 LL | struct Range<T: PartialOrd, const MIN: T, const MAX: T>(T)
    |                                                      ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-90364.stderr
+++ b/tests/ui/const-generics/issues/issue-90364.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Foo<T, const H: T>(T)
    |                            ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-ptr/forbidden_slices.rs
+++ b/tests/ui/const-ptr/forbidden_slices.rs
@@ -48,9 +48,11 @@ pub static S8: &[u64] = unsafe {
 pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
 //~^ ERROR it is undefined behavior to use this value
 pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }; // errors inside libcore
+//~^ ERROR could not evaluate static initializer
 pub static R2: &[u32] = unsafe {
     let ptr = &D0 as *const u32;
     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
+    //~^ ERROR could not evaluate static initializer
 };
 pub static R4: &[u8] = unsafe {
     //~^ ERROR: it is undefined behavior to use this value
@@ -74,13 +76,16 @@ pub static R7: &[u16] = unsafe {
 };
 pub static R8: &[u64] = unsafe {
     let ptr = (&D4 as *const [u32; 2] as *const u32).byte_add(1).cast::<u64>();
-    from_ptr_range(ptr..ptr.add(1)) //~ inside `R8`
+    from_ptr_range(ptr..ptr.add(1))
+    //~^ ERROR could not evaluate static initializer
 };
 
 // This is sneaky: &D0 and &D0 point to different objects
 // (even if at runtime they have the same address)
 pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
+//~^ ERROR could not evaluate static initializer
 pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
+//~^ ERROR could not evaluate static initializer
 
 const D0: u32 = 0x11111111; // Constant chosen for endianness-independent behavior.
 const D1: MaybeUninit<&u32> = MaybeUninit::uninit();

--- a/tests/ui/const-ptr/forbidden_slices.stderr
+++ b/tests/ui/const-ptr/forbidden_slices.stderr
@@ -100,36 +100,28 @@ LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }
            }
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'assertion failed: 0 < pointee_size && pointee_size <= isize::MAX as usize', $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-note: inside `std::ptr::const_ptr::<impl *const ()>::offset_from_unsigned`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `from_ptr_range::<'_, ()>`
-  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
-note: inside `R1`
   --> $DIR/forbidden_slices.rs:50:33
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }; // errors inside libcore
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: 0 < pointee_size && pointee_size <= isize::MAX as usize
+   |
+note: inside `from_ptr_range::<'_, ()>`
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+note: inside `std::ptr::const_ptr::<impl *const ()>::offset_from_unsigned`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+  --> $DIR/forbidden_slices.rs:54:25
    |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC10 which is only 4 bytes from the end of the allocation
+LL |     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
+   |                         ^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC10 which is only 4 bytes from the end of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u32>::add`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `R2`
-  --> $DIR/forbidden_slices.rs:53:25
-   |
-LL |     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
-   |                         ^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:55:1
+  --> $DIR/forbidden_slices.rs:57:1
    |
 LL | pub static R4: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
@@ -140,7 +132,7 @@ LL | pub static R4: &[u8] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:60:1
+  --> $DIR/forbidden_slices.rs:62:1
    |
 LL | pub static R5: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
@@ -153,7 +145,7 @@ LL | pub static R5: &[u8] = unsafe {
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:65:1
+  --> $DIR/forbidden_slices.rs:67:1
    |
 LL | pub static R6: &[bool] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
@@ -164,7 +156,7 @@ LL | pub static R6: &[bool] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:70:1
+  --> $DIR/forbidden_slices.rs:72:1
    |
 LL | pub static R7: &[u16] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
@@ -175,47 +167,35 @@ LL | pub static R7: &[u16] = unsafe {
            }
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+  --> $DIR/forbidden_slices.rs:79:25
    |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC11+0x1 which is only 7 bytes from the end of the allocation
+LL |     from_ptr_range(ptr..ptr.add(1))
+   |                         ^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC11+0x1 which is only 7 bytes from the end of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u64>::add`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `R8`
-  --> $DIR/forbidden_slices.rs:77:25
-   |
-LL |     from_ptr_range(ptr..ptr.add(1))
-   |                         ^^^^^^^^^^
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `from_ptr_range::<'_, u32>`
-  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
-note: inside `R9`
-  --> $DIR/forbidden_slices.rs:82:34
+  --> $DIR/forbidden_slices.rs:85:34
    |
 LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
    |
-   = note: `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `from_ptr_range::<'_, u32>`
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
-note: inside `R10`
-  --> $DIR/forbidden_slices.rs:83:35
+note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+
+error[E0080]: could not evaluate static initializer
+  --> $DIR/forbidden_slices.rs:87:35
    |
 LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
+   |
+note: inside `from_ptr_range::<'_, u32>`
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/const-ptr/out_of_bounds_read.stderr
+++ b/tests/ui/const-ptr/out_of_bounds_read.stderr
@@ -1,45 +1,33 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
-   |
-note: inside `std::ptr::read::<u32>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `_READ`
   --> $DIR/out_of_bounds_read.rs:10:33
    |
 LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
    |
 note: inside `std::ptr::read::<u32>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u32>::read`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `_CONST_READ`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/out_of_bounds_read.rs:11:39
    |
 LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
-   |                                       ^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |                                       ^^^^^^^^^^^^^^^^^^^ memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
    |
-   = note: memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
-   |
+note: inside `std::ptr::const_ptr::<impl *const u32>::read`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `std::ptr::read::<u32>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::mut_ptr::<impl *mut u32>::read`
-  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-note: inside `_MUT_READ`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/out_of_bounds_read.rs:12:37
    |
 LL |     const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
+   |
+note: inside `std::ptr::mut_ptr::<impl *mut u32>::read`
+  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+note: inside `std::ptr::read::<u32>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/assert-type-intrinsics.stderr
+++ b/tests/ui/consts/assert-type-intrinsics.stderr
@@ -2,19 +2,19 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/assert-type-intrinsics.rs:11:9
    |
 LL |         MaybeUninit::<!>::uninit().assume_init();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'aborted execution: attempted to instantiate uninhabited type `!`', $DIR/assert-type-intrinsics.rs:11:36
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: aborted execution: attempted to instantiate uninhabited type `!`
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/assert-type-intrinsics.rs:15:9
    |
 LL |         intrinsics::assert_mem_uninitialized_valid::<&'static i32>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'aborted execution: attempted to leave type `&i32` uninitialized, which is invalid', $DIR/assert-type-intrinsics.rs:15:9
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: aborted execution: attempted to leave type `&i32` uninitialized, which is invalid
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/assert-type-intrinsics.rs:19:9
    |
 LL |         intrinsics::assert_zero_valid::<&'static i32>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'aborted execution: attempted to zero-initialize type `&i32`, which is invalid', $DIR/assert-type-intrinsics.rs:19:9
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: aborted execution: attempted to zero-initialize type `&i32`, which is invalid
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail2.rs
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail2.rs
@@ -7,12 +7,18 @@ const X: fn(usize) -> usize = double;
 
 const fn bar(x: fn(usize) -> usize, y: usize) -> usize {
     x(y)
-    //~^ ERROR evaluation of constant value failed
-    //~| ERROR evaluation of constant value failed
+    //~^ NOTE inside `bar`
+    //~| NOTE the failure occurred here
+    //~| NOTE inside `bar`
+    //~| NOTE the failure occurred here
 }
 
 const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday
+//~^ ERROR evaluation of constant value failed
+//~| NOTE calling non-const function `double`
 const Z: usize = bar(double, 2); // FIXME: should fail to typeck someday
+//~^ ERROR evaluation of constant value failed
+//~| NOTE calling non-const function `double`
 
 fn main() {
     assert_eq!(Y, 4);

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail2.stderr
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail2.stderr
@@ -1,36 +1,26 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_fn_ptr_fail2.rs:9:5
-   |
-LL |     x(y)
-   |     ^^^^ calling non-const function `double`
-   |
-note: inside `bar`
-  --> $DIR/const_fn_ptr_fail2.rs:9:5
-   |
-LL |     x(y)
-   |     ^^^^
-note: inside `Y`
-  --> $DIR/const_fn_ptr_fail2.rs:14:18
+  --> $DIR/const_fn_ptr_fail2.rs:16:18
    |
 LL | const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday
-   |                  ^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const_fn_ptr_fail2.rs:9:5
-   |
-LL |     x(y)
-   |     ^^^^ calling non-const function `double`
+   |                  ^^^^^^^^^ calling non-const function `double`
    |
 note: inside `bar`
   --> $DIR/const_fn_ptr_fail2.rs:9:5
    |
 LL |     x(y)
-   |     ^^^^
-note: inside `Z`
-  --> $DIR/const_fn_ptr_fail2.rs:15:18
+   |     ^^^^ the failure occurred here
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const_fn_ptr_fail2.rs:19:18
    |
 LL | const Z: usize = bar(double, 2); // FIXME: should fail to typeck someday
-   |                  ^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^^^ calling non-const function `double`
+   |
+note: inside `bar`
+  --> $DIR/const_fn_ptr_fail2.rs:9:5
+   |
+LL |     x(y)
+   |     ^^^^ the failure occurred here
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
+++ b/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic-normalize-tabs-115498.rs:3:17
    |
 LL | struct Bug([u8; panic!{"\t"}]);
-   |                 ^^^^^^^^^^^^ the evaluated program panicked at '    ', $DIR/const_panic-normalize-tabs-115498.rs:3:17
+   |                 ^^^^^^^^^^^^ evaluation panicked:     
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic.stderr
+++ b/tests/ui/consts/const-eval/const_panic.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:6:15
    |
 LL | const Z: () = std::panic!("cheese");
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic.rs:6:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: cheese
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:9:16
    |
 LL | const Z2: () = std::panic!();
-   |                ^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:9:16
+   |                ^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:12:15
    |
 LL | const Y: () = std::unreachable!();
-   |               ^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:12:15
+   |               ^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `std::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:15:15
    |
 LL | const X: () = std::unimplemented!();
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:15:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `std::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +34,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:18:15
    |
 LL | const W: () = std::panic!(MSG);
-   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:18:15
+   |               ^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -42,7 +42,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:21:16
    |
 LL | const W2: () = std::panic!("{}", MSG);
-   |                ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:21:16
+   |                ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:24:20
    |
 LL | const Z_CORE: () = core::panic!("cheese");
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic.rs:24:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: cheese
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -58,7 +58,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:27:21
    |
 LL | const Z2_CORE: () = core::panic!();
-   |                     ^^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:27:21
+   |                     ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -66,7 +66,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:30:20
    |
 LL | const Y_CORE: () = core::unreachable!();
-   |                    ^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:30:20
+   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `core::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -74,7 +74,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:33:20
    |
 LL | const X_CORE: () = core::unimplemented!();
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:33:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `core::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -82,7 +82,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:36:20
    |
 LL | const W_CORE: () = core::panic!(MSG);
-   |                    ^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:36:20
+   |                    ^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -90,7 +90,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:39:21
    |
 LL | const W2_CORE: () = core::panic!("{}", MSG);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:39:21
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic_2021.stderr
+++ b/tests/ui/consts/const-eval/const_panic_2021.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:6:15
    |
 LL | const A: () = std::panic!("blåhaj");
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'blåhaj', $DIR/const_panic_2021.rs:6:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: blåhaj
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:9:15
    |
 LL | const B: () = std::panic!();
-   |               ^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic_2021.rs:9:15
+   |               ^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:12:15
    |
 LL | const C: () = std::unreachable!();
-   |               ^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_2021.rs:12:15
+   |               ^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `std::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:15:15
    |
 LL | const D: () = std::unimplemented!();
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic_2021.rs:15:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `std::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +34,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:18:15
    |
 LL | const E: () = std::panic!("{}", MSG);
-   |               ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic_2021.rs:18:15
+   |               ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -42,7 +42,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:21:20
    |
 LL | const A_CORE: () = core::panic!("shark");
-   |                    ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'shark', $DIR/const_panic_2021.rs:21:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: shark
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:24:20
    |
 LL | const B_CORE: () = core::panic!();
-   |                    ^^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic_2021.rs:24:20
+   |                    ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -58,7 +58,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:27:20
    |
 LL | const C_CORE: () = core::unreachable!();
-   |                    ^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_2021.rs:27:20
+   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `core::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -66,7 +66,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:30:20
    |
 LL | const D_CORE: () = core::unimplemented!();
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic_2021.rs:30:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `core::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -74,7 +74,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:33:20
    |
 LL | const E_CORE: () = core::panic!("{}", MSG);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic_2021.rs:33:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:8:15
    |
 LL | const Z: () = panic!("cheese");
-   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic_libcore_bin.rs:8:15
+   |               ^^^^^^^^^^^^^^^^ evaluation panicked: cheese
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:11:15
    |
 LL | const Y: () = unreachable!();
-   |               ^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_bin.rs:11:15
+   |               ^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:14:15
    |
 LL | const X: () = unimplemented!();
-   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic_libcore_bin.rs:14:15
+   |               ^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic_track_caller.rs
+++ b/tests/ui/consts/const-eval/const_panic_track_caller.rs
@@ -12,11 +12,10 @@ const fn b() -> u32 {
 }
 
 const fn c() -> u32 {
-    b()
-    //~^ ERROR evaluation of constant value failed
-    //~| NOTE the evaluated program panicked
-    //~| NOTE inside
+    b() //~ NOTE inside `c`
+    //~^ NOTE the failure occurred here
 }
 
 const X: u32 = c();
-//~^ NOTE inside
+//~^ ERROR evaluation of constant value failed
+//~| NOTE hey

--- a/tests/ui/consts/const-eval/const_panic_track_caller.stderr
+++ b/tests/ui/consts/const-eval/const_panic_track_caller.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_panic_track_caller.rs:15:5
+  --> $DIR/const_panic_track_caller.rs:19:16
    |
-LL |     b()
-   |     ^^^ the evaluated program panicked at 'hey', $DIR/const_panic_track_caller.rs:15:5
+LL | const X: u32 = c();
+   |                ^^^ evaluation panicked: hey
    |
 note: inside `c`
   --> $DIR/const_panic_track_caller.rs:15:5
    |
 LL |     b()
-   |     ^^^
-note: inside `X`
-  --> $DIR/const_panic_track_caller.rs:21:16
-   |
-LL | const X: u32 = c();
-   |                ^^^
+   |     ^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
@@ -2,11 +2,10 @@
 #![feature(const_heap)]
 use std::intrinsics;
 
-const FOO: i32 = foo();
+const FOO: i32 = foo(); //~ error: evaluation of constant value failed
 const fn foo() -> i32 {
     unsafe {
-        let _ = intrinsics::const_allocate(4, 3) as *mut i32;
-        //~^ error: evaluation of constant value failed
+        let _ = intrinsics::const_allocate(4, 3) as *mut i32; //~ inside `foo`
     }
     1
 }

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/alloc_intrinsic_errors.rs:8:17
+  --> $DIR/alloc_intrinsic_errors.rs:5:18
    |
-LL |         let _ = intrinsics::const_allocate(4, 3) as *mut i32;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid align passed to `const_allocate`: 3 is not a power of 2
+LL | const FOO: i32 = foo();
+   |                  ^^^^^ invalid align passed to `const_allocate`: 3 is not a power of 2
    |
 note: inside `foo`
   --> $DIR/alloc_intrinsic_errors.rs:8:17
    |
 LL |         let _ = intrinsics::const_allocate(4, 3) as *mut i32;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/alloc_intrinsic_errors.rs:5:18
-   |
-LL | const FOO: i32 = foo();
-   |                  ^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/panic-assoc-never-type.rs:9:21
    |
 LL |     const VOID: ! = panic!();
-   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:9:21
+   |                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/panic-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-never-type.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/panic-never-type.rs:4:17
    |
 LL | const VOID: ! = panic!();
-   |                 ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:4:17
+   |                 ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/parse_ints.rs
+++ b/tests/ui/consts/const-eval/parse_ints.rs
@@ -2,7 +2,7 @@ const _OK: () = match i32::from_str_radix("-1234", 10) {
     Ok(x) => assert!(x == -1234),
     Err(_) => panic!(),
 };
-const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); };
-const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); };
+const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); }; //~ ERROR evaluation of constant value failed
+const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); }; //~ ERROR evaluation of constant value failed
 
 fn main () {}

--- a/tests/ui/consts/const-eval/parse_ints.stderr
+++ b/tests/ui/consts/const-eval/parse_ints.stderr
@@ -1,33 +1,25 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'from_ascii_radix: radix must lie in the range `[2, 36]`', $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-note: inside `core::num::<impl u64>::from_ascii_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `core::num::<impl u64>::from_str_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `_TOO_LOW`
   --> $DIR/parse_ints.rs:5:24
    |
 LL | const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
+   |
+note: inside `core::num::<impl u64>::from_str_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+note: inside `core::num::<impl u64>::from_ascii_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
    = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'from_ascii_radix: radix must lie in the range `[2, 36]`', $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-note: inside `core::num::<impl u64>::from_ascii_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `core::num::<impl u64>::from_str_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `_TOO_HIGH`
   --> $DIR/parse_ints.rs:6:25
    |
 LL | const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
+   |
+note: inside `core::num::<impl u64>::from_str_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+note: inside `core::num::<impl u64>::from_ascii_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
    = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/consts/const-eval/raw-pointer-ub.rs
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.rs
@@ -17,7 +17,10 @@ const MISALIGNED_COPY: () = unsafe {
     let y = x.as_ptr().cast::<u32>();
     let mut z = 123;
     y.copy_to_nonoverlapping(&mut z, 1);
-    //~^NOTE
+    //~^ ERROR evaluation of constant value failed
+    //~| NOTE inside `std::ptr::const_ptr
+    //~| NOTE inside `copy_nonoverlapping::<u32>`
+    //~| NOTE accessing memory with alignment 1, but alignment 4 is required
     // The actual error points into the implementation of `copy_to_nonoverlapping`.
 };
 

--- a/tests/ui/consts/const-eval/raw-pointer-ub.stderr
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.stderr
@@ -11,28 +11,24 @@ LL |     *ptr = 0;
    |     ^^^^^^^^ accessing memory based on pointer with alignment 1, but alignment 4 is required
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
-   |
-   = note: accessing memory with alignment 1, but alignment 4 is required
-   |
-note: inside `copy_nonoverlapping::<u32>`
-  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u32>::copy_to_nonoverlapping`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `MISALIGNED_COPY`
   --> $DIR/raw-pointer-ub.rs:19:5
    |
 LL |     y.copy_to_nonoverlapping(&mut z, 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment 1, but alignment 4 is required
+   |
+note: inside `std::ptr::const_ptr::<impl *const u32>::copy_to_nonoverlapping`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `copy_nonoverlapping::<u32>`
+  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/raw-pointer-ub.rs:31:16
+  --> $DIR/raw-pointer-ub.rs:34:16
    |
 LL |     let _val = (*ptr).0;
    |                ^^^^^^^^ accessing memory based on pointer with alignment 4, but alignment 16 is required
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/raw-pointer-ub.rs:38:16
+  --> $DIR/raw-pointer-ub.rs:41:16
    |
 LL |     let _val = *ptr;
    |                ^^^^ memory access failed: expected a pointer to 8 bytes of memory, but got ALLOC0 which is only 4 bytes from the end of the allocation

--- a/tests/ui/consts/const-eval/transmute-size-mismatch.rs
+++ b/tests/ui/consts/const-eval/transmute-size-mismatch.rs
@@ -10,15 +10,19 @@ const unsafe fn mir_transmute<T, U>(x: T) -> U {
     mir!{
         {
             RET = CastTransmute(x);
-            //~^ ERROR evaluation of constant value failed
-            //~| ERROR evaluation of constant value failed
+            //~^ NOTE inside `mir_transmute
+            //~| NOTE inside `mir_transmute
+            //~| NOTE the failure occurred here
+            //~| NOTE the failure occurred here
             Return()
         }
     }
 }
 
-const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) };
+const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) }; //~ ERROR evaluation of constant value failed
+//~^ NOTE transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
 
-const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) };
+const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) }; //~ ERROR evaluation of constant value failed
+//~^ NOTE transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
 
 fn main() {}

--- a/tests/ui/consts/const-eval/transmute-size-mismatch.stderr
+++ b/tests/ui/consts/const-eval/transmute-size-mismatch.stderr
@@ -1,36 +1,26 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/transmute-size-mismatch.rs:12:13
+  --> $DIR/transmute-size-mismatch.rs:22:35
    |
-LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
+LL | const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) };
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
    |
 note: inside `mir_transmute::<i32, u16>`
   --> $DIR/transmute-size-mismatch.rs:12:13
    |
 LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FROM_BIGGER`
-  --> $DIR/transmute-size-mismatch.rs:20:35
-   |
-LL | const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/transmute-size-mismatch.rs:12:13
+  --> $DIR/transmute-size-mismatch.rs:25:36
    |
-LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
+LL | const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) };
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
    |
 note: inside `mir_transmute::<i16, u32>`
   --> $DIR/transmute-size-mismatch.rs:12:13
    |
 LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FROM_SMALLER`
-  --> $DIR/transmute-size-mismatch.rs:22:36
-   |
-LL | const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) };
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/ub-enum.rs
+++ b/tests/ui/consts/const-eval/ub-enum.rs
@@ -101,7 +101,7 @@ const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe { mem:
 const TEST_ICE_89765: () = {
     // This is a regression test for https://github.com/rust-lang/rust/issues/89765.
     unsafe { std::mem::discriminant(&*(&() as *const () as *const Never)); };
-    //~^ inside `TEST_ICE_89765`
+    //~^ ERROR evaluation of constant value failed
 };
 
 fn main() {

--- a/tests/ui/consts/const-eval/ub-enum.stderr
+++ b/tests/ui/consts/const-eval/ub-enum.stderr
@@ -117,17 +117,13 @@ LL | const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe {
    |                                                                             ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: read discriminant of an uninhabited enum variant
-   |
-note: inside `discriminant::<Never>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `TEST_ICE_89765`
   --> $DIR/ub-enum.rs:103:14
    |
 LL |     unsafe { std::mem::discriminant(&*(&() as *const () as *const Never)); };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ read discriminant of an uninhabited enum variant
+   |
+note: inside `discriminant::<Never>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/consts/const-eval/ub-invalid-values.rs
+++ b/tests/ui/consts/const-eval/ub-invalid-values.rs
@@ -1,11 +1,12 @@
 const fn bool_cast(ptr: *const bool) { unsafe {
-    let _val = *ptr as u32; //~ERROR: evaluation of constant value failed
-    //~^ interpreting an invalid 8-bit value as a bool
+    let _val = *ptr as u32; //~ NOTE inside `bool_cast`
+    //~^ NOTE the failure occurred here
 }}
 
 const _: () = {
     let v = 3_u8;
-    bool_cast(&v as *const u8 as *const bool);
+    bool_cast(&v as *const u8 as *const bool); //~ ERROR: evaluation of constant value failed
+    //~^ NOTE interpreting an invalid 8-bit value as a bool
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-invalid-values.stderr
+++ b/tests/ui/consts/const-eval/ub-invalid-values.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-invalid-values.rs:2:16
+  --> $DIR/ub-invalid-values.rs:8:5
    |
-LL |     let _val = *ptr as u32;
-   |                ^^^^^^^^^^^ interpreting an invalid 8-bit value as a bool: 0x03
+LL |     bool_cast(&v as *const u8 as *const bool);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ interpreting an invalid 8-bit value as a bool: 0x03
    |
 note: inside `bool_cast`
   --> $DIR/ub-invalid-values.rs:2:16
    |
 LL |     let _val = *ptr as u32;
-   |                ^^^^^^^^^^^
-note: inside `_`
-  --> $DIR/ub-invalid-values.rs:8:5
-   |
-LL |     bool_cast(&v as *const u8 as *const bool);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -63,7 +63,7 @@ const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
 const UNALIGNED_READ: () = unsafe {
     let x = &[0u8; 4];
     let ptr = x.as_ptr().cast::<u32>();
-    ptr.read(); //~ inside `UNALIGNED_READ`
+    ptr.read(); //~ ERROR evaluation of constant value failed
 };
 
 

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -149,19 +149,15 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: accessing memory based on pointer with alignment 1, but alignment 4 is required
-   |
-note: inside `std::ptr::read::<u32>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u32>::read`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNALIGNED_READ`
   --> $DIR/ub-ref-ptr.rs:66:5
    |
 LL |     ptr.read();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ accessing memory based on pointer with alignment 1, but alignment 4 is required
+   |
+note: inside `std::ptr::const_ptr::<impl *const u32>::read`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `std::ptr::read::<u32>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/consts/const-eval/unwind-abort.rs
+++ b/tests/ui/consts/const-eval/unwind-abort.rs
@@ -1,8 +1,8 @@
 const extern "C" fn foo() {
-    panic!() //~ ERROR evaluation of constant value failed
+    panic!() //~ inside `foo`
 }
 
-const _: () = foo();
+const _: () = foo(); //~ ERROR evaluation of constant value failed
 // Ensure that the CTFE engine handles calls to `extern "C"` aborting gracefully
 
 fn main() {

--- a/tests/ui/consts/const-eval/unwind-abort.stderr
+++ b/tests/ui/consts/const-eval/unwind-abort.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/unwind-abort.rs:2:5
+  --> $DIR/unwind-abort.rs:5:15
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/unwind-abort.rs:2:5
+LL | const _: () = foo();
+   |               ^^^^^ evaluation panicked: explicit panic
    |
 note: inside `foo`
   --> $DIR/unwind-abort.rs:2:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_`
-  --> $DIR/unwind-abort.rs:5:15
-   |
-LL | const _: () = foo();
-   |               ^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -1,6 +1,5 @@
 const fn foo() -> ! {
-    unsafe { std::mem::transmute(()) }
-    //~^ ERROR evaluation of constant value failed
+    unsafe { std::mem::transmute(()) } //~ inside `foo`
 }
 
 // Type defined in a submodule, so that it is not "visibly"
@@ -14,6 +13,7 @@ pub mod empty {
 }
 
 const FOO: [empty::Empty; 3] = [foo(); 3];
+//~^ ERROR evaluation of constant value failed
 
 const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
 //~^ ERROR evaluation of constant value failed

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/validate_uninhabited_zsts.rs:2:14
+  --> $DIR/validate_uninhabited_zsts.rs:15:33
    |
-LL |     unsafe { std::mem::transmute(()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a value of the never type `!`
+LL | const FOO: [empty::Empty; 3] = [foo(); 3];
+   |                                 ^^^^^ constructing invalid value: encountered a value of the never type `!`
    |
 note: inside `foo`
   --> $DIR/validate_uninhabited_zsts.rs:2:14
    |
 LL |     unsafe { std::mem::transmute(()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/validate_uninhabited_zsts.rs:16:33
-   |
-LL | const FOO: [empty::Empty; 3] = [foo(); 3];
-   |                                 ^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/validate_uninhabited_zsts.rs:18:42

--- a/tests/ui/consts/const-ptr-is-null.rs
+++ b/tests/ui/consts/const-ptr-is-null.rs
@@ -19,7 +19,7 @@ const MAYBE_NULL: () = {
     assert!(!ptr.wrapping_byte_sub(1).is_null());
     // ... but once we shift outside the allocation, with an offset divisible by 4,
     // we might become null.
-    assert!(!ptr.wrapping_sub(512).is_null()); //~inside `MAYBE_NULL`
+    assert!(!ptr.wrapping_sub(512).is_null()); //~ ERROR evaluation of constant value failed
 };
 
 fn main() {}

--- a/tests/ui/consts/const-ptr-is-null.stderr
+++ b/tests/ui/consts/const-ptr-is-null.stderr
@@ -1,18 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'null-ness of this pointer cannot be determined in const context', $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-note: inside `std::ptr::const_ptr::<impl *const T>::is_null::compiletime`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const i32>::is_null`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `MAYBE_NULL`
   --> $DIR/const-ptr-is-null.rs:22:14
    |
 LL |     assert!(!ptr.wrapping_sub(512).is_null());
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: null-ness of this pointer cannot be determined in const context
+   |
+note: inside `std::ptr::const_ptr::<impl *const i32>::is_null`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `std::ptr::const_ptr::<impl *const T>::is_null::compiletime`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-unwrap.rs
+++ b/tests/ui/consts/const-unwrap.rs
@@ -5,7 +5,7 @@ const FOO: i32 = Some(42i32).unwrap();
 
 const BAR: i32 = Option::<i32>::None.unwrap();
 //~^ ERROR: evaluation of constant value failed
-//~| NOTE: the evaluated program panicked
+//~| NOTE: called `Option::unwrap()` on a `None` value
 
 const BAZ: i32 = Option::<i32>::None.expect("absolutely not!");
 //~^ ERROR: evaluation of constant value failed

--- a/tests/ui/consts/const-unwrap.stderr
+++ b/tests/ui/consts/const-unwrap.stderr
@@ -2,13 +2,13 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const-unwrap.rs:6:18
    |
 LL | const BAR: i32 = Option::<i32>::None.unwrap();
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'called `Option::unwrap()` on a `None` value', $DIR/const-unwrap.rs:6:38
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: called `Option::unwrap()` on a `None` value
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-unwrap.rs:10:18
    |
 LL | const BAZ: i32 = Option::<i32>::None.expect("absolutely not!");
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'absolutely not!', $DIR/const-unwrap.rs:10:38
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: absolutely not!
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const_in_pattern/incomplete-slice.stderr
+++ b/tests/ui/consts/const_in_pattern/incomplete-slice.stderr
@@ -19,7 +19,7 @@ LL |         E_SL_var => {}
    |             ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         E_SL => {},
+LL ~         E_SL => {}
 LL +         &[] | &[_, _, ..] => todo!()
    |
 

--- a/tests/ui/consts/const_unsafe_unreachable_ub.rs
+++ b/tests/ui/consts/const_unsafe_unreachable_ub.rs
@@ -1,13 +1,14 @@
-//@ error-pattern: evaluation of constant value failed
-
 const unsafe fn foo(x: bool) -> bool {
     match x {
         true => true,
-        false => std::hint::unreachable_unchecked(),
+        false => std::hint::unreachable_unchecked(), //~ NOTE inside `foo`
     }
 }
 
 const BAR: bool = unsafe { foo(false) };
+//~^ ERROR evaluation of constant value failed
+//~| NOTE entering unreachable code
+//~| NOTE inside `unreachable_unchecked`
 
 fn main() {
     assert_eq!(BAR, true);

--- a/tests/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/tests/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -1,20 +1,16 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
+  --> $DIR/const_unsafe_unreachable_ub.rs:8:28
    |
-   = note: entering unreachable code
+LL | const BAR: bool = unsafe { foo(false) };
+   |                            ^^^^^^^^^^ entering unreachable code
    |
-note: inside `unreachable_unchecked`
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
 note: inside `foo`
-  --> $DIR/const_unsafe_unreachable_ub.rs:6:18
+  --> $DIR/const_unsafe_unreachable_ub.rs:4:18
    |
 LL |         false => std::hint::unreachable_unchecked(),
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `BAR`
-  --> $DIR/const_unsafe_unreachable_ub.rs:10:28
-   |
-LL | const BAR: bool = unsafe { foo(false) };
-   |                            ^^^^^^^^^^
+note: inside `unreachable_unchecked`
+  --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/control-flow/assert.stderr
+++ b/tests/ui/consts/control-flow/assert.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/assert.rs:5:15
    |
 LL | const _: () = assert!(false);
-   |               ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/assert.rs:5:15
+   |               ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-32829.stderr
+++ b/tests/ui/consts/issue-32829.stderr
@@ -2,7 +2,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/issue-32829.rs:1:22
    |
 LL | static S : u64 = { { panic!("foo"); 0 } };
-   |                      ^^^^^^^^^^^^^ the evaluated program panicked at 'foo', $DIR/issue-32829.rs:1:22
+   |                      ^^^^^^^^^^^^^ evaluation panicked: foo
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-66693-panic-in-array-len.stderr
+++ b/tests/ui/consts/issue-66693-panic-in-array-len.stderr
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-66693-panic-in-array-len.rs:10:21
    |
 LL |     let _ = [false; panic!()];
-   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-66693-panic-in-array-len.rs:10:21
+   |                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-66693.stderr
+++ b/tests/ui/consts/issue-66693.stderr
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-66693.rs:16:15
    |
 LL | const _: () = panic!();
-   |               ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-66693.rs:16:15
+   |               ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/issue-66693.rs:18:19
    |
 LL | static _BAR: () = panic!("panic in static");
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'panic in static', $DIR/issue-66693.rs:18:19
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: panic in static
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-76064.stderr
+++ b/tests/ui/consts/issue-76064.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-76064.rs:1:17
    |
 LL | struct Bug([u8; panic!("panic")]);
-   |                 ^^^^^^^^^^^^^^^ the evaluated program panicked at 'panic', $DIR/issue-76064.rs:1:17
+   |                 ^^^^^^^^^^^^^^^ evaluation panicked: panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-miri-1910.rs
+++ b/tests/ui/consts/issue-miri-1910.rs
@@ -5,6 +5,7 @@ const C: () = unsafe {
     let foo = Some(&42 as *const i32);
     let one_and_a_half_pointers = std::mem::size_of::<*const i32>()/2*3;
     (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
+    //~^ ERROR evaluation of constant value failed
 };
 
 fn main() {

--- a/tests/ui/consts/issue-miri-1910.stderr
+++ b/tests/ui/consts/issue-miri-1910.stderr
@@ -1,17 +1,13 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: unable to turn pointer into integer
-   |
-note: inside `std::ptr::read::<u8>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u8>::read`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `C`
   --> $DIR/issue-miri-1910.rs:7:5
    |
 LL |     (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::read`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `std::ptr::read::<u8>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 

--- a/tests/ui/consts/miri_unleashed/abi-mismatch.rs
+++ b/tests/ui/consts/miri_unleashed/abi-mismatch.rs
@@ -4,13 +4,12 @@
 const extern "C" fn c_fn() {}
 
 const fn call_rust_fn(my_fn: extern "Rust" fn()) {
-    my_fn();
-    //~^ ERROR could not evaluate static initializer
-    //~| NOTE calling a function with calling convention C using calling convention Rust
-    //~| NOTE inside `call_rust_fn`
+    my_fn(); //~ NOTE inside `call_rust_fn`
+    //~^ NOTE the failure occurred here
 }
 
 static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-//~^ NOTE inside `VAL`
+//~^ ERROR could not evaluate static initializer
+//~| NOTE calling a function with calling convention C using calling convention Rust
 
 fn main() {}

--- a/tests/ui/consts/miri_unleashed/abi-mismatch.stderr
+++ b/tests/ui/consts/miri_unleashed/abi-mismatch.stderr
@@ -1,19 +1,14 @@
 error[E0080]: could not evaluate static initializer
-  --> $DIR/abi-mismatch.rs:7:5
+  --> $DIR/abi-mismatch.rs:11:18
    |
-LL |     my_fn();
-   |     ^^^^^^^ calling a function with calling convention C using calling convention Rust
+LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calling a function with calling convention C using calling convention Rust
    |
 note: inside `call_rust_fn`
   --> $DIR/abi-mismatch.rs:7:5
    |
 LL |     my_fn();
-   |     ^^^^^^^
-note: inside `VAL`
-  --> $DIR/abi-mismatch.rs:13:18
-   |
-LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^ the failure occurred here
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/miri_unleashed/assoc_const.rs
+++ b/tests/ui/consts/miri_unleashed/assoc_const.rs
@@ -9,7 +9,7 @@ trait Foo<T> {
 }
 
 trait Bar<T, U: Foo<T>> {
-    const F: u32 = (U::X, 42).1;
+    const F: u32 = (U::X, 42).1; //~ ERROR
 }
 
 impl Foo<u32> for () {
@@ -26,5 +26,5 @@ fn main() {
     // this is fine, but would have been forbidden by the static checks on `F`
     let x = <() as Bar<u32, ()>>::F;
     // this test only causes errors due to the line below, so post-monomorphization
-    let y = <String as Bar<Vec<u32>, String>>::F; //~ constant
+    let y = <String as Bar<Vec<u32>, String>>::F;
 }

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -1,17 +1,13 @@
-error[E0080]: evaluation of `<String as Bar<Vec<u32>, String>>::F` failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<u32> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `<String as Bar<Vec<u32>, String>>::F`
+error[E0080]: evaluation of `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))` failed
   --> $DIR/assoc_const.rs:12:31
    |
 LL |     const F: u32 = (U::X, 42).1;
-   |                               ^
+   |                               ^ calling non-const function `<Vec<u32> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 note: erroneous constant encountered
   --> $DIR/assoc_const.rs:29:13

--- a/tests/ui/consts/miri_unleashed/drop.stderr
+++ b/tests/ui/consts/miri_unleashed/drop.stderr
@@ -1,15 +1,11 @@
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<i32> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `TEST_BAD`
   --> $DIR/drop.rs:17:1
    |
 LL | };
-   | ^
+   | ^ calling non-const function `<Vec<i32> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -13,7 +13,7 @@ const X: () = {
 
     // Swap them, bytewise.
     unsafe {
-        ptr::swap_nonoverlapping(
+        ptr::swap_nonoverlapping( //~ ERROR evaluation of constant value failed
             &mut ptr1 as *mut _ as *mut MaybeUninit<u8>,
             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
             mem::size_of::<&i32>(),

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -1,17 +1,4 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: unable to copy parts of a pointer from memory at ALLOC0
-   |
-note: inside `std::ptr::read::<MaybeUninit<MaybeUninit<u8>>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::swap_nonoverlapping_simple_untyped::<MaybeUninit<u8>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `swap_nonoverlapping::compiletime::<MaybeUninit<u8>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `swap_nonoverlapping::<MaybeUninit<u8>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `X`
   --> $DIR/missing_span_in_backtrace.rs:16:9
    |
 16 | /         ptr::swap_nonoverlapping(
@@ -19,7 +6,16 @@ note: inside `X`
 18 | |             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
 19 | |             mem::size_of::<&i32>(),
 20 | |         );
-   | |_________^
+   | |_________^ unable to copy parts of a pointer from memory at ALLOC0
+   |
+note: inside `swap_nonoverlapping::<MaybeUninit<u8>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `swap_nonoverlapping::compiletime::<MaybeUninit<u8>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::swap_nonoverlapping_simple_untyped::<MaybeUninit<u8>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::read::<MaybeUninit<MaybeUninit<u8>>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/consts/offset_from_ub.rs
+++ b/tests/ui/consts/offset_from_ub.rs
@@ -21,7 +21,7 @@ pub const DIFFERENT_ALLOC: usize = {
 };
 
 pub const NOT_PTR: usize = {
-    unsafe { (42 as *const u8).offset_from(&5u8) as usize }
+    unsafe { (42 as *const u8).offset_from(&5u8) as usize } //~ ERROR evaluation of constant value failed
 };
 
 pub const NOT_MULTIPLE_OF_SIZE: isize = {
@@ -107,13 +107,13 @@ pub const OFFSET_VERY_FAR1: isize = {
     let ptr1 = ptr::null::<u8>();
     let ptr2 = ptr1.wrapping_offset(isize::MAX);
     unsafe { ptr2.offset_from(ptr1) }
-    //~^ inside
+    //~^ ERROR evaluation of constant value failed
 };
 pub const OFFSET_VERY_FAR2: isize = {
     let ptr1 = ptr::null::<u8>();
     let ptr2 = ptr1.wrapping_offset(isize::MAX);
     unsafe { ptr1.offset_from(ptr2.wrapping_offset(1)) }
-    //~^ inside
+    //~^ ERROR evaluation of constant value failed
 };
 
 // If the pointers are the same, OOB/null/UAF is fine.

--- a/tests/ui/consts/offset_from_ub.stderr
+++ b/tests/ui/consts/offset_from_ub.stderr
@@ -5,17 +5,13 @@ LL |     let offset = unsafe { ptr_offset_from(field_ptr, base_ptr) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `NOT_PTR`
   --> $DIR/offset_from_ub.rs:24:14
    |
 LL |     unsafe { (42 as *const u8).offset_from(&5u8) as usize }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/offset_from_ub.rs:31:14
@@ -78,30 +74,22 @@ LL |     unsafe { ptr_offset_from_unsigned(ptr2, ptr1) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called when first pointer is too far ahead of second
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OFFSET_VERY_FAR1`
   --> $DIR/offset_from_ub.rs:109:14
    |
 LL |     unsafe { ptr2.offset_from(ptr1) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from` called when first pointer is too far before second
+   |              ^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OFFSET_VERY_FAR2`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_from_ub.rs:115:14
    |
 LL |     unsafe { ptr1.offset_from(ptr2.wrapping_offset(1)) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called when first pointer is too far before second
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/consts/offset_ub.rs
+++ b/tests/ui/consts/offset_ub.rs
@@ -5,21 +5,21 @@ use std::ptr;
 //@ normalize-stderr: "\d+ bytes" -> "$$BYTES bytes"
 
 
-pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) }; //~NOTE
-pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) }; //~NOTE
-pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) }; //~NOTE
+pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) }; //~ ERROR
+pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) }; //~ ERROR
+pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) }; //~ ERROR
 
-pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) }; //~NOTE
-pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) }; //~NOTE
-pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) }; //~NOTE
-pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) }; //~NOTE
-pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) }; //~NOTE
+pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) }; //~ ERROR
+pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) }; //~ ERROR
+pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) }; //~ ERROR
+pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) }; //~ ERROR
+pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) }; //~ ERROR
 
-pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) }; //~NOTE
-pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) }; //~NOTE
+pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) }; //~ ERROR
+pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) }; //~ ERROR
 
 // Make sure that we don't panic when computing abs(offset*size_of::<T>())
-pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) }; //~NOTE
+pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) }; //~ ERROR
 
 // Offset-by-zero is allowed.
 pub const NULL_OFFSET_ZERO: *const u8 = unsafe { ptr::null::<u8>().offset(0) };

--- a/tests/ui/consts/offset_ub.stderr
+++ b/tests/ui/consts/offset_ub.stderr
@@ -1,145 +1,101 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of 1 byte of memory, but got ALLOC0 which is at the beginning of the allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `BEFORE_START`
   --> $DIR/offset_ub.rs:8:46
    |
 LL | pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) };
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC1 which is only 1 byte from the end of the allocation
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of 1 byte of memory, but got ALLOC0 which is at the beginning of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `AFTER_END`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:9:43
    |
 LL | pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC2 which is only $BYTES bytes from the end of the allocation
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC1 which is only 1 byte from the end of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `AFTER_ARRAY`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:10:45
    |
 LL | pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC2 which is only $BYTES bytes from the end of the allocation
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
-   |
-note: inside `std::ptr::const_ptr::<impl *const u16>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OVERFLOW`
   --> $DIR/offset_ub.rs:12:43
    |
 LL | pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
    |
 note: inside `std::ptr::const_ptr::<impl *const u16>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNDERFLOW`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:13:44
    |
 LL | pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) };
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
+   |
+note: inside `std::ptr::const_ptr::<impl *const u16>::offset`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OVERFLOW_ADDRESS_SPACE`
   --> $DIR/offset_ub.rs:14:56
    |
 LL | pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) };
-   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNDERFLOW_ADDRESS_SPACE`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:15:57
    |
 LL | pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) };
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got ALLOC3-0x2 which points to before the beginning of the allocation
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `NEGATIVE_OFFSET`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:16:49
    |
 LL | pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) };
-   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to 1 byte of memory, but got ALLOC4 which is at or beyond the end of the allocation of size $BYTES bytes
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got ALLOC3-0x2 which points to before the beginning of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `ZERO_SIZED_ALLOC`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:18:50
    |
 LL | pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) };
-   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
-   |
-note: inside `std::ptr::mut_ptr::<impl *mut u8>::offset`
-  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-note: inside `DANGLING`
-  --> $DIR/offset_ub.rs:19:42
-   |
-LL | pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to 1 byte of memory, but got ALLOC4 which is at or beyond the end of the allocation of size $BYTES bytes
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNDERFLOW_ABS`
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/offset_ub.rs:19:42
+   |
+LL | pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
+   |
+note: inside `std::ptr::mut_ptr::<impl *mut u8>::offset`
+  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:22:47
    |
 LL | pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) };
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/consts/qualif-indirect-mutation-fail.rs
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.rs
@@ -15,7 +15,7 @@ pub const A1: () = {
     let b = &mut y;
     std::mem::swap(a, b);
     std::mem::forget(y);
-};
+}; //~ ERROR evaluation of constant value failed
 
 // Mutable borrow of a type with drop impl.
 pub const A2: () = {
@@ -26,7 +26,7 @@ pub const A2: () = {
     std::mem::swap(a, b);
     std::mem::forget(y);
     let _z = x; //~ ERROR destructor of
-};
+}; //~ ERROR evaluation of constant value failed
 
 // Shared borrow of a type that might be !Freeze and Drop.
 pub const fn g1<T>() {

--- a/tests/ui/consts/qualif-indirect-mutation-fail.stderr
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.stderr
@@ -8,21 +8,17 @@ LL | };
    | - value is dropped here
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<u8> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `A1`
   --> $DIR/qualif-indirect-mutation-fail.rs:18:1
    |
 LL | };
-   | ^
+   | ^ calling non-const function `<Vec<u8> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:28:9
@@ -33,21 +29,17 @@ LL | };
    | - value is dropped here
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<u8> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `A2`
   --> $DIR/qualif-indirect-mutation-fail.rs:29:1
    |
 LL | };
-   | ^
+   | ^ calling non-const function `<Vec<u8> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `(u32, Option<String>)` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:6:9

--- a/tests/ui/consts/recursive.rs
+++ b/tests/ui/consts/recursive.rs
@@ -2,9 +2,8 @@
 
 const fn f<T>(x: T) { //~ WARN function cannot return without recursing
     f(x);
-    //~^ ERROR evaluation of constant value failed
 }
 
-const X: () = f(1);
+const X: () = f(1); //~ ERROR evaluation of constant value failed
 
 fn main() {}

--- a/tests/ui/consts/recursive.stderr
+++ b/tests/ui/consts/recursive.stderr
@@ -10,26 +10,21 @@ LL |     f(x);
    = note: `#[warn(unconditional_recursion)]` on by default
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/recursive.rs:4:5
+  --> $DIR/recursive.rs:7:15
    |
-LL |     f(x);
-   |     ^^^^ reached the configured maximum number of stack frames
+LL | const X: () = f(1);
+   |               ^^^^ reached the configured maximum number of stack frames
    |
-note: inside `f::<i32>`
-  --> $DIR/recursive.rs:4:5
-   |
-LL |     f(x);
-   |     ^^^^
 note: [... 126 additional calls inside `f::<i32>` ...]
   --> $DIR/recursive.rs:4:5
    |
 LL |     f(x);
    |     ^^^^
-note: inside `X`
-  --> $DIR/recursive.rs:8:15
+note: inside `f::<i32>`
+  --> $DIR/recursive.rs:4:5
    |
-LL | const X: () = f(1);
-   |               ^^^^
+LL |     f(x);
+   |     ^^^^ the failure occurred here
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/consts/required-consts/collect-in-called-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-called-fn.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-called-fn.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-called-fn.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-called-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-called-fn.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-called-fn.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-called-fn.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-closure.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-closure.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-closure.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-closure.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-closure.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-closure.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-closure.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-closure.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-drop.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-drop.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-drop.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-drop.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-drop.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-drop.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-drop.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-drop.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-generic.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-generic.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-generic.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-generic.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `m::Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
    |
 LL |         const C: () = panic!();
-   |                       ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
+   |                       ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `m::Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
    |
 LL |         const C: () = panic!();
-   |                       ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
+   |                       ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Late::<i32>::FAIL` failed
   --> $DIR/collect-in-dead-fnptr-in-const.rs:9:22
    |
 LL |     const FAIL: () = panic!();
-   |                      ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr-in-const.rs:9:22
+   |                      ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Late::<i32>::FAIL` failed
   --> $DIR/collect-in-dead-fnptr-in-const.rs:9:22
    |
 LL |     const FAIL: () = panic!();
-   |                      ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr-in-const.rs:9:22
+   |                      ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fnptr.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fnptr.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-move.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-move.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-move.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-move.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-move.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-move.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-move.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-move.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-vtable.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-vtable.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-vtable.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-vtable.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-vtable.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-vtable.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-vtable.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-vtable.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-promoted-const.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-promoted-const.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<T>::C` failed
   --> $DIR/collect-in-promoted-const.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-promoted-const.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-promoted-const.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-promoted-const.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-const-called-fn.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-const-called-fn.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-const-called-fn.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-const-called-fn.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-promoted.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.noopt.stderr
@@ -1,20 +1,16 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
+  --> $DIR/interpret-in-promoted.rs:13:28
    |
-   = note: entering unreachable code
+LL |     let _x: &'static () = &ub();
+   |                            ^^^^ entering unreachable code
    |
-note: inside `unreachable_unchecked`
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
 note: inside `ub`
   --> $DIR/interpret-in-promoted.rs:7:5
    |
 LL |     std::hint::unreachable_unchecked();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/interpret-in-promoted.rs:13:28
-   |
-LL |     let _x: &'static () = &ub();
-   |                            ^^^^
+note: inside `unreachable_unchecked`
+  --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 note: erroneous constant encountered
   --> $DIR/interpret-in-promoted.rs:13:27

--- a/tests/ui/consts/required-consts/interpret-in-promoted.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.opt.stderr
@@ -1,20 +1,16 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
+  --> $DIR/interpret-in-promoted.rs:13:28
    |
-   = note: entering unreachable code
+LL |     let _x: &'static () = &ub();
+   |                            ^^^^ entering unreachable code
    |
-note: inside `unreachable_unchecked`
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
 note: inside `ub`
   --> $DIR/interpret-in-promoted.rs:7:5
    |
 LL |     std::hint::unreachable_unchecked();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/interpret-in-promoted.rs:13:28
-   |
-LL |     let _x: &'static () = &ub();
-   |                            ^^^^
+note: inside `unreachable_unchecked`
+  --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 note: erroneous constant encountered
   --> $DIR/interpret-in-promoted.rs:13:27

--- a/tests/ui/consts/required-consts/interpret-in-promoted.rs
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.rs
@@ -4,13 +4,13 @@
 //! Make sure we evaluate const fn calls even if they get promoted and their result ignored.
 
 const unsafe fn ub() {
-    std::hint::unreachable_unchecked();
+    std::hint::unreachable_unchecked(); //~ inside `ub`
 }
 
 pub const FOO: () = unsafe {
     // Make sure that this gets promoted and then fails to evaluate, and we deal with that
     // correctly.
-    let _x: &'static () = &ub(); //~ erroneous constant
+    let _x: &'static () = &ub(); //~ ERROR evaluation of constant value failed
 };
 
 fn main() {}

--- a/tests/ui/consts/required-consts/interpret-in-static.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-static.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-static.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-static.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-static.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-static.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-static.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-static.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/uninhabited-const-issue-61744.rs
+++ b/tests/ui/consts/uninhabited-const-issue-61744.rs
@@ -1,7 +1,7 @@
 //@ build-fail
 
 pub const unsafe fn fake_type<T>() -> T {
-    hint_unreachable() //~ ERROR evaluation of `<i32 as Const>::CONSTANT` failed
+    hint_unreachable() //~ inside
 }
 
 pub const unsafe fn hint_unreachable() -> ! {
@@ -9,7 +9,7 @@ pub const unsafe fn hint_unreachable() -> ! {
 }
 
 trait Const {
-    const CONSTANT: i32 = unsafe { fake_type() }; //~ inside
+    const CONSTANT: i32 = unsafe { fake_type() }; //~ ERROR evaluation of `fake_type::<!>` failed
 }
 
 impl<T> Const for T {}

--- a/tests/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/tests/ui/consts/uninhabited-const-issue-61744.stderr
@@ -1,649 +1,644 @@
-error[E0080]: evaluation of `<i32 as Const>::CONSTANT` failed
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+error[E0080]: evaluation of `fake_type::<!>` failed
+  --> $DIR/uninhabited-const-issue-61744.rs:12:36
    |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^ reached the configured maximum number of stack frames
+LL |     const CONSTANT: i32 = unsafe { fake_type() };
+   |                                    ^^^^^^^^^^^ reached the configured maximum number of stack frames
    |
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
 note: inside `fake_type::<i32>`
   --> $DIR/uninhabited-const-issue-61744.rs:4:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
-note: inside `<i32 as Const>::CONSTANT`
-  --> $DIR/uninhabited-const-issue-61744.rs:12:36
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
    |
-LL |     const CONSTANT: i32 = unsafe { fake_type() };
-   |                                    ^^^^^^^^^^^
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coverage-attr/allowed-positions.stderr
+++ b/tests/ui/coverage-attr/allowed-positions.stderr
@@ -82,7 +82,7 @@ error[E0788]: coverage attribute not allowed here
 LL |         #[coverage(off)]
    |         ^^^^^^^^^^^^^^^^
 LL |         () => (),
-   |         -------- not a function, impl block, or module
+   |         --------- not a function, impl block, or module
    |
    = help: coverage attribute can be applied to a function (with body), impl block, or module
 

--- a/tests/ui/error-codes/E0004.stderr
+++ b/tests/ui/error-codes/E0004.stderr
@@ -14,7 +14,7 @@ LL |     HastaLaVistaBaby,
    = note: the matched value is of type `Terminator`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Terminator::TalkToMyHand => {},
+LL ~         Terminator::TalkToMyHand => {}
 LL +         Terminator::HastaLaVistaBaby => todo!()
    |
 

--- a/tests/ui/error-codes/E0771.stderr
+++ b/tests/ui/error-codes/E0771.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn function_with_str<'a, const STRING: &'a str>() {}
    |                                         ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 warning: the feature `unsized_const_params` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/E0771.rs:1:30

--- a/tests/ui/explicit-tail-calls/ctfe-id-unlimited.return.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-id-unlimited.return.stderr
@@ -1,29 +1,24 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ctfe-id-unlimited.rs:17:42
+  --> $DIR/ctfe-id-unlimited.rs:28:20
    |
-LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
-   |                                          ^^^^^^^^^^^^^^^^^^^^^ reached the configured maximum number of stack frames
+LL | const ID_ED: u32 = rec_id(ORIGINAL);
+   |                    ^^^^^^^^^^^^^^^^ reached the configured maximum number of stack frames
    |
-note: inside `inner`
-  --> $DIR/ctfe-id-unlimited.rs:17:42
+note: inside `rec_id`
+  --> $DIR/ctfe-id-unlimited.rs:21:5
    |
-LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
-   |                                          ^^^^^^^^^^^^^^^^^^^^^
+LL |     inner(0, n)
+   |     ^^^^^^^^^^^
 note: [... 125 additional calls inside `inner` ...]
   --> $DIR/ctfe-id-unlimited.rs:17:42
    |
 LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
    |                                          ^^^^^^^^^^^^^^^^^^^^^
-note: inside `rec_id`
-  --> $DIR/ctfe-id-unlimited.rs:22:5
+note: inside `inner`
+  --> $DIR/ctfe-id-unlimited.rs:17:42
    |
-LL |     inner(0, n)
-   |     ^^^^^^^^^^^
-note: inside `ID_ED`
-  --> $DIR/ctfe-id-unlimited.rs:29:20
-   |
-LL | const ID_ED: u32 = rec_id(ORIGINAL);
-   |                    ^^^^^^^^^^^^^^^^
+LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
+   |                                          ^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/explicit-tail-calls/ctfe-id-unlimited.rs
+++ b/tests/ui/explicit-tail-calls/ctfe-id-unlimited.rs
@@ -15,7 +15,6 @@ const fn rec_id(n: u32) -> u32 {
             0 => acc,
             #[cfg(r#become)] _ => become inner(acc + 1, n - 1),
             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
-            //[return]~^ error: evaluation of constant value failed
         }
     }
 
@@ -26,7 +25,7 @@ const fn rec_id(n: u32) -> u32 {
 const ORIGINAL: u32 = 12345;
 // Original number, but with identity function applied
 // (this is the same, but requires execution of the recursion)
-const ID_ED: u32 = rec_id(ORIGINAL);
+const ID_ED: u32 = rec_id(ORIGINAL); //[return]~ error: evaluation of constant value failed
 // Assert to make absolutely sure the computation actually happens
 const ASSERT: () = assert!(ORIGINAL == ID_ED);
 

--- a/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.rs
+++ b/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.rs
@@ -6,14 +6,11 @@ pub const fn f() {
 }
 
 const fn g() {
-    panic!()
-    //~^ error: evaluation of constant value failed
-    //~| note: in this expansion of panic!
-    //~| note: inside `g`
-    //~| note: in this expansion of panic!
+    panic!() //~ NOTE inside `g`
+    //~^ NOTE in this expansion of panic!
 }
 
-const _: () = f();
-//~^ note: inside `_`
+const _: () = f(); //~ ERROR evaluation of constant value failed
+//~^ NOTE explicit panic
 
 fn main() {}

--- a/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ctfe-tail-call-panic.rs:9:5
+  --> $DIR/ctfe-tail-call-panic.rs:13:15
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/ctfe-tail-call-panic.rs:9:5
+LL | const _: () = f();
+   |               ^^^ evaluation panicked: explicit panic
    |
 note: inside `g`
   --> $DIR/ctfe-tail-call-panic.rs:9:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_`
-  --> $DIR/ctfe-tail-call-panic.rs:16:15
-   |
-LL | const _: () = f();
-   |               ^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.normal.stderr
+++ b/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.normal.stderr
@@ -1,14 +1,14 @@
 error[E0770]: the type of const parameters must not depend on other generic parameters
-  --> $DIR/issue-71169.rs:5:43
+  --> $DIR/feature-gate-generic-const-parameter-types.rs:7:50
    |
-LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
-   |                                           ^^^ the type must not depend on the parameter `LEN`
+LL | struct MyADT<const LEN: usize, const ARRAY: [u8; LEN]>;
+   |                                                  ^^^ the type must not depend on the parameter `LEN`
 
 error: `[u8; LEN]` is forbidden as the type of a const generic parameter
-  --> $DIR/issue-71169.rs:5:38
+  --> $DIR/feature-gate-generic-const-parameter-types.rs:7:45
    |
-LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
-   |                                      ^^^^^^^^^
+LL | struct MyADT<const LEN: usize, const ARRAY: [u8; LEN]>;
+   |                                             ^^^^^^^^^
    |
    = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types

--- a/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.rs
+++ b/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.rs
@@ -1,0 +1,11 @@
+//@ [feature] check-pass
+//@ revisions: normal feature
+
+#![cfg_attr(feature, feature(adt_const_params, generic_const_parameter_types))]
+#![cfg_attr(feature, expect(incomplete_features))]
+
+struct MyADT<const LEN: usize, const ARRAY: [u8; LEN]>;
+//[normal]~^ ERROR: the type of const parameters must not depend on other generic parameters
+//[normal]~| ERROR: `[u8; LEN]` is forbidden as the type of a const generic parameter
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-never_patterns.stderr
+++ b/tests/ui/feature-gates/feature-gate-never_patterns.stderr
@@ -133,7 +133,13 @@ error: a guard on a never pattern will never be run
   --> $DIR/feature-gate-never_patterns.rs:54:19
    |
 LL |         Err(!) if false,
-   |                   ^^^^^ help: remove this guard
+   |                   ^^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         Err(!) if false,
+LL +         Err(!),
+   |
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
+++ b/tests/ui/feature-gates/feature-gate-non_exhaustive_omitted_patterns_lint.stderr
@@ -84,7 +84,7 @@ LL |         C,
    = note: the matched value is of type `Foo`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Foo::B => {},
+LL ~         Foo::B => {}
 LL +         Foo::C => todo!()
    |
 

--- a/tests/ui/feature-gates/feature-gate-precise_pointer_size_matching.stderr
+++ b/tests/ui/feature-gates/feature-gate-precise_pointer_size_matching.stderr
@@ -8,7 +8,7 @@ LL |     match 0usize {
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         0..=usize::MAX => {},
+LL ~         0..=usize::MAX => {}
 LL +         usize::MAX.. => todo!()
    |
 
@@ -22,7 +22,7 @@ LL |     match 0isize {
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         isize::MIN..=isize::MAX => {},
+LL ~         isize::MIN..=isize::MAX => {}
 LL +         ..isize::MIN | isize::MAX.. => todo!()
    |
 

--- a/tests/ui/force-inlining/invalid.stderr
+++ b/tests/ui/force-inlining/invalid.stderr
@@ -316,7 +316,7 @@ LL |         #[rustc_force_inline]
    |         ^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |         1 => (),
-   |         ------- not a function definition
+   |         -------- not a function definition
 
 error: attribute should be applied to a function
   --> $DIR/invalid.rs:98:5

--- a/tests/ui/generic-const-items/def-site-eval.fail.stderr
+++ b/tests/ui/generic-const-items/def-site-eval.fail.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `_::<'_>` failed
   --> $DIR/def-site-eval.rs:14:20
    |
 LL | const _<'_a>: () = panic!();
-   |                    ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/def-site-eval.rs:14:20
+   |                    ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/generic-const-items/wfcheck_err_leak_issue_118179.stderr
+++ b/tests/ui/generic-const-items/wfcheck_err_leak_issue_118179.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct G<T, const N: Vec<T>>(T);
    |                          ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/post_monomorphization_error_backtrace.rs
+++ b/tests/ui/generics/post_monomorphization_error_backtrace.rs
@@ -6,10 +6,10 @@ fn assert_zst<T>() {
         const V: () = assert!(std::mem::size_of::<T>() == 0);
         //~^ ERROR: evaluation of `assert_zst::F::<u32>::V` failed [E0080]
         //~| NOTE: in this expansion of assert!
-        //~| NOTE: the evaluated program panicked
+        //~| NOTE: assertion failed
         //~| ERROR: evaluation of `assert_zst::F::<i32>::V` failed [E0080]
         //~| NOTE: in this expansion of assert!
-        //~| NOTE: the evaluated program panicked
+        //~| NOTE: assertion failed
     }
     F::<T>::V;
     //~^NOTE: erroneous constant

--- a/tests/ui/generics/post_monomorphization_error_backtrace.stderr
+++ b/tests/ui/generics/post_monomorphization_error_backtrace.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `assert_zst::F::<u32>::V` failed
   --> $DIR/post_monomorphization_error_backtrace.rs:6:23
    |
 LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/post_monomorphization_error_backtrace.rs:6:23
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -22,7 +22,7 @@ error[E0080]: evaluation of `assert_zst::F::<i32>::V` failed
   --> $DIR/post_monomorphization_error_backtrace.rs:6:23
    |
 LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/post_monomorphization_error_backtrace.rs:6:23
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
@@ -5,10 +5,17 @@ LL |     m!(0f32, f32::NEG_INFINITY..);
    |        ^^^^ pattern `_` not covered
    |
    = note: the matched value is of type `f32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, _ => todo!() }
-   |                                ++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:15:8
@@ -17,10 +24,17 @@ LL |     m!(0f32, ..f32::INFINITY);
    |        ^^^^ pattern `_` not covered
    |
    = note: the matched value is of type `f32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, _ => todo!() }
-   |                                ++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:24:8
@@ -29,10 +43,17 @@ LL |     m!('a', ..core::char::MAX);
    |        ^^^ pattern `'\u{10ffff}'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, '\u{10ffff}' => todo!() }
-   |                                +++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'\u{10fffe}'..='\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:25:8
@@ -41,10 +62,17 @@ LL |     m!('a', ..ALMOST_MAX);
    |        ^^^ pattern `'\u{10fffe}'..='\u{10ffff}'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, '\u{10fffe}'..='\u{10ffff}' => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'\0'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:26:8
@@ -53,10 +81,17 @@ LL |     m!('a', ALMOST_MIN..);
    |        ^^^ pattern `'\0'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, '\0' => todo!() }
-   |                                +++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:27:8
@@ -65,10 +100,17 @@ LL |     m!('a', ..=ALMOST_MAX);
    |        ^^^ pattern `'\u{10ffff}'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, '\u{10ffff}' => todo!() }
-   |                                +++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'b'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:28:8
@@ -77,10 +119,17 @@ LL |     m!('a', ..=VAL | VAL_2..);
    |        ^^^ pattern `'b'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 'b' => todo!() }
-   |                                ++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `'b'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:29:8
@@ -89,10 +138,17 @@ LL |     m!('a', ..VAL_1 | VAL_2..);
    |        ^^^ pattern `'b'` not covered
    |
    = note: the matched value is of type `char`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 'b' => todo!() }
-   |                                ++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:39:12
@@ -101,10 +157,17 @@ LL |         m!(0, ..u8::MAX);
    |            ^ pattern `u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `254_u8..=u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:40:12
@@ -113,10 +176,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `254_u8..=u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 254_u8..=u8::MAX => todo!() }
-   |                                +++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:41:12
@@ -125,10 +195,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0_u8` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 0_u8 => todo!() }
-   |                                +++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:42:12
@@ -137,10 +214,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:43:12
@@ -149,10 +233,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_u8` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u8 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:44:12
@@ -161,10 +252,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_u8` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u8 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:52:12
@@ -173,10 +271,17 @@ LL |         m!(0, ..u16::MAX);
    |            ^ pattern `u16::MAX` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u16::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `65534_u16..=u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:53:12
@@ -185,10 +290,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `65534_u16..=u16::MAX` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 65534_u16..=u16::MAX => todo!() }
-   |                                +++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:54:12
@@ -197,10 +309,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0_u16` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 0_u16 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:55:12
@@ -209,10 +328,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `u16::MAX` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u16::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:56:12
@@ -221,10 +347,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_u16` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u16 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:57:12
@@ -233,10 +366,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_u16` not covered
    |
    = note: the matched value is of type `u16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u16 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:65:12
@@ -245,10 +385,17 @@ LL |         m!(0, ..u32::MAX);
    |            ^ pattern `u32::MAX` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u32::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `4294967294_u32..=u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:66:12
@@ -257,10 +404,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `4294967294_u32..=u32::MAX` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 4294967294_u32..=u32::MAX => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:67:12
@@ -269,10 +423,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0_u32` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 0_u32 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:68:12
@@ -281,10 +442,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `u32::MAX` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u32::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:69:12
@@ -293,10 +461,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_u32` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u32 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:70:12
@@ -305,10 +480,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_u32` not covered
    |
    = note: the matched value is of type `u32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u32 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:78:12
@@ -317,10 +499,17 @@ LL |         m!(0, ..u64::MAX);
    |            ^ pattern `u64::MAX` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u64::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `18446744073709551614_u64..=u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:79:12
@@ -329,10 +518,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `18446744073709551614_u64..=u64::MAX` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 18446744073709551614_u64..=u64::MAX => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:80:12
@@ -341,10 +537,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0_u64` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 0_u64 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:81:12
@@ -353,10 +556,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `u64::MAX` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u64::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:82:12
@@ -365,10 +575,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_u64` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u64 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:83:12
@@ -377,10 +594,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_u64` not covered
    |
    = note: the matched value is of type `u64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u64 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:91:12
@@ -389,10 +613,17 @@ LL |         m!(0, ..u128::MAX);
    |            ^ pattern `u128::MAX` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u128::MAX => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `340282366920938463463374607431768211454_u128..` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:92:12
@@ -401,10 +632,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `340282366920938463463374607431768211454_u128..` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 340282366920938463463374607431768211454_u128.. => todo!() }
-   |                                +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:93:12
@@ -413,10 +651,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `0_u128` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 0_u128 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:94:12
@@ -425,10 +670,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `u128::MAX` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, u128::MAX => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:95:12
@@ -437,10 +689,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_u128` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u128 => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:96:12
@@ -449,10 +708,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_u128` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_u128 => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:107:12
@@ -461,10 +727,17 @@ LL |         m!(0, ..i8::MAX);
    |            ^ pattern `i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `126_i8..=i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:108:12
@@ -473,10 +746,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `126_i8..=i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 126_i8..=i8::MAX => todo!() }
-   |                                +++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:109:12
@@ -485,10 +765,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `i8::MIN` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i8::MIN => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:110:12
@@ -497,10 +784,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:111:12
@@ -509,10 +803,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_i8` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i8 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:112:12
@@ -521,10 +822,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_i8` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i8 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:120:12
@@ -533,10 +841,17 @@ LL |         m!(0, ..i16::MAX);
    |            ^ pattern `i16::MAX` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i16::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `32766_i16..=i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:121:12
@@ -545,10 +860,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `32766_i16..=i16::MAX` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 32766_i16..=i16::MAX => todo!() }
-   |                                +++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i16::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:122:12
@@ -557,10 +879,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `i16::MIN` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i16::MIN => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:123:12
@@ -569,10 +898,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `i16::MAX` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i16::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:124:12
@@ -581,10 +917,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_i16` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i16 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:125:12
@@ -593,10 +936,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_i16` not covered
    |
    = note: the matched value is of type `i16`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i16 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:133:12
@@ -605,10 +955,17 @@ LL |         m!(0, ..i32::MAX);
    |            ^ pattern `i32::MAX` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i32::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `2147483646_i32..=i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:134:12
@@ -617,10 +974,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `2147483646_i32..=i32::MAX` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 2147483646_i32..=i32::MAX => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i32::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:135:12
@@ -629,10 +993,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `i32::MIN` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i32::MIN => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:136:12
@@ -641,10 +1012,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `i32::MAX` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i32::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:137:12
@@ -653,10 +1031,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_i32` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i32 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:138:12
@@ -665,10 +1050,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_i32` not covered
    |
    = note: the matched value is of type `i32`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i32 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:146:12
@@ -677,10 +1069,17 @@ LL |         m!(0, ..i64::MAX);
    |            ^ pattern `i64::MAX` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i64::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `9223372036854775806_i64..=i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:147:12
@@ -689,10 +1088,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `9223372036854775806_i64..=i64::MAX` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 9223372036854775806_i64..=i64::MAX => todo!() }
-   |                                +++++++++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i64::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:148:12
@@ -701,10 +1107,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `i64::MIN` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i64::MIN => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:149:12
@@ -713,10 +1126,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `i64::MAX` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i64::MAX => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:150:12
@@ -725,10 +1145,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_i64` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i64 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:151:12
@@ -737,10 +1164,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_i64` not covered
    |
    = note: the matched value is of type `i64`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i64 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:159:12
@@ -749,10 +1183,17 @@ LL |         m!(0, ..i128::MAX);
    |            ^ pattern `i128::MAX` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i128::MAX => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `170141183460469231731687303715884105726_i128..` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:160:12
@@ -761,10 +1202,17 @@ LL |         m!(0, ..ALMOST_MAX);
    |            ^ pattern `170141183460469231731687303715884105726_i128..` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 170141183460469231731687303715884105726_i128.. => todo!() }
-   |                                +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i128::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:161:12
@@ -773,10 +1221,17 @@ LL |         m!(0, ALMOST_MIN..);
    |            ^ pattern `i128::MIN` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i128::MIN => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:162:12
@@ -785,10 +1240,17 @@ LL |         m!(0, ..=ALMOST_MAX);
    |            ^ pattern `i128::MAX` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, i128::MAX => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:163:12
@@ -797,10 +1259,17 @@ LL |         m!(0, ..=VAL | VAL_2..);
    |            ^ pattern `43_i128` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i128 => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `43_i128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:164:12
@@ -809,10 +1278,17 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    |            ^ pattern `43_i128` not covered
    |
    = note: the matched value is of type `i128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/half-open-range-pats-exhaustive-fail.rs:9:9
    |
-LL |         match $s { $($t)+ => {}, 43_i128 => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error: aborting due to 68 previous errors
 

--- a/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.stderr
+++ b/tests/ui/half-open-range-patterns/half-open-range-pats-inclusive-match-arrow.stderr
@@ -21,7 +21,7 @@ LL |     match x {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         74..=> {},
-LL ~         i32::MIN..=-1_i32 => todo!(),
+LL +         i32::MIN..=-1_i32 => todo!()
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/infinite/infinite-recursion-const-fn.rs
+++ b/tests/ui/infinite/infinite-recursion-const-fn.rs
@@ -1,11 +1,11 @@
 //https://github.com/rust-lang/rust/issues/31364
 
 const fn a() -> usize {
-    b() //~ ERROR evaluation of constant value failed [E0080]
+    b()
 }
 const fn b() -> usize {
     a()
 }
-const ARR: [i32; a()] = [5; 6];
+const ARR: [i32; a()] = [5; 6]; //~ ERROR evaluation of constant value failed [E0080]
 
 fn main() {}

--- a/tests/ui/infinite/infinite-recursion-const-fn.stderr
+++ b/tests/ui/infinite/infinite-recursion-const-fn.stderr
@@ -1,649 +1,644 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^ reached the configured maximum number of stack frames
-   |
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `ARR::{constant#0}`
   --> $DIR/infinite-recursion-const-fn.rs:9:18
    |
 LL | const ARR: [i32; a()] = [5; 6];
-   |                  ^^^
+   |                  ^^^ reached the configured maximum number of stack frames
+   |
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inline-const/const-expr-generic-err.stderr
+++ b/tests/ui/inline-const/const-expr-generic-err.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `foo::<i32>::{constant#0}` failed
   --> $DIR/const-expr-generic-err.rs:4:13
    |
 LL |     const { assert!(std::mem::size_of::<T>() == 0); }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/const-expr-generic-err.rs:4:13
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/inline-const/required-const.stderr
+++ b/tests/ui/inline-const/required-const.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `foo::<i32>::{constant#0}` failed
   --> $DIR/required-const.rs:6:17
    |
 LL |         const { panic!() }
-   |                 ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/required-const.rs:6:17
+   |                 ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/issues/issue-76191.stderr
+++ b/tests/ui/issues/issue-76191.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-76191.rs:8:37
    |
 LL | const RANGE2: RangeInclusive<i32> = panic!();
-   |                                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-76191.rs:8:37
+   |                                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/layout/invalid-unsized-in-always-sized-tail.rs
+++ b/tests/ui/layout/invalid-unsized-in-always-sized-tail.rs
@@ -12,6 +12,6 @@ struct P2 {
     //~^ ERROR: the size for values of type `[bool]` cannot be known at compilation time
 }
 
-static CHECK: () = assert!(align_of::<P2>() == 1);
+static CHECK: () = assert!(align_of::<P2>() == 1); //~ ERROR could not evaluate static initializer
 
 fn main() {}

--- a/tests/ui/layout/invalid-unsized-in-always-sized-tail.stderr
+++ b/tests/ui/layout/invalid-unsized-in-always-sized-tail.stderr
@@ -19,17 +19,13 @@ LL | struct MySlice<T>(T);
    |                this could be changed to `T: ?Sized`...
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: the type `MySlice<[bool]>` has an unknown layout
-   |
-note: inside `align_of::<P2>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `CHECK`
   --> $DIR/invalid-unsized-in-always-sized-tail.rs:15:28
    |
 LL | static CHECK: () = assert!(align_of::<P2>() == 1);
-   |                            ^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^ the type `MySlice<[bool]>` has an unknown layout
+   |
+note: inside `align_of::<P2>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/layout/unknown-when-no-type-parameter.stderr
+++ b/tests/ui/layout/unknown-when-no-type-parameter.stderr
@@ -1,15 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: the type `<() as Project>::Assoc` has an unknown layout
-   |
-note: inside `std::mem::size_of::<<() as Project>::Assoc>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `foo::{constant#0}`
   --> $DIR/unknown-when-no-type-parameter.rs:11:10
    |
 LL |     [(); size_of::<<() as Project>::Assoc>()];
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the type `<() as Project>::Assoc` has an unknown layout
+   |
+note: inside `std::mem::size_of::<<() as Project>::Assoc>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -9,8 +9,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
    |                      ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unusual-rib-combinations.rs:11:15

--- a/tests/ui/limits/issue-55878.stderr
+++ b/tests/ui/limits/issue-55878.stderr
@@ -1,15 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: values of the type `[u8; usize::MAX]` are too big for the target architecture
-   |
-note: inside `std::mem::size_of::<[u8; usize::MAX]>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `main`
   --> $DIR/issue-55878.rs:5:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ values of the type `[u8; usize::MAX]` are too big for the target architecture
+   |
+note: inside `std::mem::size_of::<[u8; usize::MAX]>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/match/intended-binding-pattern-is-const.stderr
+++ b/tests/ui/match/intended-binding-pattern-is-const.stderr
@@ -19,8 +19,9 @@ LL |         x_var => {}
    |          ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL |         x => {}, i32::MIN..=3_i32 | 5_i32..=i32::MAX => todo!()
-   |                ++++++++++++++++++++++++++++++++++++++++++++++++
+LL ~         x => {}
+LL ~         i32::MIN..=3_i32 | 5_i32..=i32::MAX => todo!()
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/match/postfix-match/pf-match-exhaustiveness.stderr
+++ b/tests/ui/match/postfix-match/pf-match-exhaustiveness.stderr
@@ -13,7 +13,7 @@ note: `Option<i32>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => {},
-LL ~         Some(_) => todo!(),
+LL +         Some(_) => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/match/validate-range-endpoints.stderr
+++ b/tests/ui/match/validate-range-endpoints.stderr
@@ -61,7 +61,7 @@ LL |     match 0i8 {
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         -10000..=0 => {},
+LL ~         -10000..=0 => {}
 LL +         i8::MIN..=-17_i8 | 1_i8..=i8::MAX => todo!()
    |
 
@@ -74,7 +74,7 @@ LL |     match 0i8 {
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         -10000.. => {},
+LL ~         -10000.. => {}
 LL +         i8::MIN..=-17_i8 => todo!()
    |
 

--- a/tests/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
+++ b/tests/ui/or-patterns/exhaustiveness-non-exhaustive.stderr
@@ -7,7 +7,7 @@ LL |     match (0u8, 0u8) {
    = note: the matched value is of type `(u8, u8)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         (0 | 1, 2 | 3) => {},
+LL ~         (0 | 1, 2 | 3) => {}
 LL +         (2_u8..=u8::MAX, _) => todo!()
    |
 
@@ -20,7 +20,7 @@ LL |     match ((0u8,),) {
    = note: the matched value is of type `((u8,),)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         ((0 | 1,) | (2 | 3,),) => {},
+LL ~         ((0 | 1,) | (2 | 3,),) => {}
 LL +         ((4_u8..=u8::MAX)) => todo!()
    |
 
@@ -33,7 +33,7 @@ LL |     match (Some(0u8),) {
    = note: the matched value is of type `(Option<u8>,)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         (None | Some(0 | 1),) => {},
+LL ~         (None | Some(0 | 1),) => {}
 LL +         (Some(2_u8..=u8::MAX)) => todo!()
    |
 

--- a/tests/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
+++ b/tests/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
@@ -1,8 +1,8 @@
 error[E0005]: refutable pattern in local binding
-  --> $DIR/issue-69875-should-have-been-expanded-earlier-non-exhaustive.rs:2:10
+  --> $DIR/issue-69875-should-have-been-expanded-earlier-non-exhaustive.rs:2:9
    |
 LL |     let (0 | (1 | 2)) = 0;
-   |          ^^^^^^^^^^^ patterns `i32::MIN..=-1_i32` and `3_i32..=i32::MAX` not covered
+   |         ^^^^^^^^^^^^^ patterns `i32::MIN..=-1_i32` and `3_i32..=i32::MAX` not covered
    |
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html

--- a/tests/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
+++ b/tests/ui/or-patterns/issue-69875-should-have-been-expanded-earlier-non-exhaustive.stderr
@@ -21,7 +21,7 @@ LL |     match 0 {
    = note: the matched value is of type `i32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         0 | (1 | 2) => {},
+LL ~         0 | (1 | 2) => {}
 LL +         i32::MIN..=-1_i32 | 3_i32..=i32::MAX => todo!()
    |
 

--- a/tests/ui/or-patterns/missing-bindings.stderr
+++ b/tests/ui/or-patterns/missing-bindings.stderr
@@ -264,8 +264,9 @@ note: `Option<foo>` defined here
    = note: the matched value is of type `Option<foo>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL |         Some(alpha | beta) => {}, None => todo!()
-   |                                 +++++++++++++++++
+LL ~         Some(alpha | beta) => {}
+LL ~         None => todo!()
+   |
 
 error: aborting due to 29 previous errors
 

--- a/tests/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-and-ref.stderr
+++ b/tests/ui/pattern/bindings-after-at/borrowck-pat-ref-mut-and-ref.stderr
@@ -10,18 +10,18 @@ error: cannot borrow value as mutable more than once at a time
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:33:9
    |
 LL |     let ref mut a @ (ref b @ ref mut c) = u(); // sub-in-sub
-   |         ^^^^^^^^^    -----   --------- value is mutably borrowed by `c` here
-   |         |            |
-   |         |            value is borrowed by `b` here
+   |         ^^^^^^^^^   ------   --------- value is mutably borrowed by `c` here
+   |         |           |
+   |         |           value is borrowed by `b` here
    |         value is mutably borrowed by `a` here
 
 error: cannot borrow value as mutable because it is also borrowed as immutable
-  --> $DIR/borrowck-pat-ref-mut-and-ref.rs:33:22
+  --> $DIR/borrowck-pat-ref-mut-and-ref.rs:33:21
    |
 LL |     let ref mut a @ (ref b @ ref mut c) = u(); // sub-in-sub
-   |                      ^^^^^   --------- value is mutably borrowed by `c` here
-   |                      |
-   |                      value is borrowed by `b` here
+   |                     ^^^^^^   --------- value is mutably borrowed by `c` here
+   |                     |
+   |                     value is borrowed by `b` here
 
 error: cannot borrow value as mutable because it is also borrowed as immutable
   --> $DIR/borrowck-pat-ref-mut-and-ref.rs:37:9

--- a/tests/ui/pattern/pattern-binding-disambiguation.stderr
+++ b/tests/ui/pattern/pattern-binding-disambiguation.stderr
@@ -77,8 +77,9 @@ LL |     BracedVariant{},
    = note: the matched value is of type `E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL |         UnitVariant => {}, E::TupleVariant | E::BracedVariant {  } => todo!() // OK, `UnitVariant` is a unit variant pattern
-   |                          ++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL ~         UnitVariant => {}
+LL ~         E::TupleVariant | E::BracedVariant {  } => todo!() // OK, `UnitVariant` is a unit variant pattern
+   |
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/pattern-binding-disambiguation.rs:51:9

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.classic2021.stderr
@@ -211,7 +211,7 @@ LL |     let [&mut &(mut x)] = &[&mut 0];
 help: consider removing `&` from the pattern
    |
 LL -     let [&mut &(mut x)] = &[&mut 0];
-LL +     let [&mut mut x)] = &[&mut 0];
+LL +     let [&mut (mut x)] = &[&mut 0];
    |
 
 error: aborting due to 14 previous errors

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.stable2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.stable2021.stderr
@@ -276,7 +276,7 @@ LL |     let [&mut &(mut x)] = &[&mut 0];
 help: consider removing `&` from the pattern
    |
 LL -     let [&mut &(mut x)] = &[&mut 0];
-LL +     let [&mut mut x)] = &[&mut 0];
+LL +     let [&mut (mut x)] = &[&mut 0];
    |
 
 error: aborting due to 21 previous errors

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2021.stderr
@@ -302,7 +302,7 @@ LL |     let [&mut &(mut x)] = &[&mut 0];
 help: consider removing `&` from the pattern
    |
 LL -     let [&mut &(mut x)] = &[&mut 0];
-LL +     let [&mut mut x)] = &[&mut 0];
+LL +     let [&mut (mut x)] = &[&mut 0];
    |
 
 error: aborting due to 21 previous errors

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2024.stderr
@@ -142,20 +142,20 @@ LL +     let &[&mut x] = &mut &mut [0];
    |
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/pattern-errors.rs:102:12
+  --> $DIR/pattern-errors.rs:102:11
    |
 LL |     let [&(mut x)] = &[&0];
-   |            ^^^^
+   |           ^^^^^
    |
    = note: see issue #123076 <https://github.com/rust-lang/rust/issues/123076> for more information
    = help: add `#![feature(mut_ref)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/pattern-errors.rs:107:12
+  --> $DIR/pattern-errors.rs:107:11
    |
 LL |     let [&(mut x)] = &mut [&0];
-   |            ^^^^
+   |           ^^^^^
    |
    = note: see issue #123076 <https://github.com/rust-lang/rust/issues/123076> for more information
    = help: add `#![feature(mut_ref)]` to the crate attributes to enable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.classic2021.stderr
@@ -107,7 +107,7 @@ LL |     let [&mut &(mut x)] = &mut [&0];
 help: consider removing `&` from the pattern
    |
 LL -     let [&mut &(mut x)] = &mut [&0];
-LL +     let [&mut mut x)] = &mut [&0];
+LL +     let [&mut (mut x)] = &mut [&0];
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.structural2021.stderr
@@ -107,7 +107,7 @@ LL |     let [&mut &(mut x)] = &mut [&0];
 help: consider removing `&` from the pattern
    |
 LL -     let [&mut &(mut x)] = &mut [&0];
-LL +     let [&mut mut x)] = &mut [&0];
+LL +     let [&mut (mut x)] = &mut [&0];
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable

--- a/tests/ui/pattern/suggest-adding-appropriate-missing-pattern-excluding-comments.fixed
+++ b/tests/ui/pattern/suggest-adding-appropriate-missing-pattern-excluding-comments.fixed
@@ -4,7 +4,7 @@ fn main() {
     match Some(1) { //~ ERROR non-exhaustive patterns: `None` not covered
         Some(1) => {}
         // hello
-        Some(_) => {},
+        Some(_) => {}
         None => todo!()
     }
 }

--- a/tests/ui/pattern/suggest-adding-appropriate-missing-pattern-excluding-comments.stderr
+++ b/tests/ui/pattern/suggest-adding-appropriate-missing-pattern-excluding-comments.stderr
@@ -12,7 +12,7 @@ note: `Option<i32>` defined here
    = note: the matched value is of type `Option<i32>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Some(_) => {},
+LL ~         Some(_) => {}
 LL +         None => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/doc-hidden-non-exhaustive.stderr
+++ b/tests/ui/pattern/usefulness/doc-hidden-non-exhaustive.stderr
@@ -12,7 +12,7 @@ LL | pub enum HiddenEnum {
    = note: the matched value is of type `HiddenEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         HiddenEnum::B => {},
+LL ~         HiddenEnum::B => {}
 LL +         _ => todo!()
    |
 
@@ -33,7 +33,7 @@ LL |     B,
    = note: the matched value is of type `HiddenEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         HiddenEnum::C => {},
+LL ~         HiddenEnum::C => {}
 LL +         HiddenEnum::B => todo!()
    |
 
@@ -54,7 +54,7 @@ LL |     B,
    = note: the matched value is of type `HiddenEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         HiddenEnum::A => {},
+LL ~         HiddenEnum::A => {}
 LL +         HiddenEnum::B | _ => todo!()
    |
 
@@ -72,7 +72,7 @@ note: `Option<HiddenEnum>` defined here
    = note: the matched value is of type `Option<HiddenEnum>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         Some(HiddenEnum::A) => {},
+LL ~         Some(HiddenEnum::A) => {}
 LL +         Some(HiddenEnum::B) | Some(_) => todo!()
    |
 
@@ -93,7 +93,7 @@ LL |     C,
    = note: the matched value is of type `InCrate`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         InCrate::B => {},
+LL ~         InCrate::B => {}
 LL +         InCrate::C => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
@@ -72,7 +72,7 @@ LL |     match 0u8 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         _ if false => {},
+LL ~         _ if false => {}
 LL +         0_u8..=u8::MAX => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
@@ -72,7 +72,7 @@ LL |     match 0u8 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         _ if false => {},
+LL ~         _ if false => {}
 LL +         0_u8..=u8::MAX => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/empty-match.rs:47:20
+  --> $DIR/empty-match.rs:53:20
    |
 LL |     match_no_arms!(0u8);
    |                    ^^^
@@ -8,7 +8,7 @@ LL |     match_no_arms!(0u8);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `i8` is non-empty
-  --> $DIR/empty-match.rs:48:20
+  --> $DIR/empty-match.rs:54:20
    |
 LL |     match_no_arms!(0i8);
    |                    ^^^
@@ -17,7 +17,7 @@ LL |     match_no_arms!(0i8);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `usize` is non-empty
-  --> $DIR/empty-match.rs:49:20
+  --> $DIR/empty-match.rs:55:20
    |
 LL |     match_no_arms!(0usize);
    |                    ^^^^^^
@@ -26,7 +26,7 @@ LL |     match_no_arms!(0usize);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `isize` is non-empty
-  --> $DIR/empty-match.rs:50:20
+  --> $DIR/empty-match.rs:56:20
    |
 LL |     match_no_arms!(0isize);
    |                    ^^^^^^
@@ -35,13 +35,13 @@ LL |     match_no_arms!(0isize);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct1` is non-empty
-  --> $DIR/empty-match.rs:51:20
+  --> $DIR/empty-match.rs:57:20
    |
 LL |     match_no_arms!(NonEmptyStruct1);
    |                    ^^^^^^^^^^^^^^^
    |
 note: `NonEmptyStruct1` defined here
-  --> $DIR/empty-match.rs:22:12
+  --> $DIR/empty-match.rs:28:12
    |
 LL |     struct NonEmptyStruct1;
    |            ^^^^^^^^^^^^^^^
@@ -49,13 +49,13 @@ LL |     struct NonEmptyStruct1;
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct2` is non-empty
-  --> $DIR/empty-match.rs:52:20
+  --> $DIR/empty-match.rs:58:20
    |
 LL |     match_no_arms!(NonEmptyStruct2(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyStruct2` defined here
-  --> $DIR/empty-match.rs:23:12
+  --> $DIR/empty-match.rs:29:12
    |
 LL |     struct NonEmptyStruct2(bool);
    |            ^^^^^^^^^^^^^^^
@@ -63,13 +63,13 @@ LL |     struct NonEmptyStruct2(bool);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/empty-match.rs:53:20
+  --> $DIR/empty-match.rs:59:20
    |
 LL |     match_no_arms!((NonEmptyUnion1 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyUnion1` defined here
-  --> $DIR/empty-match.rs:24:11
+  --> $DIR/empty-match.rs:30:11
    |
 LL |     union NonEmptyUnion1 {
    |           ^^^^^^^^^^^^^^
@@ -77,13 +77,13 @@ LL |     union NonEmptyUnion1 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/empty-match.rs:54:20
+  --> $DIR/empty-match.rs:60:20
    |
 LL |     match_no_arms!((NonEmptyUnion2 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyUnion2` defined here
-  --> $DIR/empty-match.rs:27:11
+  --> $DIR/empty-match.rs:33:11
    |
 LL |     union NonEmptyUnion2 {
    |           ^^^^^^^^^^^^^^
@@ -91,29 +91,39 @@ LL |     union NonEmptyUnion2 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:55:20
+  --> $DIR/empty-match.rs:61:20
    |
 LL |     match_no_arms!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:31:10
+  --> $DIR/empty-match.rs:37:10
    |
 LL |     enum NonEmptyEnum1 {
    |          ^^^^^^^^^^^^^
 LL |         Foo(bool),
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:56:20
+  --> $DIR/empty-match.rs:62:20
    |
 LL |     match_no_arms!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:34:10
+  --> $DIR/empty-match.rs:40:10
    |
 LL |     enum NonEmptyEnum2 {
    |          ^^^^^^^^^^^^^
@@ -122,16 +132,26 @@ LL |         Foo(bool),
 LL |         Bar,
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:57:20
+  --> $DIR/empty-match.rs:63:20
    |
 LL |     match_no_arms!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:38:10
+  --> $DIR/empty-match.rs:44:10
    |
 LL |     enum NonEmptyEnum5 {
    |          ^^^^^^^^^^^^^
@@ -146,10 +166,20 @@ LL |         V4,
 LL |         V5,
    |         -- not covered
    = note: the matched value is of type `NonEmptyEnum5`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
-  --> $DIR/empty-match.rs:58:20
+  --> $DIR/empty-match.rs:64:20
    |
 LL |     match_no_arms!(array0_of_empty);
    |                    ^^^^^^^^^^^^^^^
@@ -158,7 +188,7 @@ LL |     match_no_arms!(array0_of_empty);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `[!; N]` is non-empty
-  --> $DIR/empty-match.rs:59:20
+  --> $DIR/empty-match.rs:65:20
    |
 LL |     match_no_arms!(arrayN_of_empty);
    |                    ^^^^^^^^^^^^^^^
@@ -167,158 +197,239 @@ LL |     match_no_arms!(arrayN_of_empty);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: `0_u8..=u8::MAX` not covered
-  --> $DIR/empty-match.rs:61:24
+  --> $DIR/empty-match.rs:67:24
    |
 LL |     match_guarded_arm!(0u8);
    |                        ^^^ pattern `0_u8..=u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, 0_u8..=u8::MAX => todo!()
-   |                                 +++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=i8::MAX` not covered
-  --> $DIR/empty-match.rs:62:24
+  --> $DIR/empty-match.rs:68:24
    |
 LL |     match_guarded_arm!(0i8);
    |                        ^^^ pattern `i8::MIN..=i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, i8::MIN..=i8::MAX => todo!()
-   |                                 ++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_usize..` not covered
-  --> $DIR/empty-match.rs:63:24
+  --> $DIR/empty-match.rs:69:24
    |
 LL |     match_guarded_arm!(0usize);
    |                        ^^^^^^ pattern `0_usize..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, 0_usize.. => todo!()
-   |                                 ++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/empty-match.rs:64:24
+  --> $DIR/empty-match.rs:70:24
    |
 LL |     match_guarded_arm!(0isize);
    |                        ^^^^^^ pattern `_` not covered
    |
    = note: the matched value is of type `isize`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, _ => todo!()
-   |                                 ++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct1` not covered
-  --> $DIR/empty-match.rs:65:24
+  --> $DIR/empty-match.rs:71:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct1);
    |                        ^^^^^^^^^^^^^^^ pattern `NonEmptyStruct1` not covered
    |
 note: `NonEmptyStruct1` defined here
-  --> $DIR/empty-match.rs:22:12
+  --> $DIR/empty-match.rs:28:12
    |
 LL |     struct NonEmptyStruct1;
    |            ^^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyStruct1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyStruct1 => todo!()
-   |                                 ++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct2(_)` not covered
-  --> $DIR/empty-match.rs:66:24
+  --> $DIR/empty-match.rs:72:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct2(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyStruct2(_)` not covered
    |
 note: `NonEmptyStruct2` defined here
-  --> $DIR/empty-match.rs:23:12
+  --> $DIR/empty-match.rs:29:12
    |
 LL |     struct NonEmptyStruct2(bool);
    |            ^^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyStruct2`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyStruct2(_) => todo!()
-   |                                 +++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/empty-match.rs:67:24
+  --> $DIR/empty-match.rs:73:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion1 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion1 { .. }` not covered
    |
 note: `NonEmptyUnion1` defined here
-  --> $DIR/empty-match.rs:24:11
+  --> $DIR/empty-match.rs:30:11
    |
 LL |     union NonEmptyUnion1 {
    |           ^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyUnion1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyUnion1 { .. } => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/empty-match.rs:68:24
+  --> $DIR/empty-match.rs:74:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion2 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion2 { .. }` not covered
    |
 note: `NonEmptyUnion2` defined here
-  --> $DIR/empty-match.rs:27:11
+  --> $DIR/empty-match.rs:33:11
    |
 LL |     union NonEmptyUnion2 {
    |           ^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyUnion2`
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyUnion2 { .. } => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:69:24
+  --> $DIR/empty-match.rs:75:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum1::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:31:10
+  --> $DIR/empty-match.rs:37:10
    |
 LL |     enum NonEmptyEnum1 {
    |          ^^^^^^^^^^^^^
 LL |         Foo(bool),
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyEnum1::Foo(_) => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:70:24
+  --> $DIR/empty-match.rs:76:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum2::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:34:10
+  --> $DIR/empty-match.rs:40:10
    |
 LL |     enum NonEmptyEnum2 {
    |          ^^^^^^^^^^^^^
@@ -327,20 +438,29 @@ LL |         Foo(bool),
 LL |         Bar,
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
-   |                                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:71:24
+  --> $DIR/empty-match.rs:77:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum5::V1);
    |                        ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:38:10
+  --> $DIR/empty-match.rs:44:10
    |
 LL |     enum NonEmptyEnum5 {
    |          ^^^^^^^^^^^^^
@@ -355,38 +475,91 @@ LL |         V4,
 LL |         V5,
    |         -- not covered
    = note: the matched value is of type `NonEmptyEnum5`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, _ => todo!()
-   |                                 ++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-match.rs:72:24
+  --> $DIR/empty-match.rs:78:24
    |
 LL |     match_guarded_arm!(array0_of_empty);
    |                        ^^^^^^^^^^^^^^^ pattern `[]` not covered
    |
    = note: the matched value is of type `[!; 0]`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, [] => todo!()
-   |                                 +++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-match.rs:73:24
+  --> $DIR/empty-match.rs:79:24
    |
 LL |     match_guarded_arm!(arrayN_of_empty);
    |                        ^^^^^^^^^^^^^^^ pattern `[]` not covered
    |
    = note: the matched value is of type `[!; N]`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, [] => todo!()
-   |                                 +++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
-error: aborting due to 26 previous errors
+error[E0004]: non-exhaustive patterns: `[]` not covered
+  --> $DIR/empty-match.rs:81:15
+   |
+LL |     indirect!(arrayN_of_empty);
+   |               ^^^^^^^^^^^^^^^ pattern `[]` not covered
+   |
+   = note: the matched value is of type `[!; N]`
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
+   |
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+...
+LL |        indirect!(arrayN_of_empty);
+   |        -------------------------- in this macro invocation
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
+   = note: this error originates in the macro `indirect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 27 previous errors
 
 For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.exhaustive_patterns.stderr
@@ -176,9 +176,8 @@ LL |     match_guarded_arm!(0u8);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 0_u8..=u8::MAX => todo!()
-   |
+LL |                 _ if false => {}, 0_u8..=u8::MAX => todo!()
+   |                                 +++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=i8::MAX` not covered
   --> $DIR/empty-match.rs:62:24
@@ -190,9 +189,8 @@ LL |     match_guarded_arm!(0i8);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 i8::MIN..=i8::MAX => todo!()
-   |
+LL |                 _ if false => {}, i8::MIN..=i8::MAX => todo!()
+   |                                 ++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_usize..` not covered
   --> $DIR/empty-match.rs:63:24
@@ -204,9 +202,8 @@ LL |     match_guarded_arm!(0usize);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 0_usize.. => todo!()
-   |
+LL |                 _ if false => {}, 0_usize.. => todo!()
+   |                                 ++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/empty-match.rs:64:24
@@ -218,9 +215,8 @@ LL |     match_guarded_arm!(0isize);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 _ => todo!()
-   |
+LL |                 _ if false => {}, _ => todo!()
+   |                                 ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct1` not covered
   --> $DIR/empty-match.rs:65:24
@@ -237,9 +233,8 @@ LL |     struct NonEmptyStruct1;
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyStruct1 => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyStruct1 => todo!()
+   |                                 ++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct2(_)` not covered
   --> $DIR/empty-match.rs:66:24
@@ -256,9 +251,8 @@ LL |     struct NonEmptyStruct2(bool);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyStruct2(_) => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyStruct2(_) => todo!()
+   |                                 +++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
   --> $DIR/empty-match.rs:67:24
@@ -275,9 +269,8 @@ LL |     union NonEmptyUnion1 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyUnion1 { .. } => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyUnion1 { .. } => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
   --> $DIR/empty-match.rs:68:24
@@ -295,9 +288,8 @@ LL |     union NonEmptyUnion2 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyUnion2 { .. } => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyUnion2 { .. } => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
   --> $DIR/empty-match.rs:69:24
@@ -316,9 +308,8 @@ LL |         Foo(bool),
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyEnum1::Foo(_) => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyEnum1::Foo(_) => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
   --> $DIR/empty-match.rs:70:24
@@ -339,9 +330,8 @@ LL |         Bar,
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
+   |                                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
   --> $DIR/empty-match.rs:71:24
@@ -368,9 +358,8 @@ LL |         V5,
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~                 _ if false => {},
-LL +                 _ => todo!()
-   |
+LL |                 _ if false => {}, _ => todo!()
+   |                                 ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-match.rs:72:24
@@ -382,9 +371,8 @@ LL |     match_guarded_arm!(array0_of_empty);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 [] => todo!()
-   |
+LL |                 _ if false => {}, [] => todo!()
+   |                                 +++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-match.rs:73:24
@@ -396,9 +384,8 @@ LL |     match_guarded_arm!(arrayN_of_empty);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 [] => todo!()
-   |
+LL |                 _ if false => {}, [] => todo!()
+   |                                 +++++++++++++++
 
 error: aborting due to 26 previous errors
 

--- a/tests/ui/pattern/usefulness/empty-match.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.normal.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/empty-match.rs:47:20
+  --> $DIR/empty-match.rs:53:20
    |
 LL |     match_no_arms!(0u8);
    |                    ^^^
@@ -8,7 +8,7 @@ LL |     match_no_arms!(0u8);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `i8` is non-empty
-  --> $DIR/empty-match.rs:48:20
+  --> $DIR/empty-match.rs:54:20
    |
 LL |     match_no_arms!(0i8);
    |                    ^^^
@@ -17,7 +17,7 @@ LL |     match_no_arms!(0i8);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `usize` is non-empty
-  --> $DIR/empty-match.rs:49:20
+  --> $DIR/empty-match.rs:55:20
    |
 LL |     match_no_arms!(0usize);
    |                    ^^^^^^
@@ -26,7 +26,7 @@ LL |     match_no_arms!(0usize);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `isize` is non-empty
-  --> $DIR/empty-match.rs:50:20
+  --> $DIR/empty-match.rs:56:20
    |
 LL |     match_no_arms!(0isize);
    |                    ^^^^^^
@@ -35,13 +35,13 @@ LL |     match_no_arms!(0isize);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct1` is non-empty
-  --> $DIR/empty-match.rs:51:20
+  --> $DIR/empty-match.rs:57:20
    |
 LL |     match_no_arms!(NonEmptyStruct1);
    |                    ^^^^^^^^^^^^^^^
    |
 note: `NonEmptyStruct1` defined here
-  --> $DIR/empty-match.rs:22:12
+  --> $DIR/empty-match.rs:28:12
    |
 LL |     struct NonEmptyStruct1;
    |            ^^^^^^^^^^^^^^^
@@ -49,13 +49,13 @@ LL |     struct NonEmptyStruct1;
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct2` is non-empty
-  --> $DIR/empty-match.rs:52:20
+  --> $DIR/empty-match.rs:58:20
    |
 LL |     match_no_arms!(NonEmptyStruct2(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyStruct2` defined here
-  --> $DIR/empty-match.rs:23:12
+  --> $DIR/empty-match.rs:29:12
    |
 LL |     struct NonEmptyStruct2(bool);
    |            ^^^^^^^^^^^^^^^
@@ -63,13 +63,13 @@ LL |     struct NonEmptyStruct2(bool);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/empty-match.rs:53:20
+  --> $DIR/empty-match.rs:59:20
    |
 LL |     match_no_arms!((NonEmptyUnion1 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyUnion1` defined here
-  --> $DIR/empty-match.rs:24:11
+  --> $DIR/empty-match.rs:30:11
    |
 LL |     union NonEmptyUnion1 {
    |           ^^^^^^^^^^^^^^
@@ -77,13 +77,13 @@ LL |     union NonEmptyUnion1 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/empty-match.rs:54:20
+  --> $DIR/empty-match.rs:60:20
    |
 LL |     match_no_arms!((NonEmptyUnion2 { foo: () }));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: `NonEmptyUnion2` defined here
-  --> $DIR/empty-match.rs:27:11
+  --> $DIR/empty-match.rs:33:11
    |
 LL |     union NonEmptyUnion2 {
    |           ^^^^^^^^^^^^^^
@@ -91,29 +91,39 @@ LL |     union NonEmptyUnion2 {
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:55:20
+  --> $DIR/empty-match.rs:61:20
    |
 LL |     match_no_arms!(NonEmptyEnum1::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:31:10
+  --> $DIR/empty-match.rs:37:10
    |
 LL |     enum NonEmptyEnum1 {
    |          ^^^^^^^^^^^^^
 LL |         Foo(bool),
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:56:20
+  --> $DIR/empty-match.rs:62:20
    |
 LL |     match_no_arms!(NonEmptyEnum2::Foo(true));
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:34:10
+  --> $DIR/empty-match.rs:40:10
    |
 LL |     enum NonEmptyEnum2 {
    |          ^^^^^^^^^^^^^
@@ -122,16 +132,26 @@ LL |         Foo(bool),
 LL |         Bar,
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:57:20
+  --> $DIR/empty-match.rs:63:20
    |
 LL |     match_no_arms!(NonEmptyEnum5::V1);
    |                    ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:38:10
+  --> $DIR/empty-match.rs:44:10
    |
 LL |     enum NonEmptyEnum5 {
    |          ^^^^^^^^^^^^^
@@ -146,10 +166,20 @@ LL |         V4,
 LL |         V5,
    |         -- not covered
    = note: the matched value is of type `NonEmptyEnum5`
+note: within macro `match_no_arms`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:11:13
+   |
+LL | /     macro_rules! match_no_arms {
+LL | |         ($e:expr) => {
+LL | |             match $e {}
+   | |             ^^^^^^^^^^^
+LL | |         };
+LL | |     }
+   | |_____-
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
-  --> $DIR/empty-match.rs:58:20
+  --> $DIR/empty-match.rs:64:20
    |
 LL |     match_no_arms!(array0_of_empty);
    |                    ^^^^^^^^^^^^^^^
@@ -158,7 +188,7 @@ LL |     match_no_arms!(array0_of_empty);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: type `[!; N]` is non-empty
-  --> $DIR/empty-match.rs:59:20
+  --> $DIR/empty-match.rs:65:20
    |
 LL |     match_no_arms!(arrayN_of_empty);
    |                    ^^^^^^^^^^^^^^^
@@ -167,158 +197,239 @@ LL |     match_no_arms!(arrayN_of_empty);
    = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern
 
 error[E0004]: non-exhaustive patterns: `0_u8..=u8::MAX` not covered
-  --> $DIR/empty-match.rs:61:24
+  --> $DIR/empty-match.rs:67:24
    |
 LL |     match_guarded_arm!(0u8);
    |                        ^^^ pattern `0_u8..=u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, 0_u8..=u8::MAX => todo!()
-   |                                 +++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=i8::MAX` not covered
-  --> $DIR/empty-match.rs:62:24
+  --> $DIR/empty-match.rs:68:24
    |
 LL |     match_guarded_arm!(0i8);
    |                        ^^^ pattern `i8::MIN..=i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, i8::MIN..=i8::MAX => todo!()
-   |                                 ++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_usize..` not covered
-  --> $DIR/empty-match.rs:63:24
+  --> $DIR/empty-match.rs:69:24
    |
 LL |     match_guarded_arm!(0usize);
    |                        ^^^^^^ pattern `0_usize..` not covered
    |
    = note: the matched value is of type `usize`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, 0_usize.. => todo!()
-   |                                 ++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/empty-match.rs:64:24
+  --> $DIR/empty-match.rs:70:24
    |
 LL |     match_guarded_arm!(0isize);
    |                        ^^^^^^ pattern `_` not covered
    |
    = note: the matched value is of type `isize`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, _ => todo!()
-   |                                 ++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct1` not covered
-  --> $DIR/empty-match.rs:65:24
+  --> $DIR/empty-match.rs:71:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct1);
    |                        ^^^^^^^^^^^^^^^ pattern `NonEmptyStruct1` not covered
    |
 note: `NonEmptyStruct1` defined here
-  --> $DIR/empty-match.rs:22:12
+  --> $DIR/empty-match.rs:28:12
    |
 LL |     struct NonEmptyStruct1;
    |            ^^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyStruct1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyStruct1 => todo!()
-   |                                 ++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct2(_)` not covered
-  --> $DIR/empty-match.rs:66:24
+  --> $DIR/empty-match.rs:72:24
    |
 LL |     match_guarded_arm!(NonEmptyStruct2(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyStruct2(_)` not covered
    |
 note: `NonEmptyStruct2` defined here
-  --> $DIR/empty-match.rs:23:12
+  --> $DIR/empty-match.rs:29:12
    |
 LL |     struct NonEmptyStruct2(bool);
    |            ^^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyStruct2`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyStruct2(_) => todo!()
-   |                                 +++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/empty-match.rs:67:24
+  --> $DIR/empty-match.rs:73:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion1 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion1 { .. }` not covered
    |
 note: `NonEmptyUnion1` defined here
-  --> $DIR/empty-match.rs:24:11
+  --> $DIR/empty-match.rs:30:11
    |
 LL |     union NonEmptyUnion1 {
    |           ^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyUnion1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyUnion1 { .. } => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/empty-match.rs:68:24
+  --> $DIR/empty-match.rs:74:24
    |
 LL |     match_guarded_arm!((NonEmptyUnion2 { foo: () }));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyUnion2 { .. }` not covered
    |
 note: `NonEmptyUnion2` defined here
-  --> $DIR/empty-match.rs:27:11
+  --> $DIR/empty-match.rs:33:11
    |
 LL |     union NonEmptyUnion2 {
    |           ^^^^^^^^^^^^^^
    = note: the matched value is of type `NonEmptyUnion2`
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyUnion2 { .. } => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
-  --> $DIR/empty-match.rs:69:24
+  --> $DIR/empty-match.rs:75:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum1::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ pattern `NonEmptyEnum1::Foo(_)` not covered
    |
 note: `NonEmptyEnum1` defined here
-  --> $DIR/empty-match.rs:31:10
+  --> $DIR/empty-match.rs:37:10
    |
 LL |     enum NonEmptyEnum1 {
    |          ^^^^^^^^^^^^^
 LL |         Foo(bool),
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum1`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyEnum1::Foo(_) => todo!()
-   |                                 ++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
-  --> $DIR/empty-match.rs:70:24
+  --> $DIR/empty-match.rs:76:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum2::Foo(true));
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
    |
 note: `NonEmptyEnum2` defined here
-  --> $DIR/empty-match.rs:34:10
+  --> $DIR/empty-match.rs:40:10
    |
 LL |     enum NonEmptyEnum2 {
    |          ^^^^^^^^^^^^^
@@ -327,20 +438,29 @@ LL |         Foo(bool),
 LL |         Bar,
    |         --- not covered
    = note: the matched value is of type `NonEmptyEnum2`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
-   |                                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
-  --> $DIR/empty-match.rs:71:24
+  --> $DIR/empty-match.rs:77:24
    |
 LL |     match_guarded_arm!(NonEmptyEnum5::V1);
    |                        ^^^^^^^^^^^^^^^^^ patterns `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
    |
 note: `NonEmptyEnum5` defined here
-  --> $DIR/empty-match.rs:38:10
+  --> $DIR/empty-match.rs:44:10
    |
 LL |     enum NonEmptyEnum5 {
    |          ^^^^^^^^^^^^^
@@ -355,38 +475,91 @@ LL |         V4,
 LL |         V5,
    |         -- not covered
    = note: the matched value is of type `NonEmptyEnum5`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, _ => todo!()
-   |                                 ++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-match.rs:72:24
+  --> $DIR/empty-match.rs:78:24
    |
 LL |     match_guarded_arm!(array0_of_empty);
    |                        ^^^^^^^^^^^^^^^ pattern `[]` not covered
    |
    = note: the matched value is of type `[!; 0]`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, [] => todo!()
-   |                                 +++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
-  --> $DIR/empty-match.rs:73:24
+  --> $DIR/empty-match.rs:79:24
    |
 LL |     match_guarded_arm!(arrayN_of_empty);
    |                        ^^^^^^^^^^^^^^^ pattern `[]` not covered
    |
    = note: the matched value is of type `[!; N]`
-   = note: match arms with guards don't count towards exhaustivity
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
    |
-LL |                 _ if false => {}, [] => todo!()
-   |                                 +++++++++++++++
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
-error: aborting due to 26 previous errors
+error[E0004]: non-exhaustive patterns: `[]` not covered
+  --> $DIR/empty-match.rs:81:15
+   |
+LL |     indirect!(arrayN_of_empty);
+   |               ^^^^^^^^^^^^^^^ pattern `[]` not covered
+   |
+   = note: the matched value is of type `[!; N]`
+note: within macro `match_guarded_arm`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/empty-match.rs:16:13
+   |
+LL | /      macro_rules! match_guarded_arm {
+LL | |          ($e:expr) => {
+LL | |/             match $e {
+LL | ||                 _ if false => {}
+LL | ||             }
+   | ||_____________^
+LL | |          };
+LL | |      }
+   | |______-
+...
+LL |        indirect!(arrayN_of_empty);
+   |        -------------------------- in this macro invocation
+   = note: match arms with guards don't count towards exhaustivity
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
+   = note: this error originates in the macro `indirect` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 27 previous errors
 
 For more information about this error, try `rustc --explain E0004`.

--- a/tests/ui/pattern/usefulness/empty-match.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match.normal.stderr
@@ -176,9 +176,8 @@ LL |     match_guarded_arm!(0u8);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 0_u8..=u8::MAX => todo!()
-   |
+LL |                 _ if false => {}, 0_u8..=u8::MAX => todo!()
+   |                                 +++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i8::MIN..=i8::MAX` not covered
   --> $DIR/empty-match.rs:62:24
@@ -190,9 +189,8 @@ LL |     match_guarded_arm!(0i8);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 i8::MIN..=i8::MAX => todo!()
-   |
+LL |                 _ if false => {}, i8::MIN..=i8::MAX => todo!()
+   |                                 ++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_usize..` not covered
   --> $DIR/empty-match.rs:63:24
@@ -204,9 +202,8 @@ LL |     match_guarded_arm!(0usize);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 0_usize.. => todo!()
-   |
+LL |                 _ if false => {}, 0_usize.. => todo!()
+   |                                 ++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/empty-match.rs:64:24
@@ -218,9 +215,8 @@ LL |     match_guarded_arm!(0isize);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 _ => todo!()
-   |
+LL |                 _ if false => {}, _ => todo!()
+   |                                 ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct1` not covered
   --> $DIR/empty-match.rs:65:24
@@ -237,9 +233,8 @@ LL |     struct NonEmptyStruct1;
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyStruct1 => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyStruct1 => todo!()
+   |                                 ++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct2(_)` not covered
   --> $DIR/empty-match.rs:66:24
@@ -256,9 +251,8 @@ LL |     struct NonEmptyStruct2(bool);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyStruct2(_) => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyStruct2(_) => todo!()
+   |                                 +++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
   --> $DIR/empty-match.rs:67:24
@@ -275,9 +269,8 @@ LL |     union NonEmptyUnion1 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyUnion1 { .. } => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyUnion1 { .. } => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
   --> $DIR/empty-match.rs:68:24
@@ -295,9 +288,8 @@ LL |     union NonEmptyUnion2 {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyUnion2 { .. } => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyUnion2 { .. } => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum1::Foo(_)` not covered
   --> $DIR/empty-match.rs:69:24
@@ -316,9 +308,8 @@ LL |         Foo(bool),
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyEnum1::Foo(_) => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyEnum1::Foo(_) => todo!()
+   |                                 ++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum2::Foo(_)` and `NonEmptyEnum2::Bar` not covered
   --> $DIR/empty-match.rs:70:24
@@ -339,9 +330,8 @@ LL |         Bar,
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~                 _ if false => {},
-LL +                 NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
-   |
+LL |                 _ if false => {}, NonEmptyEnum2::Foo(_) | NonEmptyEnum2::Bar => todo!()
+   |                                 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
   --> $DIR/empty-match.rs:71:24
@@ -368,9 +358,8 @@ LL |         V5,
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~                 _ if false => {},
-LL +                 _ => todo!()
-   |
+LL |                 _ if false => {}, _ => todo!()
+   |                                 ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-match.rs:72:24
@@ -382,9 +371,8 @@ LL |     match_guarded_arm!(array0_of_empty);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 [] => todo!()
-   |
+LL |                 _ if false => {}, [] => todo!()
+   |                                 +++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-match.rs:73:24
@@ -396,9 +384,8 @@ LL |     match_guarded_arm!(arrayN_of_empty);
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~                 _ if false => {},
-LL +                 [] => todo!()
-   |
+LL |                 _ if false => {}, [] => todo!()
+   |                                 +++++++++++++++
 
 error: aborting due to 26 previous errors
 

--- a/tests/ui/pattern/usefulness/empty-match.rs
+++ b/tests/ui/pattern/usefulness/empty-match.rs
@@ -19,6 +19,12 @@ fn nonempty<const N: usize>(arrayN_of_empty: [!; N]) {
         };
     }
 
+    macro_rules! indirect {
+        ($e:expr) => {
+            match_guarded_arm!($e)
+        };
+    }
+
     struct NonEmptyStruct1;
     struct NonEmptyStruct2(bool);
     union NonEmptyUnion1 {
@@ -71,6 +77,8 @@ fn nonempty<const N: usize>(arrayN_of_empty: [!; N]) {
     match_guarded_arm!(NonEmptyEnum5::V1); //~ ERROR `NonEmptyEnum5::V1`, `NonEmptyEnum5::V2`, `NonEmptyEnum5::V3` and 2 more not covered
     match_guarded_arm!(array0_of_empty); //~ ERROR `[]` not covered
     match_guarded_arm!(arrayN_of_empty); //~ ERROR `[]` not covered
+
+    indirect!(arrayN_of_empty); //~ ERROR `[]` not covered
 }
 
 fn main() {}

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -139,7 +139,7 @@ note: `Result<u32, !>` defined here
    = note: the matched value is of type `Result<u32, !>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Err(_) => {},
+LL ~         Err(_) => {}
 LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
@@ -386,7 +386,7 @@ LL |     match slice_never {
    = note: the matched value is of type `&[!]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [_, _, _, ..] => {},
+LL ~         [_, _, _, ..] => {}
 LL +         &[] => todo!()
    |
 
@@ -400,7 +400,7 @@ LL |     match slice_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &[..] if false => {},
+LL ~         &[..] if false => {}
 LL +         &[] => todo!()
    |
 
@@ -483,7 +483,7 @@ LL |     match array_0_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [..] if false => {},
+LL ~         [..] if false => {}
 LL +         [] => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -93,7 +93,7 @@ note: `Result<u32, !>` defined here
    = note: the matched value is of type `Result<u32, !>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Err(_) => {},
+LL ~         Err(_) => {}
 LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
@@ -162,7 +162,7 @@ note: `Option<Void>` defined here
    = note: `Void` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~             None => {},
+LL ~             None => {}
 LL +             Some(!)
    |
 
@@ -334,7 +334,7 @@ LL |     match slice_never {
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [] => {},
+LL ~         [] => {}
 LL +         &[!, ..]
    |
 
@@ -347,7 +347,7 @@ LL |     match slice_never {
    = note: the matched value is of type `&[!]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         [_, _, _, ..] => {},
+LL ~         [_, _, _, ..] => {}
 LL +         &[] | &[!] | &[!, !] => todo!()
    |
 
@@ -361,7 +361,7 @@ LL |     match slice_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         &[..] if false => {},
+LL ~         &[..] if false => {}
 LL +         &[] | &[!, ..] => todo!()
    |
 
@@ -411,7 +411,7 @@ LL |     match array_0_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [..] if false => {},
+LL ~         [..] if false => {}
 LL +         [] => todo!()
    |
 
@@ -430,7 +430,7 @@ note: `Option<!>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &None => {},
+LL ~         &None => {}
 LL +         &Some(!)
    |
 
@@ -449,7 +449,7 @@ note: `Option<!>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(!)
    |
 
@@ -468,7 +468,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Ok(_) => {},
+LL ~         Ok(_) => {}
 LL +         Err(!)
    |
 
@@ -487,7 +487,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Ok(_a) => {},
+LL ~         Ok(_a) => {}
 LL +         Err(!)
    |
 
@@ -561,7 +561,7 @@ LL |     match ref_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &_a if false => {},
+LL ~         &_a if false => {}
 LL +         &!
    |
 
@@ -580,7 +580,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Err(_) => {},
+LL ~         Err(_) => {}
 LL +         Ok(!)
    |
 
@@ -599,7 +599,7 @@ note: `Option<Result<!, !>>` defined here
    = note: `Result<!, !>` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(!)
    |
 

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -84,7 +84,7 @@ note: `Result<u32, !>` defined here
    = note: the matched value is of type `Result<u32, !>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Err(_) => {},
+LL ~         Err(_) => {}
 LL ~         Ok(1_u32..=u32::MAX) => todo!()
    |
 
@@ -153,7 +153,7 @@ note: `Option<Void>` defined here
    = note: `Void` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~             None => {},
+LL ~             None => {}
 LL +             Some(_) => todo!()
    |
 
@@ -325,7 +325,7 @@ LL |     match slice_never {
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [] => {},
+LL ~         [] => {}
 LL +         &[_, ..] => todo!()
    |
 
@@ -338,7 +338,7 @@ LL |     match slice_never {
    = note: the matched value is of type `&[!]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         [_, _, _, ..] => {},
+LL ~         [_, _, _, ..] => {}
 LL +         &[] | &[_] | &[_, _] => todo!()
    |
 
@@ -352,7 +352,7 @@ LL |     match slice_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         &[..] if false => {},
+LL ~         &[..] if false => {}
 LL +         &[] | &[_, ..] => todo!()
    |
 
@@ -402,7 +402,7 @@ LL |     match array_0_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [..] if false => {},
+LL ~         [..] if false => {}
 LL +         [] => todo!()
    |
 
@@ -421,7 +421,7 @@ note: `Option<!>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &None => {},
+LL ~         &None => {}
 LL +         &Some(_) => todo!()
    |
 
@@ -440,7 +440,7 @@ note: `Option<!>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(_) => todo!()
    |
 
@@ -459,7 +459,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Ok(_) => {},
+LL ~         Ok(_) => {}
 LL +         Err(_) => todo!()
    |
 
@@ -478,7 +478,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Ok(_a) => {},
+LL ~         Ok(_a) => {}
 LL +         Err(_) => todo!()
    |
 
@@ -552,7 +552,7 @@ LL |     match ref_never {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &_a if false => {},
+LL ~         &_a if false => {}
 LL +         &_ => todo!()
    |
 
@@ -571,7 +571,7 @@ note: `Result<!, !>` defined here
    = note: `!` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Err(_) => {},
+LL ~         Err(_) => {}
 LL +         Ok(_) => todo!()
    |
 
@@ -590,7 +590,7 @@ note: `Option<Result<!, !>>` defined here
    = note: `Result<!, !>` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(_) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/floats.stderr
+++ b/tests/ui/pattern/usefulness/floats.stderr
@@ -7,7 +7,7 @@ LL |     match 0.0 {
    = note: the matched value is of type `f64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         0.0..=1.0 => {},
+LL ~         0.0..=1.0 => {}
 LL +         _ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/guards.stderr
+++ b/tests/ui/pattern/usefulness/guards.stderr
@@ -7,7 +7,7 @@ LL |     match 0u8 {
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         128 ..= 255 if true => {},
+LL ~         128 ..= 255 if true => {}
 LL +         128_u8..=u8::MAX => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
@@ -5,10 +5,17 @@ LL |     m!(0u8, 0..255);
    |        ^^^ pattern `u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/exhaustiveness.rs:48:8
@@ -17,10 +24,17 @@ LL |     m!(0u8, 0..=254);
    |        ^^^ pattern `u8::MAX` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u8` not covered
   --> $DIR/exhaustiveness.rs:49:8
@@ -29,10 +43,17 @@ LL |     m!(0u8, 1..=255);
    |        ^^^ pattern `0_u8` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, 0_u8 => todo!() }
-   |                                +++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `42_u8` not covered
   --> $DIR/exhaustiveness.rs:50:8
@@ -41,10 +62,17 @@ LL |     m!(0u8, 0..42 | 43..=255);
    |        ^^^ pattern `42_u8` not covered
    |
    = note: the matched value is of type `u8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, 42_u8 => todo!() }
-   |                                ++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/exhaustiveness.rs:51:8
@@ -53,10 +81,17 @@ LL |     m!(0i8, -128..127);
    |        ^^^ pattern `i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/exhaustiveness.rs:52:8
@@ -65,10 +100,17 @@ LL |     m!(0i8, -128..=126);
    |        ^^^ pattern `i8::MAX` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
   --> $DIR/exhaustiveness.rs:53:8
@@ -77,10 +119,17 @@ LL |     m!(0i8, -127..=127);
    |        ^^^ pattern `i8::MIN` not covered
    |
    = note: the matched value is of type `i8`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, i8::MIN => todo!() }
-   |                                ++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_i8` not covered
   --> $DIR/exhaustiveness.rs:54:11
@@ -102,10 +151,17 @@ LL |     m!(0u128, 0..=ALMOST_MAX);
    |        ^^^^^ pattern `u128::MAX` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, u128::MAX => todo!() }
-   |                                ++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `5_u128..` not covered
   --> $DIR/exhaustiveness.rs:60:8
@@ -114,10 +170,17 @@ LL |     m!(0u128, 0..=4);
    |        ^^^^^ pattern `5_u128..` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, 5_u128.. => todo!() }
-   |                                +++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `0_u128` not covered
   --> $DIR/exhaustiveness.rs:61:8
@@ -126,10 +189,17 @@ LL |     m!(0u128, 1..=u128::MAX);
    |        ^^^^^ pattern `0_u128` not covered
    |
    = note: the matched value is of type `u128`
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/exhaustiveness.rs:7:9
    |
-LL |         match $s { $($t)+ => {}, 0_u128 => todo!() }
-   |                                +++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `(126_u8..=127_u8, false)` not covered
   --> $DIR/exhaustiveness.rs:69:11

--- a/tests/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
@@ -91,7 +91,7 @@ LL |     match 0i8 {
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         1 ..= i8::MAX => {},
+LL ~         1 ..= i8::MAX => {}
 LL +         0_i8 => todo!()
    |
 
@@ -140,7 +140,7 @@ LL |     match (0u8, true) {
    = note: the matched value is of type `(u8, bool)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         (0 ..= 255, true) => {},
+LL ~         (0 ..= 255, true) => {}
 LL +         (126_u8..=127_u8, false) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
@@ -8,7 +8,7 @@ LL |     match 0usize {
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         0..=usize::MAX => {},
+LL ~         0..=usize::MAX => {}
 LL +         usize::MAX.. => todo!()
    |
 
@@ -22,7 +22,7 @@ LL |     match 0isize {
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         isize::MIN..=isize::MAX => {},
+LL ~         isize::MIN..=isize::MAX => {}
 LL +         ..isize::MIN | isize::MAX.. => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
@@ -34,10 +34,17 @@ LL |     m!(0usize, 0..=usize::MAX);
    |
    = note: the matched value is of type `usize`
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, usize::MAX.. => todo!() }
-   |                                +++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `usize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:24:8
@@ -47,10 +54,17 @@ LL |     m!(0usize, 0..5 | 5..=usize::MAX);
    |
    = note: the matched value is of type `usize`
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, usize::MAX.. => todo!() }
-   |                                +++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `usize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:26:8
@@ -60,10 +74,17 @@ LL |     m!(0usize, 0..usize::MAX | usize::MAX);
    |
    = note: the matched value is of type `usize`
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, usize::MAX.. => todo!() }
-   |                                +++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `(usize::MAX.., _)` not covered
   --> $DIR/pointer-sized-int.rs:28:8
@@ -73,10 +94,17 @@ LL |     m!((0usize, true), (0..5, true) | (5..=usize::MAX, true) | (0..=usize::
    |
    = note: the matched value is of type `(usize, bool)`
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, (usize::MAX.., _) => todo!() }
-   |                                ++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern
 
 error[E0004]: non-exhaustive patterns: `..isize::MIN` and `isize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:37:8
@@ -86,10 +114,17 @@ LL |     m!(0isize, isize::MIN..=isize::MAX);
    |
    = note: the matched value is of type `isize`
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `..isize::MIN` and `isize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:39:8
@@ -99,10 +134,17 @@ LL |     m!(0isize, isize::MIN..5 | 5..=isize::MAX);
    |
    = note: the matched value is of type `isize`
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `..isize::MIN` and `isize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:41:8
@@ -112,10 +154,17 @@ LL |     m!(0isize, isize::MIN..=-1 | 0 | 1..=isize::MAX);
    |
    = note: the matched value is of type `isize`
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `..isize::MIN` and `isize::MAX..` not covered
   --> $DIR/pointer-sized-int.rs:43:8
@@ -125,10 +174,17 @@ LL |     m!(0isize, isize::MIN..isize::MAX | isize::MAX);
    |
    = note: the matched value is of type `isize`
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, ..isize::MIN | isize::MAX.. => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: `(..isize::MIN, _)` and `(isize::MAX.., _)` not covered
   --> $DIR/pointer-sized-int.rs:46:9
@@ -138,10 +194,17 @@ LL |         (0isize, true),
    |
    = note: the matched value is of type `(isize, bool)`
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
-help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
+note: within macro `m`, this `match` expression doesn't expand to cover all patterns
+  --> $DIR/pointer-sized-int.rs:6:9
    |
-LL |         match $s { $($t)+ => {}, (..isize::MIN, _) | (isize::MAX.., _) => todo!() }
-   |                                ++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | / macro_rules! m {
+LL | |     ($s:expr, $($t:tt)+) => {
+LL | |         match $s { $($t)+ => {} }
+   | |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | |     }
+LL | | }
+   | |_-
+   = help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or multiple match arms
 
 error[E0004]: non-exhaustive patterns: type `usize` is non-empty
   --> $DIR/pointer-sized-int.rs:57:11

--- a/tests/ui/pattern/usefulness/integer-ranges/precise_pointer_matching-message.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/precise_pointer_matching-message.stderr
@@ -8,7 +8,7 @@ LL |     match 0usize {
    = note: `usize` does not have a fixed maximum value, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         0..=usize::MAX => {},
+LL ~         0..=usize::MAX => {}
 LL +         usize::MAX.. => todo!()
    |
 
@@ -22,7 +22,7 @@ LL |     match 0isize {
    = note: `isize` does not have fixed minimum and maximum values, so half-open ranges are necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         isize::MIN..=isize::MAX => {},
+LL ~         isize::MIN..=isize::MAX => {}
 LL +         ..isize::MIN | isize::MAX.. => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-105479-str-non-exhaustiveness.stderr
+++ b/tests/ui/pattern/usefulness/issue-105479-str-non-exhaustiveness.stderr
@@ -8,7 +8,7 @@ LL |     match (a, b) {
    = note: `&str` cannot be matched exhaustively, so a wildcard `_` is necessary
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         ("c", "d") => {},
+LL ~         ("c", "d") => {}
 LL +         (&_, _) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-15129.stderr
+++ b/tests/ui/pattern/usefulness/issue-15129.stderr
@@ -8,7 +8,7 @@ LL |     match (T::T1(()), V::V2(true)) {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         (T::T2(()), V::V2(b)) => (),
-LL ~         (T::T1(()), V::V2(_)) | (T::T2(()), V::V1(_)) => todo!(),
+LL +         (T::T1(()), V::V2(_)) | (T::T2(()), V::V1(_)) => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/issue-2111.stderr
+++ b/tests/ui/pattern/usefulness/issue-2111.stderr
@@ -7,7 +7,7 @@ LL |     match (a, b) {
    = note: the matched value is of type `(Option<usize>, Option<usize>)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         (Some(_), None) | (None, Some(_)) => {},
+LL ~         (Some(_), None) | (None, Some(_)) => {}
 LL +         (None, None) | (Some(_), Some(_)) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-30240.stderr
+++ b/tests/ui/pattern/usefulness/issue-30240.stderr
@@ -8,7 +8,7 @@ LL |     match "world" {
    = note: `&str` cannot be matched exhaustively, so a wildcard `_` is necessary
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         "hello" => {},
+LL ~         "hello" => {}
 LL +         &_ => todo!()
    |
 
@@ -22,7 +22,7 @@ LL |     match "world" {
    = note: `&str` cannot be matched exhaustively, so a wildcard `_` is necessary
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         "hello" => {},
+LL ~         "hello" => {}
 LL +         &_ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-35609.stderr
+++ b/tests/ui/pattern/usefulness/issue-35609.stderr
@@ -7,7 +7,7 @@ LL |     match (A, ()) {
    = note: the matched value is of type `(Enum, ())`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         (A, _) => {},
+LL ~         (A, _) => {}
 LL +         _ => todo!()
    |
 
@@ -20,7 +20,7 @@ LL |     match (A, A) {
    = note: the matched value is of type `(Enum, Enum)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         (_, A) => {},
+LL ~         (_, A) => {}
 LL +         _ => todo!()
    |
 
@@ -33,7 +33,7 @@ LL |     match ((A, ()), ()) {
    = note: the matched value is of type `((Enum, ()), ())`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         ((A, ()), _) => {},
+LL ~         ((A, ()), _) => {}
 LL +         _ => todo!()
    |
 
@@ -46,7 +46,7 @@ LL |     match ((A, ()), A) {
    = note: the matched value is of type `((Enum, ()), Enum)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         ((A, ()), _) => {},
+LL ~         ((A, ()), _) => {}
 LL +         _ => todo!()
    |
 
@@ -59,7 +59,7 @@ LL |     match ((A, ()), ()) {
    = note: the matched value is of type `((Enum, ()), ())`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         ((A, _), _) => {},
+LL ~         ((A, _), _) => {}
 LL +         _ => todo!()
    |
 
@@ -77,7 +77,7 @@ LL | struct S(Enum, ());
    = note: the matched value is of type `S`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         S(A, _) => {},
+LL ~         S(A, _) => {}
 LL +         _ => todo!()
    |
 
@@ -95,7 +95,7 @@ LL | struct Sd { x: Enum, y: () }
    = note: the matched value is of type `Sd`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         Sd { x: A, y: _ } => {},
+LL ~         Sd { x: A, y: _ } => {}
 LL +         _ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-3601.stderr
+++ b/tests/ui/pattern/usefulness/issue-3601.stderr
@@ -11,7 +11,7 @@ note: `Box<ElementKind>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~             box ElementKind::HTMLImageElement(ref d) if d.image.is_some() => true,
-LL ~             box ElementKind::HTMLImageElement(_) => todo!(),
+LL +             box ElementKind::HTMLImageElement(_) => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/issue-39362.stderr
+++ b/tests/ui/pattern/usefulness/issue-39362.stderr
@@ -15,7 +15,7 @@ LL |     Bar { bar: Bar, id: usize }
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
 LL ~         Foo::Bar { bar: Bar::B, .. } => (),
-LL ~         _ => todo!(),
+LL +         _ => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/issue-40221.stderr
+++ b/tests/ui/pattern/usefulness/issue-40221.stderr
@@ -15,7 +15,7 @@ LL |     C(PC),
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         P::C(PC::Q) => (),
-LL ~         P::C(PC::QA) => todo!(),
+LL +         P::C(PC::QA) => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/issue-50900.stderr
+++ b/tests/ui/pattern/usefulness/issue-50900.stderr
@@ -12,7 +12,7 @@ LL | pub struct Tag(pub Context, pub u16);
    = note: the matched value is of type `Tag`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Tag::ExifIFDPointer => {},
+LL ~         Tag::ExifIFDPointer => {}
 LL +         Tag(Context::Exif, _) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-56379.stderr
+++ b/tests/ui/pattern/usefulness/issue-56379.stderr
@@ -18,7 +18,7 @@ LL |     C(bool),
    = note: the matched value is of type `Foo`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         Foo::C(true) => {},
+LL ~         Foo::C(true) => {}
 LL +         Foo::A(false) | Foo::B(false) | Foo::C(false) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-72377.stderr
+++ b/tests/ui/pattern/usefulness/issue-72377.stderr
@@ -8,7 +8,7 @@ LL |     match (x, y) {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
 LL ~         (X::A, Some(X::C)) | (X::C, Some(X::A)) => false,
-LL ~         _ => todo!(),
+LL +         _ => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
+++ b/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
@@ -54,7 +54,7 @@ note: `Option<usize>` defined here
    = note: the matched value is of type `Option<usize>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(_) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
+++ b/tests/ui/pattern/usefulness/issue-85222-types-containing-non-exhaustive-types.stderr
@@ -9,7 +9,7 @@ LL |     match 0 {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         1..=usize::MAX => (),
-LL ~         usize::MAX.. => todo!(),
+LL +         usize::MAX.. => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `(usize::MAX.., _)` not covered
@@ -23,7 +23,7 @@ LL |     match (0usize, 0usize) {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         (1..=usize::MAX, 1..=usize::MAX) => (),
-LL ~         (usize::MAX.., _) => todo!(),
+LL +         (usize::MAX.., _) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `(..isize::MIN, _)` and `(isize::MAX.., _)` not covered
@@ -37,7 +37,7 @@ LL |     match (0isize, 0usize) {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         (isize::MIN..=isize::MAX, 1..=usize::MAX) => (),
-LL ~         (..isize::MIN, _) | (isize::MAX.., _) => todo!(),
+LL +         (..isize::MIN, _) | (isize::MAX.., _) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
@@ -74,7 +74,7 @@ note: `Option<usize>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => (),
-LL ~         Some(usize::MAX..) => todo!(),
+LL +         Some(usize::MAX..) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Some(Some(Some(usize::MAX..)))` not covered
@@ -97,7 +97,7 @@ note: `Option<Option<Option<usize>>>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         None => (),
-LL ~         Some(Some(Some(usize::MAX..))) => todo!(),
+LL +         Some(Some(Some(usize::MAX..))) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `A { a: usize::MAX.. }` not covered
@@ -116,7 +116,7 @@ LL | struct A<T> {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         A { a: 1..=usize::MAX } => (),
-LL ~         A { a: usize::MAX.. } => todo!(),
+LL +         A { a: usize::MAX.. } => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `B(..isize::MIN, _)` and `B(isize::MAX.., _)` not covered
@@ -135,7 +135,7 @@ LL | struct B<T, U>(T, U);
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         B(isize::MIN..=isize::MAX, 1..=usize::MAX) => (),
-LL ~         B(..isize::MIN, _) | B(isize::MAX.., _) => todo!(),
+LL +         B(..isize::MIN, _) | B(isize::MAX.., _) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `B(_, usize::MAX..)` not covered
@@ -154,7 +154,7 @@ LL | struct B<T, U>(T, U);
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         B(_, 1..=usize::MAX) => (),
-LL ~         B(_, usize::MAX..) => todo!(),
+LL +         B(_, usize::MAX..) => todo!()
    |
 
 error: aborting due to 9 previous errors

--- a/tests/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
+++ b/tests/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
@@ -7,7 +7,7 @@ LL |     match buf {
    = note: the matched value is of type `&[u8; 4]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         b"AAAA" => {},
+LL ~         b"AAAA" => {}
 LL +         &[0_u8..=64_u8, _, _, _] | &[66_u8..=u8::MAX, _, _, _] => todo!()
    |
 
@@ -20,7 +20,7 @@ LL |     match buf {
    = note: the matched value is of type `&[u8]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~         b"AAAA" => {},
+LL ~         b"AAAA" => {}
 LL +         _ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/match-privately-empty.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/match-privately-empty.exhaustive_patterns.stderr
@@ -12,7 +12,7 @@ note: `Option<Private>` defined here
    = note: the matched value is of type `Option<Private>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Some(private::Private { misc: false, .. }) => {},
+LL ~         Some(private::Private { misc: false, .. }) => {}
 LL +         Some(Private { misc: true, .. }) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/match-privately-empty.normal.stderr
+++ b/tests/ui/pattern/usefulness/match-privately-empty.normal.stderr
@@ -12,7 +12,7 @@ note: `Option<Private>` defined here
    = note: the matched value is of type `Option<Private>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Some(private::Private { misc: false, .. }) => {},
+LL ~         Some(private::Private { misc: false, .. }) => {}
 LL +         Some(Private { misc: true, .. }) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/match-slice-patterns.stderr
+++ b/tests/ui/pattern/usefulness/match-slice-patterns.stderr
@@ -8,7 +8,7 @@ LL |     match list {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &[.., Some(_), _] => {},
-LL ~         &[_, Some(_), .., None, _] => todo!(),
+LL +         &[_, Some(_), .., None, _] => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/nested-non-exhaustive-enums.stderr
+++ b/tests/ui/pattern/usefulness/nested-non-exhaustive-enums.stderr
@@ -13,7 +13,7 @@ note: `Option<NonExhaustiveEnum>` defined here
    = note: `NonExhaustiveEnum` is marked as non-exhaustive, so a wildcard `_` is necessary to match exhaustively
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         Some(_) => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-defined-here.stderr
@@ -18,7 +18,7 @@ LL |     C
    = note: the matched value is of type `E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         E::A => {},
+LL ~         E::A => {}
 LL +         E::B | E::C => todo!()
    |
 
@@ -67,7 +67,7 @@ LL |     C
    = note: the matched value is of type `&E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         E::A => {},
+LL ~         E::A => {}
 LL +         &E::B | &E::C => todo!()
    |
 
@@ -116,7 +116,7 @@ LL |     C
    = note: the matched value is of type `&&mut &E`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         E::A => {},
+LL ~         E::A => {}
 LL +         &&mut &E::B | &&mut &E::C => todo!()
    |
 
@@ -162,7 +162,7 @@ LL |     None,
    = note: the matched value is of type `Opt`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Opt::Some(ref _x) => {},
+LL ~         Opt::Some(ref _x) => {}
 LL +         Opt::None => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -12,8 +12,8 @@ LL | enum T { A, B }
    = note: the matched value is of type `T`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL |     match x { T::B => { }, T::A => todo!() }
-   |                          +++++++++++++++++
+LL |     match x { T::B => { } T::A => todo!() }
+   |                           +++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `false` not covered
   --> $DIR/non-exhaustive-match.rs:6:11
@@ -24,7 +24,7 @@ LL |     match true {
    = note: the matched value is of type `bool`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~       true => {},
+LL ~       true => {}
 LL +       false => todo!()
    |
 
@@ -42,7 +42,7 @@ note: `Option<i32>` defined here
    = note: the matched value is of type `Option<i32>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~       None => {},
+LL ~       None => {}
 LL +       Some(_) => todo!()
    |
 
@@ -55,7 +55,7 @@ LL |     match (2, 3, 4) {
    = note: the matched value is of type `(i32, i32, i32)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~       (_, _, 4) => {},
+LL ~       (_, _, 4) => {}
 LL +       (_, _, i32::MIN..=3_i32) | (_, _, 5_i32..=i32::MAX) => todo!()
    |
 
@@ -68,7 +68,7 @@ LL |     match (T::A, T::A) {
    = note: the matched value is of type `(T, T)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~       (T::B, T::A) => {},
+LL ~       (T::B, T::A) => {}
 LL +       (T::A, T::A) | (T::B, T::B) => todo!()
    |
 
@@ -86,7 +86,7 @@ LL | enum T { A, B }
    = note: the matched value is of type `T`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~       T::A => {},
+LL ~       T::A => {}
 LL +       T::B => todo!()
    |
 
@@ -99,7 +99,7 @@ LL |     match *vec {
    = note: the matched value is of type `[Option<isize>]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [None] => {},
+LL ~         [None] => {}
 LL +         [] => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
+++ b/tests/ui/pattern/usefulness/non-exhaustive-pattern-witness.stderr
@@ -13,7 +13,7 @@ LL | struct Foo {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Foo { first: false, second: Some([1, 2, 3, 4]) } => (),
-LL ~         Foo { first: false, second: Some([0_usize, _, _, _]) } | Foo { first: false, second: Some([2_usize.., _, _, _]) } => todo!(),
+LL +         Foo { first: false, second: Some([0_usize, _, _, _]) } | Foo { first: false, second: Some([2_usize.., _, _, _]) } => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Color::Red` not covered
@@ -33,7 +33,7 @@ LL |     Red,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Color::Green => (),
-LL ~         Color::Red => todo!(),
+LL +         Color::Red => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Direction::East`, `Direction::South` and `Direction::West` not covered
@@ -58,7 +58,7 @@ LL |     West,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         Direction::North => (),
-LL ~         Direction::East | Direction::South | Direction::West => todo!(),
+LL +         Direction::East | Direction::South | Direction::West => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `ExcessiveEnum::Second`, `ExcessiveEnum::Third`, `ExcessiveEnum::Fourth` and 8 more not covered
@@ -87,7 +87,7 @@ LL |     Sixth,
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
 LL ~         ExcessiveEnum::First => (),
-LL ~         _ => todo!(),
+LL +         _ => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `Color::CustomRGBA { a: true, .. }` not covered
@@ -108,7 +108,7 @@ LL |     CustomRGBA { a: bool, r: u8, g: u8, b: u8 },
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Color::CustomRGBA { a: false, r: _, g: _, b: _ } => (),
-LL ~         Color::CustomRGBA { a: true, .. } => todo!(),
+LL +         Color::CustomRGBA { a: true, .. } => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `[Enum::Second(true), Enum::Second(false)]` not covered
@@ -121,7 +121,7 @@ LL |     match *x {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         [_, _, ref tail @ .., _] => (),
-LL ~         [Enum::Second(true), Enum::Second(false)] => todo!(),
+LL +         [Enum::Second(true), Enum::Second(false)] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `((), false)` not covered
@@ -134,7 +134,7 @@ LL |     match ((), false) {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         ((), true) => (),
-LL ~         ((), false) => todo!(),
+LL +         ((), false) => todo!()
    |
 
 error: aborting due to 7 previous errors

--- a/tests/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
+++ b/tests/ui/pattern/usefulness/slice-patterns-exhaustiveness.stderr
@@ -7,7 +7,7 @@ LL |     match s2 {
    = note: the matched value is of type `&[bool; 2]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [true, .., true] => {},
+LL ~         [true, .., true] => {}
 LL +         &[false, _] => todo!()
    |
 
@@ -20,7 +20,7 @@ LL |     match s3 {
    = note: the matched value is of type `&[bool; 3]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [true, .., true] => {},
+LL ~         [true, .., true] => {}
 LL +         &[false, ..] => todo!()
    |
 
@@ -33,7 +33,7 @@ LL |     match s10 {
    = note: the matched value is of type `&[bool; 10]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [true, .., true] => {},
+LL ~         [true, .., true] => {}
 LL +         &[false, ..] => todo!()
    |
 
@@ -46,7 +46,7 @@ LL |     match s2 {
    = note: the matched value is of type `&[bool; 2]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [.., false] => {},
+LL ~         [.., false] => {}
 LL +         &[false, true] => todo!()
    |
 
@@ -59,7 +59,7 @@ LL |     match s3 {
    = note: the matched value is of type `&[bool; 3]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [.., false] => {},
+LL ~         [.., false] => {}
 LL +         &[false, .., true] => todo!()
    |
 
@@ -72,7 +72,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [.., false] => {},
+LL ~         [.., false] => {}
 LL +         &[false, .., true] => todo!()
    |
 
@@ -85,7 +85,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [] => {},
+LL ~         [] => {}
 LL +         &[_, ..] => todo!()
    |
 
@@ -99,7 +99,7 @@ LL |     match s {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         [..] if false => {},
+LL ~         [..] if false => {}
 LL +         &[] | &[_, ..] => todo!()
    |
 
@@ -112,7 +112,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [_] => {},
+LL ~         [_] => {}
 LL +         &[_, _, ..] => todo!()
    |
 
@@ -125,7 +125,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [true, ..] => {},
+LL ~         [true, ..] => {}
 LL +         &[false, ..] => todo!()
    |
 
@@ -138,7 +138,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [true, ..] => {},
+LL ~         [true, ..] => {}
 LL +         &[false, _, ..] => todo!()
    |
 
@@ -151,7 +151,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [.., true] => {},
+LL ~         [.., true] => {}
 LL +         &[_, .., false] => todo!()
    |
 
@@ -164,7 +164,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [.., false] => {},
+LL ~         [.., false] => {}
 LL +         &[_, _, .., true] => todo!()
    |
 
@@ -177,7 +177,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         [false, .., false] => {},
+LL ~         [false, .., false] => {}
 LL +         &[true, _, .., _] => todo!()
    |
 
@@ -190,7 +190,7 @@ LL |     match s {
    = note: the matched value is of type `&[bool]`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         &[true] => {},
+LL ~         &[true] => {}
 LL +         &[] | &[_, _, ..] => todo!()
    |
 
@@ -215,7 +215,7 @@ LL |         CONST_var => {}
    |              ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         CONST => {},
+LL ~         CONST => {}
 LL +         &[] | &[_, _, ..] => todo!()
    |
 
@@ -240,7 +240,7 @@ LL |         CONST_var => {}
    |              ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         &[false] => {},
+LL ~         &[false] => {}
 LL +         &[] | &[_, _, ..] => todo!()
    |
 
@@ -265,7 +265,7 @@ LL |         CONST_var => {}
    |              ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         CONST => {},
+LL ~         CONST => {}
 LL +         &[] | &[_, _, ..] => todo!()
    |
 
@@ -290,7 +290,7 @@ LL |         CONST_var => {}
    |              ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         CONST => {},
+LL ~         CONST => {}
 LL +         &[_, _, ..] => todo!()
    |
 
@@ -315,7 +315,7 @@ LL |         CONST_var => {}
    |              ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         &[_, _, ..] => {},
+LL ~         &[_, _, ..] => {}
 LL +         &[false] => todo!()
    |
 
@@ -340,7 +340,7 @@ LL |         CONST1_var => {}
    |               ++++
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         CONST1 => {},
+LL ~         CONST1 => {}
 LL +         &[false] => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/slice_of_empty.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/slice_of_empty.exhaustive_patterns.stderr
@@ -8,7 +8,7 @@ LL |     match nevers {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &[_] => (),
-LL ~         &[] => todo!(),
+LL +         &[] => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/pattern/usefulness/slice_of_empty.normal.stderr
+++ b/tests/ui/pattern/usefulness/slice_of_empty.normal.stderr
@@ -9,7 +9,7 @@ LL |     match nevers {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &[] => (),
-LL ~         &[_, ..] => todo!(),
+LL +         &[_, ..] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]` and `&[_, _, ..]` not covered
@@ -22,7 +22,7 @@ LL |     match nevers {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
 LL ~         &[_] => (),
-LL ~         &[] | &[_, _, ..] => todo!(),
+LL +         &[] | &[_, _, ..] => todo!()
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/pattern/usefulness/stable-gated-patterns.stderr
+++ b/tests/ui/pattern/usefulness/stable-gated-patterns.stderr
@@ -15,7 +15,7 @@ LL |     Stable2,
    = note: the matched value is of type `UnstableEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~         UnstableEnum::Stable => {},
+LL ~         UnstableEnum::Stable => {}
 LL +         UnstableEnum::Stable2 | _ => todo!()
    |
 
@@ -33,7 +33,7 @@ LL | pub enum UnstableEnum {
    = note: the matched value is of type `UnstableEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         UnstableEnum::Stable2 => {},
+LL ~         UnstableEnum::Stable2 => {}
 LL +         _ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/struct-like-enum-nonexhaustive.stderr
+++ b/tests/ui/pattern/usefulness/struct-like-enum-nonexhaustive.stderr
@@ -14,7 +14,7 @@ LL |     B { x: Option<isize> },
    = note: the matched value is of type `A`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         A::B { x: None } => {},
+LL ~         A::B { x: None } => {}
 LL +         A::B { x: Some(_) } => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/type_polymorphic_byte_str_literals.stderr
+++ b/tests/ui/pattern/usefulness/type_polymorphic_byte_str_literals.stderr
@@ -8,7 +8,7 @@ LL |     match data {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         b"" => 1,
-LL ~         &[_, ..] => todo!(),
+LL +         &[_, ..] => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: `&[]`, `&[_]`, `&[_, _]` and 1 more not covered
@@ -21,7 +21,7 @@ LL |     match data {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
 LL ~         [_, _, _] => 1,
-LL ~         _ => todo!(),
+LL +         _ => todo!()
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/pattern/usefulness/unions.stderr
+++ b/tests/ui/pattern/usefulness/unions.stderr
@@ -12,7 +12,7 @@ LL |     union U8AsBool {
    = note: the matched value is of type `U8AsBool`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern, a match arm with multiple or-patterns as shown, or multiple match arms
    |
-LL ~             U8AsBool { n: 1.. } => {},
+LL ~             U8AsBool { n: 1.. } => {}
 LL +             U8AsBool { n: 0_u8 } | U8AsBool { b: false } => todo!()
    |
 
@@ -25,7 +25,7 @@ LL |         match (x, true) {
    = note: the matched value is of type `(U8AsBool, bool)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern as shown, or multiple match arms
    |
-LL ~             (U8AsBool { n: 1.. }, true) => {},
+LL ~             (U8AsBool { n: 1.. }, true) => {}
 LL +             _ => todo!()
    |
 

--- a/tests/ui/pattern/usefulness/unstable-gated-patterns.stderr
+++ b/tests/ui/pattern/usefulness/unstable-gated-patterns.stderr
@@ -15,7 +15,7 @@ LL |     Unstable,
    = note: the matched value is of type `UnstableEnum`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         UnstableEnum::Stable2 => {},
+LL ~         UnstableEnum::Stable2 => {}
 LL +         UnstableEnum::Unstable => todo!()
    |
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-119271-never-arm-attr-in-guard.stderr
@@ -22,7 +22,16 @@ error: a guard on a never pattern will never be run
   --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:8:13
    |
 LL |             false
-   |             ^^^^^ help: remove this guard
+   |             ^^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         Some(!)
+LL -
+LL -             if #[deny(unused_mut)]
+LL -             false
+LL +         Some(!),
+   |
 
 error: mismatched types
   --> $DIR/ICE-119271-never-arm-attr-in-guard.rs:5:14

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block.stderr
@@ -16,10 +16,15 @@ error: a never pattern is always unreachable
   --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:10:20
    |
 LL |         if true => {}
-   |                    ^^
-   |                    |
-   |                    this will never be executed
-   |                    help: remove this expression
+   |                    ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         ! |
+LL -
+LL -         if true => {}
+LL +         ! |,
+   |
 
 error: mismatched types
   --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:8:9

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
@@ -7,7 +7,7 @@ LL |             (!|!) if false => {}
 help: remove the match arm expression
    |
 LL -             (!|!) if false => {}
-LL +             (!|!,
+LL +             (!|!),
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133063-never-arm-no-otherwise-block.stderr
@@ -2,10 +2,13 @@ error: a never pattern is always unreachable
   --> $DIR/ICE-133063-never-arm-no-otherwise-block.rs:10:31
    |
 LL |             (!|!) if false => {}
-   |                               ^^
-   |                               |
-   |                               this will never be executed
-   |                               help: remove this expression
+   |                               ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -             (!|!) if false => {}
+LL +             (!|!,
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.fixed
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.fixed
@@ -6,8 +6,8 @@ enum Void {}
 
 fn foo(x: Void) {
     match x {
-        (!|!) if true => {} //~ ERROR a never pattern is always unreachable
-        (!|!) if true => {} //~ ERROR a never pattern is always unreachable
+        (!|!), //~ ERROR a never pattern is always unreachable
+        (!|!), //~ ERROR a never pattern is always unreachable
     }
 }
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
@@ -7,7 +7,7 @@ LL |         (!|!) if true => {}
 help: remove the match arm expression
    |
 LL -         (!|!) if true => {}
-LL +         (!|!,
+LL +         (!|!),
    |
 
 error: a never pattern is always unreachable
@@ -19,7 +19,7 @@ LL |         (!|!) if true => {}
 help: remove the match arm expression
    |
 LL -         (!|!) if true => {}
-LL +         (!|!,
+LL +         (!|!),
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-133117-duplicate-never-arm.stderr
@@ -2,19 +2,25 @@ error: a never pattern is always unreachable
   --> $DIR/ICE-133117-duplicate-never-arm.rs:9:26
    |
 LL |         (!|!) if true => {}
-   |                          ^^
-   |                          |
-   |                          this will never be executed
-   |                          help: remove this expression
+   |                          ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         (!|!) if true => {}
+LL +         (!|!,
+   |
 
 error: a never pattern is always unreachable
   --> $DIR/ICE-133117-duplicate-never-arm.rs:10:26
    |
 LL |         (!|!) if true => {}
-   |                          ^^
-   |                          |
-   |                          this will never be executed
-   |                          help: remove this expression
+   |                          ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         (!|!) if true => {}
+LL +         (!|!,
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.fixed
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.fixed
@@ -13,22 +13,24 @@ macro_rules! never {
 
 fn no_arms_or_guards(x: Void) {
     match &None::<Void> {
-        Some(!) => {}
+        Some(!),
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }
     match &None::<Void> { //~ ERROR: `&Some(!)` not covered
-        Some(!) if true,
+        Some(!),
         //~^ ERROR guard on a never pattern
         None => {}
+        &Some(!)
     }
     match &None::<Void> { //~ ERROR: `&Some(!)` not covered
-        Some(!) if true => {}
+        Some(!),
         //~^ ERROR a never pattern is always unreachable
         None => {}
+        &Some(!)
     }
     match &None::<Void> {
-        Some(never!()) => {}
+        Some(never!()),
         //~^ ERROR a never pattern is always unreachable
         None => {}
     }

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
@@ -1,38 +1,53 @@
 error: a never pattern is always unreachable
-  --> $DIR/check.rs:15:20
+  --> $DIR/check.rs:16:20
    |
 LL |         Some(!) => {}
-   |                    ^^
-   |                    |
-   |                    this will never be executed
-   |                    help: remove this expression
+   |                    ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         Some(!) => {}
+LL +         Some(!),
+   |
 
 error: a guard on a never pattern will never be run
-  --> $DIR/check.rs:20:20
+  --> $DIR/check.rs:21:20
    |
 LL |         Some(!) if true,
-   |                    ^^^^ help: remove this guard
+   |                    ^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         Some(!) if true,
+LL +         Some(!),
+   |
 
 error: a never pattern is always unreachable
-  --> $DIR/check.rs:25:28
+  --> $DIR/check.rs:26:28
    |
 LL |         Some(!) if true => {}
-   |                            ^^
-   |                            |
-   |                            this will never be executed
-   |                            help: remove this expression
+   |                            ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         Some(!) if true => {}
+LL +         Some(!),
+   |
 
 error: a never pattern is always unreachable
-  --> $DIR/check.rs:30:27
+  --> $DIR/check.rs:31:27
    |
 LL |         Some(never!()) => {}
-   |                           ^^
-   |                           |
-   |                           this will never be executed
-   |                           help: remove this expression
+   |                           ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         Some(never!()) => {}
+LL +         Some(never!()),
+   |
 
 error[E0004]: non-exhaustive patterns: `&Some(!)` not covered
-  --> $DIR/check.rs:19:11
+  --> $DIR/check.rs:20:11
    |
 LL |     match &None::<Void> {
    |           ^^^^^^^^^^^^^ pattern `&Some(!)` not covered
@@ -51,7 +66,7 @@ LL +         &Some(!)
    |
 
 error[E0004]: non-exhaustive patterns: `&Some(!)` not covered
-  --> $DIR/check.rs:24:11
+  --> $DIR/check.rs:25:11
    |
 LL |     match &None::<Void> {
    |           ^^^^^^^^^^^^^ pattern `&Some(!)` not covered

--- a/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/check.stderr
@@ -46,7 +46,7 @@ note: `Option<Void>` defined here
    = note: `Void` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         &Some(!)
    |
 
@@ -65,7 +65,7 @@ note: `Option<Void>` defined here
    = note: `Void` is uninhabited but is not being matched by value, so a wildcard `_` is required
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None => {},
+LL ~         None => {}
 LL +         &Some(!)
    |
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
@@ -76,7 +76,7 @@ LL |         never!() if true,
 help: remove the match arm guard
    |
 LL -         never!() if true,
-LL +         never!() if ,,
+LL +         never!(),
    |
 
 error: aborting due to 8 previous errors

--- a/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/parse.stderr
@@ -47,19 +47,37 @@ error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:31:20
    |
 LL |         Some(!) if true
-   |                    ^^^^ help: remove this guard
+   |                    ^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         Some(!) if true
+LL +         Some(!),
+   |
 
 error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:37:20
    |
 LL |         Some(!) if true,
-   |                    ^^^^ help: remove this guard
+   |                    ^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         Some(!) if true,
+LL +         Some(!),
+   |
 
 error: a guard on a never pattern will never be run
   --> $DIR/parse.rs:49:21
    |
 LL |         never!() if true,
-   |                     ^^^^ help: remove this guard
+   |                     ^^^^
+   |
+help: remove the match arm guard
+   |
+LL -         never!() if true,
+LL +         never!() if ,,
+   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/pattern-behind-macro.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/pattern-behind-macro.rs
@@ -1,0 +1,16 @@
+#![feature(never_patterns, never_type)]
+#![allow(incomplete_features)]
+
+enum Void {}
+fn main() {}
+
+macro_rules! never {
+    () => { ! }
+}
+
+fn no_arms_or_guards(x: Void) {
+    match x {
+        never!() => {}
+        //~^ ERROR a never pattern is always unreachable
+    }
+}

--- a/tests/ui/rfcs/rfc-0000-never_patterns/pattern-behind-macro.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/pattern-behind-macro.stderr
@@ -1,0 +1,14 @@
+error: a never pattern is always unreachable
+  --> $DIR/pattern-behind-macro.rs:13:21
+   |
+LL |         never!() => {}
+   |                     ^^ this will never be executed
+   |
+help: remove the match arm expression
+   |
+LL -         never!() => {}
+LL +         never!(),
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rfcs/rfc-2005-default-binding-mode/slice.stderr
+++ b/tests/ui/rfcs/rfc-2005-default-binding-mode/slice.stderr
@@ -8,7 +8,7 @@ LL |     match sl {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         [first, remainder @ ..] => {},
-LL ~         &[] => todo!(),
+LL +         &[] => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/exhaustive.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/exhaustive.stderr
@@ -12,7 +12,7 @@ note: `Option<u32>` defined here
    = note: the matched value is of type `Option<u32>`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         None if let y = x => {},
+LL ~         None if let y = x => {}
 LL +         None => todo!()
    |
 
@@ -26,7 +26,7 @@ LL |     match x {
    = note: match arms with guards don't count towards exhaustivity
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         y if let z = y => {},
+LL ~         y if let z = y => {}
 LL +         () => todo!()
    |
 

--- a/tests/ui/simd/const-err-trumps-simd-err.stderr
+++ b/tests/ui/simd/const-err-trumps-simd-err.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `get_elem::<4>::{constant#0}` failed
   --> $DIR/const-err-trumps-simd-err.rs:16:13
    |
 LL |     const { assert!(LANE < 4); } // the error should be here...
-   |             ^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: LANE < 4', $DIR/const-err-trumps-simd-err.rs:16:13
+   |             ^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: LANE < 4
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/structs/default-field-values/invalid-const.stderr
+++ b/tests/ui/structs/default-field-values/invalid-const.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/invalid-const.rs:5:19
    |
 LL |     pub bax: u8 = panic!("asdf"),
-   |                   ^^^^^^^^^^^^^^ the evaluated program panicked at 'asdf', $DIR/invalid-const.rs:5:19
+   |                   ^^^^^^^^^^^^^^ evaluation panicked: asdf
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/thir-print/thir-tree-match.stdout
+++ b/tests/ui/thir-print/thir-tree-match.stdout
@@ -142,7 +142,7 @@ body:
                                                                             }
                                                                         lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).14))
                                                                         scope: Node(14)
-                                                                        span: $DIR/thir-tree-match.rs:17:9: 17:40 (#0)
+                                                                        span: $DIR/thir-tree-match.rs:17:9: 17:41 (#0)
                                                                     }
                                                                     Arm {
                                                                         pattern: 
@@ -194,7 +194,7 @@ body:
                                                                             }
                                                                         lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).20))
                                                                         scope: Node(20)
-                                                                        span: $DIR/thir-tree-match.rs:18:9: 18:32 (#0)
+                                                                        span: $DIR/thir-tree-match.rs:18:9: 18:33 (#0)
                                                                     }
                                                                     Arm {
                                                                         pattern: 
@@ -238,7 +238,7 @@ body:
                                                                             }
                                                                         lint_level: Explicit(HirId(DefId(0:16 ~ thir_tree_match[fcf8]::has_match).26))
                                                                         scope: Node(26)
-                                                                        span: $DIR/thir-tree-match.rs:19:9: 19:28 (#0)
+                                                                        span: $DIR/thir-tree-match.rs:19:9: 19:29 (#0)
                                                                     }
                                                                 ]
                                                             }

--- a/tests/ui/transmutability/uninhabited.stderr
+++ b/tests/ui/transmutability/uninhabited.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:41:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:41:9
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:63:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:63:9
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:87:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:87:9
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/uninhabited/uninhabited-matches-feature-gated.stderr
+++ b/tests/ui/uninhabited/uninhabited-matches-feature-gated.stderr
@@ -13,7 +13,7 @@ note: `Result<u32, &Void>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Ok(n) => n,
-LL ~         Err(_) => todo!(),
+LL +         Err(_) => todo!()
    |
 
 error[E0004]: non-exhaustive patterns: type `&Void` is non-empty
@@ -47,7 +47,7 @@ LL |     let _ = match x {
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         &[] => (),
-LL ~         &[_, ..] => todo!(),
+LL +         &[_, ..] => todo!()
    |
 
 error: aborting due to 3 previous errors

--- a/tests/ui/unsafe/issue-115348-false-positive-warning-of-unnecessary-unsafe.stderr
+++ b/tests/ui/unsafe/issue-115348-false-positive-warning-of-unnecessary-unsafe.stderr
@@ -13,7 +13,7 @@ note: `Option<u32>` defined here
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 LL ~         Some(_) => unsafe { uwu() },
-LL ~         None => todo!(),
+LL +         None => todo!()
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.rs
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.rs
@@ -3,6 +3,7 @@ trait Foo<const N: Bar<2>> {
     //~^ WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| ERROR cycle detected when computing type of `Foo::N`
+    //~| ERROR cycle detected when computing type of `Foo::N`
     fn func() {}
 }
 

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -13,7 +13,7 @@ LL | trait Foo<const N: dyn Bar<2>> {
    |                    +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:9:20
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:20
    |
 LL | trait Bar<const M: Foo<2>> {}
    |                    ^^^^^^
@@ -32,7 +32,7 @@ LL | trait Foo<const N: Bar<2>> {
    |           ^^^^^^^^^^^^^^^
    |
 note: ...which requires computing type of `Bar::M`...
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:9:11
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:11
    |
 LL | trait Bar<const M: Foo<2>> {}
    |           ^^^^^^^^^^^^^^^
@@ -44,6 +44,26 @@ LL | trait Foo<const N: Bar<2>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 1 previous error; 2 warnings emitted
+error[E0391]: cycle detected when computing type of `Foo::N`
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:2:11
+   |
+LL | trait Foo<const N: Bar<2>> {
+   |           ^^^^^^^^^^^^^^^
+   |
+note: ...which requires computing type of `Bar::M`...
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:11
+   |
+LL | trait Bar<const M: Foo<2>> {}
+   |           ^^^^^^^^^^^^^^^
+   = note: ...which again requires computing type of `Foo::N`, completing the cycle
+note: cycle used when computing explicit predicates of trait `Foo`
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:2:1
+   |
+LL | trait Foo<const N: Bar<2>> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
Successful merges:

 - #136503 (Tweak output of const panic diagnostic)
 - #137390 (tests: fix up new test for nocapture -> capture(none) change)
 - #137409 (Tweak comma handling of "missing match arm" suggestion and fix "remove this arm" suggestion, and make suggestion verbose)
 - #137617 (Introduce `feature(generic_const_parameter_types)`)
 - #137719 (Add missing case explanation for doc inlined re-export of doc hidden item)
 - #137763 (Use `mk_ty_from_kind` a bit less, clean up lifetime handling in borrowck)
 - #137769 (Do not yeet `unsafe<>` from type when formatting unsafe binder)
 - #137776 (Some `rustc_transmute` cleanups)
 - #137800 (Remove `ParamEnv::without_caller_bounds`)

Failed merges:

 - #137723 (Make `rust.description` more general-purpose and pass `CFG_VER_DESCRIPTION`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=136503,137390,137409,137617,137719,137763,137769,137776,137800)
<!-- homu-ignore:end -->