### PR TITLE
Tweak `VecCache` to improve performance

### DIFF
--- a/compiler/rustc_data_structures/src/vec_cache/tests.rs
+++ b/compiler/rustc_data_structures/src/vec_cache/tests.rs
@@ -69,6 +69,13 @@ fn slot_entries_table() {
 }
 
 #[test]
+fn bucket_entries_matches() {
+    for i in 0..BUCKETS {
+        assert_eq!(SlotIndex { bucket_idx: i, index_in_bucket: 0 }.entries(), ENTRIES_BY_BUCKET[i]);
+    }
+}
+
+#[test]
 #[cfg(not(miri))]
 fn slot_index_exhaustive() {
     let mut buckets = [0u32; 21];
@@ -81,14 +88,18 @@ fn slot_index_exhaustive() {
     let mut prev = slot_idx;
     for idx in 1..=u32::MAX {
         let slot_idx = SlotIndex::from_index(idx);
+
+        // SAFETY: Ensure indices don't go out of bounds of buckets.
+        assert!(slot_idx.index_in_bucket < slot_idx.entries());
+
         if prev.bucket_idx == slot_idx.bucket_idx {
             assert_eq!(prev.index_in_bucket + 1, slot_idx.index_in_bucket);
         } else {
             assert_eq!(slot_idx.index_in_bucket, 0);
         }
 
-        assert_eq!(buckets[slot_idx.bucket_idx], slot_idx.entries as u32);
-        assert_eq!(ENTRIES_BY_BUCKET[slot_idx.bucket_idx], slot_idx.entries, "{}", idx);
+        assert_eq!(buckets[slot_idx.bucket_idx], slot_idx.entries() as u32);
+        assert_eq!(ENTRIES_BY_BUCKET[slot_idx.bucket_idx], slot_idx.entries(), "{}", idx);
 
         prev = slot_idx;
     }


### PR DESCRIPTION
This has some tweaks to `VecCache` to improve performance.

- It saves a `compare_exchange` in `complete` using the new `put_unique` function.
- It removes bound checks on entries. These are instead checked in the `slot_index_exhaustive` test.
- `initialize_bucket` is outlined and tuned for that.

cc @Mark-Simulacrum 