### PR TITLE
rustc_target: Add msync target feature and enable it on powerpcspe targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnuspe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnuspe.rs
@@ -24,7 +24,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: "spe".into(),
             endian: Endian::Big,
-            features: "+secure-plt".into(),
+            features: "+secure-plt,+msync".into(),
             mcount: "_mcount".into(),
             ..base
         },

--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
@@ -26,6 +26,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: "spe".into(),
             endian: Endian::Big,
+            features: "+msync".into(),
             mcount: "_mcount".into(),
             ..base
         },

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -461,6 +461,7 @@ const HEXAGON_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
 static POWERPC_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start
     ("altivec", Unstable(sym::powerpc_target_feature), &[]),
+    ("msync", Unstable(sym::powerpc_target_feature), &[]),
     ("partword-atomics", Unstable(sym::powerpc_target_feature), &[]),
     ("power10-vector", Unstable(sym::powerpc_target_feature), &["power9-vector"]),
     ("power8-altivec", Unstable(sym::powerpc_target_feature), &["altivec"]),

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -151,6 +151,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `mp`
 `mp1e2`
 `msa`
+`msync`
 `mte`
 `multivalue`
 `mutable-globals`


### PR DESCRIPTION
Some older PowerPC processors do not have the `sync` (`sync 0`) and `lwsync` (`sync 1`) instructions, but instead have the `msync` instruction. (IIRC `msync` and `sync` will be assembled into the same bit-pattern, but `lwsync` will be SIGILL. See also https://gcc.gnu.org/legacy-ml/gcc-patches/2006-11/msg01238.html.)

LLVM recognizes this as the [`msync` feature](https://github.com/llvm/llvm-project/blob/cc5d8a4b2fc765c3c432f1ad0b185dae518d41bd/llvm/lib/Target/PowerPC/PPC.td#L140) and enables for some cpus such as [e500](https://github.com/llvm/llvm-project/blob/cc5d8a4b2fc765c3c432f1ad0b185dae518d41bd/llvm/lib/Target/PowerPC/PPC.td#L644).

powerpcspe is a target for CPUs such as e500 ([Debian Wiki](https://wiki.debian.org/PowerPCSPEPort)). However, the `msync` feature is currently not enabled except for vxworks, and at least since 2022-04, powerpc-unknown-linux-gnuspe was known to not work on real hardware without `-C target-cpu` (e.g., #96394, #117361).

https://github.com/rust-lang/rust/blob/8c392966a013fd8a09e6b78b3c8d6e442bc278e1/compiler/rustc_target/src/spec/targets/powerpc_wrs_vxworks_spe.rs#L28

Fixes #117361 

cc @BKPepe ([powerpc-unknown-linux-muslspe target maintainer](https://doc.rust-lang.org/nightly/rustc/platform-support/powerpc-unknown-linux-muslspe.html#target-maintainers))
cc @glaubitz (who added powerpc-unknown-linux-gnuspe in https://github.com/rust-lang/rust/pull/48484)
cc @th0ma7 (who opened #117361)

r? workingjubilee

@rustbot label +O-PowerPC +A-target-feature

