### PR TITLE
handle precompiled compiler more properly

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1991,12 +1991,12 @@ impl Step for Assemble {
             }
         }
 
-        let maybe_install_llvm_bitcode_linker = || {
+        let maybe_install_llvm_bitcode_linker = |compiler| {
             if builder.config.llvm_bitcode_linker_enabled {
                 trace!("llvm-bitcode-linker enabled, installing");
                 let llvm_bitcode_linker =
                     builder.ensure(crate::core::build_steps::tool::LlvmBitcodeLinker {
-                        compiler: target_compiler,
+                        compiler,
                         target: target_compiler.host,
                         extra_features: vec![],
                     });
@@ -2020,7 +2020,9 @@ impl Step for Assemble {
                 builder.info(&format!("Creating a sysroot for stage{stage} compiler (use `rustup toolchain link 'name' build/host/stage{stage}`)", stage=target_compiler.stage));
             }
 
-            maybe_install_llvm_bitcode_linker();
+            let mut precompiled_compiler = target_compiler;
+            precompiled_compiler.forced_compiler(true);
+            maybe_install_llvm_bitcode_linker(precompiled_compiler);
 
             return target_compiler;
         }
@@ -2203,7 +2205,7 @@ impl Step for Assemble {
             );
         }
 
-        maybe_install_llvm_bitcode_linker();
+        maybe_install_llvm_bitcode_linker(target_compiler);
 
         // Ensure that `libLLVM.so` ends up in the newly build compiler directory,
         // so that it can be found when the newly built `rustc` is run.

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -96,7 +96,7 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &str, Option<&[&'static str]>)] = &[
 pub struct Compiler {
     stage: u32,
     host: TargetSelection,
-    /// Indicates whether `compiler_for` was used to force a specific compiler stage.
+    /// Indicates whether the compiler was forced to use a specific stage.
     /// This field is ignored in `Hash` and `PartialEq` implementations as only the `stage`
     /// and `host` fields are relevant for those.
     forced_compiler: bool,
@@ -1998,7 +1998,7 @@ impl Compiler {
         self.stage == 0 && self.host == build.build
     }
 
-    /// Indicates whether `compiler_for` was used to force a specific compiler stage.
+    /// Indicates whether the compiler was forced to use a specific stage.
     pub fn is_forced_compiler(&self) -> bool {
         self.forced_compiler
     }


### PR DESCRIPTION
Fixes the build cycle problem reported on [#t-infra/bootstrap > Cycle on &#96;aarch64-apple&#96;](https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Cycle.20on.20.60aarch64-apple.60/with/504231609).