### PR TITLE
rustdoc: add unstable option `--crate-list-heading` to customize the sidebar crate list.

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -241,6 +241,10 @@ pub(crate) struct RenderOptions {
     /// What sorting mode to use for module pages.
     /// `ModuleSorting::Alphabetical` by default.
     pub(crate) module_sorting: ModuleSorting,
+    /// In the sidebar list of all crates, put the current crate(s) under this heading.
+    /// To put a crate under the unnamed primary heading, which is always listed first,
+    /// make this the empty string.
+    pub(crate) crate_list_heading: String,
     /// List of themes to extend the docs with. Original argument name is included to assist in
     /// displaying errors if it fails a theme check.
     pub(crate) themes: Vec<StylePath>,
@@ -760,6 +764,7 @@ impl Options {
         } else {
             ModuleSorting::Alphabetical
         };
+        let crate_list_heading = matches.opt_str("crate-list-heading").unwrap_or_default();
         let resource_suffix = matches.opt_str("resource-suffix").unwrap_or_default();
         let markdown_no_toc = matches.opt_present("markdown-no-toc");
         let markdown_css = matches.opt_strs("markdown-css");
@@ -859,6 +864,7 @@ impl Options {
             id_map,
             playground_url,
             module_sorting,
+            crate_list_heading,
             themes,
             extension_css,
             extern_html_root_urls,

--- a/src/librustdoc/html/render/write_shared/tests.rs
+++ b/src/librustdoc/html/render/write_shared/tests.rs
@@ -9,7 +9,8 @@ fn hack_external_crate_names() {
     let path = path.path();
     let crates = hack_get_external_crate_names(&path, "").unwrap();
     assert!(crates.is_empty());
-    fs::write(path.join("crates.js"), r#"window.ALL_CRATES = ["a","b","c"];"#).unwrap();
+    fs::write(path.join("crates.js"), r#"window.ALL_CRATES = [{"c":"a"},{"c":"b"},{"c":"c"}];"#)
+        .unwrap();
     let crates = hack_get_external_crate_names(&path, "").unwrap();
     assert_eq!(crates, ["a".to_string(), "b".to_string(), "c".to_string()]);
 }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -995,7 +995,6 @@ function preLoadCss(cssUrl) {
     }
 
     function addSidebarCrates() {
-        // @ts-expect-error
         if (!window.ALL_CRATES) {
             return;
         }
@@ -1009,7 +1008,6 @@ function preLoadCss(cssUrl) {
         const ul = document.createElement("ul");
         ul.className = "block crate";
 
-        // @ts-expect-error
         for (const crate of window.ALL_CRATES) {
             const link = document.createElement("a");
             link.href = window.rootPath + crate + "/index.html";

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -994,6 +994,7 @@ function preLoadCss(cssUrl) {
         window.register_type_impls(window.pending_type_impls);
     }
 
+    // Draw a convenient sidebar of known crates if we have a listing
     function addSidebarCrates() {
         if (!window.ALL_CRATES) {
             return;
@@ -1002,26 +1003,59 @@ function preLoadCss(cssUrl) {
         if (!sidebarElems) {
             return;
         }
-        // Draw a convenient sidebar of known crates if we have a listing
-        const h3 = document.createElement("h3");
-        h3.innerHTML = "Crates";
-        const ul = document.createElement("ul");
-        ul.className = "block crate";
 
-        for (const crate of window.ALL_CRATES) {
-            const link = document.createElement("a");
-            link.href = window.rootPath + crate + "/index.html";
-            link.textContent = crate;
+        // h2 puts this on the same level as the current crate name heading at the top
+        const allCratesHeading = document.createElement("h2");
+        allCratesHeading.textContent = "Crates";
 
-            const li = document.createElement("li");
-            if (window.rootPath !== "./" && crate === window.currentCrate) {
-                li.className = "current";
+        const allCratesSection = document.createElement("section");
+
+        // window.ALL_CRATES is in unsorted array-of-structs format; reorganize so crates with the
+        // same heading are grouped.
+        const cratesGroupedByHeading = new Map();
+        for (const entry of window.ALL_CRATES) {
+            const heading = entry.h || "";
+            const crateName = entry.c;
+            let group = cratesGroupedByHeading.get(heading);
+            if (group === undefined) {
+                group = [];
+                cratesGroupedByHeading.set(heading, group);
             }
-            li.appendChild(link);
-            ul.appendChild(li);
+            group.push(crateName);
         }
-        sidebarElems.appendChild(h3);
-        sidebarElems.appendChild(ul);
+        const headings = Array.from(cratesGroupedByHeading.keys());
+        headings.sort();
+
+        // Generate HTML for grouped crates.
+        for (const headingText of headings) {
+            // Empty string denotes a group with no named heading.
+            if (headingText !== "") {
+                const crateCategoryHeading = document.createElement("h3");
+                crateCategoryHeading.textContent = headingText;
+                allCratesSection.appendChild(crateCategoryHeading);
+            }
+
+            const cratesUl = document.createElement("ul");
+            cratesUl.className = "block crate";
+
+            for (const crateName of cratesGroupedByHeading.get(headingText)) {
+                const link = document.createElement("a");
+                link.href = window.rootPath + crateName + "/index.html";
+                link.textContent = crateName;
+
+                const li = document.createElement("li");
+                if (window.rootPath !== "./" && crateName === window.currentCrate) {
+                    li.className = "current";
+                }
+                li.appendChild(link);
+                cratesUl.appendChild(li);
+            }
+
+            allCratesSection.appendChild(cratesUl);
+        }
+
+        sidebarElems.appendChild(allCratesHeading);
+        sidebarElems.appendChild(allCratesSection);
     }
 
     function expandAllDocs() {

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -13,8 +13,10 @@ declare global {
     interface Window {
         /** Make the current theme easy to find */
         currentTheme: HTMLLinkElement|null;
+        /** Generated in `render/context.rs` */
+        SIDEBAR_ITEMS?: { [key: string]: string[] };
         /** List of all documented crates. */
-        ALL_CRATES: string[]|undefined;
+        ALL_CRATES: rustdoc.AllCratesEntry[]|undefined;
         /** Used by the popover tooltip code. */
         RUSTDOC_TOOLTIP_HOVER_MS: number;
         /** Used by the popover tooltip code. */
@@ -395,6 +397,18 @@ declare namespace rustdoc {
         generics: FingerprintableType[];
         bindings: Map<number, FingerprintableType[]>;
     };
+
+    /** Member of ALL_CRATES. */
+    interface AllCratesEntry {
+        /**
+         * Heading under which the crate should be listed.
+         * 
+         * May be empty to specify the first, primary heading.
+         */
+        h?: string,
+        /** Crate name. */
+        c: string,
+    }
 
     /**
      * The raw search data for a given crate. `n`, `t`, `d`, `i`, and `f`

--- a/src/librustdoc/html/static/js/rustdoc.d.ts
+++ b/src/librustdoc/html/static/js/rustdoc.d.ts
@@ -13,8 +13,8 @@ declare global {
     interface Window {
         /** Make the current theme easy to find */
         currentTheme: HTMLLinkElement|null;
-        /** Generated in `render/context.rs` */
-        SIDEBAR_ITEMS?: { [key: string]: string[] };
+        /** List of all documented crates. */
+        ALL_CRATES: string[]|undefined;
         /** Used by the popover tooltip code. */
         RUSTDOC_TOOLTIP_HOVER_MS: number;
         /** Used by the popover tooltip code. */

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -384,6 +384,14 @@ fn opts() -> Vec<RustcOptGroup> {
             "",
         ),
         opt(
+            Unstable,
+            Opt,
+            "",
+            "crate-list-heading",
+            "heading under which to list this crate in the sidebar crate list",
+            "TEXT",
+        ),
+        opt(
             Stable,
             Opt,
             "",

--- a/tests/rustdoc-gui/sidebar.goml
+++ b/tests/rustdoc-gui/sidebar.goml
@@ -48,7 +48,9 @@ call-function: ("switch-theme", {"theme": "light"})
 assert-text: (".sidebar > .sidebar-crate > h2 > a", "test_docs")
 // Crate root has no "location" element
 assert-count: (".sidebar .location", 0)
-assert-count: (".sidebar h2", 1)
+// Crate root has two h2s, the second of which is the the crate list
+assert-count: (".sidebar h2", 2)
+assert-text: (".sidebar #rustdoc-modnav h2", "Crates")
 assert-text: ("#all-types", "All Items")
 assert-css: ("#all-types", {"color": "#356da4"})
 // We check that we have the crates list and that the "current" on is "test_docs".

--- a/tests/rustdoc/crate-list-heading.rs
+++ b/tests/rustdoc/crate-list-heading.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -Zunstable-options --crate-list-heading=helloworld
+#![crate_name = "foo"]
+
+//@ hasraw crates.js '"h":"helloworld"'
+//@ hasraw crates.js '"c":"foo"'


### PR DESCRIPTION
When used, this option creates a subheading within the sidebar “Crates” list for this crate and all crates which pass the same value. These headings are displayed in alphabetical order; crates without the option, or with it set to the empty string, always appear first.

The intended use of this option is to allow Cargo to automatically separate a workspace’s crate list into the workspace’s own crates and their external dependencies (as requested in #85759 and, loosely, #81031). Even without Cargo support, authors could also use `RUSTDOCFLAGS` to create custom headings for their documentation builds (which may address #16328).

As currently written, merging this would break all nightly builds against a pre-existing `target/doc/`, because the format of `crates.js` (defining variable `window.ALL_CRATES`) is changed. I don’t know whether backwards compatibility is worth implementing here, but it is possible to arrange — I figured I should first get a review of the general idea before polishing it.

----

Example of the new sidebar appearance in one of my workspaces:

<img width="258" alt="image" src="https://github.com/user-attachments/assets/515e3964-a293-4301-b878-5b2394855ffd" />

<details><summary>Original obsolete version</summary>
<img width="269" alt="image" src="https://github.com/user-attachments/assets/5db8a93f-9511-4d6b-8219-9d0bc74f07ed" /></details>

The vertical margins `<h3>Dependencies</h3>` should probably adjusted to have clearer visual hierarchy, but I don’t think that should be done in this PR. Also note that this additional header will not appear until explicitly requested via the flag — in this screenshot I am also using a patched Cargo.

----

@rustbot label A-rustdoc-ui T-rustdoc T-rustdoc-frontend