### PR TITLE
Enable Non-determinism of float operations in Miri and change std tests 

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1879,7 +1879,7 @@ pub mod math {
     ///
     /// let x = 2.0_f32;
     /// let abs_difference = (f32::math::powi(x, 2) - (x * x)).abs();
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 1e-5);
     ///
     /// assert_eq!(f32::math::powi(f32::NAN, 0), 1.0);
     /// ```

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1877,7 +1877,7 @@ pub mod math {
     ///
     /// let x = 2.0_f64;
     /// let abs_difference = (f64::math::powi(x, 2) - (x * x)).abs();
-    /// assert!(abs_difference <= f64::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     ///
     /// assert_eq!(f64::math::powi(f64::NAN, 0), 1.0);
     /// ```

--- a/library/coretests/tests/floats/f32.rs
+++ b/library/coretests/tests/floats/f32.rs
@@ -23,6 +23,11 @@ const NAN_MASK1: u32 = 0x002a_aaaa;
 /// Second pattern over the mantissa
 const NAN_MASK2: u32 = 0x0055_5555;
 
+/// Miri adds some extra errors to float functions; make sure the tests still pass.
+/// These values are purely used as a canary to test against and are thus not a stable guarantee Rust provides.
+/// They serve as a way to get an idea of the real precision of floating point operations on different platforms.
+const APPROX_DELTA: f32 = if cfg!(miri) { 1e-4 } else { 1e-6 };
+
 #[test]
 fn test_num_f32() {
     super::test_num(10f32, 2f32);
@@ -437,8 +442,8 @@ fn test_powi() {
     let nan: f32 = f32::NAN;
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
-    assert_biteq!(1.0f32.powi(1), 1.0);
-    assert_approx_eq!((-3.1f32).powi(2), 9.61);
+    assert_approx_eq!(1.0f32.powi(1), 1.0);
+    assert_approx_eq!((-3.1f32).powi(2), 9.61, APPROX_DELTA);
     assert_approx_eq!(5.9f32.powi(-2), 0.028727);
     assert_biteq!(8.3f32.powi(0), 1.0);
     assert!(nan.powi(2).is_nan());

--- a/library/coretests/tests/floats/f64.rs
+++ b/library/coretests/tests/floats/f64.rs
@@ -422,7 +422,7 @@ fn test_powi() {
     let nan: f64 = f64::NAN;
     let inf: f64 = f64::INFINITY;
     let neg_inf: f64 = f64::NEG_INFINITY;
-    assert_biteq!(1.0f64.powi(1), 1.0);
+    assert_approx_eq!(1.0f64.powi(1), 1.0);
     assert_approx_eq!((-3.1f64).powi(2), 9.61);
     assert_approx_eq!(5.9f64.powi(-2), 0.028727);
     assert_biteq!(8.3f64.powi(0), 1.0);

--- a/library/coretests/tests/num/dec2flt/float.rs
+++ b/library/coretests/tests/num/dec2flt/float.rs
@@ -23,7 +23,8 @@ fn test_f16_integer_decode() {
 fn test_f32_integer_decode() {
     assert_eq!(3.14159265359f32.integer_decode(), (13176795, -22, 1));
     assert_eq!((-8573.5918555f32).integer_decode(), (8779358, -10, -1));
-    assert_eq!(2f32.powf(100.0).integer_decode(), (8388608, 77, 1));
+    // Set 2^100 directly instead of using powf, because it doesn't guarentee precision
+    assert_eq!(1.2676506e30_f32.integer_decode(), (8388608, 77, 1));
     assert_eq!(0f32.integer_decode(), (0, -150, 1));
     assert_eq!((-0f32).integer_decode(), (0, -150, -1));
     assert_eq!(f32::INFINITY.integer_decode(), (8388608, 105, 1));
@@ -39,7 +40,8 @@ fn test_f32_integer_decode() {
 fn test_f64_integer_decode() {
     assert_eq!(3.14159265359f64.integer_decode(), (7074237752028906, -51, 1));
     assert_eq!((-8573.5918555f64).integer_decode(), (4713381968463931, -39, -1));
-    assert_eq!(2f64.powf(100.0).integer_decode(), (4503599627370496, 48, 1));
+    // Set 2^100 directly instead of using powf, because it doesn't guarentee precision
+    assert_eq!(1.2676506002282294e30_f64.integer_decode(), (4503599627370496, 48, 1));
     assert_eq!(0f64.integer_decode(), (0, -1075, 1));
     assert_eq!((-0f64).integer_decode(), (0, -1075, -1));
     assert_eq!(f64::INFINITY.integer_decode(), (4503599627370496, 972, 1));

--- a/library/std/src/num/f32.rs
+++ b/library/std/src/num/f32.rs
@@ -304,7 +304,7 @@ impl f32 {
     /// ```
     /// let x = 2.0_f32;
     /// let abs_difference = (x.powi(2) - (x * x)).abs();
-    /// assert!(abs_difference <= 8.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-5);
     ///
     /// assert_eq!(f32::powi(f32::NAN, 0), 1.0);
     /// ```
@@ -328,7 +328,7 @@ impl f32 {
     /// ```
     /// let x = 2.0_f32;
     /// let abs_difference = (x.powf(2.0) - (x * x)).abs();
-    /// assert!(abs_difference <= 8.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-5);
     ///
     /// assert_eq!(f32::powf(1.0, f32::NAN), 1.0);
     /// assert_eq!(f32::powf(f32::NAN, 0.0), 1.0);
@@ -388,7 +388,7 @@ impl f32 {
     /// // ln(e) - 1 == 0
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -413,7 +413,7 @@ impl f32 {
     /// // 2^2 - 4 == 0
     /// let abs_difference = (f.exp2() - 4.0).abs();
     ///
-    /// assert!(abs_difference <= 8.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-5);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -442,7 +442,7 @@ impl f32 {
     /// // ln(e) - 1 == 0
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     /// ```
     ///
     /// Non-positive values:
@@ -479,7 +479,7 @@ impl f32 {
     /// // log5(5) - 1 == 0
     /// let abs_difference = (five.log(5.0) - 1.0).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     /// ```
     ///
     /// Non-positive values:
@@ -512,7 +512,7 @@ impl f32 {
     /// // log2(2) - 1 == 0
     /// let abs_difference = (two.log2() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     /// ```
     ///
     /// Non-positive values:
@@ -545,7 +545,7 @@ impl f32 {
     /// // log10(10) - 1 == 0
     /// let abs_difference = (ten.log10() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     /// ```
     ///
     /// Non-positive values:
@@ -652,7 +652,7 @@ impl f32 {
     /// // sqrt(x^2 + y^2)
     /// let abs_difference = (x.hypot(y) - (x.powi(2) + y.powi(2)).sqrt()).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -676,7 +676,7 @@ impl f32 {
     ///
     /// let abs_difference = (x.sin() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -700,7 +700,7 @@ impl f32 {
     ///
     /// let abs_difference = (x.cos() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -754,7 +754,7 @@ impl f32 {
     /// // asin(sin(pi/2))
     /// let abs_difference = (f.sin().asin() - std::f32::consts::FRAC_PI_2).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 1e-3);
     /// ```
     #[doc(alias = "arcsin")]
     #[rustc_allow_incoherent_impl]
@@ -784,7 +784,7 @@ impl f32 {
     /// // acos(cos(pi/4))
     /// let abs_difference = (f.cos().acos() - std::f32::consts::FRAC_PI_4).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     /// ```
     #[doc(alias = "arccos")]
     #[rustc_allow_incoherent_impl]
@@ -884,8 +884,8 @@ impl f32 {
     /// let abs_difference_0 = (f.0 - x.sin()).abs();
     /// let abs_difference_1 = (f.1 - x.cos()).abs();
     ///
-    /// assert!(abs_difference_0 <= 4.0 * f32::EPSILON);
-    /// assert!(abs_difference_1 <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference_0 <= 1e-6);
+    /// assert!(abs_difference_1 <= 1e-6);
     /// ```
     #[doc(alias = "sincos")]
     #[rustc_allow_incoherent_impl]
@@ -1067,7 +1067,7 @@ impl f32 {
     ///
     /// let abs_difference = (f - x).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-7);
     /// ```
     #[doc(alias = "arcsinh")]
     #[rustc_allow_incoherent_impl]
@@ -1095,7 +1095,7 @@ impl f32 {
     ///
     /// let abs_difference = (f - x).abs();
     ///
-    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference <= 1e-6);
     /// ```
     #[doc(alias = "arccosh")]
     #[rustc_allow_incoherent_impl]

--- a/library/std/src/num/f32.rs
+++ b/library/std/src/num/f32.rs
@@ -304,7 +304,7 @@ impl f32 {
     /// ```
     /// let x = 2.0_f32;
     /// let abs_difference = (x.powi(2) - (x * x)).abs();
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 8.0 * f32::EPSILON);
     ///
     /// assert_eq!(f32::powi(f32::NAN, 0), 1.0);
     /// ```
@@ -328,7 +328,7 @@ impl f32 {
     /// ```
     /// let x = 2.0_f32;
     /// let abs_difference = (x.powf(2.0) - (x * x)).abs();
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 8.0 * f32::EPSILON);
     ///
     /// assert_eq!(f32::powf(1.0, f32::NAN), 1.0);
     /// assert_eq!(f32::powf(f32::NAN, 0.0), 1.0);
@@ -388,7 +388,7 @@ impl f32 {
     /// // ln(e) - 1 == 0
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -413,7 +413,7 @@ impl f32 {
     /// // 2^2 - 4 == 0
     /// let abs_difference = (f.exp2() - 4.0).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 8.0 * f32::EPSILON);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -442,7 +442,7 @@ impl f32 {
     /// // ln(e) - 1 == 0
     /// let abs_difference = (e.ln() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     ///
     /// Non-positive values:
@@ -479,7 +479,7 @@ impl f32 {
     /// // log5(5) - 1 == 0
     /// let abs_difference = (five.log(5.0) - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     ///
     /// Non-positive values:
@@ -512,7 +512,7 @@ impl f32 {
     /// // log2(2) - 1 == 0
     /// let abs_difference = (two.log2() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     ///
     /// Non-positive values:
@@ -545,7 +545,7 @@ impl f32 {
     /// // log10(10) - 1 == 0
     /// let abs_difference = (ten.log10() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     ///
     /// Non-positive values:
@@ -652,7 +652,7 @@ impl f32 {
     /// // sqrt(x^2 + y^2)
     /// let abs_difference = (x.hypot(y) - (x.powi(2) + y.powi(2)).sqrt()).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -676,7 +676,7 @@ impl f32 {
     ///
     /// let abs_difference = (x.sin() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -700,7 +700,7 @@ impl f32 {
     ///
     /// let abs_difference = (x.cos() - 1.0).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
@@ -784,7 +784,7 @@ impl f32 {
     /// // acos(cos(pi/4))
     /// let abs_difference = (f.cos().acos() - std::f32::consts::FRAC_PI_4).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     #[doc(alias = "arccos")]
     #[rustc_allow_incoherent_impl]
@@ -884,8 +884,8 @@ impl f32 {
     /// let abs_difference_0 = (f.0 - x.sin()).abs();
     /// let abs_difference_1 = (f.1 - x.cos()).abs();
     ///
-    /// assert!(abs_difference_0 <= f32::EPSILON);
-    /// assert!(abs_difference_1 <= f32::EPSILON);
+    /// assert!(abs_difference_0 <= 4.0 * f32::EPSILON);
+    /// assert!(abs_difference_1 <= 4.0 * f32::EPSILON);
     /// ```
     #[doc(alias = "sincos")]
     #[rustc_allow_incoherent_impl]
@@ -1067,7 +1067,7 @@ impl f32 {
     ///
     /// let abs_difference = (f - x).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     #[doc(alias = "arcsinh")]
     #[rustc_allow_incoherent_impl]
@@ -1095,7 +1095,7 @@ impl f32 {
     ///
     /// let abs_difference = (f - x).abs();
     ///
-    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(abs_difference <= 4.0 * f32::EPSILON);
     /// ```
     #[doc(alias = "arccosh")]
     #[rustc_allow_incoherent_impl]

--- a/library/std/src/num/f64.rs
+++ b/library/std/src/num/f64.rs
@@ -304,7 +304,7 @@ impl f64 {
     /// ```
     /// let x = 2.0_f64;
     /// let abs_difference = (x.powi(2) - (x * x)).abs();
-    /// assert!(abs_difference <= f64::EPSILON);
+    /// assert!(abs_difference <= 8.0 * f64::EPSILON);
     ///
     /// assert_eq!(f64::powi(f64::NAN, 0), 1.0);
     /// ```
@@ -328,7 +328,7 @@ impl f64 {
     /// ```
     /// let x = 2.0_f64;
     /// let abs_difference = (x.powf(2.0) - (x * x)).abs();
-    /// assert!(abs_difference <= f64::EPSILON);
+    /// assert!(abs_difference <= 8.0 * f64::EPSILON);
     ///
     /// assert_eq!(f64::powf(1.0, f64::NAN), 1.0);
     /// assert_eq!(f64::powf(f64::NAN, 0.0), 1.0);

--- a/library/std/src/num/f64.rs
+++ b/library/std/src/num/f64.rs
@@ -304,7 +304,7 @@ impl f64 {
     /// ```
     /// let x = 2.0_f64;
     /// let abs_difference = (x.powi(2) - (x * x)).abs();
-    /// assert!(abs_difference <= 8.0 * f64::EPSILON);
+    /// assert!(abs_difference <= 1e-14);
     ///
     /// assert_eq!(f64::powi(f64::NAN, 0), 1.0);
     /// ```
@@ -328,7 +328,7 @@ impl f64 {
     /// ```
     /// let x = 2.0_f64;
     /// let abs_difference = (x.powf(2.0) - (x * x)).abs();
-    /// assert!(abs_difference <= 8.0 * f64::EPSILON);
+    /// assert!(abs_difference <= 1e-14);
     ///
     /// assert_eq!(f64::powf(1.0, f64::NAN), 1.0);
     /// assert_eq!(f64::powf(f64::NAN, 0.0), 1.0);
@@ -754,7 +754,7 @@ impl f64 {
     /// // asin(sin(pi/2))
     /// let abs_difference = (f.sin().asin() - std::f64::consts::FRAC_PI_2).abs();
     ///
-    /// assert!(abs_difference < 1e-10);
+    /// assert!(abs_difference < 1e-7);
     /// ```
     #[doc(alias = "arcsin")]
     #[rustc_allow_incoherent_impl]

--- a/library/std/tests/floats/f32.rs
+++ b/library/std/tests/floats/f32.rs
@@ -1,5 +1,10 @@
 use std::f32::consts;
 
+/// Miri adds some extra errors to float functions; make sure the tests still pass.
+/// These values are purely used as a canary to test against and are thus not a stable guarantee Rust provides.
+/// They serve as a way to get an idea of the real precision of floating point operations on different platforms.
+const APPROX_DELTA: f32 = if cfg!(miri) { 1e-4 } else { 1e-6 };
+
 #[allow(unused_macros)]
 macro_rules! assert_f32_biteq {
     ($left : expr, $right : expr) => {
@@ -17,9 +22,17 @@ fn test_powf() {
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
     assert_eq!(1.0f32.powf(1.0), 1.0);
-    assert_approx_eq!(3.4f32.powf(4.5), 246.408218);
+    assert_approx_eq!(
+        3.4f32.powf(4.5),
+        246.408218,
+        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
+    );
     assert_approx_eq!(2.7f32.powf(-3.2), 0.041652);
-    assert_approx_eq!((-3.1f32).powf(2.0), 9.61);
+    assert_approx_eq!(
+        (-3.1f32).powf(2.0),
+        9.61,
+        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
+    );
     assert_approx_eq!(5.9f32.powf(-2.0), 0.028727);
     assert_eq!(8.3f32.powf(0.0), 1.0);
     assert!(nan.powf(2.0).is_nan());
@@ -30,8 +43,12 @@ fn test_powf() {
 #[test]
 fn test_exp() {
     assert_eq!(1.0, 0.0f32.exp());
-    assert_approx_eq!(2.718282, 1.0f32.exp());
-    assert_approx_eq!(148.413162, 5.0f32.exp());
+    assert_approx_eq!(2.718282, 1.0f32.exp(), APPROX_DELTA);
+    assert_approx_eq!(
+        148.413162,
+        5.0f32.exp(),
+        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
+    );
 
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
@@ -43,7 +60,11 @@ fn test_exp() {
 
 #[test]
 fn test_exp2() {
-    assert_eq!(32.0, 5.0f32.exp2());
+    assert_approx_eq!(
+        32.0,
+        5.0f32.exp2(),
+        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
+    );
     assert_eq!(1.0, 0.0f32.exp2());
 
     let inf: f32 = f32::INFINITY;
@@ -66,7 +87,11 @@ fn test_ln() {
     assert!((-2.3f32).ln().is_nan());
     assert_eq!((-0.0f32).ln(), neg_inf);
     assert_eq!(0.0f32.ln(), neg_inf);
-    assert_approx_eq!(4.0f32.ln(), 1.386294);
+    assert_approx_eq!(
+        4.0f32.ln(),
+        1.386294,
+        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
+    );
 }
 
 #[test]
@@ -74,9 +99,9 @@ fn test_log() {
     let nan: f32 = f32::NAN;
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
-    assert_eq!(10.0f32.log(10.0), 1.0);
+    assert_approx_eq!(10.0f32.log(10.0), 1.0);
     assert_approx_eq!(2.3f32.log(3.5), 0.664858);
-    assert_eq!(1.0f32.exp().log(1.0f32.exp()), 1.0);
+    assert_approx_eq!(1.0f32.exp().log(1.0f32.exp()), 1.0);
     assert!(1.0f32.log(1.0).is_nan());
     assert!(1.0f32.log(-13.9).is_nan());
     assert!(nan.log(2.3).is_nan());
@@ -92,9 +117,17 @@ fn test_log2() {
     let nan: f32 = f32::NAN;
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
-    assert_approx_eq!(10.0f32.log2(), 3.321928);
+    assert_approx_eq!(
+        10.0f32.log2(),
+        3.321928,
+        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
+    );
     assert_approx_eq!(2.3f32.log2(), 1.201634);
-    assert_approx_eq!(1.0f32.exp().log2(), 1.442695);
+    assert_approx_eq!(
+        1.0f32.exp().log2(),
+        1.442695,
+        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
+    );
     assert!(nan.log2().is_nan());
     assert_eq!(inf.log2(), inf);
     assert!(neg_inf.log2().is_nan());
@@ -108,7 +141,7 @@ fn test_log10() {
     let nan: f32 = f32::NAN;
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
-    assert_eq!(10.0f32.log10(), 1.0);
+    assert_approx_eq!(10.0f32.log10(), 1.0);
     assert_approx_eq!(2.3f32.log10(), 0.361728);
     assert_approx_eq!(1.0f32.exp().log10(), 0.434294);
     assert_eq!(1.0f32.log10(), 0.0);
@@ -158,7 +191,11 @@ fn test_acosh() {
     assert_approx_eq!(3.0f32.acosh(), 1.76274717403908605046521864995958461f32);
 
     // test for low accuracy from issue 104548
-    assert_approx_eq!(60.0f32, 60.0f32.cosh().acosh());
+    assert_approx_eq!(
+        60.0f32,
+        60.0f32.cosh().acosh(),
+        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
+    );
 }
 
 #[test]
@@ -237,7 +274,11 @@ fn test_real_consts() {
     let ln_10: f32 = consts::LN_10;
 
     assert_approx_eq!(frac_pi_2, pi / 2f32);
-    assert_approx_eq!(frac_pi_3, pi / 3f32);
+    assert_approx_eq!(
+        frac_pi_3,
+        pi / 3f32,
+        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
+    );
     assert_approx_eq!(frac_pi_4, pi / 4f32);
     assert_approx_eq!(frac_pi_6, pi / 6f32);
     assert_approx_eq!(frac_pi_8, pi / 8f32);
@@ -249,5 +290,9 @@ fn test_real_consts() {
     assert_approx_eq!(log2_e, e.log2());
     assert_approx_eq!(log10_e, e.log10());
     assert_approx_eq!(ln_2, 2f32.ln());
-    assert_approx_eq!(ln_10, 10f32.ln());
+    assert_approx_eq!(
+        ln_10,
+        10f32.ln(),
+        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
+    );
 }

--- a/library/std/tests/floats/f32.rs
+++ b/library/std/tests/floats/f32.rs
@@ -3,7 +3,7 @@ use std::f32::consts;
 /// Miri adds some extra errors to float functions; make sure the tests still pass.
 /// These values are purely used as a canary to test against and are thus not a stable guarantee Rust provides.
 /// They serve as a way to get an idea of the real precision of floating point operations on different platforms.
-const APPROX_DELTA: f32 = if cfg!(miri) { 1e-4 } else { 1e-6 };
+const APPROX_DELTA: f32 = if cfg!(miri) { 1e-3 } else { 1e-6 };
 
 #[allow(unused_macros)]
 macro_rules! assert_f32_biteq {
@@ -22,17 +22,9 @@ fn test_powf() {
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
     assert_eq!(1.0f32.powf(1.0), 1.0);
-    assert_approx_eq!(
-        3.4f32.powf(4.5),
-        246.408218,
-        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
-    );
+    assert_approx_eq!(3.4f32.powf(4.5), 246.408218, APPROX_DELTA);
     assert_approx_eq!(2.7f32.powf(-3.2), 0.041652);
-    assert_approx_eq!(
-        (-3.1f32).powf(2.0),
-        9.61,
-        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
-    );
+    assert_approx_eq!((-3.1f32).powf(2.0), 9.61, APPROX_DELTA);
     assert_approx_eq!(5.9f32.powf(-2.0), 0.028727);
     assert_eq!(8.3f32.powf(0.0), 1.0);
     assert!(nan.powf(2.0).is_nan());
@@ -44,11 +36,7 @@ fn test_powf() {
 fn test_exp() {
     assert_eq!(1.0, 0.0f32.exp());
     assert_approx_eq!(2.718282, 1.0f32.exp(), APPROX_DELTA);
-    assert_approx_eq!(
-        148.413162,
-        5.0f32.exp(),
-        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
-    );
+    assert_approx_eq!(148.413162, 5.0f32.exp(), APPROX_DELTA);
 
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
@@ -60,11 +48,7 @@ fn test_exp() {
 
 #[test]
 fn test_exp2() {
-    assert_approx_eq!(
-        32.0,
-        5.0f32.exp2(),
-        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
-    );
+    assert_approx_eq!(32.0, 5.0f32.exp2(), APPROX_DELTA);
     assert_eq!(1.0, 0.0f32.exp2());
 
     let inf: f32 = f32::INFINITY;
@@ -87,11 +71,7 @@ fn test_ln() {
     assert!((-2.3f32).ln().is_nan());
     assert_eq!((-0.0f32).ln(), neg_inf);
     assert_eq!(0.0f32.ln(), neg_inf);
-    assert_approx_eq!(
-        4.0f32.ln(),
-        1.386294,
-        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
-    );
+    assert_approx_eq!(4.0f32.ln(), 1.386294, APPROX_DELTA);
 }
 
 #[test]
@@ -101,7 +81,7 @@ fn test_log() {
     let neg_inf: f32 = f32::NEG_INFINITY;
     assert_approx_eq!(10.0f32.log(10.0), 1.0);
     assert_approx_eq!(2.3f32.log(3.5), 0.664858);
-    assert_approx_eq!(1.0f32.exp().log(1.0f32.exp()), 1.0);
+    assert_approx_eq!(1.0f32.exp().log(1.0f32.exp()), 1.0, APPROX_DELTA);
     assert!(1.0f32.log(1.0).is_nan());
     assert!(1.0f32.log(-13.9).is_nan());
     assert!(nan.log(2.3).is_nan());
@@ -117,17 +97,9 @@ fn test_log2() {
     let nan: f32 = f32::NAN;
     let inf: f32 = f32::INFINITY;
     let neg_inf: f32 = f32::NEG_INFINITY;
-    assert_approx_eq!(
-        10.0f32.log2(),
-        3.321928,
-        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
-    );
+    assert_approx_eq!(10.0f32.log2(), 3.321928, APPROX_DELTA);
     assert_approx_eq!(2.3f32.log2(), 1.201634);
-    assert_approx_eq!(
-        1.0f32.exp().log2(),
-        1.442695,
-        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
-    );
+    assert_approx_eq!(1.0f32.exp().log2(), 1.442695, APPROX_DELTA);
     assert!(nan.log2().is_nan());
     assert_eq!(inf.log2(), inf);
     assert!(neg_inf.log2().is_nan());
@@ -191,11 +163,7 @@ fn test_acosh() {
     assert_approx_eq!(3.0f32.acosh(), 1.76274717403908605046521864995958461f32);
 
     // test for low accuracy from issue 104548
-    assert_approx_eq!(
-        60.0f32,
-        60.0f32.cosh().acosh(),
-        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
-    );
+    assert_approx_eq!(60.0f32, 60.0f32.cosh().acosh(), APPROX_DELTA);
 }
 
 #[test]
@@ -274,11 +242,7 @@ fn test_real_consts() {
     let ln_10: f32 = consts::LN_10;
 
     assert_approx_eq!(frac_pi_2, pi / 2f32);
-    assert_approx_eq!(
-        frac_pi_3,
-        pi / 3f32,
-        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
-    );
+    assert_approx_eq!(frac_pi_3, pi / 3f32, APPROX_DELTA);
     assert_approx_eq!(frac_pi_4, pi / 4f32);
     assert_approx_eq!(frac_pi_6, pi / 6f32);
     assert_approx_eq!(frac_pi_8, pi / 8f32);
@@ -290,9 +254,5 @@ fn test_real_consts() {
     assert_approx_eq!(log2_e, e.log2());
     assert_approx_eq!(log10_e, e.log10());
     assert_approx_eq!(ln_2, 2f32.ln());
-    assert_approx_eq!(
-        ln_10,
-        10f32.ln(),
-        APPROX_DELTA /* Miri float-non-det: Make tests pass for now */
-    );
+    assert_approx_eq!(ln_10, 10f32.ln(), APPROX_DELTA);
 }

--- a/library/std/tests/floats/f64.rs
+++ b/library/std/tests/floats/f64.rs
@@ -43,7 +43,7 @@ fn test_exp() {
 
 #[test]
 fn test_exp2() {
-    assert_eq!(32.0, 5.0f64.exp2());
+    assert_approx_eq!(32.0, 5.0f64.exp2());
     assert_eq!(1.0, 0.0f64.exp2());
 
     let inf: f64 = f64::INFINITY;
@@ -74,9 +74,9 @@ fn test_log() {
     let nan: f64 = f64::NAN;
     let inf: f64 = f64::INFINITY;
     let neg_inf: f64 = f64::NEG_INFINITY;
-    assert_eq!(10.0f64.log(10.0), 1.0);
+    assert_approx_eq!(10.0f64.log(10.0), 1.0);
     assert_approx_eq!(2.3f64.log(3.5), 0.664858);
-    assert_eq!(1.0f64.exp().log(1.0f64.exp()), 1.0);
+    assert_approx_eq!(1.0f64.exp().log(1.0f64.exp()), 1.0);
     assert!(1.0f64.log(1.0).is_nan());
     assert!(1.0f64.log(-13.9).is_nan());
     assert!(nan.log(2.3).is_nan());
@@ -108,7 +108,7 @@ fn test_log10() {
     let nan: f64 = f64::NAN;
     let inf: f64 = f64::INFINITY;
     let neg_inf: f64 = f64::NEG_INFINITY;
-    assert_eq!(10.0f64.log10(), 1.0);
+    assert_approx_eq!(10.0f64.log10(), 1.0);
     assert_approx_eq!(2.3f64.log10(), 0.361728);
     assert_approx_eq!(1.0f64.exp().log10(), 0.434294);
     assert_eq!(1.0f64.log10(), 0.0);

--- a/src/tools/miri/src/math.rs
+++ b/src/tools/miri/src/math.rs
@@ -151,6 +151,20 @@ pub(crate) fn sqrt<S: rustc_apfloat::ieee::Semantics>(x: IeeeFloat<S>) -> IeeeFl
     }
 }
 
+/// Extend functionality of rustc_apfloat softfloats
+pub trait IeeeExt: rustc_apfloat::Float {
+    #[inline]
+    fn one() -> Self {
+        Self::from_u128(1).value
+    }
+
+    #[inline]
+    fn clamp(self, min: Self, max: Self) -> Self {
+        self.maximum(min).minimum(max)
+    }
+}
+impl<S: rustc_apfloat::ieee::Semantics> IeeeExt for IeeeFloat<S> {}
+
 #[cfg(test)]
 mod tests {
     use rustc_apfloat::ieee::{DoubleS, HalfS, IeeeFloat, QuadS, SingleS};

--- a/src/tools/miri/tests/pass/float.rs
+++ b/src/tools/miri/tests/pass/float.rs
@@ -45,6 +45,31 @@ macro_rules! assert_approx_eq {
     };
 }
 
+
+/// From IEEE 754 a Signaling NaN for single precision has the following representation:
+/// ```
+/// s | 1111 1111 | 0x..x
+/// ````
+/// Were at least one `x` is a 1.
+///
+/// This sNaN has the following representation and is used for testing purposes.:
+/// ```
+/// 0 | 1111111 | 01..0
+/// ```
+const SNAN_F32: f32 = f32::from_bits(0x7fa00000);
+
+/// From IEEE 754 a Signaling NaN for double precision has the following representation:
+/// ```
+/// s | 1111 1111 111 | 0x..x
+/// ````
+/// Were at least one `x` is a 1.
+///
+/// This sNaN has the following representation and is used for testing purposes.:
+/// ```
+/// 0 | 1111 1111 111 | 01..0
+/// ```
+const SNAN_F64: f64 = f64::from_bits(0x7ff4000000000000);
+
 fn main() {
     basic();
     casts();
@@ -1008,17 +1033,82 @@ pub fn libm() {
     assert_approx_eq!(25f32.powf(-2f32), 0.0016f32);
     assert_approx_eq!(400f64.powf(0.5f64), 20f64);
 
+    // Some inputs to powf and powi result in fixed outputs
+    // and thus must be exactly equal to that value
+    // C standard says:
+    // 1^y = 1 for any y, even a NaN.
+    assert_eq!(1f32.powf(10.0), 1.0);
+    assert_eq!(1f64.powf(100.0), 1.0);
+    assert_eq!(1f32.powf(f32::INFINITY), 1.0);
+    assert_eq!(1f64.powf(f64::INFINITY), 1.0);
+    assert_eq!(1f32.powf(f32::NAN), 1.0);
+    assert_eq!(1f64.powf(f64::NAN), 1.0);
+
+    // f*::NAN is a quiet NAN and should return 1 as well.
+    assert_eq!(f32::NAN.powf(0.0), 1.0);
+    assert_eq!(f64::NAN.powf(0.0), 1.0);
+
+    assert_eq!(42f32.powf(0.0), 1.0);
+    assert_eq!(42f64.powf(0.0), 1.0);
+    assert_eq!(f32::INFINITY.powf(0.0), 1.0);
+    assert_eq!(f64::INFINITY.powf(0.0), 1.0);
+
+    // f*::NAN is a quiet NAN and should return 1 as well.
+    assert_eq!(f32::NAN.powi(0), 1.0);
+    assert_eq!(f64::NAN.powi(0), 1.0);
+
+    assert_eq!(10.0f32.powi(0), 1.0);
+    assert_eq!(10.0f64.powi(0), 1.0);
+    assert_eq!(f32::INFINITY.powi(0), 1.0);
+    assert_eq!(f64::INFINITY.powi(0), 1.0);
+
+    assert_eq!((-1f32).powf(f32::INFINITY), 1.0);
+    assert_eq!((-1f64).powf(f64::INFINITY), 1.0);
+    assert_eq!((-1f32).powf(f32::NEG_INFINITY), 1.0);
+    assert_eq!((-1f64).powf(f64::NEG_INFINITY), 1.0);
+
+    // For pow (powf in rust) the C standard says:
+    // x^0 = 1 for all x even a sNaN
+    assert_eq!(SNAN_F32.powf(0.0), 1.0);
+    assert_eq!(SNAN_F64.powf(0.0), 1.0);
+
+    // For pown (powi in rust) the C standard says:
+    // x^0 = 1 for all x even a sNaN
+    assert_eq!(SNAN_F32.powi(0), 1.0);
+    assert_eq!(SNAN_F64.powi(0), 1.0);
+
+    assert_eq!(0f32.powi(10), 0.0);
+    assert_eq!(0f64.powi(100), 0.0);
+    assert_eq!(0f32.powi(9), 0.0);
+    assert_eq!(0f64.powi(99), 0.0);
+
+    assert_biteq((-0f32).powf(10.0), 0.0, "-0^x = +0 where x is positive");
+    assert_biteq((-0f64).powf(100.0), 0.0, "-0^x = +0 where x is positive");
+    assert_biteq((-0f32).powf(9.0), -0.0, "-0^x = -0 where x is negative");
+    assert_biteq((-0f64).powf(99.0), -0.0, "-0^x = -0 where x is negative");
+
+    assert_biteq((-0f32).powi(10), 0.0, "-0^x = +0 where x is positive");
+    assert_biteq((-0f64).powi(100), 0.0, "-0^x = +0 where x is positive");
+    assert_biteq((-0f32).powi(9), -0.0, "-0^x = -0 where x is negative");
+    assert_biteq((-0f64).powi(99), -0.0, "-0^x = -0 where x is negative");
+
     assert_approx_eq!(1f32.exp(), f32::consts::E);
     assert_approx_eq!(1f64.exp(), f64::consts::E);
+    assert_eq!(0f32.exp(), 1.0);
+    assert_eq!(0f64.exp(), 1.0);
 
     assert_approx_eq!(1f32.exp_m1(), f32::consts::E - 1.0);
     assert_approx_eq!(1f64.exp_m1(), f64::consts::E - 1.0);
 
     assert_approx_eq!(10f32.exp2(), 1024f32);
     assert_approx_eq!(50f64.exp2(), 1125899906842624f64);
+    assert_eq!(0f32.exp2(), 1.0);
+    assert_eq!(0f64.exp2(), 1.0);
 
     assert_approx_eq!(f32::consts::E.ln(), 1f32);
-    assert_approx_eq!(1f64.ln(), 0f64);
+    assert_approx_eq!(f64::consts::E.ln(), 1f64);
+    assert_eq!(1f32.ln(), 0.0);
+    assert_eq!(1f64.ln(), 0.0);
 
     assert_approx_eq!(0f32.ln_1p(), 0f32);
     assert_approx_eq!(0f64.ln_1p(), 0f64);
@@ -1047,7 +1137,8 @@ pub fn libm() {
 
     // Trigonometric functions.
 
-    assert_approx_eq!(0f32.sin(), 0f32);
+    assert_eq!(0f32.sin(), 0f32);
+    assert_eq!(0f64.sin(), 0f64);
     assert_approx_eq!((f64::consts::PI / 2f64).sin(), 1f64);
     assert_approx_eq!(f32::consts::FRAC_PI_6.sin(), 0.5);
     assert_approx_eq!(f64::consts::FRAC_PI_6.sin(), 0.5);
@@ -1059,7 +1150,23 @@ pub fn libm() {
     assert_approx_eq!(2.0f32.asinh(), 1.443635475178810342493276740273105f32);
     assert_approx_eq!((-2.0f64).asinh(), -1.443635475178810342493276740273105f64);
 
-    assert_approx_eq!(0f32.cos(), 1f32);
+    // Ensure `sin` always returns something that is a valid input for `asin`, and same for
+    // `cos` and `acos`.
+    let halve_pi_f32 = std::f32::consts::FRAC_PI_2;
+    let halve_pi_f64 = std::f64::consts::FRAC_PI_2;
+    let pi_f32 = std::f32::consts::PI;
+    let pi_f64 = std::f64::consts::PI;
+    for _ in 0..64 {
+        // sin() should be clamped to [-1, 1] so asin() can never return NaN
+        assert!(!halve_pi_f32.sin().asin().is_nan());
+        assert!(!halve_pi_f64.sin().asin().is_nan());
+        // cos() should be clamped to [-1, 1] so acos() can never return NaN
+        assert!(!pi_f32.cos().acos().is_nan());
+        assert!(!pi_f64.cos().acos().is_nan());
+    }
+
+    assert_eq!(0f32.cos(), 1f32);
+    assert_eq!(0f64.cos(), 1f64);
     assert_approx_eq!((f64::consts::PI * 2f64).cos(), 1f64);
     assert_approx_eq!(f32::consts::FRAC_PI_3.cos(), 0.5);
     assert_approx_eq!(f64::consts::FRAC_PI_3.cos(), 0.5);

--- a/src/tools/miri/tests/pass/float.rs
+++ b/src/tools/miri/tests/pass/float.rs
@@ -1034,7 +1034,7 @@ pub fn libm() {
     assert_approx_eq!(400f64.powf(0.5f64), 20f64);
 
     // Some inputs to powf and powi result in fixed outputs
-    // and thus must be exactly equal to that value
+    // and thus must be exactly equal to that value.
     // C standard says:
     // 1^y = 1 for any y, even a NaN.
     assert_eq!(1f32.powf(10.0), 1.0);
@@ -1069,11 +1069,13 @@ pub fn libm() {
 
     // For pow (powf in rust) the C standard says:
     // x^0 = 1 for all x even a sNaN
+    // FIXME(#4286): this does not match the behavior of all implementations.
     assert_eq!(SNAN_F32.powf(0.0), 1.0);
     assert_eq!(SNAN_F64.powf(0.0), 1.0);
 
     // For pown (powi in rust) the C standard says:
     // x^0 = 1 for all x even a sNaN
+    // FIXME(#4286): this does not match the behavior of all implementations.
     assert_eq!(SNAN_F32.powi(0), 1.0);
     assert_eq!(SNAN_F64.powi(0), 1.0);
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Links to [#4208](https://github.com/rust-lang/miri/issues/4208) and [#3555](https://github.com/rust-lang/miri/issues/3555) in Miri.

Non-determinism of floating point operations was disabled in rust-lang/rust#137594 because it breaks the tests and doc-tests in core/coretests and std. This PR enables some of them.

This pr includes the following changes:

- Enables the float non-determinism but with a lower relative error of 4ULP instead of 16ULP
- These operations now have a fixed output based on the C23 standard, except the pow operations, this is tracked in [#4286](https://github.com/rust-lang/miri/issues/4286#issue-3010677983)
- Changes tests that made incorrect assumptions about the operations, not to make that assumption anymore (from `assert_eq!` to `assert_approx_eq!`.
- Changed the doctests of the stdlib of these operations to compare against fixed constants instead of `f*::EPSILON`, which now succeed with Miri and `-Zmiri-many-seeds`
- Added a constant `APPROX_DELTA` in `std/tests/floats/f32.rs` which is used for approximation tests, but with a different value when run in Miri. This is to make these tests succeed.
- Added tests in the float tests of Miri to test the C23 behaviour.

Fixes https://github.com/rust-lang/miri/issues/4208