### PR TITLE
Update MSVC INSTALL.md instructions to recommend VS 2022 + recent Windows 10/11 SDK

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -210,9 +210,13 @@ itself back on after some time).
 
 ### MSVC
 
-MSVC builds of Rust additionally require an installation of Visual Studio 2017
-(or later) so `rustc` can use its linker. The simplest way is to get
-[Visual Studio], check the "C++ build tools" and "Windows 10 SDK" workload.
+MSVC builds of Rust additionally requires an installation of:
+
+- Visual Studio 2022 (or later) build tools so `rustc` can use its linker. Older
+  Visual Studio versions such as 2019 *may* work but aren't actively tested.
+- A recent Windows 10 or 11 SDK.
+
+The simplest way is to get [Visual Studio], check the "C++ build tools".
 
 [Visual Studio]: https://visualstudio.microsoft.com/downloads/
 


### PR DESCRIPTION
This is generally iffy because we don't consistently [document the exact minimum versions of build tools required to build a given Rust toolchain](https://github.com/rust-lang/rust/issues/129307).

cc #129307, *maybe* rustup docs are outdated?

Anyway, I updated this because I was on a slightly older VS toolchain and I couldn't `./x build library` on MSVC (even though maybe a month ago I could) due to CI `rustc_llvm` using stuff from newer Windows 11 SDK maybe. I updated the VS toolchain + Windows 11 SDK, and then I could build.

I'm not 100% sure the requirements here are accurate. It might be too high?

r? @ChrisDenton 