### PR TITLE
Keep space if arg does not follow punctuation when lint unused parens

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -843,6 +843,10 @@ trait UnusedDelimLint {
                 && !snip.ends_with(' ')
             {
                 " "
+            } else if let Ok(snip) = sm.span_to_prev_source(value_span)
+                && snip.ends_with(|c: char| c.is_alphanumeric())
+            {
+                " "
             } else {
                 ""
             };
@@ -850,6 +854,10 @@ trait UnusedDelimLint {
             let hi_replace = if keep_space.1
                 && let Ok(snip) = sm.span_to_next_source(hi)
                 && !snip.starts_with(' ')
+            {
+                " "
+            } else if let Ok(snip) = sm.span_to_prev_source(value_span)
+                && snip.starts_with(|c: char| c.is_alphanumeric())
             {
                 " "
             } else {

--- a/tests/ui/lint/unused_parens_follow_ident.fixed
+++ b/tests/ui/lint/unused_parens_follow_ident.fixed
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+#![deny(unused_parens)]
+
+macro_rules! wrap {
+    ($name:ident $arg:expr) => {
+        $name($arg);
+    };
+}
+
+fn main() {
+    wrap!(unary routine()); //~ ERROR unnecessary parentheses around function argument
+    wrap!(unary routine()); //~ ERROR unnecessary parentheses around function argument
+}
+
+fn unary(_: ()) {}
+fn routine() {}

--- a/tests/ui/lint/unused_parens_follow_ident.rs
+++ b/tests/ui/lint/unused_parens_follow_ident.rs
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+#![deny(unused_parens)]
+
+macro_rules! wrap {
+    ($name:ident $arg:expr) => {
+        $name($arg);
+    };
+}
+
+fn main() {
+    wrap!(unary(routine())); //~ ERROR unnecessary parentheses around function argument
+    wrap!(unary (routine())); //~ ERROR unnecessary parentheses around function argument
+}
+
+fn unary(_: ()) {}
+fn routine() {}

--- a/tests/ui/lint/unused_parens_follow_ident.stderr
+++ b/tests/ui/lint/unused_parens_follow_ident.stderr
@@ -1,0 +1,31 @@
+error: unnecessary parentheses around function argument
+  --> $DIR/unused_parens_follow_ident.rs:12:16
+   |
+LL |     wrap!(unary(routine()));
+   |                ^         ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused_parens_follow_ident.rs:3:9
+   |
+LL | #![deny(unused_parens)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL -     wrap!(unary(routine()));
+LL +     wrap!(unary routine());
+   |
+
+error: unnecessary parentheses around function argument
+  --> $DIR/unused_parens_follow_ident.rs:13:17
+   |
+LL |     wrap!(unary (routine()));
+   |                 ^         ^
+   |
+help: remove these parentheses
+   |
+LL -     wrap!(unary (routine()));
+LL +     wrap!(unary routine());
+   |
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes rust-lang/rust#138234

If the arg follows punctuation, still pass `left_pos` with `None` and no space will be added, else then pass `left_pos` with `Some(arg.span.lo())`, so that we can add the space as expected.

And `emit_unused_delims` can make sure no more space will be added if the expr follows space.

---

Edited:

Directly use the `value_span` to check whether the expr removed parens will follow identifier or be followed by identifier.
