### PR TITLE
Leave a breadcrumb towards bootstrap config documentation in `bootstrap.toml`

### DIFF
--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -216,8 +216,9 @@ fn setup_config_toml(path: &Path, profile: Profile, config: &Config) {
 
     let latest_change_id = CONFIG_CHANGE_HISTORY.last().unwrap().change_id;
     let settings = format!(
-        "# Includes one of the default files in {PROFILE_DIR}\n\
-    profile = \"{profile}\"\n\
+        "# See bootstrap.example.toml for documentation of available options\n\
+    #\n\
+    profile = \"{profile}\"  # Includes one of the default files in {PROFILE_DIR}\n\
     change-id = {latest_change_id}\n"
     );
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

I was curious as to the possible bootstrap options I can put in config.toml, but had some trouble figuring it out. There is no obvious documentation in `config.toml` (obviously), the documentation in src/bootstrap/defaults is *nice*, but also rather sparse, by design.
I had to dive into the parsing code, and stuble upon [a very helpful doc comment](https://github.com/rust-lang/rust/blob/30f168ef811aec63124eac677e14699baa9395bd/src/bootstrap/src/core/config/config.rs#L181) there to realize that `config.example.toml` *exists*, and that it does, indeed, answer all of my questions.

So I figured it might be worth making this journey a bit easier for future contributors and add mention the `config.example.toml` directly in `config.toml`.

Now, since #137081 is in-flight which would rename `config(.example)?.toml` to `bootstrap(.example)?.toml`, I figure it's better to wait until that one lands, and submit the "new", "correct" filename upfront, instead of landing `config.toml` now and updating it to `boostrap.toml` later.

@rustbot blocked #137081