### PR TITLE
Git ignore citool's target directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ no_llvm_build
 /target
 /library/target
 /src/bootstrap/target
+/src/ci/citool/target
 /src/tools/x/target
 # Created by `x vendor`
 /vendor


### PR DESCRIPTION
Whenever running citool, it leaves behind a target directory. Ignore this like we do for other tools.
