### PR TITLE
Disentangle `ForwardGenericParamBan` and `ConstParamTy` ribs

### DIFF
--- a/compiler/rustc_resolve/messages.ftl
+++ b/compiler/rustc_resolve/messages.ftl
@@ -153,9 +153,13 @@ resolve_extern_crate_self_requires_renaming =
     `extern crate self;` requires renaming
     .suggestion = rename the `self` crate to be able to import it
 
+resolve_forward_declared_generic_in_const_param_ty =
+    const parameter types cannot reference parameters before they are declared
+    .label = const parameter type cannot reference `{$param}` before it is declared
+
 resolve_forward_declared_generic_param =
-    generic parameters with a default cannot use forward declared identifiers
-    .label = defaulted generic parameters cannot be forward declared
+    generic parameter defaults cannot reference parameters before they are declared
+    .label = cannot reference `{$param}` before it is declared
 
 resolve_found_an_item_configured_out =
     found an item that was configured out
@@ -377,9 +381,11 @@ resolve_self_imports_only_allowed_within_multipart_suggestion =
 resolve_self_imports_only_allowed_within_suggestion =
     consider importing the module directly
 
+resolve_self_in_const_generic_ty =
+    cannot use `Self` in const parameter type
+
 resolve_self_in_generic_param_default =
     generic parameters cannot use `Self` in their defaults
-    .label = `Self` in generic parameter default
 
 resolve_similarly_named_defined_here =
     similarly named {$candidate_descr} `{$candidate}` defined here

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -338,6 +338,16 @@ pub(crate) struct ForwardDeclaredGenericParam {
     #[primary_span]
     #[label]
     pub(crate) span: Span,
+    pub(crate) param: Symbol,
+}
+
+#[derive(Diagnostic)]
+#[diag(resolve_forward_declared_generic_in_const_param_ty)]
+pub(crate) struct ForwardDeclaredGenericInConstParamTy {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    pub(crate) param: Symbol,
 }
 
 #[derive(Diagnostic)]
