### PR TITLE
Calculate predecessor count directly

### DIFF
--- a/compiler/rustc_mir_transform/src/add_call_guards.rs
+++ b/compiler/rustc_mir_transform/src/add_call_guards.rs
@@ -32,8 +32,12 @@ pub(super) use self::AddCallGuards::*;
 
 impl<'tcx> crate::MirPass<'tcx> for AddCallGuards {
     fn run_pass(&self, _tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        let mut pred_count: IndexVec<_, _> =
-            body.basic_blocks.predecessors().iter().map(|ps| ps.len()).collect();
+        let mut pred_count = IndexVec::from_elem(0u8, &body.basic_blocks);
+        for (_, data) in body.basic_blocks.iter_enumerated() {
+            for succ in data.terminator().successors() {
+                pred_count[succ] = pred_count[succ].saturating_add(1);
+            }
+        }
 
         // We need a place to store the new blocks generated
         let mut new_blocks = Vec::new();

--- a/compiler/rustc_mir_transform/src/add_call_guards.rs
+++ b/compiler/rustc_mir_transform/src/add_call_guards.rs
@@ -34,7 +34,6 @@ impl<'tcx> crate::MirPass<'tcx> for AddCallGuards {
     fn run_pass(&self, _tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         let mut pred_count: IndexVec<_, _> =
             body.basic_blocks.predecessors().iter().map(|ps| ps.len()).collect();
-        pred_count[START_BLOCK] += 1;
 
         // We need a place to store the new blocks generated
         let mut new_blocks = Vec::new();


### PR DESCRIPTION
Avoid allocating a vector of small vectors merely to determine how many
predecessors each basic block has.

Additionally use u8 and saturating operations. The pass only needs to
distinguish between [0..1] and [2..].

