### PR TITLE
Remove `RUN_CHECK_WITH_PARALLEL_QUERIES`

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
@@ -30,7 +30,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS 1
-ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
 
 # llvm.use-linker conflicts with downloading CI LLVM
 ENV NO_DOWNLOAD_CI_LLVM 1

--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -41,8 +41,6 @@ COPY host-x86_64/mingw-check/check-default-config-profiles.sh /scripts/
 COPY host-x86_64/mingw-check/validate-toolstate.sh /scripts/
 COPY host-x86_64/mingw-check/validate-error-codes.sh /scripts/
 
-ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
-
 # Check library crates on all tier 1 targets.
 # We disable optimized compiler built-ins because that requires a C toolchain for the target.
 # We also skip the x86_64-unknown-linux-gnu target as it is well-tested by other jobs.

--- a/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
@@ -30,7 +30,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS 1
-ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
 
 # llvm.use-linker conflicts with downloading CI LLVM
 ENV NO_DOWNLOAD_CI_LLVM 1

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -260,19 +260,6 @@ else
   do_make "$RUST_CHECK_TARGET"
 fi
 
-if [ "$RUN_CHECK_WITH_PARALLEL_QUERIES" != "" ]; then
-  rm -f config.toml
-  $SRC/configure --set change-id=99999999
-
-  # Save the build metrics before we wipe the directory
-  mv build/metrics.json .
-  rm -rf build
-  mkdir build
-  mv metrics.json build
-
-  CARGO_INCREMENTAL=0 ../x check
-fi
-
 echo "::group::sccache stats"
 sccache --show-stats || true
 echo "::endgroup::"


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/132282, I'm pretty sure that this is simply useless? It just runs check with an empty config, lol.

CC @onur-ozkan

r? @Noratrieb