### PR TITLE
Make `_Unwind_Action` a type alias, not enum

### DIFF
--- a/library/std/src/sys/personality/gcc.rs
+++ b/library/std/src/sys/personality/gcc.rs
@@ -220,7 +220,7 @@ cfg_if::cfg_if! {
                     Ok(action) => action,
                     Err(_) => return uw::_URC_FATAL_PHASE1_ERROR,
                 };
-                if actions as i32 & uw::_UA_SEARCH_PHASE as i32 != 0 {
+                if actions & uw::_UA_SEARCH_PHASE != 0 {
                     match eh_action {
                         EHAction::None | EHAction::Cleanup(_) => uw::_URC_CONTINUE_UNWIND,
                         EHAction::Catch(_) | EHAction::Filter(_) => uw::_URC_HANDLER_FOUND,
@@ -230,7 +230,7 @@ cfg_if::cfg_if! {
                     match eh_action {
                         EHAction::None => uw::_URC_CONTINUE_UNWIND,
                         // Forced unwinding hits a terminate action.
-                        EHAction::Filter(_) if actions as i32 & uw::_UA_FORCE_UNWIND as i32 != 0 => uw::_URC_CONTINUE_UNWIND,
+                        EHAction::Filter(_) if actions & uw::_UA_FORCE_UNWIND != 0 => uw::_URC_CONTINUE_UNWIND,
                         EHAction::Cleanup(lpad) | EHAction::Catch(lpad) | EHAction::Filter(lpad) => {
                             uw::_Unwind_SetGR(
                                 context,

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -125,16 +125,13 @@ if #[cfg(any(target_vendor = "apple", target_os = "netbsd", not(target_arch = "a
     //
     // 32-bit ARM on iOS/tvOS/watchOS use either DWARF/Compact unwinding or
     // "setjmp-longjmp" / SjLj unwinding.
-    #[repr(C)]
-    #[derive(Copy, Clone, PartialEq)]
-    pub enum _Unwind_Action {
-        _UA_SEARCH_PHASE = 1,
-        _UA_CLEANUP_PHASE = 2,
-        _UA_HANDLER_FRAME = 4,
-        _UA_FORCE_UNWIND = 8,
-        _UA_END_OF_STACK = 16,
-    }
-    pub use _Unwind_Action::*;
+    pub type _Unwind_Action = c_int;
+
+    pub const _UA_SEARCH_PHASE: c_int = 1;
+    pub const _UA_CLEANUP_PHASE: c_int = 2;
+    pub const _UA_HANDLER_FRAME: c_int = 4;
+    pub const _UA_FORCE_UNWIND: c_int = 8;
+    pub const _UA_END_OF_STACK: c_int = 16;
 
     #[cfg_attr(
         all(feature = "llvm-libunwind", any(target_os = "fuchsia", target_os = "linux", target_os = "xous")),

--- a/library/unwind/src/unwinding.rs
+++ b/library/unwind/src/unwinding.rs
@@ -2,16 +2,13 @@
 
 use core::ffi::{c_int, c_void};
 
-#[repr(C)]
-#[derive(Copy, Clone, PartialEq)]
-pub enum _Unwind_Action {
-    _UA_SEARCH_PHASE = 1,
-    _UA_CLEANUP_PHASE = 2,
-    _UA_HANDLER_FRAME = 4,
-    _UA_FORCE_UNWIND = 8,
-    _UA_END_OF_STACK = 16,
-}
-pub use _Unwind_Action::*;
+pub type _Unwind_Action = c_int;
+
+pub const _UA_SEARCH_PHASE: c_int = 1;
+pub const _UA_CLEANUP_PHASE: c_int = 2;
+pub const _UA_HANDLER_FRAME: c_int = 4;
+pub const _UA_FORCE_UNWIND: c_int = 8;
+pub const _UA_END_OF_STACK: c_int = 16;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]


### PR DESCRIPTION
It's bitflags in practice, so an enum is unsound, as an enum must only have the described values. The x86_64 psABI declares it as a `typedef int _Unwind_Action`, which seems reasonable. I made a newtype first but that was more annoying than just a typedef. We don't really use this value for much other than a short check.

I ran `x check library --target aarch64-unknown-linux-gnu,x86_64-pc-windows-gnu,x86_64-fortanix-unknown-sgx,x86_64-unknown-haiku,x86_64-unknown-fuchsi
a,x86_64-unknown-freebsd,x86_64-unknown-dragonfly,x86_64-unknown-netbsd,x86_64-unknown-openbsd,x86_64-unknown-redox,riscv64-linux-android,armv7-unknown-freebsd` (and some more but they failed to build for other reasons :D)

fixes #138558

r? workingjubilee have fun