### PR TITLE
use target compiler on llvm-bitcode-linker

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1991,12 +1991,12 @@ impl Step for Assemble {
             }
         }
 
-        let maybe_install_llvm_bitcode_linker = |compiler| {
+        let maybe_install_llvm_bitcode_linker = || {
             if builder.config.llvm_bitcode_linker_enabled {
                 trace!("llvm-bitcode-linker enabled, installing");
                 let llvm_bitcode_linker =
                     builder.ensure(crate::core::build_steps::tool::LlvmBitcodeLinker {
-                        compiler,
+                        compiler: target_compiler,
                         target: target_compiler.host,
                         extra_features: vec![],
                     });
@@ -2020,7 +2020,7 @@ impl Step for Assemble {
                 builder.info(&format!("Creating a sysroot for stage{stage} compiler (use `rustup toolchain link 'name' build/host/stage{stage}`)", stage=target_compiler.stage));
             }
 
-            maybe_install_llvm_bitcode_linker(target_compiler);
+            maybe_install_llvm_bitcode_linker();
 
             return target_compiler;
         }
@@ -2203,7 +2203,7 @@ impl Step for Assemble {
             );
         }
 
-        maybe_install_llvm_bitcode_linker(build_compiler);
+        maybe_install_llvm_bitcode_linker();
 
         // Ensure that `libLLVM.so` ends up in the newly build compiler directory,
         // so that it can be found when the newly built `rustc` is run.


### PR DESCRIPTION
The build compiler is already resolved inside the `ToolBuild` step, so we should pass only the target compilers for `Mode::ToolRustc` tools.

Fixes https://github.com/rust-lang/rust/issues/138123

r? ghost

try-job: dist-powerpc64le-linux