### PR TITLE
Delegation: allow foreign fns `reuse`

### DIFF
--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -753,6 +753,11 @@ impl UnsafeOpKind {
         span: Span,
         suggest_unsafe_block: bool,
     ) {
+        if tcx.hir_opt_delegation_sig_id(hir_id.owner.def_id).is_some() {
+            // The body of the delegation item is synthesized, so it makes no sense
+            // to emit this lint.
+            return;
+        }
         let parent_id = tcx.hir_get_parent_item(hir_id);
         let parent_owner = tcx.hir_owner_node(parent_id);
         let should_suggest = parent_owner.fn_sig().is_some_and(|sig| {

--- a/tests/ui/delegation/foreign-fn.rs
+++ b/tests/ui/delegation/foreign-fn.rs
@@ -1,0 +1,22 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+#![deny(unsafe_op_in_unsafe_fn)]
+#![deny(unused_unsafe)]
+
+mod to_reuse {
+    unsafe extern "C" {
+        pub fn default_unsafe_foo();
+        pub unsafe fn unsafe_foo();
+        pub safe fn safe_foo();
+    }
+}
+
+reuse to_reuse::{default_unsafe_foo, unsafe_foo, safe_foo};
+
+fn main() {
+    let _: extern "C" fn() = default_unsafe_foo;
+    //~^ ERROR mismatched types
+    let _: extern "C" fn() = unsafe_foo;
+    //~^ ERROR mismatched types
+    let _: extern "C" fn() = safe_foo;
+}

--- a/tests/ui/delegation/foreign-fn.stderr
+++ b/tests/ui/delegation/foreign-fn.stderr
@@ -1,0 +1,27 @@
+error[E0308]: mismatched types
+  --> $DIR/foreign-fn.rs:17:30
+   |
+LL |     let _: extern "C" fn() = default_unsafe_foo;
+   |            ---------------   ^^^^^^^^^^^^^^^^^^ expected safe fn, found unsafe fn
+   |            |
+   |            expected due to this
+   |
+   = note: expected fn pointer `extern "C" fn()`
+                 found fn item `unsafe extern "C" fn() {default_unsafe_foo}`
+   = note: unsafe functions cannot be coerced into safe function pointers
+
+error[E0308]: mismatched types
+  --> $DIR/foreign-fn.rs:19:30
+   |
+LL |     let _: extern "C" fn() = unsafe_foo;
+   |            ---------------   ^^^^^^^^^^ expected safe fn, found unsafe fn
+   |            |
+   |            expected due to this
+   |
+   = note: expected fn pointer `extern "C" fn()`
+                 found fn item `unsafe extern "C" fn() {unsafe_foo}`
+   = note: unsafe functions cannot be coerced into safe function pointers
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION

In example:
```rust
unsafe extern "C" {
    fn foo();
}

reuse foo as bar;
```

Desugaring before:

```rust
fn bar() {
    foo()
    //~^ ERROR call to unsafe function `foo` is unsafe and requires unsafe function or block
}
```

after:

```rust
unsafe extern "C" fn bar() {
    foo()
}
```

Fixes https://github.com/rust-lang/rust/issues/127412

r? @petrochenkov