### PR TITLE
rustdoc-json: Don't also include `#[deprecated]` in `Item::attrs`

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -756,12 +756,7 @@ impl Item {
         Some(tcx.visibility(def_id))
     }
 
-    pub(crate) fn attributes(
-        &self,
-        tcx: TyCtxt<'_>,
-        cache: &Cache,
-        keep_as_is: bool,
-    ) -> Vec<String> {
+    pub(crate) fn attributes(&self, tcx: TyCtxt<'_>, cache: &Cache, is_json: bool) -> Vec<String> {
         const ALLOWED_ATTRIBUTES: &[Symbol] =
             &[sym::export_name, sym::link_section, sym::no_mangle, sym::non_exhaustive];
 
@@ -772,7 +767,7 @@ impl Item {
             .other_attrs
             .iter()
             .filter_map(|attr| {
-                if keep_as_is {
+                if is_json {
                     Some(rustc_hir_pretty::attribute_to_string(&tcx, attr))
                 } else if ALLOWED_ATTRIBUTES.contains(&attr.name_or_empty()) {
                     Some(
@@ -786,7 +781,8 @@ impl Item {
                 }
             })
             .collect();
-        if !keep_as_is
+
+        if !is_json
             && let Some(def_id) = self.def_id()
             && let ItemType::Struct | ItemType::Enum | ItemType::Union = self.type_()
         {

--- a/tests/rustdoc-json/attrs/deprecated.rs
+++ b/tests/rustdoc-json/attrs/deprecated.rs
@@ -1,0 +1,38 @@
+//@ is "$.index[*][?(@.name=='not')].attrs" '[]'
+//@ is "$.index[*][?(@.name=='not')].deprecation" null
+pub fn not() {}
+
+//@ is "$.index[*][?(@.name=='raw')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]\n"]'
+//@ is "$.index[*][?(@.name=='raw')].deprecation" '{"since": null, "note": null}'
+#[deprecated]
+pub fn raw() {}
+
+//@ is "$.index[*][?(@.name=='equals_string')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since: Unspecified, note:\n\"here is a reason\"}}]\n"]'
+//@ is "$.index[*][?(@.name=='equals_string')].deprecation" '{"since": null, "note": "here is a reason"}'
+#[deprecated = "here is a reason"]
+pub fn equals_string() {}
+
+//@ is "$.index[*][?(@.name=='since')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since:\nNonStandard(\"yoinks ago\")}}]\n"]'
+//@ is "$.index[*][?(@.name=='since')].deprecation" '{"since": "yoinks ago", "note": null}'
+#[deprecated(since = "yoinks ago")]
+pub fn since() {}
+
+//@ is "$.index[*][?(@.name=='note')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since: Unspecified, note:\n\"7\"}}]\n"]'
+//@ is "$.index[*][?(@.name=='note')].deprecation" '{"since": null, "note": "7"}'
+#[deprecated(note = "7")]
+pub fn note() {}
+
+//@ is "$.index[*][?(@.name=='since_and_note')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since:\nNonStandard(\"tomorrow\"), note: \"sorry\"}}]\n"]'
+//@ is "$.index[*][?(@.name=='since_and_note')].deprecation" '{"since": "tomorrow", "note": "sorry"}'
+#[deprecated(since = "tomorrow", note = "sorry")]
+pub fn since_and_note() {}
+
+//@ is "$.index[*][?(@.name=='note_and_since')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since:\nNonStandard(\"a year from tomorrow\"), note: \"your welcome\"}}]\n"]'
+//@ is "$.index[*][?(@.name=='note_and_since')].deprecation" '{"since": "a year from tomorrow", "note": "your welcome"}'
+#[deprecated(note = "your welcome", since = "a year from tomorrow")]
+pub fn note_and_since() {}
+
+//@ is "$.index[*][?(@.name=='neither_but_parens')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]\n"]'
+//@ is "$.index[*][?(@.name=='neither_but_parens')].deprecation" '{"since": null, "note": null}'
+#[deprecated()]
+pub fn neither_but_parens() {}

--- a/tests/rustdoc-json/attrs/deprecated.rs
+++ b/tests/rustdoc-json/attrs/deprecated.rs
@@ -1,38 +1,38 @@
-//@ is "$.index[*][?(@.name=='not')].attrs" '[]'
+//@ is "$.index[*][?(@.name=='not')].attrs" []
 //@ is "$.index[*][?(@.name=='not')].deprecation" null
 pub fn not() {}
 
-//@ is "$.index[*][?(@.name=='raw')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]\n"]'
+//@ is "$.index[*][?(@.name=='raw')].attrs" []
 //@ is "$.index[*][?(@.name=='raw')].deprecation" '{"since": null, "note": null}'
 #[deprecated]
 pub fn raw() {}
 
-//@ is "$.index[*][?(@.name=='equals_string')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since: Unspecified, note:\n\"here is a reason\"}}]\n"]'
+//@ is "$.index[*][?(@.name=='equals_string')].attrs" []
 //@ is "$.index[*][?(@.name=='equals_string')].deprecation" '{"since": null, "note": "here is a reason"}'
 #[deprecated = "here is a reason"]
 pub fn equals_string() {}
 
-//@ is "$.index[*][?(@.name=='since')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since:\nNonStandard(\"yoinks ago\")}}]\n"]'
+//@ is "$.index[*][?(@.name=='since')].attrs" []
 //@ is "$.index[*][?(@.name=='since')].deprecation" '{"since": "yoinks ago", "note": null}'
 #[deprecated(since = "yoinks ago")]
 pub fn since() {}
 
-//@ is "$.index[*][?(@.name=='note')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since: Unspecified, note:\n\"7\"}}]\n"]'
+//@ is "$.index[*][?(@.name=='note')].attrs" []
 //@ is "$.index[*][?(@.name=='note')].deprecation" '{"since": null, "note": "7"}'
 #[deprecated(note = "7")]
 pub fn note() {}
 
-//@ is "$.index[*][?(@.name=='since_and_note')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since:\nNonStandard(\"tomorrow\"), note: \"sorry\"}}]\n"]'
+//@ is "$.index[*][?(@.name=='since_and_note')].attrs" []
 //@ is "$.index[*][?(@.name=='since_and_note')].deprecation" '{"since": "tomorrow", "note": "sorry"}'
 #[deprecated(since = "tomorrow", note = "sorry")]
 pub fn since_and_note() {}
 
-//@ is "$.index[*][?(@.name=='note_and_since')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since:\nNonStandard(\"a year from tomorrow\"), note: \"your welcome\"}}]\n"]'
+//@ is "$.index[*][?(@.name=='note_and_since')].attrs" []
 //@ is "$.index[*][?(@.name=='note_and_since')].deprecation" '{"since": "a year from tomorrow", "note": "your welcome"}'
 #[deprecated(note = "your welcome", since = "a year from tomorrow")]
 pub fn note_and_since() {}
 
-//@ is "$.index[*][?(@.name=='neither_but_parens')].attrs" '["#[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]\n"]'
+//@ is "$.index[*][?(@.name=='neither_but_parens')].attrs" []
 //@ is "$.index[*][?(@.name=='neither_but_parens')].deprecation" '{"since": null, "note": null}'
 #[deprecated()]
 pub fn neither_but_parens() {}


### PR DESCRIPTION
Closes #138378

Not sure if this should bump `FORMAT_VERSION` or not. CC @Enselic @LukeMathWalker @obi1kenobi 

r? @GuillaumeGomez, best reviewed commit-by-commit