### PR TITLE
fix usage of `autodiff` macro with inner functions

### DIFF
--- a/tests/pretty/autodiff_forward.pp
+++ b/tests/pretty/autodiff_forward.pp
@@ -29,6 +29,8 @@ pub fn f1(x: &[f64], y: f64) -> f64 {
     // Make sure, that we add the None for the default return.
 
 
+    // We want to make sure that we can use the macro for functions defined inside of functions
+
     ::core::panicking::panic("not implemented")
 }
 #[rustc_autodiff(Forward, 1, Dual, Const, Dual)]
@@ -157,5 +159,18 @@ fn f8_1(x: &f32, bx_0: &f32) -> f32 {
     ::core::hint::black_box(f8(x));
     ::core::hint::black_box((bx_0,));
     ::core::hint::black_box(<f32>::default())
+}
+pub fn f9() {
+    #[rustc_autodiff]
+    #[inline(never)]
+    fn inner(x: f32) -> f32 { x * x }
+    #[rustc_autodiff(Forward, 1, Dual, DualOnly)]
+    #[inline(never)]
+    fn d_inner(x: f32, bx_0: f32) -> f32 {
+        unsafe { asm!("NOP", options(pure, nomem)); };
+        ::core::hint::black_box(inner(x));
+        ::core::hint::black_box((bx_0,));
+        ::core::hint::black_box(<f32>::default())
+    }
 }
 fn main() {}

--- a/tests/pretty/autodiff_forward.pp
+++ b/tests/pretty/autodiff_forward.pp
@@ -164,9 +164,17 @@ pub fn f9() {
     #[rustc_autodiff]
     #[inline(never)]
     fn inner(x: f32) -> f32 { x * x }
+    #[rustc_autodiff(Forward, 1, Dual, Dual)]
+    #[inline(never)]
+    fn d_inner_2(x: f32, bx_0: f32) -> (f32, f32) {
+        unsafe { asm!("NOP", options(pure, nomem)); };
+        ::core::hint::black_box(inner(x));
+        ::core::hint::black_box((bx_0,));
+        ::core::hint::black_box(<(f32, f32)>::default())
+    }
     #[rustc_autodiff(Forward, 1, Dual, DualOnly)]
     #[inline(never)]
-    fn d_inner(x: f32, bx_0: f32) -> f32 {
+    fn d_inner_1(x: f32, bx_0: f32) -> f32 {
         unsafe { asm!("NOP", options(pure, nomem)); };
         ::core::hint::black_box(inner(x));
         ::core::hint::black_box((bx_0,));

--- a/tests/pretty/autodiff_forward.rs
+++ b/tests/pretty/autodiff_forward.rs
@@ -56,7 +56,8 @@ fn f8(x: &f32) -> f32 {
 
 // We want to make sure that we can use the macro for functions defined inside of functions
 pub fn f9() {
-    #[autodiff(d_inner, Forward, Dual, DualOnly)]
+    #[autodiff(d_inner_1, Forward, Dual, DualOnly)]
+    #[autodiff(d_inner_2, Forward, Dual, Dual)]
     fn inner(x: f32) -> f32 {
         x * x
     }

--- a/tests/pretty/autodiff_forward.rs
+++ b/tests/pretty/autodiff_forward.rs
@@ -54,4 +54,12 @@ fn f8(x: &f32) -> f32 {
     unimplemented!()
 }
 
+// We want to make sure that we can use the macro for functions defined inside of functions
+pub fn f9() {
+    #[autodiff(d_inner, Forward, Dual, DualOnly)]
+    fn inner(x: f32) -> f32 {
+        x * x
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR adds additional handling into the expansion step of the `std::autodiff` macro (in `compiler/rustc_builtin_macros/src/autodiff.rs`), which allows the macro to be applied to inner functions.

```rust
#![feature(autodiff)]
use std::autodiff::autodiff;

fn main() {
    #[autodiff(d_inner, Forward, Dual, DualOnly)]
    fn inner(x: f32) -> f32 {
        x * x
    }
}
```

Previously, the compiler didn't allow this due to only handling `Annotatable::Item` and `Annotatable::AssocItem` and missing the handling of `Annotatable::Stmt`. This resulted in the rather generic error

```
error: autodiff must be applied to function
 --> src/main.rs:6:5
  |
6 | /     fn inner(x: f32) -> f32 {
7 | |         x * x
8 | |     }
  | |_____^

error: could not compile `enzyme-test` (bin "enzyme-test") due to 1 previous error
```

This issue was originally reported [here](https://github.com/EnzymeAD/rust/issues/184).

Quick question: would it make sense to add a ui test to ensure there is no regression on this?
This is my first contribution, so I'm extra grateful for any piece of feedback!! :D

r? @oli-obk 

Tracking issue for autodiff: #124509 