### PR TITLE
Stabilise `os_string_pathbuf_leak`

### DIFF
--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -568,7 +568,7 @@ impl OsString {
     /// However, keep in mind that trimming the capacity may result in a reallocation and copy.
     ///
     /// [`into_boxed_os_str`]: Self::into_boxed_os_str
-    #[unstable(feature = "os_string_pathbuf_leak", issue = "125965")]
+    #[stable(feature = "os_string_pathbuf_leak", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub fn leak<'a>(self) -> &'a mut OsStr {
         OsStr::from_inner_mut(self.inner.leak())

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1252,7 +1252,7 @@ impl PathBuf {
     /// However, keep in mind that trimming the capacity may result in a reallocation and copy.
     ///
     /// [`into_boxed_path`]: Self::into_boxed_path
-    #[unstable(feature = "os_string_pathbuf_leak", issue = "125965")]
+    #[stable(feature = "os_string_pathbuf_leak", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub fn leak<'a>(self) -> &'a mut Path {
         Path::from_inner_mut(self.inner.leak())

--- a/library/std/tests/path.rs
+++ b/library/std/tests/path.rs
@@ -3,7 +3,6 @@
     path_add_extension,
     path_file_prefix,
     maybe_uninit_slice,
-    os_string_pathbuf_leak,
     normalize_lexically
 )]
 


### PR DESCRIPTION
This PR stabilises `#[feature(os_string_pathbuf_leak)]`, which defines 2 new methods in the std:

```rs
impl OsString {
    pub fn leak<'a>(self) -> &'a mut OsStr;
}

impl PathBuf {
    pub fn leak<'a>(self) -> &'a mut Path;
}
```

ACP: https://github.com/rust-lang/libs-team/issues/389
Tracking issue: https://github.com/rust-lang/rust/issues/125965
Implementation: https://github.com/rust-lang/rust/pull/125966 