### PR TITLE
Stop making `const None` in GVN

### DIFF
--- a/tests/mir-opt/const_debuginfo.main.SingleUseConsts.diff
+++ b/tests/mir-opt/const_debuginfo.main.SingleUseConsts.diff
@@ -32,10 +32,10 @@
                           let _10: (bool, bool, u32);
                           scope 6 {
                               debug f => _10;
-                              let _11: std::option::Option<u16>;
+                              let _11: MyEnum;
                               scope 7 {
 -                                 debug o => _11;
-+                                 debug o => const Option::<u16>::Some(99_u16);
++                                 debug o => const MyEnum::Bar;
                                   let _12: Point;
                                   scope 8 {
 -                                     debug p => _12;
@@ -89,7 +89,7 @@
           StorageLive(_10);
           _10 = (const true, const false, const 123_u32);
           StorageLive(_11);
--         _11 = const Option::<u16>::Some(99_u16);
+-         _11 = const MyEnum::Bar;
 +         nop;
           StorageLive(_12);
 -         _12 = const Point {{ x: 32_u32, y: 32_u32 }};
@@ -120,6 +120,4 @@
   }
   
   ALLOC0 (size: 8, align: 4) { .. }
-  
-  ALLOC1 (size: 4, align: 2) { .. }
   

--- a/tests/mir-opt/const_debuginfo.rs
+++ b/tests/mir-opt/const_debuginfo.rs
@@ -8,6 +8,13 @@ struct Point {
     y: u32,
 }
 
+#[repr(u16)]
+enum MyEnum {
+    Foo = 88,
+    Bar = 99,
+    Baz = 111,
+}
+
 // EMIT_MIR const_debuginfo.main.SingleUseConsts.diff
 fn main() {
     // CHECK-LABEL: fn main(
@@ -17,7 +24,7 @@ fn main() {
     // CHECK: debug sum => const 6_u8;
     // CHECK: debug s => const "hello, world!";
     // CHECK: debug f => {{_.*}};
-    // CHECK: debug o => const Option::<u16>::Some(99_u16);
+    // CHECK: debug o => const MyEnum::Bar;
     // CHECK: debug p => const Point
     // CHECK: debug a => const 64_u32;
     let x = 1u8;
@@ -29,7 +36,7 @@ fn main() {
 
     let f = (true, false, 123u32);
 
-    let o = Some(99u16);
+    let o = MyEnum::Bar;
 
     let p = Point { x: 32, y: 32 };
     let a = p.x + p.y;

--- a/tests/mir-opt/const_prop/discriminant.main.GVN.32bit.diff
+++ b/tests/mir-opt/const_prop/discriminant.main.GVN.32bit.diff
@@ -17,10 +17,9 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
--         _3 = Option::<bool>::Some(const true);
+          _3 = Option::<bool>::Some(const true);
 -         _4 = discriminant(_3);
 -         switchInt(move _4) -> [1: bb1, otherwise: bb3];
-+         _3 = const Option::<bool>::Some(true);
 +         _4 = const 1_isize;
 +         switchInt(const 1_isize) -> [1: bb1, otherwise: bb3];
       }

--- a/tests/mir-opt/const_prop/discriminant.main.GVN.64bit.diff
+++ b/tests/mir-opt/const_prop/discriminant.main.GVN.64bit.diff
@@ -17,10 +17,9 @@
           StorageLive(_1);
           StorageLive(_2);
           StorageLive(_3);
--         _3 = Option::<bool>::Some(const true);
+          _3 = Option::<bool>::Some(const true);
 -         _4 = discriminant(_3);
 -         switchInt(move _4) -> [1: bb1, otherwise: bb3];
-+         _3 = const Option::<bool>::Some(true);
 +         _4 = const 1_isize;
 +         switchInt(const 1_isize) -> [1: bb1, otherwise: bb3];
       }

--- a/tests/mir-opt/const_prop/while_let_loops.change_loop_body.GVN.diff
+++ b/tests/mir-opt/const_prop/while_let_loops.change_loop_body.GVN.diff
@@ -21,10 +21,9 @@
           StorageLive(_1);
           _1 = const 0_i32;
           StorageLive(_3);
--         _3 = Option::<u32>::None;
+          _3 = Option::<u32>::None;
 -         _4 = discriminant(_3);
 -         switchInt(move _4) -> [1: bb1, otherwise: bb3];
-+         _3 = const Option::<u32>::None;
 +         _4 = const 0_isize;
 +         switchInt(const 0_isize) -> [1: bb1, otherwise: bb3];
       }

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-abort.diff
@@ -160,7 +160,7 @@
       }
   
       bb11: {
-          _6 = const Option::<usize>::None;
+          _6 = Option::<usize>::None;
           goto -> bb9;
       }
   
@@ -172,9 +172,5 @@
           StorageDead(_25);
           goto -> bb9;
       }
