### PR TITLE
Fix `x86_64-unknown-illumos` LLVM target triple

### DIFF
--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_illumos.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_illumos.rs
@@ -11,7 +11,7 @@ pub(crate) fn target() -> Target {
     Target {
         // LLVM does not currently have a separate illumos target,
         // so we still pass Solaris to it
-        llvm_target: "x86_64-pc-solaris".into(),
+        llvm_target: "x86_64-unknown-solaris".into(),
         metadata: TargetMetadata {
             description: Some("illumos".into()),
             tier: Some(2),


### PR DESCRIPTION
We were passing "pc" as the vendor component, which isn't present in the rustc triple, and is inconsistent with the Aarch64 target.

Motivation: To make it easier to verify that [`cc-rs`' conversion from `rustc` to Clang/LLVM triples](https://github.com/rust-lang/cc-rs/issues/1431) is correct.

CC target maintainers @jclulow and @pfmooney.
r? jieyouxu