### PR TITLE
privacy: Visit types and traits in impls in type privacy lints

### DIFF
--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -77,15 +77,14 @@ pub type Alias = OtherType;
 
 pub struct PublicWithPrivateImpl;
 
-// FIXME: This should trigger.
-// See https://github.com/rust-lang/rust/issues/71043
 impl OtherTrait for PublicWithPrivateImpl {}
+//~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
 
 pub trait PubTraitOnPrivate {}
 
-// FIXME: This should trigger.
-// See https://github.com/rust-lang/rust/issues/71043
 impl PubTraitOnPrivate for OtherType {}
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
+//~| ERROR type `OtherType` from private dependency 'priv_dep' in public interface
 
 pub struct AllowedPrivType {
     #[allow(exported_private_dependencies)]

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
@@ -70,5 +70,25 @@ error: type `OtherType` from private dependency 'priv_dep' in public interface
 LL | pub type Alias = OtherType;
    | ^^^^^^^^^^^^^^
 
-error: aborting due to 11 previous errors
+error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:80:1
+   |
+LL | impl OtherTrait for PublicWithPrivateImpl {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:85:1
+   |
+LL | impl PubTraitOnPrivate for OtherType {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:85:1
+   |
+LL | impl PubTraitOnPrivate for OtherType {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
With one exception to avoid false positives.

Fixes the same issue as https://github.com/rust-lang/rust/pull/134176.