### PR TITLE
Add minimal x86_64-lynx-lynxos178 support.

### DIFF
--- a/compiler/rustc_target/src/spec/base/lynxos178.rs
+++ b/compiler/rustc_target/src/spec/base/lynxos178.rs
@@ -1,0 +1,31 @@
+use std::borrow::Cow;
+
+use crate::spec::{
+    PanicStrategy, RelocModel, RelroLevel, SplitDebuginfo, StackProbeType, TargetOptions, cvs,
+};
+
+pub(crate) fn opts() -> TargetOptions {
+    TargetOptions {
+        os: "lynxos178".into(),
+        dynamic_linking: false,
+        families: cvs!["unix"],
+        position_independent_executables: false,
+        static_position_independent_executables: false,
+        relro_level: RelroLevel::Full,
+        has_thread_local: false,
+        crt_static_respected: true,
+        panic_strategy: PanicStrategy::Abort,
+        linker: Some(Cow::Borrowed("x86_64-lynx-lynxos178-gcc")),
+        no_default_libraries: false,
+        eh_frame_header: false, // GNU ld (GNU Binutils) 2.37.50 does not support --eh-frame-hdr
+        max_atomic_width: Some(64),
+        supported_split_debuginfo: Cow::Borrowed(&[
+            SplitDebuginfo::Packed,
+            SplitDebuginfo::Unpacked,
+            SplitDebuginfo::Off,
+        ]),
+        relocation_model: RelocModel::Static,
+        stack_probes: StackProbeType::Inline,
+        ..Default::default()
+    }
+}

--- a/compiler/rustc_target/src/spec/base/mod.rs
+++ b/compiler/rustc_target/src/spec/base/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod linux_musl;
 pub(crate) mod linux_ohos;
 pub(crate) mod linux_uclibc;
 pub(crate) mod linux_wasm;
+pub(crate) mod lynxos178;
 pub(crate) mod msvc;
 pub(crate) mod netbsd;
 pub(crate) mod nto_qnx;

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2078,6 +2078,7 @@ supported_targets! {
     ("riscv32imafc-unknown-nuttx-elf", riscv32imafc_unknown_nuttx_elf),
     ("riscv64imac-unknown-nuttx-elf", riscv64imac_unknown_nuttx_elf),
     ("riscv64gc-unknown-nuttx-elf", riscv64gc_unknown_nuttx_elf),
+    ("x86_64-lynx-lynxos178", x86_64_lynx_lynxos178),
 
     ("x86_64-pc-cygwin", x86_64_pc_cygwin),
 }

