### PR TITLE
Include whitespace in "remove |" suggestion and make it hidden

### DIFF
--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -1112,7 +1112,7 @@ impl<'a, G: EmissionGuarantee> Diag<'a, G> {
             .map(|snippet| {
                 debug_assert!(
                     !(sp.is_empty() && snippet.is_empty()),
-                    "Span must not be empty and have no suggestion"
+                    "Span `{sp:?}` must not be empty and have no suggestion"
                 );
                 Substitution { parts: vec![SubstitutionPart { snippet, span: sp }] }
             })

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -851,8 +851,8 @@ parse_too_many_hashes = too many `#` symbols: raw strings may be delimited by up
 
 parse_too_short_hex_escape = numeric character escape is too short
 
-parse_trailing_vert_not_allowed = a trailing `|` is not allowed in an or-pattern
-    .suggestion = remove the `{$token}`
+parse_trailing_vert_not_allowed = a trailing `{$token}` is not allowed in an or-pattern
+parse_trailing_vert_not_allowed_suggestion = remove the `{$token}`
 
 parse_trait_alias_cannot_be_auto = trait aliases cannot be `auto`
 parse_trait_alias_cannot_be_const = trait aliases cannot be `const`

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2620,7 +2620,7 @@ pub(crate) enum TopLevelOrPatternNotAllowedSugg {
         parse_sugg_remove_leading_vert_in_pattern,
         code = "",
         applicability = "machine-applicable",
-        style = "verbose"
+        style = "tool-only"
     )]
     RemoveLeadingVert {
         #[primary_span]
@@ -2653,12 +2653,25 @@ pub(crate) struct UnexpectedVertVertInPattern {
     pub start: Option<Span>,
 }
 
+#[derive(Subdiagnostic)]
+#[suggestion(
+    parse_trailing_vert_not_allowed,
+    code = "",
+    applicability = "machine-applicable",
+    style = "tool-only"
+)]
+pub(crate) struct TrailingVertSuggestion {
+    #[primary_span]
+    pub span: Span,
+}
+
 #[derive(Diagnostic)]
 #[diag(parse_trailing_vert_not_allowed)]
 pub(crate) struct TrailingVertNotAllowed {
     #[primary_span]
-    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub span: Span,
+    #[subdiagnostic]
+    pub suggestion: TrailingVertSuggestion,
     #[label(parse_label_while_parsing_or_pattern_here)]
     pub start: Option<Span>,
     pub token: Token,

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -25,10 +25,10 @@ use crate::errors::{
     GenericArgsInPatRequireTurbofishSyntax, InclusiveRangeExtraEquals, InclusiveRangeMatchArrow,
     InclusiveRangeNoEnd, InvalidMutInPattern, ParenRangeSuggestion, PatternOnWrongSideOfAt,
     RemoveLet, RepeatedMutInPattern, SwitchRefBoxOrder, TopLevelOrPatternNotAllowed,
-    TopLevelOrPatternNotAllowedSugg, TrailingVertNotAllowed, UnexpectedExpressionInPattern,
-    UnexpectedExpressionInPatternSugg, UnexpectedLifetimeInPattern, UnexpectedParenInRangePat,
-    UnexpectedParenInRangePatSugg, UnexpectedVertVertBeforeFunctionParam,
-    UnexpectedVertVertInPattern, WrapInParens,
+    TopLevelOrPatternNotAllowedSugg, TrailingVertNotAllowed, TrailingVertSuggestion,
+    UnexpectedExpressionInPattern, UnexpectedExpressionInPatternSugg, UnexpectedLifetimeInPattern,
+    UnexpectedParenInRangePat, UnexpectedParenInRangePatSugg,
+    UnexpectedVertVertBeforeFunctionParam, UnexpectedVertVertInPattern, WrapInParens,
 };
 use crate::parser::expr::{DestructuredFloat, could_be_unclosed_char_literal};
 use crate::{exp, maybe_recover_from_interpolated_ty_qpath};
@@ -268,10 +268,9 @@ impl<'a> Parser<'a> {
 
         if let PatKind::Or(pats) = &pat.kind {
             let span = pat.span;
-            let sub = if pats.len() == 1 {
-                Some(TopLevelOrPatternNotAllowedSugg::RemoveLeadingVert {
-                    span: span.with_hi(span.lo() + BytePos(1)),
-                })
+            let sub = if let [_] = &pats[..] {
+                let span = span.with_hi(span.lo() + BytePos(1));
+                Some(TopLevelOrPatternNotAllowedSugg::RemoveLeadingVert { span })
             } else {
                 Some(TopLevelOrPatternNotAllowedSugg::WrapInParens {
                     span,
@@ -363,6 +362,9 @@ impl<'a> Parser<'a> {
                 self.dcx().emit_err(TrailingVertNotAllowed {
                     span: self.token.span,
                     start: lo,
+                    suggestion: TrailingVertSuggestion {
+                        span: self.prev_token.span.shrink_to_hi().with_hi(self.token.span.hi()),
+                    },
                     token: self.token,
                     note_double_vert: self.token.kind == token::OrOr,
                 });

--- a/tests/ui/or-patterns/issue-64879-trailing-before-guard.fixed
+++ b/tests/ui/or-patterns/issue-64879-trailing-before-guard.fixed
@@ -9,9 +9,9 @@ enum E { A, B }
 fn main() {
     match E::A {
         E::A |
-        E::B | //~ ERROR a trailing `|` is not allowed in an or-pattern
+        E::B //~ ERROR a trailing `|` is not allowed in an or-pattern
         if true => {
-            let _recovery_witness: i32 = 0u32; //~ ERROR mismatched types
+            let _recovery_witness: i32 = 0i32; //~ ERROR mismatched types
         }
         _ => {}
     }

--- a/tests/ui/or-patterns/issue-64879-trailing-before-guard.stderr
+++ b/tests/ui/or-patterns/issue-64879-trailing-before-guard.stderr
@@ -1,24 +1,24 @@
 error: a trailing `|` is not allowed in an or-pattern
-  --> $DIR/issue-64879-trailing-before-guard.rs:10:14
+  --> $DIR/issue-64879-trailing-before-guard.rs:12:14
    |
 LL |         E::A |
    |         ---- while parsing this or-pattern starting here
 LL |         E::B |
    |              ^
-   |
-help: remove the `|`
-   |
-LL -         E::B |
-LL +         E::B
-   |
 
 error[E0308]: mismatched types
-  --> $DIR/issue-64879-trailing-before-guard.rs:12:42
+  --> $DIR/issue-64879-trailing-before-guard.rs:14:42
    |
-LL |             let recovery_witness: bool = 0;
-   |                                   ----   ^ expected `bool`, found integer
-   |                                   |
-   |                                   expected due to this
+LL |             let _recovery_witness: i32 = 0u32;
+   |                                    ---   ^^^^ expected `i32`, found `u32`
+   |                                    |
+   |                                    expected due to this
+   |
+help: change the type of the numeric literal from `u32` to `i32`
+   |
+LL -             let _recovery_witness: i32 = 0u32;
+LL +             let _recovery_witness: i32 = 0i32;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/or-patterns/remove-leading-vert.fixed
+++ b/tests/ui/or-patterns/remove-leading-vert.fixed
@@ -23,26 +23,26 @@ fn leading() {
 
 #[cfg(false)]
 fn trailing() {
-    let ( A  ): E; //~ ERROR a trailing `|` is not allowed in an or-pattern
-    let (a ,): (E,); //~ ERROR a trailing `|` is not allowed in an or-pattern
-    let ( A | B  ): E; //~ ERROR a trailing `|` is not allowed in an or-pattern
-    let [ A | B  ]: [E; 1]; //~ ERROR a trailing `|` is not allowed in an or-pattern
-    let S { f: B  }; //~ ERROR a trailing `|` is not allowed in an or-pattern
-    let ( A | B  ): E; //~ ERROR unexpected token `||` in pattern
+    let ( A ): E; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let (a,): (E,); //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let ( A | B ): E; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let [ A | B ]: [E; 1]; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let S { f: B }; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let ( A | B ): E; //~ ERROR unexpected token `||` in pattern
     //~^ ERROR a trailing `|` is not allowed in an or-pattern
     match A {
-        A  => {} //~ ERROR a trailing `|` is not allowed in an or-pattern
-        A  => {} //~ ERROR a trailing `|` is not allowed in an or-pattern
-        A | B  => {} //~ ERROR unexpected token `||` in pattern
+        A => {} //~ ERROR a trailing `|` is not allowed in an or-pattern
+        A => {} //~ ERROR a trailing `||` is not allowed in an or-pattern
+        A | B => {} //~ ERROR unexpected token `||` in pattern
         //~^ ERROR a trailing `|` is not allowed in an or-pattern
-        | A | B  => {}
+        | A | B => {}
         //~^ ERROR a trailing `|` is not allowed in an or-pattern
     }
 
     // These test trailing-vert in `let` bindings, but they also test that we don't emit a
     // duplicate suggestion that would confuse rustfix.
 
-    let a  : u8 = 0; //~ ERROR a trailing `|` is not allowed in an or-pattern
-    let a  = 0; //~ ERROR a trailing `|` is not allowed in an or-pattern
-    let a  ; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let a : u8 = 0; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let a = 0; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let a ; //~ ERROR a trailing `|` is not allowed in an or-pattern
 }

--- a/tests/ui/or-patterns/remove-leading-vert.rs
+++ b/tests/ui/or-patterns/remove-leading-vert.rs
@@ -32,7 +32,7 @@ fn trailing() {
     //~^ ERROR a trailing `|` is not allowed in an or-pattern
     match A {
         A | => {} //~ ERROR a trailing `|` is not allowed in an or-pattern
-        A || => {} //~ ERROR a trailing `|` is not allowed in an or-pattern
+        A || => {} //~ ERROR a trailing `||` is not allowed in an or-pattern
         A || B | => {} //~ ERROR unexpected token `||` in pattern
         //~^ ERROR a trailing `|` is not allowed in an or-pattern
         | A | B | => {}

--- a/tests/ui/or-patterns/remove-leading-vert.stderr
+++ b/tests/ui/or-patterns/remove-leading-vert.stderr
@@ -3,12 +3,6 @@ error: function parameters require top-level or-patterns in parentheses
    |
 LL |     fn fun1( | A: E) {}
    |              ^^^
-   |
-help: remove the `|`
-   |
-LL -     fn fun1( | A: E) {}
-LL +     fn fun1(  A: E) {}
-   |
 
 error: unexpected `||` before function parameter
   --> $DIR/remove-leading-vert.rs:12:14
@@ -78,12 +72,6 @@ LL |     let ( A | ): E;
    |           - ^
    |           |
    |           while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -     let ( A | ): E;
-LL +     let ( A  ): E;
-   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:27:12
@@ -92,12 +80,6 @@ LL |     let (a |,): (E,);
    |          - ^
    |          |
    |          while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -     let (a |,): (E,);
-LL +     let (a ,): (E,);
-   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:28:17
@@ -106,12 +88,6 @@ LL |     let ( A | B | ): E;
    |           -     ^
    |           |
    |           while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -     let ( A | B | ): E;
-LL +     let ( A | B  ): E;
-   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:29:17
@@ -120,12 +96,6 @@ LL |     let [ A | B | ]: [E; 1];
    |           -     ^
    |           |
    |           while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -     let [ A | B | ]: [E; 1];
-LL +     let [ A | B  ]: [E; 1];
-   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:30:18
@@ -134,12 +104,6 @@ LL |     let S { f: B | };
    |                - ^
    |                |
    |                while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -     let S { f: B | };
-LL +     let S { f: B  };
-   |
 
 error: unexpected token `||` in pattern
   --> $DIR/remove-leading-vert.rs:31:13
@@ -162,12 +126,6 @@ LL |     let ( A || B | ): E;
    |           -      ^
    |           |
    |           while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -     let ( A || B | ): E;
-LL +     let ( A || B  ): E;
-   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:34:11
@@ -176,14 +134,8 @@ LL |         A | => {}
    |         - ^
    |         |
    |         while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -         A | => {}
-LL +         A  => {}
-   |
 
-error: a trailing `|` is not allowed in an or-pattern
+error: a trailing `||` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:35:11
    |
 LL |         A || => {}
@@ -192,11 +144,6 @@ LL |         A || => {}
    |         while parsing this or-pattern starting here
    |
    = note: alternatives in or-patterns are separated with `|`, not `||`
-help: remove the `||`
-   |
-LL -         A || => {}
-LL +         A  => {}
-   |
 
 error: unexpected token `||` in pattern
   --> $DIR/remove-leading-vert.rs:36:11
@@ -219,12 +166,6 @@ LL |         A || B | => {}
    |         -      ^
    |         |
    |         while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -         A || B | => {}
-LL +         A || B  => {}
-   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:38:17
@@ -233,12 +174,6 @@ LL |         | A | B | => {}
    |         -       ^
    |         |
    |         while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -         | A | B | => {}
-LL +         | A | B  => {}
-   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:45:11
@@ -247,12 +182,6 @@ LL |     let a | : u8 = 0;
    |         - ^
    |         |
    |         while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -     let a | : u8 = 0;
-LL +     let a  : u8 = 0;
-   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:46:11
@@ -261,12 +190,6 @@ LL |     let a | = 0;
    |         - ^
    |         |
    |         while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -     let a | = 0;
-LL +     let a  = 0;
-   |
 
 error: a trailing `|` is not allowed in an or-pattern
   --> $DIR/remove-leading-vert.rs:47:11
@@ -275,12 +198,6 @@ LL |     let a | ;
    |         - ^
    |         |
    |         while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -     let a | ;
-LL +     let a  ;
-   |
 
 error: aborting due to 21 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/ICE-130779-never-arm-no-oatherwise-block.stderr
@@ -5,12 +5,6 @@ LL |         ! |
    |         - ^
    |         |
    |         while parsing this or-pattern starting here
-   |
-help: remove the `|`
-   |
-LL -         ! |
-LL +         !
-   |
 
 error: a never pattern is always unreachable
   --> $DIR/ICE-130779-never-arm-no-oatherwise-block.rs:10:20


### PR DESCRIPTION
Tweak error rendering of patterns with an extra `|` on either end.

Built on #137409. Only last commit is relevant.

? @compiler-errors 