### PR TITLE
Improve upvar analysis for deref of child capture

### DIFF
--- a/tests/ui/async-await/async-closures/imm-deref-lending.rs
+++ b/tests/ui/async-await/async-closures/imm-deref-lending.rs
@@ -1,0 +1,46 @@
+//@ edition: 2021
+//@ check-pass
+
+#![feature(impl_trait_in_bindings)]
+
+struct FooS {
+    precise: i32,
+}
+
+fn ref_inside_mut(f: &mut &FooS) {
+    let x: impl AsyncFn() = async move || {
+        let y = &f.precise;
+    };
+}
+
+fn mut_inside_ref(f: &&mut FooS) {
+    let x: impl AsyncFn() = async move || {
+        let y = &f.precise;
+    };
+}
+
+fn mut_ref_inside_mut(f: &mut &mut FooS) {
+    let x: impl AsyncFn() = async move || {
+        let y = &f.precise;
+    };
+}
+
+fn ref_inside_box(f: Box<&FooS>) {
+    let x: impl AsyncFn() = async move || {
+        let y = &f.precise;
+    };
+}
+
+fn box_inside_ref(f: &Box<FooS>) {
+    let x: impl AsyncFn() = async move || {
+        let y = &f.precise;
+    };
+}
+
+fn box_inside_box(f: Box<Box<FooS>>) {
+    let x: impl AsyncFn() = async move || {
+        let y = &f.precise;
+    };
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-closures/imm-deref-not-lending.rs
+++ b/tests/ui/async-await/async-closures/imm-deref-not-lending.rs
@@ -1,0 +1,49 @@
+//@ edition: 2021
+
+#![feature(impl_trait_in_bindings)]
+
+struct FooS {
+    precise: i32,
+}
+
+fn ref_inside_mut(f: &mut &FooS) {
+    let x: impl Fn() -> _ = async move || {
+        let y = &f.precise;
+    };
+}
+
+fn mut_inside_ref(f: &&mut FooS) {
+    let x: impl Fn() -> _ = async move || {
+        let y = &f.precise;
+    };
+}
+
+// Expected to fail, no immutable reference here.
+fn mut_ref_inside_mut(f: &mut &mut FooS) {
+    let x: impl Fn() -> _ = async move || {
+        //~^ ERROR async closure does not implement `Fn`
+        let y = &f.precise;
+    };
+}
+
+fn ref_inside_box(f: Box<&FooS>) {
+    let x: impl Fn() -> _ = async move || {
+        let y = &f.precise;
+    };
+}
+
+fn box_inside_ref(f: &Box<FooS>) {
+    let x: impl Fn() -> _ = async move || {
+        let y = &f.precise;
+    };
+}
+
+// Expected to fail, no immutable reference here.
+fn box_inside_box(f: Box<Box<FooS>>) {
+    let x: impl Fn() -> _ = async move || {
+        //~^ ERROR async closure does not implement `Fn`
+        let y = &f.precise;
+    };
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-closures/imm-deref-not-lending.stderr
+++ b/tests/ui/async-await/async-closures/imm-deref-not-lending.stderr
@@ -1,0 +1,14 @@
+error: async closure does not implement `Fn` because it captures state from its environment
+  --> $DIR/imm-deref-not-lending.rs:23:29
+   |
+LL |     let x: impl Fn() -> _ = async move || {
+   |                             ^^^^^^^^^^^^^
+
+error: async closure does not implement `Fn` because it captures state from its environment
+  --> $DIR/imm-deref-not-lending.rs:43:29
+   |
+LL |     let x: impl Fn() -> _ = async move || {
+   |                             ^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Two fixes to the heuristic I implemented in #123660. As I noted in the code:

> Luckily, if this function is not correct, then the program is not unsound, since we still borrowck and validate the choices made from this function -- the only side-effect is that the user may receive unnecessary borrowck errors.

This indeed fixes unnecessary borrowck errors.

r? oli-obk

---

The heuristic is only valid if we deref a `&T`, not a `&mut T` or `Box<T>`, so make sure to check the type. This fixes:

```rust
struct Foo { precise: i32 }

fn mut_ref_inside_mut(f: &mut Foo) {
    let x: impl AsyncFn() = async move || {
        let y = &f.precise;
    };
}
```

Since the capture from `f` to `&f.precise` needs to be treated as a lending borrow from the parent coroutine-closure to the child coroutine.

---

The heuristic is also valid if *any* deref projection in the child capture's projections is a `&T`, but we were only looking at the last one. This ensures that this function is considered not to be lending:

```rust
struct Foo { precise: i32 }

fn ref_inside_mut(f: &mut &Foo) {
    let x: impl Fn() -> _ = async move || {
        let y = &f.precise;
    };
}
```

(Specifically, checking that `impl Fn() -> _` is satisfied is exercising that the coroutine is not considered to be lending.)