### PR TITLE
Add new `unused_footnote_definition` rustdoc lint

### DIFF
--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -196,6 +196,13 @@ declare_rustdoc_lint! {
     "detects redundant explicit links in doc comments"
 }
 
+declare_rustdoc_lint! {
+    /// This lint checks for uses of footnote references without definition.
+    BROKEN_FOOTNOTE,
+    Warn,
+    "footnote reference with no associated definition"
+}
+
 pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
     vec![
         BROKEN_INTRA_DOC_LINKS,
@@ -209,6 +216,7 @@ pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
         MISSING_CRATE_LEVEL_DOCS,
         UNESCAPED_BACKTICKS,
         REDUNDANT_EXPLICIT_LINKS,
+        BROKEN_FOOTNOTE,
     ]
 });
 

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -203,6 +203,13 @@ declare_rustdoc_lint! {
     "footnote reference with no associated definition"
 }
 
+declare_rustdoc_lint! {
+    /// This lint checks if all footnote definitions are used.
+    UNUSED_FOOTNOTE_DEFINITION,
+    Warn,
+    "unused footnote definition"
+}
+
 pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
     vec![
         BROKEN_INTRA_DOC_LINKS,
@@ -217,6 +224,7 @@ pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {
         UNESCAPED_BACKTICKS,
         REDUNDANT_EXPLICIT_LINKS,
         BROKEN_FOOTNOTE,
+        UNUSED_FOOTNOTE_DEFINITION,
     ]
 });
 

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -200,14 +200,14 @@ declare_rustdoc_lint! {
     /// This lint checks for uses of footnote references without definition.
     BROKEN_FOOTNOTE,
     Warn,
-    "footnote reference with no associated definition"
+    "detects footnote references with no associated definition"
 }
 
 declare_rustdoc_lint! {
     /// This lint checks if all footnote definitions are used.
     UNUSED_FOOTNOTE_DEFINITION,
     Warn,
-    "unused footnote definition"
+    "detects unused footnote definitions"
 }
 
 pub(crate) static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {

--- a/src/librustdoc/passes/lint.rs
+++ b/src/librustdoc/passes/lint.rs
@@ -3,6 +3,7 @@
 
 mod bare_urls;
 mod check_code_block_syntax;
+mod footnotes;
 mod html_tags;
 mod redundant_explicit_links;
 mod unescaped_backticks;
@@ -41,6 +42,7 @@ impl DocVisitor<'_> for Linter<'_, '_> {
             if may_have_link {
                 bare_urls::visit_item(self.cx, item, hir_id, &dox);
                 redundant_explicit_links::visit_item(self.cx, item, hir_id);
+                footnotes::visit_item(self.cx, item, hir_id, &dox);
             }
             if may_have_code {
                 check_code_block_syntax::visit_item(self.cx, item, &dox);

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -77,26 +77,23 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
 
     #[allow(rustc::potential_query_instability)]
     for span in missing_footnote_references {
-        let (ref_span, precise) =
-            source_span_for_markdown_range(tcx, dox, &span, &item.attrs.doc_strings)
-                .map(|(span, _)| (span, true))
-                .unwrap_or_else(|| (item.attr_span(tcx), false));
+        let ref_span = source_span_for_markdown_range(tcx, dox, &span, &item.attrs.doc_strings)
+            .map(|(span, _)| span)
+            .unwrap_or_else(|| item.attr_span(tcx));
 
-        if precise {
-            tcx.emit_node_span_lint(
-                crate::lint::BROKEN_FOOTNOTE,
-                hir_id,
-                ref_span,
-                DiagDecorator(|lint| {
-                    lint.primary_message("no footnote definition matching this footnote");
-                    lint.span_suggestion(
-                        ref_span.shrink_to_lo(),
-                        "if it should not be a footnote, escape it",
-                        "\\",
-                        Applicability::MaybeIncorrect,
-                    );
-                }),
-            );
-        }
+        tcx.emit_node_span_lint(
+            crate::lint::BROKEN_FOOTNOTE,
+            hir_id,
+            ref_span,
+            DiagDecorator(|lint| {
+                lint.primary_message("no footnote definition matching this footnote");
+                lint.span_suggestion(
+                    ref_span.shrink_to_lo(),
+                    "if it should not be a footnote, escape it",
+                    "\\",
+                    Applicability::MaybeIncorrect,
+                );
+            }),
+        );
     }
 }

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -1,15 +1,3 @@
-//! Detects specific markdown syntax that's different between pulldown-cmark
-//! 0.9 and 0.11.
-//!
-//! This is a mitigation for old parser bugs that affected some
-//! real crates' docs. The old parser claimed to comply with CommonMark,
-//! but it did not. These warnings will eventually be removed,
-//! though some of them may become Clippy lints.
-//!
-//! <https://github.com/rust-lang/rust/pull/121659#issuecomment-1992752820>
-//!
-//! <https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html#add-the-lint-to-the-list-of-removed-lists>
-
 use std::ops::Range;
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -12,10 +12,11 @@
 
 use std::ops::Range;
 
-use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_errors::DiagDecorator;
 use rustc_hir::HirId;
 use rustc_lint_defs::Applicability;
-use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser};
+use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser, Tag};
 use rustc_resolve::rustdoc::source_span_for_markdown_range;
 
 use crate::clean::Item;
