### PR TITLE
rustdoc: be more strict about "Methods from Deref"

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1533,6 +1533,10 @@ impl Type {
         matches!(self, Type::BorrowedRef { .. })
     }
 
+    fn is_type_alias(&self) -> bool {
+        matches!(self, Type::Path { path: Path { res: Res::Def(DefKind::TyAlias, _), .. } })
+    }
+
     /// Check if two types are "the same" for documentation purposes.
     ///
     /// This is different from `Eq`, because it knows that things like
@@ -1561,6 +1565,16 @@ impl Type {
         } else {
             (self, other)
         };
+
+        // FIXME: `Cache` does not have the data required to unwrap type aliases,
+        // so we just assume they are equal.
+        // This is only remotely acceptable because we were previously
+        // assuming all types were equal when used
+        // as a generic parameter of a type in `Deref::Target`.
+        if self_cleared.is_type_alias() || other_cleared.is_type_alias() {
+            return true;
+        }
+
         match (self_cleared, other_cleared) {
             // Recursive cases.
             (Type::Tuple(a), Type::Tuple(b)) => {

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -533,7 +533,10 @@ fn sidebar_deref_methods<'a>(
             debug!("found inner_impl: {impls:?}");
             let mut ret = impls
                 .iter()
-                .filter(|i| i.inner_impl().trait_.is_none())
+                .filter(|i| {
+                    i.inner_impl().trait_.is_none()
+                        && real_target.is_doc_subtype_of(&i.inner_impl().for_, &c)
+                })
                 .flat_map(|i| get_methods(i.inner_impl(), true, used_links, deref_mut, cx.tcx()))
                 .collect::<Vec<_>>();
             if !ret.is_empty() {

--- a/tests/rustdoc/deref/deref-methods-24686-target.rs
+++ b/tests/rustdoc/deref/deref-methods-24686-target.rs
@@ -1,0 +1,27 @@
+#![crate_name = "foo"]
+
+// test for https://github.com/rust-lang/rust/issues/24686
+use std::ops::Deref;
+
+pub struct Foo<T>(T);
+impl Foo<i32> {
+    pub fn get_i32(&self) -> i32 { self.0 }
+}
+impl Foo<u32> {
+    pub fn get_u32(&self) -> u32 { self.0 }
+}
+
+// Note that the same href is used both on the method itself,
+// and on the sidebar items.
+//@ has foo/struct.Bar.html
+//@ has - '//a[@href="#method.get_i32"]' 'get_i32'
+//@ !has - '//a[@href="#method.get_u32"]' 'get_u32'
+//@ count - '//ul[@class="block deref-methods"]//a' 1
+//@ count - '//a[@href="#method.get_i32"]' 2
+pub struct Bar(Foo<i32>);
+impl Deref for Bar {
+    type Target = Foo<i32>;
+    fn deref(&self) -> &Foo<i32> {
+        &self.0
+    }
+}


### PR DESCRIPTION
fixes #137083
fixes #24686

Currently done:
* [x] fix `render_assoc_items_inner
* [x] fix sidebar logic
* [x] port test from https://github.com/rust-lang/rust/pull/137564
* [x] add test for sidebar items

Note that this does not yet fix the sidebar logic.<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
