### PR TITLE
Create personality stub function for no_std panic=abort crates

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -687,6 +687,7 @@ impl<'ll, 'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         get_fn(self, instance)
     }
 
+    /// Get a function pointer for the exception handling personality function.
     fn eh_personality(&self) -> &'ll Value {
         // The exception handling personality function.
         //

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -77,6 +77,7 @@ mod intrinsic;
 pub mod llvm;
 mod llvm_util;
 mod mono_item;
+mod personality_stub;
 mod type_;
 mod type_of;
 mod va_arg;
@@ -120,6 +121,15 @@ impl ExtraBackendMethods for LlvmCodegenBackend {
         unsafe {
             allocator::codegen(tcx, &mut module_llvm, module_name, kind, alloc_error_handler_kind);
         }
+        module_llvm
+    }
+    fn codegen_personality_stub<'tcx>(&self, tcx: TyCtxt<'tcx>, module_name: &str) -> Self::Module {
+        let mut module_llvm = ModuleLlvm::new_metadata(tcx, module_name);
+
+        unsafe {
+            personality_stub::codegen(tcx, &mut module_llvm, module_name);
+        }
+
         module_llvm
     }
     fn compile_codegen_unit(

--- a/compiler/rustc_codegen_llvm/src/personality_stub.rs
+++ b/compiler/rustc_codegen_llvm/src/personality_stub.rs
@@ -1,0 +1,102 @@
+use rustc_middle::ty::TyCtxt;
+use rustc_session::config::DebugInfo;
+
+use crate::common::AsCCharPtr;
+use crate::llvm::{self, Context, False, Module};
+use crate::{ModuleLlvm, attributes, debuginfo};
+
+const FEATURE_GATE_SYMBOL: &str = "__rust_personality_stub_is_unstable";
+
+pub(crate) unsafe fn codegen(tcx: TyCtxt<'_>, module_llvm: &mut ModuleLlvm, module_name: &str) {
+    let llcx = &*module_llvm.llcx;
+    let llmod = module_llvm.llmod();
+
+    // rust alloc error handler
+    create_stub_personality(tcx, llcx, llmod);
+
+    if tcx.sess.opts.debuginfo != DebugInfo::None {
+        let dbg_cx = debuginfo::CodegenUnitDebugContext::new(llmod);
+        debuginfo::metadata::build_compile_unit_di_node(tcx, module_name, &dbg_cx);
+        dbg_cx.finalize(tcx.sess);
+    }
+}
+
+fn create_stub_personality(tcx: TyCtxt<'_>, llcx: &Context, llmod: &Module) {
+    unsafe {
+        let llfn = declare_stub_personality(tcx, llcx, llmod);
+
+        let i8_ty = llvm::LLVMInt8TypeInContext(llcx);
+
+        let feature_gate = llvm::LLVMRustGetOrInsertGlobal(
+            llmod,
+            FEATURE_GATE_SYMBOL.as_c_char_ptr(),
+            FEATURE_GATE_SYMBOL.len(),
+            i8_ty,
+        );
+
+        let (trap_fn, trap_ty) = trap_intrinsic(llcx, llmod);
+
+        let llbb = llvm::LLVMAppendBasicBlockInContext(llcx, llfn, c"entry".as_ptr());
+        let llbuilder = llvm::LLVMCreateBuilderInContext(llcx);
+        llvm::LLVMPositionBuilderAtEnd(llbuilder, llbb);
+
+        let load = llvm::LLVMBuildLoad2(llbuilder, i8_ty, feature_gate, c"".as_ptr());
+        llvm::LLVMSetVolatile(load, llvm::True);
+
+        llvm::LLVMBuildCallWithOperandBundles(
+            llbuilder,
+            trap_ty,
+            trap_fn,
+            [].as_ptr(),
+            0,
+            [].as_ptr(),
+            0,
+            c"".as_ptr(),
+        );
+
+        llvm::LLVMBuildUnreachable(llbuilder);
+
+        llvm::LLVMDisposeBuilder(llbuilder);
+    }
+}
+
+fn declare_stub_personality<'ll>(
+    tcx: TyCtxt<'_>,
+    llcx: &'ll Context,
+    llmod: &'ll Module,
+) -> &'ll llvm::Value {
+    let name = "rust_eh_personality";
+    unsafe {
+        let no_return = llvm::AttributeKind::NoReturn.create_attr(llcx);
+
+        let ty = llvm::LLVMFunctionType(llvm::LLVMVoidTypeInContext(llcx), [].as_ptr(), 0, False);
+        let llfn = llvm::LLVMRustGetOrInsertFunction(llmod, name.as_c_char_ptr(), name.len(), ty);
+        attributes::apply_to_llfn(llfn, llvm::AttributePlace::Function, &[no_return]);
+        llvm::set_visibility(llfn, llvm::Visibility::from_generic(tcx.sess.default_visibility()));
+
+        if tcx.sess.must_emit_unwind_tables() {
+            let uwtable =
+                attributes::uwtable_attr(llcx, tcx.sess.opts.unstable_opts.use_sync_unwind);
+            attributes::apply_to_llfn(llfn, llvm::AttributePlace::Function, &[uwtable]);
+        }
+
+        llfn
+    }
+}
+
+fn trap_intrinsic<'ll>(
+    llcx: &'ll Context,
+    llmod: &'ll Module,
+) -> (&'ll llvm::Value, &'ll llvm::Type) {
+    let name = "llvm.trap";
+
+    unsafe {
+        let no_return = llvm::AttributeKind::NoReturn.create_attr(llcx);
+        let llty = llvm::LLVMFunctionType(llvm::LLVMVoidTypeInContext(llcx), [].as_ptr(), 0, False);
+        let llfn = llvm::LLVMRustGetOrInsertFunction(llmod, name.as_c_char_ptr(), name.len(), llty);
+        llvm::SetFunctionCallConv(llfn, llvm::CCallConv);
+        attributes::apply_to_llfn(llfn, llvm::AttributePlace::Function, &[no_return]);
+
+        (llfn, llty)
+    }
+}

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -98,6 +98,15 @@ impl<M> ModuleCodegen<M> {
         }
     }
 