-  }
-  
-  ALLOC0 (size: 8, align: 4) {
-      00 00 00 00 __ __ __ __                         │ ....░░░░
   }
   

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.32bit.panic-unwind.diff
@@ -160,7 +160,7 @@
       }
   
       bb11: {
-          _6 = const Option::<usize>::None;
+          _6 = Option::<usize>::None;
           goto -> bb9;
       }
   
@@ -172,9 +172,5 @@
           StorageDead(_25);
           goto -> bb9;
       }
-  }
-  
-  ALLOC0 (size: 8, align: 4) {
-      00 00 00 00 __ __ __ __                         │ ....░░░░
   }
   

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-abort.diff
@@ -160,7 +160,7 @@
       }
   
       bb11: {
-          _6 = const Option::<usize>::None;
+          _6 = Option::<usize>::None;
           goto -> bb9;
       }
   
@@ -172,9 +172,5 @@
           StorageDead(_25);
           goto -> bb9;
       }
-  }
-  
-  ALLOC0 (size: 16, align: 8) {
-      00 00 00 00 00 00 00 00 __ __ __ __ __ __ __ __ │ ........░░░░░░░░
   }
   

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.64bit.panic-unwind.diff
@@ -160,7 +160,7 @@
       }
   
       bb11: {
-          _6 = const Option::<usize>::None;
+          _6 = Option::<usize>::None;
           goto -> bb9;
       }
   
@@ -172,9 +172,5 @@
           StorageDead(_25);
           goto -> bb9;
       }
-  }
-  
-  ALLOC0 (size: 16, align: 8) {
-      00 00 00 00 00 00 00 00 __ __ __ __ __ __ __ __ │ ........░░░░░░░░
   }
   

--- a/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.panic-abort.mir
@@ -22,7 +22,7 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
     }
 
     bb1: {
-        _0 = const Option::<u32>::None;
+        _0 = Option::<u32>::None;
         goto -> bb3;
     }
 
@@ -38,8 +38,4 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
         StorageDead(_3);
         return;
     }
-}
-
-ALLOC0 (size: 8, align: 4) {
-    00 00 00 00 __ __ __ __                         │ ....░░░░
 }

--- a/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.checked_shl.PreCodegen.after.panic-unwind.mir
@@ -22,7 +22,7 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
     }
 
     bb1: {
-        _0 = const Option::<u32>::None;
+        _0 = Option::<u32>::None;
         goto -> bb3;
     }
 
@@ -38,8 +38,4 @@ fn checked_shl(_1: u32, _2: u32) -> Option<u32> {
         StorageDead(_3);
         return;
     }
-}
-
-ALLOC0 (size: 8, align: 4) {
-    00 00 00 00 __ __ __ __                         │ ....░░░░
 }

--- a/tests/mir-opt/pre-codegen/checked_ops.rs
+++ b/tests/mir-opt/pre-codegen/checked_ops.rs
@@ -1,4 +1,3 @@
-// skip-filecheck
 //@ compile-flags: -O -Zmir-opt-level=2
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
@@ -8,10 +7,44 @@
 // EMIT_MIR checked_ops.step_forward.PreCodegen.after.mir
 pub fn step_forward(x: u16, n: usize) -> u16 {
     // This uses `u16` so that the conversion to usize is always widening.
+
+    // CHECK-LABEL: fn step_forward
+    // CHECK: inlined{{.+}}forward
     std::iter::Step::forward(x, n)
 }
 
 // EMIT_MIR checked_ops.checked_shl.PreCodegen.after.mir
 pub fn checked_shl(x: u32, rhs: u32) -> Option<u32> {
+    // CHECK-LABEL: fn checked_shl
+    // CHECK: [[TEMP:_[0-9]+]] = ShlUnchecked(copy _1, copy _2)
+    // CHECK: _0 = Option::<u32>::Some({{move|copy}} [[TEMP]])
     x.checked_shl(rhs)
+}
+
+// EMIT_MIR checked_ops.saturating_sub_at_home.PreCodegen.after.mir
+// EMIT_MIR checked_ops.saturating_sub_at_home.GVN.diff
+pub fn saturating_sub_at_home(lhs: u32, rhs: u32) -> u32 {
+    // CHECK-LABEL: fn saturating_sub_at_home
+    // FIXME-CHECK-NOT: ={{.+}}::Some
+    // FIXME-CHECK-NOT: ={{.+}}::None
+    u32::checked_sub(lhs, rhs).unwrap_or(0)
+}
+
+// EMIT_MIR checked_ops.use_checked_sub.PreCodegen.after.mir
+// EMIT_MIR checked_ops.use_checked_sub.GVN.diff
+pub fn use_checked_sub(x: u32, rhs: u32) {
+    // We want this to be equivalent to open-coding it, leaving no `Option`s around.
+
+    // CHECK-LABEL: fn use_checked_sub
+    // FIXME-CHECK-NOT: let{{.+}}Option
+    // CHECK: inlined{{.+}}u32{{.+}}checked_sub
+    // CHECK: [[DELTA:_[0-9]+]] = SubUnchecked(copy _1, copy _2)
+    // FIXME-CHECK: do_something({{move|copy}} [[DELTA]])
+    if let Some(delta) = x.checked_sub(rhs) {
+        do_something(delta);
+    }
+}
+
+unsafe extern "Rust" {
+    safe fn do_something(_: u32);
 }

