### PR TITLE
Do not register `Self: AutoTrait` when confirming auto trait (in old solver)

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -463,28 +463,14 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             let cause = obligation.derived_cause(ObligationCauseCode::BuiltinDerived);
 
             assert_eq!(obligation.predicate.polarity(), ty::PredicatePolarity::Positive);
-            let trait_ref =
-                self.infcx.enter_forall_and_leak_universe(obligation.predicate).trait_ref;
-            let trait_obligations = self.impl_or_trait_obligations(
-                &cause,
-                obligation.recursion_depth + 1,
-                obligation.param_env,
-                trait_def_id,
-                trait_ref.args,
-                obligation.predicate,
-            );
 
-            let mut obligations = self.collect_predicates_for_types(
+            let obligations = self.collect_predicates_for_types(
                 obligation.param_env,
                 cause,
                 obligation.recursion_depth + 1,
                 trait_def_id,
                 nested,
             );
-
-            // Adds the predicates from the trait. Note that this contains a `Self: Trait`
-            // predicate as usual. It won't have any effect since auto traits are coinductive.
-            obligations.extend(trait_obligations);
 
             debug!(?obligations, "vtable_auto_impl");
 

--- a/tests/ui/traits/inductive-overflow/supertrait-auto-trait.rs
+++ b/tests/ui/traits/inductive-overflow/supertrait-auto-trait.rs
@@ -13,6 +13,6 @@ fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
 struct NoClone;
 
 fn main() {
-    let (a, b) = copy(NoClone); //~ ERROR
+    let (a, b) = copy(NoClone);
     println!("{:?} {:?}", a, b);
 }

--- a/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
+++ b/tests/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
@@ -6,31 +6,6 @@ LL | auto trait Magic: Copy {}
    |            |
    |            auto traits cannot have super traits or lifetime bounds
 
-error[E0277]: the trait bound `NoClone: Magic` is not satisfied
-  --> $DIR/supertrait-auto-trait.rs:16:23
-   |
-LL |     let (a, b) = copy(NoClone);
-   |                  ---- ^^^^^^^ the trait `Copy` is not implemented for `NoClone`
-   |                  |
-   |                  required by a bound introduced by this call
-   |
-note: required for `NoClone` to implement `Magic`
-  --> $DIR/supertrait-auto-trait.rs:8:12
-   |
-LL | auto trait Magic: Copy {}
-   |            ^^^^^
-note: required by a bound in `copy`
-  --> $DIR/supertrait-auto-trait.rs:10:12
-   |
-LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
-   |            ^^^^^ required by this bound in `copy`
-help: consider annotating `NoClone` with `#[derive(Copy)]`
-   |
-LL + #[derive(Copy)]
-LL | struct NoClone;
-   |
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0277, E0568.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0568`.


### PR DESCRIPTION
Every built-in auto impl for a trait goal like `Ty: Auto` immediately registers another obligation of `Ty: Auto` as one of its nested obligations, leading to us stressing the cycle detection machinery a lot more than we need to. This is because all traits have a `Self: Trait` predicate.

To fix this, remove the call to `impl_or_trait_obligations` in `vtable_auto_impl`, since auto traits do not have where clauses.

r? lcnr