### PR TITLE
triagebot.toml: Don't label `test/rustdoc-json` as A-rustdoc-search

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -207,7 +207,7 @@ trigger_files = [
     "tests/rustdoc",
     "tests/rustdoc-ui",
     "tests/rustdoc-gui",
-    "tests/rustdoc-js",
+    "tests/rustdoc-js/",
     "tests/rustdoc-js-std",
     "tests/rustdoc-json",
 
@@ -1307,7 +1307,7 @@ project-exploit-mitigations = [
 "/tests/rustdoc" =                                       ["rustdoc"]
 "/tests/rustdoc-gui" =                                   ["rustdoc"]
 "/tests/rustdoc-js-std" =                                ["rustdoc"]
-"/tests/rustdoc-js" =                                    ["rustdoc"]
+"/tests/rustdoc-js/" =                                   ["rustdoc"]
 "/tests/rustdoc-json" =                                  ["@aDotInTheVoid"]
 "/tests/rustdoc-ui" =                                    ["rustdoc"]
 "/tests/ui" =                                            ["compiler"]


### PR DESCRIPTION
This happened because `test/rustdoc-js` is a prefix of `test/rustdoc-json`, and triagebot works on prefixes.

Maybe this should be fixed in triagebot, but this works now.

This happened on #137956 and #137955.
