### PR TITLE
expose `is_s390x_feature_detected!` from `std::arch`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -666,6 +666,8 @@ pub mod arch {
     pub use std_detect::is_loongarch_feature_detected;
     #[unstable(feature = "is_riscv_feature_detected", issue = "111192")]
     pub use std_detect::is_riscv_feature_detected;
+    #[unstable(feature = "stdarch_s390x_feature_detection", issue = "135413")]
+    pub use std_detect::is_s390x_feature_detected;
     #[stable(feature = "simd_x86", since = "1.27.0")]
     pub use std_detect::is_x86_feature_detected;
     #[unstable(feature = "stdarch_mips_feature_detection", issue = "111188")]

--- a/library/std/tests/run-time-detect.rs
+++ b/library/std/tests/run-time-detect.rs
@@ -9,6 +9,10 @@
     feature(stdarch_aarch64_feature_detection)
 )]
 #![cfg_attr(
+    all(target_arch = "s390x", target_os = "linux"),
+    feature(stdarch_s390x_feature_detection)
+)]
+#![cfg_attr(
     all(target_arch = "powerpc", target_os = "linux"),
     feature(stdarch_powerpc_feature_detection)
 )]
@@ -129,6 +133,32 @@ fn powerpc64_linux() {
     println!("altivec: {}", is_powerpc64_feature_detected!("altivec"));
     println!("power8: {}", is_powerpc64_feature_detected!("power8"));
     println!("vsx: {}", is_powerpc64_feature_detected!("vsx"));
+    // tidy-alphabetical-end
+}
+
+#[test]
+#[cfg(all(target_arch = "s390x", target_os = "linux"))]
+fn s390x_linux() {
+    use std::arch::is_s390x_feature_detected;
+    // tidy-alphabetical-start
+    println!("deflate-conversion: {}", is_s390x_feature_detected!("deflate-conversion"));
+    println!("enhanced-sort: {}", is_s390x_feature_detected!("enhanced-sort"));
+    println!("guarded-storage: {}", is_s390x_feature_detected!("guarded-storage"));
+    println!("high-word: {}", is_s390x_feature_detected!("high-word"));
+    println!("nnp-assist: {}", is_s390x_feature_detected!("nnp-assist"));
+    println!("transactional-execution: {}", is_s390x_feature_detected!("transactional-execution"));
+    println!("vector-enhancements-1: {}", is_s390x_feature_detected!("vector-enhancements-1"));
+    println!("vector-enhancements-2: {}", is_s390x_feature_detected!("vector-enhancements-2"));
+    println!(
+        "vector-packed-decimal-enhancement-2: {}",
+        is_s390x_feature_detected!("vector-packed-decimal-enhancement-2")
+    );
+    println!(
+        "vector-packed-decimal-enhancement: {}",
+        is_s390x_feature_detected!("vector-packed-decimal-enhancement")
+    );
+    println!("vector-packed-decimal: {}", is_s390x_feature_detected!("vector-packed-decimal"));
+    println!("vector: {}", is_s390x_feature_detected!("vector"));
     // tidy-alphabetical-end
 }
 


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/135413
implementation: https://github.com/rust-lang/stdarch/pull/1699 (more features added in https://github.com/rust-lang/stdarch/pull/1720)

This macro was part of the recent `stdarch` synchronization, but not yet exposed via `std::arch`.

r? libs