### PR TITLE
Add GlobalAsm as a valid ItemKind to StableMIR

### DIFF
--- a/compiler/rustc_smir/src/rustc_smir/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/mod.rs
@@ -140,8 +140,7 @@ pub(crate) fn new_item_kind(kind: DefKind) -> ItemKind {
         | DefKind::OpaqueTy
         | DefKind::Field
         | DefKind::LifetimeParam
-        | DefKind::Impl { .. }
-        | DefKind::GlobalAsm => {
+        | DefKind::Impl { .. } => {
             unreachable!("Not a valid item kind: {kind:?}");
         }
         DefKind::Closure | DefKind::AssocFn | DefKind::Fn | DefKind::SyntheticCoroutineBody => {
@@ -150,6 +149,7 @@ pub(crate) fn new_item_kind(kind: DefKind) -> ItemKind {
         DefKind::Const | DefKind::InlineConst | DefKind::AssocConst | DefKind::AnonConst => {
             ItemKind::Const
         }
+        DefKind::GlobalAsm => ItemKind::GlobalAsm,
         DefKind::Static { .. } => ItemKind::Static,
         DefKind::Ctor(_, rustc_hir::def::CtorKind::Const) => ItemKind::Ctor(CtorKind::Const),
         DefKind::Ctor(_, rustc_hir::def::CtorKind::Fn) => ItemKind::Ctor(CtorKind::Fn),

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -112,6 +112,7 @@ pub enum ItemKind {
     Static,
     Const,
     Ctor(CtorKind),
+    GlobalAsm,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash, Serialize)]

--- a/tests/ui-fulldeps/stable-mir/check_item_kind.rs
+++ b/tests/ui-fulldeps/stable-mir/check_item_kind.rs
@@ -26,7 +26,7 @@ const CRATE_NAME: &str = "input";
 /// This function uses the Stable MIR APIs to get information about the test crate.
 fn test_item_kind() -> ControlFlow<()> {
     let items = stable_mir::all_local_items();
-    assert_eq!(items.len(), 4);
+    assert_eq!(items.len(), 5);
     // Constructor item.
     for item in items {
         let expected_kind = match item.name().as_str() {
@@ -34,6 +34,7 @@ fn test_item_kind() -> ControlFlow<()> {
             "dummy" => ItemKind::Fn,
             "unit" => ItemKind::Fn,
             "DUMMY_CONST" => ItemKind::Const,
+            name if name.contains("global_asm") => ItemKind::GlobalAsm,
             name => unreachable!("Unexpected item {name}"),
         };
         assert_eq!(item.kind(), expected_kind, "Mismatched type for {}", item.name());
@@ -75,6 +76,13 @@ fn generate_input(path: &str) -> std::io::Result<()> {
         pub fn unit() -> DummyUnit {{
             DummyUnit
         }}
+
+        std::arch::global_asm!(".global my_noop",
+            ".text",
+            "my_noop:",
+            "ret"
+        );
+
         "#
     )?;
     Ok(())


### PR DESCRIPTION
This fixes StableMIR crash when iterating over the items of a crate that contains global assembly.

Fixes https://github.com/rust-lang/project-stable-mir/issues/95
