### PR TITLE
RustWrapper: adapt for LLVM 21 change in setTargetTriple

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -153,7 +153,11 @@ extern "C" LLVMContextRef LLVMRustContextCreate(bool shouldDiscardNames) {
 
 extern "C" void LLVMRustSetNormalizedTarget(LLVMModuleRef M,
                                             const char *Triple) {
+#if LLVM_VERSION_GE(21, 0)
+  unwrap(M)->setTargetTriple(llvm::Triple(Triple::normalize(Triple)));
+#else
   unwrap(M)->setTargetTriple(Triple::normalize(Triple));
+#endif
 }
 
 extern "C" void LLVMRustPrintPassTimings(RustStringRef OutBuf) {


### PR DESCRIPTION
@rustbot label llvm-main

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
