### PR TITLE
Pass `InferCtxt` to `InlineAsmCtxt` to properly taint on error

### DIFF
--- a/tests/ui/asm/invalid-const-operand.rs
+++ b/tests/ui/asm/invalid-const-operand.rs
@@ -14,7 +14,7 @@ global_asm!("{}", const 0f32);
 global_asm!("{}", const 0 as *mut u8);
 //~^ ERROR invalid type for `const` operand
 
-fn main() {
+fn test1() {
     unsafe {
         // Const operands must be integers and must be constants.
 
@@ -27,7 +27,11 @@ fn main() {
         //~^ ERROR invalid type for `const` operand
         asm!("{}", const &0);
         //~^ ERROR invalid type for `const` operand
+    }
+}
 
+fn test2() {
+    unsafe {
         // Constants must be... constant
 
         let x = 0;
@@ -47,3 +51,5 @@ fn main() {
         //~^ ERROR attempt to use a non-constant value in a constant
     }
 }
+
+fn main() {}

--- a/tests/ui/asm/invalid-const-operand.stderr
+++ b/tests/ui/asm/invalid-const-operand.stderr
@@ -1,5 +1,5 @@
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/invalid-const-operand.rs:40:26
+  --> $DIR/invalid-const-operand.rs:44:26
    |
 LL |         asm!("{}", const x);
    |                          ^ non-constant value
@@ -11,7 +11,7 @@ LL +         const x: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/invalid-const-operand.rs:43:36
+  --> $DIR/invalid-const-operand.rs:47:36
    |
 LL |         asm!("{}", const const_foo(x));
    |                                    ^ non-constant value
@@ -23,7 +23,7 @@ LL +         const x: /* Type */ = 0;
    |
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/invalid-const-operand.rs:46:36
+  --> $DIR/invalid-const-operand.rs:50:36
    |
 LL |         asm!("{}", const const_bar(x));
    |                                    ^ non-constant value
@@ -80,7 +80,7 @@ error: invalid type for `const` operand
 LL |         asm!("{}", const &0);
    |                    ^^^^^^--
    |                          |
-   |                          is a `&{integer}`
+   |                          is a `&i32`
    |
    = help: `const` operands must be of an integer type
 

--- a/tests/ui/asm/tainting-on-error.rs
+++ b/tests/ui/asm/tainting-on-error.rs
@@ -1,0 +1,13 @@
+//@ needs-asm-support
+
+use std::arch::asm;
+
+fn main() {
+    unsafe {
+        asm!(
+            "/* {} */",
+            sym None::<()>,
+            //~^ ERROR invalid `sym` operand
+        );
+    }
+}

--- a/tests/ui/asm/tainting-on-error.stderr
+++ b/tests/ui/asm/tainting-on-error.stderr
@@ -1,0 +1,10 @@
+error: invalid `sym` operand
+  --> $DIR/tainting-on-error.rs:9:13
+   |
+LL |             sym None::<()>,
+   |             ^^^^^^^^^^^^^^ is an `Option<()>`
+   |
+   = help: `sym` operands must refer to either a function or a static
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/asm/x86_64/type-check-2.rs
+++ b/tests/ui/asm/x86_64/type-check-2.rs
@@ -7,7 +7,7 @@ use std::arch::{asm, global_asm};
 #[repr(simd)]
 struct SimdNonCopy([f32; 4]);
 
-fn main() {
+fn test1() {
     unsafe {
         // Inputs must be initialized
 
@@ -26,7 +26,11 @@ fn main() {
         asm!("{}", in(reg) v[0]);
         asm!("{}", out(reg) v[0]);
         asm!("{}", inout(reg) v[0]);
+    }
+}
 
+fn test2() {
+    unsafe {
         // Register operands must be Copy
 
         asm!("{}", in(xmm_reg) SimdNonCopy([0.0, 0.0, 0.0, 0.0]));
@@ -68,3 +72,5 @@ fn main() {
         asm!("{}", in(reg) u);
     }
 }
+
+fn main() {}

--- a/tests/ui/asm/x86_64/type-check-2.stderr
+++ b/tests/ui/asm/x86_64/type-check-2.stderr
@@ -1,13 +1,13 @@
 error: arguments for inline assembly must be copyable
-  --> $DIR/type-check-2.rs:32:32
+  --> $DIR/type-check-2.rs:36:32
    |
 LL |         asm!("{}", in(xmm_reg) SimdNonCopy([0.0, 0.0, 0.0, 0.0]));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `SimdNonCopy` does not implement the Copy trait
 
-error: cannot use value of type `{closure@$DIR/type-check-2.rs:44:28: 44:36}` for inline assembly
-  --> $DIR/type-check-2.rs:44:28
+error: cannot use value of type `{closure@$DIR/type-check-2.rs:48:28: 48:36}` for inline assembly
+  --> $DIR/type-check-2.rs:48:28
    |
 LL |         asm!("{}", in(reg) |x: i32| x);
    |                            ^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |         asm!("{}", in(reg) |x: i32| x);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `Vec<i32>` for inline assembly
-  --> $DIR/type-check-2.rs:46:28
+  --> $DIR/type-check-2.rs:50:28
    |
 LL |         asm!("{}", in(reg) vec![0]);
    |                            ^^^^^^^
@@ -24,7 +24,7 @@ LL |         asm!("{}", in(reg) vec![0]);
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot use value of type `(i32, i32, i32)` for inline assembly
-  --> $DIR/type-check-2.rs:48:28
+  --> $DIR/type-check-2.rs:52:28
    |
 LL |         asm!("{}", in(reg) (1, 2, 3));
    |                            ^^^^^^^^^
@@ -32,7 +32,7 @@ LL |         asm!("{}", in(reg) (1, 2, 3));
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `[i32; 3]` for inline assembly
-  --> $DIR/type-check-2.rs:50:28
+  --> $DIR/type-check-2.rs:54:28
    |
 LL |         asm!("{}", in(reg) [1, 2, 3]);
    |                            ^^^^^^^^^
@@ -40,7 +40,7 @@ LL |         asm!("{}", in(reg) [1, 2, 3]);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `fn() {main}` for inline assembly
-  --> $DIR/type-check-2.rs:58:31
+  --> $DIR/type-check-2.rs:62:31
    |
 LL |         asm!("{}", inout(reg) f);
    |                               ^
@@ -48,7 +48,7 @@ LL |         asm!("{}", inout(reg) f);
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
 
 error: cannot use value of type `&mut i32` for inline assembly
-  --> $DIR/type-check-2.rs:61:31
+  --> $DIR/type-check-2.rs:65:31
    |
 LL |         asm!("{}", inout(reg) r);
    |                               ^


### PR DESCRIPTION
Pass an `InferCtxt` into the `InlineAsmCtxt` so that we can use the right dcx to taint the infcx properly, so that we don't try to build invalid MIR for inline asm blocks.

Fixes #138130

Shares the first commit with #137502.

r? oli-obk