### PR TITLE
Add RTN support to rustdoc

### DIFF
--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -252,7 +252,9 @@ pub fn lower_ty<'tcx>(tcx: TyCtxt<'tcx>, hir_ty: &hir::Ty<'tcx>) -> Ty<'tcx> {
     // def-ID that will be used to determine the traits/predicates in
     // scope. This is derived from the enclosing item-like thing.
     let env_def_id = tcx.hir_get_parent_item(hir_ty.hir_id);
-    collect::ItemCtxt::new(tcx, env_def_id.def_id).lower_ty(hir_ty)
+    collect::ItemCtxt::new(tcx, env_def_id.def_id)
+        .lowerer()
+        .lower_ty_maybe_return_type_notation(hir_ty)
 }
 
 /// This is for rustdoc.

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -102,6 +102,10 @@ pub(crate) fn merge_bounds(
                     }
                 }
             },
+            PP::ReturnTypeNotation => {
+                // Cannot merge bounds with RTN.
+                return false;
+            }
         };
         true
     })

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -332,6 +332,9 @@ impl clean::GenericArgs {
                         }
                     }
                 }
+                clean::GenericArgs::ReturnTypeNotation => {
+                    f.write_str("(..)")?;
+                }
             }
             Ok(())
         })

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -176,6 +176,7 @@ impl FromClean<clean::GenericArgs> for GenericArgs {
                 inputs: inputs.into_json(renderer),
                 output: output.map(|a| (*a).into_json(renderer)),
             },
+            ReturnTypeNotation => GenericArgs::ReturnTypeNotation,
         }
     }
 }

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -30,7 +30,7 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 /// This integer is incremented with every breaking change to the API,
 /// and is returned along with the JSON blob as [`Crate::format_version`].
 /// Consuming code should assert that this value matches the format version(s) that it supports.
-pub const FORMAT_VERSION: u32 = 41;
+pub const FORMAT_VERSION: u32 = 42;
 
 /// The root of the emitted JSON blob.
 ///
@@ -229,6 +229,8 @@ pub enum GenericArgs {
         /// The output type provided after the `->`, if present.
         output: Option<Type>,
     },
+    /// `T::method(..)`
+    ReturnTypeNotation,
 }
 
 /// One argument in a list of generic arguments to a path segment.

--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -326,6 +326,7 @@ impl<'a> Validator<'a> {
                     self.check_type(o);
                 }
             }
+            GenericArgs::ReturnTypeNotation => {}
         }
     }
 

--- a/tests/rustdoc-json/return-type-notation.rs
+++ b/tests/rustdoc-json/return-type-notation.rs
@@ -1,0 +1,18 @@
+//@ edition: 2021
+// ignore-tidy-linelength
+
+#![crate_type = "lib"]
+#![feature(return_type_notation)]
+
+pub trait Foo {
+    async fn bar();
+}
+
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.args.angle_bracketed.constraints[0].args" '"return_type_notation"'
+//@ ismany "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[*].bound_predicate.type.qualified_path.args" '"return_type_notation"' '"return_type_notation"'
+pub fn foo<T: Foo<bar(..): Send>>()
+where
+    <T as Foo>::bar(..): 'static,
+    T::bar(..): Sync,
+{
+}

--- a/tests/rustdoc/return-type-notation.rs
+++ b/tests/rustdoc/return-type-notation.rs
@@ -1,0 +1,18 @@
+//@ edition: 2021
+
+#![crate_type = "lib"]
+#![feature(return_type_notation)]
+
+pub trait Foo {
+    async fn bar();
+}
+
+//@ has "return_type_notation/fn.foo.html"
+//@ has - '//pre[@class="rust item-decl"]' "pub fn foo<T: Foo<bar(..): Send>>()"
+//@ has - '//pre[@class="rust item-decl"]' "where <T as Foo>::bar(..): 'static, T::bar(..): Sync"
+pub fn foo<T: Foo<bar(..): Send>>()
+where
+    <T as Foo>::bar(..): 'static,
+    T::bar(..): Sync,
+{
+}


### PR DESCRIPTION
This adds support to rustdoc and rustdoc-json for rendering `(..)` RTN (return type notation) style generics.

---

Cleaning `rustc_middle::ty::Ty` is not correct still, though, and ends up rendering a function like:

```rust
pub fn foreign<T: Foreign<bar(..): Send>>()
where
    <T as Foreign>::bar(..): 'static,
    T::bar(..): Sync,
```

Into this:

```rust
pub fn foreign<T>()
where
    T: Foreign,
    impl Future<Output = ()>: Send + 'static + Sync,
```

This is because `clean_middle_ty` doesn't actually have sufficient context about whether the RPITIT is in its "defining scope" or not, so we don't know if the type was originally written like `-> impl Trait` or with RTN like `T::method(..)`.

Partially addresses #123996 (i.e., HIR side, not middle::ty one)