### PR TITLE
Suggest `crate` keyword when unresolved path contains current crate's name

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2003,7 +2003,18 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             Some(ModuleOrUniformRoot::Module(module)) => module.res(),
             _ => None,
         };
-        if module_res == self.graph_root.res() {
+        if ident.name == self.tcx().crate_name(0_usize.into()) {
+            (
+                format!("use of unresolved module or unlinked crate `{ident}`"),
+                Some((
+                    vec![(ident.span, String::from("crate"))],
+                    format!(
+                        "the current crate name can not be used in a path, use the keyword `crate` instead"
+                    ),
+                    Applicability::MaybeIncorrect,
+                )),
+            )
+        } else if module_res == self.graph_root.res() {
             let is_mod = |res| matches!(res, Res::Def(DefKind::Mod, _));
             let mut candidates = self.lookup_import_candidates(ident, TypeNS, parent_scope, is_mod);
             candidates
@@ -2202,17 +2213,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             });
 
             (format!("use of undeclared type `{ident}`"), suggestion)
-        } else if ident.name == self.tcx().crate_name(0_usize.into()) {
-            (
-                format!("use of unresolved module or unlinked crate `{ident}`"),
-                Some((
-                    vec![(ident.span, String::from("crate"))],
-                    format!(
-                        "the current crate name can not be used in a path, use the keyword `crate` instead"
-                    ),
-                    Applicability::MaybeIncorrect,
-                )),
-            )
         } else {
             let mut suggestion = None;
             if ident.name == sym::alloc {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2202,6 +2202,17 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             });
 
             (format!("use of undeclared type `{ident}`"), suggestion)
+        } else if ident.name == self.tcx().crate_name(0_usize.into()) {
+            (
+                format!("use of unresolved module or unlinked crate `{ident}`"),
+                Some((
+                    vec![(ident.span, String::from("crate"))],
+                    format!(
+                        "the current crate name can not be used in a path, use the keyword `crate` instead"
+                    ),
+                    Applicability::MaybeIncorrect,
+                )),
+            )
         } else {
             let mut suggestion = None;
             if ident.name == sym::alloc {

--- a/tests/ui/resolve/current-crate-name-in-path.rs
+++ b/tests/ui/resolve/current-crate-name-in-path.rs
@@ -1,0 +1,16 @@
+//! Ensure E0433 suggests replacing the crate's name with `crate` when the
+//! current crate's name is used in a path.
+
+//@ edition:2018
+// Rust 2018 is needed for the updated crate/module path system and `crate`
+// keyword.
+
+mod bar {
+    pub fn baz() {}
+}
+
+use current_crate_name_in_path::bar::baz;
+//~^ ERROR failed to resolve: use of unresolved module or unlinked crate `current_crate_name_in_path`
+//~| SUGGESTION crate
+
+fn main() {}

--- a/tests/ui/resolve/current-crate-name-in-path.rs
+++ b/tests/ui/resolve/current-crate-name-in-path.rs
@@ -1,10 +1,6 @@
 //! Ensure E0433 suggests replacing the crate's name with `crate` when the
 //! current crate's name is used in a path.
 
-//@ edition:2018
-// Rust 2018 is needed for the updated crate/module path system and `crate`
-// keyword.
-
 mod bar {
     pub fn baz() {}
 }

--- a/tests/ui/resolve/current-crate-name-in-path.rs
+++ b/tests/ui/resolve/current-crate-name-in-path.rs
@@ -7,6 +7,7 @@ mod bar {
 
 use current_crate_name_in_path::bar::baz;
 //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `current_crate_name_in_path`
+//~| HELP the current crate name can not be used in a path, use the keyword `crate` instead
 //~| SUGGESTION crate
 
 fn main() {}

--- a/tests/ui/resolve/current-crate-name-in-path.stderr
+++ b/tests/ui/resolve/current-crate-name-in-path.stderr
@@ -1,5 +1,5 @@
 error[E0433]: failed to resolve: use of unresolved module or unlinked crate `current_crate_name_in_path`
-  --> $DIR/current-crate-name-in-path.rs:12:5
+  --> $DIR/current-crate-name-in-path.rs:8:5
    |
 LL | use current_crate_name_in_path::bar::baz;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `current_crate_name_in_path`

--- a/tests/ui/resolve/current-crate-name-in-path.stderr
+++ b/tests/ui/resolve/current-crate-name-in-path.stderr
@@ -1,0 +1,15 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `current_crate_name_in_path`
+  --> $DIR/current-crate-name-in-path.rs:12:5
+   |
+LL | use current_crate_name_in_path::bar::baz;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `current_crate_name_in_path`
+   |
+help: the current crate name can not be used in a path, use the keyword `crate` instead
+   |
+LL - use current_crate_name_in_path::bar::baz;
+LL + use crate::bar::baz;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Related to #138312.

Unsure about the second "help" message suggested by the issue writer, but for at least the main part of the issue, I've added a check to emit a suggestion replacing the current crate's name in a path with `crate`. Let me know if there's a more elegant way to do this.