### PR TITLE
Disable `f16` on Aarch64 without `neon`

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -12,6 +12,11 @@ fn main() {
         .expect("CARGO_CFG_TARGET_POINTER_WIDTH was not set")
         .parse()
         .unwrap();
+    let target_features: Vec<_> = env::var("CARGO_CFG_TARGET_FEATURE")
+        .unwrap_or_default()
+        .split(",")
+        .map(ToOwned::to_owned)
+        .collect();
     let is_miri = env::var_os("CARGO_CFG_MIRI").is_some();
 
     println!("cargo:rustc-check-cfg=cfg(netbsd10)");
@@ -101,6 +106,8 @@ fn main() {
         ("s390x", _) => false,
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         ("arm64ec", _) => false,
+        // LLVM crash <https://github.com/llvm/llvm-project/issues/129394>
+        ("aarch64", _) if !target_features.iter().any(|f| f == "neon") => false,
         // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
         ("x86_64", "windows") if target_env == "gnu" && target_abi != "llvm" => false,
         // Infinite recursion <https://github.com/llvm/llvm-project/issues/97981>


### PR DESCRIPTION
LLVM has crashes at some `half` operations when built with assertions enabled if fp-armv8 is not available [1]. Things seem to usually work, but we are reaching LLVM undefined behavior so this needs to be disabled.

[1]: https://github.com/llvm/llvm-project/issues/129394