### PR TITLE
Add minimal platform support documentation for powerpc-unknown-linux-gnuspe

### DIFF
--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -68,6 +68,7 @@
     - [mipsisa\*r6\*-unknown-linux-gnu\*](platform-support/mips-release-6.md)
     - [nvptx64-nvidia-cuda](platform-support/nvptx64-nvidia-cuda.md)
     - [powerpc-unknown-openbsd](platform-support/powerpc-unknown-openbsd.md)
+    - [powerpc-unknown-linux-gnuspe](platform-support/powerpc-unknown-linux-gnuspe.md)
     - [powerpc-unknown-linux-muslspe](platform-support/powerpc-unknown-linux-muslspe.md)
     - [powerpc64-ibm-aix](platform-support/aix.md)
     - [powerpc64le-unknown-linux-musl](platform-support/powerpc64le-unknown-linux-musl.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -348,9 +348,9 @@ target | std | host | notes
 [`mipsisa64r6el-unknown-linux-gnuabi64`](platform-support/mips-release-6.md) | ✓ | ✓ | 64-bit MIPS Release 6 Little Endian
 `msp430-none-elf` | * |  | 16-bit MSP430 microcontrollers
 [`powerpc-unknown-freebsd`](platform-support/freebsd.md) | ? |   | PowerPC FreeBSD
-`powerpc-unknown-linux-gnuspe` | ✓ |  | PowerPC SPE Linux
+[`powerpc-unknown-linux-gnuspe`](platform-support/powerpc-unknown-linux-gnuspe.md) | ✓ |  | PowerPC SPE Linux
 `powerpc-unknown-linux-musl` | ? |  | PowerPC Linux with musl 1.2.3
-[`powerpc-unknown-linux-muslspe`](platform-support/powerpc-unknown-linux-muslspe.md) | ? |  | PowerPC SPE Linux
+[`powerpc-unknown-linux-muslspe`](platform-support/powerpc-unknown-linux-muslspe.md) | ? |  | PowerPC SPE Linux with musl 1.2.3
 [`powerpc-unknown-netbsd`](platform-support/netbsd.md) | ✓ | ✓ | NetBSD 32-bit powerpc systems
 [`powerpc-unknown-openbsd`](platform-support/powerpc-unknown-openbsd.md) | * |  |
 [`powerpc-wrs-vxworks`](platform-support/vxworks.md) | ✓ |  |

--- a/src/doc/rustc/src/platform-support/powerpc-unknown-linux-gnuspe.md
+++ b/src/doc/rustc/src/platform-support/powerpc-unknown-linux-gnuspe.md
@@ -1,0 +1,20 @@
+# powerpc-unknown-linux-gnuspe
+
+**Tier: 3**
+
+`powerpc-unknown-linux-gnuspe` is a target for Linux on 32-bit PowerPC
+processors that implement the Signal Processing Engine (SPE), such as e500, and
+uses a different ABI than standard `powerpc-unknown-linux-gnu`.
+When building for other 32-bit PowerPC processors, use
+`powerpc-unknown-linux-gnu` instead.
+
+See also [Debian Wiki](https://wiki.debian.org/PowerPCSPEPort) for details on
+this platform, and [ABI reference](https://web.archive.org/web/20120608163804/https://www.power.org/resources/downloads/Power-Arch-32-bit-ABI-supp-1.0-Unified.pdf)
+for details on SPE ABI.
+
+Note that support for PowerPC SPE by GCC was [removed in GCC 9](https://gcc.gnu.org/gcc-8/changes.html),
+so recent GCC cannot be used as linker/compiler for this target.
+
+## Target maintainers
+
+There are currently no formally documented target maintainers.

--- a/src/doc/rustc/src/platform-support/powerpc-unknown-linux-muslspe.md
+++ b/src/doc/rustc/src/platform-support/powerpc-unknown-linux-muslspe.md
@@ -2,8 +2,10 @@
 
 **Tier: 3**
 
-This target is very similar to already existing ones like `powerpc_unknown_linux_musl` and `powerpc_unknown_linux_gnuspe`.
+This target is very similar to already existing ones like `powerpc-unknown-linux-musl` and `powerpc-unknown-linux-gnuspe`.
 This one has PowerPC SPE support for musl. Unfortunately, the last supported gcc version with PowerPC SPE is 8.4.0.
+
+See also [platform support documentation of `powerpc-unknown-linux-gnuspe`](powerpc-unknown-linux-gnuspe.md) for information about PowerPC SPE.
 
 ## Target maintainers
 


### PR DESCRIPTION
Per https://github.com/rust-lang/rust/pull/137860#issuecomment-2692358259, add minimal platform support documentation, including a brief summary and links to more detailed information about this target.

The added documentation is minimal. This is somewhat similar to [powerpc-unknown-openbsd, which also has no target maintainer](https://doc.rust-lang.org/nightly/rustc/platform-support/powerpc-unknown-openbsd.html). The rest of the template is left to target maintainers.

I also updated powerpc-unknown-linux-muslspe platform support documentation and added link to powerpc-unknown-linux-gnuspe platform support documentation.

cc @glaubitz
cc @BKPepe
r? workingjubilee

@rustbot label +O-PowerPC