### PR TITLE
bootstrap and compiletest: Use `size_of_val` from the prelude instead of imported

### DIFF
--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -349,7 +349,7 @@ fn format_rusage_data(child: Child) -> Option<String> {
     let mut kernel_filetime = Default::default();
     let mut kernel_time = Default::default();
     let mut memory_counters = PROCESS_MEMORY_COUNTERS::default();
-    let memory_counters_size = std::mem::size_of_val(&memory_counters);
+    let memory_counters_size = size_of_val(&memory_counters);
 
     unsafe {
         GetProcessTimes(

--- a/src/bootstrap/src/utils/job.rs
+++ b/src/bootstrap/src/utils/job.rs
@@ -42,7 +42,7 @@ pub unsafe fn setup(build: &mut crate::Build) {
 #[cfg(windows)]
 mod for_windows {
     use std::ffi::c_void;
-    use std::{io, mem};
+    use std::io;
 
     use windows::Win32::Foundation::CloseHandle;
     use windows::Win32::System::Diagnostics::Debug::{
@@ -82,7 +82,7 @@ mod for_windows {
             job,
             JobObjectExtendedLimitInformation,
             &info as *const _ as *const c_void,
-            mem::size_of_val(&info) as u32,
+            size_of_val(&info) as u32,
         );
         assert!(r.is_ok(), "{}", io::Error::last_os_error());
 

--- a/src/tools/compiletest/src/raise_fd_limit.rs
+++ b/src/tools/compiletest/src/raise_fd_limit.rs
@@ -7,7 +7,6 @@
 #[cfg(target_vendor = "apple")]
 #[allow(non_camel_case_types)]
 pub unsafe fn raise_fd_limit() {
-    use std::mem::size_of_val;
     use std::ptr::null_mut;
     use std::{cmp, io};
 


### PR DESCRIPTION
Use `std::mem::size_of_val` from the prelude instead of importing or qualifying it.

This function was added to all preludes in Rust 1.80.

r? @jieyouxu