### PR TITLE
Use final path segment for diagnostic

### DIFF
--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -1265,7 +1265,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 } else {
                     CallableKind::Function
                 };
-                maybe_emit_help(def_id, path.segments[0].ident, args, callable_kind);
+                maybe_emit_help(def_id, path.segments.last().unwrap().ident, args, callable_kind);
             }
             hir::ExprKind::MethodCall(method, _receiver, args, _span) => {
                 let Some(def_id) =

--- a/tests/ui/typeck/issue-84768.stderr
+++ b/tests/ui/typeck/issue-84768.stderr
@@ -20,7 +20,7 @@ help: the return type of this call is `{integer}` due to the type of the argumen
 LL |     <F as FnOnce(&mut u8)>::call_once(f, 1)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-^
    |                                          |
-   |                                          this argument influences the return type of `FnOnce`
+   |                                          this argument influences the return type of `call_once`
 note: method defined here
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 

--- a/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -25,7 +25,7 @@ help: the return type of this call is `u32` due to the type of the argument pass
 LL |     <i32 as Add<i32>>::add(1u32, 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^----^^^^
    |                            |
-   |                            this argument influences the return type of `Add`
+   |                            this argument influences the return type of `add`
 note: method defined here
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 help: change the type of the numeric literal from `u32` to `i32`
@@ -48,7 +48,7 @@ help: the return type of this call is `u32` due to the type of the argument pass
 LL |     <i32 as Add<i32>>::add(1, 2u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^----^
    |                               |
-   |                               this argument influences the return type of `Add`
+   |                               this argument influences the return type of `add`
 note: method defined here
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
 help: change the type of the numeric literal from `u32` to `i32`


### PR DESCRIPTION
Test changes should prove the effect of this PR; we want to mention the *function name* not the arbitrary first segment of the path.