### PR TITLE
Fix post-merge workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -36,7 +36,7 @@ jobs:
           cd src/ci/citool
 
           echo "Post-merge analysis result" > output.log
-          cargo run --release post-merge-analysis ${PARENT_COMMIT} ${{ github.sha }} >> output.log
+          cargo run --release post-merge-report ${PARENT_COMMIT} ${{ github.sha }} >> output.log
           cat output.log
 
           gh pr comment ${HEAD_PR} -F output.log


### PR DESCRIPTION
The command is called `post-merge-report` not `post-merge-analysis`. See https://github.com/rust-lang/rust/blob/90384941aae4ea38de00e4702b50757e9b882a19/src/ci/citool/src/main.rs#L379

Noticed it failing in https://github.com/rust-lang/rust/pull/138310#issuecomment-2711917033.

r? @Kobzol (or @marcoieni)