### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/trace.rs
@@ -610,7 +610,7 @@ impl<'tcx> LivenessContext<'_, '_, '_, 'tcx> {
             Err(ErrorGuaranteed { .. }) => {
                 // We don't run dropck on HIR, and dropck looks inside fields of
                 // types, so there's no guarantee that it succeeds. We also
-                // can't rely on the the `ErrorGuaranteed` from `fully_perform` here
+                // can't rely on the `ErrorGuaranteed` from `fully_perform` here
                 // because it comes from delay_span_bug.
                 //
                 // Do this inside of a probe because we don't particularly care (or want)

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -18,6 +18,8 @@ codegen_ssa_atomic_compare_exchange = Atomic compare-exchange intrinsic missing 
 
 codegen_ssa_autodiff_without_lto = using the autodiff feature requires using fat-lto
 
+codegen_ssa_bare_instruction_set = `#[instruction_set]` requires an argument
+
 codegen_ssa_binary_output_to_tty = option `-o` or `--emit` is used to write binary output type `{$shorthand}` to stdout, but stdout is a tty
 
 codegen_ssa_cgu_not_recorded =
@@ -51,6 +53,10 @@ codegen_ssa_error_creating_remark_dir = failed to create remark directory: {$err
 
 codegen_ssa_error_writing_def_file =
     Error writing .DEF file: {$error}
+
+codegen_ssa_expected_name_value_pair = expected name value pair
+
+codegen_ssa_expected_one_argument = expected one argument
 
 codegen_ssa_expected_used_symbol = expected `used`, `used(compiler)` or `used(linker)`
 
@@ -88,8 +94,16 @@ codegen_ssa_incorrect_cgu_reuse_type =
 
 codegen_ssa_insufficient_vs_code_product = VS Code is a different product, and is not sufficient.
 
+codegen_ssa_invalid_argument = invalid argument
+    .help = valid inline arguments are `always` and `never`
+
+codegen_ssa_invalid_instruction_set = invalid instruction set specified
+
 codegen_ssa_invalid_link_ordinal_nargs = incorrect number of arguments to `#[link_ordinal]`
     .note = the attribute requires exactly one argument
+
+codegen_ssa_invalid_literal_value = invalid literal value
+    .label = value must be an integer between `0` and `255`
 
 codegen_ssa_invalid_monomorphization_basic_float_type = invalid monomorphization of `{$name}` intrinsic: expected basic float type, found `{$ty}`
 
@@ -217,6 +231,8 @@ codegen_ssa_msvc_missing_linker = the msvc targets depend on the msvc linker but
 
 codegen_ssa_multiple_external_func_decl = multiple declarations of external function `{$function}` from library `{$library_name}` have different calling conventions
 
+codegen_ssa_multiple_instruction_set = cannot specify more than one instruction set
+
 codegen_ssa_multiple_main_functions = entry symbol `main` declared multiple times
     .help = did you use `#[no_mangle]` on `fn main`? Use `#![no_main]` to suppress the usual Rust-generated entry point
 
@@ -229,12 +245,19 @@ codegen_ssa_no_natvis_directory = error enumerating natvis directory: {$error}
 
 codegen_ssa_no_saved_object_file = cached cgu {$cgu_name} should have an object file, but doesn't
 
+codegen_ssa_null_on_export = `export_name` may not contain null characters
+
+codegen_ssa_out_of_range_integer = integer value out of range
+    .label = value must be between `0` and `255`
+
 codegen_ssa_processing_dymutil_failed = processing debug info with `dsymutil` failed: {$status}
     .note = {$output}
 
 codegen_ssa_read_file = failed to read file: {$message}
 
 codegen_ssa_repair_vs_build_tools = the Visual Studio build tools may need to be repaired using the Visual Studio installer
+
+codegen_ssa_requires_rust_abi = `#[track_caller]` requires Rust ABI
 
 codegen_ssa_rlib_archive_build_failure = failed to build archive from rlib at `{$path}`: {$error}
 
@@ -356,6 +379,9 @@ codegen_ssa_unable_to_run_dsymutil = unable to run `dsymutil`: {$error}
 
 codegen_ssa_unable_to_write_debugger_visualizer = Unable to write debugger visualizer file `{$path}`: {$error}
 
+codegen_ssa_unexpected_parameter_name = unexpected parameter name
+    .label = expected `{$prefix_nops}` or `{$entry_nops}`
+
 codegen_ssa_unknown_archive_kind =
     Don't know how to build archive of type: {$kind}
 
@@ -366,6 +392,8 @@ codegen_ssa_unknown_atomic_ordering = unknown ordering in atomic intrinsic
 codegen_ssa_unknown_reuse_kind = unknown cgu-reuse-kind `{$kind}` specified
 
 codegen_ssa_unsupported_arch = unsupported arch `{$arch}` for os `{$os}`
+
+codegen_ssa_unsupported_instruction_set = target does not support `#[instruction_set]`
 
 codegen_ssa_unsupported_link_self_contained = option `-C link-self-contained` is not supported on this target
 

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -136,6 +136,110 @@ pub(crate) struct NoSavedObjectFile<'a> {
 }
 
 #[derive(Diagnostic)]
+#[diag(codegen_ssa_requires_rust_abi, code = E0737)]
+pub(crate) struct RequiresRustAbi {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_null_on_export, code = E0648)]
+pub(crate) struct NullOnExport {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_unsupported_instruction_set, code = E0779)]
+pub(crate) struct UnsuportedInstructionSet {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_invalid_instruction_set, code = E0779)]
+pub(crate) struct InvalidInstructionSet {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_bare_instruction_set, code = E0778)]
+pub(crate) struct BareInstructionSet {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_multiple_instruction_set, code = E0779)]
+pub(crate) struct MultipleInstructionSet {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_expected_name_value_pair)]
+pub(crate) struct ExpectedNameValuePair {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_unexpected_parameter_name)]
+pub(crate) struct UnexpectedParameterName {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub prefix_nops: Symbol,
+    pub entry_nops: Symbol,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_invalid_literal_value)]
+pub(crate) struct InvalidLiteralValue {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_out_of_range_integer)]
+pub(crate) struct OutOfRangeInteger {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_expected_one_argument, code = E0534)]
+pub(crate) struct ExpectedOneArgument {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_expected_one_argument, code = E0722)]
+pub(crate) struct ExpectedOneArgumentOptimize {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_invalid_argument, code = E0535)]
+#[help]
+pub(crate) struct InvalidArgument {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(codegen_ssa_invalid_argument, code = E0722)]
+pub(crate) struct InvalidArgumentOptimize {
+    #[primary_span]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(codegen_ssa_copy_path_buf)]
 pub(crate) struct CopyPathBuf {
     pub source_file: PathBuf,

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -363,7 +363,7 @@ pub trait Visitor<'v>: Sized {
     /// See the doc comments on [`Ty`] for an explanation of what it means for a type to be
     /// ambiguous.
     ///
-    /// The [`Visitor::visit_infer`] method should be overriden in order to handle infer vars.
+    /// The [`Visitor::visit_infer`] method should be overridden in order to handle infer vars.
     fn visit_ty(&mut self, t: &'v Ty<'v, AmbigArg>) -> Self::Result {
         walk_ty(self, t)
     }
@@ -374,7 +374,7 @@ pub trait Visitor<'v>: Sized {
     /// See the doc comments on [`ConstArg`] for an explanation of what it means for a const to be
     /// ambiguous.
     ///
-    /// The [`Visitor::visit_infer`] method should be overriden in order to handle infer vars.
+    /// The [`Visitor::visit_infer`] method should be overridden in order to handle infer vars.
     fn visit_const_arg(&mut self, c: &'v ConstArg<'v, AmbigArg>) -> Self::Result {
         walk_ambig_const_arg(self, c)
     }

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
@@ -123,6 +123,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         }
     }
 
