### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,7 +4500,6 @@ dependencies = [
  "rustc_abi",
  "rustc_data_structures",
  "rustc_hir",
- "rustc_macros",
  "rustc_middle",
  "rustc_span",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,7 +4500,6 @@ dependencies = [
  "rustc_abi",
  "rustc_data_structures",
  "rustc_hir",
- "rustc_infer",
  "rustc_macros",
  "rustc_middle",
  "rustc_span",

--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -109,6 +109,8 @@ const_eval_frame_note_inner = inside {$where_ ->
     *[other] {""}
 }
 
+const_eval_frame_note_last = the failure occurred here
+
 const_eval_in_bounds_test = out-of-bounds pointer use
 const_eval_incompatible_calling_conventions =
     calling a function with calling convention {$callee_conv} using calling convention {$caller_conv}
@@ -300,8 +302,7 @@ const_eval_overflow_arith =
 const_eval_overflow_shift =
     overflowing shift by {$shift_amount} in `{$intrinsic}`
 
-const_eval_panic =
-    the evaluated program panicked at '{$msg}', {$file}:{$line}:{$col}
+const_eval_panic = evaluation panicked: {$msg}
 
 const_eval_panic_non_str = argument to `panic!()` in a const context must have type `&str`
 

--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -48,11 +48,8 @@ impl MachineStopType for ConstEvalErrKind {
             | ModifiedGlobal
             | WriteThroughImmutablePointer => {}
             AssertFailure(kind) => kind.add_args(adder),
-            Panic { msg, line, col, file } => {
+            Panic { msg, .. } => {
                 adder("msg".into(), msg.into_diag_arg(&mut None));
-                adder("file".into(), file.into_diag_arg(&mut None));
-                adder("line".into(), line.into_diag_arg(&mut None));
-                adder("col".into(), col.into_diag_arg(&mut None));
             }
         }
     }
@@ -72,7 +69,7 @@ pub fn get_span_and_frames<'tcx>(
     let mut stacktrace = Frame::generate_stacktrace_from_stack(stack);
     // Filter out `requires_caller_location` frames.
     stacktrace.retain(|frame| !frame.instance.def.requires_caller_location(*tcx));
-    let span = stacktrace.first().map(|f| f.span).unwrap_or(tcx.span);
+    let span = stacktrace.last().map(|f| f.span).unwrap_or(tcx.span);
 
     let mut frames = Vec::new();
 
@@ -113,6 +110,20 @@ pub fn get_span_and_frames<'tcx>(
         if let Some(frame) = last_frame {
             add_frame(frame);
         }
+    }
+
+    // In `rustc`, we present const-eval errors from the outer-most place first to the inner-most.
+    // So we reverse the frames here. The first frame will be the same as the span from the current
+    // `TyCtxtAt<'_>`, so we remove it as it would be redundant.
+    frames.reverse();
+    if frames.len() > 0 {
+        frames.remove(0);
+    }
+    if let Some(last) = frames.last_mut()
+        // If the span is not going to be printed, we don't want the span label for `is_last`.
+        && tcx.sess.source_map().span_to_snippet(last.span.source_callsite()).is_ok()
+    {
+        last.has_label = true;
     }
 
     (span, frames)

