### PR TITLE
Implement explicit tail calls in the LLVM backend

### DIFF
--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -1751,6 +1751,13 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         // FIXME(bjorn3): implement
     }
 
+    fn set_tail_call(&mut self, _call_inst: RValue<'gcc>) {
+        // Explicitly fail when this method is called
+        bug!(
+            "Guaranteed tail calls with the 'become' keyword are not implemented in the GCC backend"
+        );
+    }
+
     fn set_span(&mut self, _span: Span) {}
 
     fn from_immediate(&mut self, val: Self::Value) -> Self::Value {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -1371,6 +1371,11 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         let cold_inline = llvm::AttributeKind::Cold.create_attr(self.llcx);
         attributes::apply_to_callsite(llret, llvm::AttributePlace::Function, &[cold_inline]);
     }
+
+    fn set_tail_call(&mut self, call_inst: &'ll Value) {
+        // Use musttail for guaranteed tail call optimization required by 'become'
+        llvm::LLVMRustSetTailCallKind(call_inst, llvm::TailCallKind::MustTail);
+    }
 }
 
 impl<'ll> StaticBuilderMethods for Builder<'_, 'll, '_> {

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -97,6 +97,17 @@ pub(crate) enum ModuleFlagMergeBehavior {
 
 // Consts for the LLVM CallConv type, pre-cast to usize.
 
+/// LLVM TailCallKind for musttail support
+#[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(C)]
+#[allow(dead_code)]
+pub(crate) enum TailCallKind {
+    None = 0,
+    Tail = 1,
+    MustTail = 2,
+    NoTail = 3,
+}
+
 /// LLVM CallingConv::ID. Should we wrap this?
 ///
 /// See <https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/IR/CallingConv.h>
@@ -1181,6 +1192,7 @@ unsafe extern "C" {
     pub(crate) safe fn LLVMIsGlobalConstant(GlobalVar: &Value) -> Bool;
     pub(crate) safe fn LLVMSetGlobalConstant(GlobalVar: &Value, IsConstant: Bool);
     pub(crate) safe fn LLVMSetTailCall(CallInst: &Value, IsTailCall: Bool);
+    pub(crate) safe fn LLVMRustSetTailCallKind(CallInst: &Value, Kind: TailCallKind);
 
     // Operations on attributes
     pub(crate) fn LLVMCreateStringAttribute(

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -595,6 +595,10 @@ pub trait BuilderMethods<'a, 'tcx>:
         funclet: Option<&Self::Funclet>,
         instance: Option<Instance<'tcx>>,
     ) -> Self::Value;
+
+    /// Mark a call instruction as a tail call (guaranteed tail call optimization)
+    /// Used for implementing the `become` expression
+    fn set_tail_call(&mut self, call_inst: Self::Value);
     fn zext(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;
 
     fn apply_attrs_to_cleanup_callsite(&mut self, llret: Self::Value);

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -51,6 +51,14 @@
 //
 //===----------------------------------------------------------------------===
 
+// Define TailCallKind enum values to match LLVM's
+enum LLVMRustTailCallKind {
+  LLVMRustTailCallKindNone = 0,
+  LLVMRustTailCallKindTail = 1,
+  LLVMRustTailCallKindMustTail = 2,
+  LLVMRustTailCallKindNoTail = 3
+};
+
 using namespace llvm;
 using namespace llvm::sys;
 using namespace llvm::object;
@@ -1948,4 +1956,22 @@ extern "C" void LLVMRustSetNoSanitizeHWAddress(LLVMValueRef Global) {
     MD = GV.getSanitizerMetadata();
   MD.NoHWAddress = true;
   GV.setSanitizerMetadata(MD);
+}
+
+extern "C" void LLVMRustSetTailCallKind(LLVMValueRef Call, LLVMRustTailCallKind Kind) {
+  CallInst *CI = unwrap<CallInst>(Call);
+  switch (Kind) {
+    case LLVMRustTailCallKindNone:
+      CI->setTailCallKind(CallInst::TCK_None);
+      break;
+    case LLVMRustTailCallKindTail:
+      CI->setTailCallKind(CallInst::TCK_Tail);
+      break;
+    case LLVMRustTailCallKindMustTail:
+      CI->setTailCallKind(CallInst::TCK_MustTail);
+      break;
+    case LLVMRustTailCallKindNoTail:
+      CI->setTailCallKind(CallInst::TCK_NoTail);
+      break;
+  }
 }

--- a/tests/codegen/tail-call-become.rs
+++ b/tests/codegen/tail-call-become.rs
@@ -1,0 +1,68 @@
+//@ compile-flags: -C opt-level=0 -Cpanic=abort -C no-prepopulate-passes
+//@ needs-llvm-components: x86
+
+#![feature(explicit_tail_calls)]
+#![crate_type = "lib"]
+
+// CHECK-LABEL: define {{.*}}@with_tail(
+#[no_mangle]
+#[inline(never)]
+pub fn with_tail(n: u32) -> u32 {
+    // CHECK: tail call {{.*}}@with_tail(
+    if n == 0 { 0 } else { become with_tail(n - 1) }
+}
+
+// CHECK-LABEL: define {{.*}}@no_tail(
+#[no_mangle]
+#[inline(never)]
+pub fn no_tail(n: u32) -> u32 {
+    // CHECK-NOT: tail call
+    // CHECK: call {{.*}}@no_tail(
+    if n == 0 { 0 } else { no_tail(n - 1) }
+}
+
+// CHECK-LABEL: define {{.*}}@even_with_tail(
+#[no_mangle]
+#[inline(never)]
+pub fn even_with_tail(n: u32) -> bool {
+    // CHECK: tail call {{.*}}@odd_with_tail(
+    match n {
+        0 => true,
+        _ => become odd_with_tail(n - 1),
+    }
+}
+
+// CHECK-LABEL: define {{.*}}@odd_with_tail(
+#[no_mangle]
+#[inline(never)]
+pub fn odd_with_tail(n: u32) -> bool {
+    // CHECK: tail call {{.*}}@even_with_tail(
+    match n {
+        0 => false,
+        _ => become even_with_tail(n - 1),
+    }
+}
+
+// CHECK-LABEL: define {{.*}}@even_no_tail(
+#[no_mangle]
+#[inline(never)]
+pub fn even_no_tail(n: u32) -> bool {
+    // CHECK-NOT: tail call
+    // CHECK: call {{.*}}@odd_no_tail(
+    match n {
+        0 => true,
+        _ => odd_no_tail(n - 1),
+    }
+}
+
+// CHECK-LABEL: define {{.*}}@odd_no_tail(
+#[no_mangle]
+#[inline(never)]
+pub fn odd_no_tail(n: u32) -> bool {
+    // CHECK-NOT: tail call
+    // CHECK: call {{.*}}@even_no_tail(
+    match n {
+        0 => false,
+        _ => even_no_tail(n - 1),
+    }
+}

--- a/tests/codegen/tail-call-musttail.rs
+++ b/tests/codegen/tail-call-musttail.rs
@@ -1,0 +1,33 @@
+//@ compile-flags: -C opt-level=0 -Cpanic=abort -C no-prepopulate-passes
+//@ needs-unwind
+
+#![crate_type = "lib"]
+#![feature(explicit_tail_calls)]
+
+// Ensure that explicit tail calls use musttail in LLVM
+
+// CHECK-LABEL: define {{.*}}@simple_tail_call(
+#[no_mangle]
+#[inline(never)]
+pub fn simple_tail_call(n: i32) -> i32 {
+    // CHECK: musttail call {{.*}}@simple_tail_call(
+    // CHECK-NEXT: ret i32
+    if n <= 0 {
+        0
+    } else {
+        become simple_tail_call(n - 1)
+    }
+}
+
+// CHECK-LABEL: define {{.*}}@tail_call_with_args(
+#[no_mangle]
+#[inline(never)]
+pub fn tail_call_with_args(a: i32, b: i32, c: i32) -> i32 {
+    // CHECK: musttail call {{.*}}@tail_call_with_args(
+    // CHECK-NEXT: ret i32
+    if a == 0 {
+        b + c
+    } else {
+        become tail_call_with_args(a - 1, b + 1, c)
+    }
+}

--- a/tests/ui/explicit-tail-calls/llvm-ir-tail-call.rs
+++ b/tests/ui/explicit-tail-calls/llvm-ir-tail-call.rs
@@ -1,0 +1,35 @@
+//@ compile-flags: -O
+//@ run-pass
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+
+// A deep recursive function that uses explicit tail calls
+// This will cause stack overflow without tail call optimization
+fn deep_recursion(n: u32) -> u32 {
+    match n {
+        0 => 0,
+        _ => become deep_recursion(n - 1)
+    }
+}
+
+// A deep recursive function without explicit tail calls
+// This will overflow the stack for large values
+fn deep_recursion_no_tail(n: u32) -> u32 {
+    match n {
+        0 => 0,
+        _ => deep_recursion_no_tail(n - 1)
+    }
+}
+
+fn main() {
+    // Verify correctness for small values
+    assert_eq!(deep_recursion(10), 0);
+    assert_eq!(deep_recursion_no_tail(10), 0);
+    
+    // This will succeed only if tail call optimization is working
+    // It would overflow the stack otherwise
+    println!("Starting deep recursion with 50,000 calls");
+    let result = deep_recursion(50_000);
+    assert_eq!(result, 0);
+    println!("Successfully completed 50,000 recursive calls with tail call optimization");
+}

--- a/tests/ui/explicit-tail-calls/mutual-recursion.rs
+++ b/tests/ui/explicit-tail-calls/mutual-recursion.rs
@@ -1,0 +1,63 @@
+//@ run-pass
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+
+// This is a classic example of mutual recursion:
+// even(n) calls odd(n-1), and odd(n) calls even(n-1)
+// Without tail calls, this would quickly overflow the stack for large inputs
+
+// Check if a number is even using mutual recursion
+fn is_even(n: u64) -> bool {
+    match n {
+        0 => true,
+        _ => become is_odd(n - 1)
+    }
+}
+
+// Check if a number is odd using mutual recursion
+fn is_odd(n: u64) -> bool {
+    match n {
+        0 => false,
+        _ => become is_even(n - 1)
+    }
+}
+
+// Versions without tail calls for comparison
+fn is_even_no_tail(n: u64) -> bool {
+    match n {
+        0 => true,
+        _ => is_odd_no_tail(n - 1)
+    }
+}
+
+fn is_odd_no_tail(n: u64) -> bool {
+    match n {
+        0 => false,
+        _ => is_even_no_tail(n - 1)
+    }
+}
+
+fn main() {
+    // Verify correctness for small values
+    assert_eq!(is_even(0), true);
+    assert_eq!(is_odd(0), false);
+    assert_eq!(is_even(1), false);
+    assert_eq!(is_odd(1), true);
+    assert_eq!(is_even(10), true);
+    assert_eq!(is_odd(10), false);
+    
+    // Test with an extremely large number that would definitely overflow the stack
+    // without tail call optimization - each call creates 2 stack frames (alternating between functions)
+    // so 100,000 would create 200,000 stack frames total
+    assert_eq!(is_even(100_000), true);
+    assert_eq!(is_odd(100_000), false);
+    assert_eq!(is_even(100_001), false);
+    assert_eq!(is_odd(100_001), true);
+    
+    println!("Deep mutual recursion test passed with 100,000 alternating recursive calls!");
+    
+    // Verify non-tail versions work for small values
+    assert_eq!(is_even_no_tail(10), true);
+    assert_eq!(is_odd_no_tail(10), false);
+    // But would overflow for large values (not tested to avoid crashing)
+}

--- a/tests/ui/explicit-tail-calls/runtime-deep-recursion.rs
+++ b/tests/ui/explicit-tail-calls/runtime-deep-recursion.rs
@@ -1,0 +1,38 @@
+//@ run-pass
+#![expect(incomplete_features)]
+#![feature(explicit_tail_calls)]
+
+// A function that causes deep recursion - counts down from n to 0
+// Without tail calls, this would overflow the stack for large n values
+fn countdown(n: u32) -> u32 {
+    match n {
+        0 => 0,
+        _ => become countdown(n - 1)
+    }
+}
+
+// Same function but without tail call optimization
+fn countdown_no_tail(n: u32) -> u32 {
+    match n {
+        0 => 0,
+        _ => countdown_no_tail(n - 1)
+    }
+}
+
+// This test is specifically designed to verify tail call optimization
+// We use an extremely large recursion depth (500,000) that would 
+// absolutely overflow the stack without tail call optimization
+fn main() {
+    // Small test to verify correctness
+    assert_eq!(countdown(10), 0);
+    
+    // Regular recursion would overflow here (500,000 stack frames)
+    // Only works if tail call optimization is actually happening
+    let result = countdown(500_000);
+    assert_eq!(result, 0);
+    println!("Successfully completed 500,000 recursive calls with tail call optimization");
+    
+    // We can't test the non-tail version with a large number as it would crash,
+    // but we can verify it works for small values
+    assert_eq!(countdown_no_tail(10), 0);
+}


### PR DESCRIPTION
Implements guaranteed tail calls in the LLVM backend (#112788):