--- a/compiler/rustc_target/src/spec/targets/x86_64_lynx_lynxos178.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_lynx_lynxos178.rs
@@ -1,0 +1,34 @@
+use crate::spec::{SanitizerSet, StackProbeType, Target, base};
+
+pub(crate) fn target() -> Target {
+    let mut base = base::lynxos178::opts();
+    base.cpu = "x86-64".into();
+    base.plt_by_default = false;
+    base.max_atomic_width = Some(64);
+    base.stack_probes = StackProbeType::Inline;
+    base.static_position_independent_executables = false;
+    base.supported_sanitizers = SanitizerSet::ADDRESS
+        | SanitizerSet::CFI
+        | SanitizerSet::KCFI
+        | SanitizerSet::DATAFLOW
+        | SanitizerSet::LEAK
+        | SanitizerSet::MEMORY
+        | SanitizerSet::SAFESTACK
+        | SanitizerSet::THREAD;
+    base.supports_xray = true;
+
+    Target {
+        llvm_target: "x86_64-unknown-unknown-gnu".into(),
+        metadata: crate::spec::TargetMetadata {
+            description: Some("LynxOS-178".into()),
+            tier: Some(3),
+            host_tools: Some(false),
+            std: Some(false),
+        },
+        pointer_width: 64,
+        data_layout:
+            "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128".into(),
+        arch: "x86_64".into(),
+        options: base,
+    }
+}

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -34,6 +34,7 @@ pub struct Finder {
 // Targets can be removed from this list once they are present in the stage0 compiler (usually by updating the beta compiler of the bootstrap).
 const STAGE0_MISSING_TARGETS: &[&str] = &[
     // just a dummy comment so the list doesn't get onelined
+    "x86_64-lynx-lynxos178",
 ];
 
 /// Minimum version threshold for libstdc++ required when using prebuilt LLVM

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -78,6 +78,7 @@
     - [illumos](platform-support/illumos.md)
     - [loongarch\*-unknown-linux-\*](platform-support/loongarch-linux.md)
     - [loongarch\*-unknown-none\*](platform-support/loongarch-none.md)
+    - [\*-lynxos178-\*](platform-support/lynxos178.md)
     - [m68k-unknown-linux-gnu](platform-support/m68k-unknown-linux-gnu.md)
     - [m68k-unknown-none-elf](platform-support/m68k-unknown-none-elf.md)
     - [mips64-openwrt-linux-musl](platform-support/mips64-openwrt-linux-musl.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -407,6 +407,7 @@ target | std | host | notes
 [`wasm32-wali-linux-musl`](platform-support/wasm32-wali-linux.md) | ? |  | WebAssembly with [WALI](https://github.com/arjunr2/WALI)
 [`x86_64-apple-tvos`](platform-support/apple-tvos.md) | ✓ |  | x86 64-bit tvOS
 [`x86_64-apple-watchos-sim`](platform-support/apple-watchos.md) | ✓ |  | x86 64-bit Apple WatchOS simulator
+[`x86_64-lynx-lynxos178`](platform-support/lynxos178.md) |   |  | x86_64 LynxOS-178
 [`x86_64-pc-cygwin`](platform-support/x86_64-pc-cygwin.md) | ✓ |  | 64-bit x86 Cygwin |
 [`x86_64-pc-nto-qnx710`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with default network stack (io-pkt) |
 [`x86_64-pc-nto-qnx710_iosock`](platform-support/nto-qnx.md) | ✓ |  | x86 64-bit QNX Neutrino 7.1 RTOS with new network stack (io-sock) |

--- a/src/doc/rustc/src/platform-support/lynxos178.md
+++ b/src/doc/rustc/src/platform-support/lynxos178.md
@@ -1,0 +1,77 @@
+# `*-lynxos178-*`
+
+**Tier: 3**
+
+Targets for the LynxOS-178 operating system.
+
+[LynxOS-178](https://www.lynx.com/products/lynxos-178-do-178c-certified-posix-rtos)
+is a commercial RTOS designed for safety-critical real-time systems.  It is
+developed by Lynx Software Technologies as part of the
+[MOSA.ic](https://www.lynx.com/solutions/safe-and-secure-operating-environment)
+product suite.
+
+Target triples available:
+- `x86_64-lynx-lynxos178`
+
+## Target maintainers
+
+- Renat Fatykhov, https://github.com/rfatykhov-lynx
+
+## Requirements
+
+To build Rust programs for LynxOS-178, you must first have LYNX MOSA.ic
+installed on the build machine.
+
+This target supports only cross-compilation, from the same hosts supported by
+the Lynx CDK.
+
+Currently only `no_std` programs are supported. Work to support `std` is in
+progress.
+
+## Building the target
+
+You can build Rust with support for x86_64-lynx-lynxos178 by adding that
+to the `target` list in `config.toml`, and then running `./x build --target
+x86_64-lynx-lynxos178 compiler`.
+
+## Building Rust programs
+
+Rust does not yet ship pre-compiled artifacts for this target. To compile for
+this target, you will need to build Rust with the target enabled (see "Building
+the target" above).
+
+Before executing `cargo`, you must configure the environment to build LynxOS-178
+binaries by running `source setup.sh` from the los178 directory.
+
+If your program/crates contain procedural macros, Rust must be able to build
+binaries for the host as well. The host gcc is hidden by sourcing setup.sh.  To
+deal with this, add the following to your project's `.cargo/config.toml`:
+```toml
+[target.x86_64-unknown-linux-gnu]
+linker = "lynx-host-gcc"
+```
+(If necessary substitute your host target triple for x86_64-unknown-linux-gnu.)
+
+To point `cargo` at the correct rustc binary, set the RUSTC environment
+variable.
+
+The core library should be usable. You can try by building it as part of your
+project:
+```bash
+cargo +nightly build -Z build-std=core --target x86_64-lynx-lynxos178
+```
+
+## Testing
+
+Binaries built with rust can be provided to a LynxOS-178 instance on its file
+system, where they can be executed. Rust binaries tend to be large, so it may
+be necessary to strip them first.
+
+It is possible to run the Rust testsuite by providing a test runner that takes
+the test binary and executes it under LynxOS-178. Most (all?) tests won't run
+without std support though, which is not yet supported.
+
+## Cross-compilation toolchains and C code
+
+LYNX MOSA.ic comes with all the tools required to cross-compile C code for
+LynxOS-178.

--- a/tests/assembly/targets/targets-elf.rs
+++ b/tests/assembly/targets/targets-elf.rs
@@ -571,6 +571,9 @@
 //@ revisions: x86_64_linux_android
 //@ [x86_64_linux_android] compile-flags: --target x86_64-linux-android
 //@ [x86_64_linux_android] needs-llvm-components: x86
+//@ revisions: x86_64_lynx_lynxos178
+//@ [x86_64_lynx_lynxos178] compile-flags: --target x86_64-lynx-lynxos178
+//@ [x86_64_lynx_lynxos178] needs-llvm-components: x86
 //@ revisions: x86_64_pc_nto_qnx710
 //@ [x86_64_pc_nto_qnx710] compile-flags: --target x86_64-pc-nto-qnx710
 //@ [x86_64_pc_nto_qnx710] needs-llvm-components: x86

--- a/tests/ui/check-cfg/well-known-values.stderr
+++ b/tests/ui/check-cfg/well-known-values.stderr
@@ -201,7 +201,7 @@ warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
 LL |     target_os = "_UNEXPECTED_VALUE",
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected values for `target_os` are: `aix`, `amdhsa`, `android`, `cuda`, `cygwin`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `redox`, `rtems`, `solaris`, `solid_asp3`, `teeos`, `trusty`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`, and `zkvm`
+   = note: expected values for `target_os` are: `aix`, `amdhsa`, `android`, `cuda`, `cygwin`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `lynxos178`, `macos`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `redox`, `rtems`, `solaris`, `solid_asp3`, `teeos`, `trusty`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`, and `zkvm`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: unexpected `cfg` condition value: `_UNEXPECTED_VALUE`
@@ -274,7 +274,7 @@ LL | #[cfg(target_os = "linuz")] // testing that we suggest `linux`
    |                   |
    |                   help: there is a expected value with a similar name: `"linux"`
    |
-   = note: expected values for `target_os` are: `aix`, `amdhsa`, `android`, `cuda`, `cygwin`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `redox`, `rtems`, `solaris`, `solid_asp3`, `teeos`, `trusty`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`, and `zkvm`
+   = note: expected values for `target_os` are: `aix`, `amdhsa`, `android`, `cuda`, `cygwin`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `lynxos178`, `macos`, `netbsd`, `none`, `nto`, `nuttx`, `openbsd`, `psp`, `psx`, `redox`, `rtems`, `solaris`, `solid_asp3`, `teeos`, `trusty`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, `windows`, `xous`, and `zkvm`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 warning: 28 warnings emitted


### PR DESCRIPTION
Add minimal x86_64-lynx-lynxos178 support. It's possible to build no_std
programs with this compiler.

## Tier 3 Target Policy

> A tier 3 target must have a designated developer or developers (the "target
maintainers") on record to be CCed when issues arise regarding the target. (The
mechanism to track and CC such developers may evolve over time.)

Tim Newsome (@tnewsome-lynx) will be the designated developer for
x86_64-lynx-lynxos178 support.

> Targets must use naming consistent with any existing targets; for instance, a
target for the same CPU or OS as an existing Rust target should use the same
name for that CPU or OS. Targets should normally use the same names and naming
conventions as used elsewhere in the broader ecosystem beyond Rust (such as in
other toolchains), unless they have a very good reason to diverge. Changing the
name of a target can be highly disruptive, especially once the target reaches a
higher tier, so getting the name right is important even for a tier 3 target.

I believe the target is named appropriately.

> Target names should not introduce undue confusion or ambiguity unless
absolutely necessary to maintain ecosystem compatibility. For example, if the
name of the target makes people extremely likely to form incorrect beliefs about
what it targets, the name should be changed or augmented to disambiguate it.

The target name is not confusing.

> If possible, use only letters, numbers, dashes and underscores for the name.
Periods (.) are known to cause issues in Cargo.

Done.

> Tier 3 targets may have unusual requirements to build or use, but must not
create legal issues or impose onerous legal terms for the Rust project or for
Rust developers or users.
> The target must not introduce license incompatibilities.
> Anything added to the Rust repository must be under the standard Rust license
(MIT OR Apache-2.0).

All this new code is licensed under the Apache-2.0 license.

> The target must not cause the Rust tools or libraries built for any other host
(even when supporting cross-compilation to the target) to depend on any new
dependency less permissive than the Rust licensing policy. This applies whether
the dependency is a Rust crate that would require adding new license exceptions
(as specified by the tidy tool in the rust-lang/rust repository), or whether the
dependency is a native library or binary. In other words, the introduction of
the target must not cause a user installing or running a version of Rust or the
Rust tools to be subject to any new license requirements.

Done.

> Compiling, linking, and emitting functional binaries, libraries, or other code
for the target (whether hosted on the target itself or cross-compiling from
another target) must not depend on proprietary (non-FOSS) libraries. Host tools
built for the target itself may depend on the ordinary runtime libraries
supplied by the platform and commonly used by other applications built for the
target, but those libraries must not be required for code generation for the
target; cross-compilation to the target must not require such libraries at all.
For instance, rustc built for the target may depend on a common proprietary C
runtime library or console output library, but must not depend on a proprietary
code generation library or code optimization library. Rust's license permits
such combinations, but the Rust project has no interest in maintaining such
combinations within the scope of Rust itself, even at tier 3.

I think we're in the clear here. We do link against some static libraries that
are proprietary (like libm and libc), but those are not used to generate code.
E.g. the VxWorks target requires `wr-c++` to be installed, which is not
publically available.

> "onerous" here is an intentionally subjective term. At a minimum, "onerous"
legal/licensing terms include but are not limited to: non-disclosure
requirements, non-compete requirements, contributor license agreements (CLAs) or
equivalent, "non-commercial"/"research-only"/etc terms, requirements conditional
on the employer or employment of any particular Rust developers, revocable
terms, any requirements that create liability for the Rust project or its
developers or users, or any requirements that adversely affect the livelihood or
prospects of the Rust project or its developers or users.

Our intention is to allow anyone with access to LynxOS CDK to use Rust for it.

> Neither this policy nor any decisions made regarding targets shall create any
binding agreement or estoppel by any party. If any member of an approving Rust
team serves as one of the maintainers of a target, or has any legal or
employment requirement (explicit or implicit) that might affect their decisions
regarding a target, they must recuse themselves from any approval decisions
regarding the target's tier status, though they may otherwise participate in
discussions.
> This requirement does not prevent part or all of this policy from being cited
in an explicit contract or work agreement (e.g. to implement or maintain support
for a target). This requirement exists to ensure that a developer or team
responsible for reviewing and approving a target does not face any legal threats
or obligations that would prevent them from freely exercising their judgment in
such approval, even if such judgment involves subjective matters or goes beyond
the letter of these requirements.

No problem.

> Tier 3 targets should attempt to implement as much of the standard libraries
as possible and appropriate (core for most targets, alloc for targets that can
support dynamic memory allocation, std for targets with an operating system or
equivalent layer of system-provided functionality), but may leave some code
unimplemented (either unavailable or stubbed out as appropriate), whether
because the target makes it impossible to implement or challenging to implement.
The authors of pull requests are not obligated to avoid calling any portions of
the standard library on the basis of a tier 3 target not implementing those
portions.

With this first PR, only core is supported. I am working on support for the std
library and intend to submit that once all the tests are passing.

> The target must provide documentation for the Rust community explaining how to
build for the target, using cross-compilation if possible. If the target
supports running binaries, or running tests (even if they do not pass), the
documentation must explain how to run such binaries or tests for the target,
using emulation if possible or dedicated hardware if necessary.

This is documented in `src/doc/rustc/src/platform-support/lynxos178.md`.

> Tier 3 targets must not impose burden on the authors of pull requests, or
other developers in the community, to maintain the target. In particular, do not
post comments (automated or manual) on a PR that derail or suggest a block on
the PR based on a tier 3 target. Do not send automated messages or notifications
(via any medium, including via @) to a PR author or others involved with a PR
regarding a tier 3 target, unless they have opted into such messages.
> Backlinks such as those generated by the issue/PR tracker when linking to an
issue or PR are not considered a violation of this policy, within reason.
However, such messages (even on a separate repository) must not generate
notifications to anyone involved with a PR who has not requested such
notifications.

Understood.

> Patches adding or updating tier 3 targets must not break any existing tier 2
or tier 1 target, and must not knowingly break another tier 3 target without
approval of either the compiler team or the maintainers of the other tier 3
target.
> In particular, this may come up when working on closely related targets, such
as variations of the same architecture with different features. Avoid
introducing unconditional uses of features that another variation of the target
may not have; use conditional compilation or runtime detection, as appropriate,
to let each target run code supported by that target.

As far as I know this change does not affect any other targets.

> Tier 3 targets must be able to produce assembly using at least one of rustc's
supported backends from any host target. (Having support in a fork of the
backend is not sufficient, it must be upstream.)

Many targets produce assembly for x86_64 so that also works for LynxOS-178.