### PR TITLE
Fix the OperandRef type for NullOp::{UbChecks,ContractChecks}

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -747,7 +747,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let tcx = self.cx.tcx();
                 OperandRef {
                     val: OperandValue::Immediate(val),
-                    layout: self.cx.layout_of(tcx.types.usize),
+                    layout: self.cx.layout_of(null_op.ty(tcx)),
                 }
             }
 

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -774,6 +774,15 @@ impl BorrowKind {
     }
 }
 
+impl<'tcx> NullOp<'tcx> {
+    pub fn ty(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
+        match self {
+            NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(_) => tcx.types.usize,
+            NullOp::UbChecks | NullOp::ContractChecks => tcx.types.bool,
+        }
+    }
+}
+
 impl<'tcx> UnOp {
     pub fn ty(&self, tcx: TyCtxt<'tcx>, arg_ty: Ty<'tcx>) -> Ty<'tcx> {
         match self {


### PR DESCRIPTION
Stumbled on this while looking at something totally unrelated 🙃 

r? saethlin 