### PR TITLE
rustdoc: Add attribute-related tests for rustdoc JSON.

### DIFF
--- a/tests/rustdoc-json/attrs/export_name_2021.rs
+++ b/tests/rustdoc-json/attrs/export_name_2021.rs
@@ -1,0 +1,6 @@
+//@ edition: 2021
+#![no_std]
+
+//@ is "$.index[*][?(@.name=='example')].attrs" '["#[export_name = \"altered\"]"]'
+#[export_name = "altered"]
+pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/export_name_2024.rs
+++ b/tests/rustdoc-json/attrs/export_name_2024.rs
@@ -1,0 +1,9 @@
+//@ edition: 2024
+#![no_std]
+
+// The representation of `#[unsafe(export_name = ..)]` in rustdoc in edition 2024
+// is still `#[export_name = ..]` without the `unsafe` attribute wrapper.
+
+//@ is "$.index[*][?(@.name=='example')].attrs" '["#[export_name = \"altered\"]"]'
+#[unsafe(export_name = "altered")]
+pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/must_use.rs
+++ b/tests/rustdoc-json/attrs/must_use.rs
@@ -1,0 +1,9 @@
+#![no_std]
+
+//@ is "$.index[*][?(@.name=='example')].attrs" '["#[must_use]"]'
+#[must_use]
+pub fn example() -> impl Iterator<Item = i64> {}
+
+//@ is "$.index[*][?(@.name=='explicit_message')].attrs" '["#[must_use = \"does nothing if you do not use it\"]"]'
+#[must_use = "does nothing if you do not use it"]
+pub fn explicit_message() -> impl Iterator<Item = i64> {}

--- a/tests/rustdoc-json/attrs/no_mangle_2021.rs
+++ b/tests/rustdoc-json/attrs/no_mangle_2021.rs
@@ -1,0 +1,6 @@
+//@ edition: 2021
+#![no_std]
+
+//@ is "$.index[*][?(@.name=='example')].attrs" '["#[no_mangle]"]'
+#[no_mangle]
+pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/no_mangle_2024.rs
+++ b/tests/rustdoc-json/attrs/no_mangle_2024.rs
@@ -1,0 +1,9 @@
+//@ edition: 2024
+#![no_std]
+
+// The representation of `#[unsafe(no_mangle)]` in rustdoc in edition 2024
+// is still `#[no_mangle]` without the `unsafe` attribute wrapper.
+
+//@ is "$.index[*][?(@.name=='example')].attrs" '["#[no_mangle]"]'
+#[unsafe(no_mangle)]
+pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/non_exhaustive.rs
+++ b/tests/rustdoc-json/attrs/non_exhaustive.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+//@ is "$.index[*][?(@.name=='MyEnum')].attrs" '["#[non_exhaustive]"]'
+#[non_exhaustive]
+pub enum MyEnum {
+    First,
+}
+
+pub enum NonExhaustiveVariant {
+    //@ is "$.index[*][?(@.name=='Variant')].attrs" '["#[non_exhaustive]"]'
+    #[non_exhaustive]
+    Variant(i64),
+}
+
+//@ is "$.index[*][?(@.name=='MyStruct')].attrs" '["#[non_exhaustive]"]'
+#[non_exhaustive]
+pub struct MyStruct {
+    pub x: i64,
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Add rustdoc JSON tests covering the use of the following attributes:
- `#[non_exhaustive]` applied to enums, variants, and structs
- `#[must_use]`, both with and without a message
- `#[no_mangle]`, in both edition 2021 and 2024 (`#[unsafe(no_mangle)]`) flavors
- `#[export_name]`, also in both edition 2021 and 2024 flavors

Related to #137645; this is a subset of the attributes that `cargo-semver-checks` relies on and tests in its own test suite or in the test suites of its components such as `trustfall-rustdoc-adapter`.

Helps with #81359

r? @aDotInTheVoid