--- a/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.GVN.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.GVN.panic-abort.diff
@@ -1,0 +1,89 @@
+- // MIR for `saturating_sub_at_home` before GVN
++ // MIR for `saturating_sub_at_home` after GVN
+  
+  fn saturating_sub_at_home(_1: u32, _2: u32) -> u32 {
+      debug lhs => _1;
+      debug rhs => _2;
+      let mut _0: u32;
+      let mut _3: std::option::Option<u32>;
+      let mut _4: u32;
+      let mut _5: u32;
+      let mut _8: u32;
+      scope 1 (inlined core::num::<impl u32>::checked_sub) {
+          let mut _6: bool;
+          let mut _7: u32;
+      }
+      scope 2 (inlined Option::<u32>::unwrap_or) {
+          let mut _9: isize;
+          let _10: u32;
+          scope 3 {
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = copy _1;
+          StorageLive(_5);
+          _5 = copy _2;
+          StorageLive(_6);
+-         _6 = Lt(copy _4, copy _5);
++         _6 = Lt(copy _1, copy _2);
+          switchInt(move _6) -> [0: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          _3 = const Option::<u32>::None;
+          goto -> bb3;
+      }
+  
+      bb2: {
+          StorageLive(_7);
+-         _7 = SubUnchecked(copy _4, copy _5);
++         _7 = SubUnchecked(copy _1, copy _2);
+          _3 = Option::<u32>::Some(move _7);
+          StorageDead(_7);
+          goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageDead(_4);
+          StorageLive(_8);
+          _8 = const 0_u32;
+          StorageLive(_9);
+          _9 = discriminant(_3);
+          switchInt(move _9) -> [0: bb6, 1: bb7, otherwise: bb5];
+      }
+  
+      bb4: {
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageDead(_3);
+          return;
+      }
+  
+      bb5: {
+          unreachable;
+      }
+  
+      bb6: {
+-         _0 = move _8;
++         _0 = const 0_u32;
+          goto -> bb4;
+      }
+  
+      bb7: {
+          StorageLive(_10);
+          _10 = move ((_3 as Some).0: u32);
+          _0 = move _10;
+          StorageDead(_10);
+          goto -> bb4;
+      }
+  }
+  
+  ALLOC0 (size: 8, align: 4) {
+      00 00 00 00 __ __ __ __                         │ ....░░░░
+  }
+  

--- a/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.GVN.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.GVN.panic-abort.diff
@@ -33,7 +33,7 @@
       }
   
       bb1: {
-          _3 = const Option::<u32>::None;
+          _3 = Option::<u32>::None;
           goto -> bb3;
       }
   
@@ -81,9 +81,5 @@
           StorageDead(_10);
           goto -> bb4;
       }
-  }
-  
-  ALLOC0 (size: 8, align: 4) {
-      00 00 00 00 __ __ __ __                         │ ....░░░░
   }
   

