### PR TITLE
Do not suggest using `-Zmacro-backtrace` for builtin macros

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -889,16 +889,16 @@ impl SyntaxExtension {
             })
             .unwrap_or_else(|| (None, helper_attrs));
 
-        let stability = find_attr!(attrs, AttributeKind::Stability{stability, ..} => *stability);
+        let stability = find_attr!(attrs, AttributeKind::Stability { stability, .. } => *stability);
 
         // FIXME(jdonszelmann): make it impossible to miss the or_else in the typesystem
-        if let Some(sp) = find_attr!(attrs, AttributeKind::ConstStability{span, ..} => *span) {
+        if let Some(sp) = find_attr!(attrs, AttributeKind::ConstStability { span, .. } => *span) {
             sess.dcx().emit_err(errors::MacroConstStability {
                 span: sp,
                 head_span: sess.source_map().guess_head_span(span),
             });
         }
-        if let Some(sp) = find_attr!(attrs, AttributeKind::BodyStability{span, ..} => *span) {
+        if let Some(sp) = find_attr!(attrs, AttributeKind::BodyStability{ span, .. } => *span) {
             sess.dcx().emit_err(errors::MacroBodyStability {
                 span: sp,
                 head_span: sess.source_map().guess_head_span(span),
@@ -912,7 +912,10 @@ impl SyntaxExtension {
                 // FIXME(jdonszelmann): avoid the into_iter/collect?
                 .then(|| allow_internal_unstable.iter().map(|i| i.0).collect::<Vec<_>>().into()),
             stability,
-            deprecation: find_attr!(attrs, AttributeKind::Deprecation{deprecation, ..} => *deprecation),
+            deprecation: find_attr!(
+                attrs,
+                AttributeKind::Deprecation { deprecation, .. } => *deprecation
+            ),
             helper_attrs,
             edition,
             builtin_name,
@@ -1000,6 +1003,7 @@ impl SyntaxExtension {
             self.allow_internal_unsafe,
             self.local_inner_macros,
             self.collapse_debuginfo,
+            self.builtin_name.is_some(),
         )
     }
 }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -982,6 +982,8 @@ pub struct ExpnData {
     /// Should debuginfo for the macro be collapsed to the outermost expansion site (in other
     /// words, was the macro definition annotated with `#[collapse_debuginfo]`)?
     pub(crate) collapse_debuginfo: bool,
+    /// When true, we do not display the note telling people to use the `-Zmacro-backtrace` flag.
+    pub hide_backtrace: bool,
 }
 
 impl !PartialEq for ExpnData {}
@@ -1000,6 +1002,7 @@ impl ExpnData {
         allow_internal_unsafe: bool,
         local_inner_macros: bool,
         collapse_debuginfo: bool,
+        hide_backtrace: bool,
     ) -> ExpnData {
         ExpnData {
             kind,
@@ -1014,6 +1017,7 @@ impl ExpnData {
             allow_internal_unsafe,
             local_inner_macros,
             collapse_debuginfo,
+            hide_backtrace,
         }
     }
 
@@ -1038,6 +1042,7 @@ impl ExpnData {
             allow_internal_unsafe: false,
             local_inner_macros: false,
             collapse_debuginfo: false,
+            hide_backtrace: false,
         }
     }
 

--- a/src/tools/clippy/tests/ui/derive_ord_xor_partial_ord.stderr
+++ b/src/tools/clippy/tests/ui/derive_ord_xor_partial_ord.stderr
@@ -11,7 +11,6 @@ LL | impl PartialOrd for DeriveOrd {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: `-D clippy::derive-ord-xor-partial-ord` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::derive_ord_xor_partial_ord)]`
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are deriving `Ord` but have implemented `PartialOrd` explicitly
   --> tests/ui/derive_ord_xor_partial_ord.rs:33:10
@@ -24,7 +23,6 @@ note: `PartialOrd` implemented here
    |
 LL | impl PartialOrd<DeriveOrdWithExplicitTypeVariable> for DeriveOrdWithExplicitTypeVariable {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are implementing `Ord` explicitly but have derived `PartialOrd`
   --> tests/ui/derive_ord_xor_partial_ord.rs:47:1
@@ -42,7 +40,6 @@ note: `PartialOrd` implemented here
    |
 LL | #[derive(PartialOrd, PartialEq, Eq)]
    |          ^^^^^^^^^^
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are implementing `Ord` explicitly but have derived `PartialOrd`
   --> tests/ui/derive_ord_xor_partial_ord.rs:69:5
@@ -60,7 +57,6 @@ note: `PartialOrd` implemented here
    |
 LL |     #[derive(PartialOrd, PartialEq, Eq)]
    |              ^^^^^^^^^^
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/tools/clippy/tests/ui/derived_hash_with_manual_eq.stderr
+++ b/src/tools/clippy/tests/ui/derived_hash_with_manual_eq.stderr
@@ -10,7 +10,6 @@ note: `PartialEq` implemented here
 LL | impl PartialEq for Bar {
    | ^^^^^^^^^^^^^^^^^^^^^^
    = note: `#[deny(clippy::derived_hash_with_manual_eq)]` on by default
-   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are deriving `Hash` but have implemented `PartialEq` explicitly
   --> tests/ui/derived_hash_with_manual_eq.rs:23:10
@@ -23,7 +22,6 @@ note: `PartialEq` implemented here
    |
 LL | impl PartialEq<Baz> for Baz {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/tools/clippy/tests/ui/diverging_sub_expression.stderr
+++ b/src/tools/clippy/tests/ui/diverging_sub_expression.stderr
@@ -36,8 +36,6 @@ error: sub-expression diverges
    |
 LL |                 _ => true || panic!("boo"),
    |                              ^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: sub-expression diverges
   --> tests/ui/diverging_sub_expression.rs:52:29

--- a/src/tools/clippy/tests/ui/fallible_impl_from.stderr
+++ b/src/tools/clippy/tests/ui/fallible_impl_from.stderr
@@ -38,7 +38,6 @@ note: potential failure(s)
    |
 LL |             panic!();
    |             ^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: consider implementing `TryFrom` instead
   --> tests/ui/fallible_impl_from.rs:40:1
@@ -64,7 +63,6 @@ LL |         } else if s.parse::<u32>().unwrap() != 42 {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |             panic!("{:?}", s);
    |             ^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: consider implementing `TryFrom` instead
   --> tests/ui/fallible_impl_from.rs:60:1
@@ -85,7 +83,6 @@ LL |         if s.parse::<u32>().ok().unwrap() != 42 {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |             panic!("{:?}", s);
    |             ^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/tools/clippy/tests/ui/impl_hash_with_borrow_str_and_bytes.stderr
+++ b/src/tools/clippy/tests/ui/impl_hash_with_borrow_str_and_bytes.stderr
@@ -23,7 +23,6 @@ LL | #[derive(Hash)]
    = note: ... as (`hash("abc") != hash("abc".as_bytes())`
    = help: consider either removing one of the  `Borrow` implementations (`Borrow<str>` or `Borrow<[u8]>`) ...
    = help: ... or not implementing `Hash` for this type
-   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the semantics of `Borrow<T>` around `Hash` can't be satisfied when both `Borrow<str>` and `Borrow<[u8]>` are implemented
   --> tests/ui/impl_hash_with_borrow_str_and_bytes.rs:117:6

--- a/src/tools/clippy/tests/ui/issue-7447.stderr
+++ b/src/tools/clippy/tests/ui/issue-7447.stderr
@@ -6,15 +6,12 @@ LL |     byte_view(panic!());
    |
    = note: `-D clippy::diverging-sub-expression` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::diverging_sub_expression)]`
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: sub-expression diverges
   --> tests/ui/issue-7447.rs:29:19
    |
 LL |     group_entries(panic!());
    |                   ^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/tools/clippy/tests/ui/same_name_method.stderr
+++ b/src/tools/clippy/tests/ui/same_name_method.stderr
@@ -23,7 +23,6 @@ note: existing `clone` defined here
    |
 LL |         #[derive(Clone)]
    |                  ^^^^^
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: method's name is the same as an existing method in a trait
   --> tests/ui/same_name_method.rs:46:13

--- a/src/tools/miri/tests/fail/alloc/alloc_error_handler_custom.stderr
+++ b/src/tools/miri/tests/fail/alloc/alloc_error_handler_custom.stderr
@@ -21,7 +21,6 @@ note: inside `miri_start`
    |
 LL |     handle_alloc_error(Layout::for_value(&0));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the attribute macro `alloc_error_handler` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/src/tools/miri/tests/fail/erroneous_const.stderr
+++ b/src/tools/miri/tests/fail/erroneous_const.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `PrintName::<i32>::VOID` failed
    |
 LL |     const VOID: ! = panic!();
    |                     ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> tests/fail/erroneous_const.rs:LL:CC

--- a/src/tools/miri/tests/fail/panic/no_std.stderr
+++ b/src/tools/miri/tests/fail/panic/no_std.stderr
@@ -13,7 +13,6 @@ note: inside `miri_start`
    |
 LL |     panic!("blarg I am dead")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/panic/panic_abort1.stderr
+++ b/src/tools/miri/tests/fail/panic/panic_abort1.stderr
@@ -22,7 +22,6 @@ note: inside `main`
    |
 LL |     std::panic!("panicking from libstd");
    | ^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/panic/panic_abort2.stderr
+++ b/src/tools/miri/tests/fail/panic/panic_abort2.stderr
@@ -22,7 +22,6 @@ note: inside `main`
    |
 LL |     std::panic!("{}-panicking from libstd", 42);
    | ^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/panic/panic_abort3.stderr
+++ b/src/tools/miri/tests/fail/panic/panic_abort3.stderr
@@ -22,7 +22,6 @@ note: inside `main`
    |
 LL |     core::panic!("panicking from libcore");
    | ^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/panic/panic_abort4.stderr
+++ b/src/tools/miri/tests/fail/panic/panic_abort4.stderr
@@ -22,7 +22,6 @@ note: inside `main`
    |
 LL |     core::panic!("{}-panicking from libcore", 42);
    | ^
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/run-make/non-unicode-env/non_unicode_env.stderr
+++ b/tests/run-make/non-unicode-env/non_unicode_env.stderr
@@ -3,16 +3,12 @@ error: environment variable `NON_UNICODE_VAR` is not a valid Unicode string
   |
 2 |     let _ = env!("NON_UNICODE_VAR");
   |             ^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: environment variable `NON_UNICODE_VAR` is not a valid Unicode string
  --> non_unicode_env.rs:3:13
   |
 3 |     let _ = option_env!("NON_UNICODE_VAR");
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the macro `option_env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
@@ -10,8 +10,6 @@ error: couldn't read `$DIR/relative-dir-empty-file`: $FILE_NOT_FOUND_MSG (os err
    |
 LL | let x = include_bytes!("relative-dir-empty-file");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
+++ b/tests/ui/alloc-error/alloc-error-handler-bad-signature-1.stderr
@@ -18,7 +18,6 @@ LL | fn oom(
    |    ^^^
 LL |     info: &Layout,
    |     -------------
-   = note: this error originates in the attribute macro `alloc_error_handler` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/alloc-error-handler-bad-signature-1.rs:10:1
@@ -35,7 +34,6 @@ LL | |  }
    |
    = note:   expected type `!`
            found unit type `()`
-   = note: this error originates in the attribute macro `alloc_error_handler` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
+++ b/tests/ui/alloc-error/alloc-error-handler-bad-signature-2.stderr
@@ -26,7 +26,6 @@ LL | fn oom(
    |    ^^^
 LL |     info: Layout,
    |     ------------
-   = note: this error originates in the attribute macro `alloc_error_handler` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/alloc-error-handler-bad-signature-2.rs:10:1
@@ -43,7 +42,6 @@ LL | |  }
    |
    = note:   expected type `!`
            found unit type `()`
-   = note: this error originates in the attribute macro `alloc_error_handler` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/alloc-error/alloc-error-handler-bad-signature-3.stderr
+++ b/tests/ui/alloc-error/alloc-error-handler-bad-signature-3.stderr
@@ -14,7 +14,6 @@ note: function defined here
    |
 LL | fn oom() -> ! {
    |    ^^^
-   = note: this error originates in the attribute macro `alloc_error_handler` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/allocator/not-an-allocator.stderr
+++ b/tests/ui/allocator/not-an-allocator.stderr
@@ -7,7 +7,6 @@ LL | static A: usize = 0;
    |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
-   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:11
@@ -19,7 +18,6 @@ LL | static A: usize = 0;
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:11
@@ -31,7 +29,6 @@ LL | static A: usize = 0;
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:11
@@ -43,7 +40,6 @@ LL | static A: usize = 0;
    |
    = help: the trait `GlobalAlloc` is implemented for `System`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/allocator/two-allocators.stderr
+++ b/tests/ui/allocator/two-allocators.stderr
@@ -7,8 +7,6 @@ LL | #[global_allocator]
    | ------------------- in this procedural macro expansion
 LL | static B: System = System;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot define a new global allocator
-   |
-   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/asm/ice-bad-err-span-in-template-129503.stderr
+++ b/tests/ui/asm/ice-bad-err-span-in-template-129503.stderr
@@ -5,7 +5,6 @@ LL |     asm!(concat!(r#"lJ𐏿Æ�.𐏿�"#, "r} {}"));
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched `}` in asm template string
    |
    = note: if you intended to print `}`, you can escape it using `}}`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid asm template string: unmatched `}` found
   --> $DIR/ice-bad-err-span-in-template-129503.rs:18:10
@@ -14,7 +13,6 @@ LL |     asm!(concat!("abc", "r} {}"));
    |          ^^^^^^^^^^^^^^^^^^^^^^^ unmatched `}` in asm template string
    |
    = note: if you intended to print `}`, you can escape it using `}}`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid asm template string: unmatched `}` found
   --> $DIR/ice-bad-err-span-in-template-129503.rs:24:19

--- a/tests/ui/asm/x86_64/goto.stderr
+++ b/tests/ui/asm/x86_64/goto.stderr
@@ -17,7 +17,6 @@ note: the lint level is defined here
    |
 LL | #[warn(unreachable_code)]
    |        ^^^^^^^^^^^^^^^^
-   = note: this warning originates in the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted
 

--- a/tests/ui/associated-types/issue-38821.stderr
+++ b/tests/ui/associated-types/issue-38821.stderr
@@ -53,7 +53,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -73,7 +72,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -92,7 +90,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:10
@@ -108,7 +105,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:17
@@ -123,7 +119,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -143,7 +138,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -162,7 +156,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -182,7 +175,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting the associated type
    |
 LL |     Expr: Expression<SqlType=<Col::SqlType as IntoNullable>::Nullable>, <Col as Expression>::SqlType: NotNull,
@@ -201,7 +193,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         -------  ^^^^^^^^^^^^     ^
    |         |
    |         unsatisfied trait bound introduced here
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:23
@@ -217,7 +208,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:10
@@ -233,7 +223,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:10
@@ -249,7 +238,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:23
@@ -265,7 +253,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:23
@@ -281,7 +268,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:10
@@ -297,7 +283,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `<Col as Expression>::SqlType: NotNull` is not satisfied
   --> $DIR/issue-38821.rs:23:23
@@ -313,7 +298,6 @@ LL | impl<T: NotNull> IntoNullable for T {
    |         |
    |         unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/attributes/extented-attribute-macro-error.stderr
+++ b/tests/ui/attributes/extented-attribute-macro-error.stderr
@@ -3,8 +3,6 @@ error: couldn't read the file
    |
 LL | #![doc = include_str!("../not_existing_file.md")]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/issue-114374-invalid-help-fmt-args.stderr
+++ b/tests/ui/borrowck/issue-114374-invalid-help-fmt-args.stderr
@@ -11,7 +11,6 @@ LL |     bar(x);
    |
    = note: the result of `format_args!` can only be assigned directly if no placeholders in its arguments are used
    = note: to learn more, visit <https://doc.rust-lang.org/std/macro.format_args.html>
-   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-114374-invalid-help-fmt-args.rs:10:15
@@ -26,7 +25,6 @@ LL |     bar(foo);
    |
    = note: the result of `format_args!` can only be assigned directly if no placeholders in its arguments are used
    = note: to learn more, visit <https://doc.rust-lang.org/std/macro.format_args.html>
-   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/borrowck/issue-81899.stderr
+++ b/tests/ui/borrowck/issue-81899.stderr
@@ -9,7 +9,6 @@ note: inside `f::<{closure@$DIR/issue-81899.rs:4:31: 4:34}>`
    |
 LL |     panic!()
    |     ^^^^^^^^ the failure occurred here
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/issue-81899.rs:4:23

--- a/tests/ui/borrowck/issue-88434-minimal-example.stderr
+++ b/tests/ui/borrowck/issue-88434-minimal-example.stderr
@@ -9,7 +9,6 @@ note: inside `f::<{closure@$DIR/issue-88434-minimal-example.rs:3:25: 3:28}>`
    |
 LL |     panic!()
    |     ^^^^^^^^ the failure occurred here
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/issue-88434-minimal-example.rs:3:21

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
@@ -9,7 +9,6 @@ note: inside `f::<{closure@$DIR/issue-88434-removal-index-should-be-less.rs:3:31
    |
 LL |     panic!()
    |     ^^^^^^^^ the failure occurred here
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/issue-88434-removal-index-should-be-less.rs:3:23

--- a/tests/ui/codemap_tests/issue-28308.stderr
+++ b/tests/ui/codemap_tests/issue-28308.stderr
@@ -3,8 +3,6 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
    |
 LL |     assert!("foo");
    |     ^^^^^^^^^^^^^^ cannot apply unary operator `!`
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coherence/const-errs-dont-conflict-103369.stderr
+++ b/tests/ui/coherence/const-errs-dont-conflict-103369.stderr
@@ -9,7 +9,6 @@ note: inside `my_fn`
    |
 LL |     panic!("Some error occurred");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-errs-dont-conflict-103369.rs:7:25
@@ -22,7 +21,6 @@ note: inside `my_fn`
    |
 LL |     panic!("Some error occurred");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.stderr
+++ b/tests/ui/coherence/warn-when-cycle-is-error-in-coherence.stderr
@@ -9,8 +9,6 @@ LL | | where
 LL | |     T: Borrow<Q>,
 LL | |     Q: ?Sized + PartialOrd,
    | |___________________________- first implementation here
-   |
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_bad_field.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_bad_field.stderr
@@ -15,8 +15,6 @@ LL | #[derive(std::marker::UnsizedConstParamTy, Eq, PartialEq)]
 LL |
 LL | struct CantParamDerive(NotParam);
    |                        -------- this field does not implement `ConstParamTy_`
-   |
-   = note: this error originates in the derive macro `std::marker::UnsizedConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.stderr
@@ -29,7 +29,6 @@ LL | #[derive(std::marker::UnsizedConstParamTy)]
    |
 note: required by a bound in `UnsizedConstParamTy`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
-   = note: this error originates in the derive macro `std::marker::UnsizedConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `CantParamDerive` with `#[derive(Eq)]`
    |
 LL + #[derive(Eq)]
@@ -44,7 +43,6 @@ LL | #[derive(std::marker::UnsizedConstParamTy)]
    |
 note: required by a bound in `UnsizedConstParamTy`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
-   = note: this error originates in the derive macro `std::marker::UnsizedConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/adt_const_params/nested_bad_const_param_ty.stderr
+++ b/tests/ui/const-generics/adt_const_params/nested_bad_const_param_ty.stderr
@@ -12,7 +12,6 @@ note: the `ConstParamTy_` impl for `[*const u8; 1]` requires that `*const u8: Co
    |
 LL | struct Foo([*const u8; 1]);
    |            ^^^^^^^^^^^^^^
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
   --> $DIR/nested_bad_const_param_ty.rs:11:10
@@ -28,7 +27,6 @@ note: the `ConstParamTy_` impl for `[*mut u8; 1]` requires that `*mut u8: ConstP
    |
 LL | struct Foo2([*mut u8; 1]);
    |             ^^^^^^^^^^^^
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
   --> $DIR/nested_bad_const_param_ty.rs:16:10
@@ -44,7 +42,6 @@ note: the `ConstParamTy_` impl for `[fn(); 1]` requires that `fn(): ConstParamTy
    |
 LL | struct Foo3([fn(); 1]);
    |             ^^^^^^^^^
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
   --> $DIR/nested_bad_const_param_ty.rs:6:10
@@ -60,7 +57,6 @@ note: the `ConstParamTy_` impl for `[*const u8; 1]` requires that `*const u8: Un
    |
 LL | struct Foo([*const u8; 1]);
    |            ^^^^^^^^^^^^^^
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
   --> $DIR/nested_bad_const_param_ty.rs:11:10
@@ -76,7 +72,6 @@ note: the `ConstParamTy_` impl for `[*mut u8; 1]` requires that `*mut u8: Unsize
    |
 LL | struct Foo2([*mut u8; 1]);
    |             ^^^^^^^^^^^^
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
   --> $DIR/nested_bad_const_param_ty.rs:16:10
@@ -92,7 +87,6 @@ note: the `ConstParamTy_` impl for `[fn(); 1]` requires that `fn(): UnsizedConst
    |
 LL | struct Foo3([fn(); 1]);
    |             ^^^^^^^^^
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/const-generics/adt_const_params/unsized_field-1.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsized_field-1.stderr
@@ -6,8 +6,6 @@ LL | #[derive(ConstParamTy, Eq, PartialEq)]
 LL |
 LL | struct A([u8]);
    |          ---- this field does not implement `ConstParamTy_`
-   |
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
   --> $DIR/unsized_field-1.rs:12:10
@@ -17,8 +15,6 @@ LL | #[derive(ConstParamTy, Eq, PartialEq)]
 LL |
 LL | struct B(&'static [u8]);
    |          ------------- this field does not implement `ConstParamTy_`
-   |
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
   --> $DIR/unsized_field-1.rs:16:10
@@ -28,8 +24,6 @@ LL | #[derive(ConstParamTy, Eq, PartialEq)]
 LL |
 LL | struct C(unsized_const_param::Foo);
    |          ------------------------ this field does not implement `ConstParamTy_`
-   |
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/adt_const_params/unsized_field-2.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsized_field-2.stderr
@@ -21,7 +21,6 @@ note: the `ConstParamTy_` impl for `GenericNotUnsizedParam<&'static [u8]>` requi
    |
 LL | struct A(unsized_const_param::GenericNotUnsizedParam<&'static [u8]>);
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the derive macro `std::marker::ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
+++ b/tests/ui/const-generics/adt_const_params/unsizing-wfcheck-issue-126272.stderr
@@ -26,8 +26,6 @@ LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
 ...
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |     ----------------------------------------- this field does not implement `ConstParamTy_`
-   |
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `ConstParamTy_` cannot be implemented for this type
   --> $DIR/unsizing-wfcheck-issue-126272.rs:8:32
@@ -53,7 +51,6 @@ note: the `ConstParamTy_` impl for `&'static Bar<(dyn Debug + 'static)>` require
    |
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the derive macro `ConstParamTy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
   --> $DIR/unsizing-wfcheck-issue-126272.rs:12:5
@@ -76,7 +73,6 @@ LL | struct Bar<T>(T);
    = note: 2 redundant requirements hidden
    = note: required for `&&'static Bar<(dyn Debug + 'static)>` to implement `Debug`
    = note: required for the cast from `&&&'static Bar<(dyn Debug + 'static)>` to `&dyn Debug`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `==` cannot be applied to type `&Bar<dyn Debug>`
   --> $DIR/unsizing-wfcheck-issue-126272.rs:12:5
@@ -86,8 +82,6 @@ LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
 ...
 LL |     nested: &'static Bar<dyn std::fmt::Debug>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `dyn Debug: Eq` is not satisfied
   --> $DIR/unsizing-wfcheck-issue-126272.rs:12:5
@@ -108,7 +102,6 @@ LL | #[derive(Debug, PartialEq, Eq, ConstParamTy)]
    = note: required for `&'static Bar<dyn Debug>` to implement `Eq`
 note: required by a bound in `AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `dyn Debug` cannot be known at compilation time
   --> $DIR/unsizing-wfcheck-issue-126272.rs:12:5
@@ -132,7 +125,6 @@ LL | struct Bar<T>(T);
    |            ^  - ...if indirection were used here: `Box<T>`
    |            |
    |            this could be changed to `T: ?Sized`...
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `(dyn Debug + 'static)` cannot be known at compilation time
   --> $DIR/unsizing-wfcheck-issue-126272.rs:26:33

--- a/tests/ui/const-ptr/forbidden_slices.stderr
+++ b/tests/ui/const-ptr/forbidden_slices.stderr
@@ -109,7 +109,6 @@ note: inside `from_ptr_range::<'_, ()>`
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
 note: inside `std::ptr::const_ptr::<impl *const ()>::offset_from_unsigned`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: could not evaluate static initializer
   --> $DIR/forbidden_slices.rs:54:25

--- a/tests/ui/consts/const-blocks/trait-error.stderr
+++ b/tests/ui/consts/const-blocks/trait-error.stderr
@@ -13,7 +13,6 @@ note: required for `Foo<String>` to implement `Copy`
 LL | #[derive(Copy, Clone)]
    |          ^^^^ unsatisfied trait bound introduced in this `derive` macro
    = note: the `Copy` trait is required because this value will be copied for each element of the array
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
+++ b/tests/ui/consts/const-eval/const_panic-normalize-tabs-115498.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of constant value failed
    |
 LL | struct Bug([u8; panic!{"\t"}]);
    |                 ^^^^^^^^^^^^ evaluation panicked:     
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const_panic.stderr
+++ b/tests/ui/consts/const-eval/const_panic.stderr
@@ -3,24 +3,18 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const Z: () = std::panic!("cheese");
    |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: cheese
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:9:16
    |
 LL | const Z2: () = std::panic!();
    |                ^^^^^^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:12:15
    |
 LL | const Y: () = std::unreachable!();
    |               ^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
-   |
-   = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `std::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:15:15
@@ -35,40 +29,30 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const W: () = std::panic!(MSG);
    |               ^^^^^^^^^^^^^^^^ evaluation panicked: hello
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:21:16
    |
 LL | const W2: () = std::panic!("{}", MSG);
    |                ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:24:20
    |
 LL | const Z_CORE: () = core::panic!("cheese");
    |                    ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: cheese
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:27:21
    |
 LL | const Z2_CORE: () = core::panic!();
    |                     ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:30:20
    |
 LL | const Y_CORE: () = core::unreachable!();
    |                    ^^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
-   |
-   = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `core::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:33:20
@@ -83,16 +67,12 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const W_CORE: () = core::panic!(MSG);
    |                    ^^^^^^^^^^^^^^^^^ evaluation panicked: hello
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic.rs:39:21
    |
 LL | const W2_CORE: () = core::panic!("{}", MSG);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/consts/const-eval/const_panic_2021.stderr
+++ b/tests/ui/consts/const-eval/const_panic_2021.stderr
@@ -3,24 +3,18 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const A: () = std::panic!("blåhaj");
    |               ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: blåhaj
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:9:15
    |
 LL | const B: () = std::panic!();
    |               ^^^^^^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:12:15
    |
 LL | const C: () = std::unreachable!();
    |               ^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
-   |
-   = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `std::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:15:15
@@ -35,32 +29,24 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const E: () = std::panic!("{}", MSG);
    |               ^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:21:20
    |
 LL | const A_CORE: () = core::panic!("shark");
    |                    ^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: shark
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:24:20
    |
 LL | const B_CORE: () = core::panic!();
    |                    ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:27:20
    |
 LL | const C_CORE: () = core::unreachable!();
    |                    ^^^^^^^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
-   |
-   = note: this error originates in the macro `$crate::panic::unreachable_2021` which comes from the expansion of the macro `core::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_2021.rs:30:20
@@ -75,8 +61,6 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const E_CORE: () = core::panic!("{}", MSG);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: hello
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/tests/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -3,16 +3,12 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const Z: () = panic!("cheese");
    |               ^^^^^^^^^^^^^^^^ evaluation panicked: cheese
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:11:15
    |
 LL | const Y: () = unreachable!();
    |               ^^^^^^^^^^^^^^ evaluation panicked: internal error: entered unreachable code
-   |
-   = note: this error originates in the macro `$crate::panic::unreachable_2015` which comes from the expansion of the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_panic_libcore_bin.rs:14:15

--- a/tests/ui/consts/const-eval/format.stderr
+++ b/tests/ui/consts/const-eval/format.stderr
@@ -5,7 +5,6 @@ LL |     panic!("{:?}", 0);
    |             ^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const formatting macro in constant functions
   --> $DIR/format.rs:7:15

--- a/tests/ui/consts/const-eval/issue-85907.stderr
+++ b/tests/ui/consts/const-eval/issue-85907.stderr
@@ -3,8 +3,6 @@ error: argument to `panic!()` in a const context must have type `&str`
    |
 LL |     panic!(123);
    |     ^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of constant value failed
    |
 LL |     const VOID: ! = panic!();
    |                     ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/panic-assoc-never-type.rs:14:13

--- a/tests/ui/consts/const-eval/panic-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-never-type.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const VOID: ! = panic!();
    |                 ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/unwind-abort.stderr
+++ b/tests/ui/consts/const-eval/unwind-abort.stderr
@@ -9,7 +9,6 @@ note: inside `foo`
    |
 LL |     panic!()
    |     ^^^^^^^^ the failure occurred here
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-ptr-is-null.stderr
+++ b/tests/ui/consts/const-ptr-is-null.stderr
@@ -8,7 +8,6 @@ note: inside `std::ptr::const_ptr::<impl *const i32>::is_null`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `std::ptr::const_ptr::<impl *const T>::is_null::compiletime`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   = note: this error originates in the macro `$crate::intrinsics::const_eval_select` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const_cmp_type_id.stderr
+++ b/tests/ui/consts/const_cmp_type_id.stderr
@@ -27,7 +27,6 @@ LL |         let _a = TypeId::of::<u8>() < TypeId::of::<u16>();
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/control-flow/assert.stderr
+++ b/tests/ui/consts/control-flow/assert.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const _: () = assert!(false);
    |               ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-32829.stderr
+++ b/tests/ui/consts/issue-32829.stderr
@@ -3,8 +3,6 @@ error[E0080]: could not evaluate static initializer
    |
 LL | static S : u64 = { { panic!("foo"); 0 } };
    |                      ^^^^^^^^^^^^^ evaluation panicked: foo
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-66693-panic-in-array-len.stderr
+++ b/tests/ui/consts/issue-66693-panic-in-array-len.stderr
@@ -3,16 +3,12 @@ error: argument to `panic!()` in a const context must have type `&str`
    |
 LL |     let _ = [0i32; panic!(2f32)];
    |                    ^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-66693-panic-in-array-len.rs:10:21
    |
 LL |     let _ = [false; panic!()];
    |                     ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/issue-66693.stderr
+++ b/tests/ui/consts/issue-66693.stderr
@@ -3,40 +3,30 @@ error: argument to `panic!()` in a const context must have type `&str`
    |
 LL | const _: () = panic!(1);
    |               ^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument to `panic!()` in a const context must have type `&str`
   --> $DIR/issue-66693.rs:7:19
    |
 LL | static _FOO: () = panic!(true);
    |                   ^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-66693.rs:16:15
    |
 LL | const _: () = panic!();
    |               ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: could not evaluate static initializer
   --> $DIR/issue-66693.rs:18:19
    |
 LL | static _BAR: () = panic!("panic in static");
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: panic in static
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument to `panic!()` in a const context must have type `&str`
   --> $DIR/issue-66693.rs:11:5
    |
 LL |     panic!(&1);
    |     ^^^^^^^^^^
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/consts/issue-76064.stderr
+++ b/tests/ui/consts/issue-76064.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of constant value failed
    |
 LL | struct Bug([u8; panic!("panic")]);
    |                 ^^^^^^^^^^^^^^^ evaluation panicked: panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/required-consts/collect-in-called-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-called-fn.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-called-fn.rs:19:17

--- a/tests/ui/consts/required-consts/collect-in-called-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-called-fn.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-called-fn.rs:19:17

--- a/tests/ui/consts/required-consts/collect-in-dead-closure.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-closure.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-closure.rs:17:17

--- a/tests/ui/consts/required-consts/collect-in-dead-closure.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-closure.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-closure.rs:17:17

--- a/tests/ui/consts/required-consts/collect-in-dead-drop.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-drop.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-drop.rs:16:17

--- a/tests/ui/consts/required-consts/collect-in-dead-drop.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-drop.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-drop.rs:16:17

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fn-behind-assoc-type.rs:16:17

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-assoc-type.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fn-behind-assoc-type.rs:16:17

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fn-behind-generic.rs:15:17

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-generic.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fn-behind-generic.rs:15:17

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `m::Fail::<i32>::C` failed
    |
 LL |         const C: () = panic!();
    |                       ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fn-behind-opaque-type.rs:19:21

--- a/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn-behind-opaque-type.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `m::Fail::<i32>::C` failed
    |
 LL |         const C: () = panic!();
    |                       ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fn-behind-opaque-type.rs:19:21

--- a/tests/ui/consts/required-consts/collect-in-dead-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fn.rs:19:17

--- a/tests/ui/consts/required-consts/collect-in-dead-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fn.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fn.rs:19:17

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Late::<i32>::FAIL` failed
    |
 LL |     const FAIL: () = panic!();
    |                      ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fnptr-in-const.rs:10:28

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr-in-const.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Late::<i32>::FAIL` failed
    |
 LL |     const FAIL: () = panic!();
    |                      ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fnptr-in-const.rs:10:28

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fnptr.rs:18:17

--- a/tests/ui/consts/required-consts/collect-in-dead-fnptr.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-fnptr.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-fnptr.rs:18:17

--- a/tests/ui/consts/required-consts/collect-in-dead-move.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-move.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-move.rs:16:17

--- a/tests/ui/consts/required-consts/collect-in-dead-move.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-move.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-move.rs:16:17

--- a/tests/ui/consts/required-consts/collect-in-dead-vtable.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-vtable.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-vtable.rs:22:21

--- a/tests/ui/consts/required-consts/collect-in-dead-vtable.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-dead-vtable.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-dead-vtable.rs:22:21

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.noopt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-promoted-const.rs:20:21

--- a/tests/ui/consts/required-consts/collect-in-promoted-const.opt.stderr
+++ b/tests/ui/consts/required-consts/collect-in-promoted-const.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<T>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-promoted-const.rs:20:21
@@ -17,8 +15,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/collect-in-promoted-const.rs:20:21

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/interpret-in-const-called-fn.rs:17:9

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/interpret-in-const-called-fn.rs:17:9

--- a/tests/ui/consts/required-consts/interpret-in-static.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-static.noopt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/interpret-in-static.rs:16:9

--- a/tests/ui/consts/required-consts/interpret-in-static.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-static.opt.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `Fail::<i32>::C` failed
    |
 LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/interpret-in-static.rs:16:9

--- a/tests/ui/custom_test_frameworks/mismatch.stderr
+++ b/tests/ui/custom_test_frameworks/mismatch.stderr
@@ -7,7 +7,6 @@ LL | fn wrong_kind(){}
    | ^^^^^^^^^^^^^^^^^ the trait `Testable` is not implemented for `TestDescAndFn`
    |
    = note: required for the cast from `&TestDescAndFn` to `&dyn Testable`
-   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/derives/derives-span-Clone-enum-struct-variant.stderr
+++ b/tests/ui/derives/derives-span-Clone-enum-struct-variant.stderr
@@ -7,7 +7,6 @@ LL | #[derive(Clone)]
 LL |      x: Error
    |      ^^^^^^^^ the trait `Clone` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/derives/derives-span-Clone-enum.stderr
+++ b/tests/ui/derives/derives-span-Clone-enum.stderr
@@ -7,7 +7,6 @@ LL | #[derive(Clone)]
 LL |      Error
    |      ^^^^^ the trait `Clone` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/derives/derives-span-Clone-struct.stderr
+++ b/tests/ui/derives/derives-span-Clone-struct.stderr
@@ -7,7 +7,6 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Clone` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/derives/derives-span-Clone-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-Clone-tuple-struct.stderr
@@ -7,7 +7,6 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Clone` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/derives/derives-span-Debug-enum-struct-variant.stderr
+++ b/tests/ui/derives/derives-span-Debug-enum-struct-variant.stderr
@@ -9,7 +9,6 @@ LL |      x: Error
    |
    = help: the trait `Debug` is not implemented for `Error`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/derives/derives-span-Debug-enum.stderr
+++ b/tests/ui/derives/derives-span-Debug-enum.stderr
@@ -9,7 +9,6 @@ LL |      Error
    |
    = help: the trait `Debug` is not implemented for `Error`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/derives/derives-span-Debug-struct.stderr
+++ b/tests/ui/derives/derives-span-Debug-struct.stderr
@@ -9,7 +9,6 @@ LL |     x: Error
    |
    = help: the trait `Debug` is not implemented for `Error`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/derives/derives-span-Debug-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-Debug-tuple-struct.stderr
@@ -9,7 +9,6 @@ LL |     Error
    |
    = help: the trait `Debug` is not implemented for `Error`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Debug)]`
    |
 LL + #[derive(Debug)]

--- a/tests/ui/derives/derives-span-Default-struct.stderr
+++ b/tests/ui/derives/derives-span-Default-struct.stderr
@@ -7,7 +7,6 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Default` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Default)]`
    |
 LL + #[derive(Default)]

--- a/tests/ui/derives/derives-span-Default-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-Default-tuple-struct.stderr
@@ -7,7 +7,6 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Default` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Default)]`
    |
 LL + #[derive(Default)]

--- a/tests/ui/derives/derives-span-Eq-enum-struct-variant.stderr
+++ b/tests/ui/derives/derives-span-Eq-enum-struct-variant.stderr
@@ -9,7 +9,6 @@ LL |      x: Error
    |
 note: required by a bound in `AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Eq)]`
    |
 LL + #[derive(Eq)]

--- a/tests/ui/derives/derives-span-Eq-enum.stderr
+++ b/tests/ui/derives/derives-span-Eq-enum.stderr
@@ -9,7 +9,6 @@ LL |      Error
    |
 note: required by a bound in `AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Eq)]`
    |
 LL + #[derive(Eq)]

--- a/tests/ui/derives/derives-span-Eq-struct.stderr
+++ b/tests/ui/derives/derives-span-Eq-struct.stderr
@@ -9,7 +9,6 @@ LL |     x: Error
    |
 note: required by a bound in `AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Eq)]`
    |
 LL + #[derive(Eq)]

--- a/tests/ui/derives/derives-span-Eq-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-Eq-tuple-struct.stderr
@@ -9,7 +9,6 @@ LL |     Error
    |
 note: required by a bound in `AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Eq)]`
    |
 LL + #[derive(Eq)]

--- a/tests/ui/derives/derives-span-Hash-enum-struct-variant.stderr
+++ b/tests/ui/derives/derives-span-Hash-enum-struct-variant.stderr
@@ -7,7 +7,6 @@ LL | #[derive(Hash)]
 LL |      x: Error
    |      ^^^^^^^^ the trait `Hash` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Hash)]`
    |
 LL + #[derive(Hash)]

