### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -747,7 +747,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let tcx = self.cx.tcx();
                 OperandRef {
                     val: OperandValue::Immediate(val),
-                    layout: self.cx.layout_of(tcx.types.usize),
+                    layout: self.cx.layout_of(null_op.ty(tcx)),
                 }
             }
 

--- a/compiler/rustc_middle/src/mir/statement.rs
+++ b/compiler/rustc_middle/src/mir/statement.rs
@@ -774,6 +774,15 @@ impl BorrowKind {
     }
 }
 
+impl<'tcx> NullOp<'tcx> {
+    pub fn ty(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
+        match self {
+            NullOp::SizeOf | NullOp::AlignOf | NullOp::OffsetOf(_) => tcx.types.usize,
+            NullOp::UbChecks | NullOp::ContractChecks => tcx.types.bool,
+        }
+    }
+}
+
 impl<'tcx> UnOp {
     pub fn ty(&self, tcx: TyCtxt<'tcx>, arg_ty: Ty<'tcx>) -> Ty<'tcx> {
         match self {

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -79,6 +79,7 @@ version = "0.0.0"
 dependencies = [
  "rand",
  "rand_xorshift",
+ "regex",
 ]
 
 [[package]]
@@ -296,6 +297,31 @@ checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2776,7 +2776,14 @@ impl Display for char {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> Pointer for *const T {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        pointer_fmt_inner(self.expose_provenance(), f)
+        if <<T as core::ptr::Pointee>::Metadata as core::unit::IsUnit>::is_unit() {
+            pointer_fmt_inner(self.expose_provenance(), f)
+        } else {
+            f.debug_struct("Pointer")
+                .field_with("addr", |f| pointer_fmt_inner(self.expose_provenance(), f))
+                .field("metadata", &core::ptr::metadata(*self))
+                .finish()
+        }
     }
 }
 

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -61,6 +61,8 @@ pub trait Pointee {
     // NOTE: Keep trait bounds in `static_assert_expected_bounds_for_metadata`
     // in `library/core/src/ptr/metadata.rs`
     // in sync with those here:
+    // NOTE: The metadata of `dyn Trait + 'a` is `DynMetadata<dyn Trait + 'a>`
+    // so a `'static` bound must not be added.
     type Metadata: fmt::Debug + Copy + Send + Sync + Ord + Hash + Unpin + Freeze;
 }
 

--- a/library/core/src/unit.rs
+++ b/library/core/src/unit.rs
@@ -17,3 +17,19 @@ impl FromIterator<()> for () {
         iter.into_iter().for_each(|()| {})
     }
 }
+
+pub(crate) trait IsUnit {
+    fn is_unit() -> bool;
+}
+
+impl<T: ?Sized> IsUnit for T {
+    default fn is_unit() -> bool {
+        false
+    }
+}
+
+impl IsUnit for () {
+    fn is_unit() -> bool {
+        true
+    }
+}

--- a/library/coretests/Cargo.toml
+++ b/library/coretests/Cargo.toml
@@ -25,3 +25,4 @@ test = true
 [dev-dependencies]
 rand = { version = "0.9.0", default-features = false }
 rand_xorshift = { version = "0.4.0", default-features = false }
+regex = { version = "1.11.1", default-features = false }

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -42,12 +42,12 @@ fn test_fmt_debug_of_raw_pointers() {
     check_fmt(plain as *const i32, "$HEX");
 
     let slice = &mut [200, 300, 400][..];
-    check_fmt(slice as *mut [i32], "$HEX");
-    check_fmt(slice as *const [i32], "$HEX");
+    check_fmt(slice as *mut [i32], "Pointer { addr: $HEX, metadata: 3 }");
+    check_fmt(slice as *const [i32], "Pointer { addr: $HEX, metadata: 3 }");
 
     let vtable = &mut 500 as &mut dyn Debug;
-    check_fmt(vtable as *mut dyn Debug, "$HEX");
-    check_fmt(vtable as *const dyn Debug, "$HEX");
+    check_fmt(vtable as *mut dyn Debug, "Pointer { addr: $HEX, metadata: DynMetadata($HEX) }");
+    check_fmt(vtable as *const dyn Debug, "Pointer { addr: $HEX, metadata: DynMetadata($HEX) }");
 }
 
 #[test]

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -15,8 +15,8 @@ fn test_format_flags() {
 fn test_pointer_formats_data_pointer() {
     let b: &[u8] = b"";
     let s: &str = "";
-    assert_eq!(format!("{s:p}"), format!("{:p}", s.as_ptr()));
-    assert_eq!(format!("{b:p}"), format!("{:p}", b.as_ptr()));
+    assert_eq!(format!("{s:p}"), format!("{:p}", s as *const _));
+    assert_eq!(format!("{b:p}"), format!("{:p}", b as *const _));
 }
 
 #[test]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -174,7 +174,9 @@
 //!
 //! - after-main use of thread-locals, which also affects additional features:
 //!   - [`thread::current()`]
-//! - before-main stdio file descriptors are not guaranteed to be open on unix platforms
+//! - under UNIX, before main, file descriptors 0, 1, and 2 may be unchanged
+//!   (they are guaranteed to be open during main,
+//!    and are opened to /dev/null O_RDWR if they weren't open on program start)
 //!
 //!
 //! [I/O]: io

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -41,7 +41,7 @@ macro_rules! panic {
 /// Use `print!` only for the primary output of your program. Use
 /// [`eprint!`] instead to print error and progress messages.
 ///
-/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// See the formatting documentation in [`std::fmt`](crate::fmt)
 /// for details of the macro argument syntax.
 ///
 /// [flush]: crate::io::Write::flush
@@ -106,7 +106,7 @@ macro_rules! print {
 /// Use `println!` only for the primary output of your program. Use
 /// [`eprintln!`] instead to print error and progress messages.
 ///
-/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// See the formatting documentation in [`std::fmt`](crate::fmt)
 /// for details of the macro argument syntax.
 ///
 /// [`std::fmt`]: crate::fmt
@@ -156,7 +156,7 @@ macro_rules! println {
 /// [`io::stderr`]: crate::io::stderr
 /// [`io::stdout`]: crate::io::stdout
 ///
-/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// See the formatting documentation in [`std::fmt`](crate::fmt)
 /// for details of the macro argument syntax.
 ///
 /// # Panics
@@ -190,7 +190,7 @@ macro_rules! eprint {
 /// Use `eprintln!` only for error and progress messages. Use `println!`
 /// instead for the primary output of your program.
 ///
-/// See [the formatting documentation in `std::fmt`](../std/fmt/index.html)
+/// See the formatting documentation in [`std::fmt`](crate::fmt)
 /// for details of the macro argument syntax.
 ///
 /// [`io::stderr`]: crate::io::stderr


### PR DESCRIPTION
Successful merges:

 - #135080 (core: Make `Debug` impl of raw pointers print metadata if present)
 - #137492 (libstd: rustdoc: correct note on fds 0/1/2 pre-main)
 - #137538 (fix doc path in std::fmt macro)
 - #138549 (Fix the OperandRef type for NullOp::{UbChecks,ContractChecks})

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135080,137492,137538,138549)
<!-- homu-ignore:end -->