### PR TITLE
Update cargo

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -123,7 +123,6 @@ const EXCEPTIONS_CARGO: ExceptionList = &[
     ("arrayref", "BSD-2-Clause"),
     ("bitmaps", "MPL-2.0+"),
     ("blake3", "CC0-1.0 OR Apache-2.0 OR Apache-2.0 WITH LLVM-exception"),
-    ("bytesize", "Apache-2.0"),
     ("ciborium", "Apache-2.0"),
     ("ciborium-io", "Apache-2.0"),
     ("ciborium-ll", "Apache-2.0"),


### PR DESCRIPTION
22 commits in 2622e844bc1e2e6123e54e94e4706f7b6195ce3d..ab1463d632528e39daf35f263e10c14cbe590ce8
2025-02-28 12:33:57 +0000 to 2025-03-08 01:45:05 +0000
- test: redact host target when comparing CARGO_ENV path (rust-lang/cargo#15279)
- feat: add completions for install --path (rust-lang/cargo#15266)
- fix(package): report lockfile / workspace manifest is dirty  (rust-lang/cargo#15276)
- feat(tree): Add `--depth public` behind `-Zunstable-options` (rust-lang/cargo#15243)
- Don't use `$CARGO_BUILD_TARGET` in `cargo metadata` (rust-lang/cargo#15271)
- feat: show extra build description from bootstrap (rust-lang/cargo#15269)
- Upgrade to `rustc-stable-hash v0.1.2` (rust-lang/cargo#15268)
- fix: Respect --frozen everywhere --offline or --locked is accepted (rust-lang/cargo#15263)
- feat(tree): Color the output (rust-lang/cargo#15242)
- fix(vendor): dont remove non-cached source  (rust-lang/cargo#15260)
- docs: lockfile is always included since 1.84 (rust-lang/cargo#15257)
- Remove `Cargo.toml` from `package.include` in example (rust-lang/cargo#15253)
- Small cleanup: remove unneeded result (rust-lang/cargo#15256)
- Fix typo in build-scripts.md (rust-lang/cargo#15254)
- chore(deps): update rust crate pulldown-cmark to 0.13.0 (rust-lang/cargo#15250)
- chore(deps): update compatible (rust-lang/cargo#15249)
- feat(cli): forward bash completions of third party subcommands (rust-lang/cargo#15247)
- feat: add completions for `--lockfile-path` (rust-lang/cargo#15238)
- fix: reset $CARGO if the running program is real `cargo[.exe]`  (rust-lang/cargo#15208)
- Get all members as `available targets` even though default-members was specified. (rust-lang/cargo#15199)
- refactor: control byte display precision with std::fmt options (rust-lang/cargo#15246)
- fix(package): Ensure we can package directories ending with '.rs' (rust-lang/cargo#15240)
