### PR TITLE
Delegation: one more ICE fix for `MethodCall` generation

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -330,6 +330,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             .unwrap_or_default()
             && delegation.qself.is_none()
             && !has_generic_args
+            && !args.is_empty()
         {
             let ast_segment = delegation.path.segments.last().unwrap();
             let segment = self.lower_path_segment(

--- a/tests/ui/delegation/ice-issue-138362.rs
+++ b/tests/ui/delegation/ice-issue-138362.rs
@@ -1,0 +1,15 @@
+#![feature(fn_delegation)]
+#![allow(incomplete_features)]
+
+trait HasSelf {
+    fn method(self);
+}
+trait NoSelf {
+    fn method();
+}
+impl NoSelf for u8 {
+    reuse HasSelf::method;
+    //~^ ERROR this function takes 1 argument but 0 arguments were supplied
+}
+
+fn main() {}

--- a/tests/ui/delegation/ice-issue-138362.stderr
+++ b/tests/ui/delegation/ice-issue-138362.stderr
@@ -1,0 +1,19 @@
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+  --> $DIR/ice-issue-138362.rs:11:20
+   |
+LL |     reuse HasSelf::method;
+   |                    ^^^^^^ argument #1 is missing
+   |
+note: method defined here
+  --> $DIR/ice-issue-138362.rs:5:8
+   |
+LL |     fn method(self);
+   |        ^^^^^^ ----
+help: provide the argument
+   |
+LL |     reuse HasSelf::method(/* value */);
+   |                          +++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
self-explanatory

Fixes https://github.com/rust-lang/rust/issues/138362

r? @petrochenkov