### PR TITLE
Mention me (WaffleLapkin) when changes to `rustc_codegen_ssa` occur

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -701,6 +701,9 @@ cc = ["@davidtwco", "@wesleywiser"]
 [mentions."compiler/rustc_codegen_cranelift"]
 cc = ["@bjorn3"]
 
+[mentions."compiler/rustc_codegen_ssa"]
+cc = ["@WaffleLapkin"]
+
 [mentions."compiler/rustc_codegen_gcc"]
 cc = ["@antoyo", "@GuillaumeGomez"]
 


### PR DESCRIPTION
My employer is writing a rustc backend and it's my job to resolve conflicts with upstream so I'd like to know when `rustc_codegen_ssa` is being changed =)
