### PR TITLE
Always allow rustdoc-json tests to contain long lines

### DIFF
--- a/tests/rustdoc-json/enums/discriminant/limits.rs
+++ b/tests/rustdoc-json/enums/discriminant/limits.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-linelength
 #![feature(repr128)]
 #![allow(incomplete_features)]
 

--- a/tests/rustdoc-json/enums/discriminant/num_underscore_and_suffix.rs
+++ b/tests/rustdoc-json/enums/discriminant/num_underscore_and_suffix.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 #[repr(u32)]
 pub enum Foo {
     //@ is "$.index[*][?(@.name=='Basic')].inner.variant.discriminant.value" '"0"'

--- a/tests/rustdoc-json/enums/discriminant/only_some_have_discriminant.rs
+++ b/tests/rustdoc-json/enums/discriminant/only_some_have_discriminant.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 pub enum Foo {
     //@ is "$.index[*][?(@.name=='Has')].inner.variant.discriminant" '{"expr":"0", "value":"0"}'
     Has = 0,

--- a/tests/rustdoc-json/enums/discriminant/struct.rs
+++ b/tests/rustdoc-json/enums/discriminant/struct.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 #[repr(i32)]
 //@ is "$.index[*][?(@.name=='Foo')].attrs" '["#[attr=\"Repr([ReprInt(SignedInt(I32))])\")]\n"]'
 pub enum Foo {

--- a/tests/rustdoc-json/enums/discriminant/tuple.rs
+++ b/tests/rustdoc-json/enums/discriminant/tuple.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 #[repr(u32)]
 //@ is "$.index[*][?(@.name=='Foo')].attrs" '["#[attr=\"Repr([ReprInt(UnsignedInt(U32))])\")]\n"]'
 pub enum Foo {

--- a/tests/rustdoc-json/enums/kind.rs
+++ b/tests/rustdoc-json/enums/kind.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 pub enum Foo {
     //@ set Unit = "$.index[*][?(@.name=='Unit')].id"
     //@ is "$.index[*][?(@.name=='Unit')].inner.variant.kind" '"plain"'

--- a/tests/rustdoc-json/fn_pointer/abi.rs
+++ b/tests/rustdoc-json/fn_pointer/abi.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 #![feature(abi_vectorcall)]
 
 //@ is "$.index[*][?(@.name=='AbiRust')].inner.type_alias.type.function_pointer.header.abi" \"Rust\"

--- a/tests/rustdoc-json/fn_pointer/generics.rs
+++ b/tests/rustdoc-json/fn_pointer/generics.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ count "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[*]" 1
 //@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[0][0]" '"val"'
 //@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[0][1].borrowed_ref.lifetime" \"\'c\"

--- a/tests/rustdoc-json/fn_pointer/qualifiers.rs
+++ b/tests/rustdoc-json/fn_pointer/qualifiers.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_unsafe" false
 //@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_const" false
 //@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_async" false

--- a/tests/rustdoc-json/fns/abi.rs
+++ b/tests/rustdoc-json/fns/abi.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 #![feature(abi_vectorcall)]
 
 //@ is "$.index[*][?(@.name=='abi_rust')].inner.function.header.abi" \"Rust\"

--- a/tests/rustdoc-json/fns/async_return.rs
+++ b/tests/rustdoc-json/fns/async_return.rs
@@ -1,5 +1,4 @@
 //@ edition:2021
-// ignore-tidy-linelength
 
 // Regression test for <https://github.com/rust-lang/rust/issues/101199>
 

--- a/tests/rustdoc-json/fns/generic_args.rs
+++ b/tests/rustdoc-json/fns/generic_args.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ set foo = "$.index[*][?(@.name=='Foo')].id"
 pub trait Foo {}
 

--- a/tests/rustdoc-json/fns/generic_returns.rs
+++ b/tests/rustdoc-json/fns/generic_returns.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ count "$.index[*][?(@.name=='generic_returns')].inner.module.items[*]" 2
 
 //@ set foo = "$.index[*][?(@.name=='Foo')].id"

--- a/tests/rustdoc-json/fns/generics.rs
+++ b/tests/rustdoc-json/fns/generics.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ set wham_id = "$.index[*][?(@.name=='Wham')].id"
 pub trait Wham {}
 

--- a/tests/rustdoc-json/generic-associated-types/gats.rs
+++ b/tests/rustdoc-json/generic-associated-types/gats.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 pub trait Display {}
 
 pub trait LendingIterator {

--- a/tests/rustdoc-json/impl-trait-in-assoc-type.rs
+++ b/tests/rustdoc-json/impl-trait-in-assoc-type.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-linelength
 #![feature(impl_trait_in_assoc_type)]
 
 pub struct AlwaysTrue;

--- a/tests/rustdoc-json/lifetime/longest.rs
+++ b/tests/rustdoc-json/lifetime/longest.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].name"  \"\'a\"
 //@ is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].kind"  '{"lifetime": {"outlives": []}}'
 //@ is "$.index[*][?(@.name=='longest')].inner.function.generics.params[0].kind"  '{"lifetime": {"outlives": []}}'

--- a/tests/rustdoc-json/lifetime/outlives.rs
+++ b/tests/rustdoc-json/lifetime/outlives.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ count "$.index[*][?(@.name=='foo')].inner.function.generics.params[*]" 3
 //@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates" []
 //@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[0].name" \"\'a\"

--- a/tests/rustdoc-json/lifetime/outlives_in_param.rs
+++ b/tests/rustdoc-json/lifetime/outlives_in_param.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ count '$.index[*][?(@.name=="outlives")].inner.function.generics.params[*]' 2
 //@ is    '$.index[*][?(@.name=="outlives")].inner.function.generics.params[0].name' \"\'a\"
 //@ is    '$.index[*][?(@.name=="outlives")].inner.function.generics.params[0].kind.lifetime.outlives' []

--- a/tests/rustdoc-json/lifetime/outlives_in_where.rs
+++ b/tests/rustdoc-json/lifetime/outlives_in_where.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ is '$.index[*][?(@.name=="on_lifetimes")].inner.function.generics.where_predicates' '[{"lifetime_predicate": {"lifetime": "'\''all", "outlives": ["'\''a", "'\''b", "'\''c"]}}]'
 pub fn on_lifetimes<'a, 'b, 'c, 'all>()
 where

--- a/tests/rustdoc-json/methods/abi.rs
+++ b/tests/rustdoc-json/methods/abi.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 #![feature(abi_vectorcall)]
 
 //@ has "$.index[*][?(@.name=='Foo')]"

--- a/tests/rustdoc-json/non_lifetime_binders.rs
+++ b/tests/rustdoc-json/non_lifetime_binders.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 #![feature(non_lifetime_binders)]
 #![allow(incomplete_features)]
 

--- a/tests/rustdoc-json/path_name.rs
+++ b/tests/rustdoc-json/path_name.rs
@@ -3,7 +3,6 @@
 // See https://github.com/rust-lang/rust/issues/135600
 // and https://github.com/rust-lang/rust/pull/134880#issuecomment-2596386111
 //
-// ignore-tidy-linelength
 //@ aux-build: defines_and_reexports.rs
 extern crate defines_and_reexports;
 

--- a/tests/rustdoc-json/reexport/doc_inline_external_crate.rs
+++ b/tests/rustdoc-json/reexport/doc_inline_external_crate.rs
@@ -1,6 +1,5 @@
 // Regression Test for https://github.com/rust-lang/rust/issues/110138
 //@ aux-build: enum_with_discriminant.rs
-// ignore-tidy-linelength
 
 #[doc(inline)]
 pub extern crate enum_with_discriminant;

--- a/tests/rustdoc-json/reexport/export_extern_crate_as_self.rs
+++ b/tests/rustdoc-json/reexport/export_extern_crate_as_self.rs
@@ -2,7 +2,5 @@
 
 #![crate_name = "export_extern_crate_as_self"]
 
-// ignore-tidy-linelength
-
 //@ is "$.index[*][?(@.inner.module)].name" \"export_extern_crate_as_self\"
 pub extern crate self as export_extern_crate_as_self; // Must be the same name as the crate already has

--- a/tests/rustdoc-json/reexport/private_twice_one_inline.rs
+++ b/tests/rustdoc-json/reexport/private_twice_one_inline.rs
@@ -1,5 +1,4 @@
 //@ aux-build:pub-struct.rs
-// ignore-tidy-linelength
 
 // Test for the ICE in https://github.com/rust-lang/rust/issues/83057
 // An external type re-exported with different attributes shouldn't cause an error

--- a/tests/rustdoc-json/reexport/private_two_names.rs
+++ b/tests/rustdoc-json/reexport/private_two_names.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 // Test for the ICE in https://github.com/rust-lang/rust/issues/83720
 // A pub-in-private type re-exported under two different names shouldn't cause an error
 

--- a/tests/rustdoc-json/reexport/same_type_reexported_more_than_once.rs
+++ b/tests/rustdoc-json/reexport/same_type_reexported_more_than_once.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 // Regression test for <https://github.com/rust-lang/rust/issues/97432>.
 
 #![no_std]

--- a/tests/rustdoc-json/return_private.rs
+++ b/tests/rustdoc-json/return_private.rs
@@ -1,5 +1,4 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/96161>.
-// ignore-tidy-linelength
 
 mod secret {
     //@ set struct_secret = "$.index[*][?(@.name == 'Secret' && @.inner.struct)].id"

--- a/tests/rustdoc-json/statics/extern.rs
+++ b/tests/rustdoc-json/statics/extern.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-linelength
 //@ edition: 2021
 
 extern "C" {

--- a/tests/rustdoc-json/structs/with_primitives.rs
+++ b/tests/rustdoc-json/structs/with_primitives.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ is "$.index[*][?(@.name=='WithPrimitives')].visibility" \"public\"
 //@ has "$.index[*][?(@.name=='WithPrimitives')].inner.struct"
 //@ is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.generics.params[0].name" \"\'a\"

--- a/tests/rustdoc-json/trait_alias.rs
+++ b/tests/rustdoc-json/trait_alias.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-linelength
 #![feature(trait_alias)]
 
 //@ set StrLike = "$.index[*][?(@.name=='StrLike')].id"

--- a/tests/rustdoc-json/traits/private_supertrait.rs
+++ b/tests/rustdoc-json/traits/private_supertrait.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ !has "$.index[*][?(@.name == 'sealed')]"
 mod sealed {
     //@ set sealed_id = "$.index[*][?(@.name=='Sealed')].id"

--- a/tests/rustdoc-json/traits/self.rs
+++ b/tests/rustdoc-json/traits/self.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 pub struct Foo;
 
 // Check that Self is represented uniformly between inherent impls, trait impls,

--- a/tests/rustdoc-json/traits/supertrait.rs
+++ b/tests/rustdoc-json/traits/supertrait.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ set loud_id = "$.index[*][?(@.name=='Loud')].id"
 pub trait Loud {}
 

--- a/tests/rustdoc-json/traits/trait_alias.rs
+++ b/tests/rustdoc-json/traits/trait_alias.rs
@@ -1,5 +1,4 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/104923>
-// ignore-tidy-linelength
 
 #![feature(trait_alias)]
 

--- a/tests/rustdoc-json/type/dyn.rs
+++ b/tests/rustdoc-json/type/dyn.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-linelength
 use std::fmt::Debug;
 
 //@ count "$.index[*][?(@.name=='dyn')].inner.module.items[*]" 3

--- a/tests/rustdoc-json/type/fn_lifetime.rs
+++ b/tests/rustdoc-json/type/fn_lifetime.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ has "$.index[*][?(@.name=='GenericFn')].inner.type_alias"
 
 //@ ismany "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.params[*].name" \"\'a\"

--- a/tests/rustdoc-json/type/generic_default.rs
+++ b/tests/rustdoc-json/type/generic_default.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ set result = "$.index[*][?(@.name=='Result')].id"
 pub enum Result<T, E> {
     Ok(T),

--- a/tests/rustdoc-json/type/hrtb.rs
+++ b/tests/rustdoc-json/type/hrtb.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 //@ is "$.index[*][?(@.name=='genfn')].inner.function.generics.where_predicates[0].bound_predicate.type" '{"generic": "F"}'
 //@ is "$.index[*][?(@.name=='genfn')].inner.function.generics.where_predicates[0].bound_predicate.generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
 pub fn genfn<F>(f: F)

--- a/tests/rustdoc-json/type/inherent_associated_type.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-linelength
 #![feature(inherent_associated_types)]
 #![allow(incomplete_features)]
 

--- a/tests/rustdoc-json/type/inherent_associated_type_bound.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type_bound.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-linelength
 #![feature(inherent_associated_types)]
 #![allow(incomplete_features)]
 

--- a/tests/rustdoc-json/type/inherent_associated_type_projections.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type_projections.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-linelength
 #![feature(inherent_associated_types)]
 #![allow(incomplete_features)]
 


### PR DESCRIPTION
The rustdoc-json test syntax often requires very long lines, so the checks for long lines aren't really useful.

@aDotInTheVoid told me she'd like this and

r? jieyouxu 

you're gonna tell me that the implementation is terrible. at least the performance seems reasonable: 2.5s after and 2.5s before.