### PR TITLE
Continue to check attr if meet empty repr for adt

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1998,7 +1998,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     // catch `repr()` with no arguments, applied to an item (i.e. not `#![repr()]`)
                     if item.is_some() {
                         match target {
-                            Target::Struct | Target::Union | Target::Enum => {}
+                            Target::Struct | Target::Union | Target::Enum => continue,
                             Target::Fn | Target::Method(_) => {
                                 feature_err(
                                     &self.tcx.sess,

--- a/tests/ui/repr/repr-empty-packed.rs
+++ b/tests/ui/repr/repr-empty-packed.rs
@@ -1,0 +1,9 @@
+//@ compile-flags: --crate-type=lib
+#![deny(unused_attributes)]
+
+#[repr()] //~ ERROR unused attribute
+#[repr(packed)] //~ ERROR attribute should be applied to a struct or union
+pub enum Foo {
+    Bar,
+    Baz(i32),
+}

--- a/tests/ui/repr/repr-empty-packed.stderr
+++ b/tests/ui/repr/repr-empty-packed.stderr
@@ -1,0 +1,27 @@
+error: unused attribute
+  --> $DIR/repr-empty-packed.rs:4:1
+   |
+LL | #[repr()]
+   | ^^^^^^^^^ help: remove this attribute
+   |
+   = note: attribute `repr` with an empty list has no effect
+note: the lint level is defined here
+  --> $DIR/repr-empty-packed.rs:2:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error[E0517]: attribute should be applied to a struct or union
+  --> $DIR/repr-empty-packed.rs:5:8
+   |
+LL |   #[repr(packed)]
+   |          ^^^^^^
+LL | / pub enum Foo {
+LL | |     Bar,
+LL | |     Baz(i32),
+LL | | }
+   | |_- not a struct or union
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0517`.


### PR DESCRIPTION
Fixes #138241

Returning while checking ReprEmpty results in missing the check for the next repr