### PR TITLE
setTargetTriple now accepts Triple rather than string

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -152,11 +152,11 @@ extern "C" LLVMContextRef LLVMRustContextCreate(bool shouldDiscardNames) {
 }
 
 extern "C" void LLVMRustSetNormalizedTarget(LLVMModuleRef M,
-                                            const char *Triple) {
+                                            const char *Target) {
 #if LLVM_VERSION_GE(21, 0)
-  unwrap(M)->setTargetTriple(llvm::Triple(Triple::normalize(Triple)));
+  unwrap(M)->setTargetTriple(Triple(Triple::normalize(Target)));
 #else
-  unwrap(M)->setTargetTriple(Triple::normalize(Triple));
+  unwrap(M)->setTargetTriple(Triple::normalize(Target));
 #endif
 }
 

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -153,7 +153,11 @@ extern "C" LLVMContextRef LLVMRustContextCreate(bool shouldDiscardNames) {
 
 extern "C" void LLVMRustSetNormalizedTarget(LLVMModuleRef M,
                                             const char *Triple) {
+#if LLVM_VERSION_GE(21, 0)
+  unwrap(M)->setTargetTriple(llvm::Triple(Triple::normalize(Triple)));
+#else
   unwrap(M)->setTargetTriple(Triple::normalize(Triple));
+#endif
 }
 
 extern "C" void LLVMRustPrintPassTimings(RustStringRef OutBuf) {


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/129868 updated `setTargetTriple`
