### PR TITLE
Visit `PatField` when collecting lint levels

### DIFF
--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -299,6 +299,11 @@ impl<'tcx> Visitor<'tcx> for LintLevelsBuilder<'_, LintLevelQueryMap<'tcx>> {
         intravisit::walk_expr(self, e);
     }
 
+    fn visit_pat_field(&mut self, f: &'tcx hir::PatField<'tcx>) -> Self::Result {
+        self.add_id(f.hir_id);
+        intravisit::walk_pat_field(self, f);
+    }
+
     fn visit_expr_field(&mut self, f: &'tcx hir::ExprField<'tcx>) {
         self.add_id(f.hir_id);
         intravisit::walk_expr_field(self, f);

--- a/tests/ui/lint/unused/unused-field-in-pat-field.rs
+++ b/tests/ui/lint/unused/unused-field-in-pat-field.rs
@@ -1,0 +1,21 @@
+//@ check-pass
+
+// Ensure we collect lint levels from pat fields in structs.
+
+#![deny(unused_variables)]
+
+pub struct Foo {
+    bar: u32,
+    baz: u32,
+}
+
+pub fn test(foo: Foo) {
+    let Foo {
+        #[allow(unused_variables)]
+        bar,
+        #[allow(unused_variables)]
+        baz,
+    } = foo;
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #138428

Side-note, I vaguely skimmed over the other nodes we could be visiting here and it doesn't *seem* to me that we're missing anything, though I may be mistaken given recent(?) support for attrs in where clauses(??). Can be fixed in a follow-up PR.