### PR TITLE
Emit warning while outputs is not exe and prints linkage info

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -195,9 +195,9 @@ pub fn link_binary(
                 tempfiles_for_stdout_output.push(out_filename);
             }
         }
-
-        check_link_info_print_request(sess, &codegen_results.crate_info.crate_types);
     }
+
+    check_link_info_print_request(sess, &codegen_results.crate_info.crate_types);
 
     // Remove the temporary object file and metadata if we aren't saving temps.
     sess.time("link_binary_remove_temps", || {

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -79,7 +79,7 @@ fn check_link_info_print_request(sess: &Session, crate_type: CrateType) {
                 .note(format!("consider `--crate-type staticlib` to print linkage information"));
         } else if !sess.opts.output_types.should_link() {
             sess.dcx().warn(format!(
-                    "skipping link step due to conflict: cannot output linkage information without emitting link"
+                    "cannot output linkage information when --emit link is not passed"
                 ));
         }
     }

--- a/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.rs
+++ b/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: --print native-static-libs
+//@ check-pass
+//~? WARN cannot output linkage information without staticlib crate-type
+
+fn main() {}

--- a/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.stderr
+++ b/tests/ui/print-request/emit-warning-print-link-info-without-staticlib.stderr
@@ -1,0 +1,6 @@
+warning: cannot output linkage information without staticlib crate-type
+
+note: consider `--crate-type staticlib` to print linkage information
+
+warning: 1 warning emitted
+

--- a/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.rs
+++ b/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.rs
@@ -1,3 +1,3 @@
 //@ compile-flags: --print native-static-libs --crate-type staticlib  --emit metadata
 //@ check-pass
-//~? WARN skipping link step due to conflict: cannot output linkage information without emitting link
+//~? WARN cannot output linkage information when --emit link is not passed

--- a/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.rs
+++ b/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.rs
@@ -1,0 +1,3 @@
+//@ compile-flags: --print native-static-libs --crate-type staticlib  --emit metadata
+//@ check-pass
+//~? WARN skipping link step due to conflict: cannot output linkage information without emitting link

--- a/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.stderr
+++ b/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.stderr
@@ -1,0 +1,4 @@
+warning: skipping link step due to conflict: cannot output linkage information without emitting link
+
+warning: 1 warning emitted
+

--- a/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.stderr
+++ b/tests/ui/print-request/emit-warning-while-exe-and-print-link-info.stderr
@@ -1,4 +1,4 @@
-warning: skipping link step due to conflict: cannot output linkage information without emitting link
+warning: cannot output linkage information when --emit link is not passed
 
 warning: 1 warning emitted
 

--- a/tests/ui/print-request/stability.rs
+++ b/tests/ui/print-request/stability.rs
@@ -110,3 +110,4 @@ fn main() {}
 //[check_cfg]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `check-cfg` print option
 //[supported_crate_types]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `supported-crate-types` print option
 //[target_spec_json]~? ERROR the `-Z unstable-options` flag must also be passed to enable the `target-spec-json` print option
+//[native_static_libs]~? WARNING cannot output linkage information without staticlib crate-type


### PR DESCRIPTION
cc #137384 

```bash
$ rustc +stage1 /dev/null --print native-static-libs --crate-type staticlib  --emit metadata
warning: skipping link step due to conflict: cannot output linkage information without emitting executable

note: consider emitting executable to print link information

warning: 1 warning emitted
```