### PR TITLE
[AIX] Fix hangs during testing

### DIFF
--- a/library/std/src/net/test.rs
+++ b/library/std/src/net/test.rs
@@ -31,3 +31,14 @@ pub fn tsa<A: ToSocketAddrs>(a: A) -> Result<Vec<SocketAddr>, String> {
         Err(e) => Err(e.to_string()),
     }
 }
+
+pub fn compare_ignore_zoneid(a: &SocketAddr, b: &SocketAddr) -> bool {
+    match (a, b) {
+        (SocketAddr::V6(a), SocketAddr::V6(b)) => {
+            a.ip().segments() == b.ip().segments()
+                && a.flowinfo() == b.flowinfo()
+                && a.port() == b.port()
+        }
+        _ => a == b,
+    }
+}

--- a/tests/debuginfo/pretty-huge-vec.rs
+++ b/tests/debuginfo/pretty-huge-vec.rs
@@ -1,5 +1,6 @@
 //@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
+//@ ignore-aix: FIXME(#137965)
 //@ compile-flags:-g
 
 // === GDB TESTS ===================================================================================

--- a/tests/ui/consts/large_const_alloc.rs
+++ b/tests/ui/consts/large_const_alloc.rs
@@ -2,6 +2,9 @@
 // on 32bit and 16bit platforms it is plausible that the maximum allocation size will succeed
 // FIXME (#135952) In some cases on AArch64 Linux the diagnostic does not trigger
 //@ ignore-aarch64-unknown-linux-gnu
+// AIX will allow the allocation to go through, and get SIGKILL when zero initializing
+// the overcommitted page.
+//@ ignore-aix
 
 const FOO: () = {
     // 128 TiB, unlikely anyone has that much RAM

--- a/tests/ui/consts/large_const_alloc.stderr
+++ b/tests/ui/consts/large_const_alloc.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/large_const_alloc.rs:8:13
+  --> $DIR/large_const_alloc.rs:11:13
    |
 LL |     let x = [0_u8; (1 << 47) - 1];
    |             ^^^^^^^^^^^^^^^^^^^^^ tried to allocate more memory than available to compiler
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/large_const_alloc.rs:13:13
+  --> $DIR/large_const_alloc.rs:16:13
    |
 LL |     let x = [0_u8; (1 << 47) - 1];
    |             ^^^^^^^^^^^^^^^^^^^^^ tried to allocate more memory than available to compiler

--- a/tests/ui/consts/promoted_running_out_of_memory_issue-130687.rs
+++ b/tests/ui/consts/promoted_running_out_of_memory_issue-130687.rs
@@ -5,6 +5,9 @@
 //@ only-64bit
 // FIXME (#135952) In some cases on AArch64 Linux the diagnostic does not trigger
 //@ ignore-aarch64-unknown-linux-gnu
+// AIX will allow the allocation to go through, and get SIGKILL when zero initializing
+// the overcommitted page.
+//@ ignore-aix
 
 pub struct Data([u8; (1 << 47) - 1]);
 const _: &'static Data = &Data([0; (1 << 47) - 1]);

--- a/tests/ui/consts/promoted_running_out_of_memory_issue-130687.stderr
+++ b/tests/ui/consts/promoted_running_out_of_memory_issue-130687.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/promoted_running_out_of_memory_issue-130687.rs:10:32
+  --> $DIR/promoted_running_out_of_memory_issue-130687.rs:13:32
    |
 LL | const _: &'static Data = &Data([0; (1 << 47) - 1]);
    |                                ^^^^^^^^^^^^^^^^^^ tried to allocate more memory than available to compiler


### PR DESCRIPTION
Fixes all current test hangs experienced during CI runs. 
1. ipv6 link-local (the loopback device) gets assigned an automatic zone id of 1, causing the assert to fail and hang in `library/std/src/net/udp/tests.rs`
2. Const alloc does not fail gracefully 
3. Debuginfo test has problem with gdb auto load safe path