--- a/tests/ui/derives/derives-span-Hash-enum.stderr
+++ b/tests/ui/derives/derives-span-Hash-enum.stderr
@@ -7,7 +7,6 @@ LL | #[derive(Hash)]
 LL |      Error
    |      ^^^^^ the trait `Hash` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Hash)]`
    |
 LL + #[derive(Hash)]

--- a/tests/ui/derives/derives-span-Hash-struct.stderr
+++ b/tests/ui/derives/derives-span-Hash-struct.stderr
@@ -7,7 +7,6 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Hash` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Hash)]`
    |
 LL + #[derive(Hash)]

--- a/tests/ui/derives/derives-span-Hash-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-Hash-tuple-struct.stderr
@@ -7,7 +7,6 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Hash` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Hash)]`
    |
 LL + #[derive(Hash)]

--- a/tests/ui/derives/derives-span-Ord-enum-struct-variant.stderr
+++ b/tests/ui/derives/derives-span-Ord-enum-struct-variant.stderr
@@ -7,7 +7,6 @@ LL | #[derive(Ord,Eq,PartialOrd,PartialEq)]
 LL |      x: Error
    |      ^^^^^^^^ the trait `Ord` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Ord)]`
    |
 LL + #[derive(Ord)]

--- a/tests/ui/derives/derives-span-Ord-enum.stderr
+++ b/tests/ui/derives/derives-span-Ord-enum.stderr
@@ -7,7 +7,6 @@ LL | #[derive(Ord,Eq,PartialOrd,PartialEq)]
 LL |      Error
    |      ^^^^^ the trait `Ord` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Ord)]`
    |
 LL + #[derive(Ord)]

--- a/tests/ui/derives/derives-span-Ord-struct.stderr
+++ b/tests/ui/derives/derives-span-Ord-struct.stderr
@@ -7,7 +7,6 @@ LL | struct Struct {
 LL |     x: Error
    |     ^^^^^^^^ the trait `Ord` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Ord)]`
    |
 LL + #[derive(Ord)]