@@ -25,6 +26,8 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
     let tcx = cx.tcx;
 
     let mut missing_footnote_references = FxHashSet::default();
+    let mut footnote_references = FxHashSet::default();
+    let mut footnote_definitions = FxHashMap::default();
 
     let options = Options::ENABLE_FOOTNOTES;
     let mut parser = Parser::new_ext(dox, options).into_offset_iter().peekable();
@@ -40,7 +43,35 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
             {
                 missing_footnote_references.insert(Range { start: span.start, end: end_span.end });
             }
+            Event::FootnoteReference(label) => {
+                footnote_references.insert(label);
+            }
+            Event::Start(Tag::FootnoteDefinition(label)) => {
+                footnote_definitions.insert(label, span.start + 1);
+            }
             _ => {}
+        }
+    }
+
+    #[allow(rustc::potential_query_instability)]
+    for (footnote, span) in footnote_definitions {
+        if !footnote_references.contains(&footnote) {
+            let (span, _) = source_span_for_markdown_range(
+                tcx,
+                dox,
+                &(span..span + 1),
+                &item.attrs.doc_strings,
+            )
+            .unwrap_or_else(|| (item.attr_span(tcx), false));
+
+            tcx.emit_node_span_lint(
+                crate::lint::UNUSED_FOOTNOTE_DEFINITION,
+                hir_id,
+                span,
+                DiagDecorator(|lint| {
+                    lint.primary_message("unused footnote definition");
+                }),
+            );
         }
     }
 
@@ -56,7 +87,7 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
                 crate::lint::BROKEN_FOOTNOTE,
                 hir_id,
                 ref_span,