--- a/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.GVN.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.GVN.panic-unwind.diff
@@ -1,0 +1,89 @@
+- // MIR for `saturating_sub_at_home` before GVN
++ // MIR for `saturating_sub_at_home` after GVN
+  
+  fn saturating_sub_at_home(_1: u32, _2: u32) -> u32 {
+      debug lhs => _1;
+      debug rhs => _2;
+      let mut _0: u32;
+      let mut _3: std::option::Option<u32>;
+      let mut _4: u32;
+      let mut _5: u32;
+      let mut _8: u32;
+      scope 1 (inlined core::num::<impl u32>::checked_sub) {
+          let mut _6: bool;
+          let mut _7: u32;
+      }
+      scope 2 (inlined Option::<u32>::unwrap_or) {
+          let mut _9: isize;
+          let _10: u32;
+          scope 3 {
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = copy _1;
+          StorageLive(_5);
+          _5 = copy _2;
+          StorageLive(_6);
+-         _6 = Lt(copy _4, copy _5);
++         _6 = Lt(copy _1, copy _2);
+          switchInt(move _6) -> [0: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          _3 = const Option::<u32>::None;
+          goto -> bb3;
+      }
+  
+      bb2: {
+          StorageLive(_7);
+-         _7 = SubUnchecked(copy _4, copy _5);
++         _7 = SubUnchecked(copy _1, copy _2);
+          _3 = Option::<u32>::Some(move _7);
+          StorageDead(_7);
+          goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_6);
+          StorageDead(_5);
+          StorageDead(_4);
+          StorageLive(_8);
+          _8 = const 0_u32;
+          StorageLive(_9);
+          _9 = discriminant(_3);
+          switchInt(move _9) -> [0: bb6, 1: bb7, otherwise: bb5];
+      }
+  
+      bb4: {
+          StorageDead(_9);
+          StorageDead(_8);
+          StorageDead(_3);
+          return;
+      }
+  
+      bb5: {
+          unreachable;
+      }
+  
+      bb6: {
+-         _0 = move _8;
++         _0 = const 0_u32;
+          goto -> bb4;
+      }
+  
+      bb7: {
+          StorageLive(_10);
+          _10 = move ((_3 as Some).0: u32);
+          _0 = move _10;
+          StorageDead(_10);
+          goto -> bb4;
+      }
+  }
+  
+  ALLOC0 (size: 8, align: 4) {
+      00 00 00 00 __ __ __ __                         │ ....░░░░
+  }
+  

--- a/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.GVN.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.GVN.panic-unwind.diff
@@ -33,7 +33,7 @@
       }
   
       bb1: {
-          _3 = const Option::<u32>::None;
+          _3 = Option::<u32>::None;
           goto -> bb3;
       }
   
@@ -81,9 +81,5 @@
           StorageDead(_10);
           goto -> bb4;
       }
-  }
-  
-  ALLOC0 (size: 8, align: 4) {
-      00 00 00 00 __ __ __ __                         │ ....░░░░
   }
   

--- a/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,48 @@
+// MIR for `saturating_sub_at_home` after PreCodegen
+
+fn saturating_sub_at_home(_1: u32, _2: u32) -> u32 {
+    debug lhs => _1;
+    debug rhs => _2;
+    let mut _0: u32;
+    let mut _5: std::option::Option<u32>;
+    scope 1 (inlined core::num::<impl u32>::checked_sub) {
+        let mut _3: bool;
+        let mut _4: u32;
+    }
+    scope 2 (inlined Option::<u32>::unwrap_or) {
+        let _6: u32;
+        scope 3 {
+        }
+    }
+
+    bb0: {
+        StorageLive(_5);
+        StorageLive(_3);
+        _3 = Lt(copy _1, copy _2);
+        switchInt(move _3) -> [0: bb1, otherwise: bb2];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = SubUnchecked(copy _1, copy _2);
+        _5 = Option::<u32>::Some(move _4);
+        StorageDead(_4);
+        StorageDead(_3);
+        StorageLive(_6);
+        _6 = move ((_5 as Some).0: u32);
+        _0 = move _6;
+        StorageDead(_6);
+        goto -> bb3;
+    }
+
+    bb2: {
+        StorageDead(_3);
+        _0 = const 0_u32;
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_5);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.saturating_sub_at_home.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,48 @@
+// MIR for `saturating_sub_at_home` after PreCodegen
+
+fn saturating_sub_at_home(_1: u32, _2: u32) -> u32 {
+    debug lhs => _1;
+    debug rhs => _2;
+    let mut _0: u32;
+    let mut _5: std::option::Option<u32>;
+    scope 1 (inlined core::num::<impl u32>::checked_sub) {
+        let mut _3: bool;
+        let mut _4: u32;
+    }
+    scope 2 (inlined Option::<u32>::unwrap_or) {
+        let _6: u32;
+        scope 3 {
+        }
+    }
+
+    bb0: {
+        StorageLive(_5);
+        StorageLive(_3);
+        _3 = Lt(copy _1, copy _2);
+        switchInt(move _3) -> [0: bb1, otherwise: bb2];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = SubUnchecked(copy _1, copy _2);
+        _5 = Option::<u32>::Some(move _4);
+        StorageDead(_4);
+        StorageDead(_3);
+        StorageLive(_6);
+        _6 = move ((_5 as Some).0: u32);
+        _0 = move _6;
+        StorageDead(_6);
+        goto -> bb3;
+    }
+
+    bb2: {
+        StorageDead(_3);
+        _0 = const 0_u32;
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_5);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.GVN.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.GVN.panic-abort.diff
@@ -55,7 +55,7 @@
       }
   
       bb4: {
-          _3 = const Option::<u32>::None;
+          _3 = Option::<u32>::None;
           goto -> bb6;
       }
   
@@ -79,9 +79,5 @@
       bb7: {
           unreachable;
       }
-  }
-  
-  ALLOC0 (size: 8, align: 4) {
-      00 00 00 00 __ __ __ __                         │ ....░░░░
   }
   

