### PR TITLE
Do not install rustup on Rust for Linux job

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -271,9 +271,8 @@ auto:
 
   # Tests integration with Rust for Linux.
   # Builds stage 1 compiler and tries to compile a few RfL examples with it.
-  # FIXME: fix rustup 1.28 issue
-  #  - name: x86_64-rust-for-linux
-  #    <<: *job-linux-4c
+  - name: x86_64-rust-for-linux
+    <<: *job-linux-4c
 
   - name: x86_64-gnu
     <<: *job-linux-4c


### PR DESCRIPTION
Trying to fix the RfL job after the recent rustup update.

r? @ghost

try-job: x86_64-rust-for-linux