### PR TITLE
Allow anyone to relabel `CI-spurious-*`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -18,6 +18,7 @@ allow-unauthenticated = [
     "WG-*",
     "-Z*",
     "beta-nominated",
+    "CI-spurious-*",
     "const-hack",
     "llvm-*",
     "needs-fcp",


### PR DESCRIPTION
As suggested by @Noratrieb in reference to me attempting to set this label in https://github.com/rust-lang/rust/pull/136780#issuecomment-2707364425, allow unauthenticated users to relabel `CI-spurious-*`.