### PR TITLE
Configure triagebot to accept codegen-{gcc,cranelift} ping groups and document ping groups and ping commands

### DIFF
--- a/src/doc/rustc-dev-guide/src/notification-groups/about.md
+++ b/src/doc/rustc-dev-guide/src/notification-groups/about.md
@@ -22,13 +22,15 @@ Here's the list of the notification groups:
 - [Apple](./apple.md)
 - [ARM](./arm.md)
 - [Cleanup Crew](./cleanup-crew.md)
+- [codegen-cranelift](./codegen-cranelift.md)
+- [codegen-gcc](./codegen-gcc.md)
 - [Emscripten](./emscripten.md)
 - [LLVM](./llvm.md)
 - [RISC-V](./risc-v.md)
+- [Rust for Linux](./rust-for-linux.md)
 - [WASI](./wasi.md)
 - [WebAssembly](./wasm.md)
 - [Windows](./windows.md)
-- [Rust for Linux](./rust-for-linux.md)
 
 ## What issues are a good fit for notification groups?
 
@@ -82,9 +84,12 @@ group. For example:
 @rustbot ping apple
 @rustbot ping arm
 @rustbot ping cleanup-crew
+@rustbot ping codegen-cranelift
+@rustbot ping codegen-gcc
 @rustbot ping emscripten
 @rustbot ping llvm
 @rustbot ping risc-v
+@rustbot ping rfl
 @rustbot ping wasi
 @rustbot ping wasm
 @rustbot ping windows

--- a/src/doc/rustc-dev-guide/src/notification-groups/codegen-cranelift.md
+++ b/src/doc/rustc-dev-guide/src/notification-groups/codegen-cranelift.md
@@ -1,0 +1,5 @@
+# Cranelift codegen backend notification group
+
+**Ping command:** `@rustbot ping codegen-cranelift`
+
+This ping group is intended to ping the cranelift codegen backend team for guidance on a specific issue or PR.

--- a/src/doc/rustc-dev-guide/src/notification-groups/codegen-gcc.md
+++ b/src/doc/rustc-dev-guide/src/notification-groups/codegen-gcc.md
@@ -1,0 +1,5 @@
+# GCC codegen backend notification group
+
+**Ping command:** `@rustbot ping codegen-gcc`
+
+This ping group is intended to ping the gcc codegen backend team for guidance on a specific issue or PR.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -178,6 +178,18 @@ Hi relnotes-interest-group, this PR adds release notes. Could you review this PR
 if you have time? Thanks <3
 """
 
+[ping.codegen-gcc]
+message = """\
+Hey GCC codegen backend team, this issue or PR could use some cg_gcc guidance.
+Could one of you take a look? Thanks <3
+"""
+
+[ping.codegen-cranelift]
+message = """\
+Hey cranelift codegen backend team, this issue or PR could use some cg_cranelift
+guidance. Could one of you take a look? Thanks <3
+"""
+
 [prioritize]
 label = "I-prioritize"
 


### PR DESCRIPTION
Blocked on https://github.com/rust-lang/team/pull/1685.
Discussion: [#t-infra > Triagebot ping groups for GCC and cranelift backends](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Triagebot.20ping.20groups.20for.20GCC.20and.20cranelift.20backends/with/503862444).
Closes #138116.

r? ghost