@@ -353,7 +363,13 @@ pub(crate) struct ParamInTyOfConstParam {
 #[diag(resolve_self_in_generic_param_default, code = E0735)]
 pub(crate) struct SelfInGenericParamDefault {
     #[primary_span]
-    #[label]
+    pub(crate) span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(resolve_self_in_const_generic_ty)]
+pub(crate) struct SelfInConstGenericTy {
+    #[primary_span]
     pub(crate) span: Span,
 }
 

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1117,26 +1117,16 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         debug!("validate_res_from_ribs({:?})", res);
         let ribs = &all_ribs[rib_index + 1..];
 
-        // An invalid forward use of a generic parameter from a previous default.
-        if let RibKind::ForwardGenericParamBan = all_ribs[rib_index].kind {
+        // An invalid forward use of a generic parameter from a previous default
+        // or in a const param ty.
+        if let RibKind::ForwardGenericParamBan(reason) = all_ribs[rib_index].kind {
             if let Some(span) = finalize {
                 let res_error = if rib_ident.name == kw::SelfUpper {
-                    ResolutionError::SelfInGenericParamDefault
+                    ResolutionError::ForwardDeclaredSelf(reason)
                 } else {
-                    ResolutionError::ForwardDeclaredGenericParam
+                    ResolutionError::ForwardDeclaredGenericParam(rib_ident.name, reason)
                 };
                 self.report_error(span, res_error);
-            }
-            assert_eq!(res, Res::Err);
-            return Res::Err;
-        }
-
-        if let RibKind::ConstParamTy = all_ribs[rib_index].kind {
-            if let Some(span) = finalize {
-                self.report_error(
-                    span,
-                    ResolutionError::ParamInTyOfConstParam { name: rib_ident.name },
-                );
             }
             assert_eq!(res, Res::Err);
             return Res::Err;
@@ -1153,7 +1143,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         | RibKind::FnOrCoroutine
                         | RibKind::Module(..)
                         | RibKind::MacroDefinition(..)
-                        | RibKind::ForwardGenericParamBan => {
+                        | RibKind::ForwardGenericParamBan(_) => {
                             // Nothing to do. Continue.
                         }
                         RibKind::Item(..) | RibKind::AssocItem => {
@@ -1247,10 +1237,25 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         | RibKind::MacroDefinition(..)
                         | RibKind::InlineAsmSym
                         | RibKind::AssocItem
-                        | RibKind::ConstParamTy
-                        | RibKind::ForwardGenericParamBan => {
+                        | RibKind::ForwardGenericParamBan(_) => {
                             // Nothing to do. Continue.
                             continue;
+                        }
+
+                        RibKind::ConstParamTy => {
+                            if !self.tcx.features().generic_const_parameter_types() {
+                                if let Some(span) = finalize {
+                                    self.report_error(
+                                        span,
+                                        ResolutionError::ParamInTyOfConstParam {
+                                            name: rib_ident.name,
+                                        },
+                                    );
+                                }
+                                return Res::Err;
+                            } else {
+                                continue;
+                            }
                         }
 
                         RibKind::ConstantItem(trivial, _) => {
@@ -1325,8 +1330,23 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         | RibKind::MacroDefinition(..)
                         | RibKind::InlineAsmSym
                         | RibKind::AssocItem
-                        | RibKind::ConstParamTy
-                        | RibKind::ForwardGenericParamBan => continue,
+                        | RibKind::ForwardGenericParamBan(_) => continue,
+
+                        RibKind::ConstParamTy => {
+                            if !self.tcx.features().generic_const_parameter_types() {
+                                if let Some(span) = finalize {
+                                    self.report_error(
+                                        span,
+                                        ResolutionError::ParamInTyOfConstParam {
+                                            name: rib_ident.name,
+                                        },
+                                    );
+                                }
+                                return Res::Err;
+                            } else {
+                                continue;
+                            }
+                        }
 
                         RibKind::ConstantItem(trivial, _) => {
                             if let ConstantHasGenerics::No(cause) = trivial {
@@ -1377,6 +1397,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             }
             _ => {}
         }
+
         res
     }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -32,7 +32,10 @@ use diagnostics::{ImportSuggestion, LabelSuggestion, Suggestion};
 use effective_visibilities::EffectiveVisibilitiesVisitor;
 use errors::{ParamKindInEnumDiscriminant, ParamKindInNonTrivialAnonConst};
 use imports::{Import, ImportData, ImportKind, NameResolution};
-use late::{HasGenericParams, PathSource, PatternSource, UnnecessaryQualification};
+use late::{
+    ForwardGenericParamBanReason, HasGenericParams, PathSource, PatternSource,
+    UnnecessaryQualification,
+};
 use macros::{MacroRulesBinding, MacroRulesScope, MacroRulesScopeRef};
 use rustc_arena::{DroplessArena, TypedArena};
 use rustc_ast::expand::StrippedCfgItem;
@@ -273,7 +276,7 @@ enum ResolutionError<'ra> {
         shadowed_binding_span: Span,
     },
     /// Error E0128: generic parameters with a default cannot use forward-declared identifiers.
-    ForwardDeclaredGenericParam,
+    ForwardDeclaredGenericParam(Symbol, ForwardGenericParamBanReason),
     // FIXME(generic_const_parameter_types): This should give custom output specifying it's only
     // problematic to use *forward declared* parameters when the feature is enabled.
     /// ERROR E0770: the type of const parameters must not depend on other generic parameters.
@@ -287,7 +290,7 @@ enum ResolutionError<'ra> {
     /// This error is emitted even with `generic_const_exprs`.
     ParamInEnumDiscriminant { name: Symbol, param_kind: ParamKindInEnumDiscriminant },
     /// Error E0735: generic parameters with a default cannot use `Self`
-    SelfInGenericParamDefault,
+    ForwardDeclaredSelf(ForwardGenericParamBanReason),
     /// Error E0767: use of unreachable label
     UnreachableLabel { name: Symbol, definition_span: Span, suggestion: Option<LabelSuggestion> },
     /// Error E0323, E0324, E0325: mismatch between trait item and impl item.

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.rs
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.rs
@@ -9,11 +9,11 @@
 // We may want to lift this restriction in the future.
 
 pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
-//~^ ERROR: the type of const parameters must not depend on other generic parameters
-//[min]~^^ ERROR `[u8; N]` is forbidden
+//~^ ERROR the type of const parameters must not depend on other generic parameters
+//[min]~^^ ERROR `[u8; N]` is forbidden as the type of a const generic parameter
 
 pub struct SelfDependent<const N: [u8; N]>;
-//~^ ERROR: the type of const parameters must not depend on other generic parameters
-//[min]~^^ ERROR `[u8; N]` is forbidden
+//~^ ERROR the type of const parameters must not depend on other generic parameters
+//[min]~^^ ERROR `[u8; N]` is forbidden as the type of a const generic parameter
 
 fn main() {}

--- a/tests/ui/const-generics/const-param-type-depends-on-parent-param.rs
+++ b/tests/ui/const-generics/const-param-type-depends-on-parent-param.rs
@@ -1,0 +1,8 @@
+#![feature(adt_const_params)]
+
+trait Trait<const N: usize> {
+    fn foo<const M: [u8; N]>() {}
+    //~^ ERROR the type of const parameters must not depend on other generic parameters
+}
+
+fn main() {}

--- a/tests/ui/const-generics/const-param-type-depends-on-parent-param.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-parent-param.stderr
@@ -1,8 +1,8 @@
 error[E0770]: the type of const parameters must not depend on other generic parameters
-  --> $DIR/references-parent-generics.rs:7:25
+  --> $DIR/const-param-type-depends-on-parent-param.rs:4:26
    |
-LL |     type Assoc<const N: Self>;
-   |                         ^^^^ the type must not depend on the parameter `Self`
+LL |     fn foo<const M: [u8; N]>() {}
+   |                          ^ the type must not depend on the parameter `N`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/defaults/default-const-param-cannot-reference-self.stderr
+++ b/tests/ui/const-generics/defaults/default-const-param-cannot-reference-self.stderr
@@ -2,19 +2,19 @@ error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/default-const-param-cannot-reference-self.rs:1:34
    |
 LL | struct Struct<const N: usize = { Self; 10 }>;
-   |                                  ^^^^ `Self` in generic parameter default
+   |                                  ^^^^
 
 error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/default-const-param-cannot-reference-self.rs:4:30
    |
 LL | enum Enum<const N: usize = { Self; 10 }> { }
-   |                              ^^^^ `Self` in generic parameter default
+   |                              ^^^^
 
 error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/default-const-param-cannot-reference-self.rs:7:32
    |
 LL | union Union<const N: usize = { Self; 10 }> { not_empty: () }
-   |                                ^^^^ `Self` in generic parameter default
+   |                                ^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/defaults/forward-declared.rs
+++ b/tests/ui/const-generics/defaults/forward-declared.rs
@@ -1,13 +1,13 @@
 struct Foo<const N: usize = M, const M: usize = 10>;
-//~^ ERROR generic parameters with a default cannot use forward declared identifiers
+//~^ ERROR generic parameter defaults cannot reference parameters before they are declared
 
 enum Bar<const N: usize = M, const M: usize = 10> {}
-//~^ ERROR generic parameters with a default cannot use forward declared identifiers
+//~^ ERROR generic parameter defaults cannot reference parameters before they are declared
 
 struct Foo2<const N: usize = N>;
-//~^ ERROR generic parameters with a default cannot use forward declared identifiers
+//~^ ERROR generic parameter defaults cannot reference parameters before they are declared
 
 enum Bar2<const N: usize = N> {}
-//~^ ERROR generic parameters with a default cannot use forward declared identifiers
+//~^ ERROR generic parameter defaults cannot reference parameters before they are declared
 
 fn main() {}

--- a/tests/ui/const-generics/defaults/forward-declared.stderr
+++ b/tests/ui/const-generics/defaults/forward-declared.stderr
@@ -1,26 +1,26 @@
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/forward-declared.rs:1:29
    |
 LL | struct Foo<const N: usize = M, const M: usize = 10>;
-   |                             ^ defaulted generic parameters cannot be forward declared
+   |                             ^ cannot reference `M` before it is declared
 
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/forward-declared.rs:4:27
    |
 LL | enum Bar<const N: usize = M, const M: usize = 10> {}
-   |                           ^ defaulted generic parameters cannot be forward declared
+   |                           ^ cannot reference `M` before it is declared
 
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/forward-declared.rs:7:30
    |
 LL | struct Foo2<const N: usize = N>;
-   |                              ^ defaulted generic parameters cannot be forward declared
+   |                              ^ cannot reference `N` before it is declared
 
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/forward-declared.rs:10:28
    |
 LL | enum Bar2<const N: usize = N> {}
-   |                            ^ defaulted generic parameters cannot be forward declared
+   |                            ^ cannot reference `N` before it is declared
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.rs
@@ -4,8 +4,8 @@
 use std::marker::PhantomData;
 
 struct UsesConst<const N: [u8; M], const M: usize>;
-//~^ ERROR: the type of const parameters must not depend on other generic parameters
+//~^ ERROR: const parameter types cannot reference parameters before they are declared
 struct UsesType<const N: [T; 2], T>(PhantomData<T>);
-//~^ ERROR: the type of const parameters must not depend on other generic parameters
+//~^ ERROR: const parameter types cannot reference parameters before they are declared
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/forward_declared_type.stderr
@@ -1,15 +1,14 @@
-error[E0770]: the type of const parameters must not depend on other generic parameters
+error: const parameter types cannot reference parameters before they are declared
   --> $DIR/forward_declared_type.rs:6:32
    |
 LL | struct UsesConst<const N: [u8; M], const M: usize>;
-   |                                ^ the type must not depend on the parameter `M`
+   |                                ^ const parameter type cannot reference `M` before it is declared
 
-error[E0770]: the type of const parameters must not depend on other generic parameters
+error: const parameter types cannot reference parameters before they are declared
   --> $DIR/forward_declared_type.rs:8:27
    |
 LL | struct UsesType<const N: [T; 2], T>(PhantomData<T>);
-   |                           ^ the type must not depend on the parameter `T`
+   |                           ^ const parameter type cannot reference `T` before it is declared
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/generic_const_parameter_types/references-parent-generics.feat.stderr
+++ b/tests/ui/const-generics/generic_const_parameter_types/references-parent-generics.feat.stderr
@@ -16,7 +16,7 @@ LL |     type Assoc<const N: Self>;
    = note: the only supported types are integers, `bool`, and `char`
 
 error: anonymous constants referencing generics are not yet supported
-  --> $DIR/references-parent-generics.rs:14:21
+  --> $DIR/references-parent-generics.rs:15:21
    |
 LL |     let x: T::Assoc<3>;
    |                     ^

--- a/tests/ui/const-generics/generic_const_parameter_types/references-parent-generics.rs
+++ b/tests/ui/const-generics/generic_const_parameter_types/references-parent-generics.rs
@@ -5,14 +5,15 @@
 
 trait Foo {
     type Assoc<const N: Self>;
-    //~^ ERROR `Self` is forbidden as the type of a const generic parameter
+    //[nofeat]~^ ERROR the type of const parameters must not depend on other generic parameters
+    //[feat]~^^ ERROR `Self` is forbidden as the type of a const generic parameter
 }
 
 fn foo<T: Foo>() {
     // We used to end up feeding the type of this anon const to be `T`, but the anon const
     // doesn't inherit the generics of `foo`, which led to index oob errors.
     let x: T::Assoc<3>;
-    //~^ ERROR anonymous constants referencing generics are not yet supported
+    //[feat]~^ ERROR anonymous constants referencing generics are not yet supported
 }
 
 fn main() {}

--- a/tests/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
+++ b/tests/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
@@ -4,11 +4,11 @@ error: generic parameters with a default must be trailing
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |            ^
 
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
-   |                     ^ defaulted generic parameters cannot be forward declared
+   |                     ^ cannot reference `N` before it is declared
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
+++ b/tests/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
@@ -13,11 +13,11 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    = note: type parameters may not be used in const expressions
    = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
-   |                     ^ defaulted generic parameters cannot be forward declared
+   |                     ^ cannot reference `N` before it is declared
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
+++ b/tests/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
@@ -6,7 +6,7 @@ struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
 //[min]~^ ERROR generic parameters may not be used in const operations
 
 struct Bar<T = [u8; N], const N: usize>(T);
-//~^ ERROR generic parameters with a default cannot use forward declared identifiers
+//~^ ERROR generic parameter defaults cannot reference parameters before they are declared
 //~| ERROR generic parameters with a default
 
 fn main() {}

--- a/tests/ui/error-codes/E0128.stderr
+++ b/tests/ui/error-codes/E0128.stderr
@@ -1,8 +1,8 @@
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/E0128.rs:1:14
    |
 LL | struct Foo<T=U, U=()> {
-   |              ^ defaulted generic parameters cannot be forward declared
+   |              ^ cannot reference `U` before it is declared
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/generic-non-trailing-defaults.rs
+++ b/tests/ui/generics/generic-non-trailing-defaults.rs
@@ -5,6 +5,6 @@ struct Vec<A = Heap, T>(A, T);
 
 struct Foo<A, B = Vec<C>, C>(A, B, C);
 //~^ ERROR generic parameters with a default must be trailing
-//~| ERROR generic parameters with a default cannot use
+//~| ERROR generic parameter defaults cannot reference parameters before they are declared
 
 fn main() {}

--- a/tests/ui/generics/generic-non-trailing-defaults.stderr
+++ b/tests/ui/generics/generic-non-trailing-defaults.stderr
@@ -10,11 +10,11 @@ error: generic parameters with a default must be trailing
 LL | struct Foo<A, B = Vec<C>, C>(A, B, C);
    |               ^
 
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/generic-non-trailing-defaults.rs:6:23
    |
 LL | struct Foo<A, B = Vec<C>, C>(A, B, C);
-   |                       ^ defaulted generic parameters cannot be forward declared
+   |                       ^ cannot reference `C` before it is declared
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generics/generic-type-params-forward-mention.rs
+++ b/tests/ui/generics/generic-type-params-forward-mention.rs
@@ -1,6 +1,6 @@
 // Ensure that we get an error and not an ICE for this problematic case.
 struct Foo<T = Option<U>, U = bool>(T, U);
-//~^ ERROR generic parameters with a default cannot use forward declared identifiers
+//~^ ERROR generic parameter defaults cannot reference parameters before they are declared
 fn main() {
     let x: Foo;
 }

--- a/tests/ui/generics/generic-type-params-forward-mention.stderr
+++ b/tests/ui/generics/generic-type-params-forward-mention.stderr
@@ -1,8 +1,8 @@
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/generic-type-params-forward-mention.rs:2:23
    |
 LL | struct Foo<T = Option<U>, U = bool>(T, U);
-   |                       ^ defaulted generic parameters cannot be forward declared
+   |                       ^ cannot reference `U` before it is declared
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/issue-61631-default-type-param-cannot-reference-self.stderr
+++ b/tests/ui/generics/issue-61631-default-type-param-cannot-reference-self.stderr
@@ -2,37 +2,37 @@ error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:13:25
    |
 LL | struct Snobound<'a, P = Self> { x: Option<&'a P> }
-   |                         ^^^^ `Self` in generic parameter default
+   |                         ^^^^
 
 error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:16:23
    |
 LL | enum Enobound<'a, P = Self> { A, B(Option<&'a P>) }
-   |                       ^^^^ `Self` in generic parameter default
+   |                       ^^^^
 
 error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:19:24
    |
 LL | union Unobound<'a, P = Self> { x: i32, y: Option<&'a P> }
-   |                        ^^^^ `Self` in generic parameter default
+   |                        ^^^^
 
 error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:25:31
    |
 LL | struct Ssized<'a, P: Sized = [Self]> { x: Option<&'a P> }
-   |                               ^^^^ `Self` in generic parameter default
+   |                               ^^^^
 
 error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:28:29
    |
 LL | enum Esized<'a, P: Sized = [Self]> { A, B(Option<&'a P>) }