+    pub fn new_personality_stub(name: impl Into<String>, module: M) -> Self {
+        Self {
+            name: name.into(),
+            module_llvm: module,
+            kind: ModuleKind::PersonalityStub,
+            thin_lto_buffer: None,
+        }
+    }
+
     pub fn into_compiled_module(
         self,
         emit_obj: bool,
@@ -165,6 +174,7 @@ pub enum ModuleKind {
     Regular,
     Metadata,
     Allocator,
+    PersonalityStub,
 }
 
 bitflags::bitflags! {
@@ -233,6 +243,7 @@ pub struct CrateInfo {
 pub struct CodegenResults {
     pub modules: Vec<CompiledModule>,
     pub allocator_module: Option<CompiledModule>,
+    pub personality_stub_module: Option<CompiledModule>,
     pub metadata_module: Option<CompiledModule>,
     pub metadata: rustc_metadata::EncodedMetadata,
     pub crate_info: CrateInfo,

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -108,6 +108,8 @@ pub trait ExtraBackendMethods:
         alloc_error_handler_kind: AllocatorKind,
     ) -> Self::Module;
 
+    fn codegen_personality_stub<'tcx>(&self, tcx: TyCtxt<'tcx>, module_name: &str) -> Self::Module;
+
     /// This generates the codegen unit and returns it along with
     /// a `u64` giving an estimate of the unit's processing cost.
     fn compile_codegen_unit(


### PR DESCRIPTION
**This is a very WIP state. It has no tests, no platform gates, and probably many bugs.**
I'm opening this PR mostly as a proof of concept.

Every crate that may unwind (being compiled with panic=unwind) needs a reference to a personality function in its object code.

The personality function is defined in `std`. For crates downstream of `std` (with `std` in the cstore), they will resolve to the personality lang item of std and reference that function from there (using its symbol_name `rust_eh_personality`).

For `#![no_std]` crates, they will also reference the `rust_eh_personality` symbol (directly, not via weak lang item machinery).

But when `std` is never linked into a crate graph containing panic=unwind crates (which happens on all panic=unwind default targets because of core), the symbol isn't present and we get a linker error.

This PR solves this problem by injecting a stub for `rust_eh_personality` into the final link of binaries where the previous conditions were fulfilled. This is implemented in a way that's very similar to the allocator shim.

Because we don't want to insta-stabilize this functionality, the stub doesn't just abort, it will first do a volatile read of the `__rust_personality_stub_is_unstable` symbol (once again similar to the allocator) to ensure that this functionality cannot be relied on without providing this symbol.

Example code that now works on x86_64-unknown-linux-gnu:
```rust

fn panic_handler(_: &core::panic::PanicInfo<'_>) -> ! {
    loop {}
}

unsafe extern "C" {
    fn write(fd: i32, buf: *const u8, count: usize);
}

static __rust_personality_stub_is_unstable: u8 = 0;

fn main() -> i32 {
    // bring in some code that requires the personality function
    [1].sort_unstable();

    let msg = b"meow\n";
    unsafe {
        write(1, msg.as_ptr(), msg.len());
    }
    0
}
```

When compiled with `-Cpanic=abort`, this would previously result in a linker error because the `rust_eh_personality` symbol was not found. Now, it compiles and runs successfully.

r? @ghost

random notes:
- Björn told me I need to export `__rust_personality_stub_is_unstable` from rust dylibs