--- a/compiler/rustc_const_eval/src/interpret/stack.rs
+++ b/compiler/rustc_const_eval/src/interpret/stack.rs
@@ -231,13 +231,19 @@ impl<'tcx> FrameInfo<'tcx> {
     pub fn as_note(&self, tcx: TyCtxt<'tcx>) -> errors::FrameNote {
         let span = self.span;
         if tcx.def_key(self.instance.def_id()).disambiguated_data.data == DefPathData::Closure {
-            errors::FrameNote { where_: "closure", span, instance: String::new(), times: 0 }
+            errors::FrameNote {
+                where_: "closure",
+                span,
+                instance: String::new(),
+                times: 0,
+                has_label: false,
+            }
         } else {
             let instance = format!("{}", self.instance);
             // Note: this triggers a `must_produce_diag` state, which means that if we ever get
             // here we must emit a diagnostic. We should never display a `FrameInfo` unless we
             // actually want to emit a warning or error to the user.
-            errors::FrameNote { where_: "instance", span, instance, times: 0 }
+            errors::FrameNote { where_: "instance", span, instance, times: 0, has_label: false }
         }
     }
 }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -508,6 +508,8 @@ declare_features! (
     (incomplete, generic_const_exprs, "1.56.0", Some(76560)),
     /// Allows generic parameters and where-clauses on free & associated const items.
     (incomplete, generic_const_items, "1.73.0", Some(113521)),
+    /// Allows the type of const generics to depend on generic parameters
+    (incomplete, generic_const_parameter_types, "CURRENT_RUSTC_VERSION", Some(137626)),
     /// Allows any generic constants being used as pattern type range ends
     (incomplete, generic_pattern_types, "1.86.0", Some(136574)),
     /// Allows registering static items globally, possibly across crates, to iterate over at runtime.

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -966,7 +966,7 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) -> Result<(), 
             let ty = tcx.type_of(param.def_id).instantiate_identity();
 
             if tcx.features().unsized_const_params() {
-                enter_wf_checking_ctxt(tcx, hir_ty.span, param.def_id, |wfcx| {
+                enter_wf_checking_ctxt(tcx, hir_ty.span, tcx.local_parent(param.def_id), |wfcx| {
                     wfcx.register_bound(
                         ObligationCause::new(
                             hir_ty.span,
@@ -980,7 +980,7 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) -> Result<(), 
                     Ok(())
                 })
             } else if tcx.features().adt_const_params() {
-                enter_wf_checking_ctxt(tcx, hir_ty.span, param.def_id, |wfcx| {
+                enter_wf_checking_ctxt(tcx, hir_ty.span, tcx.local_parent(param.def_id), |wfcx| {
                     wfcx.register_bound(
                         ObligationCause::new(
                             hir_ty.span,

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1822,6 +1822,9 @@ fn const_param_default<'tcx>(
         ),
     };
     let icx = ItemCtxt::new(tcx, def_id);
-    let ct = icx.lowerer().lower_const_arg(default_ct, FeedConstTy::Param(def_id.to_def_id()));
+    let identity_args = ty::GenericArgs::identity_for_item(tcx, def_id);
+    let ct = icx
+        .lowerer()
+        .lower_const_arg(default_ct, FeedConstTy::Param(def_id.to_def_id(), identity_args));
     ty::EarlyBinder::bind(ct)
 }

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -223,10 +223,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
             }
             hir::GenericParamKind::Const { .. } => {
                 let param_def_id = param.def_id.to_def_id();
-                let ct_ty = tcx
-                    .type_of(param_def_id)
-                    .no_bound_vars()
-                    .expect("const parameters cannot be generic");
+                let ct_ty = tcx.type_of(param_def_id).instantiate_identity();
                 let ct = icx.lowerer().lower_const_param(param_def_id, param.hir_id);
                 predicates
                     .insert((ty::ClauseKind::ConstArgHasType(ct, ct_ty).upcast(tcx), param.span));

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/generics.rs
@@ -273,7 +273,7 @@ pub fn lower_generic_args<'tcx: 'a, 'a>(
 
                             // We lower to an infer even when the feature gate is not enabled
                             // as it is useful for diagnostics to be able to see a `ConstKind::Infer`
-                            args.push(ctx.provided_kind(param, arg));
+                            args.push(ctx.provided_kind(&args, param, arg));
                             args_iter.next();
                             params.next();
                         }

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -260,7 +260,7 @@ pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
 pub fn lower_const_arg_for_rustdoc<'tcx>(
     tcx: TyCtxt<'tcx>,
     hir_ct: &hir::ConstArg<'tcx>,
-    feed: FeedConstTy,
+    feed: FeedConstTy<'_, 'tcx>,
 ) -> Const<'tcx> {
     let env_def_id = tcx.hir_get_parent_item(hir_ct.hir_id);
     collect::ItemCtxt::new(tcx, env_def_id.def_id).lowerer().lower_const_arg(hir_ct, feed)

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -895,20 +895,22 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                         // e.g. we want to allow `dyn T -> (dyn T,)`, etc.
                         //
                         // We also need to skip auto traits to emit an FCW and not an error.
-                        let src_obj = tcx.mk_ty_from_kind(ty::Dynamic(
+                        let src_obj = Ty::new_dynamic(
+                            tcx,
                             tcx.mk_poly_existential_predicates(
                                 &src_tty.without_auto_traits().collect::<Vec<_>>(),
                             ),
                             tcx.lifetimes.re_erased,
                             ty::Dyn,
-                        ));
-                        let dst_obj = tcx.mk_ty_from_kind(ty::Dynamic(
+                        );
+                        let dst_obj = Ty::new_dynamic(
+                            tcx,
                             tcx.mk_poly_existential_predicates(
                                 &dst_tty.without_auto_traits().collect::<Vec<_>>(),
                             ),
                             tcx.lifetimes.re_erased,
                             ty::Dyn,
-                        ));
+                        );
 
                         // `dyn Src = dyn Dst`, this checks for matching traits/generics/projections
                         // This is `fcx.demand_eqtype`, but inlined to give a better error.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -519,7 +519,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub(crate) fn lower_const_arg(
         &self,
         const_arg: &'tcx hir::ConstArg<'tcx>,
-        feed: FeedConstTy,
+        feed: FeedConstTy<'_, 'tcx>,
     ) -> ty::Const<'tcx> {
         let ct = self.lowerer().lower_const_arg(const_arg, feed);
         self.register_wf_obligation(
@@ -1135,7 +1135,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .last()
             .is_some_and(|GenericPathSegment(def_id, _)| tcx.generics_of(*def_id).has_self);
 
-        let (res, self_ctor_args) = if let Res::SelfCtor(impl_def_id) = res {
+        let (res, implicit_args) = if let Res::Def(DefKind::ConstParam, def) = res {
+            // types of const parameters are somewhat special as they are part of
+            // the same environment as the const parameter itself. this means that
+            // unlike most paths `type-of(N)` can return a type naming parameters
+            // introduced by the containing item, rather than provided through `N`.
+            //
+            // for example given `<T, const M: usize, const N: [T; M]>` and some
+            // `let a = N;` expression. The path to `N` would wind up with no args
+            // (as it has no args), but instantiating the early binder on `typeof(N)`
+            // requires providing generic arguments for `[T, M, N]`.
+            (res, Some(ty::GenericArgs::identity_for_item(tcx, tcx.parent(def))))
+        } else if let Res::SelfCtor(impl_def_id) = res {
             let ty = LoweredTy::from_raw(
                 self,
                 span,
@@ -1261,6 +1272,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             fn provided_kind(
                 &mut self,
+                preceding_args: &[ty::GenericArg<'tcx>],
                 param: &ty::GenericParamDef,
                 arg: &GenericArg<'tcx>,
             ) -> ty::GenericArg<'tcx> {
@@ -1280,7 +1292,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     (GenericParamDefKind::Const { .. }, GenericArg::Const(ct)) => self
                         .fcx
                         // Ambiguous parts of `ConstArg` are handled in the match arms below
-                        .lower_const_arg(ct.as_unambig_ct(), FeedConstTy::Param(param.def_id))
+                        .lower_const_arg(
+                            ct.as_unambig_ct(),
+                            FeedConstTy::Param(param.def_id, preceding_args),
+                        )
                         .into(),
                     (&GenericParamDefKind::Const { .. }, GenericArg::Infer(inf)) => {
                         self.fcx.ct_infer(Some(param), inf.span).into()
@@ -1320,7 +1335,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
-        let args_raw = self_ctor_args.unwrap_or_else(|| {
+        let args_raw = implicit_args.unwrap_or_else(|| {
             lower_generic_args(
                 self,
                 def_id,

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -426,6 +426,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
 
             fn provided_kind(
                 &mut self,
+                preceding_args: &[ty::GenericArg<'tcx>],
                 param: &ty::GenericParamDef,
                 arg: &GenericArg<'tcx>,
             ) -> ty::GenericArg<'tcx> {
@@ -446,7 +447,10 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                     (GenericParamDefKind::Const { .. }, GenericArg::Const(ct)) => self
                         .cfcx
                         // We handle the ambig portions of `ConstArg` in the match arms below
-                        .lower_const_arg(ct.as_unambig_ct(), FeedConstTy::Param(param.def_id))
+                        .lower_const_arg(
+                            ct.as_unambig_ct(),
+                            FeedConstTy::Param(param.def_id, preceding_args),
+                        )
                         .into(),
                     (GenericParamDefKind::Const { .. }, GenericArg::Infer(inf)) => {
                         self.cfcx.ct_infer(Some(param), inf.span).into()

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -224,7 +224,7 @@ impl<'tcx, D: TyDecoder<I = TyCtxt<'tcx>>> Decodable<D> for Ty<'tcx> {
             })
         } else {
             let tcx = decoder.interner();
-            tcx.mk_ty_from_kind(rustc_type_ir::TyKind::decode(decoder))
+            tcx.mk_ty_from_kind(ty::TyKind::decode(decoder))
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -991,12 +991,6 @@ impl<'tcx> ParamEnv<'tcx> {
         ParamEnv { caller_bounds }
     }
 
-    /// Returns this same environment but with no caller bounds.
-    #[inline]
-    pub fn without_caller_bounds(self) -> Self {
-        Self::new(ListWithCachedTypeInfo::empty())
-    }
-
     /// Creates a pair of param-env and value for use in queries.
     pub fn and<T: TypeVisitable<TyCtxt<'tcx>>>(self, value: T) -> ParamEnvAnd<'tcx, T> {
         ParamEnvAnd { param_env: self, value }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -342,6 +342,7 @@ impl ParamConst {
         ParamConst::new(def.index, def.name)
     }
 
+    #[instrument(level = "debug")]
     pub fn find_ty_from_env<'tcx>(self, env: ParamEnv<'tcx>) -> Ty<'tcx> {
         let mut candidates = env.caller_bounds().iter().filter_map(|clause| {
             // `ConstArgHasType` are never desugared to be higher ranked.

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -461,7 +461,7 @@ impl<'tcx> Ty<'tcx> {
 
     #[inline]
     pub fn new_param(tcx: TyCtxt<'tcx>, index: u32, name: Symbol) -> Ty<'tcx> {
-        tcx.mk_ty_from_kind(Param(ParamTy { index, name }))
+        Ty::new(tcx, Param(ParamTy { index, name }))
     }
 
     #[inline]

--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -102,7 +102,6 @@ pub trait SolverDelegate: Deref<Target = Self::Infcx> + Sized {
 
     fn is_transmutable(
         &self,
-        param_env: <Self::Interner as Interner>::ParamEnv,
         dst: <Self::Interner as Interner>::Ty,
         src: <Self::Interner as Interner>::Ty,
         assume: <Self::Interner as Interner>::Const,

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -1037,12 +1037,11 @@ where
 
     pub(super) fn is_transmutable(
         &mut self,
-        param_env: I::ParamEnv,
         dst: I::Ty,
         src: I::Ty,
         assume: I::Const,
     ) -> Result<Certainty, NoSolution> {
-        self.delegate.is_transmutable(param_env, dst, src, assume)
+        self.delegate.is_transmutable(dst, src, assume)
     }
 }
 

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -617,7 +617,6 @@ where
             )?;
 
             let certainty = ecx.is_transmutable(
-                goal.param_env,
                 goal.predicate.trait_ref.args.type_at(0),
                 goal.predicate.trait_ref.args.type_at(1),
                 assume,

--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -125,9 +125,6 @@ resolve_const_param_in_enum_discriminant =
 resolve_const_param_in_non_trivial_anon_const =
     const parameters may only be used as standalone arguments, i.e. `{$name}`
 
-resolve_const_param_in_ty_of_const_param =
-    const parameters may not be used in the type of const parameters
-
 resolve_constructor_private_if_any_field_private =
     a constructor is private if any of the fields is private
 
@@ -249,9 +246,6 @@ resolve_lifetime_param_in_enum_discriminant =
 
 resolve_lifetime_param_in_non_trivial_anon_const =
     lifetime parameters may not be used in const expressions
-
-resolve_lifetime_param_in_ty_of_const_param =
-    lifetime parameters may not be used in the type of const parameters
 
 resolve_lowercase_self =
     attempt to use a non-constant value in a constant
@@ -436,9 +430,6 @@ resolve_type_param_in_enum_discriminant =
 
 resolve_type_param_in_non_trivial_anon_const =
     type parameters may not be used in const expressions
-
-resolve_type_param_in_ty_of_const_param =
-    type parameters may not be used in the type of const parameters
 
 resolve_undeclared_label =
     use of undeclared label `{$name}`

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -890,9 +890,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ResolutionError::ForwardDeclaredGenericParam => {
                 self.dcx().create_err(errs::ForwardDeclaredGenericParam { span })
             }
-            ResolutionError::ParamInTyOfConstParam { name, param_kind: is_type } => self
-                .dcx()
-                .create_err(errs::ParamInTyOfConstParam { span, name, param_kind: is_type }),
+            ResolutionError::ParamInTyOfConstParam { name } => {
+                self.dcx().create_err(errs::ParamInTyOfConstParam { span, name })
+            }
             ResolutionError::ParamInNonTrivialAnonConst { name, param_kind: is_type } => {
                 self.dcx().create_err(errs::ParamInNonTrivialAnonConst {
                     span,

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -347,19 +347,6 @@ pub(crate) struct ParamInTyOfConstParam {
     #[label]
     pub(crate) span: Span,
     pub(crate) name: Symbol,
-    #[subdiagnostic]
-    pub(crate) param_kind: Option<ParamKindInTyOfConstParam>,
-}
-
-#[derive(Debug)]
-#[derive(Subdiagnostic)]
-pub(crate) enum ParamKindInTyOfConstParam {
-    #[note(resolve_type_param_in_ty_of_const_param)]
-    Type,
-    #[note(resolve_const_param_in_ty_of_const_param)]
-    Const,
-    #[note(resolve_lifetime_param_in_ty_of_const_param)]
-    Lifetime,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3052,7 +3052,6 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             .create_err(errors::ParamInTyOfConstParam {
                 span: lifetime_ref.ident.span,
                 name: lifetime_ref.ident.name,
-                param_kind: Some(errors::ParamKindInTyOfConstParam::Lifetime),
             })
             .emit();
     }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -30,9 +30,7 @@ use std::sync::Arc;
 
 use diagnostics::{ImportSuggestion, LabelSuggestion, Suggestion};
 use effective_visibilities::EffectiveVisibilitiesVisitor;
-use errors::{
-    ParamKindInEnumDiscriminant, ParamKindInNonTrivialAnonConst, ParamKindInTyOfConstParam,
-};
+use errors::{ParamKindInEnumDiscriminant, ParamKindInNonTrivialAnonConst};
 use imports::{Import, ImportData, ImportKind, NameResolution};
 use late::{HasGenericParams, PathSource, PatternSource, UnnecessaryQualification};
 use macros::{MacroRulesBinding, MacroRulesScope, MacroRulesScopeRef};
@@ -276,8 +274,10 @@ enum ResolutionError<'ra> {
     },
     /// Error E0128: generic parameters with a default cannot use forward-declared identifiers.
     ForwardDeclaredGenericParam,
+    // FIXME(generic_const_parameter_types): This should give custom output specifying it's only
+    // problematic to use *forward declared* parameters when the feature is enabled.
     /// ERROR E0770: the type of const parameters must not depend on other generic parameters.
-    ParamInTyOfConstParam { name: Symbol, param_kind: Option<ParamKindInTyOfConstParam> },
+    ParamInTyOfConstParam { name: Symbol },
     /// generic parameters must not be used inside const evaluations.
     ///
     /// This error is only emitted when using `min_const_generics`.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1037,6 +1037,7 @@ symbols! {
         generic_associated_types_extended,
         generic_const_exprs,
         generic_const_items,
+        generic_const_parameter_types,
         generic_param_attrs,
         generic_pattern_types,
         get_context,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1189,9 +1189,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let span = obligation.cause.span;
 
         let mut diag = match ty.kind() {
-            _ if ty.has_param() => {
-                span_bug!(span, "const param tys cannot mention other generic parameters");
-            }
             ty::Float(_) => {
                 struct_span_code_err!(
                     self.dcx(),

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2544,7 +2544,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             let src = trait_pred.trait_ref.args.type_at(1);
             let err_msg = format!("`{src}` cannot be safely transmuted into `{dst}`");
 
-            match rustc_transmute::TransmuteTypeEnv::new(self.infcx).is_transmutable(
+            match rustc_transmute::TransmuteTypeEnv::new(self.infcx.tcx).is_transmutable(
                 obligation.cause,
                 src_and_dst,
                 assume,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2530,9 +2530,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 return GetSafeTransmuteErrorAndReason::Silent;
             };
 
-            let Some(assume) =
-                rustc_transmute::Assume::from_const(self.infcx.tcx, obligation.param_env, assume)
-            else {
+            let Some(assume) = rustc_transmute::Assume::from_const(self.infcx.tcx, assume) else {
                 self.dcx().span_delayed_bug(
                     span,
                     "Unable to construct rustc_transmute::Assume where it was previously possible",
@@ -2544,11 +2542,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             let src = trait_pred.trait_ref.args.type_at(1);
             let err_msg = format!("`{src}` cannot be safely transmuted into `{dst}`");
 
-            match rustc_transmute::TransmuteTypeEnv::new(self.infcx.tcx).is_transmutable(
-                obligation.cause,
-                src_and_dst,
-                assume,
-            ) {
+            match rustc_transmute::TransmuteTypeEnv::new(self.infcx.tcx)
+                .is_transmutable(src_and_dst, assume)
+            {
                 Answer::No(reason) => {
                     let safe_transmute_explanation = match reason {
                         rustc_transmute::Reason::SrcIsNotYetSupported => {

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -236,7 +236,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
         };
 
         // FIXME(transmutability): This really should be returning nested goals for `Answer::If*`
-        match rustc_transmute::TransmuteTypeEnv::new(&self.0).is_transmutable(
+        match rustc_transmute::TransmuteTypeEnv::new(self.0.tcx).is_transmutable(
             ObligationCause::dummy(),
             rustc_transmute::Types { src, dst },
             assume,

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -7,7 +7,6 @@ use rustc_infer::infer::canonical::{
     Canonical, CanonicalExt as _, CanonicalQueryInput, CanonicalVarInfo, CanonicalVarValues,
 };
 use rustc_infer::infer::{InferCtxt, RegionVariableOrigin, TyCtxtInferExt};
-use rustc_infer::traits::ObligationCause;
 use rustc_infer::traits::solve::Goal;
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt as _};
@@ -222,7 +221,6 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
     // register candidates. We probably need to register >1 since we may have an OR of ANDs.
     fn is_transmutable(
         &self,
-        param_env: ty::ParamEnv<'tcx>,
         dst: Ty<'tcx>,
         src: Ty<'tcx>,
         assume: ty::Const<'tcx>,
@@ -231,16 +229,14 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
         // which will ICE for region vars.
         let (dst, src) = self.tcx.erase_regions((dst, src));
 
-        let Some(assume) = rustc_transmute::Assume::from_const(self.tcx, param_env, assume) else {
+        let Some(assume) = rustc_transmute::Assume::from_const(self.tcx, assume) else {
             return Err(NoSolution);
         };
 
         // FIXME(transmutability): This really should be returning nested goals for `Answer::If*`
-        match rustc_transmute::TransmuteTypeEnv::new(self.0.tcx).is_transmutable(
-            ObligationCause::dummy(),
-            rustc_transmute::Types { src, dst },
-            assume,
-        ) {
+        match rustc_transmute::TransmuteTypeEnv::new(self.0.tcx)
+            .is_transmutable(rustc_transmute::Types { src, dst }, assume)
+        {
             rustc_transmute::Answer::Yes => Ok(Certainty::Yes),
             rustc_transmute::Answer::No(_) | rustc_transmute::Answer::If(_) => Err(NoSolution),
         }

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -424,7 +424,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let src = predicate.trait_ref.args.type_at(1);
 
         debug!(?src, ?dst);
-        let mut transmute_env = rustc_transmute::TransmuteTypeEnv::new(self.infcx);
+        let mut transmute_env = rustc_transmute::TransmuteTypeEnv::new(self.infcx.tcx);
         let maybe_transmutable = transmute_env.is_transmutable(
             obligation.cause.clone(),
             rustc_transmute::Types { dst, src },

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -414,9 +414,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         if self.tcx().features().generic_const_exprs() {
             assume = crate::traits::evaluate_const(self.infcx, assume, obligation.param_env)
         }
-        let Some(assume) =
-            rustc_transmute::Assume::from_const(self.infcx.tcx, obligation.param_env, assume)
-        else {
+        let Some(assume) = rustc_transmute::Assume::from_const(self.infcx.tcx, assume) else {
             return Err(Unimplemented);
         };
 
@@ -425,11 +423,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         debug!(?src, ?dst);
         let mut transmute_env = rustc_transmute::TransmuteTypeEnv::new(self.infcx.tcx);
-        let maybe_transmutable = transmute_env.is_transmutable(
-            obligation.cause.clone(),
-            rustc_transmute::Types { dst, src },
-            assume,
-        );
+        let maybe_transmutable =
+            transmute_env.is_transmutable(rustc_transmute::Types { dst, src }, assume);
 
         let fully_flattened = match maybe_transmutable {
             Answer::No(_) => Err(Unimplemented)?,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1008,7 +1008,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // depend on its particular value in order to work, so we can clear
             // out the param env and get better caching.
             debug!("in global");
-            obligation.param_env = obligation.param_env.without_caller_bounds();
+            obligation.param_env = ty::ParamEnv::empty();
         }
 
         let stack = self.push_stack(previous_stack, &obligation);

--- a/compiler/rustc_transmute/Cargo.toml
+++ b/compiler/rustc_transmute/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 rustc_abi = { path = "../rustc_abi", optional = true }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_hir = { path = "../rustc_hir", optional = true }
-rustc_infer = { path = "../rustc_infer", optional = true }
 rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_middle = { path = "../rustc_middle", optional = true }
 rustc_span = { path = "../rustc_span", optional = true }
@@ -19,7 +18,6 @@ tracing = "0.1"
 rustc = [
     "dep:rustc_abi",
     "dep:rustc_hir",
-    "dep:rustc_infer",
     "dep:rustc_macros",
     "dep:rustc_middle",
     "dep:rustc_span",

--- a/compiler/rustc_transmute/Cargo.toml
+++ b/compiler/rustc_transmute/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 rustc_abi = { path = "../rustc_abi", optional = true }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_hir = { path = "../rustc_hir", optional = true }
-rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_middle = { path = "../rustc_middle", optional = true }
 rustc_span = { path = "../rustc_span", optional = true }
 tracing = "0.1"
@@ -18,7 +17,6 @@ tracing = "0.1"
 rustc = [
     "dep:rustc_abi",
     "dep:rustc_hir",
-    "dep:rustc_macros",
     "dep:rustc_middle",
     "dep:rustc_span",
 ]

--- a/compiler/rustc_transmute/src/layout/dfa.rs
+++ b/compiler/rustc_transmute/src/layout/dfa.rs
@@ -38,7 +38,7 @@ impl<R> Transitions<R>
 where
     R: Ref,
 {
-    #[allow(dead_code)]
+    #[cfg(test)]
     fn insert(&mut self, transition: Transition<R>, state: State) {
         match transition {
             Transition::Byte(b) => {
@@ -86,15 +86,6 @@ impl<R> Dfa<R>
 where
     R: Ref,
 {
-    #[allow(dead_code)]
-    pub(crate) fn unit() -> Self {
-        let transitions: Map<State, Transitions<R>> = Map::default();
-        let start = State::new();
-        let accepting = start;
-
-        Self { transitions, start, accepting }
-    }
-
     #[cfg(test)]
     pub(crate) fn bool() -> Self {
         let mut transitions: Map<State, Transitions<R>> = Map::default();

--- a/compiler/rustc_transmute/src/layout/nfa.rs
+++ b/compiler/rustc_transmute/src/layout/nfa.rs
@@ -159,11 +159,6 @@ where
         }
         Self { transitions, start, accepting }
     }
-
-    #[allow(dead_code)]
-    pub(crate) fn edges_from(&self, start: State) -> Option<&Map<Transition<R>, Set<State>>> {
-        self.transitions.get(&start)
-    }
 }
 
 impl State {

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -104,7 +104,6 @@ mod rustc {
             Self { tcx }
         }
 
-        #[allow(unused)]
         pub fn is_transmutable(
             &mut self,
             cause: ObligationCause<'tcx>,

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -81,14 +81,13 @@ pub enum Reason<T> {
 #[cfg(feature = "rustc")]
 mod rustc {
     use rustc_hir::lang_items::LangItem;
-    use rustc_macros::TypeVisitable;
     use rustc_middle::traits::ObligationCause;
     use rustc_middle::ty::{Const, ParamEnv, Ty, TyCtxt};
 
     use super::*;
 
     /// The source and destination types of a transmutation.
-    #[derive(TypeVisitable, Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy)]
     pub struct Types<'tcx> {
         /// The source type.
         pub src: Ty<'tcx>,

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -1,5 +1,4 @@
 // tidy-alphabetical-start
-#![allow(unused_variables)]
 #![feature(never_type)]
 #![warn(unreachable_pub)]
 // tidy-alphabetical-end
@@ -80,8 +79,7 @@ pub enum Reason<T> {
 #[cfg(feature = "rustc")]
 mod rustc {
     use rustc_hir::lang_items::LangItem;
-    use rustc_middle::traits::ObligationCause;
-    use rustc_middle::ty::{Const, ParamEnv, Ty, TyCtxt};
+    use rustc_middle::ty::{Const, Ty, TyCtxt};
 
     use super::*;
 
@@ -105,15 +103,11 @@ mod rustc {
 
         pub fn is_transmutable(
             &mut self,
-            cause: ObligationCause<'tcx>,
             types: Types<'tcx>,
             assume: crate::Assume,
         ) -> crate::Answer<crate::layout::rustc::Ref<'tcx>> {
             crate::maybe_transmutable::MaybeTransmutableQuery::new(
-                types.src,
-                types.dst,
-                assume,
-                self.tcx,
+                types.src, types.dst, assume, self.tcx,
             )
             .answer()
         }
@@ -121,11 +115,7 @@ mod rustc {
 
     impl Assume {
         /// Constructs an `Assume` from a given const-`Assume`.
-        pub fn from_const<'tcx>(
-            tcx: TyCtxt<'tcx>,
-            param_env: ParamEnv<'tcx>,
-            ct: Const<'tcx>,
-        ) -> Option<Self> {
+        pub fn from_const<'tcx>(tcx: TyCtxt<'tcx>, ct: Const<'tcx>) -> Option<Self> {
             use rustc_middle::ty::ScalarInt;
             use rustc_span::sym;
 

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -81,7 +81,6 @@ pub enum Reason<T> {
 #[cfg(feature = "rustc")]
 mod rustc {
     use rustc_hir::lang_items::LangItem;
-    use rustc_infer::infer::InferCtxt;
     use rustc_macros::TypeVisitable;
     use rustc_middle::traits::ObligationCause;
     use rustc_middle::ty::{Const, ParamEnv, Ty, TyCtxt};
@@ -97,13 +96,13 @@ mod rustc {
         pub dst: Ty<'tcx>,
     }
 
-    pub struct TransmuteTypeEnv<'cx, 'tcx> {
-        infcx: &'cx InferCtxt<'tcx>,
+    pub struct TransmuteTypeEnv<'tcx> {
+        tcx: TyCtxt<'tcx>,
     }
 
-    impl<'cx, 'tcx> TransmuteTypeEnv<'cx, 'tcx> {
-        pub fn new(infcx: &'cx InferCtxt<'tcx>) -> Self {
-            Self { infcx }
+    impl<'tcx> TransmuteTypeEnv<'tcx> {
+        pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+            Self { tcx }
         }
 
         #[allow(unused)]
@@ -117,7 +116,7 @@ mod rustc {
                 types.src,
                 types.dst,
                 assume,
-                self.infcx.tcx,
+                self.tcx,
             )
             .answer()
         }

--- a/compiler/rustc_transmute/src/lib.rs
+++ b/compiler/rustc_transmute/src/lib.rs
@@ -1,6 +1,5 @@
 // tidy-alphabetical-start
 #![allow(unused_variables)]
-#![feature(alloc_layout_extra)]
 #![feature(never_type)]
 #![warn(unreachable_pub)]
 // tidy-alphabetical-end

--- a/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
+++ b/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
@@ -79,12 +79,12 @@ where
     pub(crate) fn answer(self) -> Answer<<C as QueryContext>::Ref> {
         let Self { src, dst, assume, context } = self;
 
-        // Unconditionally all `Def` nodes from `src`, without pruning away the
+        // Unconditionally remove all `Def` nodes from `src`, without pruning away the
         // branches they appear in. This is valid to do for value-to-value
         // transmutations, but not for `&mut T` to `&mut U`; we will need to be
         // more sophisticated to handle transmutations between mutable
         // references.
-        let src = src.prune(&|def| false);
+        let src = src.prune(&|_def| false);
 
         if src.is_inhabited() && !dst.is_inhabited() {
             return Answer::No(Reason::DstUninhabited);
@@ -96,7 +96,7 @@ where
         let dst = if assume.safety {
             // ...if safety is assumed, don't check if they carry safety
             // invariants; retain all paths.
-            dst.prune(&|def| false)
+            dst.prune(&|_def| false)
         } else {
             // ...otherwise, prune away all paths with safety invariants from
             // the `Dst` layout.

--- a/compiler/rustc_transmute/src/maybe_transmutable/tests.rs
+++ b/compiler/rustc_transmute/src/maybe_transmutable/tests.rs
@@ -92,7 +92,6 @@ mod bool {
 
     #[test]
     fn should_permit_validity_expansion_and_reject_contraction() {
-        let un = layout::Tree::<Def, !>::uninhabited();
         let b0 = layout::Tree::<Def, !>::from_bits(0);
         let b1 = layout::Tree::<Def, !>::from_bits(1);
         let b2 = layout::Tree::<Def, !>::from_bits(2);

--- a/src/doc/rustdoc/src/write-documentation/re-exports.md
+++ b/src/doc/rustdoc/src/write-documentation/re-exports.md
@@ -85,7 +85,22 @@ pub struct Hidden;
 pub use self::Hidden as InlinedHidden;
 ```
 
-The same applies on re-exports themselves: if you have multiple re-exports and some of them have
+However, if you still want the re-export itself to be visible, you can add the `#[doc(inline)]`
+attribute on it:
+
+```rust,ignore (inline)
+// This struct won't be visible.
+#[doc(hidden)]
+pub struct Hidden;
+
+#[doc(inline)]
+pub use self::Hidden as InlinedHidden;
+```
+
+In this case, you will have `pub use self::Hidden as InlinedHidden;` in the generated documentation
+but no link to the `Hidden` item.
+
+So back to `#[doc(hidden)]`: if you have multiple re-exports and some of them have
 `#[doc(hidden)]`, then these ones (and only these) won't appear in the documentation:
 
 ```rust,ignore (inline)

--- a/src/tools/miri/tests/fail/erroneous_const.stderr
+++ b/src/tools/miri/tests/fail/erroneous_const.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `PrintName::<i32>::VOID` failed
   --> tests/fail/erroneous_const.rs:LL:CC
    |
 LL |     const VOID: ! = panic!();
-   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', tests/fail/erroneous_const.rs:LL:CC
+   |                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/tools/rustfmt/src/types.rs
+++ b/src/tools/rustfmt/src/types.rs
@@ -1019,7 +1019,11 @@ impl Rewrite for ast::Ty {
             }
             ast::TyKind::UnsafeBinder(ref binder) => {
                 let mut result = String::new();
-                if let Some(ref lifetime_str) =
+                if binder.generic_params.is_empty() {
+                    // We always want to write `unsafe<>` since `unsafe<> Ty`
+                    // and `Ty` are distinct types.
+                    result.push_str("unsafe<> ")
+                } else if let Some(ref lifetime_str) =
                     rewrite_bound_params(context, shape, &binder.generic_params)
                 {
                     result.push_str("unsafe<");

--- a/src/tools/rustfmt/tests/source/unsafe-binders.rs
+++ b/src/tools/rustfmt/tests/source/unsafe-binders.rs
@@ -9,3 +9,6 @@ struct Foo {
 struct Bar(unsafe<'a> &'a ());
 
 impl Trait for unsafe<'a> &'a () {}
+
+fn empty()
+-> unsafe<> () {}

--- a/src/tools/rustfmt/tests/target/unsafe-binders.rs
+++ b/src/tools/rustfmt/tests/target/unsafe-binders.rs
@@ -7,3 +7,5 @@ struct Foo {
 struct Bar(unsafe<'a> &'a ());
 
 impl Trait for unsafe<'a> &'a () {}
+
+fn empty() -> unsafe<> () {}

--- a/tests/codegen/uninhabited-transparent-return-abi.rs
+++ b/tests/codegen/uninhabited-transparent-return-abi.rs
@@ -24,7 +24,7 @@ extern "Rust" {
 pub fn test_uninhabited_ret_by_ref() {
     // CHECK: %_1 = alloca [24 x i8], align {{8|4}}
     // CHECK-NEXT: call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %_1)
-    // CHECK-NEXT: call void @opaque(ptr noalias nocapture noundef nonnull sret([24 x i8]) align {{8|4}} dereferenceable(24) %_1) #2
+    // CHECK-NEXT: call void @opaque({{.*}} sret([24 x i8]) {{.*}} %_1) #2
     // CHECK-NEXT: unreachable
     unsafe {
         opaque();
@@ -36,7 +36,7 @@ pub fn test_uninhabited_ret_by_ref() {
 pub fn test_uninhabited_ret_by_ref_with_arg(rsi: u32) {
     // CHECK: %_2 = alloca [24 x i8], align {{8|4}}
     // CHECK-NEXT: call void @llvm.lifetime.start.p0(i64 24, ptr nonnull %_2)
-    // CHECK-NEXT: call void @opaque_with_arg(ptr noalias nocapture noundef nonnull sret([24 x i8]) align {{8|4}} dereferenceable(24) %_2, i32 noundef %rsi) #2
+    // CHECK-NEXT: call void @opaque_with_arg({{.*}} sret([24 x i8]) {{.*}} %_2, i32 noundef %rsi) #2
     // CHECK-NEXT: unreachable
     unsafe {
         opaque_with_arg(rsi);

--- a/tests/ui/borrowck/issue-81899.rs
+++ b/tests/ui/borrowck/issue-81899.rs
@@ -1,15 +1,14 @@
 // Regression test for #81899.
 // The `panic!()` below is important to trigger the fixed ICE.
 
-const _CONST: &[u8] = &f(&[], |_| {});
+const _CONST: &[u8] = &f(&[], |_| {}); //~ ERROR evaluation of constant value failed
 //~^ constant
 
 const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
-    //~^ panic
+    panic!() //~ inside `f
 }
 
 fn main() {}

--- a/tests/ui/borrowck/issue-81899.stderr
+++ b/tests/ui/borrowck/issue-81899.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-81899.rs:11:5
+  --> $DIR/issue-81899.rs:4:24
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-81899.rs:11:5
+LL | const _CONST: &[u8] = &f(&[], |_| {});
+   |                        ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
 note: inside `f::<{closure@$DIR/issue-81899.rs:4:31: 4:34}>`
   --> $DIR/issue-81899.rs:11:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_CONST`
-  --> $DIR/issue-81899.rs:4:24
-   |
-LL | const _CONST: &[u8] = &f(&[], |_| {});
-   |                        ^^^^^^^^^^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered

--- a/tests/ui/borrowck/issue-88434-minimal-example.rs
+++ b/tests/ui/borrowck/issue-88434-minimal-example.rs
@@ -1,14 +1,13 @@
 // Regression test related to issue 88434
 
-const _CONST: &() = &f(&|_| {});
+const _CONST: &() = &f(&|_| {}); //~ ERROR evaluation of constant value failed
 //~^ constant
 
 const fn f<F>(_: &F)
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
-    //~^ panic
+    panic!() //~ inside `f
 }
 
 fn main() { }

--- a/tests/ui/borrowck/issue-88434-minimal-example.stderr
+++ b/tests/ui/borrowck/issue-88434-minimal-example.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-88434-minimal-example.rs:10:5
+  --> $DIR/issue-88434-minimal-example.rs:3:22
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-88434-minimal-example.rs:10:5
+LL | const _CONST: &() = &f(&|_| {});
+   |                      ^^^^^^^^^^ evaluation panicked: explicit panic
    |
 note: inside `f::<{closure@$DIR/issue-88434-minimal-example.rs:3:25: 3:28}>`
   --> $DIR/issue-88434-minimal-example.rs:10:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_CONST`
-  --> $DIR/issue-88434-minimal-example.rs:3:22
-   |
-LL | const _CONST: &() = &f(&|_| {});
-   |                      ^^^^^^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.rs
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.rs
@@ -1,14 +1,13 @@
 // Regression test for issue 88434
 
-const _CONST: &[u8] = &f(&[], |_| {});
+const _CONST: &[u8] = &f(&[], |_| {}); //~ ERROR evaluation of constant value failed
 //~^ constant
 
 const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ ERROR evaluation of constant value failed
-    //~^ panic
+    panic!() //~ inside `f
 }
 
 fn main() { }

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
+  --> $DIR/issue-88434-removal-index-should-be-less.rs:3:24
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-88434-removal-index-should-be-less.rs:10:5
+LL | const _CONST: &[u8] = &f(&[], |_| {});
+   |                        ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
 note: inside `f::<{closure@$DIR/issue-88434-removal-index-should-be-less.rs:3:31: 3:34}>`
   --> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_CONST`
-  --> $DIR/issue-88434-removal-index-should-be-less.rs:3:24
-   |
-LL | const _CONST: &[u8] = &f(&[], |_| {});
-   |                        ^^^^^^^^^^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered

--- a/tests/ui/coherence/const-errs-dont-conflict-103369.rs
+++ b/tests/ui/coherence/const-errs-dont-conflict-103369.rs
@@ -2,13 +2,12 @@
 
 pub trait ConstGenericTrait<const N: u32> {}
 
-impl ConstGenericTrait<{my_fn(1)}> for () {}
+impl ConstGenericTrait<{my_fn(1)}> for () {} //~ ERROR E0080
 
-impl ConstGenericTrait<{my_fn(2)}> for () {}
+impl ConstGenericTrait<{my_fn(2)}> for () {} //~ ERROR E0080
 
 const fn my_fn(v: u32) -> u32 {
-    panic!("Some error occurred"); //~ ERROR E0080
-    //~| ERROR E0080
+    panic!("Some error occurred");
 }
 
 fn main() {}

--- a/tests/ui/coherence/const-errs-dont-conflict-103369.stderr
+++ b/tests/ui/coherence/const-errs-dont-conflict-103369.stderr
@@ -1,37 +1,27 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Some error occurred', $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-note: inside `my_fn`
-  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `<() as ConstGenericTrait<{my_fn(1)}>>::{constant#0}`
   --> $DIR/const-errs-dont-conflict-103369.rs:5:25
    |
 LL | impl ConstGenericTrait<{my_fn(1)}> for () {}
-   |                         ^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
-   |
-LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Some error occurred', $DIR/const-errs-dont-conflict-103369.rs:10:5
+   |                         ^^^^^^^^ evaluation panicked: Some error occurred
    |
 note: inside `my_fn`
   --> $DIR/const-errs-dont-conflict-103369.rs:10:5
    |
 LL |     panic!("Some error occurred");
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `<() as ConstGenericTrait<{my_fn(2)}>>::{constant#0}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
+   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/const-errs-dont-conflict-103369.rs:7:25
    |
 LL | impl ConstGenericTrait<{my_fn(2)}> for () {}
-   |                         ^^^^^^^^
+   |                         ^^^^^^^^ evaluation panicked: Some error occurred
+   |
+note: inside `my_fn`
+  --> $DIR/const-errs-dont-conflict-103369.rs:10:5
+   |
+LL |     panic!("Some error occurred");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.full.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.full.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
    |                                                    ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/const-param-type-depends-on-const-param.rs:15:40
    |
 LL | pub struct SelfDependent<const N: [u8; N]>;
    |                                        ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
    |                                                    ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/const-param-type-depends-on-const-param.rs:15:40
    |
 LL | pub struct SelfDependent<const N: [u8; N]>;
    |                                        ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: `[u8; N]` is forbidden as the type of a const generic parameter
   --> $DIR/const-param-type-depends-on-const-param.rs:11:47

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct B<T, const N: T>(PhantomData<[T; N]>);
    |                      ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param.full.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                                  ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/const-param-type-depends-on-type-param.rs:11:22

--- a/tests/ui/const-generics/const-param-type-depends-on-type-param.min.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-type-param.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                                  ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0392]: type parameter `T` is never used
   --> $DIR/const-param-type-depends-on-type-param.rs:11:22

--- a/tests/ui/const-generics/generic_const_parameter_types/bad_inference.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/bad_inference.rs
@@ -1,0 +1,23 @@
+#![feature(
+    adt_const_params,
+    unsized_const_params,
+    generic_const_parameter_types,
+    generic_arg_infer
+)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<T: ConstParamTy_, const N: usize, const M: [T; N]>() -> [T; N] {
+    loop {}
+}
+
+fn main() {
+    // Requires inferring `T`/`N` from `12_u8` and `2` respectively.
+    let a = foo::<_, _, { [12_u8; 2] }>();
+    //~^ ERROR: anonymous constants with inferred types are not yet supported
+
+    // Requires inferring `T`/`N`/`12_?i`/`_` from `[u8; 2]`
+    let b: [u8; 2] = foo::<_, _, { [12; _] }>();
+    //~^ ERROR: anonymous constants with inferred types are not yet supported
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/bad_inference.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/bad_inference.stderr
@@ -1,0 +1,14 @@
+error: anonymous constants with inferred types are not yet supported
+  --> $DIR/bad_inference.rs:17:25
+   |
+LL |     let a = foo::<_, _, { [12_u8; 2] }>();
+   |                         ^^^^^^^^^^^^^^
+
+error: anonymous constants with inferred types are not yet supported
+  --> $DIR/bad_inference.rs:21:34
+   |
+LL |     let b: [u8; 2] = foo::<_, _, { [12; _] }>();
+   |                                  ^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/const-generics/generic_const_parameter_types/evaluate_const_parameter_in_mir.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/evaluate_const_parameter_in_mir.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+
+#![feature(
+    adt_const_params,
+    unsized_const_params,
+    generic_const_parameter_types,
+    generic_arg_infer
+)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<T: ConstParamTy_, const N: usize, const M: [T; N]>() -> [T; N] {
+    M
+}
+
+fn main() {
+    let a: [u8; 2] = foo::<u8, 2, { [12; _] }>();
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.rs
@@ -1,0 +1,11 @@
+#![feature(adt_const_params, generic_const_parameter_types)]
+#![expect(incomplete_features)]
+
+use std::marker::PhantomData;
+
+struct UsesConst<const N: [u8; M], const M: usize>;
+//~^ ERROR: the type of const parameters must not depend on other generic parameters
+struct UsesType<const N: [T; 2], T>(PhantomData<T>);
+//~^ ERROR: the type of const parameters must not depend on other generic parameters
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.stderr
@@ -1,0 +1,15 @@
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/forward_declared_type.rs:6:32
+   |
+LL | struct UsesConst<const N: [u8; M], const M: usize>;
+   |                                ^ the type must not depend on the parameter `M`
+
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/forward_declared_type.rs:8:27
+   |
+LL | struct UsesType<const N: [T; 2], T>(PhantomData<T>);
+   |                           ^ the type must not depend on the parameter `T`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/generic_const_parameter_types/inferred_from_arg.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/inferred_from_arg.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+
+#![feature(adt_const_params, generic_arg_infer, generic_const_parameter_types)]
+#![expect(incomplete_features)]
+
+struct Bar<const N: usize, const M: [u8; N]>;
+
+fn foo<const N: usize, const M: [u8; N]>(_: Bar<N, M>) {}
+
+fn main() {
+    foo(Bar::<2, { [1; 2] }>);
+    foo::<_, _>(Bar::<2, { [1; 2] }>);
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.rs
@@ -1,0 +1,20 @@
+#![feature(generic_const_parameter_types, adt_const_params, unsized_const_params)]
+#![expect(incomplete_features)]
+
+fn foo<'a, const N: &'a u32>() {}
+
+fn bar() {
+    foo::<'static, { &1_u32 }>();
+    //~^ ERROR: anonymous constants with lifetimes in their type are not yet supported
+    foo::<'_, { &1_u32 }>();
+    //~^ ERROR: anonymous constants with lifetimes in their type are not yet supported
+}
+
+fn borrowck<'a, const N: &'static u32, const M: &'a u32>() {
+    foo::<'a, M>();
+    foo::<'static, M>();
+    //~^ ERROR: lifetime may not live long enough
+    foo::<'static, N>();
+}
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/lifetime_dependent_const_param.stderr
@@ -1,0 +1,23 @@
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/lifetime_dependent_const_param.rs:7:20
+   |
+LL |     foo::<'static, { &1_u32 }>();
+   |                    ^^^^^^^^^^
+
+error: anonymous constants with lifetimes in their type are not yet supported
+  --> $DIR/lifetime_dependent_const_param.rs:9:15
+   |
+LL |     foo::<'_, { &1_u32 }>();
+   |               ^^^^^^^^^^
+
+error: lifetime may not live long enough
+  --> $DIR/lifetime_dependent_const_param.rs:15:5
+   |
+LL | fn borrowck<'a, const N: &'static u32, const M: &'a u32>() {
+   |             -- lifetime `'a` defined here
+LL |     foo::<'a, M>();
+LL |     foo::<'static, M>();
+   |     ^^^^^^^^^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.rs
@@ -1,0 +1,15 @@
+#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<const N: usize, const M: [u8; N]>() {}
+fn bar<T: ConstParamTy_, const M: [T; 2]>() {}
+
+fn main() {
+    foo::<3, { [1; 2] }>();
+    //~^ ERROR: mismatched type
+
+    bar::<u8, { [2_u16; 2] }>();
+    //~^ ERROR: mismatched type
+}

--- a/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/mismatched_args_with_value.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/mismatched_args_with_value.rs:10:16
+   |
+LL |     foo::<3, { [1; 2] }>();
+   |                ^^^^^^ expected an array with a size of 3, found one with a size of 2
+
+error[E0308]: mismatched types
+  --> $DIR/mismatched_args_with_value.rs:13:18
+   |
+LL |     bar::<u8, { [2_u16; 2] }>();
+   |                  ^^^^^ expected `u8`, found `u16`
+   |
+help: change the type of the numeric literal from `u16` to `u8`
+   |
+LL -     bar::<u8, { [2_u16; 2] }>();
+LL +     bar::<u8, { [2_u8; 2] }>();
+   |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.rs
@@ -1,0 +1,9 @@
+#![feature(adt_const_params, unsized_const_params, generic_const_parameter_types)]
+#![expect(incomplete_features)]
+
+use std::marker::{ConstParamTy_, PhantomData};
+
+struct UsesType<T, const N: usize, const M: [T; N]>(PhantomData<T>);
+//~^ ERROR: `[T; N]` can't be used as a const parameter type
+
+fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/no_const_param_ty_bound.stderr
@@ -1,0 +1,11 @@
+error[E0741]: `[T; N]` can't be used as a const parameter type
+  --> $DIR/no_const_param_ty_bound.rs:6:45
+   |
+LL | struct UsesType<T, const N: usize, const M: [T; N]>(PhantomData<T>);
+   |                                             ^^^^^^
+   |
+   = note: `T` must implement `UnsizedConstParamTy`, but it does not
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0741`.

--- a/tests/ui/const-generics/generic_const_parameter_types/unrelated_inferred_arg.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/unrelated_inferred_arg.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+
+#![feature(
+    adt_const_params,
+    unsized_const_params,
+    generic_const_parameter_types,
+    generic_arg_infer
+)]
+#![allow(incomplete_features)]
+
+use std::marker::ConstParamTy_;
+
+fn foo<U, T: ConstParamTy_, const N: usize, const M: [T; N]>(_: U) -> [T; N] {
+    loop {}
+}
+
+fn main() {
+    // Check that `_` doesnt cause a "Type of const argument is uninferred" error
+    // as it is not actually used by the type of `M`.
+    let a = foo::<_, u8, 2, { [12; _] }>(true);
+}

--- a/tests/ui/const-generics/issues/issue-100313.rs
+++ b/tests/ui/const-generics/issues/issue-100313.rs
@@ -6,15 +6,14 @@ struct T<const B: &'static bool>;
 impl<const B: &'static bool> T<B> {
     const fn set_false(&self) {
         unsafe {
-            *(B as *const bool as *mut bool) = false;
-            //~^ ERROR evaluation of constant value failed [E0080]
+            *(B as *const bool as *mut bool) = false; //~ inside `T
         }
     }
 }
 
 const _: () = {
     let x = T::<{ &true }>;
-    x.set_false();
+    x.set_false(); //~ ERROR evaluation of constant value failed [E0080]
 };
 
 fn main() {}

--- a/tests/ui/const-generics/issues/issue-100313.stderr
+++ b/tests/ui/const-generics/issues/issue-100313.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-100313.rs:9:13
+  --> $DIR/issue-100313.rs:16:5
    |
-LL |             *(B as *const bool as *mut bool) = false;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ writing to ALLOC0 which is read-only
+LL |     x.set_false();
+   |     ^^^^^^^^^^^^^ writing to ALLOC0 which is read-only
    |
 note: inside `T::<&true>::set_false`
   --> $DIR/issue-100313.rs:9:13
    |
 LL |             *(B as *const bool as *mut bool) = false;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `_`
-  --> $DIR/issue-100313.rs:17:5
-   |
-LL |     x.set_false();
-   |     ^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-56445-1.full.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-1.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
    |                          ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-56445-1.min.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-1.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
    |                          ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-62878.full.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |                                      ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-62878.min.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |                                      ^ the type must not depend on the parameter `N`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: `[u8; N]` is forbidden as the type of a const generic parameter
   --> $DIR/issue-62878.rs:5:33

--- a/tests/ui/const-generics/issues/issue-71169.full.stderr
+++ b/tests/ui/const-generics/issues/issue-71169.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
    |                                           ^^^ the type must not depend on the parameter `LEN`
-   |
-   = note: const parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-71381.full.stderr
+++ b/tests/ui/const-generics/issues/issue-71381.full.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                                                  ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/issue-71381.rs:23:40
    |
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-71381.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71381.min.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                                                  ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/issue-71381.rs:23:40
    |
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71381.rs:14:61

--- a/tests/ui/const-generics/issues/issue-71611.full.stderr
+++ b/tests/ui/const-generics/issues/issue-71611.full.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                               ^ the type must not depend on the parameter `A`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-71611.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71611.min.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                               ^ the type must not depend on the parameter `A`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71611.rs:5:21

--- a/tests/ui/const-generics/issues/issue-88997.stderr
+++ b/tests/ui/const-generics/issues/issue-88997.stderr
@@ -3,16 +3,12 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Range<T: PartialOrd, const MIN: T, const MAX: T>(T)
    |                                        ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
   --> $DIR/issue-88997.rs:8:54
    |
 LL | struct Range<T: PartialOrd, const MIN: T, const MAX: T>(T)
    |                                                      ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-90364.stderr
+++ b/tests/ui/const-generics/issues/issue-90364.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | pub struct Foo<T, const H: T>(T)
    |                            ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-ptr/forbidden_slices.rs
+++ b/tests/ui/const-ptr/forbidden_slices.rs
@@ -48,9 +48,11 @@ pub static S8: &[u64] = unsafe {
 pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
 //~^ ERROR it is undefined behavior to use this value
 pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }; // errors inside libcore
+//~^ ERROR could not evaluate static initializer
 pub static R2: &[u32] = unsafe {
     let ptr = &D0 as *const u32;
     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
+    //~^ ERROR could not evaluate static initializer
 };
 pub static R4: &[u8] = unsafe {
     //~^ ERROR: it is undefined behavior to use this value
@@ -74,13 +76,16 @@ pub static R7: &[u16] = unsafe {
 };
 pub static R8: &[u64] = unsafe {
     let ptr = (&D4 as *const [u32; 2] as *const u32).byte_add(1).cast::<u64>();
-    from_ptr_range(ptr..ptr.add(1)) //~ inside `R8`
+    from_ptr_range(ptr..ptr.add(1))
+    //~^ ERROR could not evaluate static initializer
 };
 
 // This is sneaky: &D0 and &D0 point to different objects
 // (even if at runtime they have the same address)
 pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
+//~^ ERROR could not evaluate static initializer
 pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
+//~^ ERROR could not evaluate static initializer
 
 const D0: u32 = 0x11111111; // Constant chosen for endianness-independent behavior.
 const D1: MaybeUninit<&u32> = MaybeUninit::uninit();

--- a/tests/ui/const-ptr/forbidden_slices.stderr
+++ b/tests/ui/const-ptr/forbidden_slices.stderr
@@ -100,36 +100,28 @@ LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }
            }
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'assertion failed: 0 < pointee_size && pointee_size <= isize::MAX as usize', $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-note: inside `std::ptr::const_ptr::<impl *const ()>::offset_from_unsigned`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `from_ptr_range::<'_, ()>`
-  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
-note: inside `R1`
   --> $DIR/forbidden_slices.rs:50:33
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) }; // errors inside libcore
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: 0 < pointee_size && pointee_size <= isize::MAX as usize
+   |
+note: inside `from_ptr_range::<'_, ()>`
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+note: inside `std::ptr::const_ptr::<impl *const ()>::offset_from_unsigned`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+  --> $DIR/forbidden_slices.rs:54:25
    |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC10 which is only 4 bytes from the end of the allocation
+LL |     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
+   |                         ^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC10 which is only 4 bytes from the end of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u32>::add`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `R2`
-  --> $DIR/forbidden_slices.rs:53:25
-   |
-LL |     from_ptr_range(ptr..ptr.add(2)) // errors inside libcore
-   |                         ^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:55:1
+  --> $DIR/forbidden_slices.rs:57:1
    |
 LL | pub static R4: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
@@ -140,7 +132,7 @@ LL | pub static R4: &[u8] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:60:1
+  --> $DIR/forbidden_slices.rs:62:1
    |
 LL | pub static R5: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
@@ -153,7 +145,7 @@ LL | pub static R5: &[u8] = unsafe {
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:65:1
+  --> $DIR/forbidden_slices.rs:67:1
    |
 LL | pub static R6: &[bool] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
@@ -164,7 +156,7 @@ LL | pub static R6: &[bool] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:70:1
+  --> $DIR/forbidden_slices.rs:72:1
    |
 LL | pub static R7: &[u16] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
@@ -175,47 +167,35 @@ LL | pub static R7: &[u16] = unsafe {
            }
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+  --> $DIR/forbidden_slices.rs:79:25
    |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC11+0x1 which is only 7 bytes from the end of the allocation
+LL |     from_ptr_range(ptr..ptr.add(1))
+   |                         ^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to 8 bytes of memory, but got ALLOC11+0x1 which is only 7 bytes from the end of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u64>::add`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `R8`
-  --> $DIR/forbidden_slices.rs:77:25
-   |
-LL |     from_ptr_range(ptr..ptr.add(1))
-   |                         ^^^^^^^^^^
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `from_ptr_range::<'_, u32>`
-  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
-note: inside `R9`
-  --> $DIR/forbidden_slices.rs:82:34
+  --> $DIR/forbidden_slices.rs:85:34
    |
 LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
    |
-   = note: `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `from_ptr_range::<'_, u32>`
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
-note: inside `R10`
-  --> $DIR/forbidden_slices.rs:83:35
+note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+
+error[E0080]: could not evaluate static initializer
+  --> $DIR/forbidden_slices.rs:87:35
    |
 LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
+   |
+note: inside `from_ptr_range::<'_, u32>`
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+note: inside `std::ptr::const_ptr::<impl *const u32>::offset_from_unsigned`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/const-ptr/out_of_bounds_read.stderr
+++ b/tests/ui/const-ptr/out_of_bounds_read.stderr
@@ -1,45 +1,33 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
-   |
-note: inside `std::ptr::read::<u32>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `_READ`
   --> $DIR/out_of_bounds_read.rs:10:33
    |
 LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
    |
 note: inside `std::ptr::read::<u32>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u32>::read`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `_CONST_READ`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/out_of_bounds_read.rs:11:39
    |
 LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
-   |                                       ^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |                                       ^^^^^^^^^^^^^^^^^^^ memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
    |
-   = note: memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
-   |
+note: inside `std::ptr::const_ptr::<impl *const u32>::read`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `std::ptr::read::<u32>`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::mut_ptr::<impl *mut u32>::read`
-  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-note: inside `_MUT_READ`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/out_of_bounds_read.rs:12:37
    |
 LL |     const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };
-   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: expected a pointer to 4 bytes of memory, but got ALLOC0+0x4 which is at or beyond the end of the allocation of size 4 bytes
+   |
+note: inside `std::ptr::mut_ptr::<impl *mut u32>::read`
+  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+note: inside `std::ptr::read::<u32>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/assert-type-intrinsics.stderr
+++ b/tests/ui/consts/assert-type-intrinsics.stderr
@@ -2,19 +2,19 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/assert-type-intrinsics.rs:11:9
    |
 LL |         MaybeUninit::<!>::uninit().assume_init();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'aborted execution: attempted to instantiate uninhabited type `!`', $DIR/assert-type-intrinsics.rs:11:36
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: aborted execution: attempted to instantiate uninhabited type `!`
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/assert-type-intrinsics.rs:15:9
    |
 LL |         intrinsics::assert_mem_uninitialized_valid::<&'static i32>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'aborted execution: attempted to leave type `&i32` uninitialized, which is invalid', $DIR/assert-type-intrinsics.rs:15:9
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: aborted execution: attempted to leave type `&i32` uninitialized, which is invalid
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/assert-type-intrinsics.rs:19:9
    |
 LL |         intrinsics::assert_zero_valid::<&'static i32>();
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'aborted execution: attempted to zero-initialize type `&i32`, which is invalid', $DIR/assert-type-intrinsics.rs:19:9
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: aborted execution: attempted to zero-initialize type `&i32`, which is invalid
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail2.rs
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail2.rs
@@ -7,12 +7,18 @@ const X: fn(usize) -> usize = double;
 
 const fn bar(x: fn(usize) -> usize, y: usize) -> usize {
     x(y)
-    //~^ ERROR evaluation of constant value failed
-    //~| ERROR evaluation of constant value failed
+    //~^ NOTE inside `bar`
+    //~| NOTE the failure occurred here
+    //~| NOTE inside `bar`
+    //~| NOTE the failure occurred here
 }
 
 const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday
+//~^ ERROR evaluation of constant value failed
+//~| NOTE calling non-const function `double`
 const Z: usize = bar(double, 2); // FIXME: should fail to typeck someday
+//~^ ERROR evaluation of constant value failed
+//~| NOTE calling non-const function `double`
 
 fn main() {
     assert_eq!(Y, 4);

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail2.stderr
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail2.stderr
@@ -1,36 +1,26 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_fn_ptr_fail2.rs:9:5
-   |
-LL |     x(y)
-   |     ^^^^ calling non-const function `double`
-   |
-note: inside `bar`
-  --> $DIR/const_fn_ptr_fail2.rs:9:5
-   |
-LL |     x(y)
-   |     ^^^^
-note: inside `Y`
-  --> $DIR/const_fn_ptr_fail2.rs:14:18
+  --> $DIR/const_fn_ptr_fail2.rs:16:18
    |
 LL | const Y: usize = bar(X, 2); // FIXME: should fail to typeck someday
-   |                  ^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const_fn_ptr_fail2.rs:9:5
-   |
-LL |     x(y)
-   |     ^^^^ calling non-const function `double`
+   |                  ^^^^^^^^^ calling non-const function `double`
    |
 note: inside `bar`
   --> $DIR/const_fn_ptr_fail2.rs:9:5
    |
 LL |     x(y)
-   |     ^^^^
-note: inside `Z`
-  --> $DIR/const_fn_ptr_fail2.rs:15:18
+   |     ^^^^ the failure occurred here
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const_fn_ptr_fail2.rs:19:18
    |
 LL | const Z: usize = bar(double, 2); // FIXME: should fail to typeck someday
-   |                  ^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^^^ calling non-const function `double`
+   |
+note: inside `bar`
+  --> $DIR/const_fn_ptr_fail2.rs:9:5
+   |
+LL |     x(y)
+   |     ^^^^ the failure occurred here
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
+++ b/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic-normalize-tabs-115498.rs:3:17
    |
 LL | struct Bug([u8; panic!{"\t"}]);
-   |                 ^^^^^^^^^^^^ the evaluated program panicked at '    ', $DIR/const_panic-normalize-tabs-115498.rs:3:17
+   |                 ^^^^^^^^^^^^ evaluation panicked:     
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic.stderr
+++ b/tests/ui/consts/const-eval/const_panic.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:6:15
    |
 LL | const Z: () = std::panic!("cheese");
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic.rs:6:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: cheese
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:9:16
    |
 LL | const Z2: () = std::panic!();
-   |                ^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:9:16
+   |                ^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:12:15
    |
 LL | const Y: () = std::unreachable!();
-   |               ^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:12:15
+   |               ^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `std::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:15:15
    |
 LL | const X: () = std::unimplemented!();
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:15:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `std::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +34,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:18:15
    |
 LL | const W: () = std::panic!(MSG);
-   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:18:15
+   |               ^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -42,7 +42,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:21:16
    |
 LL | const W2: () = std::panic!("{}", MSG);
-   |                ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:21:16
+   |                ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:24:20
    |
 LL | const Z_CORE: () = core::panic!("cheese");
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic.rs:24:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: cheese
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -58,7 +58,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:27:21
    |
 LL | const Z2_CORE: () = core::panic!();
-   |                     ^^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:27:21
+   |                     ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -66,7 +66,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:30:20
    |
 LL | const Y_CORE: () = core::unreachable!();
-   |                    ^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:30:20
+   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `core::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -74,7 +74,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:33:20
    |
 LL | const X_CORE: () = core::unimplemented!();
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:33:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `core::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -82,7 +82,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:36:20
    |
 LL | const W_CORE: () = core::panic!(MSG);
-   |                    ^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:36:20
+   |                    ^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -90,7 +90,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:39:21
    |
 LL | const W2_CORE: () = core::panic!("{}", MSG);
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic.rs:39:21
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic_2021.stderr
+++ b/tests/ui/consts/const-eval/const_panic_2021.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:6:15
    |
 LL | const A: () = std::panic!("blåhaj");
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'blåhaj', $DIR/const_panic_2021.rs:6:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: blåhaj
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:9:15
    |
 LL | const B: () = std::panic!();
-   |               ^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic_2021.rs:9:15
+   |               ^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:12:15
    |
 LL | const C: () = std::unreachable!();
-   |               ^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_2021.rs:12:15
+   |               ^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `std::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:15:15
    |
 LL | const D: () = std::unimplemented!();
-   |               ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic_2021.rs:15:15
+   |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `std::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -34,7 +34,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:18:15
    |
 LL | const E: () = std::panic!("{}", MSG);
-   |               ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic_2021.rs:18:15
+   |               ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -42,7 +42,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:21:20
    |
 LL | const A_CORE: () = core::panic!("shark");
-   |                    ^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'shark', $DIR/const_panic_2021.rs:21:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: shark
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -50,7 +50,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:24:20
    |
 LL | const B_CORE: () = core::panic!();
-   |                    ^^^^^^^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/const_panic_2021.rs:24:20
+   |                    ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -58,7 +58,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:27:20
    |
 LL | const C_CORE: () = core::unreachable!();
-   |                    ^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_2021.rs:27:20
+   |                    ^^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `core::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -66,7 +66,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:30:20
    |
 LL | const D_CORE: () = core::unimplemented!();
-   |                    ^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic_2021.rs:30:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `core::unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -74,7 +74,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:33:20
    |
 LL | const E_CORE: () = core::panic!("{}", MSG);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'hello', $DIR/const_panic_2021.rs:33:20
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:8:15
    |
 LL | const Z: () = panic!("cheese");
-   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'cheese', $DIR/const_panic_libcore_bin.rs:8:15
+   |               ^^^^^^^^^^^^^^^^ evaluation panicked: cheese
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:11:15
    |
 LL | const Y: () = unreachable!();
-   |               ^^^^^^^^^^^^^^ the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_bin.rs:11:15
+   |               ^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
    |
    = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:14:15
    |
 LL | const X: () = unimplemented!();
-   |               ^^^^^^^^^^^^^^^^ the evaluated program panicked at 'not implemented', $DIR/const_panic_libcore_bin.rs:14:15
+   |               ^^^^^^^^^^^^^^^^ evaluation panicked: not implemented
    |
    = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/const_panic_track_caller.rs
+++ b/tests/ui/consts/const-eval/const_panic_track_caller.rs
@@ -12,11 +12,10 @@ const fn b() -> u32 {
 }
 
 const fn c() -> u32 {
-    b()
-    //~^ ERROR evaluation of constant value failed
-    //~| NOTE the evaluated program panicked
-    //~| NOTE inside
+    b() //~ NOTE inside `c`
+    //~^ NOTE the failure occurred here
 }
 
 const X: u32 = c();
-//~^ NOTE inside
+//~^ ERROR evaluation of constant value failed
+//~| NOTE hey

--- a/tests/ui/consts/const-eval/const_panic_track_caller.stderr
+++ b/tests/ui/consts/const-eval/const_panic_track_caller.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_panic_track_caller.rs:15:5
+  --> $DIR/const_panic_track_caller.rs:19:16
    |
-LL |     b()
-   |     ^^^ the evaluated program panicked at 'hey', $DIR/const_panic_track_caller.rs:15:5
+LL | const X: u32 = c();
+   |                ^^^ evaluation panicked: hey
    |
 note: inside `c`
   --> $DIR/const_panic_track_caller.rs:15:5
    |
 LL |     b()
-   |     ^^^
-note: inside `X`
-  --> $DIR/const_panic_track_caller.rs:21:16
-   |
-LL | const X: u32 = c();
-   |                ^^^
+   |     ^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
@@ -2,11 +2,10 @@
 #![feature(const_heap)]
 use std::intrinsics;
 
-const FOO: i32 = foo();
+const FOO: i32 = foo(); //~ error: evaluation of constant value failed
 const fn foo() -> i32 {
     unsafe {
-        let _ = intrinsics::const_allocate(4, 3) as *mut i32;
-        //~^ error: evaluation of constant value failed
+        let _ = intrinsics::const_allocate(4, 3) as *mut i32; //~ inside `foo`
     }
     1
 }

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/alloc_intrinsic_errors.rs:8:17
+  --> $DIR/alloc_intrinsic_errors.rs:5:18
    |
-LL |         let _ = intrinsics::const_allocate(4, 3) as *mut i32;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid align passed to `const_allocate`: 3 is not a power of 2
+LL | const FOO: i32 = foo();
+   |                  ^^^^^ invalid align passed to `const_allocate`: 3 is not a power of 2
    |
 note: inside `foo`
   --> $DIR/alloc_intrinsic_errors.rs:8:17
    |
 LL |         let _ = intrinsics::const_allocate(4, 3) as *mut i32;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/alloc_intrinsic_errors.rs:5:18
-   |
-LL | const FOO: i32 = foo();
-   |                  ^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/panic-assoc-never-type.rs:9:21
    |
 LL |     const VOID: ! = panic!();
-   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type.rs:9:21
+   |                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/panic-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-never-type.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/panic-never-type.rs:4:17
    |
 LL | const VOID: ! = panic!();
-   |                 ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/panic-never-type.rs:4:17
+   |                 ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/const-eval/parse_ints.rs
+++ b/tests/ui/consts/const-eval/parse_ints.rs
@@ -2,7 +2,7 @@ const _OK: () = match i32::from_str_radix("-1234", 10) {
     Ok(x) => assert!(x == -1234),
     Err(_) => panic!(),
 };
-const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); };
-const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); };
+const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); }; //~ ERROR evaluation of constant value failed
+const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); }; //~ ERROR evaluation of constant value failed
 
 fn main () {}

--- a/tests/ui/consts/const-eval/parse_ints.stderr
+++ b/tests/ui/consts/const-eval/parse_ints.stderr
@@ -1,33 +1,25 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'from_ascii_radix: radix must lie in the range `[2, 36]`', $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-note: inside `core::num::<impl u64>::from_ascii_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `core::num::<impl u64>::from_str_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `_TOO_LOW`
   --> $DIR/parse_ints.rs:5:24
    |
 LL | const _TOO_LOW: () = { u64::from_str_radix("12345ABCD", 1); };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
+   |
+note: inside `core::num::<impl u64>::from_str_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+note: inside `core::num::<impl u64>::from_ascii_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
    = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'from_ascii_radix: radix must lie in the range `[2, 36]`', $SRC_DIR/core/src/num/mod.rs:LL:COL
-   |
-note: inside `core::num::<impl u64>::from_ascii_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `core::num::<impl u64>::from_str_radix`
-  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
-note: inside `_TOO_HIGH`
   --> $DIR/parse_ints.rs:6:25
    |
 LL | const _TOO_HIGH: () = { u64::from_str_radix("12345ABCD", 37); };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: from_ascii_radix: radix must lie in the range `[2, 36]`
+   |
+note: inside `core::num::<impl u64>::from_str_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
+note: inside `core::num::<impl u64>::from_ascii_radix`
+  --> $SRC_DIR/core/src/num/mod.rs:LL:COL
    = note: this error originates in the macro `from_str_int_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/tests/ui/consts/const-eval/raw-pointer-ub.rs
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.rs
@@ -17,7 +17,10 @@ const MISALIGNED_COPY: () = unsafe {
     let y = x.as_ptr().cast::<u32>();
     let mut z = 123;
     y.copy_to_nonoverlapping(&mut z, 1);
-    //~^NOTE
+    //~^ ERROR evaluation of constant value failed
+    //~| NOTE inside `std::ptr::const_ptr
+    //~| NOTE inside `copy_nonoverlapping::<u32>`
+    //~| NOTE accessing memory with alignment 1, but alignment 4 is required
     // The actual error points into the implementation of `copy_to_nonoverlapping`.
 };
 

--- a/tests/ui/consts/const-eval/raw-pointer-ub.stderr
+++ b/tests/ui/consts/const-eval/raw-pointer-ub.stderr
@@ -11,28 +11,24 @@ LL |     *ptr = 0;
    |     ^^^^^^^^ accessing memory based on pointer with alignment 1, but alignment 4 is required
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
-   |
-   = note: accessing memory with alignment 1, but alignment 4 is required
-   |
-note: inside `copy_nonoverlapping::<u32>`
-  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u32>::copy_to_nonoverlapping`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `MISALIGNED_COPY`
   --> $DIR/raw-pointer-ub.rs:19:5
    |
 LL |     y.copy_to_nonoverlapping(&mut z, 1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment 1, but alignment 4 is required
+   |
+note: inside `std::ptr::const_ptr::<impl *const u32>::copy_to_nonoverlapping`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `copy_nonoverlapping::<u32>`
+  --> $SRC_DIR/core/src/intrinsics/mod.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/raw-pointer-ub.rs:31:16
+  --> $DIR/raw-pointer-ub.rs:34:16
    |
 LL |     let _val = (*ptr).0;
    |                ^^^^^^^^ accessing memory based on pointer with alignment 4, but alignment 16 is required
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/raw-pointer-ub.rs:38:16
+  --> $DIR/raw-pointer-ub.rs:41:16
    |
 LL |     let _val = *ptr;
    |                ^^^^ memory access failed: expected a pointer to 8 bytes of memory, but got ALLOC0 which is only 4 bytes from the end of the allocation

--- a/tests/ui/consts/const-eval/transmute-size-mismatch.rs
+++ b/tests/ui/consts/const-eval/transmute-size-mismatch.rs
@@ -10,15 +10,19 @@ const unsafe fn mir_transmute<T, U>(x: T) -> U {
     mir!{
         {
             RET = CastTransmute(x);
-            //~^ ERROR evaluation of constant value failed
-            //~| ERROR evaluation of constant value failed
+            //~^ NOTE inside `mir_transmute
+            //~| NOTE inside `mir_transmute
+            //~| NOTE the failure occurred here
+            //~| NOTE the failure occurred here
             Return()
         }
     }
 }
 
-const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) };
+const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) }; //~ ERROR evaluation of constant value failed
+//~^ NOTE transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
 
-const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) };
+const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) }; //~ ERROR evaluation of constant value failed
+//~^ NOTE transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
 
 fn main() {}

--- a/tests/ui/consts/const-eval/transmute-size-mismatch.stderr
+++ b/tests/ui/consts/const-eval/transmute-size-mismatch.stderr
@@ -1,36 +1,26 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/transmute-size-mismatch.rs:12:13
+  --> $DIR/transmute-size-mismatch.rs:22:35
    |
-LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
+LL | const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) };
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 4-byte type to 2-byte type: `i32` -> `u16`
    |
 note: inside `mir_transmute::<i32, u16>`
   --> $DIR/transmute-size-mismatch.rs:12:13
    |
 LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FROM_BIGGER`
-  --> $DIR/transmute-size-mismatch.rs:20:35
-   |
-LL | const FROM_BIGGER: u16 = unsafe { mir_transmute(123_i32) };
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/transmute-size-mismatch.rs:12:13
+  --> $DIR/transmute-size-mismatch.rs:25:36
    |
-LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
+LL | const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) };
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ transmuting from 2-byte type to 4-byte type: `i16` -> `u32`
    |
 note: inside `mir_transmute::<i16, u32>`
   --> $DIR/transmute-size-mismatch.rs:12:13
    |
 LL |             RET = CastTransmute(x);
-   |             ^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FROM_SMALLER`
-  --> $DIR/transmute-size-mismatch.rs:22:36
-   |
-LL | const FROM_SMALLER: u32 = unsafe { mir_transmute(123_i16) };
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/ub-enum.rs
+++ b/tests/ui/consts/const-eval/ub-enum.rs
@@ -101,7 +101,7 @@ const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe { mem:
 const TEST_ICE_89765: () = {
     // This is a regression test for https://github.com/rust-lang/rust/issues/89765.
     unsafe { std::mem::discriminant(&*(&() as *const () as *const Never)); };
-    //~^ inside `TEST_ICE_89765`
+    //~^ ERROR evaluation of constant value failed
 };
 
 fn main() {

--- a/tests/ui/consts/const-eval/ub-enum.stderr
+++ b/tests/ui/consts/const-eval/ub-enum.stderr
@@ -117,17 +117,13 @@ LL | const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe {
    |                                                                             ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: read discriminant of an uninhabited enum variant
-   |
-note: inside `discriminant::<Never>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `TEST_ICE_89765`
   --> $DIR/ub-enum.rs:103:14
    |
 LL |     unsafe { std::mem::discriminant(&*(&() as *const () as *const Never)); };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ read discriminant of an uninhabited enum variant
+   |
+note: inside `discriminant::<Never>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/consts/const-eval/ub-invalid-values.rs
+++ b/tests/ui/consts/const-eval/ub-invalid-values.rs
@@ -1,11 +1,12 @@
 const fn bool_cast(ptr: *const bool) { unsafe {
-    let _val = *ptr as u32; //~ERROR: evaluation of constant value failed
-    //~^ interpreting an invalid 8-bit value as a bool
+    let _val = *ptr as u32; //~ NOTE inside `bool_cast`
+    //~^ NOTE the failure occurred here
 }}
 
 const _: () = {
     let v = 3_u8;
-    bool_cast(&v as *const u8 as *const bool);
+    bool_cast(&v as *const u8 as *const bool); //~ ERROR: evaluation of constant value failed
+    //~^ NOTE interpreting an invalid 8-bit value as a bool
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-invalid-values.stderr
+++ b/tests/ui/consts/const-eval/ub-invalid-values.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-invalid-values.rs:2:16
+  --> $DIR/ub-invalid-values.rs:8:5
    |
-LL |     let _val = *ptr as u32;
-   |                ^^^^^^^^^^^ interpreting an invalid 8-bit value as a bool: 0x03
+LL |     bool_cast(&v as *const u8 as *const bool);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ interpreting an invalid 8-bit value as a bool: 0x03
    |
 note: inside `bool_cast`
   --> $DIR/ub-invalid-values.rs:2:16
    |
 LL |     let _val = *ptr as u32;
-   |                ^^^^^^^^^^^
-note: inside `_`
-  --> $DIR/ub-invalid-values.rs:8:5
-   |
-LL |     bool_cast(&v as *const u8 as *const bool);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -63,7 +63,7 @@ const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
 const UNALIGNED_READ: () = unsafe {
     let x = &[0u8; 4];
     let ptr = x.as_ptr().cast::<u32>();
-    ptr.read(); //~ inside `UNALIGNED_READ`
+    ptr.read(); //~ ERROR evaluation of constant value failed
 };
 
 

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -149,19 +149,15 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: accessing memory based on pointer with alignment 1, but alignment 4 is required
-   |
-note: inside `std::ptr::read::<u32>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u32>::read`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNALIGNED_READ`
   --> $DIR/ub-ref-ptr.rs:66:5
    |
 LL |     ptr.read();
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ accessing memory based on pointer with alignment 1, but alignment 4 is required
+   |
+note: inside `std::ptr::const_ptr::<impl *const u32>::read`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `std::ptr::read::<u32>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/consts/const-eval/unwind-abort.rs
+++ b/tests/ui/consts/const-eval/unwind-abort.rs
@@ -1,8 +1,8 @@
 const extern "C" fn foo() {
-    panic!() //~ ERROR evaluation of constant value failed
+    panic!() //~ inside `foo`
 }
 
-const _: () = foo();
+const _: () = foo(); //~ ERROR evaluation of constant value failed
 // Ensure that the CTFE engine handles calls to `extern "C"` aborting gracefully
 
 fn main() {

--- a/tests/ui/consts/const-eval/unwind-abort.stderr
+++ b/tests/ui/consts/const-eval/unwind-abort.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/unwind-abort.rs:2:5
+  --> $DIR/unwind-abort.rs:5:15
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/unwind-abort.rs:2:5
+LL | const _: () = foo();
+   |               ^^^^^ evaluation panicked: explicit panic
    |
 note: inside `foo`
   --> $DIR/unwind-abort.rs:2:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_`
-  --> $DIR/unwind-abort.rs:5:15
-   |
-LL | const _: () = foo();
-   |               ^^^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -1,6 +1,5 @@
 const fn foo() -> ! {
-    unsafe { std::mem::transmute(()) }
-    //~^ ERROR evaluation of constant value failed
+    unsafe { std::mem::transmute(()) } //~ inside `foo`
 }
 
 // Type defined in a submodule, so that it is not "visibly"
@@ -14,6 +13,7 @@ pub mod empty {
 }
 
 const FOO: [empty::Empty; 3] = [foo(); 3];
+//~^ ERROR evaluation of constant value failed
 
 const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
 //~^ ERROR evaluation of constant value failed

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/validate_uninhabited_zsts.rs:2:14
+  --> $DIR/validate_uninhabited_zsts.rs:15:33
    |
-LL |     unsafe { std::mem::transmute(()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a value of the never type `!`
+LL | const FOO: [empty::Empty; 3] = [foo(); 3];
+   |                                 ^^^^^ constructing invalid value: encountered a value of the never type `!`
    |
 note: inside `foo`
   --> $DIR/validate_uninhabited_zsts.rs:2:14
    |
 LL |     unsafe { std::mem::transmute(()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/validate_uninhabited_zsts.rs:16:33
-   |
-LL | const FOO: [empty::Empty; 3] = [foo(); 3];
-   |                                 ^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/validate_uninhabited_zsts.rs:18:42

--- a/tests/ui/consts/const-ptr-is-null.rs
+++ b/tests/ui/consts/const-ptr-is-null.rs
@@ -19,7 +19,7 @@ const MAYBE_NULL: () = {
     assert!(!ptr.wrapping_byte_sub(1).is_null());
     // ... but once we shift outside the allocation, with an offset divisible by 4,
     // we might become null.
-    assert!(!ptr.wrapping_sub(512).is_null()); //~inside `MAYBE_NULL`
+    assert!(!ptr.wrapping_sub(512).is_null()); //~ ERROR evaluation of constant value failed
 };
 
 fn main() {}

--- a/tests/ui/consts/const-ptr-is-null.stderr
+++ b/tests/ui/consts/const-ptr-is-null.stderr
@@ -1,18 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: the evaluated program panicked at 'null-ness of this pointer cannot be determined in const context', $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-note: inside `std::ptr::const_ptr::<impl *const T>::is_null::compiletime`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const i32>::is_null`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `MAYBE_NULL`
   --> $DIR/const-ptr-is-null.rs:22:14
    |
 LL |     assert!(!ptr.wrapping_sub(512).is_null());
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: null-ness of this pointer cannot be determined in const context
+   |
+note: inside `std::ptr::const_ptr::<impl *const i32>::is_null`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `std::ptr::const_ptr::<impl *const T>::is_null::compiletime`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-unwrap.rs
+++ b/tests/ui/consts/const-unwrap.rs
@@ -5,7 +5,7 @@ const FOO: i32 = Some(42i32).unwrap();
 
 const BAR: i32 = Option::<i32>::None.unwrap();
 //~^ ERROR: evaluation of constant value failed
-//~| NOTE: the evaluated program panicked
+//~| NOTE: called `Option::unwrap()` on a `None` value
 
 const BAZ: i32 = Option::<i32>::None.expect("absolutely not!");
 //~^ ERROR: evaluation of constant value failed

--- a/tests/ui/consts/const-unwrap.stderr
+++ b/tests/ui/consts/const-unwrap.stderr
@@ -2,13 +2,13 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const-unwrap.rs:6:18
    |
 LL | const BAR: i32 = Option::<i32>::None.unwrap();
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'called `Option::unwrap()` on a `None` value', $DIR/const-unwrap.rs:6:38
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: called `Option::unwrap()` on a `None` value
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-unwrap.rs:10:18
    |
 LL | const BAZ: i32 = Option::<i32>::None.expect("absolutely not!");
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'absolutely not!', $DIR/const-unwrap.rs:10:38
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: absolutely not!
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const_unsafe_unreachable_ub.rs
+++ b/tests/ui/consts/const_unsafe_unreachable_ub.rs
@@ -1,13 +1,14 @@
-//@ error-pattern: evaluation of constant value failed
-
 const unsafe fn foo(x: bool) -> bool {
     match x {
         true => true,
-        false => std::hint::unreachable_unchecked(),
+        false => std::hint::unreachable_unchecked(), //~ NOTE inside `foo`
     }
 }
 
 const BAR: bool = unsafe { foo(false) };
+//~^ ERROR evaluation of constant value failed
+//~| NOTE entering unreachable code
+//~| NOTE inside `unreachable_unchecked`
 
 fn main() {
     assert_eq!(BAR, true);

--- a/tests/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/tests/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -1,20 +1,16 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
+  --> $DIR/const_unsafe_unreachable_ub.rs:8:28
    |
-   = note: entering unreachable code
+LL | const BAR: bool = unsafe { foo(false) };
+   |                            ^^^^^^^^^^ entering unreachable code
    |
-note: inside `unreachable_unchecked`
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
 note: inside `foo`
-  --> $DIR/const_unsafe_unreachable_ub.rs:6:18
+  --> $DIR/const_unsafe_unreachable_ub.rs:4:18
    |
 LL |         false => std::hint::unreachable_unchecked(),
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `BAR`
-  --> $DIR/const_unsafe_unreachable_ub.rs:10:28
-   |
-LL | const BAR: bool = unsafe { foo(false) };
-   |                            ^^^^^^^^^^
+note: inside `unreachable_unchecked`
+  --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/control-flow/assert.stderr
+++ b/tests/ui/consts/control-flow/assert.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/assert.rs:5:15
    |
 LL | const _: () = assert!(false);
-   |               ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/assert.rs:5:15
+   |               ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-32829.stderr
+++ b/tests/ui/consts/issue-32829.stderr
@@ -2,7 +2,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/issue-32829.rs:1:22
    |
 LL | static S : u64 = { { panic!("foo"); 0 } };
-   |                      ^^^^^^^^^^^^^ the evaluated program panicked at 'foo', $DIR/issue-32829.rs:1:22
+   |                      ^^^^^^^^^^^^^ evaluation panicked: foo
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-66693-panic-in-array-len.stderr
+++ b/tests/ui/consts/issue-66693-panic-in-array-len.stderr
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-66693-panic-in-array-len.rs:10:21
    |
 LL |     let _ = [false; panic!()];
-   |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-66693-panic-in-array-len.rs:10:21
+   |                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-66693.stderr
+++ b/tests/ui/consts/issue-66693.stderr
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-66693.rs:16:15
    |
 LL | const _: () = panic!();
-   |               ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-66693.rs:16:15
+   |               ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -26,7 +26,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/issue-66693.rs:18:19
    |
 LL | static _BAR: () = panic!("panic in static");
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'panic in static', $DIR/issue-66693.rs:18:19
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: panic in static
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-76064.stderr
+++ b/tests/ui/consts/issue-76064.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-76064.rs:1:17
    |
 LL | struct Bug([u8; panic!("panic")]);
-   |                 ^^^^^^^^^^^^^^^ the evaluated program panicked at 'panic', $DIR/issue-76064.rs:1:17
+   |                 ^^^^^^^^^^^^^^^ evaluation panicked: panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/issue-miri-1910.rs
+++ b/tests/ui/consts/issue-miri-1910.rs
@@ -5,6 +5,7 @@ const C: () = unsafe {
     let foo = Some(&42 as *const i32);
     let one_and_a_half_pointers = std::mem::size_of::<*const i32>()/2*3;
     (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
+    //~^ ERROR evaluation of constant value failed
 };
 
 fn main() {

--- a/tests/ui/consts/issue-miri-1910.stderr
+++ b/tests/ui/consts/issue-miri-1910.stderr
@@ -1,17 +1,13 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: unable to turn pointer into integer
-   |
-note: inside `std::ptr::read::<u8>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::const_ptr::<impl *const u8>::read`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `C`
   --> $DIR/issue-miri-1910.rs:7:5
    |
 LL |     (&foo as *const _ as *const u8).add(one_and_a_half_pointers).read();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::read`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+note: inside `std::ptr::read::<u8>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 

--- a/tests/ui/consts/miri_unleashed/abi-mismatch.rs
+++ b/tests/ui/consts/miri_unleashed/abi-mismatch.rs
@@ -4,13 +4,12 @@
 const extern "C" fn c_fn() {}
 
 const fn call_rust_fn(my_fn: extern "Rust" fn()) {
-    my_fn();
-    //~^ ERROR could not evaluate static initializer
-    //~| NOTE calling a function with calling convention C using calling convention Rust
-    //~| NOTE inside `call_rust_fn`
+    my_fn(); //~ NOTE inside `call_rust_fn`
+    //~^ NOTE the failure occurred here
 }
 
 static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-//~^ NOTE inside `VAL`
+//~^ ERROR could not evaluate static initializer
+//~| NOTE calling a function with calling convention C using calling convention Rust
 
 fn main() {}

--- a/tests/ui/consts/miri_unleashed/abi-mismatch.stderr
+++ b/tests/ui/consts/miri_unleashed/abi-mismatch.stderr
@@ -1,19 +1,14 @@
 error[E0080]: could not evaluate static initializer
-  --> $DIR/abi-mismatch.rs:7:5
+  --> $DIR/abi-mismatch.rs:11:18
    |
-LL |     my_fn();
-   |     ^^^^^^^ calling a function with calling convention C using calling convention Rust
+LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calling a function with calling convention C using calling convention Rust
    |
 note: inside `call_rust_fn`
   --> $DIR/abi-mismatch.rs:7:5
    |
 LL |     my_fn();
-   |     ^^^^^^^
-note: inside `VAL`
-  --> $DIR/abi-mismatch.rs:13:18
-   |
-LL | static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn()) });
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^ the failure occurred here
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/miri_unleashed/assoc_const.rs
+++ b/tests/ui/consts/miri_unleashed/assoc_const.rs
@@ -9,7 +9,7 @@ trait Foo<T> {
 }
 
 trait Bar<T, U: Foo<T>> {
-    const F: u32 = (U::X, 42).1;
+    const F: u32 = (U::X, 42).1; //~ ERROR
 }
 
 impl Foo<u32> for () {
@@ -26,5 +26,5 @@ fn main() {
     // this is fine, but would have been forbidden by the static checks on `F`
     let x = <() as Bar<u32, ()>>::F;
     // this test only causes errors due to the line below, so post-monomorphization
-    let y = <String as Bar<Vec<u32>, String>>::F; //~ constant
+    let y = <String as Bar<Vec<u32>, String>>::F;
 }

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -1,17 +1,13 @@
-error[E0080]: evaluation of `<String as Bar<Vec<u32>, String>>::F` failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<u32> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `<String as Bar<Vec<u32>, String>>::F`
+error[E0080]: evaluation of `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))` failed
   --> $DIR/assoc_const.rs:12:31
    |
 LL |     const F: u32 = (U::X, 42).1;
-   |                               ^
+   |                               ^ calling non-const function `<Vec<u32> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 note: erroneous constant encountered
   --> $DIR/assoc_const.rs:29:13

--- a/tests/ui/consts/miri_unleashed/drop.stderr
+++ b/tests/ui/consts/miri_unleashed/drop.stderr
@@ -1,15 +1,11 @@
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<i32> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `TEST_BAD`
   --> $DIR/drop.rs:17:1
    |
 LL | };
-   | ^
+   | ^ calling non-const function `<Vec<i32> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 warning: skipping const checks
    |

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -13,7 +13,7 @@ const X: () = {
 
     // Swap them, bytewise.
     unsafe {
-        ptr::swap_nonoverlapping(
+        ptr::swap_nonoverlapping( //~ ERROR evaluation of constant value failed
             &mut ptr1 as *mut _ as *mut MaybeUninit<u8>,
             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
             mem::size_of::<&i32>(),

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -1,17 +1,4 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: unable to copy parts of a pointer from memory at ALLOC0
-   |
-note: inside `std::ptr::read::<MaybeUninit<MaybeUninit<u8>>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::swap_nonoverlapping_simple_untyped::<MaybeUninit<u8>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `swap_nonoverlapping::compiletime::<MaybeUninit<u8>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `swap_nonoverlapping::<MaybeUninit<u8>>`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `X`
   --> $DIR/missing_span_in_backtrace.rs:16:9
    |
 16 | /         ptr::swap_nonoverlapping(
@@ -19,7 +6,16 @@ note: inside `X`
 18 | |             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
 19 | |             mem::size_of::<&i32>(),
 20 | |         );
-   | |_________^
+   | |_________^ unable to copy parts of a pointer from memory at ALLOC0
+   |
+note: inside `swap_nonoverlapping::<MaybeUninit<u8>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `swap_nonoverlapping::compiletime::<MaybeUninit<u8>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::swap_nonoverlapping_simple_untyped::<MaybeUninit<u8>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::read::<MaybeUninit<MaybeUninit<u8>>>`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
    = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `const_eval_select` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/consts/offset_from_ub.rs
+++ b/tests/ui/consts/offset_from_ub.rs
@@ -21,7 +21,7 @@ pub const DIFFERENT_ALLOC: usize = {
 };
 
 pub const NOT_PTR: usize = {
-    unsafe { (42 as *const u8).offset_from(&5u8) as usize }
+    unsafe { (42 as *const u8).offset_from(&5u8) as usize } //~ ERROR evaluation of constant value failed
 };
 
 pub const NOT_MULTIPLE_OF_SIZE: isize = {
@@ -107,13 +107,13 @@ pub const OFFSET_VERY_FAR1: isize = {
     let ptr1 = ptr::null::<u8>();
     let ptr2 = ptr1.wrapping_offset(isize::MAX);
     unsafe { ptr2.offset_from(ptr1) }
-    //~^ inside
+    //~^ ERROR evaluation of constant value failed
 };
 pub const OFFSET_VERY_FAR2: isize = {
     let ptr1 = ptr::null::<u8>();
     let ptr2 = ptr1.wrapping_offset(isize::MAX);
     unsafe { ptr1.offset_from(ptr2.wrapping_offset(1)) }
-    //~^ inside
+    //~^ ERROR evaluation of constant value failed
 };
 
 // If the pointers are the same, OOB/null/UAF is fine.

--- a/tests/ui/consts/offset_from_ub.stderr
+++ b/tests/ui/consts/offset_from_ub.stderr
@@ -5,17 +5,13 @@ LL |     let offset = unsafe { ptr_offset_from(field_ptr, base_ptr) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `NOT_PTR`
   --> $DIR/offset_from_ub.rs:24:14
    |
 LL |     unsafe { (42 as *const u8).offset_from(&5u8) as usize }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/offset_from_ub.rs:31:14
@@ -78,30 +74,22 @@ LL |     unsafe { ptr_offset_from_unsigned(ptr2, ptr1) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called when first pointer is too far ahead of second
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OFFSET_VERY_FAR1`
   --> $DIR/offset_from_ub.rs:109:14
    |
 LL |     unsafe { ptr2.offset_from(ptr1) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: `ptr_offset_from` called when first pointer is too far before second
+   |              ^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OFFSET_VERY_FAR2`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_from_ub.rs:115:14
    |
 LL |     unsafe { ptr1.offset_from(ptr2.wrapping_offset(1)) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called when first pointer is too far before second
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/consts/offset_ub.rs
+++ b/tests/ui/consts/offset_ub.rs
@@ -5,21 +5,21 @@ use std::ptr;
 //@ normalize-stderr: "\d+ bytes" -> "$$BYTES bytes"
 
 
-pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) }; //~NOTE
-pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) }; //~NOTE
-pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) }; //~NOTE
+pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) }; //~ ERROR
+pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) }; //~ ERROR
+pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) }; //~ ERROR
 
-pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) }; //~NOTE
-pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) }; //~NOTE
-pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) }; //~NOTE
-pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) }; //~NOTE
-pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) }; //~NOTE
+pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) }; //~ ERROR
+pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) }; //~ ERROR
+pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) }; //~ ERROR
+pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) }; //~ ERROR
+pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) }; //~ ERROR
 
-pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) }; //~NOTE
-pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) }; //~NOTE
+pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) }; //~ ERROR
+pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) }; //~ ERROR
 
 // Make sure that we don't panic when computing abs(offset*size_of::<T>())
-pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) }; //~NOTE
+pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) }; //~ ERROR
 
 // Offset-by-zero is allowed.
 pub const NULL_OFFSET_ZERO: *const u8 = unsafe { ptr::null::<u8>().offset(0) };

--- a/tests/ui/consts/offset_ub.stderr
+++ b/tests/ui/consts/offset_ub.stderr
@@ -1,145 +1,101 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of 1 byte of memory, but got ALLOC0 which is at the beginning of the allocation
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `BEFORE_START`
   --> $DIR/offset_ub.rs:8:46
    |
 LL | pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1) };
-   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC1 which is only 1 byte from the end of the allocation
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of 1 byte of memory, but got ALLOC0 which is at the beginning of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `AFTER_END`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:9:43
    |
 LL | pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC2 which is only $BYTES bytes from the end of the allocation
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC1 which is only 1 byte from the end of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `AFTER_ARRAY`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:10:45
    |
 LL | pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) };
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got ALLOC2 which is only $BYTES bytes from the end of the allocation
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
-   |
-note: inside `std::ptr::const_ptr::<impl *const u16>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OVERFLOW`
   --> $DIR/offset_ub.rs:12:43
    |
 LL | pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) };
-   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
    |
 note: inside `std::ptr::const_ptr::<impl *const u16>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNDERFLOW`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:13:44
    |
 LL | pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) };
-   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
+   |
+note: inside `std::ptr::const_ptr::<impl *const u16>::offset`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
-   |
-note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `OVERFLOW_ADDRESS_SPACE`
   --> $DIR/offset_ub.rs:14:56
    |
 LL | pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) };
-   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNDERFLOW_ADDRESS_SPACE`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:15:57
    |
 LL | pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) };
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got ALLOC3-0x2 which points to before the beginning of the allocation
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `NEGATIVE_OFFSET`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:16:49
    |
 LL | pub const NEGATIVE_OFFSET: *const u8 = unsafe { [0u8; 1].as_ptr().wrapping_offset(-2).offset(-2) };
-   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to 1 byte of memory, but got ALLOC4 which is at or beyond the end of the allocation of size $BYTES bytes
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got ALLOC3-0x2 which points to before the beginning of the allocation
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `ZERO_SIZED_ALLOC`
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:18:50
    |
 LL | pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) };
-   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
-   |
-note: inside `std::ptr::mut_ptr::<impl *mut u8>::offset`
-  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
-note: inside `DANGLING`
-  --> $DIR/offset_ub.rs:19:42
-   |
-LL | pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) };
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |
-   = note: out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to 1 byte of memory, but got ALLOC4 which is at or beyond the end of the allocation of size $BYTES bytes
    |
 note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-note: inside `UNDERFLOW_ABS`
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/offset_ub.rs:19:42
+   |
+LL | pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to $BYTES bytes of memory, but got 0x1[noalloc] which is a dangling pointer (it has no provenance)
+   |
+note: inside `std::ptr::mut_ptr::<impl *mut u8>::offset`
+  --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
+
+error[E0080]: evaluation of constant value failed
   --> $DIR/offset_ub.rs:22:47
    |
 LL | pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) };
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to the end of $BYTES bytes of memory, but got 0xf..f[noalloc] which is a dangling pointer (it has no provenance)
+   |
+note: inside `std::ptr::const_ptr::<impl *const u8>::offset`
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/consts/qualif-indirect-mutation-fail.rs
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.rs
@@ -15,7 +15,7 @@ pub const A1: () = {
     let b = &mut y;
     std::mem::swap(a, b);
     std::mem::forget(y);
-};
+}; //~ ERROR evaluation of constant value failed
 
 // Mutable borrow of a type with drop impl.
 pub const A2: () = {
@@ -26,7 +26,7 @@ pub const A2: () = {
     std::mem::swap(a, b);
     std::mem::forget(y);
     let _z = x; //~ ERROR destructor of
-};
+}; //~ ERROR evaluation of constant value failed
 
 // Shared borrow of a type that might be !Freeze and Drop.
 pub const fn g1<T>() {

--- a/tests/ui/consts/qualif-indirect-mutation-fail.stderr
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.stderr
@@ -8,21 +8,17 @@ LL | };
    | - value is dropped here
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<u8> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `A1`
   --> $DIR/qualif-indirect-mutation-fail.rs:18:1
    |
 LL | };
-   | ^
+   | ^ calling non-const function `<Vec<u8> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:28:9
@@ -33,21 +29,17 @@ LL | };
    | - value is dropped here
 
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-   |
-   = note: calling non-const function `<Vec<u8> as Drop>::drop`
-   |
-note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
-  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `A2`
   --> $DIR/qualif-indirect-mutation-fail.rs:29:1
    |
 LL | };
-   | ^
+   | ^ calling non-const function `<Vec<u8> as Drop>::drop`
+   |
+note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `(u32, Option<String>)` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:6:9

--- a/tests/ui/consts/recursive.rs
+++ b/tests/ui/consts/recursive.rs
@@ -2,9 +2,8 @@
 
 const fn f<T>(x: T) { //~ WARN function cannot return without recursing
     f(x);
-    //~^ ERROR evaluation of constant value failed
 }
 
-const X: () = f(1);
+const X: () = f(1); //~ ERROR evaluation of constant value failed
 
 fn main() {}

--- a/tests/ui/consts/recursive.stderr
+++ b/tests/ui/consts/recursive.stderr
@@ -10,26 +10,21 @@ LL |     f(x);
    = note: `#[warn(unconditional_recursion)]` on by default
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/recursive.rs:4:5
+  --> $DIR/recursive.rs:7:15
    |
-LL |     f(x);
-   |     ^^^^ reached the configured maximum number of stack frames
+LL | const X: () = f(1);
+   |               ^^^^ reached the configured maximum number of stack frames
    |
-note: inside `f::<i32>`
-  --> $DIR/recursive.rs:4:5
-   |
-LL |     f(x);
-   |     ^^^^
 note: [... 126 additional calls inside `f::<i32>` ...]
   --> $DIR/recursive.rs:4:5
    |
 LL |     f(x);
    |     ^^^^
-note: inside `X`
-  --> $DIR/recursive.rs:8:15
+note: inside `f::<i32>`
+  --> $DIR/recursive.rs:4:5
    |
-LL | const X: () = f(1);
-   |               ^^^^
+LL |     f(x);
+   |     ^^^^ the failure occurred here
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/consts/required-consts/collect-in-called-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-called-fn.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-called-fn.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-called-fn.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-called-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-called-fn.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-called-fn.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-called-fn.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-closure.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-closure.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-closure.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-closure.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-closure.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-closure.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-closure.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-closure.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-drop.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-drop.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-drop.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-drop.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-drop.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-drop.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-drop.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-drop.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-assoc-type.rs:10:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-generic.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-generic.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-generic.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-generic.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `m::Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
    |
 LL |         const C: () = panic!();
-   |                       ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
+   |                       ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `m::Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
    |
 LL |         const C: () = panic!();
-   |                       ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn-behind-opaque-type.rs:11:23
+   |                       ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fn.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fn.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Late::<i32>::FAIL` failed
   --> $DIR/collect-in-dead-fnptr-in-const.rs:9:22
    |
 LL |     const FAIL: () = panic!();
-   |                      ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr-in-const.rs:9:22
+   |                      ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Late::<i32>::FAIL` failed
   --> $DIR/collect-in-dead-fnptr-in-const.rs:9:22
    |
 LL |     const FAIL: () = panic!();
-   |                      ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr-in-const.rs:9:22
+   |                      ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fnptr.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-fnptr.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-fnptr.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-move.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-move.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-move.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-move.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-move.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-move.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-move.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-move.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-vtable.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-vtable.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-vtable.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-vtable.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-dead-vtable.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-vtable.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-dead-vtable.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-dead-vtable.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-promoted-const.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-promoted-const.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<T>::C` failed
   --> $DIR/collect-in-promoted-const.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-promoted-const.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -16,7 +16,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/collect-in-promoted-const.rs:9:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/collect-in-promoted-const.rs:9:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-const-called-fn.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-const-called-fn.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-const-called-fn.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-const-called-fn.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-promoted.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.noopt.stderr
@@ -1,20 +1,16 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
+  --> $DIR/interpret-in-promoted.rs:13:28
    |
-   = note: entering unreachable code
+LL |     let _x: &'static () = &ub();
+   |                            ^^^^ entering unreachable code
    |
-note: inside `unreachable_unchecked`
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
 note: inside `ub`
   --> $DIR/interpret-in-promoted.rs:7:5
    |
 LL |     std::hint::unreachable_unchecked();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/interpret-in-promoted.rs:13:28
-   |
-LL |     let _x: &'static () = &ub();
-   |                            ^^^^
+note: inside `unreachable_unchecked`
+  --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 note: erroneous constant encountered
   --> $DIR/interpret-in-promoted.rs:13:27

--- a/tests/ui/consts/required-consts/interpret-in-promoted.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.opt.stderr
@@ -1,20 +1,16 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
+  --> $DIR/interpret-in-promoted.rs:13:28
    |
-   = note: entering unreachable code
+LL |     let _x: &'static () = &ub();
+   |                            ^^^^ entering unreachable code
    |
-note: inside `unreachable_unchecked`
-  --> $SRC_DIR/core/src/hint.rs:LL:COL
 note: inside `ub`
   --> $DIR/interpret-in-promoted.rs:7:5
    |
 LL |     std::hint::unreachable_unchecked();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: inside `FOO`
-  --> $DIR/interpret-in-promoted.rs:13:28
-   |
-LL |     let _x: &'static () = &ub();
-   |                            ^^^^
+note: inside `unreachable_unchecked`
+  --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 note: erroneous constant encountered
   --> $DIR/interpret-in-promoted.rs:13:27

--- a/tests/ui/consts/required-consts/interpret-in-promoted.rs
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.rs
@@ -4,13 +4,13 @@
 //! Make sure we evaluate const fn calls even if they get promoted and their result ignored.
 
 const unsafe fn ub() {
-    std::hint::unreachable_unchecked();
+    std::hint::unreachable_unchecked(); //~ inside `ub`
 }
 
 pub const FOO: () = unsafe {
     // Make sure that this gets promoted and then fails to evaluate, and we deal with that
     // correctly.
-    let _x: &'static () = &ub(); //~ erroneous constant
+    let _x: &'static () = &ub(); //~ ERROR evaluation of constant value failed
 };
 
 fn main() {}

--- a/tests/ui/consts/required-consts/interpret-in-static.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-static.noopt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-static.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-static.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/required-consts/interpret-in-static.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-static.opt.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
   --> $DIR/interpret-in-static.rs:8:19
    |
 LL |     const C: () = panic!();
-   |                   ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/interpret-in-static.rs:8:19
+   |                   ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/consts/uninhabited-const-issue-61744.rs
+++ b/tests/ui/consts/uninhabited-const-issue-61744.rs
@@ -1,7 +1,7 @@
 //@ build-fail
 
 pub const unsafe fn fake_type<T>() -> T {
-    hint_unreachable() //~ ERROR evaluation of `<i32 as Const>::CONSTANT` failed
+    hint_unreachable() //~ inside
 }
 
 pub const unsafe fn hint_unreachable() -> ! {
@@ -9,7 +9,7 @@ pub const unsafe fn hint_unreachable() -> ! {
 }
 
 trait Const {
-    const CONSTANT: i32 = unsafe { fake_type() }; //~ inside
+    const CONSTANT: i32 = unsafe { fake_type() }; //~ ERROR evaluation of `fake_type::<!>` failed
 }
 
 impl<T> Const for T {}

--- a/tests/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/tests/ui/consts/uninhabited-const-issue-61744.stderr
@@ -1,649 +1,644 @@
-error[E0080]: evaluation of `<i32 as Const>::CONSTANT` failed
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+error[E0080]: evaluation of `fake_type::<!>` failed
+  --> $DIR/uninhabited-const-issue-61744.rs:12:36
    |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^ reached the configured maximum number of stack frames
+LL |     const CONSTANT: i32 = unsafe { fake_type() };
+   |                                    ^^^^^^^^^^^ reached the configured maximum number of stack frames
    |
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
-note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
-   |
-LL |     hint_unreachable()
-   |     ^^^^^^^^^^^^^^^^^^
-note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
-   |
-LL |     fake_type()
-   |     ^^^^^^^^^^^
 note: inside `fake_type::<i32>`
   --> $DIR/uninhabited-const-issue-61744.rs:4:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
-note: inside `<i32 as Const>::CONSTANT`
-  --> $DIR/uninhabited-const-issue-61744.rs:12:36
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
    |
-LL |     const CONSTANT: i32 = unsafe { fake_type() };
-   |                                    ^^^^^^^^^^^
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^
+note: inside `hint_unreachable`
+  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+   |
+LL |     fake_type()
+   |     ^^^^^^^^^^^
+note: inside `fake_type::<!>`
+  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+   |
+LL |     hint_unreachable()
+   |     ^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0771.stderr
+++ b/tests/ui/error-codes/E0771.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | fn function_with_str<'a, const STRING: &'a str>() {}
    |                                         ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 warning: the feature `unsized_const_params` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/E0771.rs:1:30

--- a/tests/ui/explicit-tail-calls/ctfe-id-unlimited.return.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-id-unlimited.return.stderr
@@ -1,29 +1,24 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ctfe-id-unlimited.rs:17:42
+  --> $DIR/ctfe-id-unlimited.rs:28:20
    |
-LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
-   |                                          ^^^^^^^^^^^^^^^^^^^^^ reached the configured maximum number of stack frames
+LL | const ID_ED: u32 = rec_id(ORIGINAL);
+   |                    ^^^^^^^^^^^^^^^^ reached the configured maximum number of stack frames
    |
-note: inside `inner`
-  --> $DIR/ctfe-id-unlimited.rs:17:42
+note: inside `rec_id`
+  --> $DIR/ctfe-id-unlimited.rs:21:5
    |
-LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
-   |                                          ^^^^^^^^^^^^^^^^^^^^^
+LL |     inner(0, n)
+   |     ^^^^^^^^^^^
 note: [... 125 additional calls inside `inner` ...]
   --> $DIR/ctfe-id-unlimited.rs:17:42
    |
 LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
    |                                          ^^^^^^^^^^^^^^^^^^^^^
-note: inside `rec_id`
-  --> $DIR/ctfe-id-unlimited.rs:22:5
+note: inside `inner`
+  --> $DIR/ctfe-id-unlimited.rs:17:42
    |
-LL |     inner(0, n)
-   |     ^^^^^^^^^^^
-note: inside `ID_ED`
-  --> $DIR/ctfe-id-unlimited.rs:29:20
-   |
-LL | const ID_ED: u32 = rec_id(ORIGINAL);
-   |                    ^^^^^^^^^^^^^^^^
+LL |             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
+   |                                          ^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/explicit-tail-calls/ctfe-id-unlimited.rs
+++ b/tests/ui/explicit-tail-calls/ctfe-id-unlimited.rs
@@ -15,7 +15,6 @@ const fn rec_id(n: u32) -> u32 {
             0 => acc,
             #[cfg(r#become)] _ => become inner(acc + 1, n - 1),
             #[cfg(r#return)] _ => return inner(acc + 1, n - 1),
-            //[return]~^ error: evaluation of constant value failed
         }
     }
 
@@ -26,7 +25,7 @@ const fn rec_id(n: u32) -> u32 {
 const ORIGINAL: u32 = 12345;
 // Original number, but with identity function applied
 // (this is the same, but requires execution of the recursion)
-const ID_ED: u32 = rec_id(ORIGINAL);
+const ID_ED: u32 = rec_id(ORIGINAL); //[return]~ error: evaluation of constant value failed
 // Assert to make absolutely sure the computation actually happens
 const ASSERT: () = assert!(ORIGINAL == ID_ED);
 

--- a/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.rs
+++ b/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.rs
@@ -6,14 +6,11 @@ pub const fn f() {
 }
 
 const fn g() {
-    panic!()
-    //~^ error: evaluation of constant value failed
-    //~| note: in this expansion of panic!
-    //~| note: inside `g`
-    //~| note: in this expansion of panic!
+    panic!() //~ NOTE inside `g`
+    //~^ NOTE in this expansion of panic!
 }
 
-const _: () = f();
-//~^ note: inside `_`
+const _: () = f(); //~ ERROR evaluation of constant value failed
+//~^ NOTE explicit panic
 
 fn main() {}

--- a/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.stderr
@@ -1,19 +1,14 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ctfe-tail-call-panic.rs:9:5
+  --> $DIR/ctfe-tail-call-panic.rs:13:15
    |
-LL |     panic!()
-   |     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/ctfe-tail-call-panic.rs:9:5
+LL | const _: () = f();
+   |               ^^^ evaluation panicked: explicit panic
    |
 note: inside `g`
   --> $DIR/ctfe-tail-call-panic.rs:9:5
    |
 LL |     panic!()
-   |     ^^^^^^^^
-note: inside `_`
-  --> $DIR/ctfe-tail-call-panic.rs:16:15
-   |
-LL | const _: () = f();
-   |               ^^^
+   |     ^^^^^^^^ the failure occurred here
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.normal.stderr
+++ b/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.normal.stderr
@@ -1,14 +1,14 @@
 error[E0770]: the type of const parameters must not depend on other generic parameters
-  --> $DIR/issue-71169.rs:5:43
+  --> $DIR/feature-gate-generic-const-parameter-types.rs:7:50
    |
-LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
-   |                                           ^^^ the type must not depend on the parameter `LEN`
+LL | struct MyADT<const LEN: usize, const ARRAY: [u8; LEN]>;
+   |                                                  ^^^ the type must not depend on the parameter `LEN`
 
 error: `[u8; LEN]` is forbidden as the type of a const generic parameter
-  --> $DIR/issue-71169.rs:5:38
+  --> $DIR/feature-gate-generic-const-parameter-types.rs:7:45
    |
-LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
-   |                                      ^^^^^^^^^
+LL | struct MyADT<const LEN: usize, const ARRAY: [u8; LEN]>;
+   |                                             ^^^^^^^^^
    |
    = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types

--- a/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.rs
+++ b/tests/ui/feature-gates/feature-gate-generic-const-parameter-types.rs
@@ -1,0 +1,11 @@
+//@ [feature] check-pass
+//@ revisions: normal feature
+
+#![cfg_attr(feature, feature(adt_const_params, generic_const_parameter_types))]
+#![cfg_attr(feature, expect(incomplete_features))]
+
+struct MyADT<const LEN: usize, const ARRAY: [u8; LEN]>;
+//[normal]~^ ERROR: the type of const parameters must not depend on other generic parameters
+//[normal]~| ERROR: `[u8; LEN]` is forbidden as the type of a const generic parameter
+
+fn main() {}

--- a/tests/ui/generic-const-items/def-site-eval.fail.stderr
+++ b/tests/ui/generic-const-items/def-site-eval.fail.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `_::<'_>` failed
   --> $DIR/def-site-eval.rs:14:20
    |
 LL | const _<'_a>: () = panic!();
-   |                    ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/def-site-eval.rs:14:20
+   |                    ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/generic-const-items/wfcheck_err_leak_issue_118179.stderr
+++ b/tests/ui/generic-const-items/wfcheck_err_leak_issue_118179.stderr
@@ -3,8 +3,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct G<T, const N: Vec<T>>(T);
    |                          ^ the type must not depend on the parameter `T`
-   |
-   = note: type parameters may not be used in the type of const parameters
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/post_monomorphization_error_backtrace.rs
+++ b/tests/ui/generics/post_monomorphization_error_backtrace.rs
@@ -6,10 +6,10 @@ fn assert_zst<T>() {
         const V: () = assert!(std::mem::size_of::<T>() == 0);
         //~^ ERROR: evaluation of `assert_zst::F::<u32>::V` failed [E0080]
         //~| NOTE: in this expansion of assert!
-        //~| NOTE: the evaluated program panicked
+        //~| NOTE: assertion failed
         //~| ERROR: evaluation of `assert_zst::F::<i32>::V` failed [E0080]
         //~| NOTE: in this expansion of assert!
-        //~| NOTE: the evaluated program panicked
+        //~| NOTE: assertion failed
     }
     F::<T>::V;
     //~^NOTE: erroneous constant

--- a/tests/ui/generics/post_monomorphization_error_backtrace.stderr
+++ b/tests/ui/generics/post_monomorphization_error_backtrace.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `assert_zst::F::<u32>::V` failed
   --> $DIR/post_monomorphization_error_backtrace.rs:6:23
    |
 LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/post_monomorphization_error_backtrace.rs:6:23
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -22,7 +22,7 @@ error[E0080]: evaluation of `assert_zst::F::<i32>::V` failed
   --> $DIR/post_monomorphization_error_backtrace.rs:6:23
    |
 LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/post_monomorphization_error_backtrace.rs:6:23
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/infinite/infinite-recursion-const-fn.rs
+++ b/tests/ui/infinite/infinite-recursion-const-fn.rs
@@ -1,11 +1,11 @@
 //https://github.com/rust-lang/rust/issues/31364
 
 const fn a() -> usize {
-    b() //~ ERROR evaluation of constant value failed [E0080]
+    b()
 }
 const fn b() -> usize {
     a()
 }
-const ARR: [i32; a()] = [5; 6];
+const ARR: [i32; a()] = [5; 6]; //~ ERROR evaluation of constant value failed [E0080]
 
 fn main() {}

--- a/tests/ui/infinite/infinite-recursion-const-fn.stderr
+++ b/tests/ui/infinite/infinite-recursion-const-fn.stderr
@@ -1,649 +1,644 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^ reached the configured maximum number of stack frames
-   |
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `b`
-  --> $DIR/infinite-recursion-const-fn.rs:7:5
-   |
-LL |     a()
-   |     ^^^
-note: inside `a`
-  --> $DIR/infinite-recursion-const-fn.rs:4:5
-   |
-LL |     b()
-   |     ^^^
-note: inside `ARR::{constant#0}`
   --> $DIR/infinite-recursion-const-fn.rs:9:18
    |
 LL | const ARR: [i32; a()] = [5; 6];
-   |                  ^^^
+   |                  ^^^ reached the configured maximum number of stack frames
+   |
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^
+note: inside `b`
+  --> $DIR/infinite-recursion-const-fn.rs:7:5
+   |
+LL |     a()
+   |     ^^^
+note: inside `a`
+  --> $DIR/infinite-recursion-const-fn.rs:4:5
+   |
+LL |     b()
+   |     ^^^ the failure occurred here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inline-const/const-expr-generic-err.stderr
+++ b/tests/ui/inline-const/const-expr-generic-err.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `foo::<i32>::{constant#0}` failed
   --> $DIR/const-expr-generic-err.rs:4:13
    |
 LL |     const { assert!(std::mem::size_of::<T>() == 0); }
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/const-expr-generic-err.rs:4:13
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/inline-const/required-const.stderr
+++ b/tests/ui/inline-const/required-const.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `foo::<i32>::{constant#0}` failed
   --> $DIR/required-const.rs:6:17
    |
 LL |         const { panic!() }
-   |                 ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/required-const.rs:6:17
+   |                 ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/issues/issue-76191.stderr
+++ b/tests/ui/issues/issue-76191.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-76191.rs:8:37
    |
 LL | const RANGE2: RangeInclusive<i32> = panic!();
-   |                                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-76191.rs:8:37
+   |                                     ^^^^^^^^ evaluation panicked: explicit panic
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/layout/invalid-unsized-in-always-sized-tail.rs
+++ b/tests/ui/layout/invalid-unsized-in-always-sized-tail.rs
@@ -12,6 +12,6 @@ struct P2 {
     //~^ ERROR: the size for values of type `[bool]` cannot be known at compilation time
 }
 
-static CHECK: () = assert!(align_of::<P2>() == 1);
+static CHECK: () = assert!(align_of::<P2>() == 1); //~ ERROR could not evaluate static initializer
 
 fn main() {}

--- a/tests/ui/layout/invalid-unsized-in-always-sized-tail.stderr
+++ b/tests/ui/layout/invalid-unsized-in-always-sized-tail.stderr
@@ -19,17 +19,13 @@ LL | struct MySlice<T>(T);
    |                this could be changed to `T: ?Sized`...
 
 error[E0080]: could not evaluate static initializer
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: the type `MySlice<[bool]>` has an unknown layout
-   |
-note: inside `align_of::<P2>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `CHECK`
   --> $DIR/invalid-unsized-in-always-sized-tail.rs:15:28
    |
 LL | static CHECK: () = assert!(align_of::<P2>() == 1);
-   |                            ^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^ the type `MySlice<[bool]>` has an unknown layout
+   |
+note: inside `align_of::<P2>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/layout/unknown-when-no-type-parameter.stderr
+++ b/tests/ui/layout/unknown-when-no-type-parameter.stderr
@@ -1,15 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: the type `<() as Project>::Assoc` has an unknown layout
-   |
-note: inside `std::mem::size_of::<<() as Project>::Assoc>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `foo::{constant#0}`
   --> $DIR/unknown-when-no-type-parameter.rs:11:10
    |
 LL |     [(); size_of::<<() as Project>::Assoc>()];
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the type `<() as Project>::Assoc` has an unknown layout
+   |
+note: inside `std::mem::size_of::<<() as Project>::Assoc>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -9,8 +9,6 @@ error[E0770]: the type of const parameters must not depend on other generic para
    |
 LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
    |                      ^^ the type must not depend on the parameter `'a`
-   |
-   = note: lifetime parameters may not be used in the type of const parameters
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unusual-rib-combinations.rs:11:15

--- a/tests/ui/limits/issue-55878.stderr
+++ b/tests/ui/limits/issue-55878.stderr
@@ -1,15 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-   = note: values of the type `[u8; usize::MAX]` are too big for the target architecture
-   |
-note: inside `std::mem::size_of::<[u8; usize::MAX]>`
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-note: inside `main`
   --> $DIR/issue-55878.rs:5:26
    |
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ values of the type `[u8; usize::MAX]` are too big for the target architecture
+   |
+note: inside `std::mem::size_of::<[u8; usize::MAX]>`
+  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/simd/const-err-trumps-simd-err.stderr
+++ b/tests/ui/simd/const-err-trumps-simd-err.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of `get_elem::<4>::{constant#0}` failed
   --> $DIR/const-err-trumps-simd-err.rs:16:13
    |
 LL |     const { assert!(LANE < 4); } // the error should be here...
-   |             ^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: LANE < 4', $DIR/const-err-trumps-simd-err.rs:16:13
+   |             ^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: LANE < 4
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/structs/default-field-values/invalid-const.stderr
+++ b/tests/ui/structs/default-field-values/invalid-const.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/invalid-const.rs:5:19
    |
 LL |     pub bax: u8 = panic!("asdf"),
-   |                   ^^^^^^^^^^^^^^ the evaluated program panicked at 'asdf', $DIR/invalid-const.rs:5:19
+   |                   ^^^^^^^^^^^^^^ evaluation panicked: asdf
    |
    = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/transmutability/uninhabited.stderr
+++ b/tests/ui/transmutability/uninhabited.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:41:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:41:9
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -10,7 +10,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:63:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:63:9
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -18,7 +18,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:87:9
    |
 LL |         assert!(false);
-   |         ^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: false', $DIR/uninhabited.rs:87:9
+   |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.rs
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.rs
@@ -3,6 +3,7 @@ trait Foo<const N: Bar<2>> {
     //~^ WARN trait objects without an explicit `dyn` are deprecated
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| ERROR cycle detected when computing type of `Foo::N`
+    //~| ERROR cycle detected when computing type of `Foo::N`
     fn func() {}
 }
 

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -13,7 +13,7 @@ LL | trait Foo<const N: dyn Bar<2>> {
    |                    +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:9:20
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:20
    |
 LL | trait Bar<const M: Foo<2>> {}
    |                    ^^^^^^
@@ -32,7 +32,7 @@ LL | trait Foo<const N: Bar<2>> {
    |           ^^^^^^^^^^^^^^^
    |
 note: ...which requires computing type of `Bar::M`...
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:9:11
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:11
    |
 LL | trait Bar<const M: Foo<2>> {}
    |           ^^^^^^^^^^^^^^^
@@ -44,6 +44,26 @@ LL | trait Foo<const N: Bar<2>> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 1 previous error; 2 warnings emitted
+error[E0391]: cycle detected when computing type of `Foo::N`
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:2:11
+   |
+LL | trait Foo<const N: Bar<2>> {
+   |           ^^^^^^^^^^^^^^^
+   |
+note: ...which requires computing type of `Bar::M`...
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:10:11
+   |
+LL | trait Bar<const M: Foo<2>> {}
+   |           ^^^^^^^^^^^^^^^
+   = note: ...which again requires computing type of `Foo::N`, completing the cycle
+note: cycle used when computing explicit predicates of trait `Foo`
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:2:1
+   |
+LL | trait Foo<const N: Bar<2>> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
Successful merges:

 - #136503 (Tweak output of const panic diagnostic)
 - #137390 (tests: fix up new test for nocapture -> capture(none) change)
 - #137617 (Introduce `feature(generic_const_parameter_types)`)
 - #137719 (Add missing case explanation for doc inlined re-export of doc hidden item)
 - #137763 (Use `mk_ty_from_kind` a bit less, clean up lifetime handling in borrowck)
 - #137769 (Do not yeet `unsafe<>` from type when formatting unsafe binder)
 - #137776 (Some `rustc_transmute` cleanups)
 - #137800 (Remove `ParamEnv::without_caller_bounds`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=136503,137390,137617,137719,137763,137769,137776,137800)
<!-- homu-ignore:end -->