### PR TITLE
Implement `feature(precise_capturing_of_types)`

### DIFF
--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -598,8 +598,10 @@ declare_features! (
     (incomplete, pin_ergonomics, "1.83.0", Some(130494)),
     /// Allows postfix match `expr.match { ... }`
     (unstable, postfix_match, "1.79.0", Some(121618)),
-    /// Allows `use<..>` precise capturign on impl Trait in traits.
+    /// Allows `use<..>` precise capturing on impl Trait in traits.
     (unstable, precise_capturing_in_traits, "1.83.0", Some(130044)),
+    /// Allows `use<..>` precise capturing to omit type and const parameters.
+    (incomplete, precise_capturing_of_types, "1.83.0", Some(130043)),
     /// Allows macro attributes on expressions, statements and non-inline modules.
     (unstable, proc_macro_hygiene, "1.30.0", Some(54727)),
     /// Allows the use of raw-dylibs on ELF platforms

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -284,15 +284,8 @@ hir_analysis_late_bound_lifetime_in_apit = `impl Trait` can only mention lifetim
 hir_analysis_late_bound_type_in_apit = `impl Trait` can only mention type parameters from an fn or impl
     .label = type parameter declared here
 
-hir_analysis_lifetime_implicitly_captured = `impl Trait` captures lifetime parameter, but it is not mentioned in `use<...>` precise captures list
-    .param_label = all lifetime parameters originating from a trait are captured implicitly
-
 hir_analysis_lifetime_must_be_first = lifetime parameter `{$name}` must be listed before non-lifetime parameters
     .label = move the lifetime before this parameter
-
-hir_analysis_lifetime_not_captured = `impl Trait` captures lifetime parameter, but it is not mentioned in `use<...>` precise captures list
-    .label = lifetime captured due to being mentioned in the bounds of the `impl Trait`
-    .param_label = this lifetime parameter is captured
 
 hir_analysis_lifetimes_or_bounds_mismatch_on_trait =
     lifetime parameters or bounds on {$item_kind} `{$ident}` do not match the trait declaration
@@ -412,6 +405,9 @@ hir_analysis_opaque_captures_higher_ranked_lifetime = `impl Trait` cannot captur
     .label = `impl Trait` implicitly captures all lifetimes in scope
     .note = lifetime declared here
 
+hir_analysis_param_implicitly_captured = `impl Trait` captures {$kind} parameter, but it is not mentioned in `use<...>` precise captures list
+    .param_label = all parameters originating from a trait are captured implicitly
+
 hir_analysis_param_in_ty_of_assoc_const_binding =
     the type of the associated constant `{$assoc_const}` must not depend on {$param_category ->
         [self] `Self`
@@ -428,7 +424,11 @@ hir_analysis_param_in_ty_of_assoc_const_binding =
         *[normal] the {$param_def_kind} `{$param_name}` is defined here
     }
 
-hir_analysis_param_not_captured = `impl Trait` must mention all {$kind} parameters in scope in `use<...>`
+hir_analysis_param_not_captured = `impl Trait` captures {$kind} parameter, but it is not mentioned in `use<...>` precise captures list
+    .label = {$kind} captured due to being mentioned in the bounds of the `impl Trait`
+    .param_label = this {$kind} parameter is captured
+
+hir_analysis_param_not_captured_forced = `impl Trait` must mention all {$kind} parameters in scope in `use<...>`
     .label = {$kind} parameter is implicitly captured by this `impl Trait`
     .note = currently, all {$kind} parameters are required to be mentioned in the precise captures list
 

--- a/compiler/rustc_hir_analysis/src/errors/precise_captures.rs
+++ b/compiler/rustc_hir_analysis/src/errors/precise_captures.rs
@@ -3,9 +3,9 @@ use rustc_macros::Diagnostic;
 use rustc_span::{Span, Symbol};
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis_param_not_captured)]
+#[diag(hir_analysis_param_not_captured_forced)]
 #[note]
