### PR TITLE
Add a test for `-znostart-stop-gc` usage with LLD

### DIFF
--- a/tests/ui/linking/no-gc-encapsulation-symbols.rs
+++ b/tests/ui/linking/no-gc-encapsulation-symbols.rs
@@ -1,0 +1,25 @@
+// This test checks that encapsulation symbols are not garbage collected by the linker.
+// LLD will remove them by default, so this test checks that we pass `-znostart-stop-gc` to LLD
+// to avoid that behavior. Without that flag, the test should fail.
+// This test is inspired by the behavior of the linkme crate.
+//
+//@ build-pass
+//@ only-x86_64-unknown-linux-gnu
+
+unsafe extern "Rust" {
+    // The __start_ section name is magical for the linker,
+    // It will put link sections named EXTERNFNS after it.
+    #[link_name = "__start_EXTERNFNS"]
+    static SECTION_START: fn();
+}
+
+#[used]
+#[unsafe(link_section = "EXTERNFNS")]
+static EXTERN_FN_LOCAL: fn() = extern_fn;
+
+fn extern_fn() {}
+
+fn main() {
+    // We need to reference the SECTION_START symbol to avoid it being garbage collected
+    let slice = unsafe { SECTION_START };
+}


### PR DESCRIPTION
This test replicates the behavior of https://github.com/dtolnay/linkme, to test that it still works even with LLD. Without `-znostart-stop-gc` the test fails.

r? @lqd

try-job: x86_64-gnu
try-job: x86_64-msvc-1