### PR TITLE
Don't display bootstrap changelog warnings in --dry-run mode

### DIFF
--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -187,7 +187,8 @@ fn check_version(config: &Config) -> Option<String> {
             "update `config.toml` to use `change-id = {latest_change_id}` instead"
         ));
 
-        if io::stdout().is_terminal() && !config.dry_run() {
+        if io::stdout().is_terminal() {
+            t!(std::fs::create_dir_all(warned_id_path.parent().unwrap()));
             t!(fs::write(warned_id_path, latest_change_id.to_string()));
         }
     } else {

--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -70,11 +70,12 @@ fn main() {
     }
 
     // check_version warnings are not printed during setup, or during CI
-    let changelog_suggestion = if matches!(config.cmd, Subcommand::Setup { .. }) || CiEnv::is_ci() {
-        None
-    } else {
-        check_version(&config)
-    };
+    let changelog_suggestion =
+        if matches!(config.cmd, Subcommand::Setup { .. }) || CiEnv::is_ci() || config.dry_run() {
+            None
+        } else {
+            check_version(&config)
+        };
 
     // NOTE: Since `./configure` generates a `config.toml`, distro maintainers will see the
     // changelog warning, not the `x.py setup` message.
@@ -188,7 +189,6 @@ fn check_version(config: &Config) -> Option<String> {
         ));
 
         if io::stdout().is_terminal() {
-            t!(std::fs::create_dir_all(warned_id_path.parent().unwrap()));
             t!(fs::write(warned_id_path, latest_change_id.to_string()));
         }
     } else {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Presently x.py displays "There have been changes to x.py since you last updated:" note only once when run normally, but on every invocation when run with `--dry-run`.
The disparity is not exactly intentonal, but just a historical accident.
It was made to be printed once in https://github.com/rust-lang/rust/pull/117815 via storing `.last-warned-change-id` on disk in `{config.out}/bootstrap` (i.e. `build/bootstrap`) directory.
But that didn't quite work for `--dry-run`, since `{config.out}/bootsrap` points to `build/tmp-dry-run/bootstrap` which *isn't* created in dry-run mode, so file creation fails.
This got fixed in https://github.com/rust-lang/rust/pull/118789 and now `--dry-run` does not save `.last-warned-change-id` at all. (Nor does it read it, since it cannot know to read from non-dry-run location)

This PR simply stops displaying the changelog altogether in --dry-run mode.

<details>
<summary>previous attempt (outdated)</summary>
This PR takes a different approach, and instead of not-writing the stamp in `--dry-run` mode it instead tries harder to yes-write it, and, specifically, creates `build/tmp-dry-run/bootstrap` directory to do so. If neccessary (i.e. if there are changes newer than the `change-id` stamp of config.toml to warn about).
Note that `build/tmp-dry-run/` was *already* being created, so making an extra `boostrap` sub-folder should not meaningfully pollute the build dir.
</details>

(Apologies for the, perhaps, excessively wordy PR, I'm new to this)