-   |                             ^^^^ `Self` in generic parameter default
+   |                             ^^^^
 
 error[E0735]: generic parameters cannot use `Self` in their defaults
   --> $DIR/issue-61631-default-type-param-cannot-reference-self.rs:31:30
    |
 LL | union Usized<'a, P: Sized = [Self]> { x: i32, y: Option<&'a P> }
-   |                              ^^^^ `Self` in generic parameter default
+   |                              ^^^^
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/issues/issue-18183.stderr
+++ b/tests/ui/issues/issue-18183.stderr
@@ -1,8 +1,8 @@
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/issue-18183.rs:1:20
    |
 LL | pub struct Foo<Bar=Bar>(Bar);
-   |                    ^^^ defaulted generic parameters cannot be forward declared
+   |                    ^^^ cannot reference `Bar` before it is declared
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-26812.rs
+++ b/tests/ui/issues/issue-26812.rs
@@ -1,5 +1,5 @@
 fn avg<T=T::Item>(_: T) {}
-//~^ ERROR generic parameters with a default cannot use forward declared identifiers
+//~^ ERROR generic parameter defaults cannot reference parameters before they are declared
 //~| ERROR defaults for type parameters
 //~| WARN previously accepted
 

--- a/tests/ui/issues/issue-26812.stderr
+++ b/tests/ui/issues/issue-26812.stderr
@@ -1,8 +1,8 @@
-error[E0128]: generic parameters with a default cannot use forward declared identifiers
+error[E0128]: generic parameter defaults cannot reference parameters before they are declared
   --> $DIR/issue-26812.rs:1:10
    |
 LL | fn avg<T=T::Item>(_: T) {}
-   |          ^^^^^^^ defaulted generic parameters cannot be forward declared
+   |          ^^^^^^^ cannot reference `T` before it is declared
 
 error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
   --> $DIR/issue-26812.rs:1:8


### PR DESCRIPTION
In #137617, the `ConstParamTy` rib was adjusted to act kinda like the `ForwardGenericParamBan`. However, this means that it no longer served its purpose banning generics from *parent items*. Although we still are checking for param type validity using the `ConstParamTy_` trait, which means that we weren't accepting code we shouldn't, I think it's a bit strange for us not to be rejecting code like this during *resolution* and instead letting these malformed const generics leak into the type system:

```rust
trait Foo<T> {
  fn bar<const N: T>() {}
}
```

This PR does a few things:
1. Introduce a `ForwardGenericParamBanReason` enum, and start using the `ForwardGenericParamBan` rib to ban forward-declared params in const tys when `generic_const_parameter_types` is enabled.
2. Start using the `ConstParamTy` rib to ban *all* generics when `generic_const_parameter_types` is disabled.
3. Improve the diagnostics for both of the cases above, and for forward-declared params in parameter defaults too :3

r? @BoxyUwU or reassign