### PR TITLE
rustdoc: Doctest merging: Remove superfluous library search path logic

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -672,18 +672,6 @@ fn run_test(
             "--extern=doctest_bundle_{edition}=",
             edition = doctest.edition
         ));
-        for extern_str in &rustdoc_options.extern_strs {
-            if let Some((_cratename, path)) = extern_str.split_once('=') {
-                // Direct dependencies of the tests themselves are
-                // indirect dependencies of the test runner.
-                // They need to be in the library search path.
-                let dir = Path::new(path)
-                    .parent()
-                    .filter(|x| x.components().count() > 0)
-                    .unwrap_or(Path::new("."));
-                runner_compiler.arg("-L").arg(dir);
-            }
-        }
         let output_bundle_file = doctest
             .test_opts
             .outdir

--- a/tests/run-make/doctests-merge-with-deps/dep_a.rs
+++ b/tests/run-make/doctests-merge-with-deps/dep_a.rs
@@ -1,0 +1,1 @@
+pub const STATUS: bool = dep_a_a::STATUS;

--- a/tests/run-make/doctests-merge-with-deps/dep_b.rs
+++ b/tests/run-make/doctests-merge-with-deps/dep_b.rs
@@ -1,0 +1,1 @@
+pub const STATUS: bool = dep_b_b::STATUS;

--- a/tests/run-make/doctests-merge-with-deps/deps/dep_a_a.rs
+++ b/tests/run-make/doctests-merge-with-deps/deps/dep_a_a.rs
@@ -1,0 +1,1 @@
+pub const STATUS: bool = true;

--- a/tests/run-make/doctests-merge-with-deps/deps/dep_b_b.rs
+++ b/tests/run-make/doctests-merge-with-deps/deps/dep_b_b.rs
@@ -1,0 +1,1 @@
+pub const STATUS: bool = true;

--- a/tests/run-make/doctests-merge-with-deps/doctest.rs
+++ b/tests/run-make/doctests-merge-with-deps/doctest.rs
@@ -1,0 +1,7 @@
+//! ```
+//! assert!(dep_a::STATUS);
+//! ```
+//!
+//! ```
+//! assert!(dep_b::STATUS);
+//! ```

--- a/tests/run-make/doctests-merge-with-deps/rmake.rs
+++ b/tests/run-make/doctests-merge-with-deps/rmake.rs
@@ -1,0 +1,68 @@
+//! Since PR <https://github.com/rust-lang/rust/pull/137899>, merged doctests reside in so-called
+//! "bundle" crates which are separate from the actual "runner" crates that contain the necessary
+//! scaffolding / infrastructure for executing the tests by utilizing the unstable crate `test`
+//! and the internal lang feature `rustc_attrs`.
+//!
+//! In the light of this two-crate setup (per edition), this test ensures that rustdoc can handle
+//! mergeable doctests with direct and transitive dependencies (which would become ("first-degree")
+//! transitive and "second-degree" transitive dependencies of the runner crates, respectively).
+//!
+//! While this is about doctest merging which is only available in Rust 2024 and beyond,
+//! we also test Rust 2021 here to ensure that in this specific scenario rustdoc doesn't
+//! grossly diverge in observable behavior.
+
+use run_make_support::{bare_rustc, rustdoc};
+
+fn main() {
+    // Re. `bare_rustc` over `rustc` (which would implicitly add `-L.`):
+    // This test is all about verifying that rustdoc is able to find dependencies
+    // and properly propagates library search paths etc.
+    // Anything implicit like that would only obfuscate this test or even
+    // accidentally break it.
+
+    //
+    // Build crate `a_a` and its dependent `a` which is the direct dependency of
+    // the doctests inside `doctest.rs` *and* of crate `doctest` itself!
+    //
+
+    bare_rustc().current_dir("deps").input("dep_a_a.rs").crate_type("lib").run();
+
+    bare_rustc().input("dep_a.rs").crate_type("lib").args(["--extern=dep_a_a", "-Ldeps"]).run();
+
+    //
+    // Build crate `b_b` and its dependent `b` which is the direct dependency of
+    // the first doctest in `doctest.rs` *but not* of crate `doctest` itself!
+    //
+
+    bare_rustc().current_dir("deps").input("dep_b_b.rs").crate_type("lib").run();
+
+    bare_rustc().input("dep_b.rs").crate_type("lib").args(["--extern=dep_b_b", "-Ldeps"]).run();
+
+    //
+    // Collect and run the doctests inside `doctest.rs`.
+    //
+
+    for edition in ["2021", "2024"] {
+        // NB: `-Ldependency=<path>` only adds *transitive* dependencies to
+        //     the search path contrary to `-L<path>`.
+
+        rustdoc()
+            .input("doctest.rs")
+            .crate_type("lib")
+            .edition(edition)
+            // Adds crate `a` as a dep of `doctest` *and* its contained doctests.
+            // Also registers transitive dependencies.
+            .extern_("dep_a", "libdep_a.rlib")
+            .arg("-Ldependency=deps")
+            // Adds crate `b` as a dep of `doctest`'s contained doctests.
+            // Also registers transitive dependencies.
+            .args([
+                "-Zunstable-options",
+                "--doctest-compilation-args",
+                "--extern=dep_b=libdep_b.rlib -Ldependency=deps",
+            ])
+            .arg("--test")
+            .arg("--test-args=--test-threads=1")
+            .run();
+    }
+}


### PR DESCRIPTION
Implements: https://github.com/rust-lang/rust/pull/137899#discussion_r1986463750. Abridged:

> I'm wondering, is \[copying `--extern`s from bundle crates to runner crates as `-L`s] actually necessary? Did you have a concrete case where this was needed?
>
> Locally I've experimented with the consequences of removing it, couldn't find any problems and all tests pass without it, too. It's possible that I missed something.
>
> Everything seems to work out just fine without this extra logic because any `--extern`s and `-L`s (most likely `-Ldependency=`s from Cargo) passed to rustdoc for the "overarching host crate" (the crate containing the doctest) get stuffed into the args file `rustdoc-cfgs` which we use for compiling both the bundle and the runner.

With `COMPILETEST_FORCE_STAGE0=1 ./x t --stage 0 tests/run-make/doctests-merge-with-deps` you should be able to verify that the test also passes on master.

r? notriddle or reassign and no rush