--- a/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.GVN.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.GVN.panic-abort.diff
@@ -1,0 +1,87 @@
+- // MIR for `use_checked_sub` before GVN
++ // MIR for `use_checked_sub` after GVN
+  
+  fn use_checked_sub(_1: u32, _2: u32) -> () {
+      debug x => _1;
+      debug rhs => _2;
+      let mut _0: ();
+      let mut _3: std::option::Option<u32>;
+      let mut _4: u32;
+      let mut _5: u32;
+      let mut _6: isize;
+      let _8: ();
+      let mut _9: u32;
+      scope 1 {
+          debug delta => _7;
+          let _7: u32;
+          scope 2 (inlined core::num::<impl u32>::checked_sub) {
+              let mut _10: bool;
+              let mut _11: u32;
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = copy _1;
+          StorageLive(_5);
+          _5 = copy _2;
+          StorageLive(_10);
+-         _10 = Lt(copy _4, copy _5);
++         _10 = Lt(copy _1, copy _2);
+          switchInt(move _10) -> [0: bb5, otherwise: bb4];
+      }
+  
+      bb1: {
+-         StorageLive(_7);
++         nop;
+          _7 = copy ((_3 as Some).0: u32);
+          StorageLive(_9);
+          _9 = copy _7;
+-         _8 = do_something(move _9) -> [return: bb2, unwind unreachable];
++         _8 = do_something(copy _7) -> [return: bb2, unwind unreachable];
+      }
+  
+      bb2: {
+          StorageDead(_9);
+-         StorageDead(_7);
++         nop;
+          goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_3);
+          return;
+      }
+  
+      bb4: {
+          _3 = const Option::<u32>::None;
+          goto -> bb6;
+      }
+  
+      bb5: {
+          StorageLive(_11);
+-         _11 = SubUnchecked(copy _4, copy _5);
++         _11 = SubUnchecked(copy _1, copy _2);
+          _3 = Option::<u32>::Some(move _11);
+          StorageDead(_11);
+          goto -> bb6;
+      }
+  
+      bb6: {
+          StorageDead(_10);
+          StorageDead(_5);
+          StorageDead(_4);
+          _6 = discriminant(_3);
+          switchInt(move _6) -> [1: bb1, 0: bb3, otherwise: bb7];
+      }
+  
+      bb7: {
+          unreachable;
+      }
+  }
+  
+  ALLOC0 (size: 8, align: 4) {
+      00 00 00 00 __ __ __ __                         │ ....░░░░
+  }
+  

--- a/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.GVN.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.GVN.panic-unwind.diff
@@ -1,0 +1,87 @@
+- // MIR for `use_checked_sub` before GVN
++ // MIR for `use_checked_sub` after GVN
+  
+  fn use_checked_sub(_1: u32, _2: u32) -> () {
+      debug x => _1;
+      debug rhs => _2;
+      let mut _0: ();
+      let mut _3: std::option::Option<u32>;
+      let mut _4: u32;
+      let mut _5: u32;
+      let mut _6: isize;
+      let _8: ();
+      let mut _9: u32;
+      scope 1 {
+          debug delta => _7;
+          let _7: u32;
+          scope 2 (inlined core::num::<impl u32>::checked_sub) {
+              let mut _10: bool;
+              let mut _11: u32;
+          }
+      }
+  
+      bb0: {
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = copy _1;
+          StorageLive(_5);
+          _5 = copy _2;
+          StorageLive(_10);
+-         _10 = Lt(copy _4, copy _5);
++         _10 = Lt(copy _1, copy _2);
+          switchInt(move _10) -> [0: bb5, otherwise: bb4];
+      }
+  
+      bb1: {
+-         StorageLive(_7);
++         nop;
+          _7 = copy ((_3 as Some).0: u32);
+          StorageLive(_9);
+          _9 = copy _7;
+-         _8 = do_something(move _9) -> [return: bb2, unwind continue];
++         _8 = do_something(copy _7) -> [return: bb2, unwind continue];
+      }
+  
+      bb2: {
+          StorageDead(_9);
+-         StorageDead(_7);
++         nop;
+          goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_3);
+          return;
+      }
+  
+      bb4: {
+          _3 = const Option::<u32>::None;
+          goto -> bb6;
+      }
+  
+      bb5: {
+          StorageLive(_11);
+-         _11 = SubUnchecked(copy _4, copy _5);
++         _11 = SubUnchecked(copy _1, copy _2);
+          _3 = Option::<u32>::Some(move _11);
+          StorageDead(_11);
+          goto -> bb6;
+      }
+  
+      bb6: {
+          StorageDead(_10);
+          StorageDead(_5);
+          StorageDead(_4);
+          _6 = discriminant(_3);
+          switchInt(move _6) -> [1: bb1, 0: bb3, otherwise: bb7];
+      }
+  
+      bb7: {
+          unreachable;
+      }
+  }
+  
+  ALLOC0 (size: 8, align: 4) {
+      00 00 00 00 __ __ __ __                         │ ....░░░░
+  }
+  

