### PR TITLE
intrinsics: remove unnecessary leading underscore from argument names

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -624,25 +624,25 @@ pub mod intrinsics {
     #[rustc_intrinsic]
     pub fn size_of<T>() -> usize;
     #[rustc_intrinsic]
-    pub unsafe fn size_of_val<T: ?::Sized>(_val: *const T) -> usize;
+    pub unsafe fn size_of_val<T: ?::Sized>(val: *const T) -> usize;
     #[rustc_intrinsic]
     pub fn min_align_of<T>() -> usize;
     #[rustc_intrinsic]
-    pub unsafe fn min_align_of_val<T: ?::Sized>(_val: *const T) -> usize;
+    pub unsafe fn min_align_of_val<T: ?::Sized>(val: *const T) -> usize;
     #[rustc_intrinsic]
-    pub unsafe fn copy<T>(_src: *const T, _dst: *mut T, _count: usize);
+    pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
     #[rustc_intrinsic]
-    pub unsafe fn transmute<T, U>(_e: T) -> U;
+    pub unsafe fn transmute<T, U>(e: T) -> U;
     #[rustc_intrinsic]
-    pub unsafe fn ctlz_nonzero<T>(_x: T) -> u32;
+    pub unsafe fn ctlz_nonzero<T>(x: T) -> u32;
     #[rustc_intrinsic]
     pub fn needs_drop<T: ?::Sized>() -> bool;
     #[rustc_intrinsic]
-    pub fn bitreverse<T>(_x: T) -> T;
+    pub fn bitreverse<T>(x: T) -> T;
     #[rustc_intrinsic]
-    pub fn bswap<T>(_x: T) -> T;
+    pub fn bswap<T>(x: T) -> T;
     #[rustc_intrinsic]
-    pub unsafe fn write_bytes<T>(_dst: *mut T, _val: u8, _count: usize);
+    pub unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
     #[rustc_intrinsic]
     pub unsafe fn unreachable() -> !;
 }

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -595,25 +595,25 @@ pub mod intrinsics {
     #[rustc_intrinsic]
     pub fn size_of<T>() -> usize;
     #[rustc_intrinsic]
-    pub unsafe fn size_of_val<T: ?::Sized>(_val: *const T) -> usize;
+    pub unsafe fn size_of_val<T: ?::Sized>(val: *const T) -> usize;
     #[rustc_intrinsic]
     pub fn min_align_of<T>() -> usize;
     #[rustc_intrinsic]
-    pub unsafe fn min_align_of_val<T: ?::Sized>(_val: *const T) -> usize;
+    pub unsafe fn min_align_of_val<T: ?::Sized>(val: *const T) -> usize;
     #[rustc_intrinsic]
-    pub unsafe fn copy<T>(_src: *const T, _dst: *mut T, _count: usize);
+    pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
     #[rustc_intrinsic]
-    pub unsafe fn transmute<T, U>(_e: T) -> U;
+    pub unsafe fn transmute<T, U>(e: T) -> U;
     #[rustc_intrinsic]
-    pub unsafe fn ctlz_nonzero<T>(_x: T) -> u32;
+    pub unsafe fn ctlz_nonzero<T>(x: T) -> u32;
     #[rustc_intrinsic]
     pub fn needs_drop<T: ?::Sized>() -> bool;
     #[rustc_intrinsic]
-    pub fn bitreverse<T>(_x: T) -> T;
+    pub fn bitreverse<T>(x: T) -> T;
     #[rustc_intrinsic]
-    pub fn bswap<T>(_x: T) -> T;
+    pub fn bswap<T>(x: T) -> T;
     #[rustc_intrinsic]
-    pub unsafe fn write_bytes<T>(_dst: *mut T, _val: u8, _count: usize);
+    pub unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
     #[rustc_intrinsic]
     pub unsafe fn unreachable() -> !;
 }

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -239,7 +239,7 @@ pub struct Box<
 /// This is the surface syntax for `box <expr>` expressions.
 #[rustc_intrinsic]
 #[unstable(feature = "liballoc_internals", issue = "none")]
