### PR TITLE
Dedup `&mut *` reborrow suggestion in loops

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -181,7 +181,6 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             let closure = self.add_moved_or_invoked_closure_note(location, used_place, &mut err);
 
             let mut is_loop_move = false;
-            let mut in_pattern = false;
             let mut seen_spans = FxIndexSet::default();
 
             for move_site in &move_site_vec {
@@ -204,7 +203,6 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     self.suggest_ref_or_clone(
                         mpi,
                         &mut err,
-                        &mut in_pattern,
                         move_spans,
                         moved_place.as_ref(),
                         &mut has_suggest_reborrow,
@@ -255,15 +253,6 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             let mpi = self.move_data.moves[move_out_indices[0]].path;
             let place = &self.move_data.move_paths[mpi].place;
             let ty = place.ty(self.body, self.infcx.tcx).ty;
-
-            // If we're in pattern, we do nothing in favor of the previous suggestion (#80913).
-            // Same for if we're in a loop, see #101119.
-            if is_loop_move & !in_pattern && !matches!(use_spans, UseSpans::ClosureUse { .. }) {
-                if let ty::Ref(_, _, hir::Mutability::Mut) = ty.kind() {
-                    // We have a `&mut` ref, we need to reborrow on each iteration (#62112).
-                    self.suggest_reborrow(&mut err, span, moved_place);
-                }
-            }
 
             if self.infcx.param_env.caller_bounds().iter().any(|c| {
                 c.as_trait_clause().is_some_and(|pred| {
@@ -330,7 +319,6 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         &self,
         mpi: MovePathIndex,
         err: &mut Diag<'infcx>,
-        in_pattern: &mut bool,
         move_spans: UseSpans<'tcx>,
         moved_place: PlaceRef<'tcx>,
         has_suggest_reborrow: &mut bool,
@@ -545,7 +533,6 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 && !move_span.is_dummy()
                 && !self.infcx.tcx.sess.source_map().is_imported(move_span)
             {
-                *in_pattern = true;
                 let mut sugg = vec![(pat.span.shrink_to_lo(), "ref ".to_string())];
                 if let Some(pat) = finder.parent_pat {
                     sugg.insert(0, (pat.span.shrink_to_lo(), "ref ".to_string()));

--- a/tests/ui/borrowck/mut-borrow-in-loop-2.stderr
+++ b/tests/ui/borrowck/mut-borrow-in-loop-2.stderr
@@ -12,10 +12,6 @@ help: consider creating a fresh reborrow of `value` here
    |
 LL |         Other::handle(&mut *value);
    |                       ++++++
-help: consider creating a fresh reborrow of `value` here
-   |
-LL |         Other::handle(&mut *value);
-   |                       ++++++
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
#73534 added a reborrow suggestion in loops; #127579 generalized this to generic parameters, making the suggestion triggers twice:
```rs
use std::io::Read;

fn decode_scalar(_reader: impl Read) {}
fn decode_array(reader: &mut impl Read) {
    for _ in 0.. {
        decode_scalar(reader);
    }
}
```
```
error[E0382]: use of moved value: `reader`
 --> src/lib.rs:6:23
  |
4 | fn decode_array(reader: &mut impl Read) {
  |                 ------ move occurs because `reader` has type `&mut impl Read`, which does not implement the `Copy` trait
5 |     for _ in 0.. {
  |     ------------ inside of this loop
6 |         decode_scalar(reader);
  |                       ^^^^^^ value moved here, in previous iteration of loop
  |
help: consider creating a fresh reborrow of `reader` here
  |
6 |         decode_scalar(&mut *reader);
  |                       ++++++
help: consider creating a fresh reborrow of `reader` here
  |
6 |         decode_scalar(&mut *reader);
  |                       ++++++
```
This PR removes the suggestion in loops, as it requires generic parameters anyway (i.e., the reborrow is automatic if there is no generic params).

@rustbot label +A-borrow-checker +A-diagnostics +A-suggestion-diagnostics +D-papercut