### PR TITLE
`name()` and `trimmed_name()` for `stable_mir::crate_def::DefId`

### DIFF
--- a/compiler/stable_mir/src/crate_def.rs
+++ b/compiler/stable_mir/src/crate_def.rs
@@ -40,20 +40,15 @@ pub trait CrateDef {
     fn def_id(&self) -> DefId;
 
     /// Return the fully qualified name of the current definition.
+    ///
+    /// See [`DefId::name`] for more details
     fn name(&self) -> Symbol {
         self.def_id().name()
     }
 
     /// Return a trimmed name of this definition.
     ///
-    /// This can be used to print more user friendly diagnostic messages.
-    ///
-    /// If a symbol name can only be imported from one place for a type, and as
-    /// long as it was not glob-imported anywhere in the current crate, we trim its
-    /// path and print only the name.
-    ///
-    /// For example, this function may shorten `std::vec::Vec` to just `Vec`,
-    /// as long as there is no other `Vec` importable anywhere.
+    /// See [`DefId::trimmed_name`] for more details
     fn trimmed_name(&self) -> Symbol {
         self.def_id().trimmed_name()
     }

--- a/compiler/stable_mir/src/crate_def.rs
+++ b/compiler/stable_mir/src/crate_def.rs
@@ -41,8 +41,7 @@ pub trait CrateDef {
 
     /// Return the fully qualified name of the current definition.
     fn name(&self) -> Symbol {
-        let def_id = self.def_id();
-        with(|cx| cx.def_name(def_id, false))
+        self.def_id().name()
     }
 
     /// Return a trimmed name of this definition.
@@ -56,8 +55,7 @@ pub trait CrateDef {
     /// For example, this function may shorten `std::vec::Vec` to just `Vec`,
     /// as long as there is no other `Vec` importable anywhere.
     fn trimmed_name(&self) -> Symbol {
-        let def_id = self.def_id();
-        with(|cx| cx.def_name(def_id, true))
+        self.def_id().trimmed_name()
     }
 
     /// Return information about the crate where this definition is declared.

--- a/compiler/stable_mir/src/crate_def.rs
+++ b/compiler/stable_mir/src/crate_def.rs
@@ -10,6 +10,27 @@ use crate::{Crate, Symbol, with};
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub struct DefId(pub(crate) usize);
 
+impl DefId {
+    /// Return fully qualified name of this definition
+    pub fn name(&self) -> Symbol {
+        with(|cx| cx.def_name(*self, false))
+    }
+
+    /// Return a trimmed name of this definition.
+    ///
+    /// This can be used to print more user friendly diagnostic messages.
+    ///
+    /// If a symbol name can only be imported from one place for a type, and as
+    /// long as it was not glob-imported anywhere in the current crate, we trim its
+    /// path and print only the name.
+    ///
+    /// For example, this function may shorten `std::vec::Vec` to just `Vec`,
+    /// as long as there is no other `Vec` importable anywhere.
+    pub fn trimmed_name(&self) -> Symbol {
+        with(|cx| cx.def_name(*self, true))
+    }
+}
+
 /// A trait for retrieving information about a particular definition.
 ///
 /// Implementors must provide the implementation of `def_id` which will be used to retrieve

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -48,10 +48,7 @@ pub type CrateNum = usize;
 
 impl Debug for DefId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DefId")
-            .field("id", &self.0)
-            .field("name", &with(|cx| cx.def_name(*self, false)))
-            .finish()
+        f.debug_struct("DefId").field("id", &self.0).field("name", &self.name()).finish()
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Resolves https://github.com/rust-lang/project-stable-mir/issues/91

* Added `stable_mir::crate_def::DefId::name()`  and  `stable_mir::crate_def::DefId::trimmed_name()`  methods
* Changed `CrateDef` and `DefId` `Debug` implementations to use new methods instead of copy-paste call to `Context::def_name`
* Updated docs to avoid duplicating description of what `name` and `trimmed_name` do

