### PR TITLE
Mention `env` and `option_env` macros in `std::env::var` docs

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -202,6 +202,9 @@ impl fmt::Debug for VarsOs {
 /// Returns [`VarError::NotUnicode`] if the variable's value is not valid
 /// Unicode. If this is not desired, consider using [`var_os`].
 ///
+/// Use [`env!`] or [`option_env!`] instead if you want to check environment
+/// variables at compile time.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/138159.

Just like there are mentions in `env!` and `option_env!` docs to `std::env::var`, it'd be nice to have a "mention back" as well.