### PR TITLE
rustc_target: update x86_win64 to match the documented calling convention for f128

### DIFF
--- a/tests/assembly/x86_64-windows-float-abi.rs
+++ b/tests/assembly/x86_64-windows-float-abi.rs
@@ -37,7 +37,8 @@ pub extern "C" fn second_f64(_: f64, x: f64) -> f64 {
 }
 
 // CHECK-LABEL: second_f128
-// CHECK: movaps %xmm1, %xmm0
+// FIXME(llvm21): this can be just %rdx instead of the regex once we don't test on LLVM 20
+// CHECK: movaps {{(%xmm1|\(%rdx\))}}, %xmm0
 // CHECK-NEXT: retq
 #[no_mangle]
 pub extern "C" fn second_f128(_: f128, x: f128) -> f128 {


### PR DESCRIPTION
llvm/llvm-project@5ee1c0b7148571ed9d60e447b66fb0f35de14576 updates llvm to match the documented calling convention to pass f128 indirectly. This change makes us do that on all versions of LLVM, not just starting with LLVM 21.

@rustbot label llvm-main

try-job: dist-x86_64-msvc
try-job: dist-x86_64-mingw
try-job: x86_64-msvc-1
try-job: x86_64-msvc-2
try-job: x86_64-mingw-1
try-job: x86_64-mingw-2