### PR TITLE
Support rmeta inputs for --crate-type=bin --emit=obj

### DIFF
--- a/compiler/rustc_metadata/src/dependency_format.rs
+++ b/compiler/rustc_metadata/src/dependency_format.rs
@@ -84,7 +84,7 @@ pub(crate) fn calculate(tcx: TyCtxt<'_>) -> Dependencies {
 fn calculate_type(tcx: TyCtxt<'_>, ty: CrateType) -> DependencyList {
     let sess = &tcx.sess;
 
-    if !sess.opts.output_types.should_codegen() {
+    if !sess.opts.output_types.should_link() {
         return IndexVec::new();
     }
 

--- a/tests/ui/rmeta/rmeta_bin-pass.rs
+++ b/tests/ui/rmeta/rmeta_bin-pass.rs
@@ -1,0 +1,14 @@
+//@ compile-flags: --emit=obj,metadata --crate-type=bin
+//@ aux-build:rmeta-meta.rs
+//@ no-prefer-dynamic
+//@ build-pass
+
+// Check that building a metadata bin crate works with a dependent, metadata
+// crate if linking is not requested.
+
+extern crate rmeta_meta;
+use rmeta_meta::Foo;
+
+pub fn main() {
+    let _ = Foo { field: 42 };
+}

--- a/tests/ui/rmeta/rmeta_bin.rs
+++ b/tests/ui/rmeta/rmeta_bin.rs
@@ -1,0 +1,14 @@
+//@ build-fail
+//@ compile-flags: --crate-type=bin
+//@ aux-build:rmeta-meta.rs
+//@ no-prefer-dynamic
+//@ error-pattern: crate `rmeta_meta` required to be available in rlib format, but was not found
+
+// Check that building a bin crate fails if a dependent crate is metadata-only.
+
+extern crate rmeta_meta;
+use rmeta_meta::Foo;
+
+fn main() {
+    let _ = Foo { field: 42 };
+}

--- a/tests/ui/rmeta/rmeta_bin.stderr
+++ b/tests/ui/rmeta/rmeta_bin.stderr
@@ -1,0 +1,4 @@
+error: crate `rmeta_meta` required to be available in rlib format, but was not found in this form
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This already works for --emit=metadata, but is possible anytime we're not linking.

Tests:
- `rmeta_bin` checks we're not changing --emit=link (already passes)
- `rmeta_bin-pass` tests the new behavior for --emit=obj (would fail today) and also --emit=metadata which isn't changing