### PR TITLE
Add a tidy check for `[lints] workspace = true`.

### DIFF
--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -93,4 +93,5 @@ pub mod unit_tests;
 pub mod unknown_revision;
 pub mod unstable_book;
 pub mod walk;
+pub mod workspace_lints;
 pub mod x_version;

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -115,6 +115,7 @@ fn main() {
         check!(fluent_alphabetical, &compiler_path, bless);
         check!(fluent_period, &compiler_path);
         check!(target_policy, &root_path);
+        check!(workspace_lints, &compiler_path);
 
         // Checks that only make sense for the std libs.
         check!(pal, &library_path);

--- a/src/tools/tidy/src/workspace_lints.rs
+++ b/src/tools/tidy/src/workspace_lints.rs
@@ -1,0 +1,26 @@
+//! Tidy check to ensure that all `compiler/` crates have `[lints] workspace =
+//! true` and therefore inherit the standard lints.
+
+use std::path::Path;
+
+use crate::walk::{filter_dirs, walk};
+
+pub fn check(path: &Path, bad: &mut bool) {
+    walk(path, |path, _is_dir| filter_dirs(path), &mut |entry, contents| {
+        let file = entry.path();
+        let filename = file.file_name().unwrap();
+        if filename != "Cargo.toml" {
+            return;
+        }
+
+        let has_lints_line = contents.lines().any(|line| line.trim() == "[lints]");
+        let has_workspace_line = contents.lines().any(|line| line.trim() == "workspace = true");
+
+        if !has_lints_line {
+            tidy_error!(bad, "{} doesn't have a `[lints]` line", file.display());
+        }
+        if !has_lints_line || !has_workspace_line {
+            tidy_error!(bad, "{} doesn't have a `workspace = true` line", file.display());
+        }
+    });
+}


### PR DESCRIPTION
For `compiler/` crates.

Closes #138195.

r? @jieyouxu 