### PR TITLE
[AIX] Ignore linting on repr(C) structs with repr(packed) or repr(align(n))

### DIFF
--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1638,6 +1638,9 @@ impl ImproperCTypesDefinitions {
             return true;
         } else if let Adt(adt_def, _) = ty.kind()
             && adt_def.is_struct()
+            && adt_def.repr().c()
+            && !adt_def.repr().packed()
+            && adt_def.repr().align.is_none()
         {
             let struct_variant = adt_def.variant(VariantIdx::ZERO);
             // Within a nested struct, all fields are examined to correctly
@@ -1659,8 +1662,11 @@ impl ImproperCTypesDefinitions {
         item: &'tcx hir::Item<'tcx>,
     ) {
         let adt_def = cx.tcx.adt_def(item.owner_id.to_def_id());
+        // repr(C) structs also with packed or aligned representation
+        // should be ignored.
         if adt_def.repr().c()
             && !adt_def.repr().packed()
+            && adt_def.repr().align.is_none()
             && cx.tcx.sess.target.os == "aix"
             && !adt_def.all_fields().next().is_none()
         {

--- a/tests/ui/layout/reprc-power-alignment.rs
+++ b/tests/ui/layout/reprc-power-alignment.rs
@@ -148,5 +148,29 @@ pub struct I {
     d: f32,
     e: f64,
 }
-
+#[repr(C)]
+pub struct J {
+    a: u8,
+    b: I,
+}
+// The lint also ignores diagnosing #[repr(align(n))].
+#[repr(C, align(8))]
+pub struct K {
+    a: u8,
+    b: u8,
+    c: f64,
+    d: f32,
+    e: f64,
+}
+#[repr(C)]
+pub struct L {
+    a: u8,
+    b: K,
+}
+#[repr(C, align(8))]
+pub struct M {
+    a: u8,
+    b: K,
+    c: L,
+}
 fn main() { }


### PR DESCRIPTION
This PR updates the lint added in 9b40bd7 to ignore repr(C) structs that also have repr(packed) or repr(align(n)).

As these representations can be modifiers on repr(C), it is assumed that users that add these should know what they are doing, and thus the the lint should not warn on the respective structs. For example, for the time being, using repr(packed) and manually padding a repr(C) struct can be done to correctly align struct members on AIX.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
