### PR TITLE
Rollup of 15 pull requests

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1783,6 +1783,13 @@ impl<'a> State<'a> {
                 self.print_mutability(*m, false);
                 self.word("self")
             }
+            SelfKind::Pinned(lt, m) => {
+                self.word("&");
+                self.print_opt_lifetime(lt);
+                self.word("pin ");
+                self.print_mutability(*m, true);
+                self.word("self")
+            }
             SelfKind::Explicit(typ, m) => {
                 self.print_mutability(*m, false);
                 self.word("self");

--- a/compiler/rustc_attr_parsing/src/parser.rs
+++ b/compiler/rustc_attr_parsing/src/parser.rs
@@ -473,6 +473,15 @@ impl<'a> MetaItemListParserContext<'a> {
         {
             self.inside_delimiters.next();
             return Some(MetaItemOrLitParser::Lit(lit));
+        } else if let Some(TokenTree::Delimited(.., Delimiter::Invisible(_), inner_tokens)) =
+            self.inside_delimiters.peek()
+        {
+            self.inside_delimiters.next();
+            return MetaItemListParserContext {
+                inside_delimiters: inner_tokens.iter().peekable(),
+                dcx: self.dcx,
+            }
+            .next();
         }
 
         // or a path.

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2120,8 +2120,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                                 //
                                 // Note that other checks (such as denying `dyn Send` -> `dyn
                                 // Debug`) are in `rustc_hir_typeck`.
-                                if let ty::Dynamic(src_tty, _src_lt, _) = *src_tail.kind()
-                                    && let ty::Dynamic(dst_tty, dst_lt, _) = *dst_tail.kind()
+                                if let ty::Dynamic(src_tty, _src_lt, ty::Dyn) = *src_tail.kind()
+                                    && let ty::Dynamic(dst_tty, dst_lt, ty::Dyn) = *dst_tail.kind()
                                     && src_tty.principal().is_some()
                                     && dst_tty.principal().is_some()
                                 {

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -3382,6 +3382,35 @@ fn add_lld_args(
     // this, `wasm-component-ld`, which is overridden if this option is passed.
     if !sess.target.is_like_wasm {
         cmd.cc_arg("-fuse-ld=lld");
+
+        // On ELF platforms like at least x64 linux, GNU ld and LLD have opposite defaults on some
+        // section garbage-collection features. For example, the somewhat popular `linkme` crate and
+        // its dependents rely in practice on this difference: when using lld, they need `-z
+        // nostart-stop-gc` to prevent encapsulation symbols and sections from being
+        // garbage-collected.
+        //
+        // More information about all this can be found in:
+        // - https://maskray.me/blog/2021-01-31-metadata-sections-comdat-and-shf-link-order
+        // - https://lld.llvm.org/ELF/start-stop-gc
+        //
+        // So when using lld, we restore, for now, the traditional behavior to help migration, but
+        // will remove it in the future.
+        // Since this only disables an optimization, it shouldn't create issues, but is in theory
+        // slightly suboptimal. However, it:
+        // - doesn't have any visible impact on our benchmarks
+        // - reduces the need to disable lld for the crates that depend on this
+        //
+        // Note that lld can detect some cases where this difference is relied on, and emits a
+        // dedicated error to add this link arg. We could make use of this error to emit an FCW. As
+        // of writing this, we don't do it, because lld is already enabled by default on nightly
+        // without this mitigation: no working project would see the FCW, so we do this to help
+        // stabilization.
+        //
+        // FIXME: emit an FCW if linking fails due its absence, and then remove this link-arg in the
+        // future.
+        if sess.target.llvm_target == "x86_64-unknown-linux-gnu" {
+            cmd.link_arg("-znostart-stop-gc");
+        }
     }
 
     if !flavor.is_gnu() {

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -599,7 +599,6 @@ pub enum StashKey {
     MaybeFruTypo,
     CallAssocMethod,
     AssociatedTypeSuggestion,
-    MaybeForgetReturn,
     /// Query cycle detected, stashing in favor of a better error.
     Cycle,
     UndeterminedMacroResolution,

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -1,6 +1,7 @@
 //! List of the unstable feature gates.
 
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rustc_data_structures::fx::FxHashSet;
 use rustc_span::{Span, Symbol, sym};
@@ -681,11 +682,13 @@ impl Features {
     ) -> Result<(), Box<dyn std::error::Error>> {
         #[derive(serde::Serialize)]
         struct LibFeature {
+            timestamp: u128,
             symbol: String,
         }
 
         #[derive(serde::Serialize)]
         struct LangFeature {
+            timestamp: u128,
             symbol: String,
             since: Option<String>,
         }
@@ -699,10 +702,20 @@ impl Features {
         let metrics_file = std::fs::File::create(metrics_path)?;
         let metrics_file = std::io::BufWriter::new(metrics_file);
 
+        let now = || {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time should always be greater than the unix epoch")
+                .as_nanos()
+        };
+
         let lib_features = self
             .enabled_lib_features
             .iter()
-            .map(|EnabledLibFeature { gate_name, .. }| LibFeature { symbol: gate_name.to_string() })
+            .map(|EnabledLibFeature { gate_name, .. }| LibFeature {
+                symbol: gate_name.to_string(),
+                timestamp: now(),
+            })
             .collect();
 
         let lang_features = self
@@ -711,6 +724,7 @@ impl Features {
             .map(|EnabledLangFeature { gate_name, stable_since, .. }| LangFeature {
                 symbol: gate_name.to_string(),
                 since: stable_since.map(|since| since.to_string()),
+                timestamp: now(),
             })
             .collect();
 

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -620,6 +620,8 @@ hir_analysis_variances_of = {$variances}
 hir_analysis_where_clause_on_main = `main` function is not allowed to have a `where` clause
     .label = `main` cannot have a `where` clause
 
+hir_analysis_within_macro = due to this macro variable
+
 hir_analysis_wrong_number_of_generic_arguments_to_intrinsic =
     intrinsic has wrong number of {$descr} parameters: found {$found}, expected {$expected}
     .label = expected {$expected} {$descr} {$expected ->

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -84,6 +84,8 @@ pub(crate) struct AssocItemNotFound<'a> {
     pub label: Option<AssocItemNotFoundLabel<'a>>,
     #[subdiagnostic]
     pub sugg: Option<AssocItemNotFoundSugg<'a>>,
+    #[label(hir_analysis_within_macro)]
+    pub within_macro_span: Option<Span>,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -153,7 +153,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             sugg: None,
             // Try to get the span of the identifier within the path's syntax context
             // (if that's different).
-            within_macro_span: assoc_name.span.within_macro(span),
+            within_macro_span: assoc_name.span.within_macro(span, tcx.sess.source_map()),
         };
 
         if is_dummy {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -151,6 +151,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             qself: &qself_str,
             label: None,
             sugg: None,
+            // Try to get the span of the identifier within the path's syntax context
+            // (if that's different).
+            within_macro_span: assoc_name.span.within_macro(span),
         };
 
         if is_dummy {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -666,12 +666,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         if !errors.is_empty() {
             self.adjust_fulfillment_errors_for_expr_obligation(&mut errors);
-            let errors_causecode = errors
-                .iter()
-                .map(|e| (e.obligation.cause.span, e.root_obligation.cause.code().clone()))
-                .collect::<Vec<_>>();
             self.err_ctxt().report_fulfillment_errors(errors);
-            self.collect_unused_stmts_for_coerce_return_ty(errors_causecode);
         }
     }
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -3,9 +3,7 @@ use std::{fmt, iter, mem};
 use itertools::Itertools;
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_errors::codes::*;
-use rustc_errors::{
-    Applicability, Diag, ErrorGuaranteed, MultiSpan, StashKey, a_or_an, listify, pluralize,
-};
+use rustc_errors::{Applicability, Diag, ErrorGuaranteed, MultiSpan, a_or_an, listify, pluralize};
 use rustc_hir::def::{CtorOf, DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::Visitor;
@@ -2164,62 +2162,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let (res, ty) = self.resolve_lang_item_path(lang_item, span, hir_id);
                 (res, LoweredTy::from_raw(self, path_span, ty))
             }
-        }
-    }
-
-    pub(super) fn collect_unused_stmts_for_coerce_return_ty(
-        &self,
-        errors_causecode: Vec<(Span, ObligationCauseCode<'tcx>)>,
-    ) {
-        for (span, code) in errors_causecode {
-            self.dcx().try_steal_modify_and_emit_err(span, StashKey::MaybeForgetReturn, |err| {
-                if let Some(fn_sig) = self.body_fn_sig()
-                    && let ObligationCauseCode::WhereClauseInExpr(_, _, binding_hir_id, ..) = code
-                    && !fn_sig.output().is_unit()
-                {
-                    let mut block_num = 0;
-                    let mut found_semi = false;
-                    for (hir_id, node) in self.tcx.hir_parent_iter(binding_hir_id) {
-                        // Don't proceed into parent bodies
-                        if hir_id.owner != binding_hir_id.owner {
-                            break;
-                        }
-                        match node {
-                            hir::Node::Stmt(stmt) => {
-                                if let hir::StmtKind::Semi(expr) = stmt.kind {
-                                    let expr_ty = self.typeck_results.borrow().expr_ty(expr);
-                                    let return_ty = fn_sig.output();
-                                    if !matches!(expr.kind, hir::ExprKind::Ret(..))
-                                        && self.may_coerce(expr_ty, return_ty)
-                                    {
-                                        found_semi = true;
-                                    }
-                                }
-                            }
-                            hir::Node::Block(_block) => {
-                                if found_semi {
-                                    block_num += 1;
-                                }
-                            }
-                            hir::Node::Item(item) => {
-                                if let hir::ItemKind::Fn { .. } = item.kind {
-                                    break;
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                    if block_num > 1 && found_semi {
-                        err.span_suggestion_verbose(
-                            // use the span of the *whole* expr
-                            self.tcx.hir().span(binding_hir_id).shrink_to_lo(),
-                            "you might have meant to return this to infer its type parameters",
-                            "return ",
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
-                }
-            });
         }
     }
 

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -158,7 +158,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.typeck_results.borrow_mut().used_trait_imports.insert(import_id);
         }
 
-        let (span, sugg_span, source, item_name, args) = match self.tcx.hir_node(call_id) {
+        let (span, expr_span, source, item_name, args) = match self.tcx.hir_node(call_id) {
             hir::Node::Expr(&hir::Expr {
                 kind: hir::ExprKind::MethodCall(segment, rcvr, args, _),
                 span,
@@ -194,6 +194,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             node => unreachable!("{node:?}"),
         };
 
+        // Try to get the span of the identifier within the expression's syntax context (if that's different).
+        let within_macro_span = span.within_macro(expr_span);
+
         // Avoid suggestions when we don't know what's going on.
         if let Err(guar) = rcvr_ty.error_reported() {
             return guar;
@@ -207,10 +210,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 call_id,
                 source,
                 args,
-                sugg_span,
+                expr_span,
                 &mut no_match_data,
                 expected,
                 trait_missing_method,
+                within_macro_span,
             ),
 
             MethodError::Ambiguity(mut sources) => {
@@ -221,6 +225,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     "multiple applicable items in scope"
                 );
                 err.span_label(item_name.span, format!("multiple `{item_name}` found"));
+                if let Some(within_macro_span) = within_macro_span {
+                    err.span_label(within_macro_span, "due to this macro variable");
+                }
 
                 self.note_candidates_on_method_error(
                     rcvr_ty,
@@ -230,7 +237,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     span,
                     &mut err,
                     &mut sources,
-                    Some(sugg_span),
+                    Some(expr_span),
                 );
                 err.emit()
             }
@@ -252,6 +259,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .span_if_local(def_id)
                     .unwrap_or_else(|| self.tcx.def_span(def_id));
                 err.span_label(sp, format!("private {kind} defined here"));
+                if let Some(within_macro_span) = within_macro_span {
+                    err.span_label(within_macro_span, "due to this macro variable");
+                }
                 self.suggest_valid_traits(&mut err, item_name, out_of_scope_traits, true);
                 err.emit()
             }
@@ -267,6 +277,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let mut err = self.dcx().struct_span_err(span, msg);
                 if !needs_mut {
                     err.span_label(bound_span, "this has a `Sized` requirement");
+                }
+                if let Some(within_macro_span) = within_macro_span {
+                    err.span_label(within_macro_span, "due to this macro variable");
                 }
                 if !candidates.is_empty() {
                     let help = format!(
@@ -581,6 +594,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         no_match_data: &mut NoMatchData<'tcx>,
         expected: Expectation<'tcx>,
         trait_missing_method: bool,
+        within_macro_span: Option<Span>,
     ) -> ErrorGuaranteed {
         let mode = no_match_data.mode;
         let tcx = self.tcx;
@@ -720,6 +734,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         if tcx.sess.source_map().is_multiline(sugg_span) {
             err.span_label(sugg_span.with_hi(span.lo()), "");
+        }
+        if let Some(within_macro_span) = within_macro_span {
+            err.span_label(within_macro_span, "due to this macro variable");
         }
 
         if short_ty_str.len() < ty_str.len() && ty_str.len() > 10 {

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -196,7 +196,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Try to get the span of the identifier within the expression's syntax context
         // (if that's different).
-        let within_macro_span = span.within_macro(expr_span);
+        let within_macro_span = span.within_macro(expr_span, self.tcx.sess.source_map());
 
         // Avoid suggestions when we don't know what's going on.
         if let Err(guar) = rcvr_ty.error_reported() {

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -194,7 +194,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             node => unreachable!("{node:?}"),
         };
 
-        // Try to get the span of the identifier within the expression's syntax context (if that's different).
+        // Try to get the span of the identifier within the expression's syntax context
+        // (if that's different).
         let within_macro_span = span.within_macro(expr_span);
 
         // Avoid suggestions when we don't know what's going on.

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -49,6 +49,9 @@ macro_rules! thir_with_elements {
             }
         )*
 
+        // Note: Making `Thir` implement `Clone` is useful for external tools that need access to
+        // THIR bodies even after the `Steal` query result has been stolen.
+        // One such tool is https://github.com/rust-corpus/qrates/.
         /// A container for a THIR body.
         ///
         /// This can be indexed directly by any THIR index (e.g. [`ExprId`]).

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -19,7 +19,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{BindingMode, ByRef, HirId, MatchSource, RangeEnd};
 use rustc_index::{IndexVec, newtype_index};
-use rustc_macros::{HashStable, TypeVisitable};
+use rustc_macros::{HashStable, TyDecodable, TyEncodable, TypeVisitable};
 use rustc_span::def_id::LocalDefId;
 use rustc_span::{ErrorGuaranteed, Span, Symbol};
 use rustc_target::asm::InlineAsmRegOrRegClass;
@@ -52,7 +52,7 @@ macro_rules! thir_with_elements {
         /// A container for a THIR body.
         ///
         /// This can be indexed directly by any THIR index (e.g. [`ExprId`]).
-        #[derive(Debug, HashStable)]
+        #[derive(Debug, HashStable, Clone)]
         pub struct Thir<'tcx> {
             pub body_type: BodyTy<'tcx>,
             $(
@@ -90,7 +90,7 @@ thir_with_elements! {
     params: ParamId => Param<'tcx> => "p{}",
 }
 
-#[derive(Debug, HashStable)]
+#[derive(Debug, HashStable, Clone)]
 pub enum BodyTy<'tcx> {
     Const(Ty<'tcx>),
     Fn(FnSig<'tcx>),
@@ -98,7 +98,7 @@ pub enum BodyTy<'tcx> {
 }
 
 /// Description of a type-checked function parameter.
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub struct Param<'tcx> {
     /// The pattern that appears in the parameter list, or None for implicit parameters.
     pub pat: Option<Box<Pat<'tcx>>>,
@@ -118,7 +118,7 @@ pub enum LintLevel {
     Explicit(HirId),
 }
 
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub struct Block {
     /// Whether the block itself has a label. Used by `label: {}`
     /// and `try` blocks.
@@ -138,7 +138,7 @@ pub struct Block {
 
 type UserTy<'tcx> = Option<Box<CanonicalUserType<'tcx>>>;
 
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub struct AdtExpr<'tcx> {
     /// The ADT we're constructing.
     pub adt_def: AdtDef<'tcx>,
@@ -155,7 +155,7 @@ pub struct AdtExpr<'tcx> {
     pub base: AdtExprBase<'tcx>,
 }
 
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub enum AdtExprBase<'tcx> {
     /// A struct expression where all the fields are explicitly enumerated: `Foo { a, b }`.
     None,
@@ -168,7 +168,7 @@ pub enum AdtExprBase<'tcx> {
     DefaultFields(Box<[Ty<'tcx>]>),
 }
 
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub struct ClosureExpr<'tcx> {
     pub closure_id: LocalDefId,
     pub args: UpvarArgs<'tcx>,
@@ -177,7 +177,7 @@ pub struct ClosureExpr<'tcx> {
     pub fake_reads: Vec<(ExprId, FakeReadCause, HirId)>,
 }
 
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub struct InlineAsmExpr<'tcx> {
     pub asm_macro: AsmMacro,
     pub template: &'tcx [InlineAsmTemplatePiece],
@@ -195,12 +195,12 @@ pub enum BlockSafety {
     ExplicitUnsafe(HirId),
 }
 
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub struct Stmt<'tcx> {
     pub kind: StmtKind<'tcx>,
 }
 
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub enum StmtKind<'tcx> {
     /// An expression with a trailing semicolon.
     Expr {
@@ -240,11 +240,11 @@ pub enum StmtKind<'tcx> {
     },
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, HashStable)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, HashStable, TyEncodable, TyDecodable)]
 pub struct LocalVarId(pub HirId);
 
 /// A THIR expression.
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub struct Expr<'tcx> {
     /// kind of expression
     pub kind: ExprKind<'tcx>,
@@ -271,7 +271,7 @@ pub struct TempLifetime {
     pub backwards_incompatible: Option<region::Scope>,
 }
 
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub enum ExprKind<'tcx> {
     /// `Scope`s are used to explicitly mark destruction scopes,
     /// and to track the `HirId` of the expressions within the scope.
@@ -548,20 +548,20 @@ pub enum ExprKind<'tcx> {
 /// Represents the association of a field identifier and an expression.
 ///
 /// This is used in struct constructors.
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub struct FieldExpr {
     pub name: FieldIdx,
     pub expr: ExprId,
 }
 
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub struct FruInfo<'tcx> {
     pub base: ExprId,
     pub field_types: Box<[Ty<'tcx>]>,
 }
 
 /// A `match` arm.
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub struct Arm<'tcx> {
     pub pattern: Box<Pat<'tcx>>,
     pub guard: Option<ExprId>,
@@ -579,7 +579,7 @@ pub enum LogicalOp {
     Or,
 }
 
-#[derive(Debug, HashStable)]
+#[derive(Clone, Debug, HashStable)]
 pub enum InlineAsmOperand<'tcx> {
     In {
         reg: InlineAsmRegOrRegClass,
@@ -616,13 +616,13 @@ pub enum InlineAsmOperand<'tcx> {
     },
 }
 
-#[derive(Debug, HashStable, TypeVisitable)]
+#[derive(Clone, Debug, HashStable, TypeVisitable)]
 pub struct FieldPat<'tcx> {
     pub field: FieldIdx,
     pub pattern: Pat<'tcx>,
 }
 
-#[derive(Debug, HashStable, TypeVisitable)]
+#[derive(Clone, Debug, HashStable, TypeVisitable)]
 pub struct Pat<'tcx> {
     pub ty: Ty<'tcx>,
     pub span: Span,
@@ -729,7 +729,7 @@ impl<'tcx> Pat<'tcx> {
     }
 }
 
-#[derive(Debug, HashStable, TypeVisitable)]
+#[derive(Clone, Debug, HashStable, TypeVisitable)]
 pub struct Ascription<'tcx> {
     pub annotation: CanonicalUserTypeAnnotation<'tcx>,
     /// Variance to use when relating the `user_ty` to the **type of the value being
@@ -753,7 +753,7 @@ pub struct Ascription<'tcx> {
     pub variance: ty::Variance,
 }
 
-#[derive(Debug, HashStable, TypeVisitable)]
+#[derive(Clone, Debug, HashStable, TypeVisitable)]
 pub enum PatKind<'tcx> {
     /// A wildcard pattern: `_`.
     Wild,

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -431,8 +431,10 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
         // Try to get the span of the identifier within the path's syntax context
         // (if that's different).
-        if let Some(within_macro_span) = base_error.span.within_macro(span) {
-            err.span_label(within_macro_span, "within this macro");
+        if let Some(within_macro_span) =
+            base_error.span.within_macro(span, self.r.tcx.sess.source_map())
+        {
+            err.span_label(within_macro_span, "due to this macro variable");
         }
 
         self.detect_missing_binding_available_from_pattern(&mut err, path, following_seg);

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -429,6 +429,12 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         let mut err = self.r.dcx().struct_span_err(base_error.span, base_error.msg.clone());
         err.code(code);
 
+        // Try to get the span of the identifier within the path's syntax context
+        // (if that's different).
+        if let Some(within_macro_span) = base_error.span.within_macro(span) {
+            err.span_label(within_macro_span, "within this macro");
+        }
+
         self.detect_missing_binding_available_from_pattern(&mut err, path, following_seg);
         self.suggest_at_operator_in_slice_pat_with_range(&mut err, path);
         self.suggest_swapping_misplaced_self_ty_and_trait(&mut err, source, res, base_error.span);

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1071,9 +1071,17 @@ impl Span {
     ///
     /// If "self" is the span of the outer_ident, and "within" is the span of the `($ident,)`
     /// expr, then this will return the span of the `$ident` macro variable.
-    pub fn within_macro(self, within: Span) -> Option<Span> {
+    pub fn within_macro(self, within: Span, sm: &SourceMap) -> Option<Span> {
         match Span::prepare_to_combine(self, within) {
-            Ok((self_, _, parent)) if self_.lo != self.lo() && self.hi() != self_.hi => {
+            // Only return something if it doesn't overlap with the original span,
+            // and the span isn't "imported" (i.e. from unavailable sources).
+            // FIXME: This does limit the usefulness of the error when the macro is
+            // from a foreign crate; we could also take into account `-Zmacro-backtrace`,
+            // which doesn't redact this span (but that would mean passing in even more
+            // args to this function, lol).
+            Ok((self_, _, parent))
+                if self_.hi < self.lo() || self.hi() < self_.lo && !sm.is_imported(within) =>
+            {
                 Some(Span::new(self_.lo, self_.hi, self_.ctxt, parent))
             }
             _ => None,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/ambiguity.rs
@@ -1,8 +1,6 @@
 use std::ops::ControlFlow;
 
-use rustc_errors::{
-    Applicability, Diag, E0283, E0284, E0790, MultiSpan, StashKey, struct_span_code_err,
-};
+use rustc_errors::{Applicability, Diag, E0283, E0284, E0790, MultiSpan, struct_span_code_err};
 use rustc_hir as hir;
 use rustc_hir::LangItem;
 use rustc_hir::def::{DefKind, Res};
@@ -197,7 +195,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 // be ignoring the fact that we don't KNOW the type works
                 // out. Though even that would probably be harmless, given that
                 // we're only talking about builtin traits, which are known to be
-                // inhabited. We used to check for `self.tcx.sess.has_errors()` to
+                // inhabited. We used to check for `self.tainted_by_errors()` to
                 // avoid inundating the user with unnecessary errors, but we now
                 // check upstream for type errors and don't add the obligations to
                 // begin with in those cases.
@@ -211,7 +209,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                                 TypeAnnotationNeeded::E0282,
                                 false,
                             );
-                            return err.stash(span, StashKey::MaybeForgetReturn).unwrap();
+                            return err.emit();
                         }
                         Some(e) => return e,
                     }

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -641,11 +641,6 @@ impl Error for JoinPathsError {
 ///     None => println!("Impossible to get your home dir!"),
 /// }
 /// ```
-#[deprecated(
-    since = "1.29.0",
-    note = "This function's behavior may be unexpected on Windows. \
-            Consider using a crate from crates.io instead."
-)]
 #[must_use]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn home_dir() -> Option<PathBuf> {

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -118,16 +118,16 @@ impl<R: Read + ?Sized> BufReader<R> {
     /// #![feature(bufreader_peek)]
     /// use std::io::{Read, BufReader};
     ///
-    /// let mut bytes = &b"oh, hello"[..];
+    /// let mut bytes = &b"oh, hello there"[..];
     /// let mut rdr = BufReader::with_capacity(6, &mut bytes);
     /// assert_eq!(rdr.peek(2).unwrap(), b"oh");
     /// let mut buf = [0; 4];
     /// rdr.read(&mut buf[..]).unwrap();
     /// assert_eq!(&buf, b"oh, ");
-    /// assert_eq!(rdr.peek(2).unwrap(), b"he");
+    /// assert_eq!(rdr.peek(5).unwrap(), b"hello");
     /// let mut s = String::new();
     /// rdr.read_to_string(&mut s).unwrap();
-    /// assert_eq!(&s, "hello");
+    /// assert_eq!(&s, "hello there");
     /// assert_eq!(rdr.peek(1).unwrap().len(), 0);
     /// ```
     #[unstable(feature = "bufreader_peek", issue = "128405")]

--- a/library/std/src/io/buffered/bufreader/buffer.rs
+++ b/library/std/src/io/buffered/bufreader/buffer.rs
@@ -109,8 +109,8 @@ impl Buffer {
 
     /// Read more bytes into the buffer without discarding any of its contents
     pub fn read_more(&mut self, mut reader: impl Read) -> io::Result<usize> {
-        let mut buf = BorrowedBuf::from(&mut self.buf[self.pos..]);
-        let old_init = self.initialized - self.pos;
+        let mut buf = BorrowedBuf::from(&mut self.buf[self.filled..]);
+        let old_init = self.initialized - self.filled;
         unsafe {
             buf.set_init(old_init);
         }

--- a/library/std/src/io/cursor.rs
+++ b/library/std/src/io/cursor.rs
@@ -439,6 +439,27 @@ fn slice_write_vectored(
     Ok(nwritten)
 }
 
+#[inline]
+fn slice_write_all(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<()> {
+    let n = slice_write(pos_mut, slice, buf)?;
+    if n < buf.len() { Err(io::Error::WRITE_ALL_EOF) } else { Ok(()) }
+}
+
+#[inline]
+fn slice_write_all_vectored(
+    pos_mut: &mut u64,
+    slice: &mut [u8],
+    bufs: &[IoSlice<'_>],
+) -> io::Result<()> {
+    for buf in bufs {
+        let n = slice_write(pos_mut, slice, buf)?;
+        if n < buf.len() {
+            return Err(io::Error::WRITE_ALL_EOF);
+        }
+    }
+    Ok(())
+}
+
 /// Reserves the required space, and pads the vec with 0s if necessary.
 fn reserve_and_pad<A: Allocator>(
     pos_mut: &mut u64,
@@ -481,9 +502,12 @@ fn reserve_and_pad<A: Allocator>(
     Ok(pos)
 }
 
-/// Writes the slice to the vec without allocating
-/// # Safety: vec must have buf.len() spare capacity
-unsafe fn vec_write_unchecked<A>(pos: usize, vec: &mut Vec<u8, A>, buf: &[u8]) -> usize
+/// Writes the slice to the vec without allocating.
+///
+/// # Safety
+///
+/// `vec` must have `buf.len()` spare capacity.
+unsafe fn vec_write_all_unchecked<A>(pos: usize, vec: &mut Vec<u8, A>, buf: &[u8]) -> usize
 where
     A: Allocator,
 {
@@ -492,7 +516,7 @@ where
     pos + buf.len()
 }
 
-/// Resizing write implementation for [`Cursor`]
+/// Resizing `write_all` implementation for [`Cursor`].
 ///
 /// Cursor is allowed to have a pre-allocated and initialised
 /// vector body, but with a position of 0. This means the [`Write`]
@@ -501,7 +525,7 @@ where
 /// This also allows for the vec body to be empty, but with a position of N.
 /// This means that [`Write`] will pad the vec with 0 initially,
 /// before writing anything from that point
-fn vec_write<A>(pos_mut: &mut u64, vec: &mut Vec<u8, A>, buf: &[u8]) -> io::Result<usize>
+fn vec_write_all<A>(pos_mut: &mut u64, vec: &mut Vec<u8, A>, buf: &[u8]) -> io::Result<usize>
 where
     A: Allocator,
 {
@@ -512,7 +536,7 @@ where
     // Safety: we have ensured that the capacity is available
     // and that all bytes get written up to pos
     unsafe {
-        pos = vec_write_unchecked(pos, vec, buf);
+        pos = vec_write_all_unchecked(pos, vec, buf);
         if pos > vec.len() {
             vec.set_len(pos);
         }
@@ -523,7 +547,7 @@ where
     Ok(buf_len)
 }
 
-/// Resizing write_vectored implementation for [`Cursor`]
+/// Resizing `write_all_vectored` implementation for [`Cursor`].
 ///
 /// Cursor is allowed to have a pre-allocated and initialised
 /// vector body, but with a position of 0. This means the [`Write`]
@@ -532,7 +556,7 @@ where
 /// This also allows for the vec body to be empty, but with a position of N.
 /// This means that [`Write`] will pad the vec with 0 initially,
 /// before writing anything from that point
-fn vec_write_vectored<A>(
+fn vec_write_all_vectored<A>(
     pos_mut: &mut u64,
     vec: &mut Vec<u8, A>,
     bufs: &[IoSlice<'_>],
@@ -550,7 +574,7 @@ where
     // and that all bytes get written up to the last pos
     unsafe {
         for buf in bufs {
-            pos = vec_write_unchecked(pos, vec, buf);
+            pos = vec_write_all_unchecked(pos, vec, buf);
         }
         if pos > vec.len() {
             vec.set_len(pos);
@@ -580,6 +604,16 @@ impl Write for Cursor<&mut [u8]> {
     }
 
     #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        slice_write_all(&mut self.pos, self.inner, buf)
+    }
+
+    #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        slice_write_all_vectored(&mut self.pos, self.inner, bufs)
+    }
+
+    #[inline]
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
@@ -591,16 +625,26 @@ where
     A: Allocator,
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        vec_write(&mut self.pos, self.inner, buf)
+        vec_write_all(&mut self.pos, self.inner, buf)
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        vec_write_vectored(&mut self.pos, self.inner, bufs)
+        vec_write_all_vectored(&mut self.pos, self.inner, bufs)
     }
 
     #[inline]
     fn is_write_vectored(&self) -> bool {
         true
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        vec_write_all(&mut self.pos, self.inner, buf)?;
+        Ok(())
+    }
+
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        vec_write_all_vectored(&mut self.pos, self.inner, bufs)?;
+        Ok(())
     }
 
     #[inline]
@@ -615,16 +659,26 @@ where
     A: Allocator,
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        vec_write(&mut self.pos, &mut self.inner, buf)
+        vec_write_all(&mut self.pos, &mut self.inner, buf)
     }
 
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
+        vec_write_all_vectored(&mut self.pos, &mut self.inner, bufs)
     }
 
     #[inline]
     fn is_write_vectored(&self) -> bool {
         true
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        vec_write_all(&mut self.pos, &mut self.inner, buf)?;
+        Ok(())
+    }
+
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        vec_write_all_vectored(&mut self.pos, &mut self.inner, bufs)?;
+        Ok(())
     }
 
     #[inline]
@@ -654,6 +708,16 @@ where
     }
 
     #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        slice_write_all(&mut self.pos, &mut self.inner, buf)
+    }
+
+    #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        slice_write_all_vectored(&mut self.pos, &mut self.inner, bufs)
+    }
+
+    #[inline]
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
@@ -674,6 +738,16 @@ impl<const N: usize> Write for Cursor<[u8; N]> {
     #[inline]
     fn is_write_vectored(&self) -> bool {
         true
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        slice_write_all(&mut self.pos, &mut self.inner, buf)
+    }
+
+    #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        slice_write_all_vectored(&mut self.pos, &mut self.inner, bufs)
     }
 
     #[inline]

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -455,7 +455,17 @@ impl Write for &mut [u8] {
 
     #[inline]
     fn write_all(&mut self, data: &[u8]) -> io::Result<()> {
-        if self.write(data)? == data.len() { Ok(()) } else { Err(io::Error::WRITE_ALL_EOF) }
+        if self.write(data)? < data.len() { Err(io::Error::WRITE_ALL_EOF) } else { Ok(()) }
+    }
+
+    #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        for buf in bufs {
+            if self.write(buf)? < buf.len() {
+                return Err(io::Error::WRITE_ALL_EOF);
+            }
+        }
+        Ok(())
     }
 
     #[inline]
@@ -492,6 +502,12 @@ impl<A: Allocator> Write for Vec<u8, A> {
     #[inline]
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
         self.extend_from_slice(buf);
+        Ok(())
+    }
+
+    #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.write_vectored(bufs)?;
         Ok(())
     }
 
@@ -641,6 +657,12 @@ impl<A: Allocator> Write for VecDeque<u8, A> {
     }
 
     #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        self.write_vectored(bufs)?;
+        Ok(())
+    }
+
+    #[inline]
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
@@ -653,6 +675,39 @@ impl<'a> io::Write for core::io::BorrowedCursor<'a> {
         let amt = cmp::min(buf.len(), self.capacity());
         self.append(&buf[..amt]);
         Ok(amt)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        let mut nwritten = 0;
+        for buf in bufs {
+            let n = self.write(buf)?;
+            nwritten += n;
+            if n < buf.len() {
+                break;
+            }
+        }
+        Ok(nwritten)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        if self.write(buf)? < buf.len() { Err(io::Error::WRITE_ALL_EOF) } else { Ok(()) }
+    }
+
+    #[inline]
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        for buf in bufs {
+            if self.write(buf)? < buf.len() {
+                return Err(io::Error::WRITE_ALL_EOF);
+            }
+        }
+        Ok(())
     }
 
     #[inline]

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -515,6 +515,7 @@ impl<A: Allocator> Read for VecDeque<u8, A> {
         Ok(n)
     }
 
+    #[inline]
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         let (front, back) = self.as_slices();
 
@@ -547,6 +548,7 @@ impl<A: Allocator> Read for VecDeque<u8, A> {
         Ok(())
     }
 
+    #[inline]
     fn read_buf_exact(&mut self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
         let len = cursor.capacity();
         let (front, back) = self.as_slices();
@@ -646,6 +648,7 @@ impl<A: Allocator> Write for VecDeque<u8, A> {
 
 #[unstable(feature = "read_buf", issue = "78485")]
 impl<'a> io::Write for core::io::BorrowedCursor<'a> {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let amt = cmp::min(buf.len(), self.capacity());
         self.append(&buf[..amt]);

--- a/src/doc/unstable-book/src/language-features/ref-pat-eat-one-layer-2024-structural.md
+++ b/src/doc/unstable-book/src/language-features/ref-pat-eat-one-layer-2024-structural.md
@@ -9,12 +9,32 @@ The tracking issue for this feature is: [#123076]
 This feature is incomplete and not yet intended for general use.
 
 This implements experimental, Edition-dependent match ergonomics under consideration for inclusion
-in Rust.
-For more information, see the corresponding typing rules for [Editions 2021 and earlier] and for
-[Editions 2024 and later].
+in Rust, allowing `&` patterns in more places. For example:
+```rust,edition2024
+#![feature(ref_pat_eat_one_layer_2024_structural)]
+#![allow(incomplete_features)]
+#
+# // Tests type equality in a way that avoids coercing `&&T` or `&mut T` to `&T`.
+# trait Eq<T> {}
+# impl<T> Eq<T> for T {}
+# fn has_type<T>(_: impl Eq<T>) {}
+
+// `&` can match against a `ref` binding mode instead of a reference type:
+let (x, &y) = &(0, 1);
+has_type::<&u8>(x);
+has_type::<u8>(y);
+
+// `&` can match against `&mut` references:
+let &z = &mut 2;
+has_type::<u8>(z);
+```
+
+For specifics, see the corresponding typing rules for [Editions 2021 and earlier] and for
+[Editions 2024 and later]. For more information on binding modes, see [The Rust Reference].
 
 For alternative experimental match ergonomics, see the feature
 [`ref_pat_eat_one_layer_2024`](./ref-pat-eat-one-layer-2024.md).
 
 [Editions 2021 and earlier]: https://nadrieril.github.io/typing-rust-patterns/?compare=false&opts1=AQEBAQIBAQEBAAAAAAAAAAAAAAAAAAA%3D&mode=rules&do_cmp=false
 [Editions 2024 and later]: https://nadrieril.github.io/typing-rust-patterns/?compare=false&opts1=AQEBAgEBAQEBAgIAAAAAAAAAAAAAAAA%3D&mode=rules&do_cmp=false
+[The Rust Reference]: https://doc.rust-lang.org/reference/patterns.html#binding-modes

--- a/src/doc/unstable-book/src/language-features/ref-pat-eat-one-layer-2024.md
+++ b/src/doc/unstable-book/src/language-features/ref-pat-eat-one-layer-2024.md
@@ -9,12 +9,33 @@ The tracking issue for this feature is: [#123076]
 This feature is incomplete and not yet intended for general use.
 
 This implements experimental, Edition-dependent match ergonomics under consideration for inclusion
-in Rust.
-For more information, see the corresponding typing rules for [Editions 2021 and earlier] and for
-[Editions 2024 and later].
+in Rust, allowing `&` patterns in more places. For example:
+
+```rust,edition2024
+#![feature(ref_pat_eat_one_layer_2024)]
+#![allow(incomplete_features)]
+#
+# // Tests type equality in a way that avoids coercing `&&T` or `&mut T` to `&T`.
+# trait Eq<T> {}
+# impl<T> Eq<T> for T {}
+# fn has_type<T>(_: impl Eq<T>) {}
+
+// `&` can match against a `ref` binding mode instead of a reference type:
+let (x, &y) = &(0, 1);
+has_type::<&u8>(x);
+has_type::<u8>(y);
+
+// `&` can match against `&mut` references:
+let &z = &mut 2;
+has_type::<u8>(z);
+```
+
+For specifics, see the corresponding typing rules for [Editions 2021 and earlier] and for
+[Editions 2024 and later]. For more information on binding modes, see [The Rust Reference].
 
 For alternative experimental match ergonomics, see the feature
 [`ref_pat_eat_one_layer_2024_structural`](./ref-pat-eat-one-layer-2024-structural.md).
 
 [Editions 2021 and earlier]: https://nadrieril.github.io/typing-rust-patterns/?compare=false&opts1=AQEBAQIBAQABAAAAAQEBAAEBAAABAAA%3D&mode=rules&do_cmp=false
 [Editions 2024 and later]: https://nadrieril.github.io/typing-rust-patterns/?compare=false&opts1=AQEBAAABAQABAgIAAQEBAAEBAAABAAA%3D&mode=rules&do_cmp=false
+[The Rust Reference]: https://doc.rust-lang.org/reference/patterns.html#binding-modes

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -2359,6 +2359,21 @@ impl Rewrite for ast::Param {
     }
 }
 
+fn rewrite_opt_lifetime(
+    context: &RewriteContext<'_>,
+    lifetime: Option<ast::Lifetime>,
+) -> RewriteResult {
+    let Some(l) = lifetime else {
+        return Ok(String::new());
+    };
+    let mut result = l.rewrite_result(
+        context,
+        Shape::legacy(context.config.max_width(), Indent::empty()),
+    )?;
+    result.push(' ');
+    Ok(result)
+}
+
 fn rewrite_explicit_self(
     context: &RewriteContext<'_>,
     explicit_self: &ast::ExplicitSelf,
@@ -2367,85 +2382,34 @@ fn rewrite_explicit_self(
     shape: Shape,
     has_multiple_attr_lines: bool,
 ) -> RewriteResult {
-    match explicit_self.node {
+    let self_str = match explicit_self.node {
         ast::SelfKind::Region(lt, m) => {
             let mut_str = format_mutability(m);
-            match lt {
-                Some(ref l) => {
-                    let lifetime_str = l.rewrite_result(
-                        context,
-                        Shape::legacy(context.config.max_width(), Indent::empty()),
-                    )?;
-                    Ok(combine_strs_with_missing_comments(
-                        context,
-                        param_attrs,
-                        &format!("&{lifetime_str} {mut_str}self"),
-                        span,
-                        shape,
-                        !has_multiple_attr_lines,
-                    )?)
-                }
-                None => Ok(combine_strs_with_missing_comments(
-                    context,
-                    param_attrs,
-                    &format!("&{mut_str}self"),
-                    span,
-                    shape,
-                    !has_multiple_attr_lines,
-                )?),
-            }
+            let lifetime_str = rewrite_opt_lifetime(context, lt)?;
+            format!("&{lifetime_str}{mut_str}self")
         }
         ast::SelfKind::Pinned(lt, m) => {
             let mut_str = m.ptr_str();
-            match lt {
-                Some(ref l) => {
-                    let lifetime_str = l.rewrite_result(
-                        context,
-                        Shape::legacy(context.config.max_width(), Indent::empty()),
-                    )?;
-                    Ok(combine_strs_with_missing_comments(
-                        context,
-                        param_attrs,
-                        &format!("&{lifetime_str} pin {mut_str} self"),
-                        span,
-                        shape,
-                        !has_multiple_attr_lines,
-                    )?)
-                }
-                None => Ok(combine_strs_with_missing_comments(
-                    context,
-                    param_attrs,
-                    &format!("&pin {mut_str} self"),
-                    span,
-                    shape,
-                    !has_multiple_attr_lines,
-                )?),
-            }
+            let lifetime_str = rewrite_opt_lifetime(context, lt)?;
+            format!("&{lifetime_str}pin {mut_str} self")
         }
         ast::SelfKind::Explicit(ref ty, mutability) => {
             let type_str = ty.rewrite_result(
                 context,
                 Shape::legacy(context.config.max_width(), Indent::empty()),
             )?;
-
-            Ok(combine_strs_with_missing_comments(
-                context,
-                param_attrs,
-                &format!("{}self: {}", format_mutability(mutability), type_str),
-                span,
-                shape,
-                !has_multiple_attr_lines,
-            )?)
+            format!("{}self: {}", format_mutability(mutability), type_str)
         }
-        ast::SelfKind::Value(mutability) => Ok(combine_strs_with_missing_comments(
-            context,
-            param_attrs,
-            &format!("{}self", format_mutability(mutability)),
-            span,
-            shape,
-            !has_multiple_attr_lines,
-        )?),
-    }
+        ast::SelfKind::Value(mutability) => format!("{}self", format_mutability(mutability)),
+    };
+    Ok(combine_strs_with_missing_comments(
+        context,
+        param_attrs,
+        &self_str,
+        span,
+        shape,
+        !has_multiple_attr_lines,
+    )?)
 }
 
 pub(crate) fn span_lo_for_param(param: &ast::Param) -> BytePos {

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -2395,6 +2395,33 @@ fn rewrite_explicit_self(
                 )?),
             }
         }
+        ast::SelfKind::Pinned(lt, m) => {
+            let mut_str = m.ptr_str();
+            match lt {
+                Some(ref l) => {
+                    let lifetime_str = l.rewrite_result(
+                        context,
+                        Shape::legacy(context.config.max_width(), Indent::empty()),
+                    )?;
+                    Ok(combine_strs_with_missing_comments(
+                        context,
+                        param_attrs,
+                        &format!("&{lifetime_str} pin {mut_str} self"),
+                        span,
+                        shape,
+                        !has_multiple_attr_lines,
+                    )?)
+                }
+                None => Ok(combine_strs_with_missing_comments(
+                    context,
+                    param_attrs,
+                    &format!("&pin {mut_str} self"),
+                    span,
+                    shape,
+                    !has_multiple_attr_lines,
+                )?),
+            }
+        }
         ast::SelfKind::Explicit(ref ty, mutability) => {
             let type_str = ty.rewrite_result(
                 context,

--- a/src/tools/rustfmt/tests/source/pin_sugar.rs
+++ b/src/tools/rustfmt/tests/source/pin_sugar.rs
@@ -8,3 +8,13 @@ fn g<'a>(x: &  'a pin const  i32) {}
 fn h<'a>(x: &  'a pin  
 mut i32) {}
 fn i(x: &pin      mut  i32) {}
+
+struct Foo;
+
+impl Foo {
+    fn f(&pin   const self) {}
+    fn g<'a>(&   'a pin const    self) {}
+    fn h<'a>(&    'a pin
+mut self) {}
+    fn i(&pin      mut   self) {}
+}

--- a/src/tools/rustfmt/tests/target/pin_sugar.rs
+++ b/src/tools/rustfmt/tests/target/pin_sugar.rs
@@ -7,3 +7,12 @@ fn f(x: &pin const i32) {}
 fn g<'a>(x: &'a pin const i32) {}
 fn h<'a>(x: &'a pin mut i32) {}
 fn i(x: &pin mut i32) {}
+
+struct Foo;
+
+impl Foo {
+    fn f(&pin const self) {}
+    fn g<'a>(&'a pin const self) {}
+    fn h<'a>(&'a pin mut self) {}
+    fn i(&pin mut self) {}
+}

--- a/tests/pretty/pin-ergonomics.rs
+++ b/tests/pretty/pin-ergonomics.rs
@@ -1,0 +1,24 @@
+//@ pp-exact
+
+#![feature(pin_ergonomics)]
+#![allow(dead_code, incomplete_features)]
+
+struct Foo;
+
+impl Foo {
+    fn baz(&pin mut self) {}
+
+    fn baz_const(&pin const self) {}
+
+    fn baz_lt<'a>(&'a pin mut self) {}
+
+    fn baz_const_lt(&'_ pin const self) {}
+}
+
+fn foo(_: &pin mut Foo) {}
+fn foo_lt<'a>(_: &'a pin mut Foo) {}
+
+fn foo_const(_: &pin const Foo) {}
+fn foo_const_lt(_: &'_ pin const Foo) {}
+
+fn main() {}

--- a/tests/run-make/repr128-dwarf/main.rs
+++ b/tests/run-make/repr128-dwarf/main.rs
@@ -19,8 +19,33 @@ pub enum I128Enum {
     I128D = i128::MAX.to_le(),
 }
 
+#[cfg(not(old_llvm))]
+#[repr(u128)]
+pub enum U128VariantEnum {
+    VariantU128A(u8) = 0_u128.to_le(),
+    VariantU128B = 1_u128.to_le(),
+    VariantU128C = (u64::MAX as u128 + 1).to_le(),
+    VariantU128D = u128::MAX.to_le(),
+}
+
+#[cfg(not(old_llvm))]
+#[repr(i128)]
+pub enum I128VariantEnum {
+    VariantI128A(u8) = 0_i128.to_le(),
+    VariantI128B = (-1_i128).to_le(),
+    VariantI128C = i128::MIN.to_le(),
+    VariantI128D = i128::MAX.to_le(),
+}
+
 pub fn f(_: U128Enum, _: I128Enum) {}
+
+#[cfg(not(old_llvm))]
+pub fn g(_: U128VariantEnum, _: I128VariantEnum) {}
 
 fn main() {
     f(U128Enum::U128A, I128Enum::I128A);
+    #[cfg(not(old_llvm))]
+    {
+        g(U128VariantEnum::VariantU128A(1), I128VariantEnum::VariantI128A(2));
+    }
 }

--- a/tests/run-make/repr128-dwarf/rmake.rs
+++ b/tests/run-make/repr128-dwarf/rmake.rs
@@ -5,13 +5,32 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use gimli::read::DebuggingInformationEntry;
 use gimli::{AttributeValue, EndianRcSlice, Reader, RunTimeEndian};
 use object::{Object, ObjectSection};
 use run_make_support::{gimli, object, rfs, rustc};
 
 fn main() {
+    // Before LLVM 20, 128-bit enums with variants didn't emit debuginfo correctly.
+    // This check can be removed once Rust no longer supports LLVM 18 and 19.
+    let llvm_version = rustc()
+        .verbose()
+        .arg("--version")
+        .run()
+        .stdout_utf8()
+        .lines()
+        .filter_map(|line| line.strip_prefix("LLVM version: "))
+        .map(|version| version.split(".").next().unwrap().parse::<u32>().unwrap())
+        .next()
+        .unwrap();
+    let is_old_llvm = llvm_version < 20;
+
     let output = PathBuf::from("repr128");
-    rustc().input("main.rs").output(&output).arg("-Cdebuginfo=2").run();
+    let mut rustc = rustc();
+    if is_old_llvm {
+        rustc.cfg("old_llvm");
+    }
+    rustc.input("main.rs").output(&output).arg("-Cdebuginfo=2").run();
     // Mach-O uses packed debug info
     let dsym_location = output
         .with_extension("dSYM")
@@ -29,7 +48,8 @@ fn main() {
     })
     .unwrap();
     let mut iter = dwarf.units();
-    let mut still_to_find = HashMap::from([
+
+    let mut enumerators_to_find = HashMap::from([
         ("U128A", 0_u128),
         ("U128B", 1_u128),
         ("U128C", u64::MAX as u128 + 1),
@@ -39,35 +59,88 @@ fn main() {
         ("I128C", i128::MIN as u128),
         ("I128D", i128::MAX as u128),
     ]);
+    let mut variants_to_find = HashMap::from([
+        ("VariantU128A", 0_u128),
+        ("VariantU128B", 1_u128),
+        ("VariantU128C", u64::MAX as u128 + 1),
+        ("VariantU128D", u128::MAX),
+        ("VariantI128A", 0_i128 as u128),
+        ("VariantI128B", (-1_i128) as u128),
+        ("VariantI128C", i128::MIN as u128),
+        ("VariantI128D", i128::MAX as u128),
+    ]);
+
     while let Some(header) = iter.next().unwrap() {
         let unit = dwarf.unit(header).unwrap();
         let mut cursor = unit.entries();
+
+        let get_name = |entry: &DebuggingInformationEntry<'_, '_, _>| {
+            let name = dwarf
+                .attr_string(
+                    &unit,
+                    entry.attr(gimli::constants::DW_AT_name).unwrap().unwrap().value(),
+                )
+                .unwrap();
+            name.to_string().unwrap().to_string()
+        };
+
         while let Some((_, entry)) = cursor.next_dfs().unwrap() {
-            if entry.tag() == gimli::constants::DW_TAG_enumerator {
-                let name = dwarf
-                    .attr_string(
-                        &unit,
-                        entry.attr(gimli::constants::DW_AT_name).unwrap().unwrap().value(),
-                    )
-                    .unwrap();
-                let name = name.to_string().unwrap();
-                if let Some(expected) = still_to_find.remove(name.as_ref()) {
-                    match entry.attr(gimli::constants::DW_AT_const_value).unwrap().unwrap().value()
+            match entry.tag() {
+                gimli::constants::DW_TAG_variant if !is_old_llvm => {
+                    let value = match entry
+                        .attr(gimli::constants::DW_AT_discr_value)
+                        .unwrap()
+                        .unwrap()
+                        .value()
                     {
-                        AttributeValue::Block(value) => {
-                            assert_eq!(
-                                value.to_slice().unwrap(),
-                                expected.to_le_bytes().as_slice(),
-                                "{name}"
-                            );
-                        }
-                        value => panic!("{name}: unexpected DW_AT_const_value of {value:?}"),
+                        AttributeValue::Block(value) => value.to_slice().unwrap().to_vec(),
+                        value => panic!("unexpected DW_AT_discr_value of {value:?}"),
+                    };
+                    // The `DW_TAG_member` that is a child of `DW_TAG_variant` will contain the
+                    // variant's name.
+                    let Some((1, child_entry)) = cursor.next_dfs().unwrap() else {
+                        panic!("Missing child of DW_TAG_variant");
+                    };
+                    assert_eq!(child_entry.tag(), gimli::constants::DW_TAG_member);
+                    let name = get_name(child_entry);
+                    if let Some(expected) = variants_to_find.remove(name.as_str()) {
+                        // This test uses LE byte order is used for consistent values across
+                        // architectures.
+                        assert_eq!(value.as_slice(), expected.to_le_bytes().as_slice(), "{name}");
                     }
                 }
+
+                gimli::constants::DW_TAG_enumerator => {
+                    let name = get_name(entry);
+                    if let Some(expected) = enumerators_to_find.remove(name.as_str()) {
+                        match entry
+                            .attr(gimli::constants::DW_AT_const_value)
+                            .unwrap()
+                            .unwrap()
+                            .value()
+                        {
+                            AttributeValue::Block(value) => {
+                                // This test uses LE byte order is used for consistent values across
+                                // architectures.
+                                assert_eq!(
+                                    value.to_slice().unwrap(),
+                                    expected.to_le_bytes().as_slice(),
+                                    "{name}"
+                                );
+                            }
+                            value => panic!("{name}: unexpected DW_AT_const_value of {value:?}"),
+                        }
+                    }
+                }
+
+                _ => {}
             }
         }
     }
-    if !still_to_find.is_empty() {
-        panic!("Didn't find debug entries for {still_to_find:?}");
+    if !enumerators_to_find.is_empty() {
+        panic!("Didn't find debug enumerator entries for {enumerators_to_find:?}");
+    }
+    if !is_old_llvm && !variants_to_find.is_empty() {
+        panic!("Didn't find debug variant entries for {variants_to_find:?}");
     }
 }

--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -60,7 +60,8 @@ fn main() {
 }
 
 fn find_lld_version_in_logs(stderr: String) -> bool {
-    let lld_version_re =
-        Regex::new(r"^warning: linker std(out|err): LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
+    // Strip the `-Wlinker-messages` wrappers prefixing the linker output.
+    let stderr = Regex::new(r"warning: linker std(out|err):").unwrap().replace_all(&stderr, "");
+    let lld_version_re = Regex::new(r"^LLD [0-9]+\.[0-9]+\.[0-9]+").unwrap();
     stderr.lines().any(|line| lld_version_re.is_match(line.trim()))
 }

--- a/tests/run-make/unstable-feature-usage-metrics/rmake.rs
+++ b/tests/run-make/unstable-feature-usage-metrics/rmake.rs
@@ -58,12 +58,17 @@ fn test_metrics_dump() {
         );
 
         let message = rfs::read_to_string(json_path);
-        let parsed: serde_json::Value =
+        let mut parsed: serde_json::Value =
             serde_json::from_str(&message).expect("metrics should be dumped as json");
+        // remove timestamps
+        assert!(parsed["lib_features"][0]["timestamp"].is_number());
+        assert!(parsed["lang_features"][0]["timestamp"].is_number());
+        parsed["lib_features"][0]["timestamp"] = serde_json::json!(null);
+        parsed["lang_features"][0]["timestamp"] = serde_json::json!(null);
         let expected = serde_json::json!(
             {
-                "lib_features":[{"symbol":"ascii_char"}],
-                "lang_features":[{"symbol":"box_patterns","since":null}]
+                "lib_features":[{"symbol":"ascii_char", "timestamp":null}],
+                "lang_features":[{"symbol":"box_patterns","since":null, "timestamp":null}]
             }
         );
 

--- a/tests/rustdoc/doc-hidden-reexports-109449.rs
+++ b/tests/rustdoc/doc-hidden-reexports-109449.rs
@@ -26,21 +26,21 @@ pub mod single_reexport {
     //@ has 'foo/single_reexport/index.html'
 
     // First we check that we have 4 type aliases.
-    //@ count - '//*[@id="main-content"]/*[@class="item-table reexports"]//code' 4
+    //@ count - '//*[@id="main-content"]/*[@class="item-table reexports"]//code' 0
 
     // Then we check that we have the correct link for each re-export.
 
     //@ !has - '//*[@href="struct.Foo.html"]' 'Foo'
-    //@ has - '//*[@id="reexport.Foo"]/code' 'pub use crate::private_module::Public as Foo;'
+    //@ !has - '//*[@id="reexport.Foo"]/code' 'pub use crate::private_module::Public as Foo;'
     pub use crate::private_module::Public as Foo;
     //@ !has - '//*[@href="type.Foo2.html"]' 'Foo2'
-    //@ has - '//*[@id="reexport.Foo2"]/code' 'pub use crate::private_module::Bar as Foo2;'
+    //@ !has - '//*[@id="reexport.Foo2"]/code' 'pub use crate::private_module::Bar as Foo2;'
     pub use crate::private_module::Bar as Foo2;
     //@ !has - '//*[@href="type.Yo.html"]' 'Yo'
-    //@ has - '//*[@id="reexport.Yo"]/code' 'pub use crate::Bar3 as Yo;'
+    //@ !has - '//*[@id="reexport.Yo"]/code' 'pub use crate::Bar3 as Yo;'
     pub use crate::Bar3 as Yo;
     //@ !has - '//*[@href="struct.Yo2.html"]' 'Yo2'
-    //@ has - '//*[@id="reexport.Yo2"]/code' 'pub use crate::FooFoo as Yo2;'
+    //@ !has - '//*[@id="reexport.Yo2"]/code' 'pub use crate::FooFoo as Yo2;'
     pub use crate::FooFoo as Yo2;
 
     // Checking that each file is also created as expected.
@@ -70,19 +70,19 @@ pub mod single_reexport_no_inline {
     //@ has - '//*[@id="main-content"]/*[@class="section-header"]' 'Re-exports'
 
     // Now we check that we don't have links to the items, just `pub use`.
-    //@ has - '//*[@id="main-content"]//*' 'pub use crate::private_module::Public as XFoo;'
+    //@ !has - '//*[@id="main-content"]//*' 'pub use crate::private_module::Public as XFoo;'
     //@ !has - '//*[@id="main-content"]//a' 'XFoo'
     #[doc(no_inline)]
     pub use crate::private_module::Public as XFoo;
-    //@ has - '//*[@id="main-content"]//*' 'pub use crate::private_module::Bar as Foo2;'
+    //@ !has - '//*[@id="main-content"]//*' 'pub use crate::private_module::Bar as Foo2;'
     //@ !has - '//*[@id="main-content"]//a' 'Foo2'
     #[doc(no_inline)]
     pub use crate::private_module::Bar as Foo2;
-    //@ has - '//*[@id="main-content"]//*' 'pub use crate::Bar3 as Yo;'
+    //@ !has - '//*[@id="main-content"]//*' 'pub use crate::Bar3 as Yo;'
     //@ !has - '//*[@id="main-content"]//a' 'Yo'
     #[doc(no_inline)]
     pub use crate::Bar3 as Yo;
-    //@ has - '//*[@id="main-content"]//*' 'pub use crate::FooFoo as Yo2;'
+    //@ !has - '//*[@id="main-content"]//*' 'pub use crate::FooFoo as Yo2;'
     //@ !has - '//*[@id="main-content"]//a' 'Yo2'
     #[doc(no_inline)]
     pub use crate::FooFoo as Yo2;

--- a/tests/rustdoc/doc-hidden-source.rs
+++ b/tests/rustdoc/doc-hidden-source.rs
@@ -1,0 +1,16 @@
+// Test for <https://github.com/rust-lang/rust/issues/137342>.
+
+#![crate_name = "foo"]
+
+//@ has 'foo/index.html'
+//@ !has - '//*[@id="main-content"]//*[@class="struct"]' 'Bar'
+#[doc(hidden)]
+pub struct Bar;
+
+//@ !has - '//*' 'pub use crate::Bar as A;'
+pub use crate::Bar as A;
+//@ !has - '//*' 'pub use crate::A as B;'
+pub use crate::A as B;
+//@ has - '//dt/a[@class="struct"]' 'C'
+#[doc(inline)]
+pub use crate::Bar as C;

--- a/tests/rustdoc/inline_cross/inline_hidden.rs
+++ b/tests/rustdoc/inline_cross/inline_hidden.rs
@@ -6,7 +6,7 @@ extern crate rustdoc_hidden;
 
 //@ has inline_hidden/index.html
 // Ensures this item is not inlined.
-//@ has - '//*[@id="reexport.Foo"]/code' 'pub use rustdoc_hidden::Foo;'
+//@ !has - '//*[@id="reexport.Foo"]/code' 'pub use rustdoc_hidden::Foo;'
 #[doc(no_inline)]
 pub use rustdoc_hidden::Foo;
 
@@ -16,7 +16,7 @@ pub use rustdoc_hidden::Foo;
 pub use rustdoc_hidden::Foo as Inlined;
 
 // Even with this import, we should not see `Foo`.
-//@ count - '//dt' 4
+//@ count - '//dt' 3
 //@ has - '//dt/a[@class="struct"]' 'Bar'
 //@ has - '//dt/a[@class="fn"]' 'foo'
 pub use rustdoc_hidden::*;

--- a/tests/rustdoc/reexport-attr-merge.rs
+++ b/tests/rustdoc/reexport-attr-merge.rs
@@ -18,7 +18,7 @@ pub use Foo1 as Foo2;
 
 // First we ensure that only the reexport `Bar2` and the inlined struct `Bar`
 // are inlined.
-//@ count - '//a[@class="struct"]' 2
+//@ count - '//a[@class="struct"]' 1
 // Then we check that `cfg` is displayed for base item, but not for intermediate re-exports.
 //@ has - '//*[@class="stab portability"]' 'foo'
 //@ !has - '//*[@class="stab portability"]' 'bar'
@@ -29,5 +29,5 @@ pub use Foo2 as Bar;
 
 // This one should appear but `Bar2` won't be linked because there is no
 // `#[doc(inline)]`.
-//@ has - '//*[@id="reexport.Bar2"]' 'pub use Foo2 as Bar2;'
+//@ !has - '//*[@id="reexport.Bar2"]' 'pub use Foo2 as Bar2;'
 pub use Foo2 as Bar2;

--- a/tests/rustdoc/reexport-doc-hidden-inside-private.rs
+++ b/tests/rustdoc/reexport-doc-hidden-inside-private.rs
@@ -9,8 +9,8 @@ mod private_module {
 }
 
 //@ has 'foo/index.html'
-//@ has - '//*[@id="reexport.Foo"]/code' 'pub use crate::private_module::Public as Foo;'
+//@ !has - '//*[@id="reexport.Foo"]/code' 'pub use crate::private_module::Public as Foo;'
 pub use crate::private_module::Public as Foo;
 // Glob re-exports with no visible items should not be displayed.
-//@ count - '//*[@class="item-table reexports"]/dt' 1
+//@ count - '//*[@class="item-table reexports"]/dt' 0
 pub use crate::private_module::*;

--- a/tests/rustdoc/reexport-doc-hidden.rs
+++ b/tests/rustdoc/reexport-doc-hidden.rs
@@ -8,7 +8,7 @@
 pub type Type = u32;
 
 //@ has 'foo/index.html'
-//@ has - '//*[@id="reexport.Type2"]/code' 'pub use crate::Type as Type2;'
+//@ !has - '//*[@id="reexport.Type2"]/code' 'pub use crate::Type as Type2;'
 pub use crate::Type as Type2;
 
 //@ count - '//*[@id="reexport.Type3"]' 0
@@ -21,5 +21,5 @@ macro_rules! foo {
     () => {};
 }
 
-//@ has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
+//@ !has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
 pub use crate::foo as Macro;

--- a/tests/rustdoc/reexport-hidden-macro.rs
+++ b/tests/rustdoc/reexport-hidden-macro.rs
@@ -5,7 +5,7 @@
 
 //@ has 'foo/index.html'
 //@ has - '//*[@id="main-content"]//a[@href="macro.Macro2.html"]' 'Macro2'
-//@ has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
+//@ !has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
 
 //@ has 'foo/macro.Macro2.html'
 //@ has - '//*[@class="docblock"]' 'Displayed'

--- a/tests/rustdoc/reexport-of-doc-hidden.rs
+++ b/tests/rustdoc/reexport-of-doc-hidden.rs
@@ -12,13 +12,13 @@ macro_rules! foo {
 }
 
 //@ has 'foo/index.html'
-//@ has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
+//@ !has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
 pub use crate::foo as Macro;
-//@ has - '//*[@id="reexport.Macro2"]/code' 'pub use crate::foo as Macro2;'
+//@ !has - '//*[@id="reexport.Macro2"]/code' 'pub use crate::foo as Macro2;'
 pub use crate::foo as Macro2;
-//@ has - '//*[@id="reexport.Boo"]/code' 'pub use crate::Bar as Boo;'
+//@ !has - '//*[@id="reexport.Boo"]/code' 'pub use crate::Bar as Boo;'
 pub use crate::Bar as Boo;
-//@ has - '//*[@id="reexport.Boo2"]/code' 'pub use crate::Bar as Boo2;'
+//@ !has - '//*[@id="reexport.Boo2"]/code' 'pub use crate::Bar as Boo2;'
 pub use crate::Bar as Boo2;
 
 pub fn fofo() {}
@@ -30,9 +30,9 @@ pub use crate::fofo as f2;
 
 pub mod sub {
     //@ has 'foo/sub/index.html'
-    //@ has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
+    //@ !has - '//*[@id="reexport.Macro"]/code' 'pub use crate::foo as Macro;'
     pub use crate::foo as Macro;
-    //@ has - '//*[@id="reexport.Macro2"]/code' 'pub use crate::foo as Macro2;'
+    //@ !has - '//*[@id="reexport.Macro2"]/code' 'pub use crate::foo as Macro2;'
     pub use crate::foo as Macro2;
 
     //@ has - '//*[@id="reexport.f1"]/code' 'pub use crate::fofo as f1;'

--- a/tests/ui/associated-types/ident-from-macro-expansion.rs
+++ b/tests/ui/associated-types/ident-from-macro-expansion.rs
@@ -1,0 +1,23 @@
+trait Trait {}
+impl Trait for () {}
+
+macro_rules! fully_qualified {
+    ($id:ident) => {
+        <() as Trait>::$id
+    }
+}
+
+macro_rules! type_dependent {
+    ($t:ident, $id:ident) => {
+        T::$id
+    }
+}
+
+fn t<T: Trait>() {
+    let x: fully_qualified!(Assoc);
+    //~^ ERROR cannot find associated type `Assoc` in trait `Trait`
+    let x: type_dependent!(T, Assoc);
+    //~^ ERROR associated type `Assoc` not found for `T`
+}
+
+fn main() {}

--- a/tests/ui/associated-types/ident-from-macro-expansion.stderr
+++ b/tests/ui/associated-types/ident-from-macro-expansion.stderr
@@ -1,0 +1,22 @@
+error[E0576]: cannot find associated type `Assoc` in trait `Trait`
+  --> $DIR/ident-from-macro-expansion.rs:17:29
+   |
+LL |         <() as Trait>::$id
+   |                        --- due to this macro variable
+...
+LL |     let x: fully_qualified!(Assoc);
+   |                             ^^^^^ not found in `Trait`
+
+error[E0220]: associated type `Assoc` not found for `T`
+  --> $DIR/ident-from-macro-expansion.rs:19:31
+   |
+LL |         T::$id
+   |            --- due to this macro variable
+...
+LL |     let x: type_dependent!(T, Assoc);
+   |                               ^^^^^ associated type `Assoc` not found
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0220, E0576.
+For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/async-await/pin-ergonomics/sugar-self.rs
+++ b/tests/ui/async-await/pin-ergonomics/sugar-self.rs
@@ -1,0 +1,46 @@
+//@ check-pass
+
+#![feature(pin_ergonomics)]
+#![allow(dead_code, incomplete_features)]
+
+// Makes sure we can handle `&pin mut self` and `&pin const self` as sugar for
+// `self: Pin<&mut Self>` and `self: Pin<&Self>`.
+
+use std::pin::Pin;
+
+struct Foo;
+
+impl Foo {
+    fn baz(&pin mut self) {}
+
+    fn baz_const(&pin const self) {}
+
+    fn baz_lt<'a>(&'a pin mut self) {}
+
+    fn baz_const_lt(&'_ pin const self) {}
+}
+
+fn foo(_: &pin mut Foo) {}
+
+fn foo_const(_: &pin const Foo) {}
+
+fn bar(x: &pin mut Foo) {
+    // For the calls below to work we need to automatically reborrow,
+    // as if the user had written `foo(x.as_mut())`.
+    foo(x);
+    foo(x);
+
+    Foo::baz(x);
+    Foo::baz(x);
+
+    // make sure we can reborrow &mut as &.
+    foo_const(x);
+    Foo::baz_const(x);
+
+    let x: &pin const _ = Pin::new(&Foo);
+
+    foo_const(x); // make sure reborrowing from & to & works.
+    foo_const(x);
+}
+
+fn main() {}

--- a/tests/ui/attributes/decl_macro_ty_in_attr_macro.rs
+++ b/tests/ui/attributes/decl_macro_ty_in_attr_macro.rs
@@ -1,0 +1,20 @@
+// tests for #137662: using a ty or (or most other) fragment inside an attr macro wouldn't work
+// because of a missing code path. With $repr: tt it did work.
+//@ check-pass
+
+macro_rules! foo {
+    {
+        $repr:ty
+    } => {
+        #[repr($repr)]
+        pub enum Foo {
+            Bar = 0i32,
+        }
+    }
+}
+
+foo! {
+    i32
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -7,9 +7,13 @@ struct Foo;
 impl Foo {
     fn foo(self: Pin<&mut Self>) {
     }
+    fn foo_sugar(&pin mut self) {} //~ ERROR pinned reference syntax is experimental
+    fn foo_sugar_const(&pin const self) {} //~ ERROR pinned reference syntax is experimental
 }
 
-fn foo(x: Pin<&mut Foo>) {
+fn foo(mut x: Pin<&mut Foo>) {
+    Foo::foo_sugar(x.as_mut());
+    Foo::foo_sugar_const(x.as_ref());
     let _y: &pin mut Foo = x; //~ ERROR pinned reference syntax is experimental
 }
 
@@ -26,5 +30,39 @@ fn baz(mut x: Pin<&mut Foo>) {
 }
 
 fn baz_sugar(_: &pin const Foo) {} //~ ERROR pinned reference syntax is experimental
+
+#[cfg(any())]
+mod not_compiled {
+    use std::pin::Pin;
+
+    struct Foo;
+
+    impl Foo {
+        fn foo(self: Pin<&mut Self>) {
+        }
+        fn foo_sugar(&pin mut self) {} //~ ERROR pinned reference syntax is experimental
+        fn foo_sugar_const(&pin const self) {} //~ ERROR pinned reference syntax is experimental
+    }
+
+    fn foo(mut x: Pin<&mut Foo>) {
+        Foo::foo_sugar(x.as_mut());
+        Foo::foo_sugar_const(x.as_ref());
+        let _y: &pin mut Foo = x; //~ ERROR pinned reference syntax is experimental
+    }
+
+    fn foo_sugar(_: &pin mut Foo) {} //~ ERROR pinned reference syntax is experimental
+
+    fn bar(x: Pin<&mut Foo>) {
+        foo(x);
+        foo(x);
+    }
+
+    fn baz(mut x: Pin<&mut Foo>) {
+        x.foo();
+        x.foo();
+    }
+
+    fn baz_sugar(_: &pin const Foo) {} //~ ERROR pinned reference syntax is experimental
+}
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -1,5 +1,25 @@
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:13:14
+  --> $DIR/feature-gate-pin_ergonomics.rs:10:19
+   |
+LL |     fn foo_sugar(&pin mut self) {}
+   |                   ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:11:25
+   |
+LL |     fn foo_sugar_const(&pin const self) {}
+   |                         ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:17:14
    |
 LL |     let _y: &pin mut Foo = x;
    |              ^^^
@@ -9,7 +29,7 @@ LL |     let _y: &pin mut Foo = x;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:16:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:20:18
    |
 LL | fn foo_sugar(_: &pin mut Foo) {}
    |                  ^^^
@@ -19,7 +39,7 @@ LL | fn foo_sugar(_: &pin mut Foo) {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: pinned reference syntax is experimental
-  --> $DIR/feature-gate-pin_ergonomics.rs:28:18
+  --> $DIR/feature-gate-pin_ergonomics.rs:32:18
    |
 LL | fn baz_sugar(_: &pin const Foo) {}
    |                  ^^^
@@ -28,8 +48,58 @@ LL | fn baz_sugar(_: &pin const Foo) {}
    = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:43:23
+   |
+LL |         fn foo_sugar(&pin mut self) {}
+   |                       ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:44:29
+   |
+LL |         fn foo_sugar_const(&pin const self) {}
+   |                             ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:50:18
+   |
+LL |         let _y: &pin mut Foo = x;
+   |                  ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:53:22
+   |
+LL |     fn foo_sugar(_: &pin mut Foo) {}
+   |                      ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: pinned reference syntax is experimental
+  --> $DIR/feature-gate-pin_ergonomics.rs:65:22
+   |
+LL |     fn baz_sugar(_: &pin const Foo) {}
+   |                      ^^^
+   |
+   = note: see issue #130494 <https://github.com/rust-lang/rust/issues/130494> for more information
+   = help: add `#![feature(pin_ergonomics)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:20:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:24:9
    |
 LL | fn bar(x: Pin<&mut Foo>) {
    |        - move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -39,15 +109,15 @@ LL |     foo(x);
    |         ^ value used here after move
    |
 note: consider changing this parameter type in function `foo` to borrow instead if owning the value isn't necessary
-  --> $DIR/feature-gate-pin_ergonomics.rs:12:11
+  --> $DIR/feature-gate-pin_ergonomics.rs:14:15
    |
-LL | fn foo(x: Pin<&mut Foo>) {
-   |    ---    ^^^^^^^^^^^^^ this parameter takes ownership of the value
+LL | fn foo(mut x: Pin<&mut Foo>) {
+   |    ---        ^^^^^^^^^^^^^ this parameter takes ownership of the value
    |    |
    |    in this function
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:25:5
+  --> $DIR/feature-gate-pin_ergonomics.rs:29:5
    |
 LL | fn baz(mut x: Pin<&mut Foo>) {
    |        ----- move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -66,7 +136,7 @@ help: consider reborrowing the `Pin` instead of moving it
 LL |     x.as_mut().foo();
    |      +++++++++
 
-error: aborting due to 5 previous errors
+error: aborting due to 12 previous errors
 
 Some errors have detailed explanations: E0382, E0658.
 For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/hygiene/generate-mod.stderr
+++ b/tests/ui/hygiene/generate-mod.stderr
@@ -1,12 +1,18 @@
 error[E0412]: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:35:13
    |
+LL |     type A = $FromOutside;
+   |              ------------ due to this macro variable
+...
 LL |     genmod!(FromOutside, Outer);
    |             ^^^^^^^^^^^ not found in this scope
 
 error[E0412]: cannot find type `Outer` in this scope
   --> $DIR/generate-mod.rs:35:26
    |
+LL |     struct $Outer;
+   |            ------ due to this macro variable
+...
 LL |     genmod!(FromOutside, Outer);
    |                          ^^^^^ not found in this scope
 

--- a/tests/ui/hygiene/globs.stderr
+++ b/tests/ui/hygiene/globs.stderr
@@ -50,6 +50,9 @@ error[E0425]: cannot find function `f` in this scope
 LL | n!(f);
    | ----- in this macro invocation
 ...
+LL |                     $j();
+   |                     -- due to this macro variable
+...
 LL |         n!(f);
    |            ^ not found in this scope
    |
@@ -62,6 +65,9 @@ error[E0425]: cannot find function `f` in this scope
    |
 LL | n!(f);
    | ----- in this macro invocation
+...
+LL |                     $j();
+   |                     -- due to this macro variable
 ...
 LL |                 f
    |                 ^ not found in this scope

--- a/tests/ui/inference/issue-86094-suggest-add-return-to-coerce-ret-ty.stderr
+++ b/tests/ui/inference/issue-86094-suggest-add-return-to-coerce-ret-ty.stderr
@@ -8,10 +8,6 @@ help: consider specifying the generic arguments
    |
 LL |         Err::<T, MyError>(MyError);
    |            ++++++++++++++
-help: you might have meant to return this to infer its type parameters
-   |
-LL |         return Err(MyError);
-   |         ++++++
 
 error[E0282]: type annotations needed
   --> $DIR/issue-86094-suggest-add-return-to-coerce-ret-ty.rs:14:9
@@ -23,10 +19,6 @@ help: consider specifying the generic arguments
    |
 LL |         Ok::<(), E>(());
    |           +++++++++
-help: you might have meant to return this to infer its type parameters
-   |
-LL |         return Ok(());
-   |         ++++++
 
 error[E0308]: mismatched types
   --> $DIR/issue-86094-suggest-add-return-to-coerce-ret-ty.rs:21:20

--- a/tests/ui/macros/macro-parameter-span.stderr
+++ b/tests/ui/macros/macro-parameter-span.stderr
@@ -1,6 +1,9 @@
 error[E0425]: cannot find value `x` in this scope
   --> $DIR/macro-parameter-span.rs:11:9
    |
+LL |         $id
+   |         --- due to this macro variable
+...
 LL |         x
    |         ^ not found in this scope
 

--- a/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
+++ b/tests/ui/macros/rfc-3086-metavar-expr/syntax-errors.stderr
@@ -338,6 +338,9 @@ LL |     no_curly__no_rhs_dollar__no_round!(a);
 error[E0425]: cannot find value `a` in this scope
   --> $DIR/syntax-errors.rs:152:37
    |
+LL |     ( $i:ident ) => { count($i) };
+   |                             -- due to this macro variable
+...
 LL |     no_curly__rhs_dollar__no_round!(a);
    |                                     ^ not found in this scope
 

--- a/tests/ui/methods/ident-from-macro-expansion.rs
+++ b/tests/ui/methods/ident-from-macro-expansion.rs
@@ -1,0 +1,18 @@
+macro_rules! dot {
+    ($id:ident) => {
+        ().$id();
+    }
+}
+
+macro_rules! dispatch {
+    ($id:ident) => {
+        <()>::$id();
+    }
+}
+
+fn main() {
+    dot!(hello);
+    //~^ ERROR no method named `hello` found for unit type `()` in the current scope
+    dispatch!(hello);
+    //~^ ERROR no function or associated item named `hello` found for unit type `()` in the current scope
+}

--- a/tests/ui/methods/ident-from-macro-expansion.stderr
+++ b/tests/ui/methods/ident-from-macro-expansion.stderr
@@ -1,0 +1,21 @@
+error[E0599]: no method named `hello` found for unit type `()` in the current scope
+  --> $DIR/ident-from-macro-expansion.rs:14:10
+   |
+LL |         ().$id();
+   |            --- due to this macro variable
+...
+LL |     dot!(hello);
+   |          ^^^^^ method not found in `()`
+
+error[E0599]: no function or associated item named `hello` found for unit type `()` in the current scope
+  --> $DIR/ident-from-macro-expansion.rs:16:15
+   |
+LL |         <()>::$id();
+   |               --- due to this macro variable
+...
+LL |     dispatch!(hello);
+   |               ^^^^^ function or associated item not found in `()`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/tests/ui/return/tail-expr-as-potential-return.rs
+++ b/tests/ui/return/tail-expr-as-potential-return.rs
@@ -60,7 +60,6 @@ fn method() -> Option<i32> {
         Receiver.generic();
         //~^ ERROR type annotations needed
         //~| HELP consider specifying the generic argument
-        //~| HELP you might have meant to return this to infer its type parameters
     }
 
     None

--- a/tests/ui/return/tail-expr-as-potential-return.stderr
+++ b/tests/ui/return/tail-expr-as-potential-return.stderr
@@ -57,10 +57,6 @@ help: consider specifying the generic argument
    |
 LL |         Receiver.generic::<T>();
    |                         +++++
-help: you might have meant to return this to infer its type parameters
-   |
-LL |         return Receiver.generic();
-   |         ++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/structs/ident-from-macro-expansion.rs
+++ b/tests/ui/structs/ident-from-macro-expansion.rs
@@ -1,0 +1,19 @@
+struct Foo {
+    inner: Inner,
+}
+
+struct Inner {
+    y: i32,
+}
+
+macro_rules! access {
+    ($expr:expr, $ident:ident) => {
+        $expr.$ident
+    }
+}
+
+fn main() {
+    let k = Foo { inner: Inner { y: 0 } };
+    access!(k, y);
+    //~^ ERROR no field `y` on type `Foo`
+}

--- a/tests/ui/structs/ident-from-macro-expansion.stderr
+++ b/tests/ui/structs/ident-from-macro-expansion.stderr
@@ -1,0 +1,14 @@
+error[E0609]: no field `y` on type `Foo`
+  --> $DIR/ident-from-macro-expansion.rs:17:16
+   |
+LL |         $expr.$ident
+   |               ------ due to this macro variable
+...
+LL |     access!(k, y);
+   |                ^ unknown field
+   |
+   = note: available field is: `inner`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0609`.

--- a/tests/ui/traits/trait-upcasting/dyn-to-dyn-star.rs
+++ b/tests/ui/traits/trait-upcasting/dyn-to-dyn-star.rs
@@ -1,0 +1,19 @@
+// While somewhat nonsensical, this is a cast from a wide pointer to a thin pointer.
+// Thus, we don't need to check an unsize goal here; there isn't any vtable casting
+// happening at all.
+
+// Regression test for <https://github.com/rust-lang/rust/issues/137579>.
+
+//@ check-pass
+
+#![allow(incomplete_features)]
+#![feature(dyn_star)]
+
+trait Foo {}
+trait Bar {}
+
+fn cast(x: *const dyn Foo) {
+    x as *const dyn* Bar;
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #135733 (Implement `&pin const self` and `&pin mut self` sugars)
 - #137107 (Override default `Write` methods for cursor-like types)
 - #137303 (Remove `MaybeForgetReturn` suggestion)
 - #137327 (Undeprecate env::home_dir)
 - #137358 (Match Ergonomics 2024: add context and examples to the unstable book)
 - #137534 ([rustdoc] hide item that is not marked as doc(inline) and whose src is doc(hidden))
 - #137565 (Try to point of macro expansion from resolver and method errors if it involves macro var)
 - #137637 (Check dyn flavor before registering upcast goal on wide pointer cast in MIR typeck)
 - #137643 (Add DWARF test case for non-C-like `repr128` enums)
 - #137685 (self-contained linker: conservatively default to `-znostart-stop-gc` on x64 linux)
 - #137744 (Re-add `Clone`-derive on `Thir`)
 - #137758 (fix usage of ty decl macro fragments in attributes)
 - #137827 (Add timestamp to unstable feature usage metrics)
 - #137832 (Fix crash in BufReader::peek())
 - #138052 (strip `-Wlinker-messages` wrappers from `rust-lld` rmake test)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135733,137107,137303,137327,137358,137534,137565,137637,137643,137685,137744,137758,137827,137832,138052)
<!-- homu-ignore:end -->