+    /// For a struct or enum with an invalid bare trait object field, suggest turning
+    /// it into a generic type bound.
     fn maybe_suggest_add_generic_impl_trait(
         &self,
         self_ty: &hir::Ty<'_>,
@@ -132,21 +134,38 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let msg = "you might be missing a type parameter";
         let mut sugg = vec![];
 
-        let parent_id = tcx.hir_get_parent_item(self_ty.hir_id).def_id;
-        let parent_item = tcx.hir_node_by_def_id(parent_id).expect_item();
-        match parent_item.kind {
-            hir::ItemKind::Struct(_, generics) | hir::ItemKind::Enum(_, generics) => {
-                sugg.push((
-                    generics.where_clause_span,
-                    format!(
-                        "<T: {}>",
-                        self.tcx().sess.source_map().span_to_snippet(self_ty.span).unwrap()
-                    ),
-                ));
-                sugg.push((self_ty.span, "T".to_string()));
+        let parent_hir_id = tcx.parent_hir_id(self_ty.hir_id);
+        let parent_item = tcx.hir_get_parent_item(self_ty.hir_id).def_id;
+
+        let generics = match tcx.hir_node_by_def_id(parent_item) {
+            hir::Node::Item(hir::Item {
+                kind: hir::ItemKind::Struct(variant, generics), ..
+            }) => {
+                if !variant.fields().iter().any(|field| field.hir_id == parent_hir_id) {
+                    return false;
+                }
+                generics
             }
-            _ => {}
-        }
+            hir::Node::Item(hir::Item { kind: hir::ItemKind::Enum(def, generics), .. }) => {
+                if !def
+                    .variants
+                    .iter()
+                    .flat_map(|variant| variant.data.fields().iter())
+                    .any(|field| field.hir_id == parent_hir_id)
+                {
+                    return false;
+                }
+                generics
+            }
+            _ => return false,
+        };
+
+        // FIXME: `T` may already be taken.
+        sugg.push((
+            generics.where_clause_span,
+            format!("<T: {}>", self.tcx().sess.source_map().span_to_snippet(self_ty.span).unwrap()),
+        ));
+        sugg.push((self_ty.span, "T".to_string()));
         diag.multipart_suggestion_verbose(msg, sugg, Applicability::MachineApplicable);
         true
     }
@@ -198,6 +217,13 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         }
     }
 
