### PR TITLE
fix: remove the check of lld not supporting @response-file

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/command.rs
+++ b/compiler/rustc_codegen_ssa/src/back/command.rs
@@ -143,13 +143,6 @@ impl Command {
             return false;
         }
 
-        // Right now LLD doesn't support the `@` syntax of passing an argument
-        // through files, so regardless of the platform we try to go to the OS
-        // on this one.
-        if let Program::Lld(..) = self.program {
-            return false;
-        }
-
         // Ok so on Windows to spawn a process is 32,768 characters in its
         // command line [1]. Unfortunately we don't actually have access to that
         // as it's calculated just before spawning. Instead we perform a


### PR DESCRIPTION
In LLVM v9, lld has supported @response-file.
LLVM v9 was released on 2019-09-19.
The check was added back to 2018-03-14 (1.26.0) via 04442af18bf0.
It has been more than five years, and we ship our own lld regardlessly.
This should be happily removed.

See also:

* <https://github.com/llvm/llvm-project/commit/bb12396f9175eaf4586d8e5c76441977d97ccf93>
* <https://reviews.llvm.org/D63024>
