### PR TITLE
type privacy: Check constructor types in tuple struct patterns

### DIFF
--- a/tests/ui/privacy/private-in-public-tuple-struct-pat.rs
+++ b/tests/ui/privacy/private-in-public-tuple-struct-pat.rs
@@ -1,0 +1,36 @@
+mod m {
+    struct Priv;
+
+    #[allow(private_interfaces)]
+    pub struct PubStruct(pub Priv);
+    pub enum PubEnum {
+        #[allow(private_interfaces)]
+        Variant(Priv),
+    }
+
+    impl PubStruct {
+        pub fn new() -> PubStruct {
+            PubStruct(Priv)
+        }
+    }
+    impl PubEnum {
+        pub fn new() -> PubEnum {
+            PubEnum::Variant(Priv)
+        }
+    }
+}
+
+fn main() {
+    match m::PubStruct::new() {
+        m::PubStruct(_) => {} //~ ERROR type `Priv` is private
+        m::PubStruct(..) => {} //~ ERROR type `Priv` is private
+    }
+
+    match m::PubEnum::new() {
+        m::PubEnum::Variant(_) => {} //~ ERROR type `Priv` is private
+        m::PubEnum::Variant(..) => {} //~ ERROR type `Priv` is private
+    }
+
+    let _ = m::PubStruct; //~ ERROR type `Priv` is private
+    let _ = m::PubEnum::Variant; //~ ERROR type `Priv` is private
+}

--- a/tests/ui/privacy/private-in-public-tuple-struct-pat.stderr
+++ b/tests/ui/privacy/private-in-public-tuple-struct-pat.stderr
@@ -1,0 +1,38 @@
+error: type `Priv` is private
+  --> $DIR/private-in-public-tuple-struct-pat.rs:25:9
+   |
+LL |         m::PubStruct(_) => {}
+   |         ^^^^^^^^^^^^ private type
+
+error: type `Priv` is private
+  --> $DIR/private-in-public-tuple-struct-pat.rs:26:9
+   |
+LL |         m::PubStruct(..) => {}
+   |         ^^^^^^^^^^^^ private type
+
+error: type `Priv` is private
+  --> $DIR/private-in-public-tuple-struct-pat.rs:30:9
+   |
+LL |         m::PubEnum::Variant(_) => {}
+   |         ^^^^^^^^^^^^^^^^^^^ private type
+
+error: type `Priv` is private
+  --> $DIR/private-in-public-tuple-struct-pat.rs:31:9
+   |
+LL |         m::PubEnum::Variant(..) => {}
+   |         ^^^^^^^^^^^^^^^^^^^ private type
+
+error: type `Priv` is private
+  --> $DIR/private-in-public-tuple-struct-pat.rs:34:13
+   |
+LL |     let _ = m::PubStruct;
+   |             ^^^^^^^^^^^^ private type
+
+error: type `Priv` is private
+  --> $DIR/private-in-public-tuple-struct-pat.rs:35:13
+   |
+LL |     let _ = m::PubEnum::Variant;
+   |             ^^^^^^^^^^^^^^^^^^^ private type
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
This fixes a hole in type privacy checker that was noticed in https://github.com/rust-lang/rust/pull/137623.

In `TupleStruct(something)` expression the `TupleStruct` part has its type recorded and we are checking it, but in patterns only type of the whole pattern is kept, so we were missing the constructor's type in the privacy check.