+    /// Try our best to approximate when adding `dyn` would be helpful for a bare
+    /// trait object.
+    ///
+    /// Right now, this is if the type is either directly nested in another ty,
+    /// or if it's in the tail field within a struct. This approximates what the
+    /// user would've gotten on edition 2015, except for the case where we have
+    /// an *obvious* knock-on `Sized` error.
     fn maybe_suggest_dyn_trait(
         &self,
         self_ty: &hir::Ty<'_>,
@@ -206,19 +232,40 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         diag: &mut Diag<'_>,
     ) -> bool {
         let tcx = self.tcx();
-        let parent_id = tcx.hir_get_parent_item(self_ty.hir_id).def_id;
-        let parent_item = tcx.hir_node_by_def_id(parent_id).expect_item();
 
-        // If the parent item is an enum, don't suggest the dyn trait.
-        if let hir::ItemKind::Enum(..) = parent_item.kind {
-            return false;
-        }
+        // Look at the direct HIR parent, since we care about the relationship between
+        // the type and the thing that directly encloses it.
+        match tcx.parent_hir_node(self_ty.hir_id) {
+            // These are all generally ok. Namely, when a trait object is nested
+            // into another expression or ty, it's either very certain that they
+            // missed the ty (e.g. `&Trait`) or it's not really possible to tell
+            // what their intention is, so let's not give confusing suggestions and
+            // just mention `dyn`. The user can make up their mind what to do here.
+            hir::Node::Ty(_)
+            | hir::Node::Expr(_)
+            | hir::Node::PatExpr(_)
+            | hir::Node::PathSegment(_)
+            | hir::Node::AssocItemConstraint(_)
+            | hir::Node::TraitRef(_)
+            | hir::Node::Item(_)
+            | hir::Node::WherePredicate(_) => {}
 
-        // If the parent item is a struct, check if self_ty is the last field.
-        if let hir::ItemKind::Struct(variant_data, _) = parent_item.kind {
-            if variant_data.fields().last().unwrap().ty.span != self_ty.span {
-                return false;
+            hir::Node::Field(field) => {
+                // Enums can't have unsized fields, fields can only have an unsized tail field.
+                if let hir::Node::Item(hir::Item {
+                    kind: hir::ItemKind::Struct(variant, _), ..
+                }) = tcx.parent_hir_node(field.hir_id)
+                    && variant
+                        .fields()
+                        .last()
+                        .is_some_and(|tail_field| tail_field.hir_id == field.hir_id)
+                {
+                    // Ok
+                } else {
+                    return false;
+                }
             }
+            _ => return false,
         }
 
         // FIXME: Only emit this suggestion if the trait is dyn-compatible.

--- a/compiler/rustc_lint/src/default_could_be_derived.rs
+++ b/compiler/rustc_lint/src/default_could_be_derived.rs
@@ -133,7 +133,7 @@ impl<'tcx> LateLintPass<'tcx> for DefaultCouldBeDerived {
             return;
         }
 
-        // At least one of the fields with a default value have been overriden in
+        // At least one of the fields with a default value have been overridden in
         // the `Default` implementation. We suggest removing it and relying on `..`
         // instead.
         let any_default_field_given =

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -653,7 +653,10 @@ fn write_mir_sig(tcx: TyCtxt<'_>, body: &Body<'_>, w: &mut dyn io::Write) -> io:
             write!(w, "static mut ")?
         }
         (_, _) if is_function => write!(w, "fn ")?,
-        (DefKind::AnonConst | DefKind::InlineConst, _) => {} // things like anon const, not an item
+        // things like anon const, not an item
+        (DefKind::AnonConst | DefKind::InlineConst, _) => {}
+        // `global_asm!` have fake bodies, which we may dump after mir-build
+        (DefKind::GlobalAsm, _) => {}
         _ => bug!("Unexpected def kind {:?}", kind),
     }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -310,7 +310,7 @@ pub use self::error::RawOsError;
 pub use self::error::SimpleMessage;
 #[unstable(feature = "io_const_error", issue = "133448")]
 pub use self::error::const_error;
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 pub use self::pipe::{PipeReader, PipeWriter, pipe};
 #[stable(feature = "is_terminal", since = "1.70.0")]
 pub use self::stdio::IsTerminal;

--- a/library/std/src/io/pipe.rs
+++ b/library/std/src/io/pipe.rs
@@ -40,7 +40,6 @@ use crate::sys::anonymous_pipe::{AnonPipe, pipe as pipe_inner};
 /// # Examples
 ///
 /// ```no_run
-/// #![feature(anonymous_pipe)]
 /// # #[cfg(miri)] fn main() {}
 /// # #[cfg(not(miri))]
 /// # fn main() -> std::io::Result<()> {
@@ -67,19 +66,19 @@ use crate::sys::anonymous_pipe::{AnonPipe, pipe as pipe_inner};
 /// ```
 /// [changes]: io#platform-specific-behavior
 /// [man page]: https://man7.org/linux/man-pages/man7/pipe.7.html
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 #[inline]
 pub fn pipe() -> io::Result<(PipeReader, PipeWriter)> {
     pipe_inner().map(|(reader, writer)| (PipeReader(reader), PipeWriter(writer)))
 }
 
 /// Read end of an anonymous pipe.
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 #[derive(Debug)]
 pub struct PipeReader(pub(crate) AnonPipe);
 
 /// Write end of an anonymous pipe.
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 #[derive(Debug)]
 pub struct PipeWriter(pub(crate) AnonPipe);
 
@@ -89,7 +88,6 @@ impl PipeReader {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(anonymous_pipe)]
     /// # #[cfg(miri)] fn main() {}
     /// # #[cfg(not(miri))]
     /// # fn main() -> std::io::Result<()> {
@@ -137,7 +135,7 @@ impl PipeReader {
     /// # Ok(())
     /// # }
     /// ```
-    #[unstable(feature = "anonymous_pipe", issue = "127154")]
+    #[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
     pub fn try_clone(&self) -> io::Result<Self> {
         self.0.try_clone().map(Self)
     }
@@ -149,7 +147,6 @@ impl PipeWriter {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(anonymous_pipe)]
     /// # #[cfg(miri)] fn main() {}
     /// # #[cfg(not(miri))]
     /// # fn main() -> std::io::Result<()> {
@@ -177,13 +174,13 @@ impl PipeWriter {
     /// # Ok(())
     /// # }
     /// ```
-    #[unstable(feature = "anonymous_pipe", issue = "127154")]
+    #[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
     pub fn try_clone(&self) -> io::Result<Self> {
         self.0.try_clone().map(Self)
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl io::Read for &PipeReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
@@ -203,7 +200,7 @@ impl io::Read for &PipeReader {
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl io::Read for PipeReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
@@ -223,7 +220,7 @@ impl io::Read for PipeReader {
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl io::Write for &PipeWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
@@ -241,7 +238,7 @@ impl io::Write for &PipeWriter {
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl io::Write for PipeWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)

--- a/library/std/src/io/pipe.rs
+++ b/library/std/src/io/pipe.rs
@@ -1,5 +1,6 @@
 use crate::io;
 use crate::sys::anonymous_pipe::{AnonPipe, pipe as pipe_inner};
+use crate::sys_common::{FromInner, IntoInner};
 
 /// Create an anonymous pipe.
 ///
@@ -81,6 +82,30 @@ pub struct PipeReader(pub(crate) AnonPipe);
 #[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 #[derive(Debug)]
 pub struct PipeWriter(pub(crate) AnonPipe);
+
+impl FromInner<AnonPipe> for PipeReader {
+    fn from_inner(inner: AnonPipe) -> Self {
+        Self(inner)
+    }
+}
+
+impl IntoInner<AnonPipe> for PipeReader {
+    fn into_inner(self) -> AnonPipe {
+        self.0
+    }
+}
+
+impl FromInner<AnonPipe> for PipeWriter {
+    fn from_inner(inner: AnonPipe) -> Self {
+        Self(inner)
+    }
+}
+
+impl IntoInner<AnonPipe> for PipeWriter {
+    fn into_inner(self) -> AnonPipe {
+        self.0
+    }
+}
 
 impl PipeReader {
     /// Create a new [`PipeReader`] instance that shares the same underlying file description.

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -15,6 +15,7 @@ use crate::os::unix::io::AsFd;
 use crate::os::unix::io::OwnedFd;
 #[cfg(target_os = "wasi")]
 use crate::os::wasi::io::OwnedFd;
+use crate::sys::fd::FileDesc;
 use crate::sys_common::{AsInner, IntoInner};
 use crate::{fs, io};
 
@@ -274,5 +275,47 @@ impl<T: AsRawFd> AsRawFd for Box<T> {
     #[inline]
     fn as_raw_fd(&self) -> RawFd {
         (**self).as_raw_fd()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl AsRawFd for io::PipeReader {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl FromRawFd for io::PipeReader {
+    unsafe fn from_raw_fd(raw_fd: RawFd) -> Self {
+        unsafe { Self(FileDesc::from_raw_fd(raw_fd)) }
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl IntoRawFd for io::PipeReader {
+    fn into_raw_fd(self) -> RawFd {
+        self.0.into_raw_fd()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl AsRawFd for io::PipeWriter {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl FromRawFd for io::PipeWriter {
+    unsafe fn from_raw_fd(raw_fd: RawFd) -> Self {
+        unsafe { Self(FileDesc::from_raw_fd(raw_fd)) }
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl IntoRawFd for io::PipeWriter {
+    fn into_raw_fd(self) -> RawFd {
+        self.0.into_raw_fd()
     }
 }

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -660,3 +660,45 @@ impl<T> From<crate::thread::JoinHandle<T>> for OwnedHandle {
         join_handle.into_inner().into_handle().into_inner()
     }
 }
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl AsHandle for io::PipeReader {
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        self.0.as_handle()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl From<io::PipeReader> for OwnedHandle {
+    fn from(pipe: io::PipeReader) -> Self {
+        pipe.into_inner().into_inner()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl AsHandle for io::PipeWriter {
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        self.0.as_handle()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl From<io::PipeWriter> for OwnedHandle {
+    fn from(pipe: io::PipeWriter) -> Self {
+        pipe.into_inner().into_inner()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl From<OwnedHandle> for io::PipeReader {
+    fn from(owned_handle: OwnedHandle) -> Self {
+        Self::from_inner(FromInner::from_inner(owned_handle))
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl From<OwnedHandle> for io::PipeWriter {
+    fn from(owned_handle: OwnedHandle) -> Self {
+        Self::from_inner(FromInner::from_inner(owned_handle))
+    }
+}

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -310,3 +310,45 @@ impl IntoRawSocket for net::UdpSocket {
         self.into_inner().into_socket().into_inner().into_raw_socket()
     }
 }
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl AsRawHandle for io::PipeReader {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.0.as_raw_handle()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl FromRawHandle for io::PipeReader {
+    unsafe fn from_raw_handle(raw_handle: RawHandle) -> Self {
+        unsafe { Self::from_inner(FromRawHandle::from_raw_handle(raw_handle)) }
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl IntoRawHandle for io::PipeReader {
+    fn into_raw_handle(self) -> RawHandle {
+        self.0.into_raw_handle()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl AsRawHandle for io::PipeWriter {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.0.as_raw_handle()
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl FromRawHandle for io::PipeWriter {
+    unsafe fn from_raw_handle(raw_handle: RawHandle) -> Self {
+        unsafe { Self::from_inner(FromRawHandle::from_raw_handle(raw_handle)) }
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl IntoRawHandle for io::PipeWriter {
+    fn into_raw_handle(self) -> RawHandle {
+        self.0.into_raw_handle()
+    }
+}

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1658,6 +1658,20 @@ impl From<io::Stderr> for Stdio {
     }
 }
 
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl From<io::PipeWriter> for Stdio {
+    fn from(pipe: io::PipeWriter) -> Self {
+        Stdio::from_inner(pipe.into_inner().into())
+    }
+}
+
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
+impl From<io::PipeReader> for Stdio {
+    fn from(pipe: io::PipeReader) -> Self {
+        Stdio::from_inner(pipe.into_inner().into())
+    }
+}
+
 /// Describes the result of a process after it has terminated.
 ///
 /// This `struct` is used to represent the exit status or other termination of a child process.

--- a/library/std/src/sys/anonymous_pipe/unix.rs
+++ b/library/std/src/sys/anonymous_pipe/unix.rs
@@ -12,88 +12,88 @@ pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     anon_pipe().map(|(rx, wx)| (rx.into_inner(), wx.into_inner()))
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl AsFd for PipeReader {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl AsRawFd for PipeReader {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<PipeReader> for OwnedFd {
     fn from(pipe: PipeReader) -> Self {
         FileDesc::into_inner(pipe.0)
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl FromRawFd for PipeReader {
     unsafe fn from_raw_fd(raw_fd: RawFd) -> Self {
         unsafe { Self(FileDesc::from_raw_fd(raw_fd)) }
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl IntoRawFd for PipeReader {
     fn into_raw_fd(self) -> RawFd {
         self.0.into_raw_fd()
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<PipeReader> for Stdio {
     fn from(pipe: PipeReader) -> Self {
         Self::from(OwnedFd::from(pipe))
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl AsFd for PipeWriter {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl AsRawFd for PipeWriter {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<PipeWriter> for OwnedFd {
     fn from(pipe: PipeWriter) -> Self {
         FileDesc::into_inner(pipe.0)
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl FromRawFd for PipeWriter {
     unsafe fn from_raw_fd(raw_fd: RawFd) -> Self {
         unsafe { Self(FileDesc::from_raw_fd(raw_fd)) }
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl IntoRawFd for PipeWriter {
     fn into_raw_fd(self) -> RawFd {
         self.0.into_raw_fd()
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<PipeWriter> for Stdio {
     fn from(pipe: PipeWriter) -> Self {
         Self::from(OwnedFd::from(pipe))
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<OwnedFd> for PipeReader {
     fn from(owned_fd: OwnedFd) -> Self {
         Self(FileDesc::from_inner(owned_fd))
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<OwnedFd> for PipeWriter {
     fn from(owned_fd: OwnedFd) -> Self {
         Self(FileDesc::from_inner(owned_fd))

--- a/library/std/src/sys/anonymous_pipe/unix.rs
+++ b/library/std/src/sys/anonymous_pipe/unix.rs
@@ -1,101 +1,11 @@
-use crate::io::{self, PipeReader, PipeWriter};
-use crate::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
-use crate::process::Stdio;
+use crate::io;
 use crate::sys::fd::FileDesc;
 use crate::sys::pipe::anon_pipe;
-use crate::sys_common::{FromInner, IntoInner};
+use crate::sys_common::IntoInner;
 
 pub type AnonPipe = FileDesc;
 
 #[inline]
 pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     anon_pipe().map(|(rx, wx)| (rx.into_inner(), wx.into_inner()))
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl AsFd for PipeReader {
-    fn as_fd(&self) -> BorrowedFd<'_> {
-        self.0.as_fd()
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl AsRawFd for PipeReader {
-    fn as_raw_fd(&self) -> RawFd {
-        self.0.as_raw_fd()
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<PipeReader> for OwnedFd {
-    fn from(pipe: PipeReader) -> Self {
-        FileDesc::into_inner(pipe.0)
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl FromRawFd for PipeReader {
-    unsafe fn from_raw_fd(raw_fd: RawFd) -> Self {
-        unsafe { Self(FileDesc::from_raw_fd(raw_fd)) }
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl IntoRawFd for PipeReader {
-    fn into_raw_fd(self) -> RawFd {
-        self.0.into_raw_fd()
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<PipeReader> for Stdio {
-    fn from(pipe: PipeReader) -> Self {
-        Self::from(OwnedFd::from(pipe))
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl AsFd for PipeWriter {
-    fn as_fd(&self) -> BorrowedFd<'_> {
-        self.0.as_fd()
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl AsRawFd for PipeWriter {
-    fn as_raw_fd(&self) -> RawFd {
-        self.0.as_raw_fd()
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<PipeWriter> for OwnedFd {
-    fn from(pipe: PipeWriter) -> Self {
-        FileDesc::into_inner(pipe.0)
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl FromRawFd for PipeWriter {
-    unsafe fn from_raw_fd(raw_fd: RawFd) -> Self {
-        unsafe { Self(FileDesc::from_raw_fd(raw_fd)) }
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl IntoRawFd for PipeWriter {
-    fn into_raw_fd(self) -> RawFd {
-        self.0.into_raw_fd()
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<PipeWriter> for Stdio {
-    fn from(pipe: PipeWriter) -> Self {
-        Self::from(OwnedFd::from(pipe))
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<OwnedFd> for PipeReader {
-    fn from(owned_fd: OwnedFd) -> Self {
-        Self(FileDesc::from_inner(owned_fd))
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<OwnedFd> for PipeWriter {
-    fn from(owned_fd: OwnedFd) -> Self {
-        Self(FileDesc::from_inner(owned_fd))
-    }
 }

--- a/library/std/src/sys/anonymous_pipe/unsupported.rs
+++ b/library/std/src/sys/anonymous_pipe/unsupported.rs
@@ -7,14 +7,14 @@ pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     Err(io::Error::UNSUPPORTED_PLATFORM)
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<PipeReader> for Stdio {
     fn from(pipe: PipeReader) -> Self {
         pipe.0.diverge()
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<PipeWriter> for Stdio {
     fn from(pipe: PipeWriter) -> Self {
         pipe.0.diverge()

--- a/library/std/src/sys/anonymous_pipe/unsupported.rs
+++ b/library/std/src/sys/anonymous_pipe/unsupported.rs
@@ -1,22 +1,7 @@
-use crate::io::{self, PipeReader, PipeWriter};
-use crate::process::Stdio;
+use crate::io;
 pub use crate::sys::pipe::AnonPipe;
 
 #[inline]
 pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     Err(io::Error::UNSUPPORTED_PLATFORM)
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<PipeReader> for Stdio {
-    fn from(pipe: PipeReader) -> Self {
-        pipe.0.diverge()
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<PipeWriter> for Stdio {
-    fn from(pipe: PipeWriter) -> Self {
-        pipe.0.diverge()
-    }
 }

--- a/library/std/src/sys/anonymous_pipe/windows.rs
+++ b/library/std/src/sys/anonymous_pipe/windows.rs
@@ -1,12 +1,7 @@
-use crate::io::{self, PipeReader, PipeWriter};
-use crate::os::windows::io::{
-    AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, IntoRawHandle, OwnedHandle, RawHandle,
-};
-use crate::process::Stdio;
-use crate::ptr;
+use crate::os::windows::io::FromRawHandle;
 use crate::sys::c;
 use crate::sys::handle::Handle;
-use crate::sys_common::{FromInner, IntoInner};
+use crate::{io, ptr};
 
 pub type AnonPipe = Handle;
 
@@ -20,97 +15,5 @@ pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
         Err(io::Error::last_os_error())
     } else {
         unsafe { Ok((Handle::from_raw_handle(read_pipe), Handle::from_raw_handle(write_pipe))) }
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl AsHandle for PipeReader {
-    fn as_handle(&self) -> BorrowedHandle<'_> {
-        self.0.as_handle()
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl AsRawHandle for PipeReader {
-    fn as_raw_handle(&self) -> RawHandle {
-        self.0.as_raw_handle()
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl FromRawHandle for PipeReader {
-    unsafe fn from_raw_handle(raw_handle: RawHandle) -> Self {
-        unsafe { Self(Handle::from_raw_handle(raw_handle)) }
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl IntoRawHandle for PipeReader {
-    fn into_raw_handle(self) -> RawHandle {
-        self.0.into_raw_handle()
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<PipeReader> for OwnedHandle {
-    fn from(pipe: PipeReader) -> Self {
-        Handle::into_inner(pipe.0)
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<PipeReader> for Stdio {
-    fn from(pipe: PipeReader) -> Self {
-        Self::from(OwnedHandle::from(pipe))
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl AsHandle for PipeWriter {
-    fn as_handle(&self) -> BorrowedHandle<'_> {
-        self.0.as_handle()
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl AsRawHandle for PipeWriter {
-    fn as_raw_handle(&self) -> RawHandle {
-        self.0.as_raw_handle()
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl FromRawHandle for PipeWriter {
-    unsafe fn from_raw_handle(raw_handle: RawHandle) -> Self {
-        unsafe { Self(Handle::from_raw_handle(raw_handle)) }
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl IntoRawHandle for PipeWriter {
-    fn into_raw_handle(self) -> RawHandle {
-        self.0.into_raw_handle()
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<PipeWriter> for OwnedHandle {
-    fn from(pipe: PipeWriter) -> Self {
-        Handle::into_inner(pipe.0)
-    }
-}
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<PipeWriter> for Stdio {
-    fn from(pipe: PipeWriter) -> Self {
-        Self::from(OwnedHandle::from(pipe))
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<OwnedHandle> for PipeReader {
-    fn from(owned_handle: OwnedHandle) -> Self {
-        Self(Handle::from_inner(owned_handle))
-    }
-}
-
-#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
-impl From<OwnedHandle> for PipeWriter {
-    fn from(owned_handle: OwnedHandle) -> Self {
-        Self(Handle::from_inner(owned_handle))
     }
 }

--- a/library/std/src/sys/anonymous_pipe/windows.rs
+++ b/library/std/src/sys/anonymous_pipe/windows.rs
@@ -23,92 +23,92 @@ pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl AsHandle for PipeReader {
     fn as_handle(&self) -> BorrowedHandle<'_> {
         self.0.as_handle()
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl AsRawHandle for PipeReader {
     fn as_raw_handle(&self) -> RawHandle {
         self.0.as_raw_handle()
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl FromRawHandle for PipeReader {
     unsafe fn from_raw_handle(raw_handle: RawHandle) -> Self {
         unsafe { Self(Handle::from_raw_handle(raw_handle)) }
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl IntoRawHandle for PipeReader {
     fn into_raw_handle(self) -> RawHandle {
         self.0.into_raw_handle()
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<PipeReader> for OwnedHandle {
     fn from(pipe: PipeReader) -> Self {
         Handle::into_inner(pipe.0)
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<PipeReader> for Stdio {
     fn from(pipe: PipeReader) -> Self {
         Self::from(OwnedHandle::from(pipe))
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl AsHandle for PipeWriter {
     fn as_handle(&self) -> BorrowedHandle<'_> {
         self.0.as_handle()
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl AsRawHandle for PipeWriter {
     fn as_raw_handle(&self) -> RawHandle {
         self.0.as_raw_handle()
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl FromRawHandle for PipeWriter {
     unsafe fn from_raw_handle(raw_handle: RawHandle) -> Self {
         unsafe { Self(Handle::from_raw_handle(raw_handle)) }
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl IntoRawHandle for PipeWriter {
     fn into_raw_handle(self) -> RawHandle {
         self.0.into_raw_handle()
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<PipeWriter> for OwnedHandle {
     fn from(pipe: PipeWriter) -> Self {
         Handle::into_inner(pipe.0)
     }
 }
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<PipeWriter> for Stdio {
     fn from(pipe: PipeWriter) -> Self {
         Self::from(OwnedHandle::from(pipe))
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<OwnedHandle> for PipeReader {
     fn from(owned_handle: OwnedHandle) -> Self {
         Self(Handle::from_inner(owned_handle))
     }
 }
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
+#[stable(feature = "anonymous_pipe", since = "CURRENT_RUSTC_VERSION")]
 impl From<OwnedHandle> for PipeWriter {
     fn from(owned_handle: OwnedHandle) -> Self {
         Self(Handle::from_inner(owned_handle))

--- a/library/std/src/sys/pal/unix/process/process_common.rs
+++ b/library/std/src/sys/pal/unix/process/process_common.rs
@@ -494,6 +494,12 @@ impl From<AnonPipe> for Stdio {
     }
 }
 
+impl From<FileDesc> for Stdio {
+    fn from(fd: FileDesc) -> Stdio {
+        Stdio::Fd(fd)
+    }
+}
+
 impl From<File> for Stdio {
     fn from(file: File) -> Stdio {
         Stdio::Fd(file.into_inner())

--- a/library/std/src/sys/pal/unsupported/pipe.rs
+++ b/library/std/src/sys/pal/unsupported/pipe.rs
@@ -1,5 +1,6 @@
 use crate::fmt;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut};
+use crate::sys_common::{FromInner, IntoInner};
 
 pub struct AnonPipe(!);
 
@@ -53,4 +54,16 @@ impl AnonPipe {
 
 pub fn read2(p1: AnonPipe, _v1: &mut Vec<u8>, _p2: AnonPipe, _v2: &mut Vec<u8>) -> io::Result<()> {
     match p1.0 {}
+}
+
+impl FromInner<!> for AnonPipe {
+    fn from_inner(inner: !) -> Self {
+        Self(inner)
+    }
+}
+
+impl IntoInner<!> for AnonPipe {
+    fn into_inner(self) -> ! {
+        self.0
+    }
 }

--- a/library/std/src/sys/pal/windows/process.rs
+++ b/library/std/src/sys/pal/windows/process.rs
@@ -621,6 +621,12 @@ impl From<AnonPipe> for Stdio {
     }
 }
 
+impl From<Handle> for Stdio {
+    fn from(pipe: Handle) -> Stdio {
+        Stdio::Handle(pipe)
+    }
+}
+
 impl From<File> for Stdio {
     fn from(file: File) -> Stdio {
         Stdio::Handle(file.into_inner())

--- a/library/std/tests/pipe_subprocess.rs
+++ b/library/std/tests/pipe_subprocess.rs
@@ -1,5 +1,3 @@
-#![feature(anonymous_pipe)]
-
 fn main() {
     #[cfg(all(not(miri), any(unix, windows), not(target_os = "emscripten")))]
     {

--- a/src/doc/unstable-book/src/language-features/default-field-values.md
+++ b/src/doc/unstable-book/src/language-features/default-field-values.md
@@ -67,7 +67,7 @@ have default field values.
 ## Lints
 
 When manually implementing the `Default` trait for a type that has default
-field values, if any of these are overriden in the impl the
+field values, if any of these are overridden in the impl the
 `default_overrides_default_fields` lint will trigger. This lint is in place
 to avoid surprising diverging behavior between `S { .. }` and
 `S::default()`, where using the same type in both ways could result in

--- a/src/tools/miri/tests/pass/shims/pipe.rs
+++ b/src/tools/miri/tests/pass/shims/pipe.rs
@@ -1,7 +1,5 @@
 //@ignore-target: windows
 
-#![feature(anonymous_pipe)]
-
 use std::io::{Read, Write, pipe};
 
 fn main() {

--- a/tests/mir-opt/global_asm.rs
+++ b/tests/mir-opt/global_asm.rs
@@ -1,0 +1,8 @@
+// skip-filecheck
+
+// `global_asm!` gets a fake body, make sure it is handled correctly
+
+// EMIT_MIR global_asm.{global_asm#0}.SimplifyLocals-final.after.mir
+std::arch::global_asm!("/* */");
+
+fn main() {}

--- a/tests/mir-opt/global_asm.{global_asm#0}.SimplifyLocals-final.after.mir
+++ b/tests/mir-opt/global_asm.{global_asm#0}.SimplifyLocals-final.after.mir
@@ -1,0 +1,9 @@
+// MIR for `{global_asm#0}` after SimplifyLocals-final
+
+{global_asm#0}: ! = {
+    let mut _0: !;
+
+    bb0: {
+        asm!("/* */", options()) -> unwind unreachable;
+    }
+}

--- a/tests/ui/check-cfg/allow-same-level.rs
+++ b/tests/ui/check-cfg/allow-same-level.rs
@@ -3,7 +3,7 @@
 //
 // It should work, but due to interactions between how #[cfg]s are
 // expanded, the lint machinery and the check-cfg impl, we
-// miss the #[allow], althrough we probably shoudln't.
+// miss the #[allow], althrough we probably shouldn't.
 //
 // cf. https://github.com/rust-lang/rust/issues/124735
 //

--- a/tests/ui/dyn-keyword/dyn-2021-edition-error.rs
+++ b/tests/ui/dyn-keyword/dyn-2021-edition-error.rs
@@ -7,6 +7,12 @@ fn function(x: &SomeTrait, y: Box<SomeTrait>) {
     //~^ ERROR expected a type, found a trait
 }
 
+// Regression test for <https://github.com/rust-lang/rust/issues/138211>.
+extern "C" {
+    fn foo() -> *const SomeTrait;
+    //~^ ERROR expected a type, found a trait
+}
+
 trait SomeTrait {}
 
 fn main() {}

--- a/tests/ui/dyn-keyword/dyn-2021-edition-error.stderr
+++ b/tests/ui/dyn-keyword/dyn-2021-edition-error.stderr
@@ -30,6 +30,17 @@ LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
    |                                   +++
 
 error[E0782]: expected a type, found a trait
+  --> $DIR/dyn-2021-edition-error.rs:12:24
+   |
+LL |     fn foo() -> *const SomeTrait;
+   |                        ^^^^^^^^^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL |     fn foo() -> *const dyn SomeTrait;
+   |                        +++
+
+error[E0782]: expected a type, found a trait
   --> $DIR/dyn-2021-edition-error.rs:6:14
    |
 LL |     let _x: &SomeTrait = todo!();
@@ -40,6 +51,6 @@ help: you can add the `dyn` keyword if you want a trait object
 LL |     let _x: &dyn SomeTrait = todo!();
    |              +++
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0782`.

--- a/tests/ui/dyn-keyword/suggest-struct-or-union-add-generic-impl-trait.rs
+++ b/tests/ui/dyn-keyword/suggest-struct-or-union-add-generic-impl-trait.rs
@@ -31,4 +31,11 @@ where
     Trait:, {}
 //~^ ERROR expected a type, found a trait
 
+struct HasGenerics<T> {
+    f: Trait,
+    //~^ ERROR expected a type, found a trait
+    t: T,
+}
+
+
 fn main() {}

--- a/tests/ui/dyn-keyword/suggest-struct-or-union-add-generic-impl-trait.rs
+++ b/tests/ui/dyn-keyword/suggest-struct-or-union-add-generic-impl-trait.rs
@@ -13,7 +13,6 @@ struct Foo2 {
     //~^ ERROR expected a type, found a trait
 }
 
-
 enum Enum1 {
     A(Trait),
     //~^ ERROR expected a type, found a trait
@@ -26,5 +25,10 @@ enum Enum2 {
     //~^ ERROR expected a type, found a trait
 }
 
+// Regression test for <https://github.com/rust-lang/rust/issues/138229>.
+pub struct InWhereClause
+where
+    Trait:, {}
+//~^ ERROR expected a type, found a trait
 
 fn main() {}

--- a/tests/ui/dyn-keyword/suggest-struct-or-union-add-generic-impl-trait.stderr
+++ b/tests/ui/dyn-keyword/suggest-struct-or-union-add-generic-impl-trait.stderr
@@ -22,7 +22,7 @@ LL |     b: dyn Trait,
    |        +++
 
 error[E0782]: expected a type, found a trait
-  --> $DIR/suggest-struct-or-union-add-generic-impl-trait.rs:18:7
+  --> $DIR/suggest-struct-or-union-add-generic-impl-trait.rs:17:7
    |
 LL |     A(Trait),
    |       ^^^^^
@@ -34,7 +34,7 @@ LL ~     A(T),
    |
 
 error[E0782]: expected a type, found a trait
-  --> $DIR/suggest-struct-or-union-add-generic-impl-trait.rs:25:7
+  --> $DIR/suggest-struct-or-union-add-generic-impl-trait.rs:24:7
    |
 LL |     B(Trait),
    |       ^^^^^
@@ -46,6 +46,17 @@ LL |     A(u32),
 LL ~     B(T),
    |
 
-error: aborting due to 4 previous errors
+error[E0782]: expected a type, found a trait
+  --> $DIR/suggest-struct-or-union-add-generic-impl-trait.rs:31:5
+   |
+LL |     Trait:, {}
+   |     ^^^^^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL |     dyn Trait:, {}
+   |     +++
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0782`.

--- a/tests/ui/dyn-keyword/suggest-struct-or-union-add-generic-impl-trait.stderr
+++ b/tests/ui/dyn-keyword/suggest-struct-or-union-add-generic-impl-trait.stderr
@@ -47,6 +47,18 @@ LL ~     B(T),
    |
 
 error[E0782]: expected a type, found a trait
+  --> $DIR/suggest-struct-or-union-add-generic-impl-trait.rs:35:8
+   |
+LL |     f: Trait,
+   |        ^^^^^
+   |
+help: you might be missing a type parameter
+   |
+LL ~ struct HasGenerics<T, U: Trait> {
+LL ~     f: U,
+   |
+
+error[E0782]: expected a type, found a trait
   --> $DIR/suggest-struct-or-union-add-generic-impl-trait.rs:31:5
    |
 LL |     Trait:, {}
@@ -57,6 +69,6 @@ help: you can add the `dyn` keyword if you want a trait object
 LL |     dyn Trait:, {}
    |     +++
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0782`.

--- a/tests/ui/patchable-function-entry/patchable-function-entry-attribute.stderr
+++ b/tests/ui/patchable-function-entry/patchable-function-entry-attribute.stderr
@@ -20,7 +20,7 @@ error: unexpected parameter name
   --> $DIR/patchable-function-entry-attribute.rs:13:46
    |
 LL | #[patchable_function_entry(prefix_nops = 10, something = 0)]
-   |                                              ^^^^^^^^^^^^^ expected prefix_nops or entry_nops
+   |                                              ^^^^^^^^^^^^^ expected `prefix_nops` or `entry_nops`
 
 error: must specify at least one parameter
   --> $DIR/patchable-function-entry-attribute.rs:16:1

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -274,7 +274,7 @@ trigger_files = [
 [autolabel."A-rustdoc-search"]
 trigger_files = [
     "src/librustdoc/html/static/js/search.js",
-    "tests/rustdoc-js",
+    "tests/rustdoc-js/",
     "tests/rustdoc-js-std",
 ]
 


### PR DESCRIPTION
Successful merges:

 - #137279 (Make some invalid codegen attr errors structured/translatable)
 - #137793 (Stablize anonymous pipe)
 - #138238 (Fix dyn -> param suggestion in struct ICEs)
 - #138270 (chore: Fix some comments)
 - #138280 (fix ICE in pretty-printing `global_asm!`)
 - #138286 (triagebot.toml: Don't label `test/rustdoc-json` as A-rustdoc-search (…)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=137279,137793,138238,138270,138280,138286)
<!-- homu-ignore:end -->