--- a/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.GVN.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.GVN.panic-unwind.diff
@@ -55,7 +55,7 @@
       }
   
       bb4: {
-          _3 = const Option::<u32>::None;
+          _3 = Option::<u32>::None;
           goto -> bb6;
       }
   
@@ -79,9 +79,5 @@
       bb7: {
           unreachable;
       }
-  }
-  
-  ALLOC0 (size: 8, align: 4) {
-      00 00 00 00 __ __ __ __                         │ ....░░░░
   }
   

--- a/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.PreCodegen.after.panic-abort.mir
@@ -1,0 +1,44 @@
+// MIR for `use_checked_sub` after PreCodegen
+
+fn use_checked_sub(_1: u32, _2: u32) -> () {
+    debug x => _1;
+    debug rhs => _2;
+    let mut _0: ();
+    let mut _5: std::option::Option<u32>;
+    let _7: ();
+    scope 1 {
+        debug delta => _6;
+        let _6: u32;
+        scope 2 (inlined core::num::<impl u32>::checked_sub) {
+            let mut _3: bool;
+            let mut _4: u32;
+        }
+    }
+
+    bb0: {
+        StorageLive(_5);
+        StorageLive(_3);
+        _3 = Lt(copy _1, copy _2);
+        switchInt(move _3) -> [0: bb1, otherwise: bb2];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = SubUnchecked(copy _1, copy _2);
+        _5 = Option::<u32>::Some(move _4);
+        StorageDead(_4);
+        StorageDead(_3);
+        _6 = copy ((_5 as Some).0: u32);
+        _7 = do_something(move _6) -> [return: bb3, unwind unreachable];
+    }
+
+    bb2: {
+        StorageDead(_3);
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_5);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.use_checked_sub.PreCodegen.after.panic-unwind.mir
@@ -1,0 +1,44 @@
+// MIR for `use_checked_sub` after PreCodegen
+
+fn use_checked_sub(_1: u32, _2: u32) -> () {
+    debug x => _1;
+    debug rhs => _2;
+    let mut _0: ();
+    let mut _5: std::option::Option<u32>;
+    let _7: ();
+    scope 1 {
+        debug delta => _6;
+        let _6: u32;
+        scope 2 (inlined core::num::<impl u32>::checked_sub) {
+            let mut _3: bool;
+            let mut _4: u32;
+        }
+    }
+
+    bb0: {
+        StorageLive(_5);
+        StorageLive(_3);
+        _3 = Lt(copy _1, copy _2);
+        switchInt(move _3) -> [0: bb1, otherwise: bb2];
+    }
+
+    bb1: {
+        StorageLive(_4);
+        _4 = SubUnchecked(copy _1, copy _2);
+        _5 = Option::<u32>::Some(move _4);
+        StorageDead(_4);
+        StorageDead(_3);
+        _6 = copy ((_5 as Some).0: u32);
+        _7 = do_something(move _6) -> [return: bb3, unwind continue];
+    }
+
+    bb2: {
+        StorageDead(_3);
+        goto -> bb3;
+    }
+
+    bb3: {
+        StorageDead(_5);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -44,8 +44,7 @@
 -         StorageLive(_1);
 +         nop;
           StorageLive(_2);
--         _2 = Option::<Layout>::None;
-+         _2 = const Option::<Layout>::None;
+          _2 = Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
 -         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb1];

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -33,8 +33,7 @@
 -         StorageLive(_1);
 +         nop;
           StorageLive(_2);
--         _2 = Option::<Layout>::None;
-+         _2 = const Option::<Layout>::None;
+          _2 = Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
 -         switchInt(move _10) -> [0: bb3, 1: bb4, otherwise: bb2];

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -44,8 +44,7 @@
 -         StorageLive(_1);
 +         nop;
           StorageLive(_2);
--         _2 = Option::<Layout>::None;
-+         _2 = const Option::<Layout>::None;
+          _2 = Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
 -         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb1];

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -33,8 +33,7 @@
 -         StorageLive(_1);
 +         nop;
           StorageLive(_2);
--         _2 = Option::<Layout>::None;
-+         _2 = const Option::<Layout>::None;
+          _2 = Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
 -         switchInt(move _10) -> [0: bb3, 1: bb4, otherwise: bb2];

--- a/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-abort.mir
@@ -38,7 +38,7 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
     }
 
     bb1: {
-        _0 = const Option::<u32>::None;
+        _0 = Option::<u32>::None;
         goto -> bb3;
     }
 
@@ -56,8 +56,4 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
         StorageDead(_4);
         return;
     }
-}
-
-ALLOC0 (size: 8, align: 4) {
-    00 00 00 00 __ __ __ __                         │ ....░░░░
 }

