### PR TITLE
Skipping user args when PatKind::Error in Pat lower_variant_or_leaf

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -519,7 +519,9 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
             }
         };
 
-        if let Some(user_ty) = self.user_args_applied_to_ty_of_hir_id(hir_id) {
+        if !matches!(kind, PatKind::Error(_))
+            && let Some(user_ty) = self.user_args_applied_to_ty_of_hir_id(hir_id)
+        {
             debug!("lower_variant_or_leaf: kind={:?} user_ty={:?} span={:?}", kind, user_ty, span);
             let annotation = CanonicalUserTypeAnnotation {
                 user_ty: Box::new(user_ty),

--- a/tests/ui/const-generics/using-a-constant-as-a-pattern-issue-138048.rs
+++ b/tests/ui/const-generics/using-a-constant-as-a-pattern-issue-138048.rs
@@ -1,0 +1,11 @@
+struct Foo;
+
+impl<'b> Foo {
+    fn bar<const V: u8>() {
+
+        let V; //~ ERROR constant parameters cannot be referenced in patterns
+    }
+}
+fn main() {
+
+}

--- a/tests/ui/const-generics/using-a-constant-as-a-pattern-issue-138048.stderr
+++ b/tests/ui/const-generics/using-a-constant-as-a-pattern-issue-138048.stderr
@@ -1,0 +1,12 @@
+error[E0158]: constant parameters cannot be referenced in patterns
+  --> $DIR/using-a-constant-as-a-pattern-issue-138048.rs:6:13
+   |
+LL |     fn bar<const V: u8>() {
+   |            ----------- constant defined here
+LL |
+LL |         let V;
+   |             ^ can't be used in patterns
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0158`.


### PR DESCRIPTION
Fixes #138048 
