### PR TITLE
Rollup of 15 pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ For submodules, changes need to be made against the repository corresponding the
 submodule, and not the main `rust-lang/rust` repository.
 
 For subtrees, prefer sending a PR against the subtree's repository if it does
-not need to be made against the main `rust-lang/rust` repostory (e.g. a
+not need to be made against the main `rust-lang/rust` repository (e.g. a
 rustc-dev-guide change that does not accompany a compiler change).
 
 ## About the [rustc-dev-guide]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -210,9 +210,13 @@ itself back on after some time).
 
 ### MSVC
 
-MSVC builds of Rust additionally require an installation of Visual Studio 2017
-(or later) so `rustc` can use its linker. The simplest way is to get
-[Visual Studio], check the "C++ build tools" and "Windows 10 SDK" workload.
+MSVC builds of Rust additionally requires an installation of:
+
+- Visual Studio 2022 (or later) build tools so `rustc` can use its linker. Older
+  Visual Studio versions such as 2019 *may* work but aren't actively tested.
+- A recent Windows 10 or 11 SDK.
+
+The simplest way is to get [Visual Studio], check the "C++ build tools".
 
 [Visual Studio]: https://visualstudio.microsoft.com/downloads/
 

--- a/compiler/rustc_data_structures/src/sync/worker_local.rs
+++ b/compiler/rustc_data_structures/src/sync/worker_local.rs
@@ -106,6 +106,12 @@ pub struct WorkerLocal<T> {
     registry: Registry,
 }
 
+// This is safe because the `deref` call will return a reference to a `T` unique to each thread
+// or it will panic for threads without an associated local. So there isn't a need for `T` to do
+// it's own synchronization. The `verify` method on `RegistryId` has an issue where the id
+// can be reused, but `WorkerLocal` has a reference to `Registry` which will prevent any reuse.
+unsafe impl<T: Send> Sync for WorkerLocal<T> {}
+
 impl<T> WorkerLocal<T> {
     /// Creates a new worker local where the `initial` closure computes the
     /// value this worker local should take for each thread in the registry.
@@ -132,11 +138,6 @@ impl<T> Deref for WorkerLocal<T> {
     fn deref(&self) -> &T {
         // This is safe because `verify` will only return values less than
         // `self.registry.thread_limit` which is the size of the `self.locals` array.
-
-        // The `deref` call will return a reference to a `T` unique to each thread
-        // or it will panic for threads without an associated local. So there isn't a need for `T` to do
-        // it's own synchronization. The `verify` method on `RegistryId` has an issue where the id
-        // can be reused, but `WorkerLocal` has a reference to `Registry` which will prevent any reuse.
         unsafe { &self.locals.get_unchecked(self.registry.id().verify()).0 }
     }
 }

--- a/compiler/rustc_error_codes/src/error_codes/E0373.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0373.md
@@ -3,7 +3,7 @@ A captured variable in a closure may not live long enough.
 Erroneous code example:
 
 ```compile_fail,E0373
-fn foo() -> Box<Fn(u32) -> u32> {
+fn foo() -> Box<dyn Fn(u32) -> u32> {
     let x = 0u32;
     Box::new(|y| x + y)
 }
@@ -42,7 +42,7 @@ This approach moves (or copies, where possible) data into the closure, rather
 than taking references to it. For example:
 
 ```
-fn foo() -> Box<Fn(u32) -> u32> {
+fn foo() -> Box<dyn Fn(u32) -> u32> {
     let x = 0u32;
     Box::new(move |y| x + y)
 }

--- a/compiler/rustc_hir_analysis/src/collect/generics_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/generics_of.rs
@@ -187,6 +187,8 @@ pub(super) fn generics_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Generics {
                         Some(parent_did)
                     }
                     Node::TyPat(_) => Some(parent_did),
+                    // Field default values inherit the ADT's generics.
+                    Node::Field(_) => Some(parent_did),
                     _ => None,
                 }
             }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -117,6 +117,80 @@ impl<'a> State<'a> {
                 ));
                 self.hardbreak()
             }
+            hir::Attribute::Parsed(AttributeKind::Deprecation { deprecation, .. }) => {
+                self.word("#[deprecated");
+
+                // There are three possible forms here:
+                // 1. a form with explicit components like
+                //    `#[deprecated(since = "1.2.3", note = "some note", suggestion = "something")]`
+                //    where each component may be present or absent.
+                // 2. `#[deprecated = "message"]`
+                // 3. `#[deprecated]`
+                //
+                // Let's figure out which we need.
+                // If there's a `since` or `suggestion` value, we're definitely in form 1.
+                if matches!(
+                    deprecation.since,
+                    rustc_attr_parsing::DeprecatedSince::RustcVersion(..)
+                        | rustc_attr_parsing::DeprecatedSince::Future
+                        | rustc_attr_parsing::DeprecatedSince::NonStandard(..)
+                ) || deprecation.suggestion.is_some()
+                {
+                    self.word("(");
+                    let mut use_comma = false;
+
+                    match &deprecation.since {
+                        rustc_attr_parsing::DeprecatedSince::RustcVersion(rustc_version) => {
+                            self.word("since = \"");
+                            self.word(format!(
+                                "{}.{}.{}",
+                                rustc_version.major, rustc_version.minor, rustc_version.patch
+                            ));
+                            self.word("\"");
+                            use_comma = true;
+                        }
+                        rustc_attr_parsing::DeprecatedSince::Future => {
+                            self.word("since = \"future\"");
+                            use_comma = true;
+                        }
+                        rustc_attr_parsing::DeprecatedSince::NonStandard(symbol) => {
+                            self.word("since = \"");
+                            self.word(symbol.to_ident_string());
+                            self.word("\"");
+                            use_comma = true;
+                        }
+                        _ => {}
+                    }
+
+                    if let Some(note) = &deprecation.note {
+                        if use_comma {
+                            self.word(", ");
+                        }
+                        self.word("note = \"");
+                        self.word(note.to_ident_string());
+                        self.word("\"");
+                        use_comma = true;
+                    }
+
+                    if let Some(suggestion) = &deprecation.suggestion {
+                        if use_comma {
+                            self.word(", ");
+                        }
+                        self.word("suggestion = \"");
+                        self.word(suggestion.to_ident_string());
+                        self.word("\"");
+                    }
+                } else if let Some(note) = &deprecation.note {
+                    // We're in form 2: `#[deprecated = "message"]`.
+                    self.word(" = \"");
+                    self.word(note.to_ident_string());
+                    self.word("\"");
+                } else {
+                    // We're in form 3: `#[deprecated]`. Nothing to do here.
+                }
+
+                self.word("]");
+            }
             hir::Attribute::Parsed(pa) => {
                 self.word("#[attr=\"");
                 pa.print_attribute(self);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -78,6 +78,7 @@ struct IsNeverPattern;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum AnonConstKind {
     EnumDiscriminant,
+    FieldDefaultValue,
     InlineConst,
     ConstArg(IsRepeatExpr),
 }
@@ -1406,7 +1407,7 @@ impl<'ra: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'r
         visit_opt!(self, visit_ident, ident);
         try_visit!(self.visit_ty(ty));
         if let Some(v) = &default {
-            self.resolve_anon_const(v, AnonConstKind::ConstArg(IsRepeatExpr::No));
+            self.resolve_anon_const(v, AnonConstKind::FieldDefaultValue);
         }
     }
 }
@@ -4658,6 +4659,7 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             AnonConstKind::EnumDiscriminant => {
                 ConstantHasGenerics::No(NoConstantGenericsReason::IsEnumDiscriminant)
             }
+            AnonConstKind::FieldDefaultValue => ConstantHasGenerics::Yes,
             AnonConstKind::InlineConst => ConstantHasGenerics::Yes,
             AnonConstKind::ConstArg(_) => {
                 if self.r.tcx.features().generic_const_exprs() || is_trivial_const_arg {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -3515,12 +3515,6 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                         }
                     }
                 }
-
-                // Record as using the suggested resolution.
-                let (_, (_, res)) = in_scope_lifetimes[0];
-                for &lt in &lifetime_refs {
-                    self.r.lifetimes_res_map.insert(lt.id, res);
-                }
             }
             _ => {
                 let lifetime_spans: Vec<_> =

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2883,14 +2883,6 @@ impl PpMode {
             | StableMir => true,
         }
     }