--- a/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-unwind.mir
@@ -38,7 +38,7 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
     }
 
     bb1: {
-        _0 = const Option::<u32>::None;
+        _0 = Option::<u32>::None;
         goto -> bb3;
     }
 
@@ -56,8 +56,4 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
         StorageDead(_4);
         return;
     }
-}
-
-ALLOC0 (size: 8, align: 4) {
-    00 00 00 00 __ __ __ __                         │ ....░░░░
 }

--- a/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/simple_option_map.ezmap.PreCodegen.after.mir
@@ -20,7 +20,7 @@ fn ezmap(_1: Option<i32>) -> Option<i32> {
     }
 
     bb1: {
-        _0 = const Option::<i32>::None;
+        _0 = Option::<i32>::None;
         goto -> bb3;
     }
 
@@ -41,8 +41,4 @@ fn ezmap(_1: Option<i32>) -> Option<i32> {
     bb4: {
         unreachable;
     }
-}
-
-ALLOC0 (size: 8, align: 4) {
-    00 00 00 00 __ __ __ __                         │ ....░░░░
 }

--- a/tests/mir-opt/pre-codegen/simple_option_map.map_via_question_mark.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/simple_option_map.map_via_question_mark.PreCodegen.after.mir
@@ -1,0 +1,70 @@
+// MIR for `map_via_question_mark` after PreCodegen
+
+fn map_via_question_mark(_1: Option<i32>) -> Option<i32> {
+    debug x => _1;
+    let mut _0: std::option::Option<i32>;
+    let mut _4: std::ops::ControlFlow<std::option::Option<std::convert::Infallible>, i32>;
+    let _5: i32;
+    let mut _6: i32;
+    scope 1 {
+        debug residual => const Option::<Infallible>::None;
+        scope 2 {
+            scope 7 (inlined <Option<i32> as FromResidual<Option<Infallible>>>::from_residual) {
+            }
+        }
+    }
+    scope 3 {
+        debug val => _5;
+        scope 4 {
+        }
+    }
+    scope 5 (inlined <Option<i32> as Try>::branch) {
+        let mut _2: isize;
+        let _3: i32;
+        scope 6 {
+        }
+    }
+
+    bb0: {
+        StorageLive(_6);
+        StorageLive(_4);
+        StorageLive(_2);
+        StorageLive(_3);
+        _2 = discriminant(_1);
+        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
+    }
+
+    bb1: {
+        StorageDead(_3);
+        StorageDead(_2);
+        _0 = const Option::<i32>::None;
+        StorageDead(_6);
+        StorageDead(_4);
+        goto -> bb3;
+    }
+
+    bb2: {
+        _3 = copy ((_1 as Some).0: i32);
+        _4 = ControlFlow::<Option<Infallible>, i32>::Continue(copy _3);
+        StorageDead(_3);
+        StorageDead(_2);
+        _5 = copy ((_4 as Continue).0: i32);
+        _6 = Add(copy _5, const 1_i32);
+        _0 = Option::<i32>::Some(move _6);
+        StorageDead(_6);
+        StorageDead(_4);
+        goto -> bb3;
+    }
+
+    bb3: {
+        return;
+    }
+
+    bb4: {
+        unreachable;
+    }
+}
+
+ALLOC0 (size: 8, align: 4) {
+    00 00 00 00 __ __ __ __                         │ ....░░░░
+}

