### PR TITLE
Remove an outdated line from a test comment

### DIFF
--- a/tests/ui/cast/ptr-to-trait-obj-wrap.rs
+++ b/tests/ui/cast/ptr-to-trait-obj-wrap.rs
@@ -2,7 +2,6 @@
 // work. Note that the metadata doesn't change when a DST is wrapped in a
 // structure, so these casts *are* fine.
 //
-// `unwrap` and `unwrap_nested` currently don't work due to a compiler limitation.
 //@ check-pass
 
 trait A {}


### PR DESCRIPTION
They *used* to not work, however this was fixed in the PR that added the test. I forgot to remove this line or possibly lost its removal while rebasing.

r? @ehuss