--- a/tests/ui/derives/derives-span-Ord-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-Ord-tuple-struct.stderr
@@ -7,7 +7,6 @@ LL | struct Struct(
 LL |     Error
    |     ^^^^^ the trait `Ord` is not implemented for `Error`
    |
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(Ord)]`
    |
 LL + #[derive(Ord)]

--- a/tests/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
+++ b/tests/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
@@ -12,7 +12,6 @@ note: an implementation of `PartialEq` might be missing for `Error`
    |
 LL | struct Error;
    | ^^^^^^^^^^^^ must implement `PartialEq`
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialEq)]`
    |
 LL + #[derive(PartialEq)]

--- a/tests/ui/derives/derives-span-PartialEq-enum.stderr
+++ b/tests/ui/derives/derives-span-PartialEq-enum.stderr
@@ -12,7 +12,6 @@ note: an implementation of `PartialEq` might be missing for `Error`
    |
 LL | struct Error;
    | ^^^^^^^^^^^^ must implement `PartialEq`
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialEq)]`
    |
 LL + #[derive(PartialEq)]

--- a/tests/ui/derives/derives-span-PartialEq-struct.stderr
+++ b/tests/ui/derives/derives-span-PartialEq-struct.stderr
@@ -12,7 +12,6 @@ note: an implementation of `PartialEq` might be missing for `Error`
    |
 LL | struct Error;
    | ^^^^^^^^^^^^ must implement `PartialEq`
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialEq)]`
    |
 LL + #[derive(PartialEq)]

