### PR TITLE
triagebot: add a `compiler_leads` ad-hoc group

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1096,6 +1096,10 @@ title = "[stable"
 branch = "stable"
 
 [assign.adhoc_groups]
+compiler_leads = [
+    "@davidtwco",
+    "@wesleywiser",
+]
 compiler = [
     "@BoxyUwU",
     "@cjgillot",


### PR DESCRIPTION
Intended for e.g. rolling reviewers for [adding new targets](https://forge.rust-lang.org/compiler/proposals-and-stabilization.html#targets).

rust-lang/rust-forge side doc update: https://github.com/rust-lang/rust-forge/pull/815

r? ghost (for testing)

cc @davidtwco or @wesleywiser