### PR TITLE
Enable `reliable_f16_math` on x86

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -466,13 +466,9 @@ fn update_target_reliable_float_cfg(sess: &Session, cfg: &mut TargetConfig) {
         _ => true,
     };
 
-    cfg.has_reliable_f16_math = match (target_arch, target_os) {
-        // x86 has a crash for `powi`: <https://github.com/llvm/llvm-project/issues/105747>
-        ("x86" | "x86_64", _) => false,
-        // Assume that working `f16` means working `f16` math for most platforms, since
-        // operations just go through `f32`.
-        _ => true,
-    } && cfg.has_reliable_f16;
+    // Assume that working `f16` means working `f16` math for most platforms, since
+    // operations just go through `f32`.
+    cfg.has_reliable_f16_math = cfg.has_reliable_f16;
 
     cfg.has_reliable_f128_math = match (target_arch, target_os) {
         // LLVM lowers `fp128` math to `long double` symbols even on platforms where


### PR DESCRIPTION
This has been disabled due to an LLVM misoptimization with `powi.f16` [1]. This was fixed upstream and the fix is included in LLVM20, so tests no longer need to be disabled.

`f16` still remains disabled on MinGW due to the ABI issue.

[1]: https://github.com/llvm/llvm-project/issues/98665

try-job: x86_64-gnu
try-job: x86_64-gnu-llvm-19-1
try-job: x86_64-gnu-llvm-20-1