--- a/tests/ui/derives/derives-span-PartialEq-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-PartialEq-tuple-struct.stderr
@@ -12,7 +12,6 @@ note: an implementation of `PartialEq` might be missing for `Error`
    |
 LL | struct Error;
    | ^^^^^^^^^^^^ must implement `PartialEq`
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialEq)]`
    |
 LL + #[derive(PartialEq)]

--- a/tests/ui/derives/derives-span-PartialOrd-enum-struct-variant.stderr
+++ b/tests/ui/derives/derives-span-PartialOrd-enum-struct-variant.stderr
@@ -8,7 +8,6 @@ LL |      x: Error
    |      ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialOrd)]`
    |
 LL + #[derive(PartialOrd)]

--- a/tests/ui/derives/derives-span-PartialOrd-enum.stderr
+++ b/tests/ui/derives/derives-span-PartialOrd-enum.stderr
@@ -8,7 +8,6 @@ LL |      Error
    |      ^^^^^ no implementation for `Error < Error` and `Error > Error`
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialOrd)]`
    |
 LL + #[derive(PartialOrd)]

--- a/tests/ui/derives/derives-span-PartialOrd-struct.stderr
+++ b/tests/ui/derives/derives-span-PartialOrd-struct.stderr
@@ -8,7 +8,6 @@ LL |     x: Error
    |     ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialOrd)]`
    |
 LL + #[derive(PartialOrd)]

--- a/tests/ui/derives/derives-span-PartialOrd-tuple-struct.stderr
+++ b/tests/ui/derives/derives-span-PartialOrd-tuple-struct.stderr
@@ -8,7 +8,6 @@ LL |     Error
    |     ^^^^^ no implementation for `Error < Error` and `Error > Error`
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Error` with `#[derive(PartialOrd)]`
    |
 LL + #[derive(PartialOrd)]

--- a/tests/ui/derives/deriving-copyclone.stderr
+++ b/tests/ui/derives/deriving-copyclone.stderr
@@ -16,7 +16,6 @@ note: required by a bound in `is_copy`
    |
 LL | fn is_copy<T: Copy>(_: T) {}
    |               ^^^^ required by this bound in `is_copy`
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider borrowing here
    |
 LL |     is_copy(B { a: 1, b: &C });
@@ -40,7 +39,6 @@ note: required by a bound in `is_clone`
    |
 LL | fn is_clone<T: Clone>(_: T) {}
    |                ^^^^^ required by this bound in `is_clone`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider borrowing here
    |
 LL |     is_clone(B { a: 1, b: &C });
@@ -64,7 +62,6 @@ note: required by a bound in `is_copy`
    |
 LL | fn is_copy<T: Copy>(_: T) {}
    |               ^^^^ required by this bound in `is_copy`
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider borrowing here
    |
 LL |     is_copy(B { a: 1, b: &D });

--- a/tests/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/tests/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -12,7 +12,6 @@ note: an implementation of `PartialEq` might be missing for `NoCloneOrEq`
    |
 LL | struct NoCloneOrEq;
    | ^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NoCloneOrEq` with `#[derive(PartialEq)]`
    |
 LL + #[derive(PartialEq)]
