### PR TITLE
improve `simd_select` error message when used with invalid mask type

### DIFF
--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -119,7 +119,8 @@ codegen_ssa_invalid_monomorphization_inserted_type = invalid monomorphization of
 
 codegen_ssa_invalid_monomorphization_invalid_bitmask = invalid monomorphization of `{$name}` intrinsic: invalid bitmask `{$mask_ty}`, expected `u{$expected_int_bits}` or `[u8; {$expected_bytes}]`
 
-codegen_ssa_invalid_monomorphization_mask_type = invalid monomorphization of `{$name}` intrinsic: mask element type is `{$ty}`, expected `i_`
+codegen_ssa_invalid_monomorphization_mask_type = invalid monomorphization of `{$name}` intrinsic: found mask element type is `{$ty}`, expected a signed integer type
+    .note = the mask may be widened, which only has the correct behavior for signed integers
 
 codegen_ssa_invalid_monomorphization_mismatched_lengths = invalid monomorphization of `{$name}` intrinsic: mismatched lengths: mask length `{$m_len}` != other vector length `{$v_len}`
 

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -957,6 +957,7 @@ pub enum InvalidMonomorphization<'tcx> {
     },
 
     #[diag(codegen_ssa_invalid_monomorphization_mask_type, code = E0511)]
