### PR TITLE
Pass `CI_JOB_DOC_URL` to Docker

### DIFF
--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -361,6 +361,7 @@ docker \
   --env TOOLSTATE_PUBLISH \
   --env RUST_CI_OVERRIDE_RELEASE_CHANNEL \
   --env CI_JOB_NAME="${CI_JOB_NAME-$IMAGE}" \
+  --env CI_JOB_DOC_URL="${CI_JOB_DOC_URL}" \
   --env BASE_COMMIT="$BASE_COMMIT" \
   --env DIST_TRY_BUILD \
   --env PR_CI_JOB \


### PR DESCRIPTION
Fix-up for https://github.com/rust-lang/rust/pull/136911. I always forget to pass new environment variables to Docker images.. :man_facepalming:

r? @marcoieni

try-job: x86_64-fuchsia