### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -292,6 +292,9 @@ James Hinshelwood <jameshinshelwood1@gmail.com> <james.hinshelwood@bigpayme.com>
 James Miller <bladeon@gmail.com> <james@aatch.net>
 James Perry <james.austin.perry@gmail.com>
 James Sanderson <zofrex@gmail.com>
+Jana Dönszelmann <jana@donsz.nl>
+Jana Dönszelmann <jana@donsz.nl> <jonathan@donsz.nl>
+Jana Dönszelmann <jana@donsz.nl> <jonabent@gmail.com>
 Jan-Erik Rediger <janerik@fnordig.de> <badboy@archlinux.us>
 Jaro Fietz <jaro.fietz@gmx.de>
 Jason Fager <jfager@gmail.com>

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -119,7 +119,8 @@ codegen_ssa_invalid_monomorphization_inserted_type = invalid monomorphization of
 
 codegen_ssa_invalid_monomorphization_invalid_bitmask = invalid monomorphization of `{$name}` intrinsic: invalid bitmask `{$mask_ty}`, expected `u{$expected_int_bits}` or `[u8; {$expected_bytes}]`
 
-codegen_ssa_invalid_monomorphization_mask_type = invalid monomorphization of `{$name}` intrinsic: mask element type is `{$ty}`, expected `i_`
+codegen_ssa_invalid_monomorphization_mask_type = invalid monomorphization of `{$name}` intrinsic: found mask element type is `{$ty}`, expected a signed integer type
+    .note = the mask may be widened, which only has the correct behavior for signed integers
 
 codegen_ssa_invalid_monomorphization_mismatched_lengths = invalid monomorphization of `{$name}` intrinsic: mismatched lengths: mask length `{$m_len}` != other vector length `{$v_len}`
 

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -957,6 +957,7 @@ pub enum InvalidMonomorphization<'tcx> {
     },
 
     #[diag(codegen_ssa_invalid_monomorphization_mask_type, code = E0511)]
+    #[note]
     MaskType {
         #[primary_span]
         span: Span,

--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnuspe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_gnuspe.rs
@@ -24,7 +24,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: "spe".into(),
             endian: Endian::Big,
-            features: "+secure-plt".into(),
+            features: "+secure-plt,+msync".into(),
             mcount: "_mcount".into(),
             ..base
         },

--- a/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
+++ b/compiler/rustc_target/src/spec/targets/powerpc_unknown_linux_muslspe.rs
@@ -26,6 +26,7 @@ pub(crate) fn target() -> Target {
         options: TargetOptions {
             abi: "spe".into(),
             endian: Endian::Big,
+            features: "+msync".into(),
             mcount: "_mcount".into(),
             ..base
         },

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -461,6 +461,7 @@ const HEXAGON_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
 static POWERPC_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start
     ("altivec", Unstable(sym::powerpc_target_feature), &[]),
+    ("msync", Unstable(sym::powerpc_target_feature), &[]),
     ("partword-atomics", Unstable(sym::powerpc_target_feature), &[]),
     ("power10-vector", Unstable(sym::powerpc_target_feature), &["power9-vector"]),
     ("power8-altivec", Unstable(sym::powerpc_target_feature), &["altivec"]),

--- a/compiler/stable_mir/src/crate_def.rs
+++ b/compiler/stable_mir/src/crate_def.rs
@@ -40,20 +40,15 @@ pub trait CrateDef {
     fn def_id(&self) -> DefId;
 
     /// Return the fully qualified name of the current definition.
+    ///
+    /// See [`DefId::name`] for more details
     fn name(&self) -> Symbol {
         self.def_id().name()
     }
 
     /// Return a trimmed name of this definition.
     ///
-    /// This can be used to print more user friendly diagnostic messages.
-    ///
-    /// If a symbol name can only be imported from one place for a type, and as
-    /// long as it was not glob-imported anywhere in the current crate, we trim its
-    /// path and print only the name.
-    ///
-    /// For example, this function may shorten `std::vec::Vec` to just `Vec`,
-    /// as long as there is no other `Vec` importable anywhere.
+    /// See [`DefId::trimmed_name`] for more details
     fn trimmed_name(&self) -> Symbol {
         self.def_id().trimmed_name()
     }

--- a/compiler/stable_mir/src/crate_def.rs
+++ b/compiler/stable_mir/src/crate_def.rs
@@ -41,8 +41,7 @@ pub trait CrateDef {
 
     /// Return the fully qualified name of the current definition.
     fn name(&self) -> Symbol {
-        let def_id = self.def_id();
-        with(|cx| cx.def_name(def_id, false))
+        self.def_id().name()
     }
 
     /// Return a trimmed name of this definition.
@@ -56,8 +55,7 @@ pub trait CrateDef {
     /// For example, this function may shorten `std::vec::Vec` to just `Vec`,
     /// as long as there is no other `Vec` importable anywhere.
     fn trimmed_name(&self) -> Symbol {
-        let def_id = self.def_id();
-        with(|cx| cx.def_name(def_id, true))
+        self.def_id().trimmed_name()
     }
 
     /// Return information about the crate where this definition is declared.

--- a/compiler/stable_mir/src/crate_def.rs
+++ b/compiler/stable_mir/src/crate_def.rs
@@ -10,6 +10,27 @@ use crate::{Crate, Symbol, with};
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 pub struct DefId(pub(crate) usize);
 
+impl DefId {
+    /// Return fully qualified name of this definition
+    pub fn name(&self) -> Symbol {
+        with(|cx| cx.def_name(*self, false))
+    }
+
+    /// Return a trimmed name of this definition.
+    ///
+    /// This can be used to print more user friendly diagnostic messages.
+    ///
+    /// If a symbol name can only be imported from one place for a type, and as
+    /// long as it was not glob-imported anywhere in the current crate, we trim its
+    /// path and print only the name.
+    ///
+    /// For example, this function may shorten `std::vec::Vec` to just `Vec`,
+    /// as long as there is no other `Vec` importable anywhere.
+    pub fn trimmed_name(&self) -> Symbol {
+        with(|cx| cx.def_name(*self, true))
+    }
+}
+
 /// A trait for retrieving information about a particular definition.
 ///
 /// Implementors must provide the implementation of `def_id` which will be used to retrieve

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -48,10 +48,7 @@ pub type CrateNum = usize;
 
 impl Debug for DefId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DefId")
-            .field("id", &self.0)
-            .field("name", &with(|cx| cx.def_name(*self, false)))
-            .finish()
+        f.debug_struct("DefId").field("id", &self.0).field("name", &self.name()).finish()
     }
 }
 

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -264,8 +264,14 @@ unsafe impl Allocator for Global {
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         if layout.size() != 0 {
-            // SAFETY: `layout` is non-zero in size,
-            // other conditions must be upheld by the caller
+            // SAFETY:
+            // * We have checked that `layout` is non-zero in size.
+            // * The caller is obligated to provide a layout that "fits", and in this case,
+            //   "fit" always means a layout that is equal to the original, because our
+            //   `allocate()`, `grow()`, and `shrink()` implementations never returns a larger
+            //   allocation than requested.
+            // * Other conditions must be upheld by the caller, as per `Allocator::deallocate()`'s
+            //   safety documentation.
             unsafe { dealloc(ptr.as_ptr(), layout) }
         }
     }

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -827,7 +827,7 @@ pub trait RangeBounds<T: ?Sized> {
     }
 
     /// Returns `true` if the range contains no items.
-    /// One-sided ranges (`RangeFrom`, etc) always return `true`.
+    /// One-sided ranges (`RangeFrom`, etc) always return `false`.
     ///
     /// # Examples
     ///

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -12,6 +12,11 @@ fn main() {
         .expect("CARGO_CFG_TARGET_POINTER_WIDTH was not set")
         .parse()
         .unwrap();
+    let target_features: Vec<_> = env::var("CARGO_CFG_TARGET_FEATURE")
+        .unwrap_or_default()
+        .split(",")
+        .map(ToOwned::to_owned)
+        .collect();
     let is_miri = env::var_os("CARGO_CFG_MIRI").is_some();
 
     println!("cargo:rustc-check-cfg=cfg(netbsd10)");
@@ -101,6 +106,8 @@ fn main() {
         ("s390x", _) => false,
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         ("arm64ec", _) => false,
+        // LLVM crash <https://github.com/llvm/llvm-project/issues/129394>
+        ("aarch64", _) if !target_features.iter().any(|f| f == "neon") => false,
         // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
         ("x86_64", "windows") if target_env == "gnu" && target_abi != "llvm" => false,
         // Infinite recursion <https://github.com/llvm/llvm-project/issues/97981>

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2534,7 +2534,7 @@ pub trait BufRead: Read {
     fn read_line(&mut self, buf: &mut String) -> Result<usize> {
         // Note that we are not calling the `.read_until` method here, but
         // rather our hardcoded implementation. For more details as to why, see
-        // the comments in `read_to_end`.
+        // the comments in `default_read_to_string`.
         unsafe { append_to_string(buf, |b| read_until(self, b'\n', b)) }
     }
 

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
@@ -100,7 +100,7 @@ This target is not a stable target. This means that there are a few engines
 which implement the `wasi-threads` feature and if they do they're likely behind a
 flag, for example:
 
-* Wasmtime - `--wasm-features=threads --wasi-modules=experimental-wasi-threads`
+* Wasmtime - `--wasi threads`
 * [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) - needs to be built with WAMR_BUILD_LIB_WASI_THREADS=1
 
 ## Building the target

--- a/src/doc/rustc/src/platform-support/wasm64-unknown-unknown.md
+++ b/src/doc/rustc/src/platform-support/wasm64-unknown-unknown.md
@@ -36,7 +36,7 @@ which implement the `memory64` feature and if they do they're likely behind a
 flag, for example:
 
 * Nodejs - `--experimental-wasm-memory64`
-* Wasmtime - `--wasm-features memory64`
+* Wasmtime - `--wasm memory64`
 
 Also note that at this time the `wasm64-unknown-unknown` target assumes the
 presence of other merged wasm proposals such as (with their LLVM feature flags):

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -151,6 +151,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `mp`
 `mp1e2`
 `msa`
+`msync`
 `mte`
 `multivalue`
 `mutable-globals`

--- a/tests/ui/simd/intrinsic/generic-gather.rs
+++ b/tests/ui/simd/intrinsic/generic-gather.rs
@@ -1,0 +1,52 @@
+//@ build-fail
+//@ ignore-emscripten
+
+// Test that the simd_{gather,scatter} intrinsics produce ok-ish error
+// messages when misused.
+
+#![feature(repr_simd, core_intrinsics)]
+#![allow(non_camel_case_types)]
+
+use std::intrinsics::simd::{simd_gather, simd_scatter};
+
+#[repr(simd)]
+#[derive(Copy, Clone, PartialEq, Debug)]
+struct x4<T>(pub [T; 4]);
+
+fn main() {
+    let mut x = [0_f32, 1., 2., 3., 4., 5., 6., 7.];
+
+    let default = x4([-3_f32, -3., -3., -3.]);
+    let s_strided = x4([0_f32, 2., -3., 6.]);
+
+    let mask = x4([-1_i32, -1, 0, -1]);
+    let umask = x4([0u16; 4]);
+    let fmask = x4([0_f32; 4]);
+
+    let pointer = x.as_mut_ptr();
+    let pointers =
+        unsafe { x4([pointer.offset(0), pointer.offset(2), pointer.offset(4), pointer.offset(6)]) };
+
+    unsafe {
+        simd_gather(default, mask, mask);
+        //~^ ERROR expected element type `i32` of second argument `x4<i32>` to be a pointer to the element type `f32`
+
+        simd_gather(default, pointers, umask);
+        //~^ ERROR expected element type `u16` of third argument `x4<u16>` to be a signed integer type
+
+        simd_gather(default, pointers, fmask);
+        //~^ ERROR expected element type `f32` of third argument `x4<f32>` to be a signed integer type
+    }
+
+    unsafe {
+        let values = x4([42_f32, 43_f32, 44_f32, 45_f32]);
+        simd_scatter(values, mask, mask);
+        //~^ ERROR expected element type `i32` of second argument `x4<i32>` to be a pointer to the element type `f32` of the first argument `x4<f32>`, found `i32` != `*mut f32`
+
+        simd_scatter(values, pointers, umask);
+        //~^ ERROR expected element type `u16` of third argument `x4<u16>` to be a signed integer type
+
+        simd_scatter(values, pointers, fmask);
+        //~^ ERROR expected element type `f32` of third argument `x4<f32>` to be a signed integer type
+    }
+}

--- a/tests/ui/simd/intrinsic/generic-gather.stderr
+++ b/tests/ui/simd/intrinsic/generic-gather.stderr
@@ -1,0 +1,39 @@
+error[E0511]: invalid monomorphization of `simd_gather` intrinsic: expected element type `i32` of second argument `x4<i32>` to be a pointer to the element type `f32` of the first argument `x4<f32>`, found `i32` != `*_ f32`
+  --> $DIR/generic-gather.rs:31:9
+   |
+LL |         simd_gather(default, mask, mask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_gather` intrinsic: expected element type `u16` of third argument `x4<u16>` to be a signed integer type
+  --> $DIR/generic-gather.rs:34:9
+   |
+LL |         simd_gather(default, pointers, umask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_gather` intrinsic: expected element type `f32` of third argument `x4<f32>` to be a signed integer type
+  --> $DIR/generic-gather.rs:37:9
+   |
+LL |         simd_gather(default, pointers, fmask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_scatter` intrinsic: expected element type `i32` of second argument `x4<i32>` to be a pointer to the element type `f32` of the first argument `x4<f32>`, found `i32` != `*mut f32`
+  --> $DIR/generic-gather.rs:43:9
+   |
+LL |         simd_scatter(values, mask, mask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_scatter` intrinsic: expected element type `u16` of third argument `x4<u16>` to be a signed integer type
+  --> $DIR/generic-gather.rs:46:9
+   |
+LL |         simd_scatter(values, pointers, umask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_scatter` intrinsic: expected element type `f32` of third argument `x4<f32>` to be a signed integer type
+  --> $DIR/generic-gather.rs:49:9
+   |
+LL |         simd_scatter(values, pointers, fmask);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0511`.

--- a/tests/ui/simd/intrinsic/generic-select.rs
+++ b/tests/ui/simd/intrinsic/generic-select.rs
@@ -37,10 +37,10 @@ fn main() {
         //~^ ERROR mismatched lengths: mask length `8` != other vector length `4`
 
         simd_select(x, x, x);
-        //~^ ERROR mask element type is `u32`, expected `i_`
+        //~^ ERROR mask element type is `u32`, expected a signed integer type
 
         simd_select(z, z, z);
-        //~^ ERROR mask element type is `f32`, expected `i_`
+        //~^ ERROR mask element type is `f32`, expected a signed integer type
 
         simd_select(m4, 0u32, 1u32);
         //~^ ERROR found non-SIMD `u32`

--- a/tests/ui/simd/intrinsic/generic-select.stderr
+++ b/tests/ui/simd/intrinsic/generic-select.stderr
@@ -4,17 +4,21 @@ error[E0511]: invalid monomorphization of `simd_select` intrinsic: mismatched le
 LL |         simd_select(m8, x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_select` intrinsic: mask element type is `u32`, expected `i_`
+error[E0511]: invalid monomorphization of `simd_select` intrinsic: found mask element type is `u32`, expected a signed integer type
   --> $DIR/generic-select.rs:39:9
    |
 LL |         simd_select(x, x, x);
    |         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the mask may be widened, which only has the correct behavior for signed integers
 
-error[E0511]: invalid monomorphization of `simd_select` intrinsic: mask element type is `f32`, expected `i_`
+error[E0511]: invalid monomorphization of `simd_select` intrinsic: found mask element type is `f32`, expected a signed integer type
   --> $DIR/generic-select.rs:42:9
    |
 LL |         simd_select(z, z, z);
    |         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the mask may be widened, which only has the correct behavior for signed integers
 
 error[E0511]: invalid monomorphization of `simd_select` intrinsic: expected SIMD argument type, found non-SIMD `u32`
   --> $DIR/generic-select.rs:45:9

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -771,7 +771,7 @@ cc = ["@fmease"]
 message = "Some changes occurred in diagnostic error codes"
 cc = ["@GuillaumeGomez"]
 
-[mentions."compiler/rustc_mir_build/src/build/matches"]
+[mentions."compiler/rustc_mir_build/src/builder/matches"]
 message = "Some changes occurred in match lowering"
 cc = ["@Nadrieril"]
 
@@ -1031,7 +1031,7 @@ cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 message = "Some changes occurred in coverage instrumentation."
 cc = ["@Zalathar"]
 
-[mentions."compiler/rustc_mir_build/src/build/coverageinfo.rs"]
+[mentions."compiler/rustc_mir_build/src/builder/coverageinfo.rs"]
 message = "Some changes occurred in coverage instrumentation."
 cc = ["@Zalathar"]
 
@@ -1260,7 +1260,7 @@ project-exploit-mitigations = [
 "/compiler/rustc_middle/src/ty" =                        ["compiler", "types"]
 "/compiler/rustc_const_eval/src/interpret" =             ["compiler", "mir"]
 "/compiler/rustc_const_eval/src/transform" =             ["compiler", "mir-opt"]
-"/compiler/rustc_mir_build/src/build" =                  ["compiler", "mir"]
+"/compiler/rustc_mir_build/src/builder" =                ["compiler", "mir"]
 "/compiler/rustc_mir_transform" =                        ["compiler", "mir", "mir-opt"]
 "/compiler/rustc_smir" =                                 ["project-stable-mir"]
 "/compiler/rustc_parse" =                                ["compiler", "parser"]


### PR DESCRIPTION
Successful merges:

 - #137375 (Minor internal comments fix for `BufRead::read_line`)
 - #137641 (More precisely document `Global::deallocate()`'s safety.)
 - #137755 (doc: update Wasmtime flags)
 - #137851 (improve `simd_select` error message when used with invalid mask type)
 - #137860 (rustc_target: Add msync target feature and enable it on powerpcspe targets)
 - #137871 (fix `RangeBounds::is_empty` documentation)
 - #137873 (Disable `f16` on Aarch64 without `neon`)
 - #137876 (Adjust triagebot.toml entries for `rustc_mir_build/src/builder/`)
 - #137883 (edit mailmap)
 - #137886 (`name()` and `trimmed_name()` for `stable_mir::crate_def::DefId`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=137375,137641,137755,137851,137860,137871,137873,137876,137883,137886)
<!-- homu-ignore:end -->