### PR TITLE
Nul terminate rust string literals

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -25,12 +25,12 @@ use crate::fluent_generated as fluent;
 
 /// Directly returns an `Allocation` containing an absolute path representation of the given type.
 pub(crate) fn alloc_type_name<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> (AllocId, u64) {
-    let mut path = crate::util::type_name(tcx, ty);
+    let mut path = crate::util::type_name(tcx, ty).into_bytes();
     let path_len = path.len().try_into().unwrap();
-    if !path.contains('\0') {
-        path.push('\0');
+    if !path.contains(&0) {
+        path.extend(b"\xff\0");
     };
-    (tcx.allocate_bytes_dedup(path.into_bytes(), CTFE_ALLOC_SALT), path_len)
+    (tcx.allocate_bytes_dedup(path, CTFE_ALLOC_SALT), path_len)
 }
 impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// Generates a value of `TypeId` for `ty` in-place.

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -25,10 +25,12 @@ use crate::fluent_generated as fluent;
 
 /// Directly returns an `Allocation` containing an absolute path representation of the given type.
 pub(crate) fn alloc_type_name<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> (AllocId, u64) {
-    let path = crate::util::type_name(tcx, ty);
-    let bytes = path.into_bytes();
-    let len = bytes.len().try_into().unwrap();
-    (tcx.allocate_bytes_dedup(bytes, CTFE_ALLOC_SALT), len)
+    let mut path = crate::util::type_name(tcx, ty);
+    let path_len = path.len().try_into().unwrap();
+    if !path.contains('\0') {
+        path.push('\0');
+    };
+    (tcx.allocate_bytes_dedup(path.into_bytes(), CTFE_ALLOC_SALT), path_len)
 }
 impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
     /// Generates a value of `TypeId` for `ty` in-place.

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -1024,11 +1024,16 @@ where
         &mut self,
         s: &str,
     ) -> InterpResult<'tcx, MPlaceTy<'tcx, M::Provenance>> {
-        let bytes = s.as_bytes();
-        let ptr = self.allocate_bytes_dedup(bytes)?;
+        let ptr = if !s.contains('\0') {
+            let mut bytes = s.as_bytes().to_owned();
+            bytes.push(0);
+            self.allocate_bytes_dedup(&bytes)?
+        } else {
+            self.allocate_bytes_dedup(s.as_bytes())?
+        };
 
         // Create length metadata for the string.
-        let meta = Scalar::from_target_usize(u64::try_from(bytes.len()).unwrap(), self);
+        let meta = Scalar::from_target_usize(u64::try_from(s.len()).unwrap(), self);
 
         // Get layout for Rust's str type.
         let layout = self.layout_of(self.tcx.types.str_).unwrap();

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -1026,7 +1026,7 @@ where
     ) -> InterpResult<'tcx, MPlaceTy<'tcx, M::Provenance>> {
         let ptr = if !s.contains('\0') {
             let mut bytes = s.as_bytes().to_owned();
-            bytes.push(0);
+            bytes.extend(b"\xff\0");
             self.allocate_bytes_dedup(&bytes)?
         } else {
             self.allocate_bytes_dedup(s.as_bytes())?

--- a/compiler/rustc_mir_build/src/builder/expr/as_constant.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_constant.rs
@@ -122,9 +122,9 @@ fn lit_to_mir_constant<'tcx>(tcx: TyCtxt<'tcx>, lit_input: LitToConstInput<'tcx>
         (ast::LitKind::Str(s, _), ty::Ref(_, inner_ty, _)) if inner_ty.is_str() => {
             let s = s.as_str();
             let allocation = if !s.contains('\0') {
-                let mut s = s.to_owned();
-                s.push('\0');
-                tcx.allocate_bytes_dedup(s.as_bytes(), CTFE_ALLOC_SALT)
+                let mut s = s.as_bytes().to_owned();
+                s.extend(b"\xff\0");
+                tcx.allocate_bytes_dedup(s, CTFE_ALLOC_SALT)
             } else {
                 tcx.allocate_bytes_dedup(s.as_bytes(), CTFE_ALLOC_SALT)
             };

--- a/compiler/rustc_mir_build/src/builder/expr/as_constant.rs
+++ b/compiler/rustc_mir_build/src/builder/expr/as_constant.rs
@@ -120,10 +120,15 @@ fn lit_to_mir_constant<'tcx>(tcx: TyCtxt<'tcx>, lit_input: LitToConstInput<'tcx>
 
     let value = match (lit, lit_ty.kind()) {
         (ast::LitKind::Str(s, _), ty::Ref(_, inner_ty, _)) if inner_ty.is_str() => {
-            let s = s.as_str().as_bytes();
-            let len = s.len();
-            let allocation = tcx.allocate_bytes_dedup(s, CTFE_ALLOC_SALT);
-            ConstValue::Slice { alloc_id: allocation, meta: len.try_into().unwrap() }
+            let s = s.as_str();
+            let allocation = if !s.contains('\0') {
+                let mut s = s.to_owned();
+                s.push('\0');
+                tcx.allocate_bytes_dedup(s.as_bytes(), CTFE_ALLOC_SALT)
+            } else {
+                tcx.allocate_bytes_dedup(s.as_bytes(), CTFE_ALLOC_SALT)
+            };
+            ConstValue::Slice { alloc_id: allocation, meta: s.len().try_into().unwrap() }
         }
         (ast::LitKind::ByteStr(byte_sym, _), ty::Ref(_, inner_ty, _))
             if matches!(inner_ty.kind(), ty::Slice(_)) =>

--- a/tests/codegen-llvm/remap_path_prefix/main.rs
+++ b/tests/codegen-llvm/remap_path_prefix/main.rs
@@ -12,7 +12,7 @@ mod aux_mod;
 include!("aux_mod.rs");
 
 // Here we check that the expansion of the file!() macro is mapped.
-// CHECK: @alloc_4079a2e7607f89f86df6b8a72ba0dd06 = private unnamed_addr constant [35 x i8] c"/the/src/remap_path_prefix/main.rs\00"
+// CHECK: @alloc_643660180b5bd639a42b5b1707ce11a5 = private unnamed_addr constant [36 x i8] c"/the/src/remap_path_prefix/main.rs\FF\00"
 pub static FILE_PATH: &'static str = file!();
 
 fn main() {

--- a/tests/codegen-llvm/remap_path_prefix/main.rs
+++ b/tests/codegen-llvm/remap_path_prefix/main.rs
@@ -12,7 +12,7 @@ mod aux_mod;
 include!("aux_mod.rs");
 
 // Here we check that the expansion of the file!() macro is mapped.
-// CHECK: @alloc_5761061597a97f66e13ef2ff92712c4b = private unnamed_addr constant [34 x i8] c"/the/src/remap_path_prefix/main.rs"
+// CHECK: @alloc_4079a2e7607f89f86df6b8a72ba0dd06 = private unnamed_addr constant [35 x i8] c"/the/src/remap_path_prefix/main.rs\00"
 pub static FILE_PATH: &'static str = file!();
 
 fn main() {

--- a/tests/mir-opt/const_allocation.main.GVN.after.32bit.mir
+++ b/tests/mir-opt/const_allocation.main.GVN.after.32bit.mir
@@ -33,12 +33,12 @@ ALLOC2 (size: 16, align: 4) {
     ╾ALLOC4<imm>╼ 03 00 00 00 ╾ALLOC5<imm>╼ 03 00 00 00 │ ╾──╼....╾──╼....
 }
 
-ALLOC4 (size: 4, align: 1) {
-    66 6f 6f 00                                     │ foo.
+ALLOC4 (size: 5, align: 1) {
+    66 6f 6f ff 00                                  │ foo..
 }
 
-ALLOC5 (size: 4, align: 1) {
-    62 61 72 00                                     │ bar.
+ALLOC5 (size: 5, align: 1) {
+    62 61 72 ff 00                                  │ bar..
 }
 
 ALLOC3 (size: 24, align: 4) {
@@ -46,14 +46,14 @@ ALLOC3 (size: 24, align: 4) {
     0x10 │ ╾ALLOC8<imm>╼ 04 00 00 00                         │ ╾──╼....
 }
 
-ALLOC6 (size: 4, align: 1) {
-    6d 65 68 00                                     │ meh.
+ALLOC6 (size: 5, align: 1) {
+    6d 65 68 ff 00                                  │ meh..
 }
 
-ALLOC7 (size: 4, align: 1) {
-    6d 6f 70 00                                     │ mop.
+ALLOC7 (size: 5, align: 1) {
+    6d 6f 70 ff 00                                  │ mop..
 }
 
-ALLOC8 (size: 5, align: 1) {
-    6d c3 b6 70 00                                  │ m..p.
+ALLOC8 (size: 6, align: 1) {
+    6d c3 b6 70 ff 00                               │ m..p..
 }

--- a/tests/mir-opt/const_allocation.main.GVN.after.32bit.mir
+++ b/tests/mir-opt/const_allocation.main.GVN.after.32bit.mir
@@ -33,12 +33,12 @@ ALLOC2 (size: 16, align: 4) {
     ╾ALLOC4<imm>╼ 03 00 00 00 ╾ALLOC5<imm>╼ 03 00 00 00 │ ╾──╼....╾──╼....
 }
 
-ALLOC4 (size: 3, align: 1) {
-    66 6f 6f                                        │ foo
+ALLOC4 (size: 4, align: 1) {
+    66 6f 6f 00                                     │ foo.
 }
 
-ALLOC5 (size: 3, align: 1) {
-    62 61 72                                        │ bar
+ALLOC5 (size: 4, align: 1) {
+    62 61 72 00                                     │ bar.
 }
 
 ALLOC3 (size: 24, align: 4) {
@@ -46,14 +46,14 @@ ALLOC3 (size: 24, align: 4) {
     0x10 │ ╾ALLOC8<imm>╼ 04 00 00 00                         │ ╾──╼....
 }
 
-ALLOC6 (size: 3, align: 1) {
-    6d 65 68                                        │ meh
+ALLOC6 (size: 4, align: 1) {
+    6d 65 68 00                                     │ meh.
 }
 
-ALLOC7 (size: 3, align: 1) {
-    6d 6f 70                                        │ mop
+ALLOC7 (size: 4, align: 1) {
+    6d 6f 70 00                                     │ mop.
 }
 
-ALLOC8 (size: 4, align: 1) {
-    6d c3 b6 70                                     │ m..p
+ALLOC8 (size: 5, align: 1) {
+    6d c3 b6 70 00                                  │ m..p.
 }

--- a/tests/mir-opt/const_allocation.main.GVN.after.64bit.mir
+++ b/tests/mir-opt/const_allocation.main.GVN.after.64bit.mir
@@ -36,12 +36,12 @@ ALLOC2 (size: 32, align: 8) {
     0x10 │ ╾ALLOC5<imm>╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
 }
 
-ALLOC4 (size: 3, align: 1) {
-    66 6f 6f                                        │ foo
+ALLOC4 (size: 4, align: 1) {
+    66 6f 6f 00                                     │ foo.
 }
 
-ALLOC5 (size: 3, align: 1) {
-    62 61 72                                        │ bar
+ALLOC5 (size: 4, align: 1) {
+    62 61 72 00                                     │ bar.
 }
 
 ALLOC3 (size: 48, align: 8) {
@@ -50,14 +50,14 @@ ALLOC3 (size: 48, align: 8) {
     0x20 │ ╾ALLOC8<imm>╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
 }
 
-ALLOC6 (size: 3, align: 1) {
-    6d 65 68                                        │ meh
+ALLOC6 (size: 4, align: 1) {
+    6d 65 68 00                                     │ meh.
 }
 
-ALLOC7 (size: 3, align: 1) {
-    6d 6f 70                                        │ mop
+ALLOC7 (size: 4, align: 1) {
+    6d 6f 70 00                                     │ mop.
 }
 
-ALLOC8 (size: 4, align: 1) {
-    6d c3 b6 70                                     │ m..p
+ALLOC8 (size: 5, align: 1) {
+    6d c3 b6 70 00                                  │ m..p.
 }

--- a/tests/mir-opt/const_allocation.main.GVN.after.64bit.mir
+++ b/tests/mir-opt/const_allocation.main.GVN.after.64bit.mir
@@ -36,12 +36,12 @@ ALLOC2 (size: 32, align: 8) {
     0x10 │ ╾ALLOC5<imm>╼ 03 00 00 00 00 00 00 00 │ ╾──────╼........
 }
 
-ALLOC4 (size: 4, align: 1) {
-    66 6f 6f 00                                     │ foo.
+ALLOC4 (size: 5, align: 1) {
+    66 6f 6f ff 00                                  │ foo..
 }
 
-ALLOC5 (size: 4, align: 1) {
-    62 61 72 00                                     │ bar.
+ALLOC5 (size: 5, align: 1) {
+    62 61 72 ff 00                                  │ bar..
 }
 
 ALLOC3 (size: 48, align: 8) {
@@ -50,14 +50,14 @@ ALLOC3 (size: 48, align: 8) {
     0x20 │ ╾ALLOC8<imm>╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
 }
 
-ALLOC6 (size: 4, align: 1) {
-    6d 65 68 00                                     │ meh.
+ALLOC6 (size: 5, align: 1) {
+    6d 65 68 ff 00                                  │ meh..
 }
 
-ALLOC7 (size: 4, align: 1) {
-    6d 6f 70 00                                     │ mop.
+ALLOC7 (size: 5, align: 1) {
+    6d 6f 70 ff 00                                  │ mop..
 }
 
-ALLOC8 (size: 5, align: 1) {
-    6d c3 b6 70 00                                  │ m..p.
+ALLOC8 (size: 6, align: 1) {
+    6d c3 b6 70 ff 00                               │ m..p..
 }

--- a/tests/ui-fulldeps/rustc_public/check_allocation.rs
+++ b/tests/ui-fulldeps/rustc_public/check_allocation.rs
@@ -77,12 +77,13 @@ fn check_bar(item: CrateItem) {
 
     let alloc_id_0 = alloc.provenance.ptrs[0].1.0;
     let GlobalAlloc::Memory(allocation) = GlobalAlloc::from(alloc_id_0) else { unreachable!() };
-    assert_eq!(allocation.bytes.len(), 4);
+    assert_eq!(allocation.bytes.len(), 5);
     assert_eq!(allocation.bytes[0].unwrap(), Char::CapitalB.to_u8());
     assert_eq!(allocation.bytes[1].unwrap(), Char::SmallA.to_u8());
     assert_eq!(allocation.bytes[2].unwrap(), Char::SmallR.to_u8());
-    assert_eq!(allocation.bytes[3].unwrap(), Char::Null.to_u8());
-    assert_eq!(std::str::from_utf8(&allocation.raw_bytes().unwrap()), Ok("Bar\0"));
+    assert_eq!(allocation.bytes[3].unwrap(), 0xff);
+    assert_eq!(allocation.bytes[4].unwrap(), Char::Null.to_u8());
+    assert_eq!(allocation.raw_bytes().unwrap(), b"Bar\xff\0");
 }
 
 /// Check the allocation data for static `C_STR`.

--- a/tests/ui-fulldeps/rustc_public/check_allocation.rs
+++ b/tests/ui-fulldeps/rustc_public/check_allocation.rs
@@ -77,11 +77,12 @@ fn check_bar(item: CrateItem) {
 
     let alloc_id_0 = alloc.provenance.ptrs[0].1.0;
     let GlobalAlloc::Memory(allocation) = GlobalAlloc::from(alloc_id_0) else { unreachable!() };
-    assert_eq!(allocation.bytes.len(), 3);
+    assert_eq!(allocation.bytes.len(), 4);
     assert_eq!(allocation.bytes[0].unwrap(), Char::CapitalB.to_u8());
     assert_eq!(allocation.bytes[1].unwrap(), Char::SmallA.to_u8());
     assert_eq!(allocation.bytes[2].unwrap(), Char::SmallR.to_u8());
-    assert_eq!(std::str::from_utf8(&allocation.raw_bytes().unwrap()), Ok("Bar"));
+    assert_eq!(allocation.bytes[3].unwrap(), Char::Null.to_u8());
+    assert_eq!(std::str::from_utf8(&allocation.raw_bytes().unwrap()), Ok("Bar\0"));
 }
 
 /// Check the allocation data for static `C_STR`.

--- a/tests/ui-fulldeps/rustc_public/check_transform.rs
+++ b/tests/ui-fulldeps/rustc_public/check_transform.rs
@@ -37,7 +37,7 @@ fn test_transform() -> ControlFlow<()> {
     let target_fn = *get_item(&items, (ItemKind::Fn, "dummy")).unwrap();
     let instance = Instance::try_from(target_fn).unwrap();
     let body = instance.body().unwrap();
-    check_msg(&body, "oops");
+    check_msg(&body, "oops\0");
 
     let new_msg = "new panic message";
     let new_body = change_panic_msg(body, new_msg);

--- a/tests/ui-fulldeps/rustc_public/check_transform.rs
+++ b/tests/ui-fulldeps/rustc_public/check_transform.rs
@@ -17,14 +17,15 @@ extern crate rustc_interface;
 #[macro_use]
 extern crate rustc_public;
 
+use std::convert::TryFrom;
+use std::io::Write;
+use std::ops::ControlFlow;
+
 use rustc_public::mir::alloc::GlobalAlloc;
 use rustc_public::mir::mono::Instance;
 use rustc_public::mir::{Body, ConstOperand, Operand, Rvalue, StatementKind, TerminatorKind};
 use rustc_public::ty::{ConstantKind, MirConst};
 use rustc_public::{CrateDef, CrateItems, ItemKind};
-use std::convert::TryFrom;
-use std::io::Write;
-use std::ops::ControlFlow;
 
 const CRATE_NAME: &str = "input";
 
@@ -37,17 +38,17 @@ fn test_transform() -> ControlFlow<()> {
     let target_fn = *get_item(&items, (ItemKind::Fn, "dummy")).unwrap();
     let instance = Instance::try_from(target_fn).unwrap();
     let body = instance.body().unwrap();
-    check_msg(&body, "oops\0");
+    check_msg(&body, b"oops\xff\0");
 
     let new_msg = "new panic message";
     let new_body = change_panic_msg(body, new_msg);
-    check_msg(&new_body, new_msg);
+    check_msg(&new_body, new_msg.as_bytes());
 
     ControlFlow::Continue(())
 }
 
 /// Check that the body panic message matches the given message.
-fn check_msg(body: &Body, expected: &str) {
+fn check_msg(body: &Body, expected: &[u8]) {
     let msg = body
         .blocks
         .iter()
@@ -80,7 +81,7 @@ fn check_msg(body: &Body, expected: &str) {
                     unreachable!()
                 };
                 let bytes = val.raw_bytes().unwrap();
-                Some(std::str::from_utf8(&bytes).unwrap().to_string())
+                Some(bytes.to_owned())
             }
             _ => None,
         })


### PR DESCRIPTION
This allows taking advantage of the C string merging functionality of linkers, reducing code size.

Marked as draft to see if this actually has much of an effect. The disadvantage of this is that people may start to rely on string literals getting nul terminated. A potential solution for that would be to put a byte that is not part of a valid UTF-8 character right before the nul terminator.

Builds on https://github.com/rust-lang/rust/pull/138503