-pub(crate) struct ParamNotCaptured {
+pub(crate) struct ParamNotCapturedForced {
     #[primary_span]
     pub opaque_span: Span,
     #[label]
@@ -24,23 +24,25 @@ pub(crate) struct SelfTyNotCaptured {
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis_lifetime_not_captured)]
-pub(crate) struct LifetimeNotCaptured {
+#[diag(hir_analysis_param_not_captured)]
+pub(crate) struct ParamNotCaptured {
     #[primary_span]
     pub use_span: Span,
     #[label(hir_analysis_param_label)]
     pub param_span: Span,
     #[label]
     pub opaque_span: Span,
+    pub kind: &'static str,
 }
 
 #[derive(Diagnostic)]
-#[diag(hir_analysis_lifetime_implicitly_captured)]
-pub(crate) struct LifetimeImplicitlyCaptured {
+#[diag(hir_analysis_param_implicitly_captured)]
+pub(crate) struct ParamImplicitlyCaptured {
     #[primary_span]
     pub opaque_span: Span,
     #[label(hir_analysis_param_label)]
     pub param_span: Span,
+    pub kind: &'static str,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_middle/messages.ftl
+++ b/compiler/rustc_middle/messages.ftl
@@ -46,9 +46,6 @@ middle_consider_type_length_limit =
 middle_const_eval_non_int =
     constant evaluation of enum discriminant resulted in non-integer
 
-middle_const_not_used_in_type_alias =
-    const parameter `{$ct}` is part of concrete type but not used in parameter list for the `impl Trait` type alias
-
 middle_deprecated = use of deprecated {$kind} `{$path}`{$has_note ->
         [true] : {$note}
         *[other] {""}

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -99,14 +99,6 @@ pub(crate) struct RequiresLangItem {
     pub name: Symbol,
 }
 
-#[derive(Diagnostic)]
-#[diag(middle_const_not_used_in_type_alias)]
-pub(super) struct ConstNotUsedTraitAlias {
-    pub ct: String,
-    #[primary_span]
-    pub span: Span,
-}
-
 pub struct CustomSubdiagnostic<'a> {
     pub msg: fn() -> DiagMessage,
     pub add_args: Box<dyn FnOnce(&mut dyn FnMut(DiagArgName, DiagArgValue)) + 'a>,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -771,6 +771,10 @@ impl<'tcx> rustc_type_ir::inherent::Features<TyCtxt<'tcx>> for &'tcx rustc_featu
     fn associated_const_equality(self) -> bool {
         self.associated_const_equality()
     }
+
+    fn precise_capturing_of_types(self) -> bool {
+        self.precise_capturing_of_types()
+    }
 }
 
 impl<'tcx> rustc_type_ir::inherent::Span<TyCtxt<'tcx>> for Span {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1570,6 +1570,7 @@ symbols! {
         pre_dash_lto: "pre-lto",
         precise_capturing,
         precise_capturing_in_traits,
+        precise_capturing_of_types,
         precise_pointer_size_matching,
         pref_align_of,
         prefetch_read_data,

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -575,6 +575,8 @@ pub trait Features<I: Interner>: Copy {
     fn coroutine_clone(self) -> bool;
 
     fn associated_const_equality(self) -> bool;
+
+    fn precise_capturing_of_types(self) -> bool;
 }
 
 pub trait DefId<I: Interner>: Copy + Debug + Hash + Eq + TypeFoldable<I> {

--- a/tests/ui/feature-gates/feature-gate-precise-capturing-of-types.rs
+++ b/tests/ui/feature-gates/feature-gate-precise-capturing-of-types.rs
@@ -1,0 +1,4 @@
+fn foo<T>() -> impl Sized + use<> {}
+//~^ ERROR `impl Trait` must mention all type parameters in scope in `use<...>`
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-precise-capturing-of-types.stderr
+++ b/tests/ui/feature-gates/feature-gate-precise-capturing-of-types.stderr
@@ -1,0 +1,12 @@
+error: `impl Trait` must mention all type parameters in scope in `use<...>`
+  --> $DIR/feature-gate-precise-capturing-of-types.rs:1:16
+   |
+LL | fn foo<T>() -> impl Sized + use<> {}
+   |        -       ^^^^^^^^^^^^^^^^^^
+   |        |
+   |        type parameter is implicitly captured by this `impl Trait`
+   |
+   = note: currently, all type parameters are required to be mentioned in the precise captures list
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/impl-trait/issue-55872-2.rs
+++ b/tests/ui/impl-trait/issue-55872-2.rs
@@ -12,8 +12,8 @@ impl<S> Bar for S {
     type E = impl std::marker::Send;
     fn foo<T>() -> Self::E {
         async {}
-        //~^ ERROR type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
-        //~| ERROR type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+        //~^ ERROR type parameter `T` is mentioned
+        //~| ERROR type parameter `T` is mentioned
     }
 }
 

--- a/tests/ui/impl-trait/issue-55872-2.stderr
+++ b/tests/ui/impl-trait/issue-55872-2.stderr
@@ -1,10 +1,10 @@
-error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+error: type parameter `T` is mentioned in hidden type of type alias impl trait, but is not declared in its generic args
   --> $DIR/issue-55872-2.rs:14:9
    |
 LL |         async {}
    |         ^^^^^^^^
 
-error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+error: type parameter `T` is mentioned in hidden type of type alias impl trait, but is not declared in its generic args
   --> $DIR/issue-55872-2.rs:14:9
    |
 LL |         async {}

--- a/tests/ui/impl-trait/issue-55872.rs
+++ b/tests/ui/impl-trait/issue-55872.rs
@@ -11,7 +11,7 @@ impl<S> Bar for S {
 
     fn foo<T>() -> Self::E {
         || ()
-        //~^ ERROR type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+        //~^ ERROR type parameter `T` is mentioned
     }
 }
 

--- a/tests/ui/impl-trait/issue-55872.stderr
+++ b/tests/ui/impl-trait/issue-55872.stderr
@@ -1,4 +1,4 @@
-error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+error: type parameter `T` is mentioned in hidden type of type alias impl trait, but is not declared in its generic args
   --> $DIR/issue-55872.rs:13:9
    |
 LL |         || ()

--- a/tests/ui/impl-trait/precise-capturing/of-types-eq-uncaptured.rs
+++ b/tests/ui/impl-trait/precise-capturing/of-types-eq-uncaptured.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+
+#![feature(precise_capturing_of_types)]
+//~^ WARN the feature `precise_capturing_of_types` is incomplete
+
+fn uncaptured<T>() -> impl Sized + use<> {}
+
+fn main() {
+    let mut x = uncaptured::<i32>();
+    x = uncaptured::<u32>();
+}

--- a/tests/ui/impl-trait/precise-capturing/of-types-eq-uncaptured.stderr
+++ b/tests/ui/impl-trait/precise-capturing/of-types-eq-uncaptured.stderr
@@ -1,0 +1,11 @@
+warning: the feature `precise_capturing_of_types` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/of-types-eq-uncaptured.rs:3:12
+   |
+LL | #![feature(precise_capturing_of_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #130043 <https://github.com/rust-lang/rust/issues/130043> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/impl-trait/precise-capturing/of-types-hidden-capture.rs
+++ b/tests/ui/impl-trait/precise-capturing/of-types-hidden-capture.rs
@@ -1,0 +1,9 @@
+#![feature(precise_capturing_of_types)]
+//~^ WARN the feature `precise_capturing_of_types` is incomplete
+
+fn foo<T>(x: T) -> impl Sized + use<> {
+    x
+    //~^ ERROR hidden type mentions uncaptured type parameter `T`
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/of-types-hidden-capture.stderr
+++ b/tests/ui/impl-trait/precise-capturing/of-types-hidden-capture.stderr
@@ -1,0 +1,17 @@
+warning: the feature `precise_capturing_of_types` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/of-types-hidden-capture.rs:1:12
+   |
+LL | #![feature(precise_capturing_of_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #130043 <https://github.com/rust-lang/rust/issues/130043> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: hidden type mentions uncaptured type parameter `T`
+  --> $DIR/of-types-hidden-capture.rs:5:5
+   |
+LL |     x
+   |     ^
+
+error: aborting due to 1 previous error; 1 warning emitted
+

--- a/tests/ui/impl-trait/precise-capturing/of-types-outlives.rs
+++ b/tests/ui/impl-trait/precise-capturing/of-types-outlives.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+
+#![feature(precise_capturing_of_types)]
+//~^ WARN the feature `precise_capturing_of_types` is incomplete
+
+fn uncaptured<T>() -> impl Sized + use<> {}
+
+fn outlives_static<T: 'static>(_: T) {}
+
+fn foo<'a>() {
+    outlives_static(uncaptured::<&'a ()>());
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/of-types-outlives.stderr
+++ b/tests/ui/impl-trait/precise-capturing/of-types-outlives.stderr
@@ -1,0 +1,11 @@
+warning: the feature `precise_capturing_of_types` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/of-types-outlives.rs:3:12
+   |
+LL | #![feature(precise_capturing_of_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #130043 <https://github.com/rust-lang/rust/issues/130043> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/impl-trait/precise-capturing/of-types.rs
+++ b/tests/ui/impl-trait/precise-capturing/of-types.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+
+#![feature(precise_capturing_of_types)]
+//~^ WARN the feature `precise_capturing_of_types` is incomplete
+
+use std::fmt::Display;
+use std::ops::Deref;
+
+fn len<T: Deref<Target: Deref<Target = [u8]>>>(x: T) -> impl Display + use<> {
+    x.len()
+}
+
+fn main() {
+    let x = vec![1, 2, 3];
+    let len = len(&x);
+    drop(x);
+    println!("len = {len}");
+}

--- a/tests/ui/impl-trait/precise-capturing/of-types.stderr
+++ b/tests/ui/impl-trait/precise-capturing/of-types.stderr
@@ -1,0 +1,11 @@
+warning: the feature `precise_capturing_of_types` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/of-types.rs:3:12
+   |
+LL | #![feature(precise_capturing_of_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #130043 <https://github.com/rust-lang/rust/issues/130043> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/impl-trait/precise-capturing/rpitit.stderr
+++ b/tests/ui/impl-trait/precise-capturing/rpitit.stderr
@@ -2,7 +2,7 @@ error: `impl Trait` captures lifetime parameter, but it is not mentioned in `use
   --> $DIR/rpitit.rs:11:19
    |
 LL | trait TraitLt<'a: 'a> {
-   |               -- all lifetime parameters originating from a trait are captured implicitly
+   |               -- all parameters originating from a trait are captured implicitly
 LL |     fn hello() -> impl Sized + use<Self>;
    |                   ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/type-alias-impl-trait/generic_not_used.rs
+++ b/tests/ui/type-alias-impl-trait/generic_not_used.rs
@@ -8,5 +8,5 @@ type WrongGeneric<T: 'static> = impl 'static;
 #[define_opaque(WrongGeneric)]
 fn wrong_generic<U: 'static, V: 'static>(_: U, v: V) -> WrongGeneric<U> {
     v
-    //~^ ERROR type parameter `V` is part of concrete type but not used in parameter list
+    //~^ ERROR type parameter `V` is mentioned
 }

--- a/tests/ui/type-alias-impl-trait/generic_not_used.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_not_used.stderr
@@ -4,7 +4,7 @@ error: at least one trait must be specified
 LL | type WrongGeneric<T: 'static> = impl 'static;
    |                                 ^^^^^^^^^^^^
 
-error: type parameter `V` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+error: type parameter `V` is mentioned in hidden type of type alias impl trait, but is not declared in its generic args
   --> $DIR/generic_not_used.rs:10:5
    |
 LL |     v

--- a/tests/ui/type-alias-impl-trait/issue-53598.rs
+++ b/tests/ui/type-alias-impl-trait/issue-53598.rs
@@ -18,7 +18,7 @@ impl Foo for S2 {
 
     fn foo<T: Debug>(_: T) -> Self::Item {
         S::<T>(Default::default())
-        //~^ Error type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+        //~^ Error type parameter `T` is mentioned
     }
 }
 

--- a/tests/ui/type-alias-impl-trait/issue-53598.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53598.stderr
@@ -1,4 +1,4 @@
-error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+error: type parameter `T` is mentioned in hidden type of type alias impl trait, but is not declared in its generic args
   --> $DIR/issue-53598.rs:20:9
    |
 LL |         S::<T>(Default::default())


### PR DESCRIPTION
1. Set uncaptured ty/ct substs as bivariant. I'm almost certain is still quite broken, and I'll come up with a follow-up PR hopefully soon exercising some of the ways that it doesn't work today (related to the fact that "invariant xform bivariant = invariant").
2. Validate that uncaptured ty/ct substs don't show up in the hidden type. I also reworked uncaptured ty/ct errors for TAITs. That diagnostic could also be improved tbh.
3. Add a couple simple tests.

r? lcnr or reassign if you're not interested in reviewing feature work

tracking:
* https://github.com/rust-lang/rust/issues/130043