### PR TITLE
triagebot.toml: Don't label `test/rustdoc-json` as A-rustdoc-search (…

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -274,7 +274,7 @@ trigger_files = [
 [autolabel."A-rustdoc-search"]
 trigger_files = [
     "src/librustdoc/html/static/js/search.js",
-    "tests/rustdoc-js",
+    "tests/rustdoc-js/",
     "tests/rustdoc-js-std",
 ]
 


### PR DESCRIPTION
Followup to #137958. I managed to miss a place, as shown by the questionable labeling of #138285.
