### PR TITLE
Turn `Cow::is_borrowed,is_owned` into associated functions.

### DIFF
--- a/compiler/rustc_mir_transform/src/gvn.rs
+++ b/compiler/rustc_mir_transform/src/gvn.rs
@@ -746,7 +746,7 @@ impl<'body, 'tcx> VnState<'body, 'tcx> {
             }
         }
 
-        if projection.is_owned() {
+        if Cow::is_owned(&projection) {
             place.projection = self.tcx.mk_place_elems(&projection);
         }
 

--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -212,6 +212,10 @@ impl<B: ?Sized + ToOwned> Clone for Cow<'_, B> {
 impl<B: ?Sized + ToOwned> Cow<'_, B> {
     /// Returns true if the data is borrowed, i.e. if `to_mut` would require additional work.
     ///
+    /// Note: this is an associated function, which means that you have to call
+    /// it as `Cow::is_borrowed(&c)` instead of `c.is_borrowed()`. This is so
+    /// that there is no conflict with a method on the inner type.
+    ///
     /// # Examples
     ///
     /// ```
@@ -219,20 +223,24 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
     /// use std::borrow::Cow;
     ///
     /// let cow = Cow::Borrowed("moo");
-    /// assert!(cow.is_borrowed());
+    /// assert!(Cow::is_borrowed(&cow));
     ///
     /// let bull: Cow<'_, str> = Cow::Owned("...moo?".to_string());
-    /// assert!(!bull.is_borrowed());
+    /// assert!(!Cow::is_borrowed(&bull));
     /// ```
     #[unstable(feature = "cow_is_borrowed", issue = "65143")]
-    pub const fn is_borrowed(&self) -> bool {
-        match *self {
+    pub const fn is_borrowed(c: &Self) -> bool {
+        match *c {
             Borrowed(_) => true,
             Owned(_) => false,
         }
     }
 
     /// Returns true if the data is owned, i.e. if `to_mut` would be a no-op.
+    ///
+    /// Note: this is an associated function, which means that you have to call
+    /// it as `Cow::is_owned(&c)` instead of `c.is_owned()`. This is so that
+    /// there is no conflict with a method on the inner type.
     ///
     /// # Examples
     ///
@@ -241,14 +249,14 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
     /// use std::borrow::Cow;
     ///
     /// let cow: Cow<'_, str> = Cow::Owned("moo".to_string());
-    /// assert!(cow.is_owned());
+    /// assert!(Cow::is_owned(&cow));
     ///
     /// let bull = Cow::Borrowed("...moo?");
-    /// assert!(!bull.is_owned());
+    /// assert!(!Cow::is_owned(&bull));
     /// ```
     #[unstable(feature = "cow_is_borrowed", issue = "65143")]
-    pub const fn is_owned(&self) -> bool {
-        !self.is_borrowed()
+    pub const fn is_owned(c: &Self) -> bool {
+        !Cow::is_borrowed(c)
     }
 
     /// Acquires a mutable reference to the owned form of the data.

--- a/library/alloctests/tests/borrow.rs
+++ b/library/alloctests/tests/borrow.rs
@@ -52,9 +52,9 @@ fn cow_const() {
 
     const COW: Cow<'_, str> = Cow::Borrowed("moo");
 
-    const IS_BORROWED: bool = COW.is_borrowed();
+    const IS_BORROWED: bool = Cow::is_borrowed(&COW);
     assert!(IS_BORROWED);
 
-    const IS_OWNED: bool = COW.is_owned();
+    const IS_OWNED: bool = Cow::is_owned(&COW);
     assert!(!IS_OWNED);
 }


### PR DESCRIPTION
This is done because `Cow` implements `Deref`. Therefore, to avoid conflicts with an inner type having a method of the same name, we use an associated method, like `Box::into_raw`.

Tracking issue: #65143

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
