### PR TITLE
remove invalid workspaceFolder prefix from the zed rust-analyzer config

### DIFF
--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -606,6 +606,7 @@ Select which editor you would like to set up [default: None]: ";
             EditorKind::Zed => &[
                 "bbce727c269d1bd0c98afef4d612eb4ce27aea3c3a8968c5f10b31affbc40b6c",
                 "a5380cf5dd9328731aecc5dfb240d16dac46ed272126b9728006151ef42f5909",
+                "9d6f1f99e8a98467173126fcb480aa8203ea5bdabdb55a903bee03da8307e483".
             ],
         }
     }

--- a/src/etc/rust_analyzer_zed.json
+++ b/src/etc/rust_analyzer_zed.json
@@ -28,15 +28,15 @@
           "compiler/rustc_codegen_gcc/Cargo.toml"
         ],
         "procMacro": {
-            "enable": true,
-            "server": "${workspaceFolder}/build/host/stage0/libexec/rust-analyzer-proc-macro-srv"
+          "enable": true,
+          "server": "build/host/stage0/libexec/rust-analyzer-proc-macro-srv"
         },
         "rustc": {
           "source": "./Cargo.toml"
         },
         "rustfmt": {
           "overrideCommand": [
-            "${workspaceFolder}/build/host/rustfmt/bin/rustfmt",
+            "build/host/rustfmt/bin/rustfmt",
             "--edition=2021"
           ]
         },


### PR DESCRIPTION
using `${workspaceFolder}` causes a lot of incorrect diagnostics on the latest version of zed

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
