### PR TITLE
Use sa_sigaction instead of sa_union.__su_sigaction for AIX

### DIFF
--- a/tests/ui/runtime/on-broken-pipe/auxiliary/assert-sigpipe-disposition.rs
+++ b/tests/ui/runtime/on-broken-pipe/auxiliary/assert-sigpipe-disposition.rs
@@ -26,14 +26,7 @@ extern "C" fn main(argc: core::ffi::c_int, argv: *const *const u8) -> core::ffi:
     let actual = unsafe {
         let mut actual: libc::sigaction = core::mem::zeroed();
         libc::sigaction(libc::SIGPIPE, core::ptr::null(), &mut actual);
-        #[cfg(not(target_os = "aix"))]
-        {
-            actual.sa_sigaction
-        }
-        #[cfg(target_os = "aix")]
-        {
-            actual.sa_union.__su_sigaction as libc::sighandler_t
-        }
+        actual.sa_sigaction
     };
 
     assert_eq!(actual, expected, "actual and expected SIGPIPE disposition in child differs");

--- a/tests/ui/runtime/on-broken-pipe/auxiliary/sigpipe-utils.rs
+++ b/tests/ui/runtime/on-broken-pipe/auxiliary/sigpipe-utils.rs
@@ -20,14 +20,7 @@ pub fn assert_sigpipe_handler(expected_handler: SignalHandler) {
         let actual = unsafe {
             let mut actual: libc::sigaction = std::mem::zeroed();
             libc::sigaction(libc::SIGPIPE, std::ptr::null(), &mut actual);
-            #[cfg(not(target_os = "aix"))]
-            {
-                actual.sa_sigaction
-            }
-            #[cfg(target_os = "aix")]
-            {
-                actual.sa_union.__su_sigaction as libc::sighandler_t
-            }
+            actual.sa_sigaction
         };
 
         let expected = match expected_handler {

--- a/tests/ui/runtime/signal-alternate-stack-cleanup.rs
+++ b/tests/ui/runtime/signal-alternate-stack-cleanup.rs
@@ -29,14 +29,7 @@ fn main() {
         // Install signal handler that runs on alternate signal stack.
         let mut action: sigaction = std::mem::zeroed();
         action.sa_flags = (SA_ONSTACK | SA_SIGINFO) as _;
-        #[cfg(not(target_os = "aix"))]
-        {
-            action.sa_sigaction = signal_handler as sighandler_t;
-        }
-        #[cfg(target_os = "aix")]
-        {
-            action.sa_union.__su_sigaction = signal_handler as sighandler_t;
-        }
+        action.sa_sigaction = signal_handler as sighandler_t;
         sigaction(SIGWINCH, &action, std::ptr::null_mut());
 
         // Send SIGWINCH on exit.


### PR DESCRIPTION
Revert test cases to use `sa_sigaction` instead of `sa_union.__su_sigaction`, now that the `libc` crate implementation for AIX defines `sa_sigaction` as a direct member of `struct sigaction`, aligning it with implementations on other similar platforms. ([[AIX] Use sa_sigaction instead of the union](https://github.com/rust-lang/libc/pull/4250)).

 <!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
