### PR TITLE
Re-add `DynSend` and `DynSync` impls for `TyCtxt`

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1327,7 +1327,9 @@ pub struct TyCtxt<'tcx> {
     gcx: &'tcx GlobalCtxt<'tcx>,
 }
 
-// Explicitly implement `DynSync` and `DynSend` for `TyCtxt` to short circuit trait resolution.
+// Explicitly implement `DynSync` and `DynSend` for `TyCtxt` to short circuit trait resolution. Its
+// field are asserted to implement these traits below, so this is trivially safe, and it greatly
+// speeds-up compilation of this crate and its dependents.
 unsafe impl DynSend for TyCtxt<'_> {}
 unsafe impl DynSync for TyCtxt<'_> {}
 fn _assert_tcx_fields() {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1327,6 +1327,9 @@ pub struct TyCtxt<'tcx> {
     gcx: &'tcx GlobalCtxt<'tcx>,
 }
 
+// Explicitly implement `DynSync` and `DynSend` for `TyCtxt` to short circuit trait resolution.
+unsafe impl DynSend for TyCtxt<'_> {}
+unsafe impl DynSync for TyCtxt<'_> {}
 fn _assert_tcx_fields() {
     sync::assert_dyn_sync::<&'_ GlobalCtxt<'_>>();
     sync::assert_dyn_send::<&'_ GlobalCtxt<'_>>();


### PR DESCRIPTION
They were somewhat unexpectedly removed in #136731. This PR adds them back, as requested in https://github.com/rust-lang/rust/pull/136731#issuecomment-2702504644. I've also tried to expand the comments a bit to make it less likely that they're removed again in the future.

r? @SparrowLii 