-pub fn box_new<T>(_x: T) -> Box<T>;
+pub fn box_new<T>(x: T) -> Box<T>;
 
 impl<T> Box<T> {
     /// Allocates memory on the heap and then places `x` into it.

--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -306,15 +306,15 @@ impl<'f> Drop for VaListImpl<'f> {
 /// `va_copy`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-unsafe fn va_end(_ap: &mut VaListImpl<'_>);
+unsafe fn va_end(ap: &mut VaListImpl<'_>);
 
 /// Copies the current location of arglist `src` to the arglist `dst`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-unsafe fn va_copy<'f>(_dest: *mut VaListImpl<'f>, _src: &VaListImpl<'f>);
+unsafe fn va_copy<'f>(dest: *mut VaListImpl<'f>, src: &VaListImpl<'f>);
 
 /// Loads an argument of type `T` from the `va_list` `ap` and increment the
 /// argument `ap` points to.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-unsafe fn va_arg<T: sealed_trait::VaArgSafe>(_ap: &mut VaListImpl<'_>) -> T;
+unsafe fn va_arg<T: sealed_trait::VaArgSafe>(ap: &mut VaListImpl<'_>) -> T;

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -97,7 +97,7 @@ pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_relaxed_relaxed<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_relaxed_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -106,7 +106,7 @@ pub unsafe fn atomic_cxchg_relaxed_relaxed<T: Copy>(_dst: *mut T, _old: T, _src:
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_relaxed_acquire<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_relaxed_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -115,7 +115,7 @@ pub unsafe fn atomic_cxchg_relaxed_acquire<T: Copy>(_dst: *mut T, _old: T, _src:
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_relaxed_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_relaxed_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -124,7 +124,7 @@ pub unsafe fn atomic_cxchg_relaxed_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: 
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_acquire_relaxed<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_acquire_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -133,7 +133,7 @@ pub unsafe fn atomic_cxchg_acquire_relaxed<T: Copy>(_dst: *mut T, _old: T, _src:
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_acquire_acquire<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_acquire_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -142,7 +142,7 @@ pub unsafe fn atomic_cxchg_acquire_acquire<T: Copy>(_dst: *mut T, _old: T, _src:
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_acquire_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_acquire_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -151,7 +151,7 @@ pub unsafe fn atomic_cxchg_acquire_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: 
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_release_relaxed<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_release_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -160,7 +160,7 @@ pub unsafe fn atomic_cxchg_release_relaxed<T: Copy>(_dst: *mut T, _old: T, _src:
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_release_acquire<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_release_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -169,7 +169,7 @@ pub unsafe fn atomic_cxchg_release_acquire<T: Copy>(_dst: *mut T, _old: T, _src:
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_release_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_release_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -178,7 +178,7 @@ pub unsafe fn atomic_cxchg_release_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: 
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_acqrel_relaxed<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_acqrel_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -187,7 +187,7 @@ pub unsafe fn atomic_cxchg_acqrel_relaxed<T: Copy>(_dst: *mut T, _old: T, _src: 
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_acqrel_acquire<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_acqrel_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -196,7 +196,7 @@ pub unsafe fn atomic_cxchg_acqrel_acquire<T: Copy>(_dst: *mut T, _old: T, _src: 
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_acqrel_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_acqrel_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -205,7 +205,7 @@ pub unsafe fn atomic_cxchg_acqrel_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_seqcst_relaxed<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_seqcst_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -214,7 +214,7 @@ pub unsafe fn atomic_cxchg_seqcst_relaxed<T: Copy>(_dst: *mut T, _old: T, _src: 
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_seqcst_acquire<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_seqcst_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -223,7 +223,7 @@ pub unsafe fn atomic_cxchg_seqcst_acquire<T: Copy>(_dst: *mut T, _old: T, _src: 
 /// For example, [`AtomicBool::compare_exchange`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchg_seqcst_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchg_seqcst_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 
 /// Stores a value if the current value is the same as the `old` value.
 ///
@@ -259,8 +259,7 @@ pub unsafe fn atomic_cxchgweak_relaxed_acquire<T: Copy>(
 /// For example, [`AtomicBool::compare_exchange_weak`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchgweak_relaxed_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T)
--> (T, bool);
+pub unsafe fn atomic_cxchgweak_relaxed_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -295,8 +294,7 @@ pub unsafe fn atomic_cxchgweak_acquire_acquire<T: Copy>(
 /// For example, [`AtomicBool::compare_exchange_weak`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchgweak_acquire_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T)
--> (T, bool);
+pub unsafe fn atomic_cxchgweak_acquire_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -331,8 +329,7 @@ pub unsafe fn atomic_cxchgweak_release_acquire<T: Copy>(
 /// For example, [`AtomicBool::compare_exchange_weak`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchgweak_release_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T)
--> (T, bool);
+pub unsafe fn atomic_cxchgweak_release_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -341,8 +338,7 @@ pub unsafe fn atomic_cxchgweak_release_seqcst<T: Copy>(_dst: *mut T, _old: T, _s
 /// For example, [`AtomicBool::compare_exchange_weak`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchgweak_acqrel_relaxed<T: Copy>(_dst: *mut T, _old: T, _src: T)
--> (T, bool);
+pub unsafe fn atomic_cxchgweak_acqrel_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -351,8 +347,7 @@ pub unsafe fn atomic_cxchgweak_acqrel_relaxed<T: Copy>(_dst: *mut T, _old: T, _s
 /// For example, [`AtomicBool::compare_exchange_weak`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchgweak_acqrel_acquire<T: Copy>(_dst: *mut T, _old: T, _src: T)
--> (T, bool);
+pub unsafe fn atomic_cxchgweak_acqrel_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -361,7 +356,7 @@ pub unsafe fn atomic_cxchgweak_acqrel_acquire<T: Copy>(_dst: *mut T, _old: T, _s
 /// For example, [`AtomicBool::compare_exchange_weak`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchgweak_acqrel_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchgweak_acqrel_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -370,8 +365,7 @@ pub unsafe fn atomic_cxchgweak_acqrel_seqcst<T: Copy>(_dst: *mut T, _old: T, _sr
 /// For example, [`AtomicBool::compare_exchange_weak`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchgweak_seqcst_relaxed<T: Copy>(_dst: *mut T, _old: T, _src: T)
--> (T, bool);
+pub unsafe fn atomic_cxchgweak_seqcst_relaxed<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -380,8 +374,7 @@ pub unsafe fn atomic_cxchgweak_seqcst_relaxed<T: Copy>(_dst: *mut T, _old: T, _s
 /// For example, [`AtomicBool::compare_exchange_weak`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchgweak_seqcst_acquire<T: Copy>(_dst: *mut T, _old: T, _src: T)
--> (T, bool);
+pub unsafe fn atomic_cxchgweak_seqcst_acquire<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 /// Stores a value if the current value is the same as the `old` value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -390,7 +383,7 @@ pub unsafe fn atomic_cxchgweak_seqcst_acquire<T: Copy>(_dst: *mut T, _old: T, _s
 /// For example, [`AtomicBool::compare_exchange_weak`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_cxchgweak_seqcst_seqcst<T: Copy>(_dst: *mut T, _old: T, _src: T) -> (T, bool);
+pub unsafe fn atomic_cxchgweak_seqcst_seqcst<T: Copy>(dst: *mut T, old: T, src: T) -> (T, bool);
 
 /// Loads the current value of the pointer.
 ///
@@ -399,7 +392,7 @@ pub unsafe fn atomic_cxchgweak_seqcst_seqcst<T: Copy>(_dst: *mut T, _old: T, _sr
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::load`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_load_seqcst<T: Copy>(_src: *const T) -> T;
+pub unsafe fn atomic_load_seqcst<T: Copy>(src: *const T) -> T;
 /// Loads the current value of the pointer.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -407,7 +400,7 @@ pub unsafe fn atomic_load_seqcst<T: Copy>(_src: *const T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::load`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_load_acquire<T: Copy>(_src: *const T) -> T;
+pub unsafe fn atomic_load_acquire<T: Copy>(src: *const T) -> T;
 /// Loads the current value of the pointer.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -415,13 +408,13 @@ pub unsafe fn atomic_load_acquire<T: Copy>(_src: *const T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::load`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_load_relaxed<T: Copy>(_src: *const T) -> T;
+pub unsafe fn atomic_load_relaxed<T: Copy>(src: *const T) -> T;
 /// Do NOT use this intrinsic; "unordered" operations do not exist in our memory model!
 /// In terms of the Rust Abstract Machine, this operation is equivalent to `src.read()`,
 /// i.e., it performs a non-atomic read.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_load_unordered<T: Copy>(_src: *const T) -> T;
+pub unsafe fn atomic_load_unordered<T: Copy>(src: *const T) -> T;
 
 /// Stores the value at the specified memory location.
 ///
@@ -430,7 +423,7 @@ pub unsafe fn atomic_load_unordered<T: Copy>(_src: *const T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::store`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_store_seqcst<T: Copy>(_dst: *mut T, _val: T);
+pub unsafe fn atomic_store_seqcst<T: Copy>(dst: *mut T, val: T);
 /// Stores the value at the specified memory location.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -438,7 +431,7 @@ pub unsafe fn atomic_store_seqcst<T: Copy>(_dst: *mut T, _val: T);
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::store`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_store_release<T: Copy>(_dst: *mut T, _val: T);
+pub unsafe fn atomic_store_release<T: Copy>(dst: *mut T, val: T);
 /// Stores the value at the specified memory location.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -446,13 +439,13 @@ pub unsafe fn atomic_store_release<T: Copy>(_dst: *mut T, _val: T);
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::store`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_store_relaxed<T: Copy>(_dst: *mut T, _val: T);
+pub unsafe fn atomic_store_relaxed<T: Copy>(dst: *mut T, val: T);
 /// Do NOT use this intrinsic; "unordered" operations do not exist in our memory model!
 /// In terms of the Rust Abstract Machine, this operation is equivalent to `dst.write(val)`,
 /// i.e., it performs a non-atomic write.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_store_unordered<T: Copy>(_dst: *mut T, _val: T);
+pub unsafe fn atomic_store_unordered<T: Copy>(dst: *mut T, val: T);
 
 /// Stores the value at the specified memory location, returning the old value.
 ///
@@ -461,7 +454,7 @@ pub unsafe fn atomic_store_unordered<T: Copy>(_dst: *mut T, _val: T);
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::swap`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xchg_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xchg_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Stores the value at the specified memory location, returning the old value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -469,7 +462,7 @@ pub unsafe fn atomic_xchg_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::swap`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xchg_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xchg_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Stores the value at the specified memory location, returning the old value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -477,7 +470,7 @@ pub unsafe fn atomic_xchg_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::swap`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xchg_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xchg_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Stores the value at the specified memory location, returning the old value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -485,7 +478,7 @@ pub unsafe fn atomic_xchg_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::swap`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xchg_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xchg_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Stores the value at the specified memory location, returning the old value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -493,7 +486,7 @@ pub unsafe fn atomic_xchg_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::swap`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xchg_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xchg_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// Adds to the current value, returning the previous value.
 ///
@@ -502,7 +495,7 @@ pub unsafe fn atomic_xchg_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicIsize::fetch_add`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xadd_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xadd_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Adds to the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -510,7 +503,7 @@ pub unsafe fn atomic_xadd_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicIsize::fetch_add`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xadd_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xadd_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Adds to the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -518,7 +511,7 @@ pub unsafe fn atomic_xadd_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicIsize::fetch_add`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xadd_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xadd_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Adds to the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -526,7 +519,7 @@ pub unsafe fn atomic_xadd_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicIsize::fetch_add`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xadd_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xadd_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Adds to the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -534,7 +527,7 @@ pub unsafe fn atomic_xadd_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicIsize::fetch_add`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xadd_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xadd_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// Subtract from the current value, returning the previous value.
 ///
@@ -543,7 +536,7 @@ pub unsafe fn atomic_xadd_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xsub_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xsub_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Subtract from the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -551,7 +544,7 @@ pub unsafe fn atomic_xsub_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xsub_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xsub_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Subtract from the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -559,7 +552,7 @@ pub unsafe fn atomic_xsub_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xsub_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xsub_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Subtract from the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -567,7 +560,7 @@ pub unsafe fn atomic_xsub_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xsub_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xsub_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Subtract from the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -575,7 +568,7 @@ pub unsafe fn atomic_xsub_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicIsize::fetch_sub`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xsub_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xsub_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// Bitwise and with the current value, returning the previous value.
 ///
@@ -584,7 +577,7 @@ pub unsafe fn atomic_xsub_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_and`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_and_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_and_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise and with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -592,7 +585,7 @@ pub unsafe fn atomic_and_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_and`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_and_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_and_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise and with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -600,7 +593,7 @@ pub unsafe fn atomic_and_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_and`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_and_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_and_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise and with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -608,7 +601,7 @@ pub unsafe fn atomic_and_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_and`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_and_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_and_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise and with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -616,7 +609,7 @@ pub unsafe fn atomic_and_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_and`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_and_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_and_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// Bitwise nand with the current value, returning the previous value.
 ///
@@ -625,7 +618,7 @@ pub unsafe fn atomic_and_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_nand`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_nand_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_nand_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise nand with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -633,7 +626,7 @@ pub unsafe fn atomic_nand_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_nand`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_nand_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_nand_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise nand with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -641,7 +634,7 @@ pub unsafe fn atomic_nand_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_nand`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_nand_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_nand_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise nand with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -649,7 +642,7 @@ pub unsafe fn atomic_nand_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_nand`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_nand_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_nand_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise nand with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -657,7 +650,7 @@ pub unsafe fn atomic_nand_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_nand`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_nand_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_nand_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// Bitwise or with the current value, returning the previous value.
 ///
@@ -666,7 +659,7 @@ pub unsafe fn atomic_nand_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_or`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_or_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_or_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise or with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -674,7 +667,7 @@ pub unsafe fn atomic_or_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_or`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_or_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_or_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise or with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -682,7 +675,7 @@ pub unsafe fn atomic_or_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_or`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_or_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_or_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise or with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -690,7 +683,7 @@ pub unsafe fn atomic_or_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_or`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_or_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_or_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise or with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -698,7 +691,7 @@ pub unsafe fn atomic_or_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_or`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_or_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_or_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// Bitwise xor with the current value, returning the previous value.
 ///
@@ -707,7 +700,7 @@ pub unsafe fn atomic_or_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicBool::fetch_xor`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xor_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xor_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise xor with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -715,7 +708,7 @@ pub unsafe fn atomic_xor_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicBool::fetch_xor`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xor_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xor_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise xor with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -723,7 +716,7 @@ pub unsafe fn atomic_xor_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicBool::fetch_xor`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xor_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xor_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise xor with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -731,7 +724,7 @@ pub unsafe fn atomic_xor_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicBool::fetch_xor`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xor_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xor_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Bitwise xor with the current value, returning the previous value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -739,7 +732,7 @@ pub unsafe fn atomic_xor_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicBool::fetch_xor`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_xor_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_xor_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// Maximum with the current value using a signed comparison.
 ///
@@ -748,7 +741,7 @@ pub unsafe fn atomic_xor_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicI32::fetch_max`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_max_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_max_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Maximum with the current value using a signed comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -756,7 +749,7 @@ pub unsafe fn atomic_max_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicI32::fetch_max`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_max_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_max_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Maximum with the current value using a signed comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -764,7 +757,7 @@ pub unsafe fn atomic_max_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicI32::fetch_max`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_max_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_max_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Maximum with the current value using a signed comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -772,7 +765,7 @@ pub unsafe fn atomic_max_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicI32::fetch_max`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_max_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_max_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Maximum with the current value.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -780,7 +773,7 @@ pub unsafe fn atomic_max_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicI32::fetch_max`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_max_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_max_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// Minimum with the current value using a signed comparison.
 ///
@@ -789,7 +782,7 @@ pub unsafe fn atomic_max_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicI32::fetch_min`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_min_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_min_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Minimum with the current value using a signed comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -797,7 +790,7 @@ pub unsafe fn atomic_min_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicI32::fetch_min`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_min_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_min_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Minimum with the current value using a signed comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -805,7 +798,7 @@ pub unsafe fn atomic_min_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicI32::fetch_min`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_min_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_min_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Minimum with the current value using a signed comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -813,7 +806,7 @@ pub unsafe fn atomic_min_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicI32::fetch_min`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_min_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_min_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Minimum with the current value using a signed comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -821,7 +814,7 @@ pub unsafe fn atomic_min_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicI32::fetch_min`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_min_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_min_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// Minimum with the current value using an unsigned comparison.
 ///
@@ -830,7 +823,7 @@ pub unsafe fn atomic_min_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicU32::fetch_min`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_umin_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_umin_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Minimum with the current value using an unsigned comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -838,7 +831,7 @@ pub unsafe fn atomic_umin_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicU32::fetch_min`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_umin_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_umin_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Minimum with the current value using an unsigned comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -846,7 +839,7 @@ pub unsafe fn atomic_umin_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicU32::fetch_min`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_umin_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_umin_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Minimum with the current value using an unsigned comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -854,7 +847,7 @@ pub unsafe fn atomic_umin_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicU32::fetch_min`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_umin_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_umin_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Minimum with the current value using an unsigned comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -862,7 +855,7 @@ pub unsafe fn atomic_umin_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicU32::fetch_min`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_umin_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_umin_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// Maximum with the current value using an unsigned comparison.
 ///
@@ -871,7 +864,7 @@ pub unsafe fn atomic_umin_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::SeqCst`] as the `order`. For example, [`AtomicU32::fetch_max`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_umax_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_umax_seqcst<T: Copy>(dst: *mut T, src: T) -> T;
 /// Maximum with the current value using an unsigned comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -879,7 +872,7 @@ pub unsafe fn atomic_umax_seqcst<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Acquire`] as the `order`. For example, [`AtomicU32::fetch_max`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_umax_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_umax_acquire<T: Copy>(dst: *mut T, src: T) -> T;
 /// Maximum with the current value using an unsigned comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -887,7 +880,7 @@ pub unsafe fn atomic_umax_acquire<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Release`] as the `order`. For example, [`AtomicU32::fetch_max`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_umax_release<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_umax_release<T: Copy>(dst: *mut T, src: T) -> T;
 /// Maximum with the current value using an unsigned comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -895,7 +888,7 @@ pub unsafe fn atomic_umax_release<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::AcqRel`] as the `order`. For example, [`AtomicU32::fetch_max`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_umax_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_umax_acqrel<T: Copy>(dst: *mut T, src: T) -> T;
 /// Maximum with the current value using an unsigned comparison.
 ///
 /// The stabilized version of this intrinsic is available on the
@@ -903,7 +896,7 @@ pub unsafe fn atomic_umax_acqrel<T: Copy>(_dst: *mut T, _src: T) -> T;
 /// [`Ordering::Relaxed`] as the `order`. For example, [`AtomicU32::fetch_max`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn atomic_umax_relaxed<T: Copy>(_dst: *mut T, _src: T) -> T;
+pub unsafe fn atomic_umax_relaxed<T: Copy>(dst: *mut T, src: T) -> T;
 
 /// An atomic fence.
 ///
@@ -1002,7 +995,7 @@ pub unsafe fn atomic_singlethreadfence_acqrel();
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn prefetch_read_data<T>(_data: *const T, _locality: i32);
+pub unsafe fn prefetch_read_data<T>(data: *const T, locality: i32);
 /// The `prefetch` intrinsic is a hint to the code generator to insert a prefetch instruction
 /// if supported; otherwise, it is a no-op.
 /// Prefetches have no effect on the behavior of the program but can change its performance
@@ -1014,7 +1007,7 @@ pub unsafe fn prefetch_read_data<T>(_data: *const T, _locality: i32);
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn prefetch_write_data<T>(_data: *const T, _locality: i32);
+pub unsafe fn prefetch_write_data<T>(data: *const T, locality: i32);
 /// The `prefetch` intrinsic is a hint to the code generator to insert a prefetch instruction
 /// if supported; otherwise, it is a no-op.
 /// Prefetches have no effect on the behavior of the program but can change its performance
@@ -1026,7 +1019,7 @@ pub unsafe fn prefetch_write_data<T>(_data: *const T, _locality: i32);
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn prefetch_read_instruction<T>(_data: *const T, _locality: i32);
+pub unsafe fn prefetch_read_instruction<T>(data: *const T, locality: i32);
 /// The `prefetch` intrinsic is a hint to the code generator to insert a prefetch instruction
 /// if supported; otherwise, it is a no-op.
 /// Prefetches have no effect on the behavior of the program but can change its performance
@@ -1038,7 +1031,7 @@ pub unsafe fn prefetch_read_instruction<T>(_data: *const T, _locality: i32);
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn prefetch_write_instruction<T>(_data: *const T, _locality: i32);
+pub unsafe fn prefetch_write_instruction<T>(data: *const T, locality: i32);
 
 /// Executes a breakpoint trap, for inspection by a debugger.
 ///
@@ -1539,7 +1532,7 @@ pub const fn forget<T: ?Sized>(_: T);
 #[rustc_diagnostic_item = "transmute"]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn transmute<Src, Dst>(_src: Src) -> Dst;
+pub const unsafe fn transmute<Src, Dst>(src: Src) -> Dst;
 
 /// Like [`transmute`], but even less checked at compile-time: rather than
 /// giving an error for `size_of::<Src>() != size_of::<Dst>()`, it's
@@ -1553,7 +1546,7 @@ pub const unsafe fn transmute<Src, Dst>(_src: Src) -> Dst;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn transmute_unchecked<Src, Dst>(_src: Src) -> Dst;
+pub const unsafe fn transmute_unchecked<Src, Dst>(src: Src) -> Dst;
 
 /// Returns `true` if the actual type given as `T` requires drop
 /// glue; returns `false` if the actual type provided for `T`
@@ -1593,7 +1586,7 @@ pub const fn needs_drop<T: ?Sized>() -> bool;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn offset<Ptr, Delta>(_dst: Ptr, _offset: Delta) -> Ptr;
+pub const unsafe fn offset<Ptr, Delta>(dst: Ptr, offset: Delta) -> Ptr;
 
 /// Calculates the offset from a pointer, potentially wrapping.
 ///
@@ -1612,7 +1605,7 @@ pub const unsafe fn offset<Ptr, Delta>(_dst: Ptr, _offset: Delta) -> Ptr;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn arith_offset<T>(_dst: *const T, _offset: isize) -> *const T;
+pub const unsafe fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;
 
 /// Masks out bits of the pointer according to a mask.
 ///
@@ -1624,7 +1617,7 @@ pub const unsafe fn arith_offset<T>(_dst: *const T, _offset: isize) -> *const T;
 /// Consider using [`pointer::mask`] instead.
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub fn ptr_mask<T>(_ptr: *const T, _mask: usize) -> *const T;
+pub fn ptr_mask<T>(ptr: *const T, mask: usize) -> *const T;
 
 /// Equivalent to the appropriate `llvm.memcpy.p0i8.0i8.*` intrinsic, with
 /// a size of `count` * `size_of::<T>()` and an alignment of
@@ -1636,7 +1629,7 @@ pub fn ptr_mask<T>(_ptr: *const T, _mask: usize) -> *const T;
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn volatile_copy_nonoverlapping_memory<T>(_dst: *mut T, _src: *const T, _count: usize);
+pub unsafe fn volatile_copy_nonoverlapping_memory<T>(dst: *mut T, src: *const T, count: usize);
 /// Equivalent to the appropriate `llvm.memmove.p0i8.0i8.*` intrinsic, with
 /// a size of `count * size_of::<T>()` and an alignment of
 /// `min_align_of::<T>()`
@@ -1647,7 +1640,7 @@ pub unsafe fn volatile_copy_nonoverlapping_memory<T>(_dst: *mut T, _src: *const 
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn volatile_copy_memory<T>(_dst: *mut T, _src: *const T, _count: usize);
+pub unsafe fn volatile_copy_memory<T>(dst: *mut T, src: *const T, count: usize);
 /// Equivalent to the appropriate `llvm.memset.p0i8.*` intrinsic, with a
 /// size of `count * size_of::<T>()` and an alignment of
 /// `min_align_of::<T>()`.
@@ -1658,20 +1651,20 @@ pub unsafe fn volatile_copy_memory<T>(_dst: *mut T, _src: *const T, _count: usiz
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn volatile_set_memory<T>(_dst: *mut T, _val: u8, _count: usize);
+pub unsafe fn volatile_set_memory<T>(dst: *mut T, val: u8, count: usize);
 
 /// Performs a volatile load from the `src` pointer.
 ///
 /// The stabilized version of this intrinsic is [`core::ptr::read_volatile`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn volatile_load<T>(_src: *const T) -> T;
+pub unsafe fn volatile_load<T>(src: *const T) -> T;
 /// Performs a volatile store to the `dst` pointer.
 ///
 /// The stabilized version of this intrinsic is [`core::ptr::write_volatile`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn volatile_store<T>(_dst: *mut T, _val: T);
+pub unsafe fn volatile_store<T>(dst: *mut T, val: T);
 
 /// Performs a volatile load from the `src` pointer
 /// The pointer is not required to be aligned.
@@ -1680,7 +1673,7 @@ pub unsafe fn volatile_store<T>(_dst: *mut T, _val: T);
 #[rustc_intrinsic]
 #[rustc_nounwind]
 #[rustc_diagnostic_item = "intrinsics_unaligned_volatile_load"]
-pub unsafe fn unaligned_volatile_load<T>(_src: *const T) -> T;
+pub unsafe fn unaligned_volatile_load<T>(src: *const T) -> T;
 /// Performs a volatile store to the `dst` pointer.
 /// The pointer is not required to be aligned.
 ///
@@ -1688,7 +1681,7 @@ pub unsafe fn unaligned_volatile_load<T>(_src: *const T) -> T;
 #[rustc_intrinsic]
 #[rustc_nounwind]
 #[rustc_diagnostic_item = "intrinsics_unaligned_volatile_store"]
-pub unsafe fn unaligned_volatile_store<T>(_dst: *mut T, _val: T);
+pub unsafe fn unaligned_volatile_store<T>(dst: *mut T, val: T);
 
 /// Returns the square root of an `f16`
 ///
@@ -1696,28 +1689,28 @@ pub unsafe fn unaligned_volatile_store<T>(_dst: *mut T, _val: T);
 /// [`f16::sqrt`](../../std/primitive.f16.html#method.sqrt)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn sqrtf16(_x: f16) -> f16;
+pub unsafe fn sqrtf16(x: f16) -> f16;
 /// Returns the square root of an `f32`
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::sqrt`](../../std/primitive.f32.html#method.sqrt)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn sqrtf32(_x: f32) -> f32;
+pub unsafe fn sqrtf32(x: f32) -> f32;
 /// Returns the square root of an `f64`
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::sqrt`](../../std/primitive.f64.html#method.sqrt)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn sqrtf64(_x: f64) -> f64;
+pub unsafe fn sqrtf64(x: f64) -> f64;
 /// Returns the square root of an `f128`
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::sqrt`](../../std/primitive.f128.html#method.sqrt)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn sqrtf128(_x: f128) -> f128;
+pub unsafe fn sqrtf128(x: f128) -> f128;
 
 /// Raises an `f16` to an integer power.
 ///
@@ -1725,28 +1718,28 @@ pub unsafe fn sqrtf128(_x: f128) -> f128;
 /// [`f16::powi`](../../std/primitive.f16.html#method.powi)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn powif16(_a: f16, _x: i32) -> f16;
+pub unsafe fn powif16(a: f16, x: i32) -> f16;
 /// Raises an `f32` to an integer power.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::powi`](../../std/primitive.f32.html#method.powi)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn powif32(_a: f32, _x: i32) -> f32;
+pub unsafe fn powif32(a: f32, x: i32) -> f32;
 /// Raises an `f64` to an integer power.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::powi`](../../std/primitive.f64.html#method.powi)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn powif64(_a: f64, _x: i32) -> f64;
+pub unsafe fn powif64(a: f64, x: i32) -> f64;
 /// Raises an `f128` to an integer power.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::powi`](../../std/primitive.f128.html#method.powi)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn powif128(_a: f128, _x: i32) -> f128;
+pub unsafe fn powif128(a: f128, x: i32) -> f128;
 
 /// Returns the sine of an `f16`.
 ///
@@ -1754,28 +1747,28 @@ pub unsafe fn powif128(_a: f128, _x: i32) -> f128;
 /// [`f16::sin`](../../std/primitive.f16.html#method.sin)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn sinf16(_x: f16) -> f16;
+pub unsafe fn sinf16(x: f16) -> f16;
 /// Returns the sine of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::sin`](../../std/primitive.f32.html#method.sin)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn sinf32(_x: f32) -> f32;
+pub unsafe fn sinf32(x: f32) -> f32;
 /// Returns the sine of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::sin`](../../std/primitive.f64.html#method.sin)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn sinf64(_x: f64) -> f64;
+pub unsafe fn sinf64(x: f64) -> f64;
 /// Returns the sine of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::sin`](../../std/primitive.f128.html#method.sin)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn sinf128(_x: f128) -> f128;
+pub unsafe fn sinf128(x: f128) -> f128;
 
 /// Returns the cosine of an `f16`.
 ///
@@ -1783,28 +1776,28 @@ pub unsafe fn sinf128(_x: f128) -> f128;
 /// [`f16::cos`](../../std/primitive.f16.html#method.cos)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn cosf16(_x: f16) -> f16;
+pub unsafe fn cosf16(x: f16) -> f16;
 /// Returns the cosine of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::cos`](../../std/primitive.f32.html#method.cos)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn cosf32(_x: f32) -> f32;
+pub unsafe fn cosf32(x: f32) -> f32;
 /// Returns the cosine of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::cos`](../../std/primitive.f64.html#method.cos)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn cosf64(_x: f64) -> f64;
+pub unsafe fn cosf64(x: f64) -> f64;
 /// Returns the cosine of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::cos`](../../std/primitive.f128.html#method.cos)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn cosf128(_x: f128) -> f128;
+pub unsafe fn cosf128(x: f128) -> f128;
 
 /// Raises an `f16` to an `f16` power.
 ///
@@ -1812,28 +1805,28 @@ pub unsafe fn cosf128(_x: f128) -> f128;
 /// [`f16::powf`](../../std/primitive.f16.html#method.powf)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn powf16(_a: f16, _x: f16) -> f16;
+pub unsafe fn powf16(a: f16, x: f16) -> f16;
 /// Raises an `f32` to an `f32` power.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::powf`](../../std/primitive.f32.html#method.powf)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn powf32(_a: f32, _x: f32) -> f32;
+pub unsafe fn powf32(a: f32, x: f32) -> f32;
 /// Raises an `f64` to an `f64` power.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::powf`](../../std/primitive.f64.html#method.powf)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn powf64(_a: f64, _x: f64) -> f64;
+pub unsafe fn powf64(a: f64, x: f64) -> f64;
 /// Raises an `f128` to an `f128` power.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::powf`](../../std/primitive.f128.html#method.powf)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn powf128(_a: f128, _x: f128) -> f128;
+pub unsafe fn powf128(a: f128, x: f128) -> f128;
 
 /// Returns the exponential of an `f16`.
 ///
@@ -1841,28 +1834,28 @@ pub unsafe fn powf128(_a: f128, _x: f128) -> f128;
 /// [`f16::exp`](../../std/primitive.f16.html#method.exp)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn expf16(_x: f16) -> f16;
+pub unsafe fn expf16(x: f16) -> f16;
 /// Returns the exponential of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::exp`](../../std/primitive.f32.html#method.exp)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn expf32(_x: f32) -> f32;
+pub unsafe fn expf32(x: f32) -> f32;
 /// Returns the exponential of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::exp`](../../std/primitive.f64.html#method.exp)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn expf64(_x: f64) -> f64;
+pub unsafe fn expf64(x: f64) -> f64;
 /// Returns the exponential of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::exp`](../../std/primitive.f128.html#method.exp)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn expf128(_x: f128) -> f128;
+pub unsafe fn expf128(x: f128) -> f128;
 
 /// Returns 2 raised to the power of an `f16`.
 ///
@@ -1870,28 +1863,28 @@ pub unsafe fn expf128(_x: f128) -> f128;
 /// [`f16::exp2`](../../std/primitive.f16.html#method.exp2)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn exp2f16(_x: f16) -> f16;
+pub unsafe fn exp2f16(x: f16) -> f16;
 /// Returns 2 raised to the power of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::exp2`](../../std/primitive.f32.html#method.exp2)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn exp2f32(_x: f32) -> f32;
+pub unsafe fn exp2f32(x: f32) -> f32;
 /// Returns 2 raised to the power of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::exp2`](../../std/primitive.f64.html#method.exp2)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn exp2f64(_x: f64) -> f64;
+pub unsafe fn exp2f64(x: f64) -> f64;
 /// Returns 2 raised to the power of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::exp2`](../../std/primitive.f128.html#method.exp2)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn exp2f128(_x: f128) -> f128;
+pub unsafe fn exp2f128(x: f128) -> f128;
 
 /// Returns the natural logarithm of an `f16`.
 ///
@@ -1899,28 +1892,28 @@ pub unsafe fn exp2f128(_x: f128) -> f128;
 /// [`f16::ln`](../../std/primitive.f16.html#method.ln)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn logf16(_x: f16) -> f16;
+pub unsafe fn logf16(x: f16) -> f16;
 /// Returns the natural logarithm of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::ln`](../../std/primitive.f32.html#method.ln)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn logf32(_x: f32) -> f32;
+pub unsafe fn logf32(x: f32) -> f32;
 /// Returns the natural logarithm of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::ln`](../../std/primitive.f64.html#method.ln)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn logf64(_x: f64) -> f64;
+pub unsafe fn logf64(x: f64) -> f64;
 /// Returns the natural logarithm of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::ln`](../../std/primitive.f128.html#method.ln)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn logf128(_x: f128) -> f128;
+pub unsafe fn logf128(x: f128) -> f128;
 
 /// Returns the base 10 logarithm of an `f16`.
 ///
@@ -1928,28 +1921,28 @@ pub unsafe fn logf128(_x: f128) -> f128;
 /// [`f16::log10`](../../std/primitive.f16.html#method.log10)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn log10f16(_x: f16) -> f16;
+pub unsafe fn log10f16(x: f16) -> f16;
 /// Returns the base 10 logarithm of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::log10`](../../std/primitive.f32.html#method.log10)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn log10f32(_x: f32) -> f32;
+pub unsafe fn log10f32(x: f32) -> f32;
 /// Returns the base 10 logarithm of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::log10`](../../std/primitive.f64.html#method.log10)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn log10f64(_x: f64) -> f64;
+pub unsafe fn log10f64(x: f64) -> f64;
 /// Returns the base 10 logarithm of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::log10`](../../std/primitive.f128.html#method.log10)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn log10f128(_x: f128) -> f128;
+pub unsafe fn log10f128(x: f128) -> f128;
 
 /// Returns the base 2 logarithm of an `f16`.
 ///
@@ -1957,28 +1950,28 @@ pub unsafe fn log10f128(_x: f128) -> f128;
 /// [`f16::log2`](../../std/primitive.f16.html#method.log2)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn log2f16(_x: f16) -> f16;
+pub unsafe fn log2f16(x: f16) -> f16;
 /// Returns the base 2 logarithm of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::log2`](../../std/primitive.f32.html#method.log2)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn log2f32(_x: f32) -> f32;
+pub unsafe fn log2f32(x: f32) -> f32;
 /// Returns the base 2 logarithm of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::log2`](../../std/primitive.f64.html#method.log2)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn log2f64(_x: f64) -> f64;
+pub unsafe fn log2f64(x: f64) -> f64;
 /// Returns the base 2 logarithm of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::log2`](../../std/primitive.f128.html#method.log2)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn log2f128(_x: f128) -> f128;
+pub unsafe fn log2f128(x: f128) -> f128;
 
 /// Returns `a * b + c` for `f16` values.
 ///
@@ -1986,28 +1979,28 @@ pub unsafe fn log2f128(_x: f128) -> f128;
 /// [`f16::mul_add`](../../std/primitive.f16.html#method.mul_add)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fmaf16(_a: f16, _b: f16, _c: f16) -> f16;
+pub unsafe fn fmaf16(a: f16, b: f16, c: f16) -> f16;
 /// Returns `a * b + c` for `f32` values.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::mul_add`](../../std/primitive.f32.html#method.mul_add)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fmaf32(_a: f32, _b: f32, _c: f32) -> f32;
+pub unsafe fn fmaf32(a: f32, b: f32, c: f32) -> f32;
 /// Returns `a * b + c` for `f64` values.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::mul_add`](../../std/primitive.f64.html#method.mul_add)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fmaf64(_a: f64, _b: f64, _c: f64) -> f64;
+pub unsafe fn fmaf64(a: f64, b: f64, c: f64) -> f64;
 /// Returns `a * b + c` for `f128` values.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::mul_add`](../../std/primitive.f128.html#method.mul_add)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fmaf128(_a: f128, _b: f128, _c: f128) -> f128;
+pub unsafe fn fmaf128(a: f128, b: f128, c: f128) -> f128;
 
 /// Returns `a * b + c` for `f16` values, non-deterministically executing
 /// either a fused multiply-add or two operations with rounding of the
@@ -2021,7 +2014,7 @@ pub unsafe fn fmaf128(_a: f128, _b: f128, _c: f128) -> f128;
 /// example.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fmuladdf16(_a: f16, _b: f16, _c: f16) -> f16;
+pub unsafe fn fmuladdf16(a: f16, b: f16, c: f16) -> f16;
 /// Returns `a * b + c` for `f32` values, non-deterministically executing
 /// either a fused multiply-add or two operations with rounding of the
 /// intermediate result.
@@ -2034,7 +2027,7 @@ pub unsafe fn fmuladdf16(_a: f16, _b: f16, _c: f16) -> f16;
 /// example.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fmuladdf32(_a: f32, _b: f32, _c: f32) -> f32;
+pub unsafe fn fmuladdf32(a: f32, b: f32, c: f32) -> f32;
 /// Returns `a * b + c` for `f64` values, non-deterministically executing
 /// either a fused multiply-add or two operations with rounding of the
 /// intermediate result.
@@ -2047,7 +2040,7 @@ pub unsafe fn fmuladdf32(_a: f32, _b: f32, _c: f32) -> f32;
 /// example.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fmuladdf64(_a: f64, _b: f64, _c: f64) -> f64;
+pub unsafe fn fmuladdf64(a: f64, b: f64, c: f64) -> f64;
 /// Returns `a * b + c` for `f128` values, non-deterministically executing
 /// either a fused multiply-add or two operations with rounding of the
 /// intermediate result.
@@ -2060,7 +2053,7 @@ pub unsafe fn fmuladdf64(_a: f64, _b: f64, _c: f64) -> f64;
 /// example.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fmuladdf128(_a: f128, _b: f128, _c: f128) -> f128;
+pub unsafe fn fmuladdf128(a: f128, b: f128, c: f128) -> f128;
 
 /// Returns the largest integer less than or equal to an `f16`.
 ///
@@ -2068,28 +2061,28 @@ pub unsafe fn fmuladdf128(_a: f128, _b: f128, _c: f128) -> f128;
 /// [`f16::floor`](../../std/primitive.f16.html#method.floor)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn floorf16(_x: f16) -> f16;
+pub unsafe fn floorf16(x: f16) -> f16;
 /// Returns the largest integer less than or equal to an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::floor`](../../std/primitive.f32.html#method.floor)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn floorf32(_x: f32) -> f32;
+pub unsafe fn floorf32(x: f32) -> f32;
 /// Returns the largest integer less than or equal to an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::floor`](../../std/primitive.f64.html#method.floor)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn floorf64(_x: f64) -> f64;
+pub unsafe fn floorf64(x: f64) -> f64;
 /// Returns the largest integer less than or equal to an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::floor`](../../std/primitive.f128.html#method.floor)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn floorf128(_x: f128) -> f128;
+pub unsafe fn floorf128(x: f128) -> f128;
 
 /// Returns the smallest integer greater than or equal to an `f16`.
 ///
@@ -2097,28 +2090,28 @@ pub unsafe fn floorf128(_x: f128) -> f128;
 /// [`f16::ceil`](../../std/primitive.f16.html#method.ceil)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn ceilf16(_x: f16) -> f16;
+pub unsafe fn ceilf16(x: f16) -> f16;
 /// Returns the smallest integer greater than or equal to an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::ceil`](../../std/primitive.f32.html#method.ceil)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn ceilf32(_x: f32) -> f32;
+pub unsafe fn ceilf32(x: f32) -> f32;
 /// Returns the smallest integer greater than or equal to an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::ceil`](../../std/primitive.f64.html#method.ceil)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn ceilf64(_x: f64) -> f64;
+pub unsafe fn ceilf64(x: f64) -> f64;
 /// Returns the smallest integer greater than or equal to an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::ceil`](../../std/primitive.f128.html#method.ceil)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn ceilf128(_x: f128) -> f128;
+pub unsafe fn ceilf128(x: f128) -> f128;
 
 /// Returns the integer part of an `f16`.
 ///
@@ -2126,28 +2119,28 @@ pub unsafe fn ceilf128(_x: f128) -> f128;
 /// [`f16::trunc`](../../std/primitive.f16.html#method.trunc)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn truncf16(_x: f16) -> f16;
+pub unsafe fn truncf16(x: f16) -> f16;
 /// Returns the integer part of an `f32`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::trunc`](../../std/primitive.f32.html#method.trunc)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn truncf32(_x: f32) -> f32;
+pub unsafe fn truncf32(x: f32) -> f32;
 /// Returns the integer part of an `f64`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::trunc`](../../std/primitive.f64.html#method.trunc)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn truncf64(_x: f64) -> f64;
+pub unsafe fn truncf64(x: f64) -> f64;
 /// Returns the integer part of an `f128`.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::trunc`](../../std/primitive.f128.html#method.trunc)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn truncf128(_x: f128) -> f128;
+pub unsafe fn truncf128(x: f128) -> f128;
 
 /// Returns the nearest integer to an `f16`. Rounds half-way cases to the number with an even
 /// least significant digit.
@@ -2157,14 +2150,14 @@ pub unsafe fn truncf128(_x: f128) -> f128;
 #[rustc_intrinsic]
 #[rustc_nounwind]
 #[cfg(not(bootstrap))]
-pub fn round_ties_even_f16(_x: f16) -> f16;
+pub fn round_ties_even_f16(x: f16) -> f16;
 
 /// To be removed on next bootstrap bump.
 #[cfg(bootstrap)]
 pub fn round_ties_even_f16(x: f16) -> f16 {
     #[rustc_intrinsic]
     #[rustc_nounwind]
-    unsafe fn rintf16(_x: f16) -> f16;
+    unsafe fn rintf16(x: f16) -> f16;
 
     // SAFETY: this intrinsic isn't actually unsafe
     unsafe { rintf16(x) }
@@ -2178,14 +2171,14 @@ pub fn round_ties_even_f16(x: f16) -> f16 {
 #[rustc_intrinsic]
 #[rustc_nounwind]
 #[cfg(not(bootstrap))]
-pub fn round_ties_even_f32(_x: f32) -> f32;
+pub fn round_ties_even_f32(x: f32) -> f32;
 
 /// To be removed on next bootstrap bump.
 #[cfg(bootstrap)]
 pub fn round_ties_even_f32(x: f32) -> f32 {
     #[rustc_intrinsic]
     #[rustc_nounwind]
-    unsafe fn rintf32(_x: f32) -> f32;
+    unsafe fn rintf32(x: f32) -> f32;
 
     // SAFETY: this intrinsic isn't actually unsafe
     unsafe { rintf32(x) }
@@ -2205,14 +2198,14 @@ pub unsafe fn rintf32(x: f32) -> f32 {
 #[rustc_intrinsic]
 #[rustc_nounwind]
 #[cfg(not(bootstrap))]
-pub fn round_ties_even_f64(_x: f64) -> f64;
+pub fn round_ties_even_f64(x: f64) -> f64;
 
 /// To be removed on next bootstrap bump.
 #[cfg(bootstrap)]
 pub fn round_ties_even_f64(x: f64) -> f64 {
     #[rustc_intrinsic]
     #[rustc_nounwind]
-    unsafe fn rintf64(_x: f64) -> f64;
+    unsafe fn rintf64(x: f64) -> f64;
 
     // SAFETY: this intrinsic isn't actually unsafe
     unsafe { rintf64(x) }
@@ -2232,14 +2225,14 @@ pub unsafe fn rintf64(x: f64) -> f64 {
 #[rustc_intrinsic]
 #[rustc_nounwind]
 #[cfg(not(bootstrap))]
-pub fn round_ties_even_f128(_x: f128) -> f128;
+pub fn round_ties_even_f128(x: f128) -> f128;
 
 /// To be removed on next bootstrap bump.
 #[cfg(bootstrap)]
 pub fn round_ties_even_f128(x: f128) -> f128 {
     #[rustc_intrinsic]
     #[rustc_nounwind]
-    unsafe fn rintf128(_x: f128) -> f128;
+    unsafe fn rintf128(x: f128) -> f128;
 
     // SAFETY: this intrinsic isn't actually unsafe
     unsafe { rintf128(x) }
@@ -2251,28 +2244,28 @@ pub fn round_ties_even_f128(x: f128) -> f128 {
 /// [`f16::round`](../../std/primitive.f16.html#method.round)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn roundf16(_x: f16) -> f16;
+pub unsafe fn roundf16(x: f16) -> f16;
 /// Returns the nearest integer to an `f32`. Rounds half-way cases away from zero.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f32::round`](../../std/primitive.f32.html#method.round)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn roundf32(_x: f32) -> f32;
+pub unsafe fn roundf32(x: f32) -> f32;
 /// Returns the nearest integer to an `f64`. Rounds half-way cases away from zero.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f64::round`](../../std/primitive.f64.html#method.round)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn roundf64(_x: f64) -> f64;
+pub unsafe fn roundf64(x: f64) -> f64;
 /// Returns the nearest integer to an `f128`. Rounds half-way cases away from zero.
 ///
 /// The stabilized version of this intrinsic is
 /// [`f128::round`](../../std/primitive.f128.html#method.round)
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn roundf128(_x: f128) -> f128;
+pub unsafe fn roundf128(x: f128) -> f128;
 
 /// Float addition that allows optimizations based on algebraic rules.
 /// May assume inputs are finite.
@@ -2280,7 +2273,7 @@ pub unsafe fn roundf128(_x: f128) -> f128;
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fadd_fast<T: Copy>(_a: T, _b: T) -> T;
+pub unsafe fn fadd_fast<T: Copy>(a: T, b: T) -> T;
 
 /// Float subtraction that allows optimizations based on algebraic rules.
 /// May assume inputs are finite.
@@ -2288,7 +2281,7 @@ pub unsafe fn fadd_fast<T: Copy>(_a: T, _b: T) -> T;
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fsub_fast<T: Copy>(_a: T, _b: T) -> T;
+pub unsafe fn fsub_fast<T: Copy>(a: T, b: T) -> T;
 
 /// Float multiplication that allows optimizations based on algebraic rules.
 /// May assume inputs are finite.
@@ -2296,7 +2289,7 @@ pub unsafe fn fsub_fast<T: Copy>(_a: T, _b: T) -> T;
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fmul_fast<T: Copy>(_a: T, _b: T) -> T;
+pub unsafe fn fmul_fast<T: Copy>(a: T, b: T) -> T;
 
 /// Float division that allows optimizations based on algebraic rules.
 /// May assume inputs are finite.
@@ -2304,7 +2297,7 @@ pub unsafe fn fmul_fast<T: Copy>(_a: T, _b: T) -> T;
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn fdiv_fast<T: Copy>(_a: T, _b: T) -> T;
+pub unsafe fn fdiv_fast<T: Copy>(a: T, b: T) -> T;
 
 /// Float remainder that allows optimizations based on algebraic rules.
 /// May assume inputs are finite.
@@ -2312,7 +2305,7 @@ pub unsafe fn fdiv_fast<T: Copy>(_a: T, _b: T) -> T;
 /// This intrinsic does not have a stable counterpart.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn frem_fast<T: Copy>(_a: T, _b: T) -> T;
+pub unsafe fn frem_fast<T: Copy>(a: T, b: T) -> T;
 
 /// Converts with LLVM’s fptoui/fptosi, which may return undef for values out of range
 /// (<https://github.com/rust-lang/rust/issues/10184>)
@@ -2320,42 +2313,42 @@ pub unsafe fn frem_fast<T: Copy>(_a: T, _b: T) -> T;
 /// Stabilized as [`f32::to_int_unchecked`] and [`f64::to_int_unchecked`].
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+pub unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 /// Float addition that allows optimizations based on algebraic rules.
 ///
 /// This intrinsic does not have a stable counterpart.
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub fn fadd_algebraic<T: Copy>(_a: T, _b: T) -> T;
+pub fn fadd_algebraic<T: Copy>(a: T, b: T) -> T;
 
 /// Float subtraction that allows optimizations based on algebraic rules.
 ///
 /// This intrinsic does not have a stable counterpart.
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub fn fsub_algebraic<T: Copy>(_a: T, _b: T) -> T;
+pub fn fsub_algebraic<T: Copy>(a: T, b: T) -> T;
 
 /// Float multiplication that allows optimizations based on algebraic rules.
 ///
 /// This intrinsic does not have a stable counterpart.
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub fn fmul_algebraic<T: Copy>(_a: T, _b: T) -> T;
+pub fn fmul_algebraic<T: Copy>(a: T, b: T) -> T;
 
 /// Float division that allows optimizations based on algebraic rules.
 ///
 /// This intrinsic does not have a stable counterpart.
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub fn fdiv_algebraic<T: Copy>(_a: T, _b: T) -> T;
+pub fn fdiv_algebraic<T: Copy>(a: T, b: T) -> T;
 
 /// Float remainder that allows optimizations based on algebraic rules.
 ///
 /// This intrinsic does not have a stable counterpart.
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub fn frem_algebraic<T: Copy>(_a: T, _b: T) -> T;
+pub fn frem_algebraic<T: Copy>(a: T, b: T) -> T;
 
 /// Returns the number of bits set in an integer type `T`
 ///
@@ -2370,7 +2363,7 @@ pub fn frem_algebraic<T: Copy>(_a: T, _b: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn ctpop<T: Copy>(_x: T) -> u32;
+pub const fn ctpop<T: Copy>(x: T) -> u32;
 
 /// Returns the number of leading unset bits (zeroes) in an integer type `T`.
 ///
@@ -2411,7 +2404,7 @@ pub const fn ctpop<T: Copy>(_x: T) -> u32;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn ctlz<T: Copy>(_x: T) -> u32;
+pub const fn ctlz<T: Copy>(x: T) -> u32;
 
 /// Like `ctlz`, but extra-unsafe as it returns `undef` when
 /// given an `x` with value `0`.
@@ -2433,7 +2426,7 @@ pub const fn ctlz<T: Copy>(_x: T) -> u32;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn ctlz_nonzero<T: Copy>(_x: T) -> u32;
+pub const unsafe fn ctlz_nonzero<T: Copy>(x: T) -> u32;
 
 /// Returns the number of trailing unset bits (zeroes) in an integer type `T`.
 ///
@@ -2474,7 +2467,7 @@ pub const unsafe fn ctlz_nonzero<T: Copy>(_x: T) -> u32;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn cttz<T: Copy>(_x: T) -> u32;
+pub const fn cttz<T: Copy>(x: T) -> u32;
 
 /// Like `cttz`, but extra-unsafe as it returns `undef` when
 /// given an `x` with value `0`.
@@ -2496,7 +2489,7 @@ pub const fn cttz<T: Copy>(_x: T) -> u32;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn cttz_nonzero<T: Copy>(_x: T) -> u32;
+pub const unsafe fn cttz_nonzero<T: Copy>(x: T) -> u32;
 
 /// Reverses the bytes in an integer type `T`.
 ///
@@ -2511,7 +2504,7 @@ pub const unsafe fn cttz_nonzero<T: Copy>(_x: T) -> u32;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn bswap<T: Copy>(_x: T) -> T;
+pub const fn bswap<T: Copy>(x: T) -> T;
 
 /// Reverses the bits in an integer type `T`.
 ///
@@ -2526,7 +2519,7 @@ pub const fn bswap<T: Copy>(_x: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn bitreverse<T: Copy>(_x: T) -> T;
+pub const fn bitreverse<T: Copy>(x: T) -> T;
 
 /// Does a three-way comparison between the two integer arguments.
 ///
@@ -2536,7 +2529,7 @@ pub const fn bitreverse<T: Copy>(_x: T) -> T;
 ///
 /// The stabilized version of this intrinsic is [`Ord::cmp`].
 #[rustc_intrinsic]
-pub const fn three_way_compare<T: Copy>(_lhs: T, _rhss: T) -> crate::cmp::Ordering;
+pub const fn three_way_compare<T: Copy>(lhs: T, rhss: T) -> crate::cmp::Ordering;
 
 /// Combine two values which have no bits in common.
 ///
@@ -2571,7 +2564,7 @@ pub const unsafe fn disjoint_bitor<T: ~const fallback::DisjointBitOr>(a: T, b: T
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn add_with_overflow<T: Copy>(_x: T, _y: T) -> (T, bool);
+pub const fn add_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
 /// Performs checked integer subtraction
 ///
@@ -2586,7 +2579,7 @@ pub const fn add_with_overflow<T: Copy>(_x: T, _y: T) -> (T, bool);
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn sub_with_overflow<T: Copy>(_x: T, _y: T) -> (T, bool);
+pub const fn sub_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
 /// Performs checked integer multiplication
 ///
@@ -2601,7 +2594,7 @@ pub const fn sub_with_overflow<T: Copy>(_x: T, _y: T) -> (T, bool);
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn mul_with_overflow<T: Copy>(_x: T, _y: T) -> (T, bool);
+pub const fn mul_with_overflow<T: Copy>(x: T, y: T) -> (T, bool);
 
 /// Performs full-width multiplication and addition with a carry:
 /// `multiplier * multiplicand + addend + carry`.
@@ -2637,7 +2630,7 @@ pub const fn carrying_mul_add<T: ~const fallback::CarryingMulAdd<Unsigned = U>, 
 /// This intrinsic does not have a stable counterpart.
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn exact_div<T: Copy>(_x: T, _y: T) -> T;
+pub const unsafe fn exact_div<T: Copy>(x: T, y: T) -> T;
 
 /// Performs an unchecked division, resulting in undefined behavior
 /// where `y == 0` or `x == T::MIN && y == -1`
@@ -2648,7 +2641,7 @@ pub const unsafe fn exact_div<T: Copy>(_x: T, _y: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn unchecked_div<T: Copy>(_x: T, _y: T) -> T;
+pub const unsafe fn unchecked_div<T: Copy>(x: T, y: T) -> T;
 /// Returns the remainder of an unchecked division, resulting in
 /// undefined behavior when `y == 0` or `x == T::MIN && y == -1`
 ///
@@ -2658,7 +2651,7 @@ pub const unsafe fn unchecked_div<T: Copy>(_x: T, _y: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn unchecked_rem<T: Copy>(_x: T, _y: T) -> T;
+pub const unsafe fn unchecked_rem<T: Copy>(x: T, y: T) -> T;
 
 /// Performs an unchecked left shift, resulting in undefined behavior when
 /// `y < 0` or `y >= N`, where N is the width of T in bits.
@@ -2669,7 +2662,7 @@ pub const unsafe fn unchecked_rem<T: Copy>(_x: T, _y: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn unchecked_shl<T: Copy, U: Copy>(_x: T, _y: U) -> T;
+pub const unsafe fn unchecked_shl<T: Copy, U: Copy>(x: T, y: U) -> T;
 /// Performs an unchecked right shift, resulting in undefined behavior when
 /// `y < 0` or `y >= N`, where N is the width of T in bits.
 ///
@@ -2679,7 +2672,7 @@ pub const unsafe fn unchecked_shl<T: Copy, U: Copy>(_x: T, _y: U) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn unchecked_shr<T: Copy, U: Copy>(_x: T, _y: U) -> T;
+pub const unsafe fn unchecked_shr<T: Copy, U: Copy>(x: T, y: U) -> T;
 
 /// Returns the result of an unchecked addition, resulting in
 /// undefined behavior when `x + y > T::MAX` or `x + y < T::MIN`.
@@ -2689,7 +2682,7 @@ pub const unsafe fn unchecked_shr<T: Copy, U: Copy>(_x: T, _y: U) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn unchecked_add<T: Copy>(_x: T, _y: T) -> T;
+pub const unsafe fn unchecked_add<T: Copy>(x: T, y: T) -> T;
 
 /// Returns the result of an unchecked subtraction, resulting in
 /// undefined behavior when `x - y > T::MAX` or `x - y < T::MIN`.
@@ -2699,7 +2692,7 @@ pub const unsafe fn unchecked_add<T: Copy>(_x: T, _y: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn unchecked_sub<T: Copy>(_x: T, _y: T) -> T;
+pub const unsafe fn unchecked_sub<T: Copy>(x: T, y: T) -> T;
 
 /// Returns the result of an unchecked multiplication, resulting in
 /// undefined behavior when `x * y > T::MAX` or `x * y < T::MIN`.
@@ -2709,7 +2702,7 @@ pub const unsafe fn unchecked_sub<T: Copy>(_x: T, _y: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn unchecked_mul<T: Copy>(_x: T, _y: T) -> T;
+pub const unsafe fn unchecked_mul<T: Copy>(x: T, y: T) -> T;
 
 /// Performs rotate left.
 ///
@@ -2724,7 +2717,7 @@ pub const unsafe fn unchecked_mul<T: Copy>(_x: T, _y: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn rotate_left<T: Copy>(_x: T, _shift: u32) -> T;
+pub const fn rotate_left<T: Copy>(x: T, shift: u32) -> T;
 
 /// Performs rotate right.
 ///
@@ -2739,7 +2732,7 @@ pub const fn rotate_left<T: Copy>(_x: T, _shift: u32) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn rotate_right<T: Copy>(_x: T, _shift: u32) -> T;
+pub const fn rotate_right<T: Copy>(x: T, shift: u32) -> T;
 
 /// Returns (a + b) mod 2<sup>N</sup>, where N is the width of T in bits.
 ///
@@ -2754,7 +2747,7 @@ pub const fn rotate_right<T: Copy>(_x: T, _shift: u32) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn wrapping_add<T: Copy>(_a: T, _b: T) -> T;
+pub const fn wrapping_add<T: Copy>(a: T, b: T) -> T;
 /// Returns (a - b) mod 2<sup>N</sup>, where N is the width of T in bits.
 ///
 /// Note that, unlike most intrinsics, this is safe to call;
@@ -2768,7 +2761,7 @@ pub const fn wrapping_add<T: Copy>(_a: T, _b: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn wrapping_sub<T: Copy>(_a: T, _b: T) -> T;
+pub const fn wrapping_sub<T: Copy>(a: T, b: T) -> T;
 /// Returns (a * b) mod 2<sup>N</sup>, where N is the width of T in bits.
 ///
 /// Note that, unlike most intrinsics, this is safe to call;
@@ -2782,7 +2775,7 @@ pub const fn wrapping_sub<T: Copy>(_a: T, _b: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn wrapping_mul<T: Copy>(_a: T, _b: T) -> T;
+pub const fn wrapping_mul<T: Copy>(a: T, b: T) -> T;
 
 /// Computes `a + b`, saturating at numeric bounds.
 ///
@@ -2797,7 +2790,7 @@ pub const fn wrapping_mul<T: Copy>(_a: T, _b: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn saturating_add<T: Copy>(_a: T, _b: T) -> T;
+pub const fn saturating_add<T: Copy>(a: T, b: T) -> T;
 /// Computes `a - b`, saturating at numeric bounds.
 ///
 /// Note that, unlike most intrinsics, this is safe to call;
@@ -2811,7 +2804,7 @@ pub const fn saturating_add<T: Copy>(_a: T, _b: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn saturating_sub<T: Copy>(_a: T, _b: T) -> T;
+pub const fn saturating_sub<T: Copy>(a: T, b: T) -> T;
 
 /// This is an implementation detail of [`crate::ptr::read`] and should
 /// not be used anywhere else.  See its comments for why this exists.
@@ -2822,7 +2815,7 @@ pub const fn saturating_sub<T: Copy>(_a: T, _b: T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn read_via_copy<T>(_ptr: *const T) -> T;
+pub const unsafe fn read_via_copy<T>(ptr: *const T) -> T;
 
 /// This is an implementation detail of [`crate::ptr::write`] and should
 /// not be used anywhere else.  See its comments for why this exists.
@@ -2833,7 +2826,7 @@ pub const unsafe fn read_via_copy<T>(_ptr: *const T) -> T;
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn write_via_move<T>(_ptr: *mut T, _value: T);
+pub const unsafe fn write_via_move<T>(ptr: *mut T, value: T);
 
 /// Returns the value of the discriminant for the variant in 'v';
 /// if `T` has no discriminant, returns `0`.
@@ -2847,7 +2840,7 @@ pub const unsafe fn write_via_move<T>(_ptr: *mut T, _value: T);
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn discriminant_value<T>(_v: &T) -> <T as DiscriminantKind>::Discriminant;
+pub const fn discriminant_value<T>(v: &T) -> <T as DiscriminantKind>::Discriminant;
 
 /// Rust's "try catch" construct for unwinding. Invokes the function pointer `try_fn` with the
 /// data pointer `data`, and calls `catch_fn` if unwinding occurs while `try_fn` runs.
@@ -2881,19 +2874,19 @@ pub unsafe fn catch_unwind(
 /// in ways that are not allowed for regular writes).
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn nontemporal_store<T>(_ptr: *mut T, _val: T);
+pub unsafe fn nontemporal_store<T>(ptr: *mut T, val: T);
 
 /// See documentation of `<*const T>::offset_from` for details.
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn ptr_offset_from<T>(_ptr: *const T, _base: *const T) -> isize;
+pub const unsafe fn ptr_offset_from<T>(ptr: *const T, base: *const T) -> isize;
 
 /// See documentation of `<*const T>::sub_ptr` for details.
 #[rustc_nounwind]
 #[rustc_intrinsic]
 #[rustc_intrinsic_const_stable_indirect]
-pub const unsafe fn ptr_offset_from_unsigned<T>(_ptr: *const T, _base: *const T) -> usize;
+pub const unsafe fn ptr_offset_from_unsigned<T>(ptr: *const T, base: *const T) -> usize;
 
 /// See documentation of `<*const T>::guaranteed_eq` for details.
 /// Returns `2` if the result is unknown.
@@ -2933,7 +2926,7 @@ pub const fn ptr_guaranteed_cmp<T>(ptr: *const T, other: *const T) -> u8 {
 /// which is UB if any of their inputs are `undef`.)
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn raw_eq<T>(_a: &T, _b: &T) -> bool;
+pub const unsafe fn raw_eq<T>(a: &T, b: &T) -> bool;
 
 /// Lexicographically compare `[left, left + bytes)` and `[right, right + bytes)`
 /// as unsigned bytes, returning negative if `left` is less, zero if all the
@@ -2951,7 +2944,7 @@ pub const unsafe fn raw_eq<T>(_a: &T, _b: &T) -> bool;
 /// [valid]: crate::ptr#safety
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn compare_bytes(_left: *const u8, _right: *const u8, _bytes: usize) -> i32;
+pub const unsafe fn compare_bytes(left: *const u8, right: *const u8, bytes: usize) -> i32;
 
 /// See documentation of [`std::hint::black_box`] for details.
 ///
@@ -2959,7 +2952,7 @@ pub const unsafe fn compare_bytes(_left: *const u8, _right: *const u8, _bytes: u
 #[rustc_nounwind]
 #[rustc_intrinsic]
 #[rustc_intrinsic_const_stable_indirect]
-pub const fn black_box<T>(_dummy: T) -> T;
+pub const fn black_box<T>(dummy: T) -> T;
 
 /// Selects which function to call depending on the context.
 ///
@@ -3318,7 +3311,7 @@ pub fn contract_check_ensures<'a, Ret, C: Fn(&'a Ret) -> bool>(ret: &'a Ret, con
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
-pub unsafe fn vtable_size(_ptr: *const ()) -> usize;
+pub unsafe fn vtable_size(ptr: *const ()) -> usize;
 
 /// The intrinsic will return the alignment stored in that vtable.
 ///
@@ -3328,7 +3321,7 @@ pub unsafe fn vtable_size(_ptr: *const ()) -> usize;
 #[rustc_nounwind]
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
-pub unsafe fn vtable_align(_ptr: *const ()) -> usize;
+pub unsafe fn vtable_align(ptr: *const ()) -> usize;
 
 /// The size of a type in bytes.
 ///
@@ -3395,7 +3388,7 @@ pub const fn variant_count<T>() -> usize;
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
 #[rustc_intrinsic_const_stable_indirect]
-pub const unsafe fn size_of_val<T: ?Sized>(_ptr: *const T) -> usize;
+pub const unsafe fn size_of_val<T: ?Sized>(ptr: *const T) -> usize;
 
 /// The required alignment of the referenced value.
 ///
@@ -3408,7 +3401,7 @@ pub const unsafe fn size_of_val<T: ?Sized>(_ptr: *const T) -> usize;
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
 #[rustc_intrinsic_const_stable_indirect]
-pub const unsafe fn min_align_of_val<T: ?Sized>(_ptr: *const T) -> usize;
+pub const unsafe fn min_align_of_val<T: ?Sized>(ptr: *const T) -> usize;
 
 /// Gets a static string slice containing the name of a type.
 ///
@@ -3447,7 +3440,7 @@ pub const fn type_id<T: ?Sized + 'static>() -> u128;
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const fn aggregate_raw_ptr<P: AggregateRawPtr<D, Metadata = M>, D, M>(_data: D, _meta: M) -> P;
+pub const fn aggregate_raw_ptr<P: AggregateRawPtr<D, Metadata = M>, D, M>(data: D, meta: M) -> P;
 
 #[unstable(feature = "core_intrinsics", issue = "none")]
 pub trait AggregateRawPtr<D> {
@@ -3467,7 +3460,7 @@ impl<P: ?Sized, T: ptr::Thin> AggregateRawPtr<*mut T> for *mut P {
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const fn ptr_metadata<P: ptr::Pointee<Metadata = M> + ?Sized, M>(_ptr: *const P) -> M;
+pub const fn ptr_metadata<P: ptr::Pointee<Metadata = M> + ?Sized, M>(ptr: *const P) -> M;
 
 // Some functions are defined here because they accidentally got made
 // available in this module on stable. See <https://github.com/rust-lang/rust/issues/15702>.
@@ -3569,7 +3562,7 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
     #[rustc_intrinsic_const_stable_indirect]
     #[rustc_nounwind]
     #[rustc_intrinsic]
-    const unsafe fn copy_nonoverlapping<T>(_src: *const T, _dst: *mut T, _count: usize);
+    const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
 
     ub_checks::assert_unsafe_precondition!(
         check_language_ub,
@@ -3670,7 +3663,7 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     #[rustc_intrinsic_const_stable_indirect]
     #[rustc_nounwind]
     #[rustc_intrinsic]
-    const unsafe fn copy<T>(_src: *const T, _dst: *mut T, _count: usize);
+    const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
 
     // SAFETY: the safety contract for `copy` must be upheld by the caller.
     unsafe {
@@ -3750,7 +3743,7 @@ pub const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize) {
     #[rustc_intrinsic_const_stable_indirect]
     #[rustc_nounwind]
     #[rustc_intrinsic]
-    const unsafe fn write_bytes<T>(_dst: *mut T, _val: u8, _count: usize);
+    const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
 
     // SAFETY: the safety contract for `write_bytes` must be upheld by the caller.
     unsafe {
@@ -3778,7 +3771,7 @@ pub const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize) {
 /// [`f16::min`]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn minnumf16(_x: f16, _y: f16) -> f16;
+pub const fn minnumf16(x: f16, y: f16) -> f16;
 
 /// Returns the minimum of two `f32` values.
 ///
@@ -3792,7 +3785,7 @@ pub const fn minnumf16(_x: f16, _y: f16) -> f16;
 #[rustc_nounwind]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const fn minnumf32(_x: f32, _y: f32) -> f32;
+pub const fn minnumf32(x: f32, y: f32) -> f32;
 
 /// Returns the minimum of two `f64` values.
 ///
@@ -3806,7 +3799,7 @@ pub const fn minnumf32(_x: f32, _y: f32) -> f32;
 #[rustc_nounwind]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const fn minnumf64(_x: f64, _y: f64) -> f64;
+pub const fn minnumf64(x: f64, y: f64) -> f64;
 
 /// Returns the minimum of two `f128` values.
 ///
@@ -3819,7 +3812,7 @@ pub const fn minnumf64(_x: f64, _y: f64) -> f64;
 /// [`f128::min`]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn minnumf128(_x: f128, _y: f128) -> f128;
+pub const fn minnumf128(x: f128, y: f128) -> f128;
 
 /// Returns the maximum of two `f16` values.
 ///
@@ -3832,7 +3825,7 @@ pub const fn minnumf128(_x: f128, _y: f128) -> f128;
 /// [`f16::max`]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn maxnumf16(_x: f16, _y: f16) -> f16;
+pub const fn maxnumf16(x: f16, y: f16) -> f16;
 
 /// Returns the maximum of two `f32` values.
 ///
@@ -3846,7 +3839,7 @@ pub const fn maxnumf16(_x: f16, _y: f16) -> f16;
 #[rustc_nounwind]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const fn maxnumf32(_x: f32, _y: f32) -> f32;
+pub const fn maxnumf32(x: f32, y: f32) -> f32;
 
 /// Returns the maximum of two `f64` values.
 ///
@@ -3860,7 +3853,7 @@ pub const fn maxnumf32(_x: f32, _y: f32) -> f32;
 #[rustc_nounwind]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const fn maxnumf64(_x: f64, _y: f64) -> f64;
+pub const fn maxnumf64(x: f64, y: f64) -> f64;
 
 /// Returns the maximum of two `f128` values.
 ///
@@ -3873,7 +3866,7 @@ pub const fn maxnumf64(_x: f64, _y: f64) -> f64;
 /// [`f128::max`]
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const fn maxnumf128(_x: f128, _y: f128) -> f128;
+pub const fn maxnumf128(x: f128, y: f128) -> f128;
 
 /// Returns the absolute value of an `f16`.
 ///
@@ -3881,7 +3874,7 @@ pub const fn maxnumf128(_x: f128, _y: f128) -> f128;
 /// [`f16::abs`](../../std/primitive.f16.html#method.abs)
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn fabsf16(_x: f16) -> f16;
+pub const unsafe fn fabsf16(x: f16) -> f16;
 
 /// Returns the absolute value of an `f32`.
 ///
@@ -3890,7 +3883,7 @@ pub const unsafe fn fabsf16(_x: f16) -> f16;
 #[rustc_nounwind]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const unsafe fn fabsf32(_x: f32) -> f32;
+pub const unsafe fn fabsf32(x: f32) -> f32;
 
 /// Returns the absolute value of an `f64`.
 ///
@@ -3899,7 +3892,7 @@ pub const unsafe fn fabsf32(_x: f32) -> f32;
 #[rustc_nounwind]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const unsafe fn fabsf64(_x: f64) -> f64;
+pub const unsafe fn fabsf64(x: f64) -> f64;
 
 /// Returns the absolute value of an `f128`.
 ///
@@ -3907,7 +3900,7 @@ pub const unsafe fn fabsf64(_x: f64) -> f64;
 /// [`f128::abs`](../../std/primitive.f128.html#method.abs)
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn fabsf128(_x: f128) -> f128;
+pub const unsafe fn fabsf128(x: f128) -> f128;
 
 /// Copies the sign from `y` to `x` for `f16` values.
 ///
@@ -3915,7 +3908,7 @@ pub const unsafe fn fabsf128(_x: f128) -> f128;
 /// [`f16::copysign`](../../std/primitive.f16.html#method.copysign)
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn copysignf16(_x: f16, _y: f16) -> f16;
+pub const unsafe fn copysignf16(x: f16, y: f16) -> f16;
 
 /// Copies the sign from `y` to `x` for `f32` values.
 ///
@@ -3924,7 +3917,7 @@ pub const unsafe fn copysignf16(_x: f16, _y: f16) -> f16;
 #[rustc_nounwind]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const unsafe fn copysignf32(_x: f32, _y: f32) -> f32;
+pub const unsafe fn copysignf32(x: f32, y: f32) -> f32;
 /// Copies the sign from `y` to `x` for `f64` values.
 ///
 /// The stabilized version of this intrinsic is
@@ -3932,7 +3925,7 @@ pub const unsafe fn copysignf32(_x: f32, _y: f32) -> f32;
 #[rustc_nounwind]
 #[rustc_intrinsic_const_stable_indirect]
 #[rustc_intrinsic]
-pub const unsafe fn copysignf64(_x: f64, _y: f64) -> f64;
+pub const unsafe fn copysignf64(x: f64, y: f64) -> f64;
 
 /// Copies the sign from `y` to `x` for `f128` values.
 ///
@@ -3940,7 +3933,7 @@ pub const unsafe fn copysignf64(_x: f64, _y: f64) -> f64;
 /// [`f128::copysign`](../../std/primitive.f128.html#method.copysign)
 #[rustc_nounwind]
 #[rustc_intrinsic]
-pub const unsafe fn copysignf128(_x: f128, _y: f128) -> f128;
+pub const unsafe fn copysignf128(x: f128, y: f128) -> f128;
 
 /// Inform Miri that a given pointer definitely has a certain alignment.
 #[cfg(miri)]

--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -11,7 +11,7 @@
 /// `idx` must be in-bounds of the vector.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub const unsafe fn simd_insert<T, U>(_x: T, _idx: u32, _val: U) -> T;
+pub const unsafe fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;
 
 /// Extracts an element from a vector.
 ///
@@ -22,28 +22,28 @@ pub const unsafe fn simd_insert<T, U>(_x: T, _idx: u32, _val: U) -> T;
 /// `idx` must be in-bounds of the vector.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub const unsafe fn simd_extract<T, U>(_x: T, _idx: u32) -> U;
+pub const unsafe fn simd_extract<T, U>(x: T, idx: u32) -> U;
 
 /// Adds two simd vectors elementwise.
 ///
 /// `T` must be a vector of integers or floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_add<T>(_x: T, _y: T) -> T;
+pub unsafe fn simd_add<T>(x: T, y: T) -> T;
 
 /// Subtracts `rhs` from `lhs` elementwise.
 ///
 /// `T` must be a vector of integers or floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_sub<T>(_lhs: T, _rhs: T) -> T;
+pub unsafe fn simd_sub<T>(lhs: T, rhs: T) -> T;
 
 /// Multiplies two simd vectors elementwise.
 ///
 /// `T` must be a vector of integers or floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_mul<T>(_x: T, _y: T) -> T;
+pub unsafe fn simd_mul<T>(x: T, y: T) -> T;
 
 /// Divides `lhs` by `rhs` elementwise.
 ///
@@ -54,7 +54,7 @@ pub unsafe fn simd_mul<T>(_x: T, _y: T) -> T;
 /// Additionally for signed integers, `<int>::MIN / -1` is undefined behavior.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_div<T>(_lhs: T, _rhs: T) -> T;
+pub unsafe fn simd_div<T>(lhs: T, rhs: T) -> T;
 
 /// Returns remainder of two vectors elementwise.
 ///
@@ -65,7 +65,7 @@ pub unsafe fn simd_div<T>(_lhs: T, _rhs: T) -> T;
 /// Additionally for signed integers, `<int>::MIN / -1` is undefined behavior.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_rem<T>(_lhs: T, _rhs: T) -> T;
+pub unsafe fn simd_rem<T>(lhs: T, rhs: T) -> T;
 
 /// Shifts vector left elementwise, with UB on overflow.
 ///
@@ -78,7 +78,7 @@ pub unsafe fn simd_rem<T>(_lhs: T, _rhs: T) -> T;
 /// Each element of `rhs` must be less than `<int>::BITS`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_shl<T>(_lhs: T, _rhs: T) -> T;
+pub unsafe fn simd_shl<T>(lhs: T, rhs: T) -> T;
 
 /// Shifts vector right elementwise, with UB on overflow.
 ///
@@ -91,28 +91,28 @@ pub unsafe fn simd_shl<T>(_lhs: T, _rhs: T) -> T;
 /// Each element of `rhs` must be less than `<int>::BITS`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_shr<T>(_lhs: T, _rhs: T) -> T;
+pub unsafe fn simd_shr<T>(lhs: T, rhs: T) -> T;
 
 /// "Ands" vectors elementwise.
 ///
 /// `T` must be a vector of integers.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_and<T>(_x: T, _y: T) -> T;
+pub unsafe fn simd_and<T>(x: T, y: T) -> T;
 
 /// "Ors" vectors elementwise.
 ///
 /// `T` must be a vector of integers.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_or<T>(_x: T, _y: T) -> T;
+pub unsafe fn simd_or<T>(x: T, y: T) -> T;
 
 /// "Exclusive ors" vectors elementwise.
 ///
 /// `T` must be a vector of integers.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_xor<T>(_x: T, _y: T) -> T;
+pub unsafe fn simd_xor<T>(x: T, y: T) -> T;
 
 /// Numerically casts a vector, elementwise.
 ///
@@ -133,7 +133,7 @@ pub unsafe fn simd_xor<T>(_x: T, _y: T) -> T;
 /// * Be representable in the return type, after truncating off its fractional part
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_cast<T, U>(_x: T) -> U;
+pub unsafe fn simd_cast<T, U>(x: T) -> U;
 
 /// Numerically casts a vector, elementwise.
 ///
@@ -147,7 +147,7 @@ pub unsafe fn simd_cast<T, U>(_x: T) -> U;
 /// Otherwise, truncates or extends the value, maintaining the sign for signed integers.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_as<T, U>(_x: T) -> U;
+pub unsafe fn simd_as<T, U>(x: T) -> U;
 
 /// Negates a vector elementwise.
 ///
@@ -156,14 +156,14 @@ pub unsafe fn simd_as<T, U>(_x: T) -> U;
 /// Rust panics for `-<int>::Min` due to overflow, but it is not UB with this intrinsic.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_neg<T>(_x: T) -> T;
+pub unsafe fn simd_neg<T>(x: T) -> T;
 
 /// Returns absolute value of a vector, elementwise.
 ///
 /// `T` must be a vector of floating-point primitive types.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_fabs<T>(_x: T) -> T;
+pub unsafe fn simd_fabs<T>(x: T) -> T;
 
 /// Returns the minimum of two vectors, elementwise.
 ///
@@ -172,7 +172,7 @@ pub unsafe fn simd_fabs<T>(_x: T) -> T;
 /// Follows IEEE-754 `minNum` semantics.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_fmin<T>(_x: T, _y: T) -> T;
+pub unsafe fn simd_fmin<T>(x: T, y: T) -> T;
 
 /// Returns the maximum of two vectors, elementwise.
 ///
@@ -181,7 +181,7 @@ pub unsafe fn simd_fmin<T>(_x: T, _y: T) -> T;
 /// Follows IEEE-754 `maxNum` semantics.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_fmax<T>(_x: T, _y: T) -> T;
+pub unsafe fn simd_fmax<T>(x: T, y: T) -> T;
 
 /// Tests elementwise equality of two vectors.
 ///
@@ -192,7 +192,7 @@ pub unsafe fn simd_fmax<T>(_x: T, _y: T) -> T;
 /// Returns `0` for false and `!0` for true.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_eq<T, U>(_x: T, _y: T) -> U;
+pub unsafe fn simd_eq<T, U>(x: T, y: T) -> U;
 
 /// Tests elementwise inequality equality of two vectors.
 ///
@@ -203,7 +203,7 @@ pub unsafe fn simd_eq<T, U>(_x: T, _y: T) -> U;
 /// Returns `0` for false and `!0` for true.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_ne<T, U>(_x: T, _y: T) -> U;
+pub unsafe fn simd_ne<T, U>(x: T, y: T) -> U;
 
 /// Tests if `x` is less than `y`, elementwise.
 ///
@@ -214,7 +214,7 @@ pub unsafe fn simd_ne<T, U>(_x: T, _y: T) -> U;
 /// Returns `0` for false and `!0` for true.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_lt<T, U>(_x: T, _y: T) -> U;
+pub unsafe fn simd_lt<T, U>(x: T, y: T) -> U;
 
 /// Tests if `x` is less than or equal to `y`, elementwise.
 ///
@@ -225,7 +225,7 @@ pub unsafe fn simd_lt<T, U>(_x: T, _y: T) -> U;
 /// Returns `0` for false and `!0` for true.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_le<T, U>(_x: T, _y: T) -> U;
+pub unsafe fn simd_le<T, U>(x: T, y: T) -> U;
 
 /// Tests if `x` is greater than `y`, elementwise.
 ///
@@ -236,7 +236,7 @@ pub unsafe fn simd_le<T, U>(_x: T, _y: T) -> U;
 /// Returns `0` for false and `!0` for true.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_gt<T, U>(_x: T, _y: T) -> U;
+pub unsafe fn simd_gt<T, U>(x: T, y: T) -> U;
 
 /// Tests if `x` is greater than or equal to `y`, elementwise.
 ///
@@ -247,7 +247,7 @@ pub unsafe fn simd_gt<T, U>(_x: T, _y: T) -> U;
 /// Returns `0` for false and `!0` for true.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_ge<T, U>(_x: T, _y: T) -> U;
+pub unsafe fn simd_ge<T, U>(x: T, y: T) -> U;
 
 /// Shuffles two vectors by const indices.
 ///
@@ -263,7 +263,7 @@ pub unsafe fn simd_ge<T, U>(_x: T, _y: T) -> U;
 /// of `xy`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_shuffle<T, U, V>(_x: T, _y: T, _idx: U) -> V;
+pub unsafe fn simd_shuffle<T, U, V>(x: T, y: T, idx: U) -> V;
 
 /// Reads a vector of pointers.
 ///
@@ -284,7 +284,7 @@ pub unsafe fn simd_shuffle<T, U, V>(_x: T, _y: T, _idx: U) -> V;
 /// `mask` must only contain `0` or `!0` values.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_gather<T, U, V>(_val: T, _ptr: U, _mask: V) -> T;
+pub unsafe fn simd_gather<T, U, V>(val: T, ptr: U, mask: V) -> T;
 
 /// Writes to a vector of pointers.
 ///
@@ -308,7 +308,7 @@ pub unsafe fn simd_gather<T, U, V>(_val: T, _ptr: U, _mask: V) -> T;
 /// `mask` must only contain `0` or `!0` values.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_scatter<T, U, V>(_val: T, _ptr: U, _mask: V);
+pub unsafe fn simd_scatter<T, U, V>(val: T, ptr: U, mask: V);
 
 /// Reads a vector of pointers.
 ///
@@ -331,7 +331,7 @@ pub unsafe fn simd_scatter<T, U, V>(_val: T, _ptr: U, _mask: V);
 /// `mask` must only contain `0` or `!0` values.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_masked_load<V, U, T>(_mask: V, _ptr: U, _val: T) -> T;
+pub unsafe fn simd_masked_load<V, U, T>(mask: V, ptr: U, val: T) -> T;
 
 /// Writes to a vector of pointers.
 ///
@@ -353,14 +353,14 @@ pub unsafe fn simd_masked_load<V, U, T>(_mask: V, _ptr: U, _val: T) -> T;
 /// `mask` must only contain `0` or `!0` values.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_masked_store<V, U, T>(_mask: V, _ptr: U, _val: T);
+pub unsafe fn simd_masked_store<V, U, T>(mask: V, ptr: U, val: T);
 
 /// Adds two simd vectors elementwise, with saturation.
 ///
 /// `T` must be a vector of integer primitive types.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_saturating_add<T>(_x: T, _y: T) -> T;
+pub unsafe fn simd_saturating_add<T>(x: T, y: T) -> T;
 
 /// Subtracts two simd vectors elementwise, with saturation.
 ///
@@ -369,7 +369,7 @@ pub unsafe fn simd_saturating_add<T>(_x: T, _y: T) -> T;
 /// Subtract `rhs` from `lhs`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_saturating_sub<T>(_lhs: T, _rhs: T) -> T;
+pub unsafe fn simd_saturating_sub<T>(lhs: T, rhs: T) -> T;
 
 /// Adds elements within a vector from left to right.
 ///
@@ -380,7 +380,7 @@ pub unsafe fn simd_saturating_sub<T>(_lhs: T, _rhs: T) -> T;
 /// Starting with the value `y`, add the elements of `x` and accumulate.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_add_ordered<T, U>(_x: T, _y: U) -> U;
+pub unsafe fn simd_reduce_add_ordered<T, U>(x: T, y: U) -> U;
 
 /// Adds elements within a vector in arbitrary order. May also be re-associated with
 /// unordered additions on the inputs/outputs.
@@ -390,7 +390,7 @@ pub unsafe fn simd_reduce_add_ordered<T, U>(_x: T, _y: U) -> U;
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_add_unordered<T, U>(_x: T) -> U;
+pub unsafe fn simd_reduce_add_unordered<T, U>(x: T) -> U;
 
 /// Multiplies elements within a vector from left to right.
 ///
@@ -401,7 +401,7 @@ pub unsafe fn simd_reduce_add_unordered<T, U>(_x: T) -> U;
 /// Starting with the value `y`, multiply the elements of `x` and accumulate.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_mul_ordered<T, U>(_x: T, _y: U) -> U;
+pub unsafe fn simd_reduce_mul_ordered<T, U>(x: T, y: U) -> U;
 
 /// Multiplies elements within a vector in arbitrary order. May also be re-associated with
 /// unordered additions on the inputs/outputs.
@@ -411,7 +411,7 @@ pub unsafe fn simd_reduce_mul_ordered<T, U>(_x: T, _y: U) -> U;
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_mul_unordered<T, U>(_x: T) -> U;
+pub unsafe fn simd_reduce_mul_unordered<T, U>(x: T) -> U;
 
 /// Checks if all mask values are true.
 ///
@@ -421,7 +421,7 @@ pub unsafe fn simd_reduce_mul_unordered<T, U>(_x: T) -> U;
 /// `x` must contain only `0` or `!0`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_all<T>(_x: T) -> bool;
+pub unsafe fn simd_reduce_all<T>(x: T) -> bool;
 
 /// Checks if any mask value is true.
 ///
@@ -431,7 +431,7 @@ pub unsafe fn simd_reduce_all<T>(_x: T) -> bool;
 /// `x` must contain only `0` or `!0`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_any<T>(_x: T) -> bool;
+pub unsafe fn simd_reduce_any<T>(x: T) -> bool;
 
 /// Returns the maximum element of a vector.
 ///
@@ -442,7 +442,7 @@ pub unsafe fn simd_reduce_any<T>(_x: T) -> bool;
 /// For floating-point values, uses IEEE-754 `maxNum`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_max<T, U>(_x: T) -> U;
+pub unsafe fn simd_reduce_max<T, U>(x: T) -> U;
 
 /// Returns the minimum element of a vector.
 ///
@@ -453,7 +453,7 @@ pub unsafe fn simd_reduce_max<T, U>(_x: T) -> U;
 /// For floating-point values, uses IEEE-754 `minNum`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_min<T, U>(_x: T) -> U;
+pub unsafe fn simd_reduce_min<T, U>(x: T) -> U;
 
 /// Logical "ands" all elements together.
 ///
@@ -462,7 +462,7 @@ pub unsafe fn simd_reduce_min<T, U>(_x: T) -> U;
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_and<T, U>(_x: T) -> U;
+pub unsafe fn simd_reduce_and<T, U>(x: T) -> U;
 
 /// Logical "ors" all elements together.
 ///
@@ -471,7 +471,7 @@ pub unsafe fn simd_reduce_and<T, U>(_x: T) -> U;
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_or<T, U>(_x: T) -> U;
+pub unsafe fn simd_reduce_or<T, U>(x: T) -> U;
 
 /// Logical "exclusive ors" all elements together.
 ///
@@ -480,7 +480,7 @@ pub unsafe fn simd_reduce_or<T, U>(_x: T) -> U;
 /// `U` must be the element type of `T`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_reduce_xor<T, U>(_x: T) -> U;
+pub unsafe fn simd_reduce_xor<T, U>(x: T) -> U;
 
 /// Truncates an integer vector to a bitmask.
 ///
@@ -517,7 +517,7 @@ pub unsafe fn simd_reduce_xor<T, U>(_x: T) -> U;
 /// `x` must contain only `0` and `!0`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_bitmask<T, U>(_x: T) -> U;
+pub unsafe fn simd_bitmask<T, U>(x: T) -> U;
 
 /// Selects elements from a mask.
 ///
@@ -533,7 +533,7 @@ pub unsafe fn simd_bitmask<T, U>(_x: T) -> U;
 /// `mask` must only contain `0` and `!0`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_select<M, T>(_mask: M, _if_true: T, _if_false: T) -> T;
+pub unsafe fn simd_select<M, T>(mask: M, if_true: T, if_false: T) -> T;
 
 /// Selects elements from a bitmask.
 ///
@@ -551,7 +551,7 @@ pub unsafe fn simd_select<M, T>(_mask: M, _if_true: T, _if_false: T) -> T;
 /// Padding bits must be all zero.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_select_bitmask<M, T>(_m: M, _yes: T, _no: T) -> T;
+pub unsafe fn simd_select_bitmask<M, T>(m: M, yes: T, no: T) -> T;
 
 /// Calculates the offset from a pointer vector elementwise, potentially
 /// wrapping.
@@ -563,14 +563,14 @@ pub unsafe fn simd_select_bitmask<M, T>(_m: M, _yes: T, _no: T) -> T;
 /// Operates as if by `<ptr>::wrapping_offset`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_arith_offset<T, U>(_ptr: T, _offset: U) -> T;
+pub unsafe fn simd_arith_offset<T, U>(ptr: T, offset: U) -> T;
 
 /// Casts a vector of pointers.
 ///
 /// `T` and `U` must be vectors of pointers with the same number of elements.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_cast_ptr<T, U>(_ptr: T) -> U;
+pub unsafe fn simd_cast_ptr<T, U>(ptr: T) -> U;
 
 /// Exposes a vector of pointers as a vector of addresses.
 ///
@@ -579,7 +579,7 @@ pub unsafe fn simd_cast_ptr<T, U>(_ptr: T) -> U;
 /// `U` must be a vector of `usize` with the same length as `T`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_expose_provenance<T, U>(_ptr: T) -> U;
+pub unsafe fn simd_expose_provenance<T, U>(ptr: T) -> U;
 
 /// Creates a vector of pointers from a vector of addresses.
 ///
@@ -588,56 +588,56 @@ pub unsafe fn simd_expose_provenance<T, U>(_ptr: T) -> U;
 /// `U` must be a vector of pointers, with the same length as `T`.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_with_exposed_provenance<T, U>(_addr: T) -> U;
+pub unsafe fn simd_with_exposed_provenance<T, U>(addr: T) -> U;
 
 /// Swaps bytes of each element.
 ///
 /// `T` must be a vector of integers.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_bswap<T>(_x: T) -> T;
+pub unsafe fn simd_bswap<T>(x: T) -> T;
 
 /// Reverses bits of each element.
 ///
 /// `T` must be a vector of integers.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_bitreverse<T>(_x: T) -> T;
+pub unsafe fn simd_bitreverse<T>(x: T) -> T;
 
 /// Counts the leading zeros of each element.
 ///
 /// `T` must be a vector of integers.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_ctlz<T>(_x: T) -> T;
+pub unsafe fn simd_ctlz<T>(x: T) -> T;
 
 /// Counts the number of ones in each element.
 ///
 /// `T` must be a vector of integers.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_ctpop<T>(_x: T) -> T;
+pub unsafe fn simd_ctpop<T>(x: T) -> T;
 
 /// Counts the trailing zeros of each element.
 ///
 /// `T` must be a vector of integers.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_cttz<T>(_x: T) -> T;
+pub unsafe fn simd_cttz<T>(x: T) -> T;
 
 /// Rounds up each element to the next highest integer-valued float.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_ceil<T>(_x: T) -> T;
+pub unsafe fn simd_ceil<T>(x: T) -> T;
 
 /// Rounds down each element to the next lowest integer-valued float.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_floor<T>(_x: T) -> T;
+pub unsafe fn simd_floor<T>(x: T) -> T;
 
 /// Rounds each element to the closest integer-valued float.
 /// Ties are resolved by rounding away from 0.
@@ -645,7 +645,7 @@ pub unsafe fn simd_floor<T>(_x: T) -> T;
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_round<T>(_x: T) -> T;
+pub unsafe fn simd_round<T>(x: T) -> T;
 
 /// Returns the integer part of each element as an integer-valued float.
 /// In other words, non-integer values are truncated towards zero.
@@ -653,21 +653,21 @@ pub unsafe fn simd_round<T>(_x: T) -> T;
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_trunc<T>(_x: T) -> T;
+pub unsafe fn simd_trunc<T>(x: T) -> T;
 
 /// Takes the square root of each element.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_fsqrt<T>(_x: T) -> T;
+pub unsafe fn simd_fsqrt<T>(x: T) -> T;
 
 /// Computes `(x*y) + z` for each element, but without any intermediate rounding.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_fma<T>(_x: T, _y: T, _z: T) -> T;
+pub unsafe fn simd_fma<T>(x: T, y: T, z: T) -> T;
 
 /// Computes `(x*y) + z` for each element, non-deterministically executing either
 /// a fused multiply-add or two operations with rounding of the intermediate result.
@@ -682,53 +682,53 @@ pub unsafe fn simd_fma<T>(_x: T, _y: T, _z: T) -> T;
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_relaxed_fma<T>(_x: T, _y: T, _z: T) -> T;
+pub unsafe fn simd_relaxed_fma<T>(x: T, y: T, z: T) -> T;
 
 // Computes the sine of each element.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_fsin<T>(_a: T) -> T;
+pub unsafe fn simd_fsin<T>(a: T) -> T;
 
 // Computes the cosine of each element.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_fcos<T>(_a: T) -> T;
+pub unsafe fn simd_fcos<T>(a: T) -> T;
 
 // Computes the exponential function of each element.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_fexp<T>(_a: T) -> T;
+pub unsafe fn simd_fexp<T>(a: T) -> T;
 
 // Computes 2 raised to the power of each element.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_fexp2<T>(_a: T) -> T;
+pub unsafe fn simd_fexp2<T>(a: T) -> T;
 
 // Computes the base 10 logarithm of each element.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_flog10<T>(_a: T) -> T;
+pub unsafe fn simd_flog10<T>(a: T) -> T;
 
 // Computes the base 2 logarithm of each element.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_flog2<T>(_a: T) -> T;
+pub unsafe fn simd_flog2<T>(a: T) -> T;
 
 // Computes the natural logarithm of each element.
 ///
 /// `T` must be a vector of floats.
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_flog<T>(_a: T) -> T;
+pub unsafe fn simd_flog<T>(a: T) -> T;

--- a/src/tools/miri/tests/fail/intrinsics/copy_overlapping.rs
+++ b/src/tools/miri/tests/fail/intrinsics/copy_overlapping.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn copy_nonoverlapping<T>(_src: *const T, _dst: *mut T, _count: usize);
+unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
 
 fn main() {
     let mut data = [0u8; 16];

--- a/src/tools/miri/tests/fail/intrinsics/copy_unaligned.rs
+++ b/src/tools/miri/tests/fail/intrinsics/copy_unaligned.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn copy_nonoverlapping<T>(_src: *const T, _dst: *mut T, _count: usize);
+unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
 
 fn main() {
     let mut data = [0u16; 8];

--- a/src/tools/miri/tests/fail/intrinsics/ctlz_nonzero.rs
+++ b/src/tools/miri/tests/fail/intrinsics/ctlz_nonzero.rs
@@ -2,7 +2,7 @@
 
 mod rusti {
     #[rustc_intrinsic]
-    pub unsafe fn ctlz_nonzero<T>(_x: T) -> u32;
+    pub unsafe fn ctlz_nonzero<T>(x: T) -> u32;
 }
 
 pub fn main() {

--- a/src/tools/miri/tests/fail/intrinsics/cttz_nonzero.rs
+++ b/src/tools/miri/tests/fail/intrinsics/cttz_nonzero.rs
@@ -2,7 +2,7 @@
 
 mod rusti {
     #[rustc_intrinsic]
-    pub unsafe fn cttz_nonzero<T>(_x: T) -> u32;
+    pub unsafe fn cttz_nonzero<T>(x: T) -> u32;
 }
 
 pub fn main() {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_32_inf1.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_32_inf1.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_32_infneg1.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_32_infneg1.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_32_nan.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_32_nan.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_32_nanneg.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_32_nanneg.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_32_neg.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_32_neg.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_32_too_big1.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_32_too_big1.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_32_too_big2.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_32_too_big2.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_32_too_small1.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_32_too_small1.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_inf1.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_inf1.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_infneg1.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_infneg1.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_infneg2.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_infneg2.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_nan.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_nan.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_neg.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_neg.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big1.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big1.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big2.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big2.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big3.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big3.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big4.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big4.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big5.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big5.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big6.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big6.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big7.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_big7.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_small1.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_small1.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_small2.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_small2.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_small3.rs
+++ b/src/tools/miri/tests/fail/intrinsics/float_to_int_64_too_small3.rs
@@ -2,7 +2,7 @@
 
 // Directly call intrinsic to avoid debug assertions in libstd
 #[rustc_intrinsic]
-unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(_value: Float) -> Int;
+unsafe fn float_to_int_unchecked<Float: Copy, Int: Copy>(value: Float) -> Int;
 
 fn main() {
     unsafe {

--- a/src/tools/miri/tests/pass/intrinsics/portable-simd.rs
+++ b/src/tools/miri/tests/pass/intrinsics/portable-simd.rs
@@ -16,7 +16,7 @@ use std::simd::prelude::*;
 
 #[rustc_intrinsic]
 #[rustc_nounwind]
-pub unsafe fn simd_shuffle_const_generic<T, U, const IDX: &'static [u32]>(_x: T, _y: T) -> U;
+pub unsafe fn simd_shuffle_const_generic<T, U, const IDX: &'static [u32]>(x: T, y: T) -> U;
 
 fn simd_ops_f32() {
     let a = f32x4::splat(10.0);


### PR DESCRIPTION
This is unnecessary since https://github.com/rust-lang/rust/pull/135840.