### PR TITLE
Optimize multi-char string patterns

### DIFF
--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -282,4 +282,4 @@ macro_rules! impl_slice_contains {
     };
 }
 
-impl_slice_contains!(u16, u32, u64, i16, i32, i64, f32, f64, usize, isize);
+impl_slice_contains!(u16, u32, u64, i16, i32, i64, f32, f64, usize, isize, char);

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -644,21 +644,21 @@ where
 impl<const N: usize> MultiCharEq for [char; N] {
     #[inline]
     fn matches(&mut self, c: char) -> bool {
-        self.iter().any(|&m| m == c)
+        self.contains(&c)
     }
 }
 
 impl<const N: usize> MultiCharEq for &[char; N] {
     #[inline]
     fn matches(&mut self, c: char) -> bool {
-        self.iter().any(|&m| m == c)
+        self.contains(&c)
     }
 }
 
 impl MultiCharEq for &[char] {
     #[inline]
     fn matches(&mut self, c: char) -> bool {
-        self.iter().any(|&m| m == c)
+        self.contains(&c)
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Uses specialization for `[T]::contains` from #130991 to optimize multi-char patterns in string searches.
Requesting a perf run to see if this actually has an effect 🙏
(I think that adding `char` to the list of types for which the `SliceContains` is specialized is a good idea, even if it doesn't show up on perf - might be helpful for downstream users)