+    #[note]
     MaskType {
         #[primary_span]
         span: Span,

--- a/tests/ui/simd/intrinsic/generic-gather.rs
+++ b/tests/ui/simd/intrinsic/generic-gather.rs
@@ -1,0 +1,52 @@
+//@ build-fail
+//@ ignore-emscripten
+
+// Test that the simd_{gather,scatter} intrinsics produce ok-ish error
+// messages when misused.
+
+#![feature(repr_simd, core_intrinsics)]
+#![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{simd_gather, simd_scatter};
+
+#[repr(simd)]
+#[derive(Copy, Clone, PartialEq, Debug)]
+struct x4<T>(pub [T; 4]);
+
+fn main() {
+    let mut x = [0_f32, 1., 2., 3., 4., 5., 6., 7.];
+
+    let default = x4([-3_f32, -3., -3., -3.]);
+    let s_strided = x4([0_f32, 2., -3., 6.]);
+
+    let mask = x4([-1_i32, -1, 0, -1]);
+    let umask = x4([0u16; 4]);
+    let fmask = x4([0_f32; 4]);
+
+    let pointer = x.as_mut_ptr();
+    let pointers =
+        unsafe { x4([pointer.offset(0), pointer.offset(2), pointer.offset(4), pointer.offset(6)]) };
+
+    unsafe {
+        simd_gather(default, mask, mask);
+        //~^ ERROR expected element type `i32` of second argument `x4<i32>` to be a pointer to the element type `f32`
+
+        simd_gather(default, pointers, umask);
+        //~^ ERROR expected element type `u16` of third argument `x4<u16>` to be a signed integer type
+
+        simd_gather(default, pointers, fmask);
+        //~^ ERROR expected element type `f32` of third argument `x4<f32>` to be a signed integer type
+    }
+
+    unsafe {
+        let values = x4([42_f32, 43_f32, 44_f32, 45_f32]);
+        simd_scatter(values, mask, mask);
+        //~^ ERROR expected element type `i32` of second argument `x4<i32>` to be a pointer to the element type `f32` of the first argument `x4<f32>`, found `i32` != `*mut f32`
+
+        simd_scatter(values, pointers, umask);
+        //~^ ERROR expected element type `u16` of third argument `x4<u16>` to be a signed integer type
+
+        simd_scatter(values, pointers, fmask);
+        //~^ ERROR expected element type `f32` of third argument `x4<f32>` to be a signed integer type
+    }
+}

--- a/tests/ui/simd/intrinsic/generic-gather.stderr
+++ b/tests/ui/simd/intrinsic/generic-gather.stderr
@@ -1,0 +1,39 @@
+error[E0511]: invalid monomorphization of `simd_gather` intrinsic: expected element type `i32` of second argument `x4<i32>` to be a pointer to the element type `f32` of the first argument `x4<f32>`, found `i32` != `*_ f32`
+  --> $DIR/generic-gather.rs:31:9
+   |
+LL |         simd_gather(default, mask, mask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_gather` intrinsic: expected element type `u16` of third argument `x4<u16>` to be a signed integer type
+  --> $DIR/generic-gather.rs:34:9
+   |
+LL |         simd_gather(default, pointers, umask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_gather` intrinsic: expected element type `f32` of third argument `x4<f32>` to be a signed integer type
+  --> $DIR/generic-gather.rs:37:9
+   |
+LL |         simd_gather(default, pointers, fmask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_scatter` intrinsic: expected element type `i32` of second argument `x4<i32>` to be a pointer to the element type `f32` of the first argument `x4<f32>`, found `i32` != `*mut f32`
+  --> $DIR/generic-gather.rs:43:9
+   |
+LL |         simd_scatter(values, mask, mask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_scatter` intrinsic: expected element type `u16` of third argument `x4<u16>` to be a signed integer type
+  --> $DIR/generic-gather.rs:46:9
+   |
+LL |         simd_scatter(values, pointers, umask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_scatter` intrinsic: expected element type `f32` of third argument `x4<f32>` to be a signed integer type
+  --> $DIR/generic-gather.rs:49:9
+   |
+LL |         simd_scatter(values, pointers, fmask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0511`.

--- a/tests/ui/simd/intrinsic/generic-select.rs
+++ b/tests/ui/simd/intrinsic/generic-select.rs
@@ -37,10 +37,10 @@ fn main() {
         //~^ ERROR mismatched lengths: mask length `8` != other vector length `4`
 
         simd_select(x, x, x);
-        //~^ ERROR mask element type is `u32`, expected `i_`
+        //~^ ERROR mask element type is `u32`, expected a signed integer type
 
         simd_select(z, z, z);
-        //~^ ERROR mask element type is `f32`, expected `i_`
+        //~^ ERROR mask element type is `f32`, expected a signed integer type
 
         simd_select(m4, 0u32, 1u32);
         //~^ ERROR found non-SIMD `u32`

--- a/tests/ui/simd/intrinsic/generic-select.stderr
+++ b/tests/ui/simd/intrinsic/generic-select.stderr
@@ -4,17 +4,21 @@ error[E0511]: invalid monomorphization of `simd_select` intrinsic: mismatched le
 LL |         simd_select(m8, x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_select` intrinsic: mask element type is `u32`, expected `i_`
+error[E0511]: invalid monomorphization of `simd_select` intrinsic: found mask element type is `u32`, expected a signed integer type
   --> $DIR/generic-select.rs:39:9
    |
 LL |         simd_select(x, x, x);
    |         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the mask may be widened, which only has the correct behavior for signed integers
 
-error[E0511]: invalid monomorphization of `simd_select` intrinsic: mask element type is `f32`, expected `i_`
+error[E0511]: invalid monomorphization of `simd_select` intrinsic: found mask element type is `f32`, expected a signed integer type
   --> $DIR/generic-select.rs:42:9
    |
 LL |         simd_select(z, z, z);
    |         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the mask may be widened, which only has the correct behavior for signed integers
 
 error[E0511]: invalid monomorphization of `simd_select` intrinsic: expected SIMD argument type, found non-SIMD `u32`
   --> $DIR/generic-select.rs:45:9


### PR DESCRIPTION
followup to https://github.com/rust-lang/rust/pull/137828

This PR improves the error message for an invalid `simd_select` mask type, and adds testing for `simd_scatter` and `simd_gather` being used with invalid mask types.

the `simd_masked_load` and `simd_masked_store` intrinsics already generated a better error message:

https://github.com/rust-lang/rust/blob/0c72c0d11adeba449886089c6bd5d48363f7a2cd/tests/ui/simd/masked-load-store-build-fail.rs#L24-L37

r? @workingjubilee 