### PR TITLE
Implement pick[23]_mut via get_disjoint_mut [rustc cleanup] #138196

### DIFF
--- a/compiler/rustc_index/src/slice.rs
+++ b/compiler/rustc_index/src/slice.rs
@@ -118,16 +118,7 @@ impl<I: Idx, T> IndexSlice<I, T> {
     /// Panics if `a == b`.
     #[inline]
     pub fn pick2_mut(&mut self, a: I, b: I) -> (&mut T, &mut T) {
-        let (ai, bi) = (a.index(), b.index());
-        assert!(ai != bi);
-
-        if ai < bi {
-            let (c1, c2) = self.raw.split_at_mut(bi);
-            (&mut c1[ai], &mut c2[0])
-        } else {
-            let (c2, c1) = self.pick2_mut(b, a);
-            (c1, c2)
-        }
+        self.raw.get_disjoint_mut([a.index(), b.index()]).unwrap()
     }
 
     /// Returns mutable references to three distinct elements.
@@ -135,12 +126,7 @@ impl<I: Idx, T> IndexSlice<I, T> {
     /// Panics if the elements are not distinct.
     #[inline]
     pub fn pick3_mut(&mut self, a: I, b: I, c: I) -> (&mut T, &mut T, &mut T) {
-        let (ai, bi, ci) = (a.index(), b.index(), c.index());
-        assert!(ai != bi && bi != ci && ci != ai);
-        let len = self.raw.len();
-        assert!(ai < len && bi < len && ci < len);
-        let ptr = self.raw.as_mut_ptr();
-        unsafe { (&mut *ptr.add(ai), &mut *ptr.add(bi), &mut *ptr.add(ci)) }
+        self.raw.get_disjoint_mut([a.index(), b.index(), c.index()]).unwrap()
     }
 
     #[inline]

--- a/compiler/rustc_index/src/slice.rs
+++ b/compiler/rustc_index/src/slice.rs
@@ -118,7 +118,7 @@ impl<I: Idx, T> IndexSlice<I, T> {
     /// Panics if `a == b`.
     #[inline]
     pub fn pick2_mut(&mut self, a: I, b: I) -> (&mut T, &mut T) {
-        self.raw.get_disjoint_mut([a.index(), b.index()]).unwrap()
+        self.raw.get_disjoint_mut([a.index(), b.index()]).unwrap().into()
     }
 
     /// Returns mutable references to three distinct elements.
@@ -126,7 +126,7 @@ impl<I: Idx, T> IndexSlice<I, T> {
     /// Panics if the elements are not distinct.
     #[inline]
     pub fn pick3_mut(&mut self, a: I, b: I, c: I) -> (&mut T, &mut T, &mut T) {
-        self.raw.get_disjoint_mut([a.index(), b.index(), c.index()]).unwrap()
+        self.raw.get_disjoint_mut([a.index(), b.index(), c.index()]).unwrap().into()
     }
 
     #[inline]


### PR DESCRIPTION
This PR replaces the manual implementation of 'pick2_mut' and 'pick3_mut' in 'IndexSlice' with 'get_disjoint_mut', which provides a safer and more concise way to get multiple mutable references into the slice.

All relevant tests in 'rustc_index' pass, and 'tidy' checks have been verified.





