### PR TITLE
Remove fake borrows of refs that are converted into non-refs in `MakeByMoveBody`

### DIFF
--- a/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
+++ b/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
@@ -1,0 +1,81 @@
+// MIR for `foo::{closure#0}::{closure#0}` after built
+
+fn foo::{closure#0}::{closure#0}(_1: {async closure body@$DIR/async_closure_fake_read_for_by_move.rs:12:27: 15:6}, _2: ResumeTy) -> ()
+yields ()
+ {
+    debug _task_context => _2;
+    debug f => (*(_1.0: &&Foo));
+    let mut _0: ();
+    let mut _3: &Foo;
+    let mut _4: &&Foo;
+    let mut _5: &&&Foo;
+    let mut _6: isize;
+    let mut _7: bool;
+
+    bb0: {
+        PlaceMention((*(_1.0: &&Foo)));
+        _6 = discriminant((*(*(_1.0: &&Foo))));
+        switchInt(move _6) -> [0: bb2, otherwise: bb1];
+    }
+
+    bb1: {
+        _0 = const ();
+        goto -> bb10;
+    }
+
+    bb2: {
+        falseEdge -> [real: bb5, imaginary: bb1];
+    }
+
+    bb3: {
+        goto -> bb1;
+    }
+
+    bb4: {
+        FakeRead(ForMatchedPlace(None), (*(_1.0: &&Foo)));
+        unreachable;
+    }
+
+    bb5: {
+        _3 = &fake shallow (*(*(_1.0: &&Foo)));
+        _4 = &fake shallow (*(_1.0: &&Foo));
+        _5 = &fake shallow (_1.0: &&Foo);
+        StorageLive(_7);
+        _7 = const true;
+        switchInt(move _7) -> [0: bb8, otherwise: bb7];
+    }
+
+    bb6: {
+        falseEdge -> [real: bb3, imaginary: bb1];
+    }
+
+    bb7: {
+        StorageDead(_7);
+        FakeRead(ForMatchGuard, _3);
+        FakeRead(ForMatchGuard, _4);
+        FakeRead(ForMatchGuard, _5);
+        _0 = const ();
+        goto -> bb10;
+    }
+
+    bb8: {
+        goto -> bb9;
+    }
+
+    bb9: {
+        StorageDead(_7);
+        goto -> bb6;
+    }
+
+    bb10: {
+        drop(_1) -> [return: bb11, unwind: bb12];
+    }
+
+    bb11: {
+        return;
+    }
+
+    bb12 (cleanup): {
+        resume;
+    }
+}

--- a/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#1}.built.after.mir
+++ b/tests/mir-opt/async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#1}.built.after.mir
@@ -1,0 +1,64 @@
+// MIR for `foo::{closure#0}::{closure#1}` after built
+
+fn foo::{closure#0}::{closure#1}(_1: {async closure body@$DIR/async_closure_fake_read_for_by_move.rs:12:27: 15:6}, _2: ResumeTy) -> ()
+yields ()
+ {
+    debug _task_context => _2;
+    debug f => (_1.0: &Foo);
+    let mut _0: ();
+    let mut _3: &Foo;
+    let mut _4: &&Foo;
+    let mut _5: &&&Foo;
+    let mut _6: isize;
+    let mut _7: bool;
+
+    bb0: {
+        PlaceMention((_1.0: &Foo));
+        _6 = discriminant((*(_1.0: &Foo)));
+        switchInt(move _6) -> [0: bb2, otherwise: bb1];
+    }
+
+    bb1: {
+        _0 = const ();
+        goto -> bb6;
+    }
+
+    bb2: {
+        falseEdge -> [real: bb3, imaginary: bb1];
+    }
+
+    bb3: {
+        _3 = &fake shallow (*(_1.0: &Foo));
+        _4 = &fake shallow (_1.0: &Foo);
+        nop;
+        StorageLive(_7);
+        _7 = const true;
+        switchInt(move _7) -> [0: bb5, otherwise: bb4];
+    }
+
+    bb4: {
+        StorageDead(_7);
+        FakeRead(ForMatchGuard, _3);
+        FakeRead(ForMatchGuard, _4);
+        FakeRead(ForMatchGuard, _5);
+        _0 = const ();
+        goto -> bb6;
+    }
+
+    bb5: {
+        StorageDead(_7);
+        falseEdge -> [real: bb1, imaginary: bb1];
+    }
+
+    bb6: {
+        drop(_1) -> [return: bb7, unwind: bb8];
+    }
+
+    bb7: {
+        return;
+    }
+
+    bb8 (cleanup): {
+        resume;
+    }
+}

--- a/tests/mir-opt/async_closure_fake_read_for_by_move.rs
+++ b/tests/mir-opt/async_closure_fake_read_for_by_move.rs
@@ -1,0 +1,18 @@
+//@ edition:2021
+// skip-filecheck
+
+enum Foo {
+    Bar,
+    Baz,
+}
+
+// EMIT_MIR async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#0}.built.after.mir
+// EMIT_MIR async_closure_fake_read_for_by_move.foo-{closure#0}-{closure#1}.built.after.mir
+fn foo(f: &Foo) {
+    let x = async move || match f {
+        Foo::Bar if true => {}
+        _ => {}
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
Remove fake borrows of closure captures if that capture has been replaced with a by-move version of that capture.

For example, given an async closure that looks like:

```
let f: Foo;
let c = async move || {
    match f { ... }
};
```

... in this pair of coroutine-closure + coroutine, we capture `Foo` in the parent and `&Foo` in the child. We will emit two fake borrows like:

```
_2 = &fake shallow (*(_1.0: &Foo));
_3 = &fake shallow (_1.0: &Foo);
```

However, since the by-move-body transform is responsible for replacing `_1.0: &Foo` with `_1.0: Foo` (since the `AsyncFnOnce` coroutine will own `Foo` by value), that makes the second fake borrow obsolete since we never have an upvar of type `&Foo`, and we should replace it with a `nop`.

As a side-note, we don't actually even care about fake borrows here at all since they're fully a MIR borrowck artifact, and we don't need to borrowck by-move MIR bodies. But it's best to preserve as much as we can between these two bodies :)

Fixes #138501

r? oli-obk