### PR TITLE
fix `RangeBounds::is_empty` documentation

### DIFF
--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -827,7 +827,7 @@ pub trait RangeBounds<T: ?Sized> {
     }
 
     /// Returns `true` if the range contains no items.
-    /// One-sided ranges (`RangeFrom`, etc) always return `true`.
+    /// One-sided ranges (`RangeFrom`, etc) always return `false`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
One-sided ranges are never empty

follow-up for https://github.com/rust-lang/rust/pull/137304#pullrequestreview-2646899461

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