--- a/tests/mir-opt/pre-codegen/simple_option_map.map_via_question_mark.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/simple_option_map.map_via_question_mark.PreCodegen.after.mir
@@ -37,7 +37,7 @@ fn map_via_question_mark(_1: Option<i32>) -> Option<i32> {
     bb1: {
         StorageDead(_3);
         StorageDead(_2);
-        _0 = const Option::<i32>::None;
+        _0 = Option::<i32>::None;
         StorageDead(_6);
         StorageDead(_4);
         goto -> bb3;
@@ -63,8 +63,4 @@ fn map_via_question_mark(_1: Option<i32>) -> Option<i32> {
     bb4: {
         unreachable;
     }
-}
-
-ALLOC0 (size: 8, align: 4) {
-    00 00 00 00 __ __ __ __                         │ ....░░░░
 }

--- a/tests/mir-opt/pre-codegen/simple_option_map.rs
+++ b/tests/mir-opt/pre-codegen/simple_option_map.rs
@@ -17,6 +17,11 @@ pub fn ezmap(x: Option<i32>) -> Option<i32> {
     map(x, |n| n + 1)
 }
 
+// EMIT_MIR simple_option_map.map_via_question_mark.PreCodegen.after.mir
+pub fn map_via_question_mark(x: Option<i32>) -> Option<i32> {
+    Some(x? + 1)
+}
+
 fn main() {
     assert_eq!(None, ezmap(None));
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-abort.mir
@@ -30,7 +30,7 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
 
     bb1: {
         StorageDead(_3);
-        _0 = const Option::<&mut u32>::None;
+        _0 = Option::<&mut u32>::None;
         goto -> bb3;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-unwind.mir
@@ -30,7 +30,7 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
 
     bb1: {
         StorageDead(_3);
-        _0 = const Option::<&mut u32>::None;
+        _0 = Option::<&mut u32>::None;
         goto -> bb3;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.PreCodegen.after.panic-abort.mir
@@ -94,7 +94,7 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
     }
 
     bb3: {
-        _0 = const {transmute(0x0000000000000000): Option<&T>};
+        _0 = Option::<&T>::None;
         StorageDead(_7);
         goto -> bb8;
     }
@@ -105,7 +105,7 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
     }
 
     bb5: {
-        _0 = const {transmute(0x0000000000000000): Option<&T>};
+        _0 = Option::<&T>::None;
         goto -> bb8;
     }
 

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_next.PreCodegen.after.panic-unwind.mir
@@ -94,7 +94,7 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
     }
 
     bb3: {
-        _0 = const {transmute(0x0000000000000000): Option<&T>};
+        _0 = Option::<&T>::None;
         StorageDead(_7);
         goto -> bb8;
     }
@@ -105,7 +105,7 @@ fn slice_iter_next(_1: &mut std::slice::Iter<'_, T>) -> Option<&T> {
     }
 
     bb5: {
-        _0 = const {transmute(0x0000000000000000): Option<&T>};
+        _0 = Option::<&T>::None;
         goto -> bb8;
     }
 

--- a/tests/mir-opt/separate_const_switch.too_complex.JumpThreading.diff
+++ b/tests/mir-opt/separate_const_switch.too_complex.JumpThreading.diff
@@ -56,7 +56,7 @@
       bb5: {
           StorageLive(_8);
           _8 = copy ((_2 as Break).0: usize);
-          _0 = const Option::<i32>::None;
+          _0 = Option::<i32>::None;
           StorageDead(_8);
           goto -> bb7;
       }
@@ -76,9 +76,5 @@
 +         _6 = discriminant(_2);
 +         goto -> bb5;
       }
-  }
-  
-  ALLOC0 (size: 8, align: 4) {
-      00 00 00 00 __ __ __ __                         │ ....░░░░
   }
   

--- a/tests/mir-opt/simplify_aggregate_to_copy_miscompile.foo.GVN.diff
+++ b/tests/mir-opt/simplify_aggregate_to_copy_miscompile.foo.GVN.diff
@@ -42,10 +42,8 @@
 +         nop;
           _6 = copy (((*_2) as Some).0: i32);
           StorageLive(_8);
--         _8 = Option::<i32>::None;
--         (*_1) = move _8;
-+         _8 = const Option::<i32>::None;
-+         (*_1) = const Option::<i32>::None;
+          _8 = Option::<i32>::None;
+          (*_1) = move _8;
           StorageDead(_8);
           StorageLive(_9);
           _9 = copy _6;
@@ -64,9 +62,5 @@
           StorageLive(_10);
           unreachable;
       }
-+ }
-+ 
-+ ALLOC0 (size: 8, align: 4) {
-+     00 00 00 00 __ __ __ __                         │ ....░░░░
   }
   

--- a/tests/ui/sized/peek-iter-of-str.rs
+++ b/tests/ui/sized/peek-iter-of-str.rs
@@ -1,5 +1,9 @@
-//@ known-bug: #136442
+//@ build-pass
 //@ compile-flags: -Copt-level=0 -Zmir-enable-passes=+Inline -Zmir-enable-passes=+JumpThreading --crate-type lib
+
+// Regression test for <https://github.com/rust-lang/rust/issues/136442>
+// Used to fail in MIR but #138526 (accidentally) worked around that.
+
 pub fn problem_thingy(items: &mut impl Iterator<Item = str>) {
     let mut peeker = items.peekable();
     match peeker.peek() {


### PR DESCRIPTION
Having `ALLOC`s for these seems unhelpful, since it's extra stuff to keep track of, makes it harder for other passes to know what's in it (reversing a tag constant to a `VariantIdx` isn't trivial), and even in codegen it's arguably harder to get a `None` from a valtree than from seeing "oh, aggregate nothing with this `VariantIdx`".

Making constants for the `discriminant(_n)` is useful for putting in `switchInt`s, and still happens with this PR.  It's just for the full enum that we don't make consts (except for might-as-well-be-an-integer enums like `Ordering`, or ones that are actually ZSTs like `const Option::<Infallible>::None`).

This also adds a couple tests I've been using as I look at how we're doing enums in MIR.  They're not really *improved* by this change materially, but they help motivate why I'm trying to tweak how the enums come out.