### PR TITLE
Stop putting `Assume`s in MIR for every `enum`-`as` cast

### DIFF
--- a/compiler/rustc_mir_transform/src/validate.rs
+++ b/compiler/rustc_mir_transform/src/validate.rs
@@ -1303,37 +1303,27 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                         }
                     }
                     CastKind::Transmute => {
-                        if let MirPhase::Runtime(..) = self.body.phase {
-                            // Unlike `mem::transmute`, a MIR `Transmute` is well-formed
-                            // for any two `Sized` types, just potentially UB to run.
+                        // Unlike `mem::transmute`, a MIR `Transmute` is well-formed
+                        // for any two `Sized` types, just potentially UB to run.
 
-                            if !self
-                                .tcx
-                                .normalize_erasing_regions(self.typing_env, op_ty)
-                                .is_sized(self.tcx, self.typing_env)
-                            {
-                                self.fail(
-                                    location,
-                                    format!("Cannot transmute from non-`Sized` type {op_ty:?}"),
-                                );
-                            }
-                            if !self
-                                .tcx
-                                .normalize_erasing_regions(self.typing_env, *target_type)
-                                .is_sized(self.tcx, self.typing_env)
-                            {
-                                self.fail(
-                                    location,
-                                    format!("Cannot transmute to non-`Sized` type {target_type:?}"),
-                                );
-                            }
-                        } else {
+                        if !self
+                            .tcx
+                            .normalize_erasing_regions(self.typing_env, op_ty)
+                            .is_sized(self.tcx, self.typing_env)
+                        {
                             self.fail(
                                 location,
-                                format!(
-                                    "Transmute is not supported in non-runtime phase {:?}.",
-                                    self.body.phase
-                                ),
+                                format!("Cannot transmute from non-`Sized` type {op_ty:?}"),
+                            );
+                        }
+                        if !self
+                            .tcx
+                            .normalize_erasing_regions(self.typing_env, *target_type)
+                            .is_sized(self.tcx, self.typing_env)
+                        {
+                            self.fail(
+                                location,
+                                format!("Cannot transmute to non-`Sized` type {target_type:?}"),
                             );
                         }
                     }

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -400,7 +400,7 @@ impl Ordering {
     #[inline]
     const fn as_raw(self) -> i8 {
         // FIXME(const-hack): just use `PartialOrd` against `Equal` once that's const
-        crate::intrinsics::discriminant_value(&self)
+        self as i8
     }
 
     /// Returns `true` if the ordering is the `Equal` variant.

--- a/tests/mir-opt/building/enum_cast.bar.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.bar.built.after.mir
@@ -4,17 +4,12 @@ fn bar(_1: Bar) -> usize {
     debug bar => _1;
     let mut _0: usize;
     let _2: Bar;
-    let mut _3: isize;
-    let mut _4: u8;
-    let mut _5: bool;
+    let mut _3: u8;
 
     bb0: {
         StorageLive(_2);
         _2 = move _1;
-        _3 = discriminant(_2);
-        _4 = copy _3 as u8 (IntToInt);
-        _5 = Le(copy _4, const 1_u8);
-        assume(move _5);
+        _3 = move _2 as u8 (Transmute);
         _0 = move _3 as usize (IntToInt);
         StorageDead(_2);
         return;

--- a/tests/mir-opt/building/enum_cast.boo.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.boo.built.after.mir
@@ -5,16 +5,11 @@ fn boo(_1: Boo) -> usize {
     let mut _0: usize;
     let _2: Boo;
     let mut _3: u8;
-    let mut _4: u8;
-    let mut _5: bool;
 
     bb0: {
         StorageLive(_2);
         _2 = move _1;
-        _3 = discriminant(_2);
-        _4 = copy _3 as u8 (IntToInt);
-        _5 = Le(copy _4, const 1_u8);
-        assume(move _5);
+        _3 = move _2 as u8 (Transmute);
         _0 = move _3 as usize (IntToInt);
         StorageDead(_2);
         return;

--- a/tests/mir-opt/building/enum_cast.custom_single_variant.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.custom_single_variant.built.after.mir
@@ -1,0 +1,84 @@
+// MIR for `custom_single_variant` after built
+
+fn custom_single_variant(_1: SingleVariantWithCustomDiscriminant, _2: SingleVariantWithCustomDiscriminantAndRepr) -> impl Sized {
+    debug a => _1;
+    debug b => _2;
+    let mut _0: impl Sized;
+    let mut _3: isize;
+    let _4: SingleVariantWithCustomDiscriminant;
+    let mut _5: usize;
+    let _6: SingleVariantWithCustomDiscriminant;
+    let mut _7: i16;
+    let _8: SingleVariantWithCustomDiscriminant;
+    let mut _9: u16;
+    let _10: SingleVariantWithCustomDiscriminant;
+    let mut _11: isize;
+    let _12: SingleVariantWithCustomDiscriminantAndRepr;
+    let mut _13: u16;
+    let mut _14: usize;
+    let _15: SingleVariantWithCustomDiscriminantAndRepr;
+    let mut _16: u16;
+    let mut _17: i16;
+    let _18: SingleVariantWithCustomDiscriminantAndRepr;
+    let mut _19: u16;
+    let mut _20: u16;
+    let _21: SingleVariantWithCustomDiscriminantAndRepr;
+    let mut _22: u16;
+
+    bb0: {
+        StorageLive(_3);
+        StorageLive(_4);
+        _4 = copy _1;
+        _3 = const 42_isize as isize (IntToInt);
+        StorageDead(_4);
+        StorageLive(_5);
+        StorageLive(_6);
+        _6 = copy _1;
+        _5 = const 42_isize as usize (IntToInt);
+        StorageDead(_6);
+        StorageLive(_7);
+        StorageLive(_8);
+        _8 = copy _1;
+        _7 = const 42_isize as i16 (IntToInt);
+        StorageDead(_8);
+        StorageLive(_9);
+        StorageLive(_10);
+        _10 = copy _1;
+        _9 = const 42_isize as u16 (IntToInt);
+        StorageDead(_10);
+        StorageLive(_11);
+        StorageLive(_12);
+        _12 = copy _2;
+        _13 = move _12 as u16 (Transmute);
+        _11 = move _13 as isize (IntToInt);
+        StorageDead(_12);
+        StorageLive(_14);
+        StorageLive(_15);
+        _15 = copy _2;
+        _16 = move _15 as u16 (Transmute);
+        _14 = move _16 as usize (IntToInt);
+        StorageDead(_15);
+        StorageLive(_17);
+        StorageLive(_18);
+        _18 = copy _2;
+        _19 = move _18 as u16 (Transmute);
+        _17 = move _19 as i16 (IntToInt);
+        StorageDead(_18);
+        StorageLive(_20);
+        StorageLive(_21);
+        _21 = copy _2;
+        _22 = move _21 as u16 (Transmute);
+        _20 = move _22 as u16 (IntToInt);
+        StorageDead(_21);
+        _0 = (move _3, move _5, move _7, move _9, move _11, move _14, move _17, move _20);
+        StorageDead(_20);
+        StorageDead(_17);
+        StorageDead(_14);
+        StorageDead(_11);
+        StorageDead(_9);
+        StorageDead(_7);
+        StorageDead(_5);
+        StorageDead(_3);
+        return;
+    }
+}

--- a/tests/mir-opt/building/enum_cast.far.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.far.built.after.mir
@@ -5,16 +5,11 @@ fn far(_1: Far) -> isize {
     let mut _0: isize;
     let _2: Far;
     let mut _3: i16;
-    let mut _4: u16;
-    let mut _5: bool;
 
     bb0: {
         StorageLive(_2);
         _2 = move _1;
-        _3 = discriminant(_2);
-        _4 = copy _3 as u16 (IntToInt);
-        _5 = Le(copy _4, const 1_u16);
-        assume(move _5);
+        _3 = move _2 as i16 (Transmute);
         _0 = move _3 as isize (IntToInt);
         StorageDead(_2);
         return;

--- a/tests/mir-opt/building/enum_cast.foo.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.foo.built.after.mir
@@ -4,13 +4,11 @@ fn foo(_1: Foo) -> usize {
     debug foo => _1;
     let mut _0: usize;
     let _2: Foo;
-    let mut _3: isize;
 
     bb0: {
         StorageLive(_2);
         _2 = move _1;
-        _3 = discriminant(_2);
-        _0 = move _3 as usize (IntToInt);
+        _0 = const 0_isize as usize (IntToInt);
         StorageDead(_2);
         return;
     }

--- a/tests/mir-opt/building/enum_cast.offsetty.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.offsetty.built.after.mir
@@ -4,21 +4,12 @@ fn offsetty(_1: NotStartingAtZero) -> u32 {
     debug x => _1;
     let mut _0: u32;
     let _2: NotStartingAtZero;
-    let mut _3: isize;
-    let mut _4: u8;
-    let mut _5: bool;
-    let mut _6: bool;
-    let mut _7: bool;
+    let mut _3: u8;
 
     bb0: {
         StorageLive(_2);
         _2 = move _1;
-        _3 = discriminant(_2);
-        _4 = copy _3 as u8 (IntToInt);
-        _5 = Ge(copy _4, const 4_u8);
-        _6 = Le(copy _4, const 8_u8);
-        _7 = BitAnd(move _5, move _6);
-        assume(move _7);
+        _3 = move _2 as u8 (Transmute);
         _0 = move _3 as u32 (IntToInt);
         StorageDead(_2);
         return;

--- a/tests/mir-opt/building/enum_cast.rs
+++ b/tests/mir-opt/building/enum_cast.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 // EMIT_MIR enum_cast.foo.built.after.mir
 // EMIT_MIR enum_cast.bar.built.after.mir
 // EMIT_MIR enum_cast.boo.built.after.mir
@@ -25,20 +24,77 @@ enum Far {
     B,
 }
 
+// CHECK-LABEL: fn foo(
 fn foo(foo: Foo) -> usize {
+    // CHECK: _0 = const 0_usize;
     foo as usize
 }
 
+// CHECK-LABEL: fn bar(
 fn bar(bar: Bar) -> usize {
+    // CHECK: _2 = copy _1 as u8 (Transmute);
+    // CHECK: _0 = move _2 as usize (IntToInt);
     bar as usize
 }
 
+// CHECK-LABEL: fn boo(
 fn boo(boo: Boo) -> usize {
+    // CHECK: _2 = copy _1 as u8 (Transmute);
+    // CHECK: _0 = move _2 as usize (IntToInt);
     boo as usize
 }
 
+// CHECK-LABEL: fn far(
 fn far(far: Far) -> isize {
+    // CHECK: _2 = copy _1 as i16 (Transmute);
+    // CHECK: _0 = move _2 as isize (IntToInt);
     far as isize
+}
+
+#[derive(Copy, Clone)]
+enum SingleVariantWithCustomDiscriminant {
+    FourtyTwo = 42,
+}
+
+#[derive(Copy, Clone)]
+#[repr(u16)]
+enum SingleVariantWithCustomDiscriminantAndRepr {
+    FourtyTwo = 42,
+}
+
+// EMIT_MIR enum_cast.custom_single_variant.built.after.mir
+// CHECK-LABEL: fn custom_single_variant(
+#[rustfmt::skip] // No, I don't want the comments on the same lines with the commas
+fn custom_single_variant(
+    a: SingleVariantWithCustomDiscriminant,
+    b: SingleVariantWithCustomDiscriminantAndRepr,
+) -> impl Sized {
+    (
+        a as isize,
+        a as usize,
+        a as i16,
+        a as u16,
+        // CHECK: [[REPR:_.+]] = copy _2 as u16 (Transmute)
+        // CHECK: [[B0:_.+]] = copy [[REPR]] as isize (IntToInt)
+        b as isize,
+        // CHECK: [[B1:_.+]] = copy [[REPR]] as usize (IntToInt)
+        b as usize,
+        // CHECK: [[B2:_.+]] = copy [[REPR]] as i16 (IntToInt)
+        b as i16,
+        b as u16,
+    )
+    // CHECK: _0 = (const 42_isize, const 42_usize, const 42_i16, const 42_u16,
+    // CHECK-SAME: move [[B0]], move [[B1]], move [[B2]], copy [[REPR]]);
+}
+
+// EMIT_MIR enum_cast.unreachable.built.after.mir
+// CHECK-LABEL: fn unreachable
+fn unreachable(x: std::convert::Infallible) -> u16 {
+    // CHECK: debug x => const ZeroSized: Infallible;
+    // CHECK: bb0: {
+    // CHECK-NEXT: unreachable;
+    // CHECK-NEXT: }
+    x as _
 }
 
 #[repr(i16)]
@@ -56,13 +112,16 @@ enum UnsignedAroundZero {
 }
 
 // EMIT_MIR enum_cast.signy.built.after.mir
+// CHECK-LABEL: fn signy(
 fn signy(x: SignedAroundZero) -> i16 {
+    // CHECK: _0 = copy _1 as i16 (Transmute);
     x as i16
 }
 
 // EMIT_MIR enum_cast.unsigny.built.after.mir
+// CHECK-LABEL: fn unsigny(
 fn unsigny(x: UnsignedAroundZero) -> u16 {
-    // FIXME: This doesn't get an around-the-end range today, sadly.
+    // CHECK: _0 = copy _1 as u16 (Transmute);
     x as u16
 }
 
@@ -73,8 +132,36 @@ enum NotStartingAtZero {
 }
 
 // EMIT_MIR enum_cast.offsetty.built.after.mir
+// CHECK-LABEL: fn offsetty(
 fn offsetty(x: NotStartingAtZero) -> u32 {
+    // CHECK: _2 = copy _1 as u8 (Transmute);
+    // CHECK: _0 = move _2 as u32 (IntToInt);
     x as u32
+}
+
+enum ReallyBigDiscr {
+    One = 0x4321,
+}
+
+// CHECK-LABEL: fn really_big_discr(
+fn really_big_discr(x: ReallyBigDiscr) -> u8 {
+    // Better not ICE on this!
+    // CHECK: _0 = const 33_u8;
+    x as u8
+}
+
+// `align` gives this `Memory` ABI instead of `Scalar`
+#[repr(align(8))]
+enum Aligned {
+    Zero = 0,
+    One = 1,
+}
+
+// CHECK-LABEL: fn aligned_as(
+fn aligned_as(x: Aligned) -> u8 {
+    // CHECK: _2 = discriminant(_1);
+    // CHECK: _0 = move _2 as u8 (IntToInt);
+    x as u8
 }
 
 fn main() {}

--- a/tests/mir-opt/building/enum_cast.signy.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.signy.built.after.mir
@@ -5,20 +5,11 @@ fn signy(_1: SignedAroundZero) -> i16 {
     let mut _0: i16;
     let _2: SignedAroundZero;
     let mut _3: i16;
-    let mut _4: u16;
-    let mut _5: bool;
-    let mut _6: bool;
-    let mut _7: bool;
 
     bb0: {
         StorageLive(_2);
         _2 = move _1;
-        _3 = discriminant(_2);
-        _4 = copy _3 as u16 (IntToInt);
-        _5 = Ge(copy _4, const 65534_u16);
-        _6 = Le(copy _4, const 2_u16);
-        _7 = BitOr(move _5, move _6);
-        assume(move _7);
+        _3 = move _2 as i16 (Transmute);
         _0 = move _3 as i16 (IntToInt);
         StorageDead(_2);
         return;

--- a/tests/mir-opt/building/enum_cast.unreachable.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.unreachable.built.after.mir
@@ -1,0 +1,24 @@
+// MIR for `unreachable` after built
+
+| User Type Annotations
+| 0: user_ty: Canonical { value: Ty(^0), max_universe: U0, variables: [CanonicalVarInfo { kind: Ty(General(U0)) }] }, span: $DIR/enum_cast.rs:97:10: 97:11, inferred_ty: u16
+|
+fn unreachable(_1: Infallible) -> u16 {
+    debug x => _1;
+    let mut _0: u16;
+    let mut _2: u16;
+    let _3: std::convert::Infallible;
+
+    bb0: {
+        StorageLive(_2);
+        StorageLive(_3);
+        _3 = copy _1;
+        assume(const false);
+        _2 = const 0_u16 as u16 (IntToInt);
+        AscribeUserType(_2, o, UserTypeProjection { base: UserType(0), projs: [] });
+        _0 = copy _2;
+        StorageDead(_3);
+        StorageDead(_2);
+        return;
+    }
+}

--- a/tests/mir-opt/building/enum_cast.unsigny.built.after.mir
+++ b/tests/mir-opt/building/enum_cast.unsigny.built.after.mir
@@ -9,7 +9,7 @@ fn unsigny(_1: UnsignedAroundZero) -> u16 {
     bb0: {
         StorageLive(_2);
         _2 = move _1;
-        _3 = discriminant(_2);
+        _3 = move _2 as u16 (Transmute);
         _0 = move _3 as u16 (IntToInt);
         StorageDead(_2);
         return;

--- a/tests/mir-opt/pre-codegen/derived_ord.demo_le.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/derived_ord.demo_le.PreCodegen.after.mir
@@ -79,7 +79,7 @@ fn demo_le(_1: &MultiField, _2: &MultiField) -> bool {
     bb3: {
         _12 = move ((_11 as Some).0: std::cmp::Ordering);
         StorageLive(_13);
-        _13 = discriminant(_12);
+        _13 = copy _12 as i8 (Transmute);
         _0 = Le(move _13, const 0_i8);
         StorageDead(_13);
         StorageDead(_11);

--- a/tests/mir-opt/pre-codegen/derived_ord.rs
+++ b/tests/mir-opt/pre-codegen/derived_ord.rs
@@ -24,7 +24,7 @@ pub fn demo_le(a: &MultiField, b: &MultiField) -> bool {
     // CHECK: [[B1:_[0-9]+]] = copy ((*_2).1: i16);
     // CHECK: Cmp(move [[A1]], move [[B1]]);
 
-    // CHECK: [[D1:_[0-9]+]] = discriminant({{.+}});
+    // CHECK: [[D1:_[0-9]+]] = copy {{.+}} as i8 (Transmute);
     // CHECK: _0 = Le(move [[D1]], const 0_i8);
     *a <= *b
 }


### PR DESCRIPTION
Now that we have `range` attributes on parameters -- so an `Ordering` passed by-value is already [*known* to be in `-1, 0, +1`](https://rust.godbolt.org/z/Evaxq8757), for example -- these are much less useful than they used to be.

Having all these extra instructions in the MIR means more instructions for MIR passes (including `check` things like borrowck) and make them look like worse inlining candidates, even though I can't think of a time it'd be bad to inline an `as` cast on an enum -- after all, if the cast is allowed at all it's because reading the tag does literally nothing in LLVM.

It made sense at the time, but now we have `Transmute` in MIR, and backends handle appropriate `assume`ing for that, because `as` casts can only add assumes for concrete types so any generic cases need to be [handled](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_codegen_ssa/traits/trait.BuilderMethods.html#method.assume_integer_range) by the backend anyway.

And, TBH, I like to be able to just say "no, don't transmute your field-less enum to an integer -- the `as` cast produces the identical MIR" if anyone asks, so that they're never tempted to do the unsafe thing by hand.