-    pub fn needs_hir(&self) -> bool {
-        use PpMode::*;
-        match *self {
-            Source(_) | AstTree | AstTreeExpanded => false,
-
-            Hir(_) | HirTree | ThirTree | ThirFlat | Mir | MirCFG | StableMir => true,
-        }
-    }
 
     pub fn needs_analysis(&self) -> bool {
         use PpMode::*;

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -937,8 +937,6 @@ impl<T, A: Allocator> Box<mem::MaybeUninit<T>, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(box_uninit_write)]
-    ///
     /// let big_box = Box::<[usize; 1024]>::new_uninit();
     ///
     /// let mut array = [0; 1024];
@@ -954,7 +952,7 @@ impl<T, A: Allocator> Box<mem::MaybeUninit<T>, A> {
     ///     assert_eq!(*x, i);
     /// }
     /// ```
-    #[unstable(feature = "box_uninit_write", issue = "129397")]
+    #[stable(feature = "box_uninit_write", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub fn write(mut boxed: Self, value: T) -> Box<T, A> {
         unsafe {

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -102,7 +102,6 @@
 #![feature(assert_matches)]
 #![feature(async_fn_traits)]
 #![feature(async_iterator)]
-#![feature(box_uninit_write)]
 #![feature(bstr)]
 #![feature(bstr_internals)]
 #![feature(char_max_len)]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -78,7 +78,7 @@ pub use raw::{from_raw_parts, from_raw_parts_mut};
 
 /// Calculates the direction and split point of a one-sided range.
 ///
-/// This is a helper function for `take` and `take_mut` that returns
+/// This is a helper function for `split_off` and `split_off_mut` that returns
 /// the direction of the split (front or back) as well as the index at
 /// which to split. Returns `None` if the split index would overflow.
 #[inline]
@@ -4313,8 +4313,6 @@ impl<T> [T] {
     /// Splitting off the first three elements of a slice:
     ///
     /// ```
-    /// #![feature(slice_take)]
-    ///
     /// let mut slice: &[_] = &['a', 'b', 'c', 'd'];
     /// let mut first_three = slice.split_off(..3).unwrap();
     ///
@@ -4325,8 +4323,6 @@ impl<T> [T] {
     /// Splitting off the last two elements of a slice:
     ///
     /// ```
-    /// #![feature(slice_take)]
-    ///
     /// let mut slice: &[_] = &['a', 'b', 'c', 'd'];
     /// let mut tail = slice.split_off(2..).unwrap();
     ///
@@ -4337,8 +4333,6 @@ impl<T> [T] {
     /// Getting `None` when `range` is out of bounds:
     ///
     /// ```
-    /// #![feature(slice_take)]
-    ///
     /// let mut slice: &[_] = &['a', 'b', 'c', 'd'];
     ///
     /// assert_eq!(None, slice.split_off(5..));
@@ -4349,7 +4343,7 @@ impl<T> [T] {
     /// ```
     #[inline]
     #[must_use = "method does not modify the slice if the range is out of bounds"]
-    #[unstable(feature = "slice_take", issue = "62280")]
+    #[stable(feature = "slice_take", since = "CURRENT_RUSTC_VERSION")]
     pub fn split_off<'a, R: OneSidedRange<usize>>(
         self: &mut &'a Self,
         range: R,
@@ -4385,8 +4379,6 @@ impl<T> [T] {
     /// Splitting off the first three elements of a slice:
     ///
     /// ```
-    /// #![feature(slice_take)]
-    ///
     /// let mut slice: &mut [_] = &mut ['a', 'b', 'c', 'd'];
     /// let mut first_three = slice.split_off_mut(..3).unwrap();
     ///
@@ -4397,8 +4389,6 @@ impl<T> [T] {
     /// Taking the last two elements of a slice:
     ///
     /// ```
-    /// #![feature(slice_take)]
-    ///
     /// let mut slice: &mut [_] = &mut ['a', 'b', 'c', 'd'];
     /// let mut tail = slice.split_off_mut(2..).unwrap();
     ///
@@ -4409,8 +4399,6 @@ impl<T> [T] {
     /// Getting `None` when `range` is out of bounds:
     ///
     /// ```
-    /// #![feature(slice_take)]
-    ///
     /// let mut slice: &mut [_] = &mut ['a', 'b', 'c', 'd'];
     ///
     /// assert_eq!(None, slice.split_off_mut(5..));
@@ -4421,7 +4409,7 @@ impl<T> [T] {
     /// ```
     #[inline]
     #[must_use = "method does not modify the slice if the range is out of bounds"]
-    #[unstable(feature = "slice_take", issue = "62280")]
+    #[stable(feature = "slice_take", since = "CURRENT_RUSTC_VERSION")]
     pub fn split_off_mut<'a, R: OneSidedRange<usize>>(
         self: &mut &'a mut Self,
         range: R,
@@ -4451,8 +4439,6 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(slice_take)]
-    ///
     /// let mut slice: &[_] = &['a', 'b', 'c'];
     /// let first = slice.split_off_first().unwrap();
     ///
@@ -4460,7 +4446,7 @@ impl<T> [T] {
     /// assert_eq!(first, &'a');
     /// ```
     #[inline]
-    #[unstable(feature = "slice_take", issue = "62280")]
+    #[stable(feature = "slice_take", since = "CURRENT_RUSTC_VERSION")]
     pub fn split_off_first<'a>(self: &mut &'a Self) -> Option<&'a T> {
         let (first, rem) = self.split_first()?;
         *self = rem;
@@ -4475,8 +4461,6 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(slice_take)]
-    ///
     /// let mut slice: &mut [_] = &mut ['a', 'b', 'c'];
     /// let first = slice.split_off_first_mut().unwrap();
     /// *first = 'd';
@@ -4485,7 +4469,7 @@ impl<T> [T] {
     /// assert_eq!(first, &'d');
     /// ```
     #[inline]
-    #[unstable(feature = "slice_take", issue = "62280")]
+    #[stable(feature = "slice_take", since = "CURRENT_RUSTC_VERSION")]
     pub fn split_off_first_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
         let (first, rem) = mem::take(self).split_first_mut()?;
         *self = rem;
@@ -4500,8 +4484,6 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(slice_take)]
-    ///
     /// let mut slice: &[_] = &['a', 'b', 'c'];
     /// let last = slice.split_off_last().unwrap();
     ///
@@ -4509,7 +4491,7 @@ impl<T> [T] {
     /// assert_eq!(last, &'c');
     /// ```
     #[inline]
-    #[unstable(feature = "slice_take", issue = "62280")]
+    #[stable(feature = "slice_take", since = "CURRENT_RUSTC_VERSION")]
     pub fn split_off_last<'a>(self: &mut &'a Self) -> Option<&'a T> {
         let (last, rem) = self.split_last()?;
         *self = rem;
@@ -4524,8 +4506,6 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(slice_take)]
-    ///
     /// let mut slice: &mut [_] = &mut ['a', 'b', 'c'];
     /// let last = slice.split_off_last_mut().unwrap();
     /// *last = 'd';
@@ -4534,7 +4514,7 @@ impl<T> [T] {
     /// assert_eq!(last, &'d');
     /// ```
     #[inline]
-    #[unstable(feature = "slice_take", issue = "62280")]
+    #[stable(feature = "slice_take", since = "CURRENT_RUSTC_VERSION")]
     pub fn split_off_last_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
         let (last, rem) = mem::take(self).split_last_mut()?;
         *self = rem;

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -73,7 +73,6 @@
 #![feature(slice_internals)]
 #![feature(slice_partition_dedup)]
 #![feature(slice_split_once)]
-#![feature(slice_take)]
 #![feature(split_array)]
 #![feature(split_as_slice)]
 #![feature(std_internals)]

--- a/library/std/src/sys/pal/uefi/process.rs
+++ b/library/std/src/sys/pal/uefi/process.rs
@@ -757,7 +757,7 @@ mod uefi_command_internal {
 }
 
 /// Create a map of environment variable changes. Allows efficient setting and rolling back of
-/// enviroment variable changes.
+/// environment variable changes.
 ///
 /// Entry: (Old Value, New Value)
 fn env_changes(env: &CommandEnv) -> Option<BTreeMap<EnvKey, (Option<OsString>, Option<OsString>)>> {

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -50,6 +50,7 @@
     - [\*-linux-ohos](platform-support/openharmony.md)
     - [\*-hurd-gnu](platform-support/hurd.md)
     - [aarch64-unknown-teeos](platform-support/aarch64-unknown-teeos.md)
+    - [avr-none](platform-support/avr-none.md)
     - [\*-espidf](platform-support/esp-idf.md)
     - [\*-unknown-fuchsia](platform-support/fuchsia.md)
     - [\*-unknown-trusty](platform-support/trusty.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -301,7 +301,7 @@ target | std | host | notes
 [`armv8r-none-eabihf`](platform-support/armv8r-none-eabihf.md) | * |  | Bare Armv8-R, hardfloat
 [`armv7a-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv7-A with NuttX
 [`armv7a-nuttx-eabihf`](platform-support/nuttx.md) | ✓ |  | ARMv7-A with NuttX, hardfloat
-`avr-none` | * |  | AVR; requires `-Zbuild-std=core` and `-Ctarget-cpu=...`
+[`avr-none`](platform-support/avr-none.md) | * |  | AVR; requires `-Zbuild-std=core` and `-Ctarget-cpu=...`
 `bpfeb-unknown-none` | * |  | BPF (big endian)
 `bpfel-unknown-none` | * |  | BPF (little endian)
 `csky-unknown-linux-gnuabiv2` | ✓ |  | C-SKY abiv2 Linux (little endian)

--- a/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-gnu.md
@@ -65,7 +65,7 @@ section below.
 
 A RISC-V toolchain can be obtained for Windows/Mac/Linux from the
 [`riscv-gnu-toolchain`](https://github.com/riscv-collab/riscv-gnu-toolchain)
-repostory. Binaries are available via
+repository. Binaries are available via
 [embecosm](https://www.embecosm.com/resources/tool-chain-downloads/#riscv-linux),
 and may also be available from your OS's package manager.
 

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -123,7 +123,7 @@ declare namespace rustdoc {
      * Same as QueryElement, but bindings and typeFilter support strings
      */
     interface ParserQueryElement {
-        name: string,
+        name: string|null,
         id: number|null,
         fullPath: Array<string>,
         pathWithoutLast: Array<string>,
@@ -131,10 +131,16 @@ declare namespace rustdoc {
         normalizedPathLast: string,
         generics: Array<ParserQueryElement>,
         bindings: Map<string, Array<ParserQueryElement>>,
-        bindingName: {name: string, generics: ParserQueryElement[]}|null,
+        bindingName: {name: string|null, generics: ParserQueryElement[]}|null,
         typeFilter: string|null,
     }
 
+    /**
+     * Same as ParserQueryElement, but all fields are optional.
+     */
+    type ParserQueryElementFields = {
+        [K in keyof ParserQueryElement]?: ParserQueryElement[T]
+    }
     /**
      * Intermediate parser state. Discarded when parsing is done.
      */

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -132,7 +132,7 @@ declare namespace rustdoc {
         generics: Array<ParserQueryElement>,
         bindings: Map<string, Array<ParserQueryElement>>,
         bindingName: {name: string|null, generics: ParserQueryElement[]}|null,
-        typeFilter: string|null,
+        typeFilter: number|string|null,
     }
 
     /**

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -182,10 +182,11 @@ declare namespace rustdoc {
         name: string,
         normalizedName: string,
         word: string,
+        paramNames: string[],
         parent: ({ty: number, name: string, path: string, exactPath: string}|null|undefined),
         path: string,
         ty: number,
-        type?: FunctionSearchType
+        type: FunctionSearchType | null,
     }
 
     /**

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -397,7 +397,7 @@ declare namespace rustdoc {
      */
     type RawSearchIndexCrate = {
     doc: string,
-    a: Object,
+    a: { [key: string]: number[] },
     n: Array<string>,
     t: string,
     D: string,

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -638,7 +638,6 @@ function getNextElem(query, parserState, elems, isInGenerics) {
                 getFilteredNextElem(query, parserState, generics, isInGenerics);
                 generics[generics.length - 1].bindingName = makePrimitiveElement("output");
             } else {
-                // @ts-expect-error
                 generics.push(makePrimitiveElement(null, {
                     bindingName: makePrimitiveElement("output"),
                     typeFilter: null,
@@ -791,7 +790,7 @@ function createQueryElement(query, parserState, name, generics, isInGenerics) {
         generics: generics.filter(gen => {
             // Syntactically, bindings are parsed as generics,
             // but the query engine treats them differently.
-            if (gen.bindingName !== null) {
+            if (gen.bindingName !== null && gen.bindingName.name !== null) {
                 if (gen.name !== null) {
                     gen.bindingName.generics.unshift(gen);
                 }
@@ -811,8 +810,8 @@ function createQueryElement(query, parserState, name, generics, isInGenerics) {
 
 /**
  *
- * @param {string} name
- * @param {Object=} extra
+ * @param {string|null} name
+ * @param {rustdoc.ParserQueryElementFields=} extra
  * @returns {rustdoc.ParserQueryElement}
  */
 function makePrimitiveElement(name, extra) {

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2834,7 +2834,7 @@ class DocSearch {
             }
             let fnInputs = null;
             let fnOutput = null;
-            // @ts-expect-error
+            /** @type {Map<number, number> | null} */
             let mgens = null;
             if (typeInfo !== "elems" && typeInfo !== "returned") {
                 fnInputs = unifyFunctionTypes(
@@ -3047,7 +3047,6 @@ class DocSearch {
                             writeFn(nested, result);
                         }
                         return;
-                    // @ts-expect-error
                     } else if (mgens) {
                         for (const [queryId, fnId] of mgens) {
                             if (fnId === fnType.id) {

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2759,9 +2759,9 @@ class DocSearch {
          * Add extra data to result objects, and filter items that have been
          * marked for removal.
          *
-         * @param {[rustdoc.ResultObject]} results
+         * @param {rustdoc.ResultObject[]} results
          * @param {"sig"|"elems"|"returned"|null} typeInfo
-         * @returns {[rustdoc.ResultObject]}
+         * @returns {rustdoc.ResultObject[]}
          */
         const transformResults = (results, typeInfo) => {
             const duplicates = new Set();
@@ -3175,7 +3175,7 @@ class DocSearch {
          * @param {rustdoc.Results} results
          * @param {"sig"|"elems"|"returned"|null} typeInfo
          * @param {string} preferredCrate
-         * @returns {Promise<[rustdoc.ResultObject]>}
+         * @returns {Promise<rustdoc.ResultObject[]>}
          */
         const sortResults = async(results, typeInfo, preferredCrate) => {
             const userQuery = parsedQuery.userQuery;
@@ -3331,7 +3331,6 @@ class DocSearch {
                 return 0;
             });
 
-            // @ts-expect-error
             return transformResults(result_list, typeInfo);
         };
 

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -3062,7 +3062,7 @@ class DocSearch {
                         name: fnParamNames[-1 - fnType.id],
                         highlighted: !!fnType.highlighted,
                     }, result);
-                    // @ts-expect-error
+                    /** @type{string[]} */
                     const where = [];
                     onEachBtwn(
                         fnType.generics,
@@ -3072,7 +3072,6 @@ class DocSearch {
                         () => pushText({ name: " + ", highlighted: false }, where),
                     );
                     if (where.length > 0) {
-                        // @ts-expect-error
                         whereClause.set(fnParamNames[-1 - fnType.id], where);
                     }
                 } else {

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2740,7 +2740,11 @@ class DocSearch {
             return [displayPath, href, `${exactPath}::${name}`];
         };
 
-        // @ts-expect-error
+        /**
+         *
+         * @param {string} path
+         * @returns {string}
+         */
         function pathSplitter(path) {
             const tmp = "<span>" + path.replace(/::/g, "::</span><span>");
             if (tmp.endsWith("<span>")) {

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2269,16 +2269,14 @@ class DocSearch {
                         continue;
                     }
 
-                    // @ts-expect-error
+                    /** @type{number[]} */
                     let currentNameAliases;
                     if (currentCrateAliases.has(alias_name)) {
                         currentNameAliases = currentCrateAliases.get(alias_name);
                     } else {
                         currentNameAliases = [];
-                        // @ts-expect-error
                         currentCrateAliases.set(alias_name, currentNameAliases);
                     }
-                    // @ts-expect-error
                     for (const local_alias of aliases[alias_name]) {
                         currentNameAliases.push(local_alias + currentIndex);
                     }

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2398,9 +2398,9 @@ class DocSearch {
                     continue;
                 }
                 if (!foundStopChar) {
-                    let extra = "";
+                    /** @type String[] */
+                    let extra = [];
                     if (isLastElemGeneric(query.elems, parserState)) {
-                        // @ts-expect-error
                         extra = [" after ", ">"];
                     } else if (prevIs(parserState, "\"")) {
                         throw ["Cannot have more than one element if you use quotes"];

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2319,7 +2319,7 @@ class DocSearch {
          * @param {rustdoc.ParserQueryElement} elem
          */
         function convertTypeFilterOnElem(elem) {
-            if (typeof elem.typeFilter === 'string') {
+            if (typeof elem.typeFilter === "string") {
                 let typeFilter = elem.typeFilter;
                 if (typeFilter === "const") {
                     typeFilter = "constant";

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2538,7 +2538,7 @@ class DocSearch {
          * See `buildTypeMapIndex` for more information.
          *
          * @param {rustdoc.QueryElement} elem
-         * @param {boolean} isAssocType
+         * @param {boolean=} isAssocType
          */
         const convertNameToId = (elem, isAssocType) => {
             const loweredName = elem.pathLast.toLowerCase();
@@ -2618,7 +2618,6 @@ class DocSearch {
                 ];
             }
             for (const elem2 of elem.generics) {
-                // @ts-expect-error
                 convertNameToId(elem2);
             }
             elem.bindings = new Map(Array.from(elem.bindings.entries())

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1584,17 +1584,17 @@ class DocSearch {
      * This is effectively string interning, so that function matching can be
      * done more quickly. Two types with the same name but different item kinds
      * get the same ID.
-	 *
-	 * @template T extends string
-	 * @overload
+     *
+     * @template T extends string
+     * @overload
      * @param {T} name
      * @param {boolean=} isAssocType - True if this is an assoc type
      * @returns {T extends "" ? null : number}
-	 *
-	 * @param {string} name
+     *
+     * @param {string} name
      * @param {boolean=} isAssocType
      * @returns {number | null}
-	 * 
+     *
      */
     buildTypeMapIndex(name, isAssocType) {
         if (name === "" || name === null) {

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2102,8 +2102,6 @@ class DocSearch {
             // an array of [(Number) item type,
             //              (String) name]
             const rawPaths = crateCorpus.p;
-            // an array of [(String) alias name
-            //             [Number] index to items]
             const aliases = crateCorpus.a;
             // an array of [(Number) item index,
             //              (String) comma-separated list of function generic param names]

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1477,73 +1477,61 @@ class DocSearch {
          * Special type name IDs for searching by array.
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfArray = this.buildTypeMapIndex("array");
         /**
          * Special type name IDs for searching by slice.
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfSlice = this.buildTypeMapIndex("slice");
         /**
          * Special type name IDs for searching by both array and slice (`[]` syntax).
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfArrayOrSlice = this.buildTypeMapIndex("[]");
         /**
          * Special type name IDs for searching by tuple.
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfTuple = this.buildTypeMapIndex("tuple");
         /**
          * Special type name IDs for searching by unit.
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfUnit = this.buildTypeMapIndex("unit");
         /**
          * Special type name IDs for searching by both tuple and unit (`()` syntax).
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfTupleOrUnit = this.buildTypeMapIndex("()");
         /**
          * Special type name IDs for searching `fn`.
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfFn = this.buildTypeMapIndex("fn");
         /**
          * Special type name IDs for searching `fnmut`.
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfFnMut = this.buildTypeMapIndex("fnmut");
         /**
          * Special type name IDs for searching `fnonce`.
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfFnOnce = this.buildTypeMapIndex("fnonce");
         /**
          * Special type name IDs for searching higher order functions (`->` syntax).
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfHof = this.buildTypeMapIndex("->");
         /**
          * Special type name IDs the output assoc type.
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfOutput = this.buildTypeMapIndex("output", true);
         /**
          * Special type name IDs for searching by reference.
          * @type {number}
          */
-        // @ts-expect-error
         this.typeNameIdOfReference = this.buildTypeMapIndex("reference");
 
         /**
@@ -1596,11 +1584,17 @@ class DocSearch {
      * This is effectively string interning, so that function matching can be
      * done more quickly. Two types with the same name but different item kinds
      * get the same ID.
-     *
-     * @param {string} name
+	 *
+	 * @template T extends string
+	 * @overload
+     * @param {T} name
      * @param {boolean=} isAssocType - True if this is an assoc type
-     *
-     * @returns {number?}
+     * @returns {T extends "" ? null : number}
+	 *
+	 * @param {string} name
+     * @param {boolean=} isAssocType
+     * @returns {number | null}
+	 * 
      */
     buildTypeMapIndex(name, isAssocType) {
         if (name === "" || name === null) {

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2319,15 +2319,13 @@ class DocSearch {
          * @param {rustdoc.ParserQueryElement} elem
          */
         function convertTypeFilterOnElem(elem) {
-            if (elem.typeFilter !== null) {
+            if (typeof elem.typeFilter === 'string') {
                 let typeFilter = elem.typeFilter;
                 if (typeFilter === "const") {
                     typeFilter = "constant";
                 }
-                // @ts-expect-error
                 elem.typeFilter = itemTypeFromName(typeFilter);
             } else {
-                // @ts-expect-error
                 elem.typeFilter = NO_TYPE_FILTER;
             }
             for (const elem2 of elem.generics) {

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1573,7 +1573,6 @@ class DocSearch {
         /**
          *  @type {Array<rustdoc.Row>}
          */
-        // @ts-expect-error
         this.searchIndex = this.buildIndex(rawSearchIndex);
     }
 
@@ -1902,6 +1901,7 @@ class DocSearch {
      * Convert raw search index into in-memory search index.
      *
      * @param {Map<string, rustdoc.RawSearchIndexCrate>} rawSearchIndex
+     * @returns {rustdoc.Row[]}
      */
     buildIndex(rawSearchIndex) {
         /**
@@ -2001,6 +2001,7 @@ class DocSearch {
             return cb;
         };
 
+        /** @type {rustdoc.Row[]} */
         const searchIndex = [];
         let currentIndex = 0;
         let id = 0;
@@ -2225,6 +2226,7 @@ class DocSearch {
                 // object defined above.
                 const itemParentIdx = itemParentIdxDecoder.next();
                 normalizedName = word.indexOf("_") === -1 ? word : word.replace(/_/g, "");
+                /** @type {rustdoc.Row} */
                 const row = {
                     crate,
                     ty: itemTypes.charCodeAt(i) - 65, // 65 = "A"

--- a/tests/ui-fulldeps/stable-mir/check_ty_fold.rs
+++ b/tests/ui-fulldeps/stable-mir/check_ty_fold.rs
@@ -18,9 +18,11 @@ extern crate rustc_interface;
 extern crate stable_mir;
 
 use rustc_smir::rustc_internal;
-use stable_mir::ty::{RigidTy, TyKind, Ty, };
-use stable_mir::mir::{Body, MirVisitor, FieldIdx, Place, ProjectionElem, visit::{Location,
-                                                                            PlaceContext}};
+use stable_mir::mir::{
+    Body, FieldIdx, MirVisitor, Place, ProjectionElem,
+    visit::{Location, PlaceContext},
+};
+use stable_mir::ty::{RigidTy, Ty, TyKind};
 use std::io::Write;
 use std::ops::ControlFlow;
 
@@ -29,8 +31,8 @@ const CRATE_NAME: &str = "input";
 /// This function uses the Stable MIR APIs to get information about the test crate.
 fn test_stable_mir() -> ControlFlow<()> {
     let main_fn = stable_mir::entry_fn();
-    let body = main_fn.unwrap().body();
-    let mut visitor = PlaceVisitor{ body: &body, tested: false};
+    let body = main_fn.unwrap().expect_body();
+    let mut visitor = PlaceVisitor { body: &body, tested: false };
     visitor.visit_body(&body);
     assert!(visitor.tested);
     ControlFlow::Continue(())

--- a/tests/ui-fulldeps/stable-mir/projections.rs
+++ b/tests/ui-fulldeps/stable-mir/projections.rs
@@ -18,10 +18,10 @@ extern crate rustc_interface;
 extern crate stable_mir;
 
 use rustc_smir::rustc_internal;
+use stable_mir::ItemKind;
 use stable_mir::crate_def::CrateDef;
 use stable_mir::mir::{ProjectionElem, Rvalue, StatementKind};
 use stable_mir::ty::{RigidTy, TyKind, UintTy};
-use stable_mir::ItemKind;
 use std::assert_matches::assert_matches;
 use std::io::Write;
 use std::ops::ControlFlow;
@@ -31,7 +31,7 @@ const CRATE_NAME: &str = "input";
 /// Tests projections within Place objects
 fn test_place_projections() -> ControlFlow<()> {
     let items = stable_mir::all_local_items();
-    let body = get_item(&items, (ItemKind::Fn, "projections")).unwrap().body();
+    let body = get_item(&items, (ItemKind::Fn, "projections")).unwrap().expect_body();
     assert_eq!(body.blocks.len(), 4);
     // The first statement assigns `&s.c` to a local. The projections include a deref for `s`, since
     // `s` is passed as a reference argument, and a field access for field `c`.
@@ -53,7 +53,7 @@ fn test_place_projections() -> ControlFlow<()> {
                     );
                     let ty = place.ty(body.locals()).unwrap();
                     assert_matches!(ty.kind().rigid(), Some(RigidTy::Ref(..)));
-                },
+                }
                 other => panic!(
                     "Unable to match against expected rvalue projection. Expected the projection \
                      for `s.c`, which is a Deref and u8 Field. Got: {:?}",
@@ -137,9 +137,7 @@ fn get_item<'a>(
     items: &'a stable_mir::CrateItems,
     item: (ItemKind, &str),
 ) -> Option<&'a stable_mir::CrateItem> {
-    items.iter().find(|crate_item| {
-        crate_item.kind() == item.0 && crate_item.name() == item.1
-    })
+    items.iter().find(|crate_item| crate_item.kind() == item.0 && crate_item.name() == item.1)
 }
 
 /// This test will generate and analyze a dummy crate using the stable mir.

--- a/tests/ui-fulldeps/stable-mir/smir_internal.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_internal.rs
@@ -26,7 +26,7 @@ const CRATE_NAME: &str = "input";
 
 fn test_translation(tcx: TyCtxt<'_>) -> ControlFlow<()> {
     let main_fn = stable_mir::entry_fn().unwrap();
-    let body = main_fn.body();
+    let body = main_fn.expect_body();
     let orig_ty = body.locals()[0].ty;
     let rustc_ty = rustc_internal::internal(tcx, &orig_ty);
     assert!(rustc_ty.is_unit());

--- a/tests/ui-fulldeps/stable-mir/smir_serde.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_serde.rs
@@ -14,33 +14,29 @@ extern crate rustc_smir;
 extern crate rustc_driver;
 extern crate rustc_interface;
 extern crate rustc_middle;
-extern crate stable_mir;
 extern crate serde;
 extern crate serde_json;
+extern crate stable_mir;
 
 use rustc_middle::ty::TyCtxt;
 use rustc_smir::rustc_internal;
-use stable_mir::mir::Body;
-use std::io::{Write, BufWriter};
-use std::ops::ControlFlow;
 use serde_json::to_string;
-
+use stable_mir::mir::Body;
+use std::io::{BufWriter, Write};
+use std::ops::ControlFlow;
 
 const CRATE_NAME: &str = "input";
 
 fn serialize_to_json(_tcx: TyCtxt<'_>) -> ControlFlow<()> {
     let path = "output.json";
-    let mut writer = BufWriter::new(std::fs::File::create(path)
-        .expect("Failed to create path"));
+    let mut writer = BufWriter::new(std::fs::File::create(path).expect("Failed to create path"));
     let local_crate = stable_mir::local_crate();
-    let items: Vec<Body> = stable_mir::all_local_items()
-        .iter()
-        .map(|item| { item.body() })
-        .collect();
-    let crate_data = ( local_crate.name, items );
-    writer.write_all(to_string(&crate_data)
-        .expect("serde_json failed")
-        .as_bytes()).expect("JSON serialization failed");
+    let items: Vec<Body> =
+        stable_mir::all_local_items().iter().map(|item| item.expect_body()).collect();
+    let crate_data = (local_crate.name, items);
+    writer
+        .write_all(to_string(&crate_data).expect("serde_json failed").as_bytes())
+        .expect("JSON serialization failed");
     ControlFlow::Continue(())
 }
 

--- a/tests/ui-fulldeps/stable-mir/smir_visitor.rs
+++ b/tests/ui-fulldeps/stable-mir/smir_visitor.rs
@@ -16,10 +16,10 @@ extern crate rustc_driver;
 extern crate rustc_interface;
 extern crate stable_mir;
 
-use std::collections::HashSet;
 use rustc_smir::rustc_internal;
-use stable_mir::*;
 use stable_mir::mir::MirVisitor;
+use stable_mir::*;
+use std::collections::HashSet;
 use std::io::Write;
 use std::ops::ControlFlow;
 
@@ -27,7 +27,7 @@ const CRATE_NAME: &str = "input";
 
 fn test_visitor() -> ControlFlow<()> {
     let main_fn = stable_mir::entry_fn();
-    let main_body = main_fn.unwrap().body();
+    let main_body = main_fn.unwrap().expect_body();
     let main_visitor = TestVisitor::collect(&main_body);
     assert!(main_visitor.ret_val.is_some());
     assert!(main_visitor.args.is_empty());
@@ -51,7 +51,7 @@ struct TestVisitor<'a> {
     pub tys: HashSet<ty::Ty>,
     pub ret_val: Option<mir::LocalDecl>,
     pub args: Vec<mir::LocalDecl>,
-    pub calls: Vec<mir::mono::Instance>
+    pub calls: Vec<mir::mono::Instance>,
 }
 
 impl<'a> TestVisitor<'a> {
@@ -90,8 +90,8 @@ impl<'a> mir::MirVisitor for TestVisitor<'a> {
     fn visit_terminator(&mut self, term: &mir::Terminator, location: mir::visit::Location) {
         if let mir::TerminatorKind::Call { func, .. } = &term.kind {
             let ty::TyKind::RigidTy(ty) = func.ty(self.body.locals()).unwrap().kind() else {
-                unreachable!
-            () };
+                unreachable!()
+            };
             let ty::RigidTy::FnDef(def, args) = ty else { unreachable!() };
             self.calls.push(mir::mono::Instance::resolve(def, &args).unwrap());
         }

--- a/tests/ui/async-await/issues/issue-63388-2.rs
+++ b/tests/ui/async-await/issues/issue-63388-2.rs
@@ -12,7 +12,6 @@ impl Xyz {
     ) -> &dyn Foo //~ ERROR missing lifetime specifier
     {
         foo
-        //~^ ERROR explicit lifetime required in the type of `foo` [E0621]
     }
 }
 

--- a/tests/ui/async-await/issues/issue-63388-2.stderr
+++ b/tests/ui/async-await/issues/issue-63388-2.stderr
@@ -12,16 +12,6 @@ help: consider using the `'a` lifetime
 LL |     ) -> &'a dyn Foo
    |           ++
 
-error[E0621]: explicit lifetime required in the type of `foo`
-  --> $DIR/issue-63388-2.rs:14:9
-   |
-LL |         foo: &dyn Foo, bar: &'a dyn Foo
-   |              -------- help: add explicit lifetime `'a` to the type of `foo`: `&'a (dyn Foo + 'a)`
-...
-LL |         foo
-   |         ^^^ lifetime `'a` required
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0106, E0621.
-For more information about an error, try `rustc --explain E0106`.
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.rs
+++ b/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.rs
@@ -8,8 +8,6 @@ trait Foo {
 
 impl Foo for () {
     fn bar() -> i32 {
-        //~^ ERROR method `bar` has an incompatible type for trait
-        //~| ERROR method `bar` has an incompatible return type for trait
         0
     }
 }

--- a/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
+++ b/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
@@ -11,7 +11,7 @@ LL |     fn bar() -> Wrapper<'static, impl Sized>;
    |                         ++++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/opaque-and-lifetime-mismatch.rs:18:24
+  --> $DIR/opaque-and-lifetime-mismatch.rs:16:24
    |
 LL |     fn foo() -> Wrapper<impl Sized>;
    |                        ^ expected named lifetime parameter
@@ -23,7 +23,7 @@ LL |     fn foo() -> Wrapper<'static, impl Sized>;
    |                         ++++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/opaque-and-lifetime-mismatch.rs:24:24
+  --> $DIR/opaque-and-lifetime-mismatch.rs:22:24
    |
 LL |     fn foo() -> Wrapper<impl Sized> {
    |                        ^ expected named lifetime parameter
@@ -49,7 +49,7 @@ LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
 
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/opaque-and-lifetime-mismatch.rs:18:17
+  --> $DIR/opaque-and-lifetime-mismatch.rs:16:17
    |
 LL |     fn foo() -> Wrapper<impl Sized>;
    |                 ^^^^^^^ ---------- help: remove the unnecessary generic argument
@@ -62,36 +62,8 @@ note: struct defined here, with 0 generic parameters
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
 
-error[E0053]: method `bar` has an incompatible return type for trait
-  --> $DIR/opaque-and-lifetime-mismatch.rs:10:17
-   |
-LL |     fn bar() -> i32 {
-   |                 ^^^
-   |                 |
-   |                 expected `Wrapper<'static>`, found `i32`
-   |                 return type in trait
-
-error[E0053]: method `bar` has an incompatible type for trait
-  --> $DIR/opaque-and-lifetime-mismatch.rs:10:17
-   |
-LL |     fn bar() -> i32 {
-   |                 ^^^ expected `Wrapper<'static>`, found `i32`
-   |
-note: type in trait
-  --> $DIR/opaque-and-lifetime-mismatch.rs:4:17
-   |
-LL |     fn bar() -> Wrapper<impl Sized>;
-   |                 ^^^^^^^^^^^^^^^^^^^
-   = note: expected signature `fn() -> Wrapper<'static>`
-              found signature `fn() -> i32`
-help: change the output type to match the trait
-   |
-LL -     fn bar() -> i32 {
-LL +     fn bar() -> Wrapper<'static> {
-   |
-
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/opaque-and-lifetime-mismatch.rs:24:17
+  --> $DIR/opaque-and-lifetime-mismatch.rs:22:17
    |
 LL |     fn foo() -> Wrapper<impl Sized> {
    |                 ^^^^^^^ ---------- help: remove the unnecessary generic argument
@@ -104,7 +76,7 @@ note: struct defined here, with 0 generic parameters
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0053, E0106, E0107.
-For more information about an error, try `rustc --explain E0053`.
+Some errors have detailed explanations: E0106, E0107.
+For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/impl-trait/opaque-used-in-extraneous-argument.stderr
+++ b/tests/ui/impl-trait/opaque-used-in-extraneous-argument.stderr
@@ -75,7 +75,7 @@ error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/opaque-used-in-extraneous-argument.rs:20:5
    |
 LL |     open_parent(&old_path)
-   |     ^^^^^^^^^^^ --------- unexpected argument of type `&impl Fn<{type error}> + FnOnce<{type error}, Output = {type error}> + 'static`
+   |     ^^^^^^^^^^^ --------- unexpected argument of type `&impl Fn<{type error}> + FnOnce<{type error}, Output = {type error}> + '_`
    |
 note: function defined here
   --> $DIR/opaque-used-in-extraneous-argument.rs:12:4

--- a/tests/ui/impl-trait/precise-capturing/bad-lifetimes.rs
+++ b/tests/ui/impl-trait/precise-capturing/bad-lifetimes.rs
@@ -1,6 +1,5 @@
 fn no_elided_lt() -> impl Sized + use<'_> {}
 //~^ ERROR missing lifetime specifier
-//~| ERROR expected lifetime parameter in `use<...>` precise captures list, found `'_`
 
 fn static_lt() -> impl Sized + use<'static> {}
 //~^ ERROR expected lifetime parameter in `use<...>` precise captures list, found `'static`

--- a/tests/ui/impl-trait/precise-capturing/bad-lifetimes.stderr
+++ b/tests/ui/impl-trait/precise-capturing/bad-lifetimes.stderr
@@ -12,26 +12,20 @@ LL + fn no_elided_lt() -> impl Sized + use<'static> {}
    |
 
 error[E0261]: use of undeclared lifetime name `'missing`
-  --> $DIR/bad-lifetimes.rs:8:37
+  --> $DIR/bad-lifetimes.rs:7:37
    |
 LL | fn missing_lt() -> impl Sized + use<'missing> {}
    |              -                      ^^^^^^^^ undeclared lifetime
    |              |
    |              help: consider introducing lifetime `'missing` here: `<'missing>`
 
-error: expected lifetime parameter in `use<...>` precise captures list, found `'_`
-  --> $DIR/bad-lifetimes.rs:1:39
-   |
-LL | fn no_elided_lt() -> impl Sized + use<'_> {}
-   |                                       ^^
-
 error: expected lifetime parameter in `use<...>` precise captures list, found `'static`
-  --> $DIR/bad-lifetimes.rs:5:36
+  --> $DIR/bad-lifetimes.rs:4:36
    |
 LL | fn static_lt() -> impl Sized + use<'static> {}
    |                                    ^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0106, E0261.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/issues/issue-13497.rs
+++ b/tests/ui/issues/issue-13497.rs
@@ -3,7 +3,6 @@ fn read_lines_borrowed1() -> Vec<
 > {
     let rawLines: Vec<String> = vec!["foo  ".to_string(), "  bar".to_string()];
     rawLines.iter().map(|l| l.trim()).collect()
-    //~^ ERROR: cannot return value referencing
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-13497.stderr
+++ b/tests/ui/issues/issue-13497.stderr
@@ -15,16 +15,6 @@ LL -     &str
 LL +     String
    |
 
-error[E0515]: cannot return value referencing local variable `rawLines`
-  --> $DIR/issue-13497.rs:5:5
-   |
-LL |     rawLines.iter().map(|l| l.trim()).collect()
-   |     --------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     returns a value referencing data owned by the current function
-   |     `rawLines` is borrowed here
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0106, E0515.
-For more information about an error, try `rustc --explain E0106`.
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/lifetimes/issue-26638.rs
+++ b/tests/ui/lifetimes/issue-26638.rs
@@ -3,7 +3,6 @@ fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next() 
 
 fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
 //~^ ERROR missing lifetime specifier [E0106]
-//~| ERROR mismatched types
 //~| ERROR function takes 1 argument but 0 arguments were supplied
 
 fn parse_type_3() -> &str { unimplemented!() }

--- a/tests/ui/lifetimes/issue-26638.stderr
+++ b/tests/ui/lifetimes/issue-26638.stderr
@@ -32,7 +32,7 @@ LL + fn parse_type_2(iter: fn(&u8)->&u8) -> String { iter() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/issue-26638.rs:9:22
+  --> $DIR/issue-26638.rs:8:22
    |
 LL | fn parse_type_3() -> &str { unimplemented!() }
    |                      ^ expected named lifetime parameter
@@ -59,18 +59,7 @@ help: provide the argument
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter(/* &u8 */) }
    |                                                    +++++++++
 
-error[E0308]: mismatched types
-  --> $DIR/issue-26638.rs:4:47
-   |
-LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
-   |                                        ----   ^^^^^^ expected `&str`, found `&u8`
-   |                                        |
-   |                                        expected `&'static str` because of return type
-   |
-   = note: expected reference `&'static str`
-              found reference `&u8`
+error: aborting due to 4 previous errors
 
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0061, E0106, E0308.
+Some errors have detailed explanations: E0061, E0106.
 For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/structs/default-field-values/do-not-ice-on-invalid-lifetime.rs
+++ b/tests/ui/structs/default-field-values/do-not-ice-on-invalid-lifetime.rs
@@ -1,5 +1,5 @@
 #![feature(default_field_values)]
-struct A<'a> { //~ ERROR lifetime parameter `'a` is never used
+struct A<'a> {
     x: Vec<A> = Vec::new(), //~ ERROR missing lifetime specifier
 }
 

--- a/tests/ui/structs/default-field-values/do-not-ice-on-invalid-lifetime.stderr
+++ b/tests/ui/structs/default-field-values/do-not-ice-on-invalid-lifetime.stderr
@@ -9,15 +9,6 @@ help: consider using the `'a` lifetime
 LL |     x: Vec<A<'a>> = Vec::new(),
    |             ++++
 
-error[E0392]: lifetime parameter `'a` is never used
-  --> $DIR/do-not-ice-on-invalid-lifetime.rs:2:10
-   |
-LL | struct A<'a> {
-   |          ^^ unused lifetime parameter
-   |
-   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0106, E0392.
-For more information about an error, try `rustc --explain E0106`.
+For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/structs/default-field-values/failures.rs
+++ b/tests/ui/structs/default-field-values/failures.rs
@@ -17,9 +17,9 @@ pub struct Bar {
 
 #[derive(Default)]
 pub struct Qux<const C: i32> {
-    bar: S = Self::S, //~ ERROR generic `Self` types are currently not permitted in anonymous constants
+    bar: S = Self::S,
     baz: i32 = foo(),
-    bat: i32 = <Qux<{ C }> as T>::K, //~ ERROR generic parameters may not be used in const operations
+    bat: i32 = <Qux<{ C }> as T>::K,
     bay: i32 = C,
 }
 

--- a/tests/ui/structs/default-field-values/failures.stderr
+++ b/tests/ui/structs/default-field-values/failures.stderr
@@ -6,26 +6,11 @@ LL |     Variant {}
    |
    = help: consider a manual implementation of `Default`
 
-error: generic parameters may not be used in const operations
-  --> $DIR/failures.rs:22:23
-   |
-LL |     bat: i32 = <Qux<{ C }> as T>::K,
-   |                       ^ cannot perform const operation using `C`
-   |
-   = help: const parameters may only be used as standalone arguments, i.e. `C`
-   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
-
 error: default fields are not supported in tuple structs
   --> $DIR/failures.rs:26:22
    |
 LL | pub struct Rak(i32 = 42);
    |                      ^^ default fields are only supported on structs
-
-error: generic `Self` types are currently not permitted in anonymous constants
-  --> $DIR/failures.rs:20:14
-   |
-LL |     bar: S = Self::S,
-   |              ^^^^
 
 error[E0277]: the trait bound `S: Default` is not satisfied
   --> $DIR/failures.rs:14:5
@@ -112,7 +97,7 @@ LL -     let _ = Rak(.., 0);
 LL +     let _ = Rak(0);
    |
 
-error: aborting due to 9 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0061, E0277, E0308.
 For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/structs/default-field-values/field-references-param.rs
+++ b/tests/ui/structs/default-field-values/field-references-param.rs
@@ -1,0 +1,29 @@
+//@ build-pass
+
+#![feature(default_field_values)]
+
+struct W<const X: usize>;
+
+impl<const X: usize> W<X> {
+    const fn new() -> Self { W }
+}
+
+struct Z<const X: usize> {
+    // No inference.
+    one: W<X> = W::<X>::new(),
+
+    // Inference works too.
+    two: W<X> = W::new(),
+
+    // An anon const that is too generic before substitution.
+    too_generic: usize = X + 1,
+}
+
+fn use_generically<const X: usize>() {
+    let x: Z<X> = Z { .. };
+}
+
+fn main() {
+    let x: Z<0> = Z { .. };
+    use_generically::<0>();
+}

--- a/tests/ui/structs/default-field-values/post-mono.direct.stderr
+++ b/tests/ui/structs/default-field-values/post-mono.direct.stderr
@@ -1,0 +1,23 @@
+error[E0080]: evaluation of `Z::<1>::post_mono::{constant#0}` failed
+  --> $DIR/post-mono.rs:7:24
+   |
+LL |     post_mono: usize = X / 0,
+   |                        ^^^^^ attempt to divide `1_usize` by zero
+
+note: erroneous constant encountered
+  --> $DIR/post-mono.rs:17:19
+   |
+LL |     let x: Z<1> = Z { .. };
+   |                   ^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/post-mono.rs:17:19
+   |
+LL |     let x: Z<1> = Z { .. };
+   |                   ^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/structs/default-field-values/post-mono.indirect.stderr
+++ b/tests/ui/structs/default-field-values/post-mono.indirect.stderr
@@ -1,0 +1,29 @@
+error[E0080]: evaluation of `Z::<1>::post_mono::{constant#0}` failed
+  --> $DIR/post-mono.rs:7:24
+   |
+LL |     post_mono: usize = X / 0,
+   |                        ^^^^^ attempt to divide `1_usize` by zero
+
+note: erroneous constant encountered
+  --> $DIR/post-mono.rs:12:19
+   |
+LL |     let x: Z<X> = Z { .. };
+   |                   ^^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/post-mono.rs:12:19
+   |
+LL |     let x: Z<X> = Z { .. };
+   |                   ^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: the above error was encountered while instantiating `fn indirect::<1>`
+  --> $DIR/post-mono.rs:22:5
+   |
+LL |     indirect::<1>();
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/structs/default-field-values/post-mono.rs
+++ b/tests/ui/structs/default-field-values/post-mono.rs
@@ -1,0 +1,23 @@
+//@ build-fail
+//@ revisions: direct indirect
+
+#![feature(default_field_values)]
+
+struct Z<const X: usize> {
+    post_mono: usize = X / 0,
+    //~^ ERROR evaluation of `Z::<1>::post_mono::{constant#0}` failed
+}
+
+fn indirect<const X: usize>() {
+    let x: Z<X> = Z { .. };
+}
+
+#[cfg(direct)]
+fn main() {
+    let x: Z<1> = Z { .. };
+}
+
+#[cfg(indirect)]
+fn main() {
+    indirect::<1>();
+}

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.rs
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.rs
@@ -18,7 +18,6 @@ mod elided {
     // But that lifetime does not participate in resolution.
     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
     //~^ ERROR missing lifetime specifier
-    //~| ERROR lifetime may not live long enough
 }
 
 mod underscore {
@@ -37,7 +36,6 @@ mod underscore {
     // But that lifetime does not participate in resolution.
     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
     //~^ ERROR missing lifetime specifier
-    //~| ERROR lifetime may not live long enough
 }
 
 mod alone_in_path {

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -41,7 +41,7 @@ LL +     async fn i(mut x: impl Iterator<Item = &()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:28:58
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:27:58
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                          ^^ expected named lifetime parameter
@@ -64,7 +64,7 @@ LL +     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:64
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:37:64
    |
 LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                                ^^ expected named lifetime parameter
@@ -87,7 +87,7 @@ LL +     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next(
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:49:37
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:47:37
    |
 LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                                     ^ expected named lifetime parameter
@@ -108,7 +108,7 @@ LL +     fn g(mut x: impl Foo) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:60:41
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:58:41
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                                         ^ expected named lifetime parameter
@@ -129,7 +129,7 @@ LL +     fn g(mut x: impl Foo<()>) -> Option<()> { x.next() }
    |
 
 warning: elided lifetime has a name
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:66:57
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:64:57
    |
 LL | fn resolved_anonymous<'a, T: 'a>(f: impl Fn(&'a str) -> &T) {
    |                       -- lifetime `'a` declared here    ^ this elided lifetime gets resolved as `'a`
@@ -162,16 +162,8 @@ help: consider introducing a named lifetime parameter
 LL |     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&()> { x.next() }
    |         ++++                              ++
 
-error: lifetime may not live long enough
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:19:67
-   |
-LL |     async fn i(mut x: impl Iterator<Item = &()>) -> Option<&()> { x.next() }
-   |     -----------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
-   |     |
-   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
-
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:25:35
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:24:35
    |
 LL |     fn f(_: impl Iterator<Item = &'_ ()>) {}
    |                                   ^^ expected named lifetime parameter
@@ -185,7 +177,7 @@ LL +     fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
    |
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:28:39
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:27:39
    |
 LL |     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                       ^^ expected named lifetime parameter
@@ -198,16 +190,8 @@ LL -     fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() 
 LL +     fn g<'a>(mut x: impl Iterator<Item = &'a ()>) -> Option<&'_ ()> { x.next() }
    |
 
-error: lifetime may not live long enough
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:38:73
-   |
-LL |     async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
-   |     -----------------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
-   |     |
-   |     return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
-
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:46:18
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:44:18
    |
 LL |     fn f(_: impl Foo) {}
    |                  ^^^ expected named lifetime parameter
@@ -220,7 +204,7 @@ LL |     fn f<'a>(_: impl Foo<'a>) {}
    |         ++++            ++++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:49:22
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:47:22
    |
 LL |     fn g(mut x: impl Foo) -> Option<&()> { x.next() }
    |                      ^^^ expected named lifetime parameter
@@ -233,7 +217,7 @@ LL |     fn g<'a>(mut x: impl Foo<'a>) -> Option<&()> { x.next() }
    |         ++++                ++++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:57:22
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:55:22
    |
 LL |     fn f(_: impl Foo<()>) {}
    |                      ^ expected named lifetime parameter
@@ -246,7 +230,7 @@ LL |     fn f<'a>(_: impl Foo<'a, ()>) {}
    |         ++++             +++
 
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:60:26
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:58:26
    |
 LL |     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
    |                          ^ expected named lifetime parameter
@@ -258,7 +242,7 @@ help: consider introducing a named lifetime parameter
 LL |     fn g<'a>(mut x: impl Foo<'a, ()>) -> Option<&()> { x.next() }
    |         ++++                 +++
 
-error: aborting due to 16 previous errors; 1 warning emitted
+error: aborting due to 14 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0106, E0658.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/impl-trait-missing-lifetime.rs
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime.rs
@@ -8,7 +8,6 @@ fn f(_: impl Iterator<Item = &'_ ()>) {}
 // But that lifetime does not participate in resolution.
 fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
 //~^ ERROR missing lifetime specifier
-//~| ERROR lifetime may not live long enough
 
 // This is understood as `fn foo<'_1>(_: impl Iterator<Item = &'_1 ()>) {}`.
 async fn h(_: impl Iterator<Item = &'_ ()>) {}
@@ -16,6 +15,5 @@ async fn h(_: impl Iterator<Item = &'_ ()>) {}
 // But that lifetime does not participate in resolution.
 async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
 //~^ ERROR missing lifetime specifier
-//~| ERROR lifetime may not live long enough
 
 fn main() {}

--- a/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime.stderr
@@ -22,7 +22,7 @@ LL + fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime.rs:17:60
+  --> $DIR/impl-trait-missing-lifetime.rs:16:60
    |
 LL | async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                            ^^ expected named lifetime parameter
@@ -44,20 +44,6 @@ LL - async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next(
 LL + async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<()> { x.next() }
    |
 
-error: lifetime may not live long enough
-  --> $DIR/impl-trait-missing-lifetime.rs:17:69
-   |
-LL | async fn i(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
-   | -----------------------------------------------------------------   ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
-   | |
-   | return type `impl Future<Output = Option<&'static ()>>` contains a lifetime `'1`
-
-error: lifetime may not live long enough
-  --> $DIR/impl-trait-missing-lifetime.rs:9:63
-   |
-LL | fn g(mut x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
-   |      ----- has type `x`                                       ^^^^^^^^ returning this value requires that `'1` must outlive `'static`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/missing-lt-for-hrtb.rs
+++ b/tests/ui/suggestions/missing-lt-for-hrtb.rs
@@ -8,8 +8,6 @@ fn main() {
     let x = S(&|x| {
         println!("hi");
         x
-        //~^ ERROR lifetime may not live long enough
-        //~| ERROR lifetime may not live long enough
     });
     x.0(&X(&()));
 }

--- a/tests/ui/suggestions/missing-lt-for-hrtb.stderr
+++ b/tests/ui/suggestions/missing-lt-for-hrtb.stderr
@@ -31,28 +31,6 @@ help: consider using one of the available lifetimes here
 LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &'lifetime X<'lifetime>);
    |                                         +++++++++  +++++++++++
 
-error: lifetime may not live long enough
-  --> $DIR/missing-lt-for-hrtb.rs:10:9
-   |
-LL |     let x = S(&|x| {
-   |                 -- return type of closure is &'2 X<'_>
-   |                 |
-   |                 has type `&'1 X<'_>`
-LL |         println!("hi");
-LL |         x
-   |         ^ returning this value requires that `'1` must outlive `'2`
-
-error: lifetime may not live long enough
-  --> $DIR/missing-lt-for-hrtb.rs:10:9
-   |
-LL |     let x = S(&|x| {
-   |                 -- return type of closure is &X<'4>
-   |                 |
-   |                 has type `&X<'3>`
-LL |         println!("hi");
-LL |         x
-   |         ^ returning this value requires that `'3` must outlive `'4`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/unpretty/deprecated-attr.rs
+++ b/tests/ui/unpretty/deprecated-attr.rs
@@ -1,0 +1,17 @@
+//@ compile-flags: -Zunpretty=hir
+//@ check-pass
+
+#[deprecated]
+pub struct PlainDeprecated;
+
+#[deprecated = "here's why this is deprecated"]
+pub struct DirectNote;
+
+#[deprecated(note = "here's why this is deprecated")]
+pub struct ExplicitNote;
+
+#[deprecated(since = "1.2.3", note = "here's why this is deprecated")]
+pub struct SinceAndNote;
+
+#[deprecated(note = "here's why this is deprecated", since = "1.2.3")]
+pub struct FlippedOrder;

--- a/tests/ui/unpretty/deprecated-attr.stdout
+++ b/tests/ui/unpretty/deprecated-attr.stdout
@@ -1,0 +1,21 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+//@ compile-flags: -Zunpretty=hir
+//@ check-pass
+
+#[deprecated]
+struct PlainDeprecated;
+
+#[deprecated = "here's why this is deprecated"]
+struct DirectNote;
+
+#[deprecated = "here's why this is deprecated"]
+struct ExplicitNote;
+
+#[deprecated(since = "1.2.3", note = "here's why this is deprecated"]
+struct SinceAndNote;
+
+#[deprecated(since = "1.2.3", note = "here's why this is deprecated"]
+struct FlippedOrder;

--- a/tests/ui/unpretty/diagnostic-attr.rs
+++ b/tests/ui/unpretty/diagnostic-attr.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -Zunpretty=hir
+//@ check-pass
+
+#[diagnostic::on_unimplemented(
+    message = "My Message for `ImportantTrait<{A}>` implemented for `{Self}`",
+    label = "My Label",
+    note = "Note 1",
+    note = "Note 2"
+)]
+pub trait ImportantTrait<A> {}
+
+#[diagnostic::do_not_recommend]
+impl<T> ImportantTrait<T> for T where T: Clone {}

--- a/tests/ui/unpretty/diagnostic-attr.stdout
+++ b/tests/ui/unpretty/diagnostic-attr.stdout
@@ -1,0 +1,16 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+//@ compile-flags: -Zunpretty=hir
+//@ check-pass
+
+#[diagnostic::on_unimplemented(message =
+"My Message for `ImportantTrait<{A}>` implemented for `{Self}`", label =
+"My Label", note = "Note 1", note = "Note 2")]
+trait ImportantTrait<A> { }
+
+#[diagnostic::do_not_recommend]
+impl <T> ImportantTrait<T> for T where T: Clone
+    {#![diagnostic::do_not_recommend]
+}


### PR DESCRIPTION
Successful merges:

 - #137829 (Stabilize [T]::split_off... methods)
 - #137850 (Stabilize `box_uninit_write`)
 - #137912 (Do not recover missing lifetime with random in-scope lifetime)
 - #137913 (Allow struct field default values to reference struct's generics)
 - #137923 (Simplify `<Postorder as Iterator>::size_hint`)
 - #137949 (Update MSVC INSTALL.md instructions to recommend VS 2022 + recent Windows 10/11 SDK)
 - #137963 (Add ``dyn`` keyword to `E0373` examples)
 - #137975 (Remove unused `PpMode::needs_hir`)
 - #137981 (rustdoc search: increase strictness of typechecking)
 - #137986 (Fix some typos)
 - #137991 (Add `avr-none` to SUMMARY.md and platform-support.md)
 - #137993 (Remove obsolete comment from DeduceReadOnly)
 - #137996 (Revert "compiler/rustc_data_structures/src/sync/worker_local.rs: delete "unsafe impl Sync"")
 - #138019 (Pretty-print `#[deprecated]` attribute in HIR.)
 - #138026 (Make CrateItem::body() function return an option)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=137829,137850,137912,137913,137923,137949,137963,137975,137981,137986,137991,137993,137996,138019,138026)
<!-- homu-ignore:end -->