### PR TITLE
deref patterns: implement implicit deref patterns

### DIFF
--- a/compiler/rustc_hir_analysis/src/autoderef.rs
+++ b/compiler/rustc_hir_analysis/src/autoderef.rs
@@ -2,8 +2,8 @@ use rustc_infer::infer::InferCtxt;
 use rustc_infer::traits::PredicateObligations;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt};
 use rustc_session::Limit;
-use rustc_span::Span;
 use rustc_span::def_id::{LOCAL_CRATE, LocalDefId};
+use rustc_span::{ErrorGuaranteed, Span};
 use rustc_trait_selection::traits::ObligationCtxt;
 use tracing::{debug, instrument};
 
@@ -259,7 +259,11 @@ impl<'a, 'tcx> Autoderef<'a, 'tcx> {
     }
 }
 
-pub fn report_autoderef_recursion_limit_error<'tcx>(tcx: TyCtxt<'tcx>, span: Span, ty: Ty<'tcx>) {
+pub fn report_autoderef_recursion_limit_error<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    span: Span,
+    ty: Ty<'tcx>,
+) -> ErrorGuaranteed {
     // We've reached the recursion limit, error gracefully.
     let suggested_limit = match tcx.recursion_limit() {
         Limit(0) => Limit(2),
@@ -270,5 +274,5 @@ pub fn report_autoderef_recursion_limit_error<'tcx>(tcx: TyCtxt<'tcx>, span: Spa
         ty,
         suggested_limit,
         crate_name: tcx.crate_name(LOCAL_CRATE),
-    });
+    })
 }

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -1227,9 +1227,9 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         // actually this is somewhat "disjoint" from the code below
         // that aims to account for `ref x`.
         if let Some(vec) = self.cx.typeck_results().pat_adjustments().get(pat.hir_id) {
-            if let Some(first_ty) = vec.first() {
-                debug!("pat_ty(pat={:?}) found adjusted ty `{:?}`", pat, first_ty);
-                return Ok(*first_ty);
+            if let Some(first_adjust) = vec.first() {
+                debug!("pat_ty(pat={:?}) found adjustment `{:?}`", pat, first_adjust);
+                return Ok(first_adjust.source);
             }
         } else if let PatKind::Ref(subpat, _) = pat.kind
             && self.cx.typeck_results().skipped_ref_pats().contains(pat.hir_id)

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -1000,6 +1000,8 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                     // determines whether to borrow *at the level of the deref pattern* rather than
                     // borrowing the bound place (since that inner place is inside the temporary that
                     // stores the result of calling `deref()`/`deref_mut()` so can't be captured).
+                    // HACK: this could be a fake pattern corresponding to a deref inserted by match
+                    // ergonomics, in which case `pat.hir_id` will be the id of the subpattern.
                     let mutable = self.cx.typeck_results().pat_has_ref_mut_binding(subpattern);
                     let mutability =
                         if mutable { hir::Mutability::Mut } else { hir::Mutability::Not };
@@ -1675,12 +1677,31 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         // Then we see that to get the same result, we must start with
         // `deref { deref { place_foo }}` instead of `place_foo` since the pattern is now `Some(x,)`
         // and not `&&Some(x,)`, even though its assigned type is that of `&&Some(x,)`.
-        for _ in
-            0..self.cx.typeck_results().pat_adjustments().get(pat.hir_id).map_or(0, |v| v.len())
-        {
+        let typeck_results = self.cx.typeck_results();
+        let adjustments: &[adjustment::PatAdjustment<'tcx>] =
+            typeck_results.pat_adjustments().get(pat.hir_id).map_or(&[], |v| &**v);
+        let mut adjusts = adjustments.iter().peekable();
+        while let Some(adjust) = adjusts.next() {
             debug!("applying adjustment to place_with_id={:?}", place_with_id);
-            place_with_id = self.cat_deref(pat.hir_id, place_with_id)?;
+            place_with_id = match adjust.kind {
+                adjustment::PatAdjust::BuiltinDeref => self.cat_deref(pat.hir_id, place_with_id)?,
+                adjustment::PatAdjust::OverloadedDeref => {
+                    // This adjustment corresponds to an overloaded deref; it borrows the scrutinee to
+                    // call `Deref::deref` or `DerefMut::deref_mut`. Invoke the callback before setting
+                    // `place_with_id` to the temporary storing the result of the deref.
+                    // HACK(dianne): giving the callback a fake deref pattern makes sure it behaves the
+                    // same as it would if this were an explicit deref pattern.
+                    op(&place_with_id, &hir::Pat { kind: PatKind::Deref(pat), ..*pat })?;
+                    let target_ty = match adjusts.peek() {
+                        Some(&&next_adjust) => next_adjust.source,
+                        // At the end of the deref chain, we get `pat`'s scrutinee.
+                        None => self.pat_ty_unadjusted(pat)?,
+                    };
+                    self.pat_deref_temp(pat.hir_id, pat, target_ty)?
+                }
+            };
         }
+        drop(typeck_results); // explicitly release borrow of typeck results, just in case.
         let place_with_id = place_with_id; // lose mutability
         debug!("applied adjustment derefs to get place_with_id={:?}", place_with_id);
 
@@ -1783,14 +1804,8 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
                 self.cat_pattern(subplace, subpat, op)?;
             }
             PatKind::Deref(subpat) => {
-                let mutable = self.cx.typeck_results().pat_has_ref_mut_binding(subpat);
-                let mutability = if mutable { hir::Mutability::Mut } else { hir::Mutability::Not };
-                let re_erased = self.cx.tcx().lifetimes.re_erased;
                 let ty = self.pat_ty_adjusted(subpat)?;
-                let ty = Ty::new_ref(self.cx.tcx(), re_erased, ty, mutability);
-                // A deref pattern generates a temporary.
-                let base = self.cat_rvalue(pat.hir_id, ty);
-                let place = self.cat_deref(pat.hir_id, base)?;
+                let place = self.pat_deref_temp(pat.hir_id, subpat, ty)?;
                 self.cat_pattern(place, subpat, op)?;
             }
 
@@ -1841,6 +1856,23 @@ impl<'tcx, Cx: TypeInformationCtxt<'tcx>, D: Delegate<'tcx>> ExprUseVisitor<'tcx
         }
 
         Ok(())
+    }
+
+    /// Represents the place of the temp that stores the scrutinee of a deref pattern's interior.
+    fn pat_deref_temp(
+        &self,
+        hir_id: HirId,
+        inner: &hir::Pat<'_>,
+        target_ty: Ty<'tcx>,
+    ) -> Result<PlaceWithHirId<'tcx>, Cx::Error> {
+        let mutable = self.cx.typeck_results().pat_has_ref_mut_binding(inner);
+        let mutability = if mutable { hir::Mutability::Mut } else { hir::Mutability::Not };
+        let re_erased = self.cx.tcx().lifetimes.re_erased;
+        let ty = Ty::new_ref(self.cx.tcx(), re_erased, target_ty, mutability);
+        // A deref pattern stores the result of `Deref::deref` or `DerefMut::deref_mut` ...
+        let base = self.cat_rvalue(hir_id, ty);
+        // ... and the inner pattern matches on the place behind that reference.
+        self.cat_deref(hir_id, base)
     }
 
     fn is_multivariant_adt(&self, ty: Ty<'tcx>, span: Span) -> bool {

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -29,6 +29,7 @@ use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::traits::{ObligationCause, ObligationCauseCode};
 use tracing::{debug, instrument, trace};
 use ty::VariantDef;
+use ty::adjustment::{PatAdjust, PatAdjustment};
 
 use super::report_unexpected_variant_res;
 use crate::expectation::Expectation;
@@ -415,7 +416,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     .pat_adjustments_mut()
                     .entry(pat.hir_id)
                     .or_default()
-                    .push(expected);
+                    .push(PatAdjustment { kind: PatAdjust::BuiltinDeref, source: expected });
 
                 let mut binding_mode = ByRef::Yes(match pat_info.binding_mode {
                     // If default binding mode is by value, make it `ref` or `ref mut`

--- a/compiler/rustc_middle/src/ty/adjustment.rs
+++ b/compiler/rustc_middle/src/ty/adjustment.rs
@@ -214,3 +214,25 @@ pub enum CustomCoerceUnsized {
     /// Records the index of the field being coerced.
     Struct(FieldIdx),
 }
+
+/// Represents an implicit coercion applied to the scrutinee of a match before testing a pattern
+/// against it. Currently, this is used only for implicit dereferences.
+#[derive(Clone, Copy, TyEncodable, TyDecodable, HashStable, TypeFoldable, TypeVisitable)]
+pub struct PatAdjustment<'tcx> {
+    pub kind: PatAdjust,
+    /// The type of the scrutinee before the adjustment is applied, or the "adjusted type" of the
+    /// pattern.
+    pub source: Ty<'tcx>,
+}
+
+/// Represents implicit coercions of patterns' types, rather than values' types.
+#[derive(Clone, Copy, PartialEq, Debug, TyEncodable, TyDecodable, HashStable)]
+#[derive(TypeFoldable, TypeVisitable)]
+pub enum PatAdjust {
+    /// An implicit dereference before matching, such as when matching the pattern `0` against a
+    /// scrutinee of type `&u8` or `&mut u8`.
+    BuiltinDeref,
+    /// An implicit call to `Deref(Mut)::deref(_mut)` before matching, such as when matching the
+    /// pattern `[..]` against a scrutinee of type `Vec<T>`.
+    OverloadedDeref,
+}

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -61,6 +61,12 @@ impl<'tcx> fmt::Debug for ty::adjustment::Adjustment<'tcx> {
     }
 }
 
+impl<'tcx> fmt::Debug for ty::adjustment::PatAdjustment<'tcx> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} -> {:?}", self.source, self.kind)
+    }
+}
+
 impl fmt::Debug for ty::BoundRegionKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -90,7 +90,7 @@ pub struct TypeckResults<'tcx> {
     ///
     /// See:
     /// <https://github.com/rust-lang/rfcs/blob/master/text/2005-match-ergonomics.md#definitions>