-                rustc_errors::DiagDecorator(|lint| {
+                DiagDecorator(|lint| {
                     lint.primary_message("no footnote definition matching this footnote");
                     lint.span_suggestion(
                         ref_span.shrink_to_lo(),

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -1,0 +1,71 @@
+//! Detects specific markdown syntax that's different between pulldown-cmark
+//! 0.9 and 0.11.
+//!
+//! This is a mitigation for old parser bugs that affected some
+//! real crates' docs. The old parser claimed to comply with CommonMark,
+//! but it did not. These warnings will eventually be removed,
+//! though some of them may become Clippy lints.
+//!
+//! <https://github.com/rust-lang/rust/pull/121659#issuecomment-1992752820>
+//!
+//! <https://rustc-dev-guide.rust-lang.org/bug-fix-procedure.html#add-the-lint-to-the-list-of-removed-lists>
+
+use std::ops::Range;
+
+use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::HirId;
+use rustc_lint_defs::Applicability;
+use rustc_resolve::rustdoc::pulldown_cmark::{Event, Options, Parser};
+use rustc_resolve::rustdoc::source_span_for_markdown_range;
+
+use crate::clean::Item;
+use crate::core::DocContext;
+
+pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &str) {
+    let tcx = cx.tcx;
+
+    let mut missing_footnote_references = FxHashSet::default();
+
+    let options = Options::ENABLE_FOOTNOTES;
+    let mut parser = Parser::new_ext(dox, options).into_offset_iter().peekable();
+    while let Some((event, span)) = parser.next() {
+        match event {
+            Event::Text(text)
+                if &*text == "["
+                    && let Some((Event::Text(text), _)) = parser.peek()
+                    && text.trim_start().starts_with('^')
+                    && parser.next().is_some()
+                    && let Some((Event::Text(text), end_span)) = parser.peek()
+                    && &**text == "]" =>
+            {
+                missing_footnote_references.insert(Range { start: span.start, end: end_span.end });
+            }
+            _ => {}
+        }
+    }
+
+    #[allow(rustc::potential_query_instability)]
+    for span in missing_footnote_references {
+        let (ref_span, precise) =
+            source_span_for_markdown_range(tcx, dox, &span, &item.attrs.doc_strings)
+                .map(|(span, _)| (span, true))
+                .unwrap_or_else(|| (item.attr_span(tcx), false));
+
+        if precise {
+            tcx.emit_node_span_lint(
+                crate::lint::BROKEN_FOOTNOTE,
+                hir_id,
+                ref_span,
+                rustc_errors::DiagDecorator(|lint| {
+                    lint.primary_message("no footnote definition matching this footnote");
+                    lint.span_suggestion(
+                        ref_span.shrink_to_lo(),
+                        "if it should not be a footnote, escape it",
+                        "\\",
+                        Applicability::MaybeIncorrect,
+                    );
+                }),
+            );
+        }
+    }
+}

--- a/src/librustdoc/passes/lint/footnotes.rs
+++ b/src/librustdoc/passes/lint/footnotes.rs
@@ -23,13 +23,11 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
         match event {
             Event::Text(text)
                 if &*text == "["
-                    && let Some((Event::Text(text), _)) = parser.peek()
-                    && text.trim_start().starts_with('^')
-                    && parser.next().is_some()
-                    && let Some((Event::Text(text), end_span)) = parser.peek()
-                    && &**text == "]" =>
+                    && (span.start == 0 || dox.as_bytes().get(span.start - 1) != Some(&b'\\'))
+                    && let Some(len) = scan_footnote_ref(&dox[span.start..]) =>
             {
-                missing_footnote_references.insert(Range { start: span.start, end: end_span.end });
+                missing_footnote_references
+                    .insert(Range { start: span.start, end: span.start + len });
             }
             Event::FootnoteReference(label) => {
                 footnote_references.insert(label);
@@ -84,4 +82,36 @@ pub(crate) fn visit_item(cx: &DocContext<'_>, item: &Item, hir_id: HirId, dox: &
             }),
         );
     }
+}
+
+fn scan_footnote_ref(dox: &str) -> Option<usize> {
+    let dox = dox.as_bytes();
+    let mut i = 0;
+    if dox.get(i) != Some(&b'[') {
+        return None;
+    }
+    i += 1;
+    if dox.get(i) != Some(&b'^') {
+        return None;
+    }
+    i += 1;
+    while let Some(&c) = dox.get(i) {
+        if c == b']' {
+            i += 1;
+            return Some(i);
+        }
+        if c == b'\r' || c == b'\n' || c == b'[' {
+            // Can't nest things like this.
+            break;
+        }
+        if c == b'\\' {
+            i += 1;
+        }
+        if dox.get(i) == Some(&b'\r') || dox.get(i) == Some(&b'\n') {
+            // Can't have line breaks in footnote refs
+            break;
+        }
+        i += 1;
+    }
+    None
 }

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -1,0 +1,7 @@
+#![deny(rustdoc::broken_footnote)]
+
+//! Footnote referenced [^1]. And [^2]. And [^bla].
+//!
+//! [^1]: footnote defined
+//~^^^ ERROR: no footnote definition matching this footnote
+//~| ERROR: no footnote definition matching this footnote

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -5,3 +5,12 @@
 //! [^1]: footnote defined
 //~^^^ ERROR: no footnote definition matching this footnote
 //~| ERROR: no footnote definition matching this footnote
+
+// Should not lint.
+//! foo[^1]
+//!
+//! ```
+//!
+//! [^1]: bar
+//!
+//! ```

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -14,3 +14,31 @@
 //! [^1]: bar
 //!
 //! ```
+
+// Edge cases from https://pulldown-cmark.github.io/pulldown-cmark/specs/footnotes.html
+/// The following are not footnote references:
+///
+/// \[^a]
+///
+/// [\^b]
+///
+/// [^c\]
+///
+/// [^d
+/// e]
+///
+/// [^f\
+/// g]
+pub struct NotReferences;
+
+/// The following are not footnote references:
+///
+/// [^a b]
+//~^ ERROR: no footnote definition matching this footnote
+///
+/// [^1\.2]
+//~^ ERROR: no footnote definition matching this footnote
+///
+/// [^*]
+//~^ ERROR: no footnote definition matching this footnote
+pub struct EdgeCases;

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -35,10 +35,16 @@ pub struct NotReferences;
 ///
 /// [^a b]
 //~^ ERROR: no footnote definition matching this footnote
+pub struct EdgeCases1;
+
+/// Another:
 ///
 /// [^1\.2]
 //~^ ERROR: no footnote definition matching this footnote
+pub struct EdgeCases2;
+
+/// Last:
 ///
 /// [^*]
 //~^ ERROR: no footnote definition matching this footnote
-pub struct EdgeCases;
+pub struct EdgeCases3; 

--- a/tests/rustdoc-ui/lints/broken-footnote.rs
+++ b/tests/rustdoc-ui/lints/broken-footnote.rs
@@ -47,4 +47,4 @@ pub struct EdgeCases2;
 ///
 /// [^*]
 //~^ ERROR: no footnote definition matching this footnote
-pub struct EdgeCases3; 
+pub struct EdgeCases3;

--- a/tests/rustdoc-ui/lints/broken-footnote.stderr
+++ b/tests/rustdoc-ui/lints/broken-footnote.stderr
@@ -1,0 +1,24 @@
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:3:45
+   |
+LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
+   |                                             -^^^^^
+   |                                             |
+   |                                             help: if it should not be a footnote, escape it: `\`
+   |
+note: the lint level is defined here
+  --> $DIR/broken-footnote.rs:1:9
+   |
+LL | #![deny(rustdoc::broken_footnote)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:3:35
+   |
+LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
+   |                                   -^^^
+   |                                   |
+   |                                   help: if it should not be a footnote, escape it: `\`
+
+error: aborting due to 2 previous errors
+

--- a/tests/rustdoc-ui/lints/broken-footnote.stderr
+++ b/tests/rustdoc-ui/lints/broken-footnote.stderr
@@ -20,5 +20,29 @@ LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
    |                                   |
    |                                   help: if it should not be a footnote, escape it: `\`
 
-error: aborting due to 2 previous errors
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:39:5
+   |
+LL | /// [^1\.2]
+   |     -^^^^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:42:5
+   |
+LL | /// [^*]
+   |     -^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:36:5
+   |
+LL | /// [^a b]
+   |     -^^^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\`
+
+error: aborting due to 5 previous errors
 

--- a/tests/rustdoc-ui/lints/broken-footnote.stderr
+++ b/tests/rustdoc-ui/lints/broken-footnote.stderr
@@ -21,7 +21,15 @@ LL | //! Footnote referenced [^1]. And [^2]. And [^bla].
    |                                   help: if it should not be a footnote, escape it: `\`
 
 error: no footnote definition matching this footnote
-  --> $DIR/broken-footnote.rs:39:5
+  --> $DIR/broken-footnote.rs:36:5
+   |
+LL | /// [^a b]
+   |     -^^^^^
+   |     |
+   |     help: if it should not be a footnote, escape it: `\`
+
+error: no footnote definition matching this footnote
+  --> $DIR/broken-footnote.rs:42:5
    |
 LL | /// [^1\.2]
    |     -^^^^^^
@@ -29,18 +37,10 @@ LL | /// [^1\.2]
    |     help: if it should not be a footnote, escape it: `\`
 
 error: no footnote definition matching this footnote
-  --> $DIR/broken-footnote.rs:42:5
+  --> $DIR/broken-footnote.rs:48:5
    |
 LL | /// [^*]
    |     -^^^
-   |     |
-   |     help: if it should not be a footnote, escape it: `\`
-
-error: no footnote definition matching this footnote
-  --> $DIR/broken-footnote.rs:36:5
-   |
-LL | /// [^a b]
-   |     -^^^^^
    |     |
    |     help: if it should not be a footnote, escape it: `\`
 

--- a/tests/rustdoc-ui/lints/unused-footnote.rs
+++ b/tests/rustdoc-ui/lints/unused-footnote.rs
@@ -1,4 +1,4 @@
-// This test ensures that the rustdoc `unused_footnote` is working as expected.
+// This test ensures that the `rustdoc::unused_footnote` lint is working as expected.
 
 #![deny(rustdoc::unused_footnote_definition)]
 

--- a/tests/rustdoc-ui/lints/unused-footnote.rs
+++ b/tests/rustdoc-ui/lints/unused-footnote.rs
@@ -1,0 +1,9 @@
+// This test ensures that the rustdoc `unused_footnote` is working as expected.
+
+#![deny(rustdoc::unused_footnote_definition)]
+
+//! Footnote referenced. [^2]
+//!
+//! [^1]: footnote defined
+//! [^2]: footnote defined
+//~^^ ERROR: unused_footnote_definition

--- a/tests/rustdoc-ui/lints/unused-footnote.stderr
+++ b/tests/rustdoc-ui/lints/unused-footnote.stderr
@@ -1,0 +1,14 @@
+error: unused footnote definition
+  --> $DIR/unused-footnote.rs:7:6
+   |
+LL | //! [^1]: footnote defined
+   |      ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-footnote.rs:3:9
+   |
+LL | #![deny(rustdoc::unused_footnote_definition)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/137858)*
<!-- homu-ignore:end -->

Follow-up of rust-lang/rust#137803 (where the two first commits come from).

It adds a new lint which checks for unused footnote definitions.

r? @notriddle 