### PR TITLE
core/slice: Mark some `split_off` variants unstably const

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -4446,8 +4446,10 @@ impl<T> [T] {
     /// ```
     #[inline]
     #[stable(feature = "slice_take", since = "CURRENT_RUSTC_VERSION")]
-    pub fn split_off_first<'a>(self: &mut &'a Self) -> Option<&'a T> {
-        let (first, rem) = self.split_first()?;
+    #[rustc_const_unstable(feature = "const_split_off_first_last", issue = "138539")]
+    pub const fn split_off_first<'a>(self: &mut &'a Self) -> Option<&'a T> {
+        // FIXME(const-hack): Use `?` when available in const instead of `let-else`.
+        let Some((first, rem)) = self.split_first() else { return None };
         *self = rem;
         Some(first)
     }
@@ -4469,8 +4471,11 @@ impl<T> [T] {
     /// ```
     #[inline]
     #[stable(feature = "slice_take", since = "CURRENT_RUSTC_VERSION")]
-    pub fn split_off_first_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
-        let (first, rem) = mem::take(self).split_first_mut()?;
+    #[rustc_const_unstable(feature = "const_split_off_first_last", issue = "138539")]
+    pub const fn split_off_first_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
+        // FIXME(const-hack): Use `mem::take` and `?` when available in const.
+        // Original: `mem::take(self).split_first_mut()?`
+        let Some((first, rem)) = mem::replace(self, &mut []).split_first_mut() else { return None };
         *self = rem;
         Some(first)
     }
@@ -4491,8 +4496,10 @@ impl<T> [T] {
     /// ```
     #[inline]
     #[stable(feature = "slice_take", since = "CURRENT_RUSTC_VERSION")]
-    pub fn split_off_last<'a>(self: &mut &'a Self) -> Option<&'a T> {
-        let (last, rem) = self.split_last()?;
+    #[rustc_const_unstable(feature = "const_split_off_first_last", issue = "138539")]
+    pub const fn split_off_last<'a>(self: &mut &'a Self) -> Option<&'a T> {
+        // FIXME(const-hack): Use `?` when available in const instead of `let-else`.
+        let Some((last, rem)) = self.split_last() else { return None };
         *self = rem;
         Some(last)
     }
@@ -4514,8 +4521,11 @@ impl<T> [T] {
     /// ```
     #[inline]
     #[stable(feature = "slice_take", since = "CURRENT_RUSTC_VERSION")]
-    pub fn split_off_last_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
-        let (last, rem) = mem::take(self).split_last_mut()?;
+    #[rustc_const_unstable(feature = "const_split_off_first_last", issue = "138539")]
+    pub const fn split_off_last_mut<'a>(self: &mut &'a mut Self) -> Option<&'a mut T> {
+        // FIXME(const-hack): Use `mem::take` and `?` when available in const.
+        // Original: `mem::take(self).split_last_mut()?`
+        let Some((last, rem)) = mem::replace(self, &mut []).split_last_mut() else { return None };
         *self = rem;
         Some(last)
     }


### PR DESCRIPTION
Tracking issue: #138539

Add feature gate `#![feature(const_split_off_first_last)]`
Mark `split_off_first`, `split_off_first_mut`, `split_off_last`, and `split_off_last_mut` slice methods unstably const


