### PR TITLE
Fix ICE: attempted to remap an already remapped filename

### DIFF
--- a/src/librustdoc/clean/render_macro_matchers.rs
+++ b/src/librustdoc/clean/render_macro_matchers.rs
@@ -4,8 +4,8 @@ use rustc_ast_pretty::pprust::PrintState;
 use rustc_ast_pretty::pprust::state::State as Printer;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::parse::ParseSess;
-use rustc_span::Span;
 use rustc_span::symbol::{Ident, Symbol, kw};
+use rustc_span::{FileName, Span};
 
 /// Render a macro matcher in a format suitable for displaying to the user
 /// as part of an item declaration.
@@ -63,7 +63,7 @@ fn snippet_equal_to_token(tcx: TyCtxt<'_>, matcher: &TokenTree) -> Option<String
 
     // Create a Parser.
     let psess = ParseSess::new(rustc_driver::DEFAULT_LOCALE_RESOURCES.to_vec());
-    let file_name = source_map.span_to_filename(span);
+    let file_name = FileName::macro_expansion_source_code(&snippet);
     let mut parser =
         match rustc_parse::new_parser_from_source_str(&psess, file_name, snippet.clone()) {
             Ok(parser) => parser,

--- a/tests/rustdoc-ui/remap-path-prefix-macro.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-macro.rs
@@ -1,0 +1,9 @@
+// Regression test for "attempted to remap an already remapped filename" ICE in rustdoc
+// when using --remap-path-prefix with macro rendering.
+// <https://github.com/rust-lang/rust/issues/138520>
+
+//@ compile-flags:-Z unstable-options --remap-path-prefix={{src-base}}=remapped_path
+//@ rustc-env:RUST_BACKTRACE=0
+//@ build-pass
+
+macro_rules! f(() => {});


### PR DESCRIPTION
This commit fixes an internal compiler error (ICE) that occurs when
rustdoc attempts to process macros with a remapped filename. The issue
arose during macro expansion when the `--remap-path-prefix` option was
used.

Instead of passing remapped filenames through, which would trigger the
"attempted to remap an already remapped filename" panic, we now
extract the original local path from remapped filenames before
processing them.

A test case has been added to verify this behavior.

Fixes #138520

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