-    pat_adjustments: ItemLocalMap<Vec<Ty<'tcx>>>,
+    pat_adjustments: ItemLocalMap<Vec<ty::adjustment::PatAdjustment<'tcx>>>,
 
     /// Set of reference patterns that match against a match-ergonomics inserted reference
     /// (as opposed to against a reference in the scrutinee type).
@@ -403,11 +403,15 @@ impl<'tcx> TypeckResults<'tcx> {
         LocalTableInContextMut { hir_owner: self.hir_owner, data: &mut self.pat_binding_modes }
     }
 
-    pub fn pat_adjustments(&self) -> LocalTableInContext<'_, Vec<Ty<'tcx>>> {
+    pub fn pat_adjustments(
+        &self,
+    ) -> LocalTableInContext<'_, Vec<ty::adjustment::PatAdjustment<'tcx>>> {
         LocalTableInContext { hir_owner: self.hir_owner, data: &self.pat_adjustments }
     }
 
-    pub fn pat_adjustments_mut(&mut self) -> LocalTableInContextMut<'_, Vec<Ty<'tcx>>> {
+    pub fn pat_adjustments_mut(
+        &mut self,
+    ) -> LocalTableInContextMut<'_, Vec<ty::adjustment::PatAdjustment<'tcx>>> {
         LocalTableInContextMut { hir_owner: self.hir_owner, data: &mut self.pat_adjustments }
     }
 

--- a/compiler/rustc_middle/src/ty/typeck_results.rs
+++ b/compiler/rustc_middle/src/ty/typeck_results.rs
@@ -77,8 +77,8 @@ pub struct TypeckResults<'tcx> {
     /// to a form valid in all Editions, either as a lint diagnostic or hard error.
     rust_2024_migration_desugared_pats: ItemLocalMap<Rust2024IncompatiblePatInfo>,
 
-    /// Stores the types which were implicitly dereferenced in pattern binding modes
-    /// for later usage in THIR lowering. For example,
+    /// Stores the types which were implicitly dereferenced in pattern binding modes or deref
+    /// patterns for later usage in THIR lowering. For example,
     ///
     /// ```
     /// match &&Some(5i32) {
@@ -86,7 +86,16 @@ pub struct TypeckResults<'tcx> {
     ///     _ => {},
     /// }
     /// ```
-    /// leads to a `vec![&&Option<i32>, &Option<i32>]`. Empty vectors are not stored.
+    /// leads to a `vec![&&Option<i32>, &Option<i32>]` and
+    ///
+    /// ```
+    /// #![feature(deref_patterns)]
+    /// match &Box::new(Some(5i32)) {
+    ///     Some(n) => {},
+    ///     _ => {},
+    /// }
+    /// ```
+    /// leads to a `vec![&Box<Option<i32>>, Box<Option<i32>>]`. Empty vectors are not stored.
     ///
     /// See:
     /// <https://github.com/rust-lang/rfcs/blob/master/text/2005-match-ergonomics.md#definitions>

--- a/compiler/rustc_mir_build/src/thir/pattern/migration.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/migration.rs
@@ -5,7 +5,7 @@ use rustc_errors::MultiSpan;
 use rustc_hir::{BindingMode, ByRef, HirId, Mutability};
 use rustc_lint as lint;
 use rustc_middle::span_bug;
-use rustc_middle::ty::{self, Rust2024IncompatiblePatInfo, Ty, TyCtxt};
+use rustc_middle::ty::{self, Rust2024IncompatiblePatInfo, TyCtxt};
 use rustc_span::{Ident, Span};
 
 use crate::errors::{Rust2024IncompatiblePat, Rust2024IncompatiblePatSugg};
@@ -93,10 +93,10 @@ impl<'a> PatMigration<'a> {
     pub(super) fn visit_implicit_derefs<'tcx>(
         &mut self,
         pat_span: Span,
-        adjustments: &[Ty<'tcx>],
+        adjustments: &[ty::adjustment::PatAdjustment<'tcx>],
     ) -> Option<(Span, Mutability)> {
-        let implicit_deref_mutbls = adjustments.iter().map(|ref_ty| {
-            let &ty::Ref(_, _, mutbl) = ref_ty.kind() else {
+        let implicit_deref_mutbls = adjustments.iter().map(|adjust| {
+            let &ty::Ref(_, _, mutbl) = adjust.source.kind() else {
                 span_bug!(pat_span, "pattern implicitly dereferences a non-ref type");
             };
             mutbl

--- a/compiler/rustc_mir_build/src/thir/pattern/migration.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/migration.rs
@@ -4,7 +4,6 @@ use rustc_data_structures::fx::FxIndexMap;
 use rustc_errors::MultiSpan;
 use rustc_hir::{BindingMode, ByRef, HirId, Mutability};
 use rustc_lint as lint;
-use rustc_middle::span_bug;
 use rustc_middle::ty::{self, Rust2024IncompatiblePatInfo, TyCtxt};
 use rustc_span::{Ident, Span};
 
@@ -87,19 +86,18 @@ impl<'a> PatMigration<'a> {
     }
 
     /// Tracks when we're lowering a pattern that implicitly dereferences the scrutinee.
-    /// This should only be called when the pattern type adjustments list `adjustments` is
-    /// non-empty. Returns the prior default binding mode; this should be followed by a call to
-    /// [`PatMigration::leave_ref`] to restore it when we leave the pattern.
+    /// This should only be called when the pattern type adjustments list `adjustments` contains an
+    /// implicit deref of a reference type. Returns the prior default binding mode; this should be
+    /// followed by a call to [`PatMigration::leave_ref`] to restore it when we leave the pattern.
     pub(super) fn visit_implicit_derefs<'tcx>(
         &mut self,
         pat_span: Span,
         adjustments: &[ty::adjustment::PatAdjustment<'tcx>],
     ) -> Option<(Span, Mutability)> {
-        let implicit_deref_mutbls = adjustments.iter().map(|adjust| {
-            let &ty::Ref(_, _, mutbl) = adjust.source.kind() else {
-                span_bug!(pat_span, "pattern implicitly dereferences a non-ref type");
-            };
-            mutbl
+        // Implicitly dereferencing references changes the default binding mode, but implicit derefs
+        // of smart pointers do not. Thus, we only consider implicit derefs of reference types.
+        let implicit_deref_mutbls = adjustments.iter().filter_map(|adjust| {
+            if let &ty::Ref(_, _, mutbl) = adjust.source.kind() { Some(mutbl) } else { None }
         });
 
         if !self.info.suggest_eliding_modes {

--- a/src/doc/unstable-book/src/language-features/box-patterns.md
+++ b/src/doc/unstable-book/src/language-features/box-patterns.md
@@ -6,6 +6,8 @@ The tracking issue for this feature is: [#29641]
 
 ------------------------
 
+> **Note**: This feature will be superseded by [`deref_patterns`] in the future.
+
 Box patterns let you match on `Box<T>`s:
 
 
@@ -28,3 +30,5 @@ fn main() {
     }
 }
 ```
+
+[`deref_patterns`]: ./deref-patterns.md

--- a/src/doc/unstable-book/src/language-features/deref-patterns.md
+++ b/src/doc/unstable-book/src/language-features/deref-patterns.md
@@ -1,0 +1,57 @@
+# `deref_patterns`
+
+The tracking issue for this feature is: [#87121]
+
+[#87121]: https://github.com/rust-lang/rust/issues/87121
+
+------------------------
+
+> **Note**: This feature is incomplete. In the future, it is meant to supersede
+> [`box_patterns`](./box-patterns.md) and [`string_deref_patterns`](./string-deref-patterns.md).
+
+This feature permits pattern matching on [smart pointers in the standard library] through their
+`Deref` target types, either implicitly or with explicit `deref!(_)` patterns (the syntax of which
+is currently a placeholder).
+
+```rust
+#![feature(deref_patterns)]
+#![allow(incomplete_features)]
+
+let mut v = vec![Box::new(Some(0))];
+
+// Implicit dereferences are inserted when a pattern can match against the
+// result of repeatedly dereferencing but can't match against a smart
+// pointer itself. This works alongside match ergonomics for references.
+if let [Some(x)] = &mut v {
+    *x += 1;
+}
+
+// Explicit `deref!(_)` patterns may instead be used when finer control is
+// needed, e.g. to dereference only a single smart pointer, or to bind the
+// the result of dereferencing to a variable.
+if let deref!([deref!(opt_x @ Some(1))]) = &mut v {
+    opt_x.as_mut().map(|x| *x += 1);
+}
+
+assert_eq!(v, [Box::new(Some(2))]);
+```
+
+Without this feature, it may be necessary to introduce temporaries to represent dereferenced places
+when matching on nested structures:
+
+```rust
+let mut v = vec![Box::new(Some(0))];
+if let [b] = &mut *v {
+    if let Some(x) = &mut **b {
+        *x += 1;
+    }
+}
+if let [b] = &mut *v {
+    if let opt_x @ Some(1) = &mut **b {
+        opt_x.as_mut().map(|x| *x += 1);
+    }
+}
+assert_eq!(v, [Box::new(Some(2))]);
+```
+
+[smart pointers in the standard library]: https://doc.rust-lang.org/std/ops/trait.DerefPure.html#implementors

--- a/src/doc/unstable-book/src/language-features/string-deref-patterns.md
+++ b/src/doc/unstable-book/src/language-features/string-deref-patterns.md
@@ -6,6 +6,8 @@ The tracking issue for this feature is: [#87121]
 
 ------------------------
 
+> **Note**: This feature will be superseded by [`deref_patterns`] in the future.
+
 This feature permits pattern matching `String` to `&str` through [its `Deref` implementation].
 
 ```rust
@@ -42,4 +44,5 @@ pub fn is_it_the_answer(value: Value) -> bool {
 }
 ```
 
+[`deref_patterns`]: ./deref-patterns.md
 [its `Deref` implementation]: https://doc.rust-lang.org/std/string/struct.String.html#impl-Deref-for-String

--- a/src/tools/clippy/clippy_lints/src/pattern_type_mismatch.rs
+++ b/src/tools/clippy/clippy_lints/src/pattern_type_mismatch.rs
@@ -179,7 +179,7 @@ fn find_first_mismatch(cx: &LateContext<'_>, pat: &Pat<'_>) -> Option<(Span, Mut
         };
         if let Some(adjustments) = cx.typeck_results().pat_adjustments().get(adjust_pat.hir_id) {
             if let [first, ..] = **adjustments {
-                if let ty::Ref(.., mutability) = *first.kind() {
+                if let ty::Ref(.., mutability) = *first.source.kind() {
                     let level = if p.hir_id == pat.hir_id {
                         Level::Top
                     } else {

--- a/tests/ui/pattern/deref-patterns/bindings.rs
+++ b/tests/ui/pattern/deref-patterns/bindings.rs
@@ -51,6 +51,7 @@ fn nested_vec(vecvec: Vec<Vec<u32>>) -> u32 {
     }
 }
 
+#[cfg(explicit)]
 fn ref_mut(val: u32) -> u32 {
     let mut b = Box::new(0u32);
     match &mut b {
@@ -64,12 +65,39 @@ fn ref_mut(val: u32) -> u32 {
     *x
 }
 
+#[cfg(implicit)]
+fn ref_mut(val: u32) -> u32 {
+    let mut b = Box::new((0u32,));
+    match &mut b {
+        (_x,) if false => unreachable!(),
+        (x,) => {
+            *x = val;
+        }
+        _ => unreachable!(),
+    }
+    let (x,) = &b else { unreachable!() };
+    *x
+}
+
+#[cfg(explicit)]
 #[rustfmt::skip]
 fn or_and_guard(tuple: (u32, u32)) -> u32 {
     let mut sum = 0;
     let b = Box::new(tuple);
     match b {
         deref!((x, _) | (_, x)) if { sum += x; false } => {},
+        _ => {},
+    }
+    sum
+}
+
+#[cfg(implicit)]
+#[rustfmt::skip]
+fn or_and_guard(tuple: (u32, u32)) -> u32 {
+    let mut sum = 0;
+    let b = Box::new(tuple);
+    match b {
+        (x, _) | (_, x) if { sum += x; false } => {},
         _ => {},
     }
     sum

--- a/tests/ui/pattern/deref-patterns/bindings.rs
+++ b/tests/ui/pattern/deref-patterns/bindings.rs
@@ -1,7 +1,9 @@
+//@ revisions: explicit implicit
 //@ run-pass
 #![feature(deref_patterns)]
 #![allow(incomplete_features)]
 
+#[cfg(explicit)]
 fn simple_vec(vec: Vec<u32>) -> u32 {
     match vec {
         deref!([]) => 100,
@@ -13,6 +15,19 @@ fn simple_vec(vec: Vec<u32>) -> u32 {
     }
 }
 
+#[cfg(implicit)]
+fn simple_vec(vec: Vec<u32>) -> u32 {
+    match vec {
+        [] => 100,
+        [x] if x == 4 => x + 4,
+        [x] => x,
+        [1, x] => x + 200,
+        deref!(ref slice) => slice.iter().sum(),
+        _ => 2000,
+    }
+}
+
+#[cfg(explicit)]
 fn nested_vec(vecvec: Vec<Vec<u32>>) -> u32 {
     match vecvec {
         deref!([]) => 0,
@@ -20,6 +35,18 @@ fn nested_vec(vecvec: Vec<Vec<u32>>) -> u32 {
         deref!([deref!([0, x]) | deref!([1, x])]) => x,
         deref!([ref x]) => x.iter().sum(),
         deref!([deref!([]), deref!([1, x, y])]) => y - x,
+        _ => 2000,
+    }
+}
+
+#[cfg(implicit)]
+fn nested_vec(vecvec: Vec<Vec<u32>>) -> u32 {
+    match vecvec {
+        [] => 0,
+        [[x]] => x,
+        [[0, x] | [1, x]] => x,
+        [ref x] => x.iter().sum(),
+        [[], [1, x, y]] => y - x,
         _ => 2000,
     }
 }

--- a/tests/ui/pattern/deref-patterns/branch.rs
+++ b/tests/ui/pattern/deref-patterns/branch.rs
@@ -1,8 +1,10 @@
+//@ revisions: explicit implicit
 //@ run-pass
 // Test the execution of deref patterns.
 #![feature(deref_patterns)]
 #![allow(incomplete_features)]
 
+#[cfg(explicit)]
 fn branch(vec: Vec<u32>) -> u32 {
     match vec {
         deref!([]) => 0,
@@ -12,10 +14,30 @@ fn branch(vec: Vec<u32>) -> u32 {
     }
 }
 
+#[cfg(implicit)]
+fn branch(vec: Vec<u32>) -> u32 {
+    match vec {
+        [] => 0,
+        [1, _, 3] => 1,
+        [2, ..] => 2,
+        _ => 1000,
+    }
+}
+
+#[cfg(explicit)]
 fn nested(vec: Vec<Vec<u32>>) -> u32 {
     match vec {
         deref!([deref!([]), ..]) => 1,
         deref!([deref!([0, ..]), deref!([1, ..])]) => 2,
+        _ => 1000,
+    }
+}
+
+#[cfg(implicit)]
+fn nested(vec: Vec<Vec<u32>>) -> u32 {
+    match vec {
+        [[], ..] => 1,
+        [[0, ..], [1, ..]] => 2,
         _ => 1000,
     }
 }

--- a/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.rs
+++ b/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.rs
@@ -21,4 +21,22 @@ fn cant_move_out_rc(rc: Rc<Struct>) -> Struct {
     }
 }
 
+struct Container(Struct);
+
+fn cant_move_out_box_implicit(b: Box<Container>) -> Struct {
+    match b {
+        //~^ ERROR: cannot move out of a shared reference
+        Container(x) => x,
+        _ => unreachable!(),
+    }
+}
+
+fn cant_move_out_rc_implicit(rc: Rc<Container>) -> Struct {
+    match rc {
+        //~^ ERROR: cannot move out of a shared reference
+        Container(x) => x,
+        _ => unreachable!(),
+    }
+}
+
 fn main() {}

--- a/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.stderr
+++ b/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.stderr
@@ -32,6 +32,40 @@ help: consider borrowing the pattern binding
 LL |         deref!(ref x) => x,
    |                +++
 
-error: aborting due to 2 previous errors
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/cant_move_out_of_pattern.rs:27:11
+   |
+LL |     match b {
+   |           ^
+LL |
+LL |         Container(x) => x,
+   |                   -
+   |                   |
+   |                   data moved here
+   |                   move occurs because `x` has type `Struct`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         Container(ref x) => x,
+   |                   +++
+
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/cant_move_out_of_pattern.rs:35:11
+   |
+LL |     match rc {
+   |           ^^
+LL |
+LL |         Container(x) => x,
+   |                   -
+   |                   |
+   |                   data moved here
+   |                   move occurs because `x` has type `Struct`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         Container(ref x) => x,
+   |                   +++
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/pattern/deref-patterns/closure_capture.rs
+++ b/tests/ui/pattern/deref-patterns/closure_capture.rs
@@ -11,6 +11,15 @@ fn main() {
     assert_eq!(b.len(), 3);
     f();
 
+    let v = vec![1, 2, 3];
+    let f = || {
+        // this should count as a borrow of `v` as a whole
+        let [.., x] = v else { unreachable!() };
+        assert_eq!(x, 3);
+    };
+    assert_eq!(v, [1, 2, 3]);
+    f();
+
     let mut b = Box::new("aaa".to_string());
     let mut f = || {
         let deref!(ref mut s) = b else { unreachable!() };
@@ -18,4 +27,22 @@ fn main() {
     };
     f();
     assert_eq!(b.len(), 5);
+
+    let mut v = vec![1, 2, 3];
+    let mut f = || {
+        // this should count as a mutable borrow of `v` as a whole
+        let [.., ref mut x] = v else { unreachable!() };
+        *x = 4;
+    };
+    f();
+    assert_eq!(v, [1, 2, 4]);
+
+    let mut v = vec![1, 2, 3];
+    let mut f = || {
+        // here, `[.., x]` is adjusted by both an overloaded deref and a builtin deref
+        let [.., x] = &mut v else { unreachable!() };
+        *x = 4;
+    };
+    f();
+    assert_eq!(v, [1, 2, 4]);
 }

--- a/tests/ui/pattern/deref-patterns/fake_borrows.rs
+++ b/tests/ui/pattern/deref-patterns/fake_borrows.rs
@@ -11,4 +11,11 @@ fn main() {
         deref!(false) => {}
         _ => {},
     }
+    match b {
+        true => {}
+        _ if { *b = true; false } => {}
+        //~^ ERROR cannot assign `*b` in match guard
+        false => {}
+        _ => {},
+    }
 }

--- a/tests/ui/pattern/deref-patterns/fake_borrows.stderr
+++ b/tests/ui/pattern/deref-patterns/fake_borrows.stderr
@@ -7,6 +7,15 @@ LL |         deref!(true) => {}
 LL |         _ if { *b = true; false } => {}
    |                ^^^^^^^^^ cannot assign
 
-error: aborting due to 1 previous error
+error[E0510]: cannot assign `*b` in match guard
+  --> $DIR/fake_borrows.rs:16:16
+   |
+LL |     match b {
+   |           - value is immutable in match guard
+LL |         true => {}
+LL |         _ if { *b = true; false } => {}
+   |                ^^^^^^^^^ cannot assign
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0510`.

--- a/tests/ui/pattern/deref-patterns/implicit-const-deref.rs
+++ b/tests/ui/pattern/deref-patterns/implicit-const-deref.rs
@@ -1,0 +1,19 @@
+//! Test that we get an error about structural equality rather than a type error when attempting to
+//! use const patterns of library pointer types. Currently there aren't any smart pointers that can
+//! be used in constant patterns, but we still need to make sure we don't implicitly dereference the
+//! scrutinee and end up with a type error; this would prevent us from reporting that only constants
+//! supporting structural equality can be used as patterns.
+#![feature(deref_patterns)]
+#![allow(incomplete_features)]
+
+const EMPTY: Vec<()> = Vec::new();
+
+fn main() {
+    // FIXME(inline_const_pat): if `inline_const_pat` is reinstated, there should be a case here for
+    // inline const block patterns as well; they're checked differently than named constants.
+    match vec![()] {
+        EMPTY => {}
+        //~^ ERROR: constant of non-structural type `Vec<()>` in a pattern
+        _ => {}
+    }
+}

--- a/tests/ui/pattern/deref-patterns/implicit-const-deref.stderr
+++ b/tests/ui/pattern/deref-patterns/implicit-const-deref.stderr
@@ -1,0 +1,16 @@
+error: constant of non-structural type `Vec<()>` in a pattern
+  --> $DIR/implicit-const-deref.rs:15:9
+   |
+LL | const EMPTY: Vec<()> = Vec::new();
+   | -------------------- constant defined here
+...
+LL |         EMPTY => {}
+   |         ^^^^^ constant of non-structural type
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+   = note: `Vec<()>` must be annotated with `#[derive(PartialEq)]` to be usable in patterns
+   |
+   = note: see https://doc.rust-lang.org/stable/std/marker/trait.StructuralPartialEq.html for details
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/pattern/deref-patterns/implicit-cow-deref.rs
+++ b/tests/ui/pattern/deref-patterns/implicit-cow-deref.rs
@@ -1,0 +1,44 @@
+//@ run-pass
+//! Test that implicit deref patterns interact as expected with `Cow` constructor patterns.
+#![feature(deref_patterns)]
+#![allow(incomplete_features)]
+
+use std::borrow::Cow;
+
+fn main() {
+    let cow: Cow<'static, [u8]> = Cow::from(&[1, 2, 3]);
+
+    match cow {
+        [..] => {}
+        _ => unreachable!(),
+    }
+
+    match cow {
+        Cow::Borrowed(_) => {}
+        Cow::Owned(_) => unreachable!(),
+    }
+
+    match Box::new(&cow) {
+        Cow::Borrowed { 0: _ } => {}
+        Cow::Owned { 0: _ } => unreachable!(),
+        _ => unreachable!(),
+    }
+
+    let cow_of_cow: Cow<'_, Cow<'static, [u8]>> = Cow::Owned(cow);
+
+    match cow_of_cow {
+        [..] => {}
+        _ => unreachable!(),
+    }
+
+    match cow_of_cow {
+        Cow::Borrowed(_) => unreachable!(),
+        Cow::Owned(_) => {}
+    }
+
+    match Box::new(&cow_of_cow) {
+        Cow::Borrowed { 0: _ } => unreachable!(),
+        Cow::Owned { 0: _ } => {}
+        _ => unreachable!(),
+    }
+}

--- a/tests/ui/pattern/deref-patterns/implicit-cow-deref.rs
+++ b/tests/ui/pattern/deref-patterns/implicit-cow-deref.rs
@@ -6,7 +6,7 @@
 use std::borrow::Cow;
 
 fn main() {
-    let cow: Cow<'static, [u8]> = Cow::from(&[1, 2, 3]);
+    let cow: Cow<'static, [u8]> = Cow::Borrowed(&[1, 2, 3]);
 
     match cow {
         [..] => {}
@@ -31,6 +31,7 @@ fn main() {
         _ => unreachable!(),
     }
 
+    // This matches on the outer `Cow` (the owned one).
     match cow_of_cow {
         Cow::Borrowed(_) => unreachable!(),
         Cow::Owned(_) => {}

--- a/tests/ui/pattern/deref-patterns/needs-gate.rs
+++ b/tests/ui/pattern/deref-patterns/needs-gate.rs
@@ -1,0 +1,15 @@
+// gate-test-deref_patterns
+
+fn main() {
+    match Box::new(0) {
+        deref!(0) => {}
+        //~^ ERROR: use of unstable library feature `deref_patterns`: placeholder syntax for deref patterns
+        _ => {}
+    }
+
+    match Box::new(0) {
+        0 => {}
+        //~^ ERROR: mismatched types
+        _ => {}
+    }
+}

--- a/tests/ui/pattern/deref-patterns/needs-gate.stderr
+++ b/tests/ui/pattern/deref-patterns/needs-gate.stderr
@@ -1,0 +1,29 @@
+error[E0658]: use of unstable library feature `deref_patterns`: placeholder syntax for deref patterns
+  --> $DIR/needs-gate.rs:5:9
+   |
+LL |         deref!(0) => {}
+   |         ^^^^^
+   |
+   = note: see issue #87121 <https://github.com/rust-lang/rust/issues/87121> for more information
+   = help: add `#![feature(deref_patterns)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0308]: mismatched types
+  --> $DIR/needs-gate.rs:11:9
+   |
+LL |     match Box::new(0) {
+   |           ----------- this expression has type `Box<{integer}>`
+LL |         0 => {}
+   |         ^ expected `Box<{integer}>`, found integer
+   |
+   = note: expected struct `Box<{integer}>`
+                found type `{integer}`
+help: consider dereferencing to access the inner value using the Deref trait
+   |
+LL |     match *Box::new(0) {
+   |           +
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/pattern/deref-patterns/recursion-limit.rs
+++ b/tests/ui/pattern/deref-patterns/recursion-limit.rs
@@ -1,0 +1,23 @@
+//! Test that implicit deref patterns respect the recursion limit
+#![feature(deref_patterns)]
+#![allow(incomplete_features)]
+#![recursion_limit = "8"]
+
+use std::ops::Deref;
+
+struct Cyclic;
+impl Deref for Cyclic {
+    type Target = Cyclic;
+    fn deref(&self) -> &Cyclic {
+        &Cyclic
+    }
+}
+
+fn main() {
+    match &Box::new(Cyclic) {
+        () => {}
+        //~^ ERROR: reached the recursion limit while auto-dereferencing `Cyclic`
+        //~| ERROR: the trait bound `Cyclic: DerefPure` is not satisfied
+        _ => {}
+    }
+}

--- a/tests/ui/pattern/deref-patterns/recursion-limit.stderr
+++ b/tests/ui/pattern/deref-patterns/recursion-limit.stderr
@@ -1,0 +1,18 @@
+error[E0055]: reached the recursion limit while auto-dereferencing `Cyclic`
+  --> $DIR/recursion-limit.rs:18:9
+   |
+LL |         () => {}
+   |         ^^ deref recursion limit reached
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "16"]` attribute to your crate (`recursion_limit`)
+
+error[E0277]: the trait bound `Cyclic: DerefPure` is not satisfied
+  --> $DIR/recursion-limit.rs:18:9
+   |
+LL |         () => {}
+   |         ^^ the trait `DerefPure` is not implemented for `Cyclic`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0055, E0277.
+For more information about an error, try `rustc --explain E0055`.

--- a/tests/ui/pattern/deref-patterns/ref-mut.rs
+++ b/tests/ui/pattern/deref-patterns/ref-mut.rs
@@ -8,10 +8,19 @@ fn main() {
         deref!(x) => {}
         _ => {}
     }
+    match &mut vec![1] {
+        [x] => {}
+        _ => {}
+    }
 
     match &mut Rc::new(1) {
         deref!(x) => {}
         //~^ ERROR the trait bound `Rc<{integer}>: DerefMut` is not satisfied
+        _ => {}
+    }
+    match &mut Rc::new((1,)) {
+        (x,) => {}
+        //~^ ERROR the trait bound `Rc<({integer},)>: DerefMut` is not satisfied
         _ => {}
     }
 }

--- a/tests/ui/pattern/deref-patterns/ref-mut.stderr
+++ b/tests/ui/pattern/deref-patterns/ref-mut.stderr
@@ -8,13 +8,19 @@ LL | #![feature(deref_patterns)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: the trait bound `Rc<{integer}>: DerefMut` is not satisfied
-  --> $DIR/ref-mut.rs:13:9
+  --> $DIR/ref-mut.rs:17:9
    |
 LL |         deref!(x) => {}
    |         ^^^^^^^^^ the trait `DerefMut` is not implemented for `Rc<{integer}>`
    |
    = note: this error originates in the macro `deref` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error; 1 warning emitted
+error[E0277]: the trait bound `Rc<({integer},)>: DerefMut` is not satisfied
+  --> $DIR/ref-mut.rs:22:9
+   |
+LL |         (x,) => {}
+   |         ^^^^ the trait `DerefMut` is not implemented for `Rc<({integer},)>`
+
+error: aborting due to 2 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/pattern/deref-patterns/typeck.rs
+++ b/tests/ui/pattern/deref-patterns/typeck.rs
@@ -10,26 +10,32 @@ fn main() {
     let vec: Vec<u32> = Vec::new();
     match vec {
         deref!([..]) => {}
+        [..] => {}
         _ => {}
     }
     match Box::new(true) {
         deref!(true) => {}
+        true => {}
         _ => {}
     }
     match &Box::new(true) {
         deref!(true) => {}
+        true => {}
         _ => {}
     }
     match &Rc::new(0) {
         deref!(1..) => {}
+        1.. => {}
         _ => {}
     }
     let _: &Struct = match &Rc::new(Struct) {
         deref!(x) => x,
+        Struct => &Struct,
         _ => unreachable!(),
     };
     let _: &[Struct] = match &Rc::new(vec![Struct]) {
         deref!(deref!(x)) => x,
+        [Struct] => &[Struct],
         _ => unreachable!(),
     };
 }

--- a/tests/ui/pattern/deref-patterns/typeck_fail.rs
+++ b/tests/ui/pattern/deref-patterns/typeck_fail.rs
@@ -7,10 +7,21 @@ fn main() {
     match "foo".to_string() {
         deref!("foo") => {}
         //~^ ERROR: mismatched types
+        "foo" => {}
+        //~^ ERROR: mismatched types
         _ => {}
     }
     match &"foo".to_string() {
         deref!("foo") => {}
+        //~^ ERROR: mismatched types
+        "foo" => {}
+        //~^ ERROR: mismatched types
+        _ => {}
+    }
+
+    // Make sure we don't try implicitly dereferncing any ADT.
+    match Some(0) {
+        Ok(0) => {}
         //~^ ERROR: mismatched types
         _ => {}
     }

--- a/tests/ui/pattern/deref-patterns/typeck_fail.stderr
+++ b/tests/ui/pattern/deref-patterns/typeck_fail.stderr
@@ -7,13 +7,45 @@ LL |         deref!("foo") => {}
    |                ^^^^^ expected `str`, found `&str`
 
 error[E0308]: mismatched types
-  --> $DIR/typeck_fail.rs:13:16
+  --> $DIR/typeck_fail.rs:10:9
+   |
+LL |     match "foo".to_string() {
+   |           ----------------- this expression has type `String`
+...
+LL |         "foo" => {}
+   |         ^^^^^ expected `String`, found `&str`
+
+error[E0308]: mismatched types
+  --> $DIR/typeck_fail.rs:15:16
    |
 LL |     match &"foo".to_string() {
    |           ------------------ this expression has type `&String`
 LL |         deref!("foo") => {}
    |                ^^^^^ expected `str`, found `&str`
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/typeck_fail.rs:17:9
+   |
+LL |     match &"foo".to_string() {
+   |           ------------------ this expression has type `&String`
+...
+LL |         "foo" => {}
+   |         ^^^^^ expected `&String`, found `&str`
+   |
+   = note: expected reference `&String`
+              found reference `&'static str`
+
+error[E0308]: mismatched types
+  --> $DIR/typeck_fail.rs:24:9
+   |
+LL |     match Some(0) {
+   |           ------- this expression has type `Option<{integer}>`
+LL |         Ok(0) => {}
+   |         ^^^^^ expected `Option<{integer}>`, found `Result<_, _>`
+   |
+   = note: expected enum `Option<{integer}>`
+              found enum `Result<_, _>`
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/pattern/deref-patterns/unsatisfied-bounds.rs
+++ b/tests/ui/pattern/deref-patterns/unsatisfied-bounds.rs
@@ -1,0 +1,21 @@
+#![feature(deref_patterns)]
+#![allow(incomplete_features)]
+
+struct MyPointer;
+
+impl std::ops::Deref for MyPointer {
+    type Target = ();
+    fn deref(&self) -> &() {
+        &()
+    }
+}
+
+fn main() {
+    // Test that we get a trait error if a user attempts implicit deref pats on their own impls.
+    // FIXME(deref_patterns): there should be a special diagnostic for missing `DerefPure`.
+    match MyPointer {
+        () => {}
+        //~^ the trait bound `MyPointer: DerefPure` is not satisfied
+        _ => {}
+    }
+}

--- a/tests/ui/pattern/deref-patterns/unsatisfied-bounds.stderr
+++ b/tests/ui/pattern/deref-patterns/unsatisfied-bounds.stderr
@@ -1,0 +1,9 @@
+error[E0277]: the trait bound `MyPointer: DerefPure` is not satisfied
+  --> $DIR/unsatisfied-bounds.rs:17:9
+   |
+LL |         () => {}
+   |         ^^ the trait `DerefPure` is not implemented for `MyPointer`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This implements implicit deref patterns (per https://hackmd.io/4qDDMcvyQ-GDB089IPcHGg#Implicit-deref-patterns) and adds tests and an unstable book chapter.

Best reviewed commit-by-commit. Overall there's a lot of additions, but a lot of that is tests, documentation, and simple(?) refactoring.

Tracking issue: #87121

r? @Nadrieril 