### PR TITLE
Add `std::io::Seek` instance for `std::io::Take`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -325,6 +325,7 @@
 #![feature(try_blocks)]
 #![feature(try_trait_v2)]
 #![feature(type_alias_impl_trait)]
+#![feature(unsigned_signed_diff)]
 // tidy-alphabetical-end
 //
 // Library features (core):


### PR DESCRIPTION
Library tracking issue [#97227](https://github.com/rust-lang/rust/issues/97227).
ACP: https://github.com/rust-lang/libs-team/issues/555

1. add a `len` field to `Take` to keep track of the original number of bytes that `Take` could read
2. add a `position()` method to return the current position of the cursor inside `Take`
3. implement `std::io::Seek` for `std::io::Take`

Closes: https://github.com/rust-lang/libs-team/issues/555