### PR TITLE
Install licenses into `share/doc/rust/licenses`

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -519,7 +519,7 @@ impl Step for Rustc {
 
             // The REUSE-managed license files
             let license = |path: &Path| {
-                builder.install(path, &image.join("share/doc/rust/licences"), 0o644);
+                builder.install(path, &image.join("share/doc/rust/licenses"), 0o644);
             };
             for entry in t!(std::fs::read_dir(builder.src.join("LICENSES"))).flatten() {
                 license(&entry.path());


### PR DESCRIPTION
This changes the path from "licences" to "licenses" for consistency
across the repo, including the usage directly around this line. This is
a US/UK spelling difference, but I believe the US spelling is also more
common in open source in general.
