### PR TITLE
tidy: add triagebot checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5260,6 +5260,7 @@ dependencies = [
  "serde",
  "similar",
  "termcolor",
+ "toml 0.7.8",
  "walkdir",
 ]
 

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -17,6 +17,7 @@ termcolor = "1.1.3"
 rustc-hash = "2.0.0"
 fluent-syntax = "0.11.1"
 similar = "2.5.0"
+toml = "0.7.8"
 
 [features]
 build-metrics = ["dep:serde"]

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -88,6 +88,7 @@ pub mod target_policy;
 pub mod target_specific_tests;
 pub mod tests_placement;
 pub mod tests_revision_unpaired_stdout_stderr;
+pub mod triagebot;
 pub mod ui_tests;
 pub mod unit_tests;
 pub mod unknown_revision;

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -146,6 +146,8 @@ fn main() {
 
         check!(x_version, &root_path, &cargo);
 
+        check!(triagebot, &root_path);
+
         let collected = {
             drain_handles(&mut handles);
 

--- a/src/tools/tidy/src/triagebot.rs
+++ b/src/tools/tidy/src/triagebot.rs
@@ -1,0 +1,93 @@
+//! Tidy check to ensure paths mentioned in triagebot.toml exist in the project.
+
+use std::path::Path;
+
+use toml::Value;
+
+pub fn check(path: &Path, bad: &mut bool) {
+    let triagebot_path = path.join("triagebot.toml");
+    if !triagebot_path.exists() {
+        tidy_error!(bad, "triagebot.toml file not found");
+        return;
+    }
+
+    let contents = std::fs::read_to_string(&triagebot_path).unwrap();
+    let config: Value = toml::from_str(&contents).unwrap();
+
+    // Check [mentions."*"] sections, i.e. [mentions."compiler/rustc_const_eval/src/"]
+    if let Some(Value::Table(mentions)) = config.get("mentions") {
+        for path_str in mentions.keys() {
+            // Remove quotes from the path
+            let clean_path = path_str.trim_matches('"');
+            let full_path = path.join(clean_path);
+
+            if !full_path.exists() {
+                tidy_error!(
+                    bad,
+                    "triagebot.toml [mentions.*] contains path '{}' which doesn't exist",
+                    clean_path
+                );
+            }
+        }
+    } else {
+        tidy_error!(
+            bad,
+            "triagebot.toml missing [mentions.*] section, this wrong for rust-lang/rust repo."
+        );
+    }
+
+    // Check [assign.owners] sections, i.e.
+    // [assign.owners]
+    // "/.github/workflows" = ["infra-ci"]
+    if let Some(Value::Table(assign)) = config.get("assign") {
+        if let Some(Value::Table(owners)) = assign.get("owners") {
+            for path_str in owners.keys() {
+                // Remove quotes and leading slash from the path
+                let clean_path = path_str.trim_matches('"').trim_start_matches('/');
+                let full_path = path.join(clean_path);
+
+                if !full_path.exists() {
+                    tidy_error!(
+                        bad,
+                        "triagebot.toml [assign.owners] contains path '{}' which doesn't exist",
+                        clean_path
+                    );
+                }
+            }
+        } else {
+            tidy_error!(
+                bad,
+                "triagebot.toml missing [assign.owners] section, this wrong for rust-lang/rust repo."
+            );
+        }
+    }
+
+    // Verify that trigger_files in [autolabel."*"] exist in the project, i.e.
+    // [autolabel."A-rustdoc-search"]
+    // trigger_files = [
+    //    "src/librustdoc/html/static/js/search.js",
+    //    "tests/rustdoc-js",
+    //    "tests/rustdoc-js-std",
+    // ]
+    if let Some(Value::Table(autolabels)) = config.get("autolabel") {
+        for (label, content) in autolabels {
+            if let Some(trigger_files) = content.get("trigger_files").and_then(|v| v.as_array()) {
+                for file in trigger_files {
+                    if let Some(file_str) = file.as_str() {
+                        let full_path = path.join(file_str);
+
+                        // Handle both file and directory paths
+                        if !full_path.exists() {
+                            tidy_error!(
+                                bad,
+                                "triagebot.toml [autolabel.{}] contains trigger_files path '{}' which doesn't exist",
+                                label,
+                                file_str
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -252,7 +252,6 @@ trigger_files = [
     "compiler/rustc_passes/src/check_attr.rs",
     "compiler/rustc_attr_parsing",
     "compiler/rustc_attr_data_structures",
-    "compiler/rustc_attr_validation",
 ]
 
 [autolabel."T-rustdoc-frontend"]
@@ -316,7 +315,6 @@ trigger_files = [
     "library/panic_unwind",
     "library/std",
     "library/stdarch",
-    "library/term",
     "library/test",
 ]
 exclude_labels = [
@@ -331,7 +329,7 @@ trigger_files = [
 [autolabel."O-apple"]
 trigger_files = [
     "library/std/src/os/darwin",
-    "library/std/src/sys/pal/unix/thread_parking/darwin.rs",
+    "library/std/src/sys/sync/thread_parking/darwin.rs",
     "compiler/rustc_target/src/spec/base/apple",
 ]
 
@@ -408,7 +406,8 @@ trigger_files = [
 [autolabel."O-wasm"]
 trigger_files = [
     "library/std/src/sys/pal/wasm",
-    "library/std/src/os/wasm"
+    "library/std/src/os/wasi",
+    "library/std/src/os/wasip2"
 ]
 
 [autolabel."O-windows"]
@@ -499,7 +498,6 @@ trigger_files = [
     "CONTRIBUTING.md",
     "INSTALL.md",
     "REUSE.toml",
-    ".reuse",
     ".mailmap",
     ".git-blame-ignore-revs",
     ".editorconfig"
@@ -524,7 +522,6 @@ exclude_labels = [
 
 [autolabel."WG-trait-system-refactor"]
 trigger_files = [
-    "compiler/rustc_middle/src/traits/solve",
     "compiler/rustc_next_trait_solver",
     "compiler/rustc_trait_selection/src/solve",
     "compiler/rustc_type_ir/src/solve",
@@ -791,7 +788,7 @@ cc = ["@Nadrieril"]
 message = "Some changes occurred in cfg and check-cfg configuration"
 cc = ["@Urgau"]
 
-[mentions."compiler/rustc_lint/src/context/diagnostics/check_cfg.rs"]
+[mentions."compiler/rustc_lint/src/early/diagnostics/check_cfg.rs"]
 message = "Some changes occurred in check-cfg diagnostics"
 cc = ["@Urgau"]
 
@@ -963,7 +960,7 @@ If appropriate, please update `CONFIG_CHANGE_HISTORY` in `src/bootstrap/src/util
 [mentions."src/bootstrap/src/core/build_steps/llvm.rs"]
 message = "This PR changes how LLVM is built. Consider updating src/bootstrap/download-ci-llvm-stamp."
 
-[mentions."test/crashes"]
+[mentions."tests/crashes"]
 message = "This PR changes a file inside `tests/crashes`. If a crash was fixed, please move into the corresponding `ui` subdir and add 'Fixes #<issueNr>' to the PR description to autoclose the issue upon merge."
 
 [mentions."tests/rustdoc-json"]
@@ -1076,8 +1073,6 @@ cc = ["@jdonszelmann"]
 [mentions."compiler/rustc_attr_parsing"]
 cc = ["@jdonszelmann"]
 [mentions."compiler/rustc_attr_data_structures"]
-cc = ["@jdonszelmann"]
-[mentions."compiler/rustc_attr_validation"]
 cc = ["@jdonszelmann"]
 
 [assign]
@@ -1263,7 +1258,6 @@ project-exploit-mitigations = [
 "/compiler/rustc_middle/src/traits" =                    ["compiler", "types"]
 "/compiler/rustc_middle/src/ty" =                        ["compiler", "types"]
 "/compiler/rustc_const_eval/src/interpret" =             ["compiler", "mir"]
-"/compiler/rustc_const_eval/src/transform" =             ["compiler", "mir-opt"]
 "/compiler/rustc_mir_build/src/builder" =                ["compiler", "mir"]
 "/compiler/rustc_mir_transform" =                        ["compiler", "mir", "mir-opt"]
 "/compiler/rustc_smir" =                                 ["project-stable-mir"]


### PR DESCRIPTION
Validates triagebot.toml to have existing paths:

`[mentions."*"]` sections, i.e.
```toml
[mentions."compiler/rustc_const_eval/src/"]
```
or
```toml
[assign.owners]
"/.github/workflows" = ["infra-ci"]
```
or

```toml
trigger_files = [
 "src/librustdoc/html/static/js/search.js",
 "tests/rustdoc-js",
 "tests/rustdoc-js-std",
 ]
```
Looked at #137876 and implemented check.
