### PR TITLE
Stop projecting into SIMD types in `ui/simd/` tests

### DIFF
--- a/tests/ui/simd/generics.rs
+++ b/tests/ui/simd/generics.rs
@@ -8,18 +8,30 @@ use std::ops;
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct f32x4([f32; 4]);
+impl f32x4 {
+    fn to_array(self) -> [f32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct A<const N: usize>([f32; N]);
+impl<const N: usize> A<N> {
+    fn to_array(self) -> [f32; N] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct B<T>([T; 4]);
+impl<T> B<T> {
+    fn to_array(self) -> [T; 4] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct C<T, const N: usize>([T; N]);
+impl<T, const N: usize> C<T, N> {
+    fn to_array(self) -> [T; N] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 fn add<T: ops::Add<Output = T>>(lhs: T, rhs: T) -> T {
     lhs + rhs
@@ -63,18 +75,18 @@ pub fn main() {
 
     // lame-o
     let a = f32x4([1.0f32, 2.0f32, 3.0f32, 4.0f32]);
-    let f32x4([a0, a1, a2, a3]) = add(a, a);
+    let [a0, a1, a2, a3] = add(a, a).to_array();
     assert_eq!(a0, 2.0f32);
     assert_eq!(a1, 4.0f32);
     assert_eq!(a2, 6.0f32);
     assert_eq!(a3, 8.0f32);
 
     let a = A(x);
-    assert_eq!(add(a, a).0, y);
+    assert_eq!(add(a, a).to_array(), y);
 
     let b = B(x);
-    assert_eq!(add(b, b).0, y);
+    assert_eq!(add(b, b).to_array(), y);
 
     let c = C(x);
-    assert_eq!(add(c, c).0, y);
+    assert_eq!(add(c, c).to_array(), y);
 }

--- a/tests/ui/simd/intrinsic/float-math-pass.rs
+++ b/tests/ui/simd/intrinsic/float-math-pass.rs
@@ -12,8 +12,11 @@
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct f32x4(pub [f32; 4]);
+impl f32x4 {
+    fn to_array(self) -> [f32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 use std::intrinsics::simd::*;
 
@@ -25,12 +28,12 @@ macro_rules! assert_approx_eq_f32 {
 }
 macro_rules! assert_approx_eq {
     ($a:expr, $b:expr) => {{
-        let a = $a;
-        let b = $b;
-        assert_approx_eq_f32!(a.0[0], b.0[0]);
-        assert_approx_eq_f32!(a.0[1], b.0[1]);
-        assert_approx_eq_f32!(a.0[2], b.0[2]);
-        assert_approx_eq_f32!(a.0[3], b.0[3]);
+        let a = $a.to_array();
+        let b = $b.to_array();
+        assert_approx_eq_f32!(a[0], b[0]);
+        assert_approx_eq_f32!(a[1], b[1]);
+        assert_approx_eq_f32!(a[2], b[2]);
+        assert_approx_eq_f32!(a[3], b[3]);
     }};
 }
 
@@ -77,15 +80,15 @@ fn main() {
 
         // rounding functions
         let r = simd_floor(h);
-        assert_eq!(z, r);
+        assert_eq!(z.to_array(), r.to_array());
 
         let r = simd_ceil(h);
-        assert_eq!(x, r);
+        assert_eq!(x.to_array(), r.to_array());
 
         let r = simd_round(h);
-        assert_eq!(x, r);
+        assert_eq!(x.to_array(), r.to_array());
 
         let r = simd_trunc(h);
-        assert_eq!(z, r);
+        assert_eq!(z.to_array(), r.to_array());
     }
 }

--- a/tests/ui/simd/intrinsic/float-minmax-pass.rs
+++ b/tests/ui/simd/intrinsic/float-minmax-pass.rs
@@ -7,10 +7,21 @@
 #![allow(non_camel_case_types)]
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct f32x4(pub [f32; 4]);
+impl f32x4 {
+    fn to_array(self) -> [f32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 use std::intrinsics::simd::*;
+
+macro_rules! all_eq {
+    ($a: expr, $b: expr) => {{
+        let a = $a;
+        let b = $b;
+        assert_eq!(a.to_array(), b.to_array());
+    }};
+}
 
 fn main() {
     let x = f32x4([1.0, 2.0, 3.0, 4.0]);
@@ -28,22 +39,22 @@ fn main() {
     unsafe {
         let min0 = simd_fmin(x, y);
         let min1 = simd_fmin(y, x);
-        assert_eq!(min0, min1);
+        all_eq!(min0, min1);
         let e = f32x4([1.0, 1.0, 3.0, 3.0]);
-        assert_eq!(min0, e);
+        all_eq!(min0, e);
         let minn = simd_fmin(x, n);
-        assert_eq!(minn, x);
+        all_eq!(minn, x);
         let minn = simd_fmin(y, n);
-        assert_eq!(minn, y);
+        all_eq!(minn, y);
 
         let max0 = simd_fmax(x, y);
         let max1 = simd_fmax(y, x);
-        assert_eq!(max0, max1);
+        all_eq!(max0, max1);
         let e = f32x4([2.0, 2.0, 4.0, 4.0]);
-        assert_eq!(max0, e);
+        all_eq!(max0, e);
         let maxn = simd_fmax(x, n);
-        assert_eq!(maxn, x);
+        all_eq!(maxn, x);
         let maxn = simd_fmax(y, n);
-        assert_eq!(maxn, y);
+        all_eq!(maxn, y);
     }
 }

--- a/tests/ui/simd/intrinsic/generic-arithmetic-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-pass.rs
@@ -5,20 +5,29 @@
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct i32x4(pub [i32; 4]);
+impl i32x4 {
+    fn to_array(self) -> [i32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct U32<const N: usize>([u32; N]);
+impl<const N: usize> U32<N> {
+    fn to_array(self) -> [u32; N] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct f32x4(pub [f32; 4]);
+impl f32x4 {
+    fn to_array(self) -> [f32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 macro_rules! all_eq {
     ($a: expr, $b: expr) => {{
         let a = $a;
         let b = $b;
-        assert!(a.0 == b.0);
+        assert!(a.to_array() == b.to_array());
     }};
 }
 

--- a/tests/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
@@ -7,12 +7,26 @@
 use std::intrinsics::simd::{simd_saturating_add, simd_saturating_sub};
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct u32x4(pub [u32; 4]);
+impl u32x4 {
+    fn to_array(self) -> [u32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct I32<const N: usize>([i32; N]);
+impl<const N: usize> I32<N> {
+    fn to_array(self) -> [i32; N] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
+
+macro_rules! all_eq {
+    ($a: expr, $b: expr) => {{
+        let a = $a;
+        let b = $b;
+        assert_eq!(a.to_array(), b.to_array());
+    }};
+}
 
 fn main() {
     // unsigned
@@ -26,20 +40,20 @@ fn main() {
         let z = u32x4([0, 0, 0, 0]);
 
         unsafe {
-            assert_eq!(simd_saturating_add(z, z), z);
-            assert_eq!(simd_saturating_add(z, a), a);
-            assert_eq!(simd_saturating_add(b, z), b);
-            assert_eq!(simd_saturating_add(a, a), b);
-            assert_eq!(simd_saturating_add(a, m), m);
-            assert_eq!(simd_saturating_add(m, b), m);
-            assert_eq!(simd_saturating_add(m1, a), m);
+            all_eq!(simd_saturating_add(z, z), z);
+            all_eq!(simd_saturating_add(z, a), a);
+            all_eq!(simd_saturating_add(b, z), b);
+            all_eq!(simd_saturating_add(a, a), b);
+            all_eq!(simd_saturating_add(a, m), m);
+            all_eq!(simd_saturating_add(m, b), m);
+            all_eq!(simd_saturating_add(m1, a), m);
 
-            assert_eq!(simd_saturating_sub(b, z), b);
-            assert_eq!(simd_saturating_sub(b, a), a);
-            assert_eq!(simd_saturating_sub(a, a), z);
-            assert_eq!(simd_saturating_sub(a, b), z);
-            assert_eq!(simd_saturating_sub(a, m1), z);
-            assert_eq!(simd_saturating_sub(b, m1), z);
+            all_eq!(simd_saturating_sub(b, z), b);
+            all_eq!(simd_saturating_sub(b, a), a);
+            all_eq!(simd_saturating_sub(a, a), z);
+            all_eq!(simd_saturating_sub(a, b), z);
+            all_eq!(simd_saturating_sub(a, m1), z);
+            all_eq!(simd_saturating_sub(b, m1), z);
         }
     }
 
@@ -61,28 +75,28 @@ fn main() {
         let z = I32::<4>([0, 0, 0, 0]);
 
         unsafe {
-            assert_eq!(simd_saturating_add(z, z).0, z.0);
-            assert_eq!(simd_saturating_add(z, a).0, a.0);
-            assert_eq!(simd_saturating_add(b, z).0, b.0);
-            assert_eq!(simd_saturating_add(a, a).0, b.0);
-            assert_eq!(simd_saturating_add(a, max).0, max.0);
-            assert_eq!(simd_saturating_add(max, b).0, max.0);
-            assert_eq!(simd_saturating_add(max1, a).0, max.0);
-            assert_eq!(simd_saturating_add(min1, z).0, min1.0);
-            assert_eq!(simd_saturating_add(min, z).0, min.0);
-            assert_eq!(simd_saturating_add(min1, c).0, min.0);
-            assert_eq!(simd_saturating_add(min, c).0, min.0);
-            assert_eq!(simd_saturating_add(min1, d).0, min.0);
-            assert_eq!(simd_saturating_add(min, d).0, min.0);
+            all_eq!(simd_saturating_add(z, z), z);
+            all_eq!(simd_saturating_add(z, a), a);
+            all_eq!(simd_saturating_add(b, z), b);
+            all_eq!(simd_saturating_add(a, a), b);
+            all_eq!(simd_saturating_add(a, max), max);
+            all_eq!(simd_saturating_add(max, b), max);
+            all_eq!(simd_saturating_add(max1, a), max);
+            all_eq!(simd_saturating_add(min1, z), min1);
+            all_eq!(simd_saturating_add(min, z), min);
+            all_eq!(simd_saturating_add(min1, c), min);
+            all_eq!(simd_saturating_add(min, c), min);
+            all_eq!(simd_saturating_add(min1, d), min);
+            all_eq!(simd_saturating_add(min, d), min);
 
-            assert_eq!(simd_saturating_sub(b, z).0, b.0);
-            assert_eq!(simd_saturating_sub(b, a).0, a.0);
-            assert_eq!(simd_saturating_sub(a, a).0, z.0);
-            assert_eq!(simd_saturating_sub(a, b).0, c.0);
-            assert_eq!(simd_saturating_sub(z, max).0, min1.0);
-            assert_eq!(simd_saturating_sub(min1, z).0, min1.0);
-            assert_eq!(simd_saturating_sub(min1, a).0, min.0);
-            assert_eq!(simd_saturating_sub(min1, b).0, min.0);
+            all_eq!(simd_saturating_sub(b, z), b);
+            all_eq!(simd_saturating_sub(b, a), a);
+            all_eq!(simd_saturating_sub(a, a), z);
+            all_eq!(simd_saturating_sub(a, b), c);
+            all_eq!(simd_saturating_sub(z, max), min1);
+            all_eq!(simd_saturating_sub(min1, z), min1);
+            all_eq!(simd_saturating_sub(min1, a), min);
+            all_eq!(simd_saturating_sub(min1, b), min);
         }
     }
 }

--- a/tests/ui/simd/intrinsic/generic-as.rs
+++ b/tests/ui/simd/intrinsic/generic-as.rs
@@ -7,40 +7,43 @@ use std::intrinsics::simd::simd_as;
 #[derive(Copy, Clone)]
 #[repr(simd)]
 struct V<T>([T; 2]);
+impl<T> V<T> {
+    fn to_array(self) -> [T; 2] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 fn main() {
     unsafe {
         let u = V::<u32>([u32::MIN, u32::MAX]);
         let i: V<i16> = simd_as(u);
-        assert_eq!(i.0[0], u.0[0] as i16);
-        assert_eq!(i.0[1], u.0[1] as i16);
+        assert_eq!(i.to_array()[0], u.to_array()[0] as i16);
+        assert_eq!(i.to_array()[1], u.to_array()[1] as i16);
     }
 
     unsafe {
         let f = V::<f32>([f32::MIN, f32::MAX]);
         let i: V<i16> = simd_as(f);
-        assert_eq!(i.0[0], f.0[0] as i16);
-        assert_eq!(i.0[1], f.0[1] as i16);
+        assert_eq!(i.to_array()[0], f.to_array()[0] as i16);
+        assert_eq!(i.to_array()[1], f.to_array()[1] as i16);
     }
 
     unsafe {
         let f = V::<f32>([f32::MIN, f32::MAX]);
         let u: V<u8> = simd_as(f);
-        assert_eq!(u.0[0], f.0[0] as u8);
-        assert_eq!(u.0[1], f.0[1] as u8);
+        assert_eq!(u.to_array()[0], f.to_array()[0] as u8);
+        assert_eq!(u.to_array()[1], f.to_array()[1] as u8);
     }
 
     unsafe {
         let f = V::<f64>([f64::MIN, f64::MAX]);
         let i: V<isize> = simd_as(f);
-        assert_eq!(i.0[0], f.0[0] as isize);
-        assert_eq!(i.0[1], f.0[1] as isize);
+        assert_eq!(i.to_array()[0], f.to_array()[0] as isize);
+        assert_eq!(i.to_array()[1], f.to_array()[1] as isize);
     }
 
     unsafe {
         let f = V::<f64>([f64::MIN, f64::MAX]);
         let u: V<usize> = simd_as(f);
-        assert_eq!(u.0[0], f.0[0] as usize);
-        assert_eq!(u.0[1], f.0[1] as usize);
+        assert_eq!(u.to_array()[0], f.to_array()[0] as usize);
+        assert_eq!(u.to_array()[1], f.to_array()[1] as usize);
     }
 }

--- a/tests/ui/simd/intrinsic/generic-bswap-byte.rs
+++ b/tests/ui/simd/intrinsic/generic-bswap-byte.rs
@@ -7,14 +7,20 @@ use std::intrinsics::simd::simd_bswap;
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct i8x4([i8; 4]);
+impl i8x4 {
+    fn to_array(self) -> [i8; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct u8x4([u8; 4]);
+impl u8x4 {
+    fn to_array(self) -> [u8; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 fn main() {
     unsafe {
-        assert_eq!(simd_bswap(i8x4([0, 1, 2, 3])).0, [0, 1, 2, 3]);
-        assert_eq!(simd_bswap(u8x4([0, 1, 2, 3])).0, [0, 1, 2, 3]);
+        assert_eq!(simd_bswap(i8x4([0, 1, 2, 3])).to_array(), [0, 1, 2, 3]);
+        assert_eq!(simd_bswap(u8x4([0, 1, 2, 3])).to_array(), [0, 1, 2, 3]);
     }
 }

--- a/tests/ui/simd/intrinsic/generic-cast-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-cast-pass.rs
@@ -9,27 +9,30 @@ use std::cmp::{max, min};
 #[derive(Copy, Clone)]
 #[repr(simd)]
 struct V<T>([T; 2]);
+impl<T> V<T> {
+    fn to_array(self) -> [T; 2] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 fn main() {
     unsafe {
         let u = V::<u32>([i16::MIN as u32, i16::MAX as u32]);
         let i: V<i16> = simd_cast(u);
-        assert_eq!(i.0[0], u.0[0] as i16);
-        assert_eq!(i.0[1], u.0[1] as i16);
+        assert_eq!(i.to_array()[0], u.to_array()[0] as i16);
+        assert_eq!(i.to_array()[1], u.to_array()[1] as i16);
     }
 
     unsafe {
         let f = V::<f32>([i16::MIN as f32, i16::MAX as f32]);
         let i: V<i16> = simd_cast(f);
-        assert_eq!(i.0[0], f.0[0] as i16);
-        assert_eq!(i.0[1], f.0[1] as i16);
+        assert_eq!(i.to_array()[0], f.to_array()[0] as i16);
+        assert_eq!(i.to_array()[1], f.to_array()[1] as i16);
     }
 
     unsafe {
         let f = V::<f32>([u8::MIN as f32, u8::MAX as f32]);
         let u: V<u8> = simd_cast(f);
-        assert_eq!(u.0[0], f.0[0] as u8);
-        assert_eq!(u.0[1], f.0[1] as u8);
+        assert_eq!(u.to_array()[0], f.to_array()[0] as u8);
+        assert_eq!(u.to_array()[1], f.to_array()[1] as u8);
     }
 
     unsafe {
@@ -40,8 +43,8 @@ fn main() {
             min(isize::MAX, i32::MAX as isize) as f64,
         ]);
         let i: V<isize> = simd_cast(f);
-        assert_eq!(i.0[0], f.0[0] as isize);
-        assert_eq!(i.0[1], f.0[1] as isize);
+        assert_eq!(i.to_array()[0], f.to_array()[0] as isize);
+        assert_eq!(i.to_array()[1], f.to_array()[1] as isize);
     }
 
     unsafe {
@@ -50,7 +53,7 @@ fn main() {
             min(usize::MAX, u32::MAX as usize) as f64,
         ]);
         let u: V<usize> = simd_cast(f);
-        assert_eq!(u.0[0], f.0[0] as usize);
-        assert_eq!(u.0[1], f.0[1] as usize);
+        assert_eq!(u.to_array()[0], f.to_array()[0] as usize);
+        assert_eq!(u.to_array()[1], f.to_array()[1] as usize);
     }
 }

--- a/tests/ui/simd/intrinsic/generic-cast-pointer-width.rs
+++ b/tests/ui/simd/intrinsic/generic-cast-pointer-width.rs
@@ -6,13 +6,20 @@ use std::intrinsics::simd::simd_cast;
 #[derive(Copy, Clone)]
 #[repr(simd)]
 struct V<T>([T; 4]);
+impl<T> V<T> {
+    fn to_array(self) -> [T; 4] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 fn main() {
     let u = V::<usize>([0, 1, 2, 3]);
     let uu32: V<u32> = unsafe { simd_cast(u) };
     let ui64: V<i64> = unsafe { simd_cast(u) };
 
-    for (u, (uu32, ui64)) in u.0.iter().zip(uu32.0.iter().zip(ui64.0.iter())) {
+    for (u, (uu32, ui64)) in u
+        .to_array()
+        .iter()
+        .zip(uu32.to_array().iter().zip(ui64.to_array().iter()))
+    {
         assert_eq!(*u as u32, *uu32);
         assert_eq!(*u as i64, *ui64);
     }

--- a/tests/ui/simd/intrinsic/generic-comparison-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-comparison-pass.rs
@@ -10,21 +10,34 @@ use std::intrinsics::simd::{simd_eq, simd_ge, simd_gt, simd_le, simd_lt, simd_ne
 struct i32x4([i32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct u32x4(pub [u32; 4]);
+struct u32x4([u32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct f32x4(pub [f32; 4]);
+struct f32x4([f32; 4]);
+
+impl i32x4 {
+    fn to_array(self) -> [i32; 4] { unsafe { std::mem::transmute(self) } }
+}
+impl u32x4 {
+    fn to_array(self) -> [u32; 4] { unsafe { std::mem::transmute(self) } }
+}
+impl f32x4 {
+    fn to_array(self) -> [f32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 macro_rules! cmp {
     ($method: ident($lhs: expr, $rhs: expr)) => {{
         let lhs = $lhs;
         let rhs = $rhs;
         let e: u32x4 = concat_idents!(simd_, $method)($lhs, $rhs);
+        let lhs = lhs.to_array();
+        let rhs = rhs.to_array();
+        let e = e.to_array();
         // assume the scalar version is correct/the behaviour we want.
-        assert!((e.0[0] != 0) == lhs.0[0].$method(&rhs.0[0]));
-        assert!((e.0[1] != 0) == lhs.0[1].$method(&rhs.0[1]));
-        assert!((e.0[2] != 0) == lhs.0[2].$method(&rhs.0[2]));
-        assert!((e.0[3] != 0) == lhs.0[3].$method(&rhs.0[3]));
+        assert!((e[0] != 0) == lhs[0].$method(&rhs[0]));
+        assert!((e[1] != 0) == lhs[1].$method(&rhs[1]));
+        assert!((e[2] != 0) == lhs[2].$method(&rhs[2]));
+        assert!((e[3] != 0) == lhs[3].$method(&rhs[3]));
     }};
 }
 macro_rules! tests {

--- a/tests/ui/simd/intrinsic/generic-elements-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-elements-pass.rs
@@ -8,22 +8,46 @@ use std::intrinsics::simd::{simd_extract, simd_insert, simd_shuffle};
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 struct i32x2([i32; 2]);
+impl ToArray for i32x2 {
+    type T = [i32; 2];
+    fn to_array(self) -> [i32; 2] { unsafe { std::mem::transmute(self) } }
+}
+
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 struct i32x4([i32; 4]);
+impl ToArray for i32x4 {
+    type T = [i32; 4];
+    fn to_array(self) -> [i32; 4] { unsafe { std::mem::transmute(self) } }
+}
+
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 struct i32x8([i32; 8]);
+impl ToArray for i32x8 {
+    type T = [i32; 8];
+    fn to_array(self) -> [i32; 8] { unsafe { std::mem::transmute(self) } }
+}
+
+impl ToArray for i32 {
+    type T = [i32; 1];
+    fn to_array(self) -> [i32; 1] { [self] }
+}
 
 #[repr(simd)]
 struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
 
+trait ToArray {
+    type T: Copy;
+    fn to_array(self) -> Self::T;
+}
+
 macro_rules! all_eq {
     ($a: expr, $b: expr) => {{
-        let a = $a;
-        let b = $b;
+        let [b, a] = [$b, $a];
+        let [b, a] = [b.to_array(), a.to_array()];
         // type inference works better with the concrete type on the
         // left, but humans work better with the expected on the
         // right.

--- a/tests/ui/simd/intrinsic/generic-gather-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-gather-pass.rs
@@ -9,8 +9,12 @@
 use std::intrinsics::simd::{simd_gather, simd_scatter};
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct x4<T>(pub [T; 4]);
+
+impl<T> x4<T> {
+    fn to_array(self) -> [T; 4] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 fn main() {
     let mut x = [0_f32, 1., 2., 3., 4., 5., 6., 7.];
@@ -27,7 +31,7 @@ fn main() {
 
         let r_strided = simd_gather(default, pointers, mask);
 
-        assert_eq!(r_strided, s_strided);
+        assert_eq!(r_strided.to_array(), s_strided.to_array());
     }
 
     // reading from *mut
@@ -38,7 +42,7 @@ fn main() {
 
         let r_strided = simd_gather(default, pointers, mask);
 
-        assert_eq!(r_strided, s_strided);
+        assert_eq!(r_strided.to_array(), s_strided.to_array());
     }
 
     // writing to *mut
@@ -76,7 +80,7 @@ fn main() {
 
         let r_strided = simd_gather(default, pointers, mask);
 
-        assert_eq!(r_strided, s_strided);
+        assert_eq!(r_strided.to_array(), s_strided.to_array());
     }
 
     // reading from *mut
@@ -87,7 +91,7 @@ fn main() {
 
         let r_strided = simd_gather(default, pointers, mask);
 
-        assert_eq!(r_strided, s_strided);
+        assert_eq!(r_strided.to_array(), s_strided.to_array());
     }
 
     // writing to *mut

--- a/tests/ui/simd/intrinsic/generic-select-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-select-pass.rs
@@ -9,24 +9,47 @@
 use std::intrinsics::simd::{simd_select, simd_select_bitmask};
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct i32x4(pub [i32; 4]);
+impl i32x4 {
+    fn to_array(self) -> [i32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct u32x4(pub [u32; 4]);
+impl u32x4 {
+    fn to_array(self) -> [u32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct u32x8([u32; 8]);
+impl u32x8 {
+    fn to_array(self) -> [u32; 8] { unsafe { std::mem::transmute(self) } }
+}
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct f32x4(pub [f32; 4]);
+impl f32x4 {
+    fn to_array(self) -> [f32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct b8x4(pub [i8; 4]);
+impl b8x4 {
+    fn to_array(self) -> [i8; 4] { unsafe { std::mem::transmute(self) } }
+}
+
+macro_rules! all_eq {
+    ($a: expr, $b: expr) => {{
+        let a = $a;
+        let b = $b;
+        assert_eq!(a.to_array(), b.to_array());
+    }};
+}
 
 fn main() {
     let m0 = b8x4([!0, !0, !0, !0]);
@@ -41,23 +64,23 @@ fn main() {
 
         let r: i32x4 = simd_select(m0, a, b);
         let e = a;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: i32x4 = simd_select(m1, a, b);
         let e = b;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: i32x4 = simd_select(m2, a, b);
         let e = i32x4([1, -2, -7, 8]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: i32x4 = simd_select(m3, a, b);
         let e = i32x4([5, 6, 3, 4]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: i32x4 = simd_select(m4, a, b);
         let e = i32x4([1, 6, 3, 8]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
     }
 
     unsafe {
@@ -66,23 +89,23 @@ fn main() {
 
         let r: u32x4 = simd_select(m0, a, b);
         let e = a;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x4 = simd_select(m1, a, b);
         let e = b;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x4 = simd_select(m2, a, b);
         let e = u32x4([1, 2, 7, 8]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x4 = simd_select(m3, a, b);
         let e = u32x4([5, 6, 3, 4]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x4 = simd_select(m4, a, b);
         let e = u32x4([1, 6, 3, 8]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
     }
 
     unsafe {
@@ -91,23 +114,23 @@ fn main() {
 
         let r: f32x4 = simd_select(m0, a, b);
         let e = a;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: f32x4 = simd_select(m1, a, b);
         let e = b;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: f32x4 = simd_select(m2, a, b);
         let e = f32x4([1., 2., 7., 8.]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: f32x4 = simd_select(m3, a, b);
         let e = f32x4([5., 6., 3., 4.]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: f32x4 = simd_select(m4, a, b);
         let e = f32x4([1., 6., 3., 8.]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
     }
 
     unsafe {
@@ -118,23 +141,23 @@ fn main() {
 
         let r: b8x4 = simd_select(m0, a, b);
         let e = a;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: b8x4 = simd_select(m1, a, b);
         let e = b;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: b8x4 = simd_select(m2, a, b);
         let e = b8x4([t, f, f, t]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: b8x4 = simd_select(m3, a, b);
         let e = b8x4([f, f, t, f]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: b8x4 = simd_select(m4, a, b);
         let e = b8x4([t, f, t, t]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
     }
 
     unsafe {
@@ -143,23 +166,23 @@ fn main() {
 
         let r: u32x8 = simd_select_bitmask(0u8, a, b);
         let e = b;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x8 = simd_select_bitmask(0xffu8, a, b);
         let e = a;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x8 = simd_select_bitmask(0b01010101u8, a, b);
         let e = u32x8([0, 9, 2, 11, 4, 13, 6, 15]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x8 = simd_select_bitmask(0b10101010u8, a, b);
         let e = u32x8([8, 1, 10, 3, 12, 5, 14, 7]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x8 = simd_select_bitmask(0b11110000u8, a, b);
         let e = u32x8([8, 9, 10, 11, 4, 5, 6, 7]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
     }
 
     unsafe {
@@ -168,22 +191,22 @@ fn main() {
 
         let r: u32x4 = simd_select_bitmask(0u8, a, b);
         let e = b;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x4 = simd_select_bitmask(0xfu8, a, b);
         let e = a;
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x4 = simd_select_bitmask(0b0101u8, a, b);
         let e = u32x4([0, 5, 2, 7]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x4 = simd_select_bitmask(0b1010u8, a, b);
         let e = u32x4([4, 1, 6, 3]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
 
         let r: u32x4 = simd_select_bitmask(0b1100u8, a, b);
         let e = u32x4([4, 5, 2, 3]);
-        assert_eq!(r, e);
+        all_eq!(r, e);
     }
 }

--- a/tests/ui/simd/intrinsic/inlining-issue67557.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557.rs
@@ -8,8 +8,11 @@
 use std::intrinsics::simd::simd_shuffle;
 
 #[repr(simd)]
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone)]
 struct Simd2([u8; 2]);
+impl Simd2 {
+    fn to_array(self) -> [u8; 2] { unsafe { std::mem::transmute(self) } }
+}
 
 #[repr(simd)]
 struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
@@ -27,12 +30,12 @@ fn main() {
 
 #[inline(never)]
 fn assert_10_11(x: Simd2) {
-    assert_eq!(x, Simd2([10, 11]));
+    assert_eq!(x.to_array(), Simd2([10, 11]).to_array());
 }
 
 #[inline(never)]
 fn assert_10_13(x: Simd2) {
-    assert_eq!(x, Simd2([10, 13]));
+    assert_eq!(x.to_array(), Simd2([10, 13]).to_array());
 }
 
 #[inline(always)]

--- a/tests/ui/simd/intrinsic/ptr-cast.rs
+++ b/tests/ui/simd/intrinsic/ptr-cast.rs
@@ -7,6 +7,9 @@ use std::intrinsics::simd::{simd_cast_ptr, simd_expose_provenance, simd_with_exp
 #[derive(Copy, Clone)]
 #[repr(simd)]
 struct V<T>([T; 2]);
+impl<T> V<T> {
+    fn to_array(self) -> [T; 2] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 fn main() {
     unsafe {
@@ -22,8 +25,8 @@ fn main() {
 
         let with_exposed_provenance: V<*mut i8> = simd_with_exposed_provenance(exposed_addr);
 
-        assert!(const_ptrs.0 == [ptr as *const u8, core::ptr::null()]);
-        assert!(exposed_addr.0 == [ptr as usize, 0]);
-        assert!(with_exposed_provenance.0 == ptrs.0);
+        assert!(const_ptrs.to_array() == [ptr as *const u8, core::ptr::null()]);
+        assert!(exposed_addr.to_array() == [ptr as usize, 0]);
+        assert!(with_exposed_provenance.to_array() == ptrs.to_array());
     }
 }

--- a/tests/ui/simd/issue-39720.rs
+++ b/tests/ui/simd/issue-39720.rs
@@ -3,15 +3,19 @@
 #![feature(repr_simd, core_intrinsics)]
 
 #[repr(simd)]
-#[derive(Copy, Clone, Debug)]
-pub struct Char3(pub [i8; 3]);
+#[derive(Copy, Clone)]
+pub struct Char3([i8; 3]);
 
 #[repr(simd)]
-#[derive(Copy, Clone, Debug)]
-pub struct Short3(pub [i16; 3]);
+#[derive(Copy, Clone)]
+pub struct Short3([i16; 3]);
 
 fn main() {
     let cast: Short3 = unsafe { std::intrinsics::simd::simd_cast(Char3([10, -3, -9])) };
 
+    // It's unclear what, if anything, this test was testing because #137108
+    // showed that projecting into non-power-of-two types (as this was
+    // originally doing) just wasn't working despite it.
+    let cast = unsafe { &*std::ptr::from_ref(&cast).cast::<[i16; 3]>() };
     println!("{:?}", cast);
 }

--- a/tests/ui/simd/issue-85915-simd-ptrs.rs
+++ b/tests/ui/simd/issue-85915-simd-ptrs.rs
@@ -9,19 +9,22 @@
 use std::intrinsics::simd::{simd_gather, simd_scatter};
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct cptrx4<T>([*const T; 4]);
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct mptrx4<T>([*mut T; 4]);
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct f32x4([f32; 4]);
+impl f32x4 {
+    fn to_array(self) -> [f32; 4] { unsafe { std::mem::transmute(self) } }
+}
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct i32x4([i32; 4]);
 
 fn main() {
@@ -43,7 +46,7 @@ fn main() {
 
         let r_strided = simd_gather(default, pointers, mask);
 
-        assert_eq!(r_strided, s_strided);
+        assert_eq!(r_strided.to_array(), s_strided.to_array());
     }
 
     // writing to *mut

--- a/tests/ui/simd/issue-89193.rs
+++ b/tests/ui/simd/issue-89193.rs
@@ -9,8 +9,11 @@
 use std::intrinsics::simd::simd_gather;
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone)]
 struct x4<T>(pub [T; 4]);
+impl<T> x4<T> {
+    fn to_array(self) -> [T; 4] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 fn main() {
     let x: [usize; 4] = [10, 11, 12, 13];
@@ -24,7 +27,7 @@ fn main() {
         let pointers =
             x4([pointer.offset(0), pointer.offset(1), pointer.offset(2), pointer.offset(3)]);
         let result = simd_gather(default, pointers, mask);
-        assert_eq!(result, expected);
+        assert_eq!(result.to_array(), expected.to_array());
     }
 
     // and again for isize
@@ -37,6 +40,6 @@ fn main() {
         let pointers =
             x4([pointer.offset(0), pointer.offset(1), pointer.offset(2), pointer.offset(3)]);
         let result = simd_gather(default, pointers, mask);
-        assert_eq!(result, expected);
+        assert_eq!(result.to_array(), expected.to_array());
     }
 }

--- a/tests/ui/simd/masked-load-store.rs
+++ b/tests/ui/simd/masked-load-store.rs
@@ -7,6 +7,10 @@ use std::intrinsics::simd::{simd_masked_load, simd_masked_store};
 #[repr(simd)]
 struct Simd<T, const N: usize>([T; N]);
 
+impl<T, const N: usize> Simd<T, N> {
+    fn to_array(self) -> [T; N] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
+
 fn main() {
     unsafe {
         let a = Simd::<u8, 4>([0, 1, 2, 3]);
@@ -15,7 +19,7 @@ fn main() {
         let b: Simd<u8, 4> =
             simd_masked_load(Simd::<i8, 4>([-1, 0, -1, -1]), b_src.as_ptr(), b_default);
 
-        assert_eq!(&b.0, &[4, 9, 6, 7]);
+        assert_eq!(b.to_array(), [4, 9, 6, 7]);
 
         let mut output = [u8::MAX; 5];
 

--- a/tests/ui/simd/monomorphize-shuffle-index.generic.stderr
+++ b/tests/ui/simd/monomorphize-shuffle-index.generic.stderr
@@ -1,5 +1,5 @@
 error: overly complex generic constant
-  --> $DIR/monomorphize-shuffle-index.rs:36:51
+  --> $DIR/monomorphize-shuffle-index.rs:39:51
    |
 LL |         return simd_shuffle_const_generic::<_, _, { &Self::I.0 }>(a, b);
    |                                                   ^^----------^^

--- a/tests/ui/simd/monomorphize-shuffle-index.rs
+++ b/tests/ui/simd/monomorphize-shuffle-index.rs
@@ -21,6 +21,9 @@ unsafe fn simd_shuffle_const_generic<T, U, const I: &'static [u32]>(a: T, b: T) 
 #[derive(Copy, Clone)]
 #[repr(simd)]
 struct Simd<T, const N: usize>([T; N]);
+impl<T, const N: usize> Simd<T, N> {
+    const fn to_array(self) -> [T; N] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
 
 trait Shuffle<const N: usize> {
     const I: Simd<u32, N>;
@@ -57,9 +60,9 @@ fn main() {
     let b = Simd::<u8, 4>([4, 5, 6, 7]);
     unsafe {
         let x: Simd<u8, 4> = I1.shuffle(a, b);
-        assert_eq!(x.0, [0, 2, 4, 6]);
+        assert_eq!(x.to_array(), [0, 2, 4, 6]);
 
         let y: Simd<u8, 2> = I2.shuffle(a, b);
-        assert_eq!(y.0, [1, 5]);
+        assert_eq!(y.to_array(), [1, 5]);
     }
 }

--- a/tests/ui/simd/repr_packed.rs
+++ b/tests/ui/simd/repr_packed.rs
@@ -42,7 +42,6 @@ fn main() {
         // non-powers-of-two should have padding (which is removed by #[repr(packed)]),
         // but the intrinsic handles it
         let x: Simd<f64, 3> = simd_add(Simd::<f64, 3>([0., 1., 2.]), Simd::<f64, 3>([2., 2., 2.]));
-        let arr: [f64; 3] = x.0;
-        assert_eq!(arr, [2., 3., 4.]);
+        assert_eq!(std::mem::transmute::<_, [f64; 3]>(x), [2., 3., 4.]);
     }
 }

--- a/tests/ui/simd/simd-bitmask-notpow2.rs
+++ b/tests/ui/simd/simd-bitmask-notpow2.rs
@@ -10,12 +10,13 @@ fn main() {
     // Non-power-of-2 multi-byte mask.
     #[repr(simd, packed)]
     #[allow(non_camel_case_types)]
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Copy, Clone)]
     struct i32x10([i32; 10]);
     impl i32x10 {
         fn splat(x: i32) -> Self {
             Self([x; 10])
         }
+        fn to_array(self) -> [i32; 10] { unsafe { std::mem::transmute(self) } }
     }
     unsafe {
         let mask = i32x10([!0, !0, 0, !0, 0, 0, !0, 0, !0, 0]);
@@ -38,19 +39,20 @@ fn main() {
             i32x10::splat(!0), // yes
             i32x10::splat(0),  // no
         );
-        assert_eq!(selected1, mask);
-        assert_eq!(selected2, mask);
+        assert_eq!(selected1.to_array(), mask.to_array());
+        assert_eq!(selected2.to_array(), mask.to_array());
     }
 
     // Test for a mask where the next multiple of 8 is not a power of two.
     #[repr(simd, packed)]
     #[allow(non_camel_case_types)]
-    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[derive(Copy, Clone)]
     struct i32x20([i32; 20]);
     impl i32x20 {
         fn splat(x: i32) -> Self {
             Self([x; 20])
         }
+        fn to_array(self) -> [i32; 20] { unsafe { std::mem::transmute(self) } }
     }
     unsafe {
         let mask = i32x20([!0, !0, 0, !0, 0, 0, !0, 0, !0, 0, 0, 0, 0, !0, !0, !0, !0, !0, !0, !0]);
@@ -80,7 +82,7 @@ fn main() {
             i32x20::splat(!0), // yes
             i32x20::splat(0),  // no
         );
-        assert_eq!(selected1, mask);
-        assert_eq!(selected2, mask);
+        assert_eq!(selected1.to_array(), mask.to_array());
+        assert_eq!(selected2.to_array(), mask.to_array());
     }
 }

--- a/tests/ui/simd/simd-bitmask.rs
+++ b/tests/ui/simd/simd-bitmask.rs
@@ -7,6 +7,10 @@ use std::intrinsics::simd::{simd_bitmask, simd_select_bitmask};
 #[repr(simd)]
 struct Simd<T, const N: usize>([T; N]);
 
+impl<T, const N: usize> Simd<T, N> {
+    fn to_array(self) -> [T; N] { unsafe { std::intrinsics::transmute_unchecked(self) } }
+}
+
 fn main() {
     unsafe {
         let v = Simd::<i8, 4>([-1, 0, -1, 0]);
@@ -41,11 +45,11 @@ fn main() {
 
         let mask = if cfg!(target_endian = "little") { 0b0101u8 } else { 0b1010u8 };
         let r = simd_select_bitmask(mask, a, b);
-        assert_eq!(r.0, e);
+        assert_eq!(r.to_array(), e);
 
         let mask = if cfg!(target_endian = "little") { [0b0101u8] } else { [0b1010u8] };
         let r = simd_select_bitmask(mask, a, b);
-        assert_eq!(r.0, e);
+        assert_eq!(r.to_array(), e);
 
         let a = Simd::<i32, 16>([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
         let b = Simd::<i32, 16>([16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
@@ -57,7 +61,7 @@ fn main() {
             0b0011000000001010u16
         };
         let r = simd_select_bitmask(mask, a, b);
-        assert_eq!(r.0, e);
+        assert_eq!(r.to_array(), e);
 
         let mask = if cfg!(target_endian = "little") {
             [0b00001100u8, 0b01010000u8]
@@ -65,6 +69,6 @@ fn main() {
             [0b00110000u8, 0b00001010u8]
         };
         let r = simd_select_bitmask(mask, a, b);
-        assert_eq!(r.0, e);
+        assert_eq!(r.to_array(), e);
     }
 }

--- a/tests/ui/simd/target-feature-mixup.rs
+++ b/tests/ui/simd/target-feature-mixup.rs
@@ -12,6 +12,12 @@
 use std::process::{Command, ExitStatus};
 use std::env;
 
+macro_rules! assert_eq_simd {
+    ($a:expr, $b: expr) => {
+        assert_eq!($a.to_array(), $b.to_array());
+    };
+}
+
 fn main() {
     if let Some(level) = env::args().nth(1) {
         return test::main(&level)
@@ -52,18 +58,27 @@ fn is_sigill(status: ExitStatus) -> bool {
 mod test {
     // An SSE type
     #[repr(simd)]
-    #[derive(PartialEq, Debug, Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct __m128i([u64; 2]);
+    impl __m128i {
+        fn to_array(self) -> [u64; 2] { unsafe { std::mem::transmute(self) } }
+    }
 
     // An AVX type
     #[repr(simd)]
-    #[derive(PartialEq, Debug, Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct __m256i([u64; 4]);
+    impl __m256i {
+        fn to_array(self) -> [u64; 4] { unsafe { std::mem::transmute(self) } }
+    }
 
     // An AVX-512 type
     #[repr(simd)]
-    #[derive(PartialEq, Debug, Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct __m512i([u64; 8]);
+    impl __m512i {
+        fn to_array(self) -> [u64; 8] { unsafe { std::mem::transmute(self) } }
+    }
 
     pub fn main(level: &str) {
         unsafe {
@@ -92,23 +107,23 @@ mod test {
                 let m128 = __m128i([1, 2]);
                 let m256 = __m256i([3, 4, 5, 6]);
                 let m512 = __m512i([7, 8, 9, 10, 11, 12, 13, 14]);
-                assert_eq!(id_sse_128(m128), m128);
-                assert_eq!(id_sse_256(m256), m256);
-                assert_eq!(id_sse_512(m512), m512);
+                assert_eq_simd!(id_sse_128(m128), m128);
+                assert_eq_simd!(id_sse_256(m256), m256);
+                assert_eq_simd!(id_sse_512(m512), m512);
 
                 if level == "sse" {
                     return
                 }
-                assert_eq!(id_avx_128(m128), m128);
-                assert_eq!(id_avx_256(m256), m256);
-                assert_eq!(id_avx_512(m512), m512);
+                assert_eq_simd!(id_avx_128(m128), m128);
+                assert_eq_simd!(id_avx_256(m256), m256);
+                assert_eq_simd!(id_avx_512(m512), m512);
 
                 if level == "avx" {
                     return
                 }
-                assert_eq!(id_avx512_128(m128), m128);
-                assert_eq!(id_avx512_256(m256), m256);
-                assert_eq!(id_avx512_512(m512), m512);
+                assert_eq_simd!(id_avx512_128(m128), m128);
+                assert_eq_simd!(id_avx512_256(m256), m256);
+                assert_eq_simd!(id_avx512_512(m512), m512);
             }
         )*)
     }
@@ -126,55 +141,55 @@ mod test {
 
     #[target_feature(enable = "sse2")]
     unsafe fn id_sse_128(a: __m128i) -> __m128i {
-        assert_eq!(a, __m128i([1, 2]));
+        assert_eq_simd!(a, __m128i([1, 2]));
         a.clone()
     }
 
     #[target_feature(enable = "sse2")]
     unsafe fn id_sse_256(a: __m256i) -> __m256i {
-        assert_eq!(a, __m256i([3, 4, 5, 6]));
+        assert_eq_simd!(a, __m256i([3, 4, 5, 6]));
         a.clone()
     }
 
     #[target_feature(enable = "sse2")]
     unsafe fn id_sse_512(a: __m512i) -> __m512i {
-        assert_eq!(a, __m512i([7, 8, 9, 10, 11, 12, 13, 14]));
+        assert_eq_simd!(a, __m512i([7, 8, 9, 10, 11, 12, 13, 14]));
         a.clone()
     }
 
     #[target_feature(enable = "avx")]
     unsafe fn id_avx_128(a: __m128i) -> __m128i {
-        assert_eq!(a, __m128i([1, 2]));
+        assert_eq_simd!(a, __m128i([1, 2]));
         a.clone()
     }
 
     #[target_feature(enable = "avx")]
     unsafe fn id_avx_256(a: __m256i) -> __m256i {
-        assert_eq!(a, __m256i([3, 4, 5, 6]));
+        assert_eq_simd!(a, __m256i([3, 4, 5, 6]));
         a.clone()
     }
 
     #[target_feature(enable = "avx")]
     unsafe fn id_avx_512(a: __m512i) -> __m512i {
-        assert_eq!(a, __m512i([7, 8, 9, 10, 11, 12, 13, 14]));
+        assert_eq_simd!(a, __m512i([7, 8, 9, 10, 11, 12, 13, 14]));
         a.clone()
     }
 
     #[target_feature(enable = "avx512bw")]
     unsafe fn id_avx512_128(a: __m128i) -> __m128i {
-        assert_eq!(a, __m128i([1, 2]));
+        assert_eq_simd!(a, __m128i([1, 2]));
         a.clone()
     }
 
     #[target_feature(enable = "avx512bw")]
     unsafe fn id_avx512_256(a: __m256i) -> __m256i {
-        assert_eq!(a, __m256i([3, 4, 5, 6]));
+        assert_eq_simd!(a, __m256i([3, 4, 5, 6]));
         a.clone()
     }
 
     #[target_feature(enable = "avx512bw")]
     unsafe fn id_avx512_512(a: __m512i) -> __m512i {
-        assert_eq!(a, __m512i([7, 8, 9, 10, 11, 12, 13, 14]));
+        assert_eq_simd!(a, __m512i([7, 8, 9, 10, 11, 12, 13, 14]));
         a.clone()
     }
 }


### PR DESCRIPTION
Part of [MCP838](https://github.com/rust-lang/compiler-team/issues/838)

This intentionally leaves projections in two places, as a double-check that what stdarch is still using (for now) continues to work
- https://github.com/rust-lang/rust/blob/master/tests/ui/simd/issue-105439.rs
- https://github.com/rust-lang/rust/blob/master/tests/codegen/simd/project-to-simd-array-field.rs

But the things that aren't testing that change to not using `.0` on the `repr(simd)` type.
