### PR TITLE
fix ICE in pretty-printing `global_asm!`

### DIFF
--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -653,7 +653,10 @@ fn write_mir_sig(tcx: TyCtxt<'_>, body: &Body<'_>, w: &mut dyn io::Write) -> io:
             write!(w, "static mut ")?
         }
         (_, _) if is_function => write!(w, "fn ")?,
-        (DefKind::AnonConst | DefKind::InlineConst, _) => {} // things like anon const, not an item
+        // things like anon const, not an item
+        (DefKind::AnonConst | DefKind::InlineConst, _) => {}
+        // `global_asm!` have fake bodies, which we may dump after mir-build
+        (DefKind::GlobalAsm, _) => {}
         _ => bug!("Unexpected def kind {:?}", kind),
     }
 

--- a/tests/mir-opt/global_asm.rs
+++ b/tests/mir-opt/global_asm.rs
@@ -1,0 +1,9 @@
+// skip-filecheck
+//@ needs-asm-support
+
+// `global_asm!` gets a fake body, make sure it is handled correctly
+
+// EMIT_MIR global_asm.{global_asm#0}.SimplifyLocals-final.after.mir
+core::arch::global_asm!("/* */");
+
+fn main() {}

--- a/tests/mir-opt/global_asm.{global_asm#0}.SimplifyLocals-final.after.mir
+++ b/tests/mir-opt/global_asm.{global_asm#0}.SimplifyLocals-final.after.mir
@@ -1,0 +1,9 @@
+// MIR for `{global_asm#0}` after SimplifyLocals-final
+
+{global_asm#0}: ! = {
+    let mut _0: !;
+
+    bb0: {
+        asm!("/* */", options()) -> unwind unreachable;
+    }
+}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/138260

since https://github.com/rust-lang/rust/pull/137180, `global_asm!` gets a fake body, that the pretty printing logic did not know what to do with.

based on [#t-compiler/help > tests for MIR pretty printing](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/tests.20for.20MIR.20pretty.20printing) I created `tests/ui/unpretty/mir` which seemed as good a place as any for a test. If there is a better place, let me know.

try-job: test-various
try-job: x86_64-apple-2