### PR TITLE
strip `-Wlinker-messages` wrappers from `rust-lld` rmake test

### DIFF
--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -60,7 +60,8 @@ fn main() {
 }
 
 fn find_lld_version_in_logs(stderr: String) -> bool {
-    let lld_version_re =
-        Regex::new(r"^warning: linker std(out|err): LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
+    // Strip the `-Wlinker-messages` wrappers prefixing the linker output.
+    let stderr = Regex::new(r"warning: linker std(out|err):").unwrap().replace_all(&stderr, "");
+    let lld_version_re = Regex::new(r"^LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
     stderr.lines().any(|line| lld_version_re.is_match(line.trim()))
 }


### PR DESCRIPTION
The `tests/run-make/rust-lld` rmake test is failing locally on my M1, due to linker messages being in a different shape than the test expects: it asserts that the LLD version is the first linker message, which is seemingly not always the case on osx I guess.

```console
thread 'main' panicked at /Users/lqd/rust/lqd-rust/tests/run-make/rust-lld/rmake.rs:24:5:
the LLD version string should be present in the output logs:
warning: linker stderr: rust-lld: directory not found for option -L/usr/local/lib
         LLD 20.1.0 (https://github.com/rust-lang/llvm-project.git 1c3bb96fdb6db7b8e8f24edb016099c223fdd27e)
         Library search paths:
             /Users/lqd/rust/lqd-rust/build/aarch64-apple-darwin/test/run-make/rust-lld/rmake_out
             /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib
         Framework search paths:
             /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks
```

This PR normalizes away the `-Wlinker-messages` wrappers around the linker output, to remove the requirement that the linker version is the first linker message / is prefixed with the warning wrapper in the regex.

(also another strange thing to explain the pre-existing regex: it seems the LLD version is sometimes output on stderr sometimes on stdout cool stuff)

We could do this for the other lld rmake tests, but they're only enabled on x64 linux so less likely to have random linker messages appearing without anyone noticing.