### PR TITLE
trim channel value in `get_closest_merge_commit`

### DIFF
--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -129,7 +129,7 @@ pub fn get_closest_merge_commit(
         git.current_dir(git_dir);
     }
 
-    let channel = include_str!("../../ci/channel");
+    let channel = include_str!("../../ci/channel").trim();
 
     let merge_base = {
         if CiEnv::is_ci() &&


### PR DESCRIPTION
This was a silly bug which caused `git_upstream_merge_base` to never work because it was `nightly\n` not `nightly`.