@@ -28,7 +27,6 @@ LL | struct C {
 LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NoCloneOrEq`
    |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `NoCloneOrEq` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/derives/deriving-with-repr-packed-move-errors.stderr
+++ b/tests/ui/derives/deriving-with-repr-packed-move-errors.stderr
@@ -7,7 +7,6 @@ LL | struct StructA(String);
    |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Debug)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
@@ -22,7 +21,6 @@ LL | struct StructA(String);
    |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(PartialEq)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
@@ -37,7 +35,6 @@ LL | struct StructA(String);
    |                ^^^^^^ move occurs because `other.0` has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(PartialEq)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
@@ -52,7 +49,6 @@ LL | struct StructA(String);
    |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(PartialOrd)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
@@ -67,7 +63,6 @@ LL | struct StructA(String);
    |                ^^^^^^ move occurs because `other.0` has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(PartialOrd)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
@@ -82,7 +77,6 @@ LL | struct StructA(String);
    |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Ord)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
@@ -97,7 +91,6 @@ LL | struct StructA(String);
    |                ^^^^^^ move occurs because `other.0` has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Ord)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
@@ -112,7 +105,6 @@ LL | struct StructA(String);
    |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Hash)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
@@ -127,7 +119,6 @@ LL | struct StructA(String);
    |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Clone)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());

--- a/tests/ui/derives/deriving-with-repr-packed.stderr
+++ b/tests/ui/derives/deriving-with-repr-packed.stderr
@@ -16,7 +16,6 @@ LL | struct Y(usize);
 LL | struct X(Y);
    |          - you could clone this value
    = note: `#[derive(Debug)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0161]: cannot move a value of type `[u8]`
   --> $DIR/deriving-with-repr-packed.rs:29:5
@@ -34,7 +33,6 @@ LL |     data: [u8],
    |     ^^^^^^^^^^ move occurs because `self.data` has type `[u8]`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Debug)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0161]: cannot move a value of type `str`
   --> $DIR/deriving-with-repr-packed.rs:38:5
@@ -52,7 +50,6 @@ LL |     data: str,
    |     ^^^^^^^^^ move occurs because `self.data` has type `str`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Debug)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/derives/duplicate-derive-copy-clone-diagnostics.stderr
+++ b/tests/ui/derives/duplicate-derive-copy-clone-diagnostics.stderr
@@ -5,8 +5,6 @@ LL | #[derive(Copy, Clone)]
    |          ---- first implementation here
 LL | #[derive(Copy, Clone)]
    |          ^^^^ conflicting implementation for `E`
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0119]: conflicting implementations of trait `Clone` for type `E`
   --> $DIR/duplicate-derive-copy-clone-diagnostics.rs:6:16
@@ -15,8 +13,6 @@ LL | #[derive(Copy, Clone)]
    |                ----- first implementation here
 LL | #[derive(Copy, Clone)]
    |                ^^^^^ conflicting implementation for `E`
-   |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/derives/issue-97343.stderr
+++ b/tests/ui/derives/issue-97343.stderr
@@ -14,7 +14,6 @@ note: type parameter `Irrelevant` defined here
    |
 LL | pub struct Irrelevant<Irrelevant> {
    |                       ^^^^^^^^^^
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/deriving/deriving-coerce-pointee-neg.stderr
+++ b/tests/ui/deriving/deriving-coerce-pointee-neg.stderr
@@ -3,40 +3,30 @@ error[E0802]: `CoercePointee` can only be derived on `struct`s with `#[repr(tran
    |
 LL | #[derive(CoercePointee)]
    |          ^^^^^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0802]: `CoercePointee` can only be derived on `struct`s with at least one field
   --> $DIR/deriving-coerce-pointee-neg.rs:15:10
    |
 LL | #[derive(CoercePointee)]
    |          ^^^^^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0802]: `CoercePointee` can only be derived on `struct`s with at least one field
   --> $DIR/deriving-coerce-pointee-neg.rs:22:10
    |
 LL | #[derive(CoercePointee)]
    |          ^^^^^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0802]: `CoercePointee` can only be derived on `struct`s that are generic over at least one type
   --> $DIR/deriving-coerce-pointee-neg.rs:29:10
    |
 LL | #[derive(CoercePointee)]
    |          ^^^^^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0802]: exactly one generic type parameter must be marked as `#[pointee]` to derive `CoercePointee` traits
   --> $DIR/deriving-coerce-pointee-neg.rs:34:10
    |
 LL | #[derive(CoercePointee)]
    |          ^^^^^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0802]: only one type parameter can be marked as `#[pointee]` when deriving `CoercePointee` traits
   --> $DIR/deriving-coerce-pointee-neg.rs:43:39
@@ -126,8 +116,6 @@ LL | #[derive(CoercePointee)]
 ...
 LL |     inner: std::rc::Rc<(i32, Box<T>)>,
    |     --------------------------------- `Rc<(i32, Box<T>)>` must be a pointer, reference, or smart pointer that is allowed to be unsized
-   |
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0375]: implementing `CoerceUnsized` does not allow multiple fields to be coerced
   --> $DIR/deriving-coerce-pointee-neg.rs:153:10
@@ -142,7 +130,6 @@ LL |     inner1: Box<T>,
    |     ^^^^^^^^^^^^^^
 LL |     inner2: Box<T>,
    |     ^^^^^^^^^^^^^^
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: for `UsingNonCoercePointeeData<T>` to have a valid implementation of `CoerceUnsized`, it must be possible to coerce the field of type `NotCoercePointeeData<T>`
   --> $DIR/deriving-coerce-pointee-neg.rs:164:10
@@ -152,8 +139,6 @@ LL | #[derive(CoercePointee)]
 LL |
 LL | struct UsingNonCoercePointeeData<T: ?Sized>(NotCoercePointeeData<T>);
    |                                             ----------------------- `NotCoercePointeeData<T>` must be a pointer, reference, or smart pointer that is allowed to be unsized
-   |
-   = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0690]: transparent struct needs at most one field with non-trivial size or alignment, but has 2
   --> $DIR/deriving-coerce-pointee-neg.rs:155:1

--- a/tests/ui/deriving/do-not-suggest-calling-fn-in-derive-macro.stderr
+++ b/tests/ui/deriving/do-not-suggest-calling-fn-in-derive-macro.stderr
@@ -6,8 +6,6 @@ LL | #[derive(PartialEq)]
 LL | pub struct Function {
 LL |     callback: Rc<dyn Fn()>,
    |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/deriving/issue-103157.stderr
+++ b/tests/ui/deriving/issue-103157.stderr
@@ -20,7 +20,6 @@ LL |     Float(Option<f64>),
    = note: required for `Option<f64>` to implement `Eq`
 note: required by a bound in `AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/deriving/multiple-defaults.stderr
+++ b/tests/ui/deriving/multiple-defaults.stderr
@@ -11,7 +11,6 @@ LL |     B,
    |     - additional default
    |
    = note: only one variant can be default
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: multiple declared defaults
   --> $DIR/multiple-defaults.rs:18:10
@@ -26,7 +25,6 @@ LL |     A,
    |     - additional default
    |
    = note: only one variant can be default
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0428]: the name `A` is defined multiple times
   --> $DIR/multiple-defaults.rs:23:5

--- a/tests/ui/diagnostic-width/tabs-trimming.stderr
+++ b/tests/ui/diagnostic-width/tabs-trimming.stderr
@@ -15,8 +15,6 @@ LL | ...                     v @ 1 | 2 | 3 => panic!("You gave me too little mon
    |                         |
    |                         binding initialized here in some conditions
    |                         binding declared here but left uninitialized
-   |
-   = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/env-macro/env-escaped-var.stderr
+++ b/tests/ui/env-macro/env-escaped-var.stderr
@@ -5,7 +5,6 @@ LL |     env!("\t");
    |     ^^^^^^^^^^
    |
    = help: use `std::env::var("\t")` to read the variable at run time
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/env-macro/env-not-defined-custom.stderr
+++ b/tests/ui/env-macro/env-not-defined-custom.stderr
@@ -3,8 +3,6 @@ error: my error message
    |
 LL | fn main() { env!("__HOPEFULLY_NOT_DEFINED__", "my error message"); }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/env-macro/env-not-defined-default.stderr
+++ b/tests/ui/env-macro/env-not-defined-default.stderr
@@ -5,7 +5,6 @@ LL |     env!("CARGO__HOPEFULLY_NOT_DEFINED__");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: Cargo sets build script variables at run time. Use `std::env::var("CARGO__HOPEFULLY_NOT_DEFINED__")` instead
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/env-macro/error-recovery-issue-55897.stderr
+++ b/tests/ui/env-macro/error-recovery-issue-55897.stderr
@@ -5,7 +5,6 @@ LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `std::env::var("NON_EXISTENT")` to read the variable at run time
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: suffixes on string literals are invalid
   --> $DIR/error-recovery-issue-55897.rs:15:22

--- a/tests/ui/env-macro/name-whitespace-issue-110547.stderr
+++ b/tests/ui/env-macro/name-whitespace-issue-110547.stderr
@@ -5,7 +5,6 @@ LL |     env!{"\t"};
    |     ^^^^^^^^^^
    |
    = help: use `std::env::var("\t")` to read the variable at run time
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: environment variable `\t` not defined at compile time
   --> $DIR/name-whitespace-issue-110547.rs:5:5
@@ -14,7 +13,6 @@ LL |     env!("\t");
    |     ^^^^^^^^^^
    |
    = help: use `std::env::var("\t")` to read the variable at run time
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: environment variable `\u{2069}` not defined at compile time
   --> $DIR/name-whitespace-issue-110547.rs:6:5
@@ -23,7 +21,6 @@ LL |     env!("\u{2069}");
    |     ^^^^^^^^^^^^^^^^
    |
    = help: use `std::env::var("\u{2069}")` to read the variable at run time
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/error-codes/E0184.stderr
+++ b/tests/ui/error-codes/E0184.stderr
@@ -3,8 +3,6 @@ error[E0184]: the trait `Copy` cannot be implemented for this type; the type has
    |
 LL | #[derive(Copy)]
    |          ^^^^ `Copy` not allowed on types with destructors
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/exclusive-drop-and-copy.stderr
+++ b/tests/ui/exclusive-drop-and-copy.stderr
@@ -3,16 +3,12 @@ error[E0184]: the trait `Copy` cannot be implemented for this type; the type has
    |
 LL | #[derive(Copy, Clone)]
    |          ^^^^ `Copy` not allowed on types with destructors
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0184]: the trait `Copy` cannot be implemented for this type; the type has a destructor
   --> $DIR/exclusive-drop-and-copy.rs:10:10
    |
 LL | #[derive(Copy, Clone)]
    |          ^^^^ `Copy` not allowed on types with destructors
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-tail-call-panic.stderr
@@ -9,7 +9,6 @@ note: inside `g`
    |
 LL |     panic!()
    |     ^^^^^^^^ the failure occurred here
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/feature-gates/feature-gate-concat_idents2.stderr
+++ b/tests/ui/feature-gates/feature-gate-concat_idents2.stderr
@@ -13,8 +13,6 @@ error[E0425]: cannot find value `ab` in this scope
    |
 LL |     concat_idents!(a, b);
    |     ^^^^^^^^^^^^^^^^^^^^ not found in this scope
-   |
-   = note: this error originates in the macro `concat_idents` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/fmt/format-args-capture-first-literal-is-macro.stderr
+++ b/tests/ui/fmt/format-args-capture-first-literal-is-macro.stderr
@@ -24,7 +24,6 @@ LL |     format!(concat!("{a}"));
    |
    = note: did you intend to capture a variable `a` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/fmt/format-args-capture-from-pm-first-arg-macro.stderr
+++ b/tests/ui/fmt/format-args-capture-from-pm-first-arg-macro.stderr
@@ -6,7 +6,6 @@ LL |     format_string_proc_macro::bad_format_args_captures!();
    |
    = note: did you intend to capture a variable `x` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/fmt/format-args-capture-macro-hygiene.stderr
+++ b/tests/ui/fmt/format-args-capture-macro-hygiene.stderr
@@ -6,7 +6,6 @@ LL |     format!(concat!("{foo}"));
    |
    = note: did you intend to capture a variable `foo` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: there is no argument named `bar`
   --> $DIR/format-args-capture-macro-hygiene.rs:16:13
@@ -16,7 +15,6 @@ LL |     format!(concat!("{ba", "r} {}"), 1);
    |
    = note: did you intend to capture a variable `bar` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: there is no argument named `foo`
   --> $DIR/format-args-capture-macro-hygiene.rs:7:13

--- a/tests/ui/fmt/format-expanded-string.stderr
+++ b/tests/ui/fmt/format-expanded-string.stderr
@@ -5,7 +5,6 @@ LL |     format!(concat!("abc}"));
    |             ^^^^^^^^^^^^^^^ unmatched `}` in format string
    |
    = note: if you intended to print `}`, you can escape it using `}}`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid format string: unmatched `}` found
   --> $DIR/format-expanded-string.rs:22:34

--- a/tests/ui/fmt/ifmt-bad-format-args.stderr
+++ b/tests/ui/fmt/ifmt-bad-format-args.stderr
@@ -3,8 +3,6 @@ error: requires at least a format string argument
    |
 LL |     format_args!();
    |     ^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: format argument must be a string literal
   --> $DIR/ifmt-bad-format-args.rs:3:18

--- a/tests/ui/fmt/issue-86085.stderr
+++ b/tests/ui/fmt/issue-86085.stderr
@@ -5,7 +5,6 @@ LL | format ! ( concat ! ( r#"lJ𐏿Æ�.𐏿�"# , "r} {}" )     ) ;
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched `}` in format string
    |
    = note: if you intended to print `}`, you can escape it using `}}`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/fmt/issue-91556.stderr
+++ b/tests/ui/fmt/issue-91556.stderr
@@ -5,7 +5,6 @@ LL |   let _ = format!(concat!("{0}𝖳𝖾𝗌𝗍{"), i);
    |                   ^^^^^^^^^^^^^^^^^^^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/fmt/raw-idents.stderr
+++ b/tests/ui/fmt/raw-idents.stderr
@@ -27,7 +27,6 @@ LL |     println!(concat!("{r#", "type}"));
    |              ^^^^^^^^^^^^^^^^^^^^^^^ raw identifier used here in format string
    |
    = note: identifiers in format strings can be keywords and don't need to be prefixed with `r#`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid format string: raw identifiers are not supported
   --> $DIR/raw-idents.rs:11:16

--- a/tests/ui/fmt/respanned-literal-issue-106191.stderr
+++ b/tests/ui/fmt/respanned-literal-issue-106191.stderr
@@ -13,7 +13,6 @@ LL |     format_args!(r#concat!("¡        {"));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
-   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generic-associated-types/impl_bounds.stderr
+++ b/tests/ui/generic-associated-types/impl_bounds.stderr
@@ -41,7 +41,6 @@ LL | trait Foo {
 ...
 LL |     type C where Self: Clone;
    |          ^ this trait's associated type doesn't have the requirement `Fooy<T>: Copy`
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> Foo for Fooy<T> {
@@ -66,7 +65,6 @@ LL | trait Foo {
 ...
 LL |     fn d() where Self: Clone;
    |        ^ this trait's method doesn't have the requirement `Fooy<T>: Copy`
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> Foo for Fooy<T> {

--- a/tests/ui/generic-const-items/def-site-eval.fail.stderr
+++ b/tests/ui/generic-const-items/def-site-eval.fail.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `_::<'_>` failed
    |
 LL | const _<'_a>: () = panic!();
    |                    ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/post_monomorphization_error_backtrace.stderr
+++ b/tests/ui/generics/post_monomorphization_error_backtrace.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `assert_zst::F::<u32>::V` failed
    |
 LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/post_monomorphization_error_backtrace.rs:14:5
@@ -23,8 +21,6 @@ error[E0080]: evaluation of `assert_zst::F::<i32>::V` failed
    |
 LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/post_monomorphization_error_backtrace.rs:14:5

--- a/tests/ui/include-macros/mismatched-types.stderr
+++ b/tests/ui/include-macros/mismatched-types.stderr
@@ -11,7 +11,6 @@ LL |     let b: &[u8] = include_str!("file.txt");
    |
    = note: expected reference `&[u8]`
               found reference `&'static str`
-   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/mismatched-types.rs:3:19
@@ -23,7 +22,6 @@ LL |     let s: &str = include_bytes!("file.txt");
    |
    = note: expected reference `&str`
               found reference `&'static [u8; 0]`
-   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/include-macros/parent_dir.stderr
+++ b/tests/ui/include-macros/parent_dir.stderr
@@ -4,7 +4,6 @@ error: couldn't read `$DIR/include-macros/file.txt`: $FILE_NOT_FOUND_MSG
 LL |     let _ = include_str!("include-macros/file.txt");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: there is a file with the same name in a different directory
    |
 LL -     let _ = include_str!("include-macros/file.txt");
@@ -17,7 +16,6 @@ error: couldn't read `$DIR/hello.rs`: $FILE_NOT_FOUND_MSG
 LL |     let _ = include_str!("hello.rs");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: there is a file with the same name in a different directory
    |
 LL |     let _ = include_str!("../hello.rs");
@@ -29,7 +27,6 @@ error: couldn't read `$DIR/../../data.bin`: $FILE_NOT_FOUND_MSG
 LL |     let _ = include_bytes!("../../data.bin");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: there is a file with the same name in a different directory
    |
 LL -     let _ = include_bytes!("../../data.bin");
@@ -42,7 +39,6 @@ error: couldn't read `$DIR/tests/ui/include-macros/file.txt`: $FILE_NOT_FOUND_MS
 LL |     let _ = include_str!("tests/ui/include-macros/file.txt");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: there is a file with the same name in a different directory
    |
 LL -     let _ = include_str!("tests/ui/include-macros/file.txt");

--- a/tests/ui/inline-const/const-expr-generic-err.stderr
+++ b/tests/ui/inline-const/const-expr-generic-err.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `foo::<i32>::{constant#0}` failed
    |
 LL |     const { assert!(std::mem::size_of::<T>() == 0); }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: std::mem::size_of::<T>() == 0
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/const-expr-generic-err.rs:4:5

--- a/tests/ui/inline-const/required-const.stderr
+++ b/tests/ui/inline-const/required-const.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `foo::<i32>::{constant#0}` failed
    |
 LL |         const { panic!() }
    |                 ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/required-const.rs:6:9

--- a/tests/ui/issues/issue-14091-2.stderr
+++ b/tests/ui/issues/issue-14091-2.stderr
@@ -11,7 +11,6 @@ LL | pub struct BytePos(pub u32);
    | ^^^^^^^^^^^^^^^^^^ must implement `Not`
 note: the trait `Not` must be implemented
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-21160.stderr
+++ b/tests/ui/issues/issue-21160.stderr
@@ -6,7 +6,6 @@ LL | #[derive(Hash)]
 LL | struct Foo(Bar);
    |            ^^^ the trait `Hash` is not implemented for `Bar`
    |
-   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Bar` with `#[derive(Hash)]`
    |
 LL + #[derive(Hash)]

--- a/tests/ui/issues/issue-27340.stderr
+++ b/tests/ui/issues/issue-27340.stderr
@@ -6,8 +6,6 @@ LL | #[derive(Copy, Clone)]
 LL |
 LL | struct Bar(Foo);
    |            --- this field does not implement `Copy`
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Foo: Clone` is not satisfied
   --> $DIR/issue-27340.rs:4:12
@@ -20,7 +18,6 @@ LL | struct Bar(Foo);
    |
 note: required by a bound in `AssertParamIsClone`
   --> $SRC_DIR/core/src/clone.rs:LL:COL
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Foo` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/issues/issue-27592.stderr
+++ b/tests/ui/issues/issue-27592.stderr
@@ -6,16 +6,12 @@ LL |     write(|| format_args!("{}", String::from("Hello world")));
    |              |                  |
    |              |                  temporary value created here
    |              returns a value referencing data owned by the current function
-   |
-   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0515]: cannot return reference to temporary value
   --> $DIR/issue-27592.rs:16:14
    |
 LL |     write(|| format_args!("{}", String::from("Hello world")));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returns a reference to data owned by the current function
-   |
-   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-32950.stderr
+++ b/tests/ui/issues/issue-32950.stderr
@@ -9,8 +9,6 @@ error[E0412]: cannot find type `FooBar` in this scope
    |
 LL |     concat_idents!(Foo, Bar)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
-   |
-   = note: this error originates in the macro `concat_idents` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-34229.stderr
+++ b/tests/ui/issues/issue-34229.stderr
@@ -7,7 +7,6 @@ LL | #[derive(PartialEq, PartialOrd)] struct Nope(Comparable);
    |                     in this derive macro expansion
    |
    = help: the trait `PartialOrd` is not implemented for `Comparable`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Comparable` with `#[derive(PartialOrd)]`
    |
 LL | #[derive(PartialEq)] #[derive(PartialOrd)]

--- a/tests/ui/issues/issue-76191.stderr
+++ b/tests/ui/issues/issue-76191.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of constant value failed
    |
 LL | const RANGE2: RangeInclusive<i32> = panic!();
    |                                     ^^^^^^^^ evaluation panicked: explicit panic
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/issue-76191.rs:14:9

--- a/tests/ui/lint/test-inner-fn.stderr
+++ b/tests/ui/lint/test-inner-fn.stderr
@@ -5,15 +5,12 @@ LL |     #[test]
    |     ^^^^^^^
    |
    = note: requested on the command line with `-D unnameable-test-items`
-   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot test inner items
   --> $DIR/test-inner-fn.rs:13:9
    |
 LL |         #[test]
    |         ^^^^^^^
-   |
-   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/builtin-env-issue-114010.stderr
+++ b/tests/ui/macros/builtin-env-issue-114010.stderr
@@ -5,7 +5,6 @@ LL | env![r#"oopsie"#];
    | ^^^^^^^^^^^^^^^^^
    |
    = help: use `std::env::var(r#"oopsie"#)` to read the variable at run time
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: environment variable `a""a` not defined at compile time
   --> $DIR/builtin-env-issue-114010.rs:7:1
@@ -14,7 +13,6 @@ LL | env![r#"a""a"#];
    | ^^^^^^^^^^^^^^^
    |
    = help: use `std::env::var(r#"a""a"#)` to read the variable at run time
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/macros/cfg.stderr
+++ b/tests/ui/macros/cfg.stderr
@@ -3,8 +3,6 @@ error: macro requires a cfg-pattern as an argument
    |
 LL |     cfg!();
    |     ^^^^^^ cfg-pattern required
-   |
-   = note: this error originates in the macro `cfg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0565]: literal in `cfg` predicate value must be a boolean
   --> $DIR/cfg.rs:3:10
@@ -23,8 +21,6 @@ error: expected 1 cfg-pattern
    |
 LL |     cfg!(foo, bar);
    |     ^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `cfg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/macros/macros-nonfatal-errors.stderr
+++ b/tests/ui/macros/macros-nonfatal-errors.stderr
@@ -57,7 +57,6 @@ LL | |     Bar,
 LL | | }
    | |_- this enum needs a unit variant marked with `#[default]`
    |
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: make this unit variant default by placing `#[default]` on it
    |
 LL |     #[default] Foo,
@@ -77,8 +76,6 @@ LL | |     Foo(i32),
 LL | |     Bar(i32),
 LL | | }
    | |_- this enum needs a unit variant marked with `#[default]`
-   |
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: multiple declared defaults
   --> $DIR/macros-nonfatal-errors.rs:54:10
@@ -96,7 +93,6 @@ LL |     Baz,
    |     --- additional default
    |
    = note: only one variant can be default
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[default]` attribute does not accept a value
   --> $DIR/macros-nonfatal-errors.rs:66:5
@@ -200,7 +196,6 @@ LL |     env!("RUST_HOPEFULLY_THIS_DOESNT_EXIST");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `std::env::var("RUST_HOPEFULLY_THIS_DOESNT_EXIST")` to read the variable at run time
-   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: format argument must be a string literal
   --> $DIR/macros-nonfatal-errors.rs:114:13
@@ -230,8 +225,6 @@ error: couldn't read `$DIR/i'd be quite surprised if a file with this name exist
    |
 LL |     include_str!("i'd be quite surprised if a file with this name existed");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument must be a string literal
   --> $DIR/macros-nonfatal-errors.rs:120:20
@@ -244,8 +237,6 @@ error: couldn't read `$DIR/i'd be quite surprised if a file with this name exist
    |
 LL |     include_bytes!("i'd be quite surprised if a file with this name existed");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trace_macros! accepts only `true` or `false`
   --> $DIR/macros-nonfatal-errors.rs:123:5

--- a/tests/ui/macros/not-utf8.stderr
+++ b/tests/ui/macros/not-utf8.stderr
@@ -9,7 +9,6 @@ note: byte `193` is not valid utf-8
    |
 LL | �|�␂!5�cc␕␂�Ӻi��WWj�ȥ�'�}�␒�J�ȉ��W�␞O�@����␜w�V���LO����␔[ ␃_�'���SQ�~ذ��ų&��-    ��lN~��!@␌ _#���kQ��h�␝�:�␜␇�
    | ^
-   = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/unreachable-format-args.edition_2015.stderr
+++ b/tests/ui/macros/unreachable-format-args.edition_2015.stderr
@@ -6,7 +6,6 @@ LL |     unreachable!("x is {x} and y is {y}", y = 0);
    |
    = note: did you intend to capture a variable `x` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in the macro `$crate::concat` which comes from the expansion of the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/malformed/malformed-derive-entry.stderr
+++ b/tests/ui/malformed/malformed-derive-entry.stderr
@@ -24,7 +24,6 @@ LL | #[derive(Copy(Bad))]
    |
 note: required by a bound in `Copy`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Test1` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]
@@ -39,7 +38,6 @@ LL | #[derive(Copy="bad")]
    |
 note: required by a bound in `Copy`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Test2` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/never_type/fallback-closure-wrap.fallback.stderr
+++ b/tests/ui/never_type/fallback-closure-wrap.fallback.stderr
@@ -9,7 +9,6 @@ LL |         panic!("Can't connect to server.");
    = note: expected unit type `()`
                    found type `!`
    = note: required for the cast from `Box<{closure@$DIR/fallback-closure-wrap.rs:18:40: 18:47}>` to `Box<dyn FnMut()>`
-   = note: this error originates in the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
+++ b/tests/ui/proc-macro/issue-104884-trait-impl-sugg-err.stderr
@@ -7,7 +7,6 @@ LL | #[derive(PartialOrd, AddImpl)]
    = help: the trait `PartialEq` is not implemented for `PriorityQueue<T>`
 note: required by a bound in `PartialOrd`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `PriorityQueue<T>: Eq` is not satisfied
   --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:22
@@ -32,7 +31,6 @@ LL | #[derive(PartialOrd, AddImpl)]
    |          ^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
 note: required by a bound in `Ord`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `AddImpl` which comes from the expansion of the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `BinaryHeap<PriorityQueueEntry<T>>` with `_`
   --> $DIR/issue-104884-trait-impl-sugg-err.rs:20:25
@@ -44,7 +42,6 @@ LL | struct PriorityQueue<T>(BinaryHeap<PriorityQueueEntry<T>>);
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `BinaryHeap<PriorityQueueEntry<T>> < _` and `BinaryHeap<PriorityQueueEntry<T>> > _`
    |
    = help: the trait `PartialOrd<_>` is not implemented for `BinaryHeap<PriorityQueueEntry<T>>`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `cmp` found for struct `BinaryHeap<PriorityQueueEntry<T>>` in the current scope
   --> $DIR/issue-104884-trait-impl-sugg-err.rs:13:22

--- a/tests/ui/proc-macro/quote/not-quotable.stderr
+++ b/tests/ui/proc-macro/quote/not-quotable.stderr
@@ -17,7 +17,6 @@ LL |     let _ = quote! { $ip };
              Rc<T>
              bool
            and 24 others
-   = note: this error originates in the macro `quote` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/range/range_traits-1.stderr
+++ b/tests/ui/range/range_traits-1.stderr
@@ -8,7 +8,6 @@ LL |     a: Range<usize>,
    |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<usize>`
   --> $DIR/range_traits-1.rs:8:5
@@ -20,7 +19,6 @@ LL |     b: RangeTo<usize>,
    |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFrom<usize>`
   --> $DIR/range_traits-1.rs:11:5
@@ -32,7 +30,6 @@ LL |     c: RangeFrom<usize>,
    |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
   --> $DIR/range_traits-1.rs:14:5
@@ -44,7 +41,6 @@ LL |     d: RangeFull,
    |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::RangeInclusive<usize>`
   --> $DIR/range_traits-1.rs:17:5
@@ -56,7 +52,6 @@ LL |     e: RangeInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::RangeToInclusive<usize>`
   --> $DIR/range_traits-1.rs:20:5
@@ -68,7 +63,6 @@ LL |     f: RangeToInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
-   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::Range<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:5:5
@@ -78,8 +72,6 @@ LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 LL | struct AllTheRanges {
 LL |     a: Range<usize>,
    |     ^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::Range<usize>`
-   |
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeTo<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:8:5
@@ -89,8 +81,6 @@ LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 ...
 LL |     b: RangeTo<usize>,
    |     ^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeTo<usize>`
-   |
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeFrom<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:11:5
@@ -100,8 +90,6 @@ LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 ...
 LL |     c: RangeFrom<usize>,
    |     ^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFrom<usize>`
-   |
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeFull: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:14:5
@@ -111,8 +99,6 @@ LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 ...
 LL |     d: RangeFull,
    |     ^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFull`
-   |
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeInclusive<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:17:5
@@ -122,8 +108,6 @@ LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 ...
 LL |     e: RangeInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeInclusive<usize>`
-   |
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeToInclusive<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:20:5
@@ -133,8 +117,6 @@ LL | #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 ...
 LL |     f: RangeToInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeToInclusive<usize>`
-   |
-   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/range/range_traits-2.stderr
+++ b/tests/ui/range/range_traits-2.stderr
@@ -5,8 +5,6 @@ LL | #[derive(Copy, Clone)]
    |          ^^^^
 LL | struct R(Range<usize>);
    |          ------------ this field does not implement `Copy`
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/range/range_traits-3.stderr
+++ b/tests/ui/range/range_traits-3.stderr
@@ -5,8 +5,6 @@ LL | #[derive(Copy, Clone)]
    |          ^^^^
 LL | struct R(RangeFrom<usize>);
    |          ---------------- this field does not implement `Copy`
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/range/range_traits-6.stderr
+++ b/tests/ui/range/range_traits-6.stderr
@@ -5,8 +5,6 @@ LL | #[derive(Copy, Clone)]
    |          ^^^^
 LL | struct R(RangeInclusive<usize>);
    |          --------------------- this field does not implement `Copy`
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/multiple_definitions_attribute_merging.stderr
+++ b/tests/ui/resolve/multiple_definitions_attribute_merging.stderr
@@ -15,8 +15,8 @@ LL | #[derive(PartialEq)]
 LL | #[repr(C)]
 LL | struct Dealigned<T>(u8, T);
    |                         ^
-   |
-   = 
+
+
 Box<dyn Any>
 query stack during panic:
 #0 [mir_built] building MIR for `<impl at $DIR/multiple_definitions_attribute_merging.rs:15:10: 15:19>::eq`

--- a/tests/ui/resolve/proc_macro_generated_packed.stderr
+++ b/tests/ui/resolve/proc_macro_generated_packed.stderr
@@ -6,8 +6,8 @@ LL | #[derive(PartialEq)]
 ...
 LL | struct Dealigned<T>(u8, T);
    |                         ^
-   |
-   = 
+
+
 Box<dyn Any>
 query stack during panic:
 #0 [mir_built] building MIR for `<impl at $DIR/proc_macro_generated_packed.rs:15:10: 15:19>::eq`

--- a/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/tests/ui/rfcs/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -9,7 +9,6 @@ LL | fn can_parse_zero_as_f32() -> Result<f32, ParseFloatError> {
    = note: required for `Result<f32, ParseFloatError>` to implement `Termination`
 note: required by a bound in `assert_test_result`
   --> $SRC_DIR/test/src/lib.rs:LL:COL
-   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/simd/array-trait.stderr
+++ b/tests/ui/simd/array-trait.stderr
@@ -22,8 +22,6 @@ LL | #[derive(Copy, Clone)]
    |                ----- in this derive macro expansion
 LL | pub struct T<S: Simd>([S::Lane; S::SIZE]);
    |                       ^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/simd/const-err-trumps-simd-err.stderr
+++ b/tests/ui/simd/const-err-trumps-simd-err.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of `get_elem::<4>::{constant#0}` failed
    |
 LL |     const { assert!(LANE < 4); } // the error should be here...
    |             ^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: LANE < 4
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
   --> $DIR/const-err-trumps-simd-err.rs:16:5

--- a/tests/ui/span/E0204.stderr
+++ b/tests/ui/span/E0204.stderr
@@ -15,8 +15,6 @@ LL | #[derive(Copy)]
 LL | struct Foo2<'a> {
 LL |     ty: &'a mut bool,
    |     ---------------- this field does not implement `Copy`
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/E0204.rs:17:15
@@ -35,8 +33,6 @@ LL | #[derive(Copy)]
 LL | enum EFoo2<'a> {
 LL |     Bar(&'a mut bool),
    |         ------------ this field does not implement `Copy`
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/structs/default-field-values/failures.stderr
+++ b/tests/ui/structs/default-field-values/failures.stderr
@@ -21,7 +21,6 @@ LL | pub struct Bar {
 LL |     pub bar: S,
    |     ^^^^^^^^^^ the trait `Default` is not implemented for `S`
    |
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `S` with `#[derive(Default)]`
    |
 LL + #[derive(Default)]

--- a/tests/ui/structs/default-field-values/invalid-const.stderr
+++ b/tests/ui/structs/default-field-values/invalid-const.stderr
@@ -3,8 +3,6 @@ error[E0080]: evaluation of constant value failed
    |
 LL |     pub bax: u8 = panic!("asdf"),
    |                   ^^^^^^^^^^^^^^ evaluation panicked: asdf
-   |
-   = note: this error originates in the macro `$crate::panic::panic_2015` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of `Baz::<C>::bat::{constant#0}` failed
   --> $DIR/invalid-const.rs:11:19

--- a/tests/ui/suggestions/derive-clone-for-eq.stderr
+++ b/tests/ui/suggestions/derive-clone-for-eq.stderr
@@ -13,7 +13,6 @@ LL | impl<T: Clone, U> PartialEq<U> for Struct<T>
    |         unsatisfied trait bound introduced here
 note: required by a bound in `Eq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Clone`
    |
 LL | pub struct Struct<T: std::clone::Clone>(T);

--- a/tests/ui/suggestions/derive-macro-missing-bounds.stderr
+++ b/tests/ui/suggestions/derive-macro-missing-bounds.stderr
@@ -8,7 +8,6 @@ LL |     struct Outer<T>(Inner<T>);
    |
    = help: the trait `Debug` is not implemented for `a::Inner<T>`
    = note: add `#[derive(Debug)]` to `a::Inner<T>` or manually `impl Debug for a::Inner<T>`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `a::Inner<T>` with `#[derive(Debug)]`
    |
 LL +     #[derive(Debug)]
@@ -37,7 +36,6 @@ LL |     impl<T: Debug + Trait> Debug for Inner<T> {
    = note: 1 redundant requirement hidden
    = note: required for `&c::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&c::Inner<T>` to `&dyn Debug`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Trait`
    |
 LL |     struct Outer<T: c::Trait>(Inner<T>);
@@ -59,7 +57,6 @@ LL |     impl<T> Debug for Inner<T> where T: Debug, T: Trait {
    = note: 1 redundant requirement hidden
    = note: required for `&d::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&d::Inner<T>` to `&dyn Debug`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Trait`
    |
 LL |     struct Outer<T: d::Trait>(Inner<T>);
@@ -81,7 +78,6 @@ LL |     impl<T> Debug for Inner<T> where T: Debug + Trait {
    = note: 1 redundant requirement hidden
    = note: required for `&e::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&e::Inner<T>` to `&dyn Debug`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Trait`
    |
 LL |     struct Outer<T: e::Trait>(Inner<T>);
@@ -103,7 +99,6 @@ LL |     impl<T: Debug> Debug for Inner<T> where T: Trait {
    = note: 1 redundant requirement hidden
    = note: required for `&f::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&f::Inner<T>` to `&dyn Debug`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Trait`
    |
 LL |     struct Outer<T: f::Trait>(Inner<T>);

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
@@ -31,7 +31,6 @@ LL | #[derive(Debug, Copy, Clone)]
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
@@ -51,7 +50,6 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
@@ -73,7 +71,6 @@ LL | #[derive(Debug, Copy, Clone)]
    |                       ^^^^^
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -12,7 +12,6 @@ note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
    |
 LL |     pub loc: Vector2<K>,
    |              ^^^^^^^^^^
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + Debug>{
@@ -43,7 +42,6 @@ LL | pub struct AABB<K: Copy>{
 LL |     pub loc: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
@@ -58,7 +56,6 @@ LL | #[derive(Debug, Copy, Clone)]
 LL |     pub size: Vector2<K>
    |     ^^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -12,7 +12,6 @@ note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
    |
 LL |     pub loc: Vector2<K>,
    |              ^^^^^^^^^^
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: Debug> {
@@ -67,7 +66,6 @@ LL | #[derive(Debug, Copy, Clone)]
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {
@@ -82,7 +80,6 @@ LL | pub struct AABB<K> {
 LL |     pub loc: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: std::fmt::Debug> {
@@ -102,7 +99,6 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {
@@ -117,7 +113,6 @@ LL | #[derive(Debug, Copy, Clone)]
 LL |     pub size: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: std::fmt::Debug> {
@@ -139,7 +134,6 @@ LL | #[derive(Debug, Copy, Clone)]
    |                       ^^^^^
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {

--- a/tests/ui/test-attrs/custom-test-frameworks/issue-107454.stderr
+++ b/tests/ui/test-attrs/custom-test-frameworks/issue-107454.stderr
@@ -9,7 +9,6 @@ note: the lint level is defined here
    |
 LL | #![deny(unnameable_test_items)]
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the attribute macro `test_case` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/test-attrs/issue-12997-2.stderr
+++ b/tests/ui/test-attrs/issue-12997-2.stderr
@@ -14,7 +14,6 @@ note: function defined here
    |
 LL | fn bar(x: isize) { }
    |    ^^^ --------
-   = note: this error originates in the attribute macro `bench` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/test-attrs/test-function-signature.stderr
+++ b/tests/ui/test-attrs/test-function-signature.stderr
@@ -32,7 +32,6 @@ LL | fn bar() -> i32 {
    |
 note: required by a bound in `assert_test_result`
   --> $SRC_DIR/test/src/lib.rs:LL:COL
-   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/traits/const-traits/const_derives/derive-const-gate.stderr
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-gate.stderr
@@ -15,7 +15,6 @@ LL | #[derive_const(Default)]
    |
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/const_derives/derive-const-non-const-type.stderr
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-non-const-type.stderr
@@ -6,7 +6,6 @@ LL | #[derive_const(Default)]
    |
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const associated function `<A as Default>::default` in constant functions
   --> $DIR/derive-const-non-const-type.rs:11:14
@@ -17,7 +16,6 @@ LL | pub struct S(A);
    |              ^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/const_derives/derive-const-use.stderr
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-use.stderr
@@ -27,7 +27,6 @@ LL | #[derive_const(Default, PartialEq)]
    |
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: const `impl` for trait `PartialEq` which is not marked with `#[const_trait]`
   --> $DIR/derive-const-use.rs:11:12
@@ -46,7 +45,6 @@ LL | #[derive_const(Default, PartialEq)]
    |
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const associated function `<S as Default>::default` in constants
   --> $DIR/derive-const-use.rs:18:35
@@ -73,7 +71,6 @@ LL | pub struct S((), A);
    |              ^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const associated function `<A as Default>::default` in constant functions
   --> $DIR/derive-const-use.rs:16:18
@@ -84,7 +81,6 @@ LL | pub struct S((), A);
    |                  ^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/derive-const-use.rs:16:14
@@ -95,7 +91,6 @@ LL | pub struct S((), A);
    |              ^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/derive-const-use.rs:16:18
@@ -106,7 +101,6 @@ LL | pub struct S((), A);
    |                  ^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 12 previous errors
 

--- a/tests/ui/traits/const-traits/const_derives/derive-const-with-params.stderr
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-with-params.stderr
@@ -6,7 +6,6 @@ LL | #[derive_const(PartialEq)]
    |
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `~const` can only be applied to `#[const_trait]` traits
    |
@@ -22,7 +21,6 @@ LL | pub struct Reverse<T>(T);
    |                       ^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/derive-const-with-params.rs:11:5

--- a/tests/ui/traits/issue-106072.stderr
+++ b/tests/ui/traits/issue-106072.stderr
@@ -13,8 +13,6 @@ error[E0782]: expected a type, found a trait
    |
 LL | #[derive(Clone)]
    |          ^^^^^
-   |
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0782]: expected a type, found a trait
   --> $DIR/issue-106072.rs:1:10
@@ -23,7 +21,6 @@ LL | #[derive(Clone)]
    |          ^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -79,8 +79,6 @@ LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                                                    --------  ------ this field does not implement `Copy`
    |                                                    |
    |                                                    this field does not implement `Copy`
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `Copy` cannot be implemented for this type
   --> $DIR/issue-50480.rs:11:17
@@ -92,8 +90,6 @@ LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                                                          --------  ------ this field does not implement `Copy`
    |                                                          |
    |                                                          this field does not implement `Copy`
-   |
-   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `i32` is not an iterator
   --> $DIR/issue-50480.rs:14:33
@@ -118,7 +114,6 @@ LL | #[derive(Clone, Copy)]
    |          ^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `i32` is not an iterator
   --> $DIR/issue-50480.rs:14:33
@@ -130,7 +125,6 @@ LL | struct Bar<T>(T, N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^ `i32` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `i32`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/traits/issue-71136.stderr
+++ b/tests/ui/traits/issue-71136.stderr
@@ -8,7 +8,6 @@ LL |     the_foos: Vec<Foo>,
    |     ^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `Foo`
    |
    = note: required for `Vec<Foo>` to implement `Clone`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `Foo` with `#[derive(Clone)]`
    |
 LL + #[derive(Clone)]

--- a/tests/ui/traits/issue-79458.stderr
+++ b/tests/ui/traits/issue-79458.stderr
@@ -9,7 +9,6 @@ LL |     bar: &'a mut T
    |
    = help: the trait `Clone` is implemented for `&T`
    = note: `Clone` is implemented for `&T`, but not for `&mut T`
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/global-cache-and-parallel-frontend.stderr
+++ b/tests/ui/traits/next-solver/global-cache-and-parallel-frontend.stderr
@@ -13,7 +13,6 @@ LL | impl<T: Clone, U> PartialEq<U> for Struct<T>
    |         unsatisfied trait bound introduced here
 note: required by a bound in `Eq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T` with trait `Clone`
    |
 LL | pub struct Struct<T: std::clone::Clone>(T);

--- a/tests/ui/transmutability/uninhabited.stderr
+++ b/tests/ui/transmutability/uninhabited.stderr
@@ -3,24 +3,18 @@ error[E0080]: evaluation of constant value failed
    |
 LL |         assert!(false);
    |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:63:9
    |
 LL |         assert!(false);
    |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/uninhabited.rs:87:9
    |
 LL |         assert!(false);
    |         ^^^^^^^^^^^^^^ evaluation panicked: assertion failed: false
-   |
-   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `()` cannot be safely transmuted into `void::Void`
   --> $DIR/uninhabited.rs:29:41

--- a/tests/ui/type/pattern_types/derives.stderr
+++ b/tests/ui/type/pattern_types/derives.stderr
@@ -6,8 +6,6 @@ LL | #[derive(Clone, Copy, PartialEq)]
 LL | #[repr(transparent)]
 LL | struct Nanoseconds(NanoI32);
    |                    ^^^^^^^
-   |
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/union/union-derive-clone.stderr
+++ b/tests/ui/union/union-derive-clone.stderr
@@ -6,7 +6,6 @@ LL | #[derive(Clone)]
    |
 note: required by a bound in `AssertParamIsCopy`
   --> $SRC_DIR/core/src/clone.rs:LL:COL
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `U1` with `#[derive(Copy)]`
    |
 LL + #[derive(Copy)]

--- a/tests/ui/union/union-derive-eq.current.stderr
+++ b/tests/ui/union/union-derive-eq.current.stderr
@@ -9,7 +9,6 @@ LL |     a: PartialEqNotEq,
    |
 note: required by a bound in `AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `PartialEqNotEq` with `#[derive(Eq)]`
    |
 LL + #[derive(Eq)]

--- a/tests/ui/union/union-derive-eq.next.stderr
+++ b/tests/ui/union/union-derive-eq.next.stderr
@@ -9,7 +9,6 @@ LL |     a: PartialEqNotEq,
    |
 note: required by a bound in `AssertParamIsEq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
-   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider annotating `PartialEqNotEq` with `#[derive(Eq)]`
    |
 LL + #[derive(Eq)]


### PR DESCRIPTION
For macros that are implemented on the compiler, or that are annotated with `rustc_diagnostic_item`, which have arbitrary implementations from the point of view of the user and might as well be intrinsics, we do *not* mention the `-Zmacro-backtrace` flag. This includes `derive`s and standard macros like `panic!` and `format!`.

This PR adds a field to every `Span`'s `ExpnData` stating whether it comes from a builtin macro. This is determined by the macro being annotated with either `#[rustc_builtin_macro]` or `#[rustc_diagnostic_item]`. An alternative to using these attributes that already exist for other uses would be to introduce another attribute like `#[rustc_no_backtrace]` to have finer control on which macros are affected (for example, an error within `vec![]` now doesn't mention the backtrace, but one could make the case that it should). Ideally, instead of carrying this information in the `ExpnData` we'd instead try to query the `DefId` of the macro (that is already stored) to see if it is annotated in some way, but we do not have access to the `TyCtxt` from `rustc_errors`.

r? @petrochenkov 