### PR TITLE
Properly escape regexes in Python scripts

### DIFF
--- a/src/etc/lldb_batchmode.py
+++ b/src/etc/lldb_batchmode.py
@@ -40,7 +40,7 @@ def print_debug(s):
 
 def normalize_whitespace(s):
     """Replace newlines, tabs, multiple spaces, etc with exactly one space"""
-    return re.sub("\s+", " ", s)
+    return re.sub(r"\s+", " ", s)
 
 
 def breakpoint_callback(frame, bp_loc, dict):
@@ -234,7 +234,7 @@ try:
         if (
             command == "run"
             or command == "r"
-            or re.match("^process\s+launch.*", command)
+            or re.match(r"^process\s+launch.*", command)
         ):
             # Before starting to run the program, let the thread sleep a bit, so all
             # breakpoint added events can be processed


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

According to the [Python 3.12 release note](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes) string literals containing typical invalid escape sequences like `"\d"` are now rejected. There seems to remain only two instances of escape sequences in regex. This change will allow us to work with newer Python interpreter.