### PR TITLE
naked functions: on windows emit `.endef` without the symbol name

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/naked_asm.rs
@@ -245,7 +245,7 @@ fn prefix_and_suffix<'tcx>(
             writeln!(begin, ".def {asm_name}").unwrap();
             writeln!(begin, ".scl 2").unwrap();
             writeln!(begin, ".type 32").unwrap();
-            writeln!(begin, ".endef {asm_name}").unwrap();
+            writeln!(begin, ".endef").unwrap();
             writeln!(begin, "{asm_name}:").unwrap();
 
             writeln!(end).unwrap();

--- a/tests/codegen/naked-fn/naked-functions.rs
+++ b/tests/codegen/naked-fn/naked-functions.rs
@@ -1,10 +1,12 @@
 //@ add-core-stubs
-//@ revisions: linux win macos thumb
+//@ revisions: linux win_x86 win_i686 macos thumb
 //
 //@[linux] compile-flags: --target x86_64-unknown-linux-gnu
 //@[linux] needs-llvm-components: x86
-//@[win] compile-flags: --target x86_64-pc-windows-gnu
-//@[win] needs-llvm-components: x86
+//@[win_x86] compile-flags: --target x86_64-pc-windows-gnu
+//@[win_x86] needs-llvm-components: x86
+//@[win_i686] compile-flags: --target i686-pc-windows-gnu
+//@[win_i686] needs-llvm-components: x86
 //@[macos] compile-flags: --target aarch64-apple-darwin
 //@[macos] needs-llvm-components: arm
 //@[thumb] compile-flags: --target thumbv7em-none-eabi
@@ -19,10 +21,11 @@ use minicore::*;
 
 // linux,win: .intel_syntax
 //
-// linux:   .pushsection .text.naked_empty,\22ax\22, @progbits
-// macos:   .pushsection __TEXT,__text,regular,pure_instructions
-// win: .pushsection .text.naked_empty,\22xr\22
-// thumb:   .pushsection .text.naked_empty,\22ax\22, %progbits
+// linux:    .pushsection .text.naked_empty,\22ax\22, @progbits
+// macos:    .pushsection __TEXT,__text,regular,pure_instructions
+// win_x86:  .pushsection .text.naked_empty,\22xr\22
+// win_i686: .pushsection .text._naked_empty,\22xr\22
+// thumb:    .pushsection .text.naked_empty,\22ax\22, %progbits
 //
 // CHECK: .balign 4
 //
@@ -34,10 +37,12 @@ use minicore::*;
 //
 // linux: .type naked_empty, @function
 //
-// win: .def naked_empty
-// win: .scl 2
-// win: .type 32
-// win: .endef naked_empty
+// win_x86:  .def naked_empty
+// win_i686: .def _naked_empty
+//
+// win_x86,win_i686: .scl 2
+// win_x86,win_i686: .type 32
+// win_x86,win_i686: .endef
 //
 // thumb: .type naked_empty, %function
 // thumb: .thumb
@@ -66,10 +71,11 @@ pub unsafe extern "C" fn naked_empty() {
 
 // linux,win: .intel_syntax
 //
-// linux:   .pushsection .text.naked_with_args_and_return,\22ax\22, @progbits
-// macos:   .pushsection __TEXT,__text,regular,pure_instructions
-// win: .pushsection .text.naked_with_args_and_return,\22xr\22
-// thumb:   .pushsection .text.naked_with_args_and_return,\22ax\22, %progbits
+// linux:    .pushsection .text.naked_with_args_and_return,\22ax\22, @progbits
+// macos:    .pushsection __TEXT,__text,regular,pure_instructions
+// win_x86:  .pushsection .text.naked_with_args_and_return,\22xr\22
+// win_i686: .pushsection .text._naked_with_args_and_return,\22xr\22
+// thumb:    .pushsection .text.naked_with_args_and_return,\22ax\22, %progbits
 //
 // CHECK: .balign 4
 //
@@ -81,10 +87,12 @@ pub unsafe extern "C" fn naked_empty() {
 //
 // linux: .type naked_with_args_and_return, @function
 //
-// win: .def naked_with_args_and_return
-// win: .scl 2
-// win: .type 32
-// win: .endef naked_with_args_and_return
+// win_x86:  .def naked_with_args_and_return
+// win_i686: .def _naked_with_args_and_return
+//
+// win_x86,win_i686: .scl 2
+// win_x86,win_i686: .type 32
+// win_x86,win_i686: .endef
 //
 // thumb: .type naked_with_args_and_return, %function
 // thumb: .thumb
@@ -92,7 +100,7 @@ pub unsafe extern "C" fn naked_empty() {
 //
 // CHECK-LABEL: naked_with_args_and_return:
 //
-// linux, win: lea rax, [rdi + rsi]
+// linux, win_x86,win_i686: lea rax, [rdi + rsi]
 // macos: add x0, x0, x1
 // thumb: adds r0, r0, r1
 //
@@ -124,10 +132,10 @@ pub unsafe extern "C" fn naked_with_args_and_return(a: isize, b: isize) -> isize
     }
 }
 
-// linux:   .pushsection .text.some_different_name,\22ax\22, @progbits
-// macos:   .pushsection .text.some_different_name,regular,pure_instructions
-// win: .pushsection .text.some_different_name,\22xr\22
-// thumb:   .pushsection .text.some_different_name,\22ax\22, %progbits
+// linux:            .pushsection .text.some_different_name,\22ax\22, @progbits
+// macos:            .pushsection .text.some_different_name,regular,pure_instructions
+// win_x86,win_i686: .pushsection .text.some_different_name,\22xr\22
+// thumb:            .pushsection .text.some_different_name,\22ax\22, %progbits
 // CHECK-LABEL: test_link_section:
 #[no_mangle]
 #[naked]
@@ -138,4 +146,20 @@ pub unsafe extern "C" fn test_link_section() {
 
     #[cfg(all(target_arch = "arm", target_feature = "thumb-mode"))]
     naked_asm!("bx lr");
+}
+
+// win_x86:  .def fastcall_cc
+// win_i686: .def @fastcall_cc@4
+//
+// win_x86,win_i686: .scl 2
+// win_x86,win_i686: .type 32
+// win_x86,win_i686: .endef
+//
+// win_x86-LABEL: fastcall_cc:
+// win_i686-LABEL: @fastcall_cc@4:
+#[cfg(target_os = "windows")]
+#[no_mangle]
+#[naked]
+pub unsafe extern "fastcall" fn fastcall_cc(x: i32) -> i32 {
+    naked_asm!("ret");
 }


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/90957
fixes https://github.com/rust-lang/rust/issues/138320

The `.endef` directive does not take the name as an argument. Apparently the LLVM x86_64 parser does accept this, but on i686 it's rejected. In general `i686` does some special name mangling stuff, so it's good to include it in the naked function tests.

r? @ChrisDenton (because windows)