### PR TITLE
Fix false-positive in `expr_or_init` and in the `invalid_from_utf8` lint

### DIFF
--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -6,6 +6,7 @@
 use std::cell::Cell;
 use std::slice;
 
+use rustc_ast::BindingMode;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::sync;
 use rustc_data_structures::unord::UnordMap;
@@ -14,6 +15,7 @@ use rustc_feature::Features;
 use rustc_hir::def::Res;
 use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_hir::definitions::{DefPathData, DisambiguatedDefPathData};
+use rustc_hir::{Pat, PatKind};
 use rustc_middle::bug;
 use rustc_middle::middle::privacy::EffectiveVisibilities;
 use rustc_middle::ty::layout::{LayoutError, LayoutOfHelpers, TyAndLayout};
@@ -890,7 +892,12 @@ impl<'tcx> LateContext<'tcx> {
             }
             && let Some(init) = match parent_node {
                 hir::Node::Expr(expr) => Some(expr),
-                hir::Node::LetStmt(hir::LetStmt { init, .. }) => *init,
+                hir::Node::LetStmt(hir::LetStmt {
+                    init,
+                    // Binding is immutable, init cannot be re-assigned
+                    pat: Pat { kind: PatKind::Binding(BindingMode::NONE, ..), .. },
+                    ..
+                }) => *init,
                 _ => None,
             }
         {
@@ -935,7 +942,12 @@ impl<'tcx> LateContext<'tcx> {
             }
             && let Some(init) = match parent_node {
                 hir::Node::Expr(expr) => Some(expr),
-                hir::Node::LetStmt(hir::LetStmt { init, .. }) => *init,
+                hir::Node::LetStmt(hir::LetStmt {
+                    init,
+                    // Binding is immutable, init cannot be re-assigned
+                    pat: Pat { kind: PatKind::Binding(BindingMode::NONE, ..), .. },
+                    ..
+                }) => *init,
                 hir::Node::Item(item) => match item.kind {
                     hir::ItemKind::Const(.., body_id) | hir::ItemKind::Static(.., body_id) => {
                         Some(self.tcx.hir_body(body_id).value)

--- a/tests/ui/lint/invalid_from_utf8.stderr
+++ b/tests/ui/lint/invalid_from_utf8.stderr
@@ -202,60 +202,25 @@ LL |         str::from_utf8(concat_bytes!(b"cl", b"\x82ippy"));
    |                        |
    |                        the literal was valid UTF-8 up to the 2 bytes
 
-warning: calls to `std::str::from_utf8_mut` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:132:5
-   |
-LL |     let mut a = [99, 108, 130, 105, 112, 112, 121];
-   |                 ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
-LL |     std::str::from_utf8_mut(&mut a);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: calls to `str::from_utf8_mut` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:134:5
-   |
-LL |     let mut a = [99, 108, 130, 105, 112, 112, 121];
-   |                 ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
-...
-LL |     str::from_utf8_mut(&mut a);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: calls to `std::str::from_utf8_mut` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:138:5
-   |
-LL |     let mut a = [99, 108, 130, 105, 112, 112, 121];
-   |                 ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
-...
-LL |     std::str::from_utf8_mut(c);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: calls to `str::from_utf8_mut` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:140:5
-   |
-LL |     let mut a = [99, 108, 130, 105, 112, 112, 121];
-   |                 ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
-...
-LL |     str::from_utf8_mut(c);
-   |     ^^^^^^^^^^^^^^^^^^^^^
-
 warning: calls to `std::str::from_utf8` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:143:5
+  --> $DIR/invalid_from_utf8.rs:146:5
    |
-LL |     let mut c = &[99, 108, 130, 105, 112, 112, 121];
-   |                  ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
+LL |     let c = &[99, 108, 130, 105, 112, 112, 121];
+   |              ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
 LL |     std::str::from_utf8(c);
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: calls to `str::from_utf8` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:145:5
+  --> $DIR/invalid_from_utf8.rs:148:5
    |
-LL |     let mut c = &[99, 108, 130, 105, 112, 112, 121];
-   |                  ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
+LL |     let c = &[99, 108, 130, 105, 112, 112, 121];
+   |              ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
 ...
 LL |     str::from_utf8(c);
    |     ^^^^^^^^^^^^^^^^^
 
 warning: calls to `std::str::from_utf8` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:148:5
+  --> $DIR/invalid_from_utf8.rs:151:5
    |
 LL |     const INVALID_1: [u8; 7] = [99, 108, 130, 105, 112, 112, 121];
    |                                ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
@@ -263,7 +228,7 @@ LL |     std::str::from_utf8(&INVALID_1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: calls to `str::from_utf8` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:150:5
+  --> $DIR/invalid_from_utf8.rs:153:5
    |
 LL |     const INVALID_1: [u8; 7] = [99, 108, 130, 105, 112, 112, 121];
    |                                ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
@@ -272,7 +237,7 @@ LL |     str::from_utf8(&INVALID_1);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: calls to `std::str::from_utf8` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:153:5
+  --> $DIR/invalid_from_utf8.rs:156:5
    |
 LL |     static INVALID_2: [u8; 7] = [99, 108, 130, 105, 112, 112, 121];
    |                                 ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
@@ -280,7 +245,7 @@ LL |     std::str::from_utf8(&INVALID_2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: calls to `str::from_utf8` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:155:5
+  --> $DIR/invalid_from_utf8.rs:158:5
    |
 LL |     static INVALID_2: [u8; 7] = [99, 108, 130, 105, 112, 112, 121];
    |                                 ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
@@ -289,7 +254,7 @@ LL |     str::from_utf8(&INVALID_2);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: calls to `std::str::from_utf8` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:158:5
+  --> $DIR/invalid_from_utf8.rs:161:5
    |
 LL |     const INVALID_3: &'static [u8; 7] = &[99, 108, 130, 105, 112, 112, 121];
    |                                          ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
@@ -297,7 +262,7 @@ LL |     std::str::from_utf8(INVALID_3);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: calls to `str::from_utf8` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:160:5
+  --> $DIR/invalid_from_utf8.rs:163:5
    |
 LL |     const INVALID_3: &'static [u8; 7] = &[99, 108, 130, 105, 112, 112, 121];
    |                                          ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
@@ -306,7 +271,7 @@ LL |     str::from_utf8(INVALID_3);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: calls to `std::str::from_utf8` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:163:5
+  --> $DIR/invalid_from_utf8.rs:166:5
    |
 LL |     const INVALID_4: &'static [u8; 7] = { &[99, 108, 130, 105, 112, 112, 121] };
    |                                            ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
@@ -314,7 +279,7 @@ LL |     std::str::from_utf8(INVALID_4);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: calls to `str::from_utf8` with an invalid literal always return an error
-  --> $DIR/invalid_from_utf8.rs:165:5
+  --> $DIR/invalid_from_utf8.rs:168:5
    |
 LL |     const INVALID_4: &'static [u8; 7] = { &[99, 108, 130, 105, 112, 112, 121] };
    |                                            ---------------------------------- the literal was valid UTF-8 up to the 2 bytes
@@ -322,5 +287,5 @@ LL |     const INVALID_4: &'static [u8; 7] = { &[99, 108, 130, 105, 112, 112, 12
 LL |     str::from_utf8(INVALID_4);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 38 warnings emitted
+warning: 34 warnings emitted
 


### PR DESCRIPTION
This PR fixes the logic for finding initializer in the `expr_or_init` and `expr_or_init_with_outside_body` functions.

If the binding were to be mutable (`let mut`), the logic wouldn't consider that the initializer expression could have been modified and would return the init expression even-trough multiple subsequent assignments could have been done.

Example:
```rust
let mut a = [99, 108, 130, 105, 112, 112]; // invalid, not UTF-8
loop {
    a = *b"clippy"; // valid
    break;
}
std::str::from_utf8_mut(&mut a); // currently warns, with this PR it doesn't
```

This PR modifies the logic to excludes mutable let bindings.

Found when using `expr_or_init` in https://github.com/rust-lang/rust/pull/119220.

r? compiler