### PR TITLE
Remove usage of legacy scheme paths on RedoxOS

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -294,11 +294,6 @@ where
     }
 }
 
-// Detect scheme on Redox
-pub(crate) fn has_redox_scheme(s: &[u8]) -> bool {
-    cfg!(target_os = "redox") && s.contains(&b':')
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Cross-platform, iterator-independent parsing
 ////////////////////////////////////////////////////////////////////////////////
@@ -2834,8 +2829,7 @@ impl Path {
         Components {
             path: self.as_u8_slice(),
             prefix,
-            has_physical_root: has_physical_root(self.as_u8_slice(), prefix)
-                || has_redox_scheme(self.as_u8_slice()),
+            has_physical_root: has_physical_root(self.as_u8_slice(), prefix),
             front: State::Prefix,
             back: State::Body,
         }

--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -484,7 +484,12 @@ pub fn current_exe() -> io::Result<PathBuf> {
     }
 }
 
-#[cfg(any(target_os = "redox", target_os = "rtems"))]
+#[cfg(target_os = "redox")]
+pub fn current_exe() -> io::Result<PathBuf> {
+    crate::fs::read_to_string("/scheme/sys/exe").map(PathBuf::from)
+}
+
+#[cfg(target_os = "rtems")]
 pub fn current_exe() -> io::Result<PathBuf> {
     crate::fs::read_to_string("sys:exe").map(PathBuf::from)
 }

--- a/library/std/src/sys/pal/unix/process/process_common.rs
+++ b/library/std/src/sys/pal/unix/process/process_common.rs
@@ -19,8 +19,6 @@ use crate::{fmt, io, ptr};
 cfg_if::cfg_if! {
     if #[cfg(target_os = "fuchsia")] {
         // fuchsia doesn't have /dev/null
-    } else if #[cfg(target_os = "redox")] {
-        const DEV_NULL: &CStr = c"null:";
     } else if #[cfg(target_os = "vxworks")] {
         const DEV_NULL: &CStr = c"/null";
     } else {

--- a/library/std/src/sys/path/unix.rs
+++ b/library/std/src/sys/path/unix.rs
@@ -62,10 +62,7 @@ pub(crate) fn absolute(path: &Path) -> io::Result<PathBuf> {
 }
 
 pub(crate) fn is_absolute(path: &Path) -> bool {
-    if cfg!(target_os = "redox") {
-        // FIXME: Allow Redox prefixes
-        path.has_root() || crate::path::has_redox_scheme(path.as_u8_slice())
-    } else if cfg!(any(unix, target_os = "hermit", target_os = "wasi")) {
+    if cfg!(any(unix, target_os = "hermit", target_os = "wasi")) {
         path.has_root()
     } else {
         path.has_root() && path.prefix().is_some()


### PR DESCRIPTION
The `name:/path` path syntax is getting phased out[^1] in favor of `/scheme/name/path`. Also using `null:` is no longer necessary as `/dev/null` is available on Redox OS too.

[^1]: https://gitlab.redox-os.org/redox-os/rfcs/-/blob/master/text/0006-scheme-path.md

cc @jackpot51 