### PR TITLE
Improve error message for `AsyncFn` trait failure for RPIT

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3191,7 +3191,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     false
                 };
 
-                if !is_upvar_tys_infer_tuple {
+                let is_builtin_async_fn_trait =
+                    tcx.async_fn_trait_kind_from_def_id(data.parent_trait_pred.def_id()).is_some();
+
+                if !is_upvar_tys_infer_tuple && !is_builtin_async_fn_trait {
                     let ty_str = tcx.short_string(ty, err.long_ty_path());
                     let msg = format!("required because it appears within the type `{ty_str}`");
                     match ty.kind() {

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -984,8 +984,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 return Err(SelectionError::Unimplemented);
             }
         } else {
-            nested.push(obligation.with(
+            nested.push(Obligation::new(
                 self.tcx(),
+                obligation.derived_cause(ObligationCauseCode::BuiltinDerived),
+                obligation.param_env,
                 ty::TraitRef::new(
                     self.tcx(),
                     self.tcx().require_lang_item(

--- a/tests/ui/async-await/async-closures/kind-due-to-rpit.rs
+++ b/tests/ui/async-await/async-closures/kind-due-to-rpit.rs
@@ -1,0 +1,14 @@
+//@ edition: 2024
+
+// Make sure the error message is understandable when an `AsyncFn` goal is not satisfied
+// (due to closure kind), and that goal originates from an RPIT.
+
+fn repro(foo: impl Into<bool>) -> impl AsyncFn() {
+    let inner_fn = async move || {
+        //~^ ERROR expected a closure that implements the `AsyncFn` trait
+        let _ = foo.into();
+    };
+    inner_fn
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-closures/kind-due-to-rpit.stderr
+++ b/tests/ui/async-await/async-closures/kind-due-to-rpit.stderr
@@ -1,0 +1,17 @@
+error[E0525]: expected a closure that implements the `AsyncFn` trait, but this closure only implements `AsyncFnOnce`
+  --> $DIR/kind-due-to-rpit.rs:7:20
+   |
+LL | fn repro(foo: impl Into<bool>) -> impl AsyncFn() {
+   |                                   -------------- the requirement to implement `AsyncFn` derives from here
+LL |     let inner_fn = async move || {
+   |                    ^^^^^^^^^^^^^ this closure implements `AsyncFnOnce`, not `AsyncFn`
+LL |
+LL |         let _ = foo.into();
+   |                 --- closure is `AsyncFnOnce` because it moves the variable `foo` out of its environment
+LL |     };
+LL |     inner_fn
+   |     -------- return type was inferred to be `{async closure@$DIR/kind-due-to-rpit.rs:7:20: 7:33}` here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0525`.


### PR DESCRIPTION
Use a `WellFormedDerived` obligation cause to make sure we can turn an `AsyncFnKindHelper` trait goal into its parent `AsyncFn*` goal, then fix the logic for reporting `AsyncFn*` kind mismatches.

Best reviewed without whitespace.

Fixes #137905

r? oli-obk