### PR TITLE
doc: clarify that consume can be called after BufReader::peek

### DIFF
--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -109,8 +109,12 @@ impl<R: Read + ?Sized> BufReader<R> {
     ///
     /// `n` must be less than or equal to `capacity`.
     ///
-    /// the returned slice may be less than `n` bytes long if
+    /// The returned slice may be less than `n` bytes long if
     /// end of file is reached.
+    ///
+    /// After calling this method, you may call [`consume`](BufRead::consume)
+    /// with a value less than or equal to `n` to advance over some or all of
+    /// the returned bytes.
     ///
     /// ## Examples
     ///


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

tracking issue #128405 
