### PR TITLE
Don't require `alloca`s for consuming simple enums

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1821,7 +1821,7 @@ pub enum Variants<FieldIdx: Idx, VariantIdx: Idx> {
 
     /// Single enum variants, structs/tuples, unions, and all non-ADTs.
     Single {
-        /// Always `0` for types that cannot have multiple variants.
+        /// Always [`FIRST_VARIANT`] for types that cannot have multiple variants.
         index: VariantIdx,
     },
 

--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -1,12 +1,13 @@
 //! An analysis to determine which locals require allocas and
 //! which do not.
 
+use rustc_abi as abi;
 use rustc_data_structures::graph::dominators::Dominators;
 use rustc_index::bit_set::DenseBitSet;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::mir::visit::{MutatingUseContext, NonMutatingUseContext, PlaceContext, Visitor};
 use rustc_middle::mir::{self, DefLocation, Location, TerminatorKind, traversal};
-use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf};
+use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::{bug, span_bug};
 use tracing::debug;
 
@@ -99,63 +100,110 @@ impl<'a, 'b, 'tcx, Bx: BuilderMethods<'b, 'tcx>> LocalAnalyzer<'a, 'b, 'tcx, Bx>
         context: PlaceContext,
         location: Location,
     ) {
-        let cx = self.fx.cx;
+        const COPY_CONTEXT: PlaceContext =
+            PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy);
 
-        if let Some((place_base, elem)) = place_ref.last_projection() {
-            let mut base_context = if context.is_mutating_use() {
-                PlaceContext::MutatingUse(MutatingUseContext::Projection)
-            } else {
-                PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection)
-            };
+        // `PlaceElem::Index` is the only variant that can mention other `Local`s,
+        // so check for those up-front before any potential short-circuits.
+        for elem in place_ref.projection {
+            if let mir::PlaceElem::Index(index_local) = *elem {
+                self.visit_local(index_local, COPY_CONTEXT, location);
+            }
+        }
 
-            // Allow uses of projections that are ZSTs or from scalar fields.
-            let is_consume = matches!(
-                context,
-                PlaceContext::NonMutatingUse(
-                    NonMutatingUseContext::Copy | NonMutatingUseContext::Move,
-                )
-            );
-            if is_consume {
-                let base_ty = place_base.ty(self.fx.mir, cx.tcx());
-                let base_ty = self.fx.monomorphize(base_ty);
+        // If our local is already memory, nothing can make it *more* memory
+        // so we don't need to bother checking the projections further.
+        if self.locals[place_ref.local] == LocalKind::Memory {
+            return;
+        }
 
-                // ZSTs don't require any actual memory access.
-                let elem_ty = base_ty.projection_ty(cx.tcx(), self.fx.monomorphize(elem)).ty;
-                let span = self.fx.mir.local_decls[place_ref.local].source_info.span;
-                if cx.spanned_layout_of(elem_ty, span).is_zst() {
-                    return;
+        if place_ref.is_indirect_first_projection() {
+            // If this starts with a `Deref`, we only need to record a read of the
+            // pointer being dereferenced, as all the subsequent projections are
+            // working on a place which is always supported. (And because we're
+            // looking at codegen MIR, it can only happen as the first projection.)
+            self.visit_local(place_ref.local, COPY_CONTEXT, location);
+            return;
+        }
+
+        if !place_ref.projection.is_empty() {
+            if context.is_mutating_use() {
+                // If it's a mutating use it doesn't matter what the projections are,
+                // if there are *any* then we need a place to write. (For example,
+                // `_1 = Foo()` works in SSA but `_2.0 = Foo()` does not.)
+                let mut_projection = PlaceContext::MutatingUse(MutatingUseContext::Projection);
+                self.visit_local(place_ref.local, mut_projection, location);
+                return;
+            }
+
+            // Scan through to ensure the only projections are those which
+            // `FunctionCx::maybe_codegen_consume_direct` can handle.
+            let base_ty = self.fx.monomorphized_place_ty(mir::PlaceRef::from(place_ref.local));
+            let mut layout = self.fx.cx.layout_of(base_ty);
+            for elem in place_ref.projection {
+                if layout.is_zst() {
+                    // Any further projections must still be ZSTs, so we're good.
+                    break;
                 }
 
-                if let mir::ProjectionElem::Field(..) = elem {
-                    let layout = cx.spanned_layout_of(base_ty.ty, span);
-                    if cx.is_backend_immediate(layout) || cx.is_backend_scalar_pair(layout) {
-                        // Recurse with the same context, instead of `Projection`,
-                        // potentially stopping at non-operand projections,
-                        // which would trigger `not_ssa` on locals.
-                        base_context = context;
+                #[track_caller]
+                fn compatible_projection(src: TyAndLayout<'_>, tgt: TyAndLayout<'_>) -> bool {
+                    fn compatible_initness(a: abi::Scalar, b: abi::Scalar) -> bool {
+                        !a.is_uninit_valid() || b.is_uninit_valid()
+                    }
+
+                    use abi::BackendRepr::*;
+                    match (src.backend_repr, tgt.backend_repr) {
+                        _ if tgt.is_zst() => true,
+                        (Scalar(a), Scalar(b))
+                        | (SimdVector { element: a, .. }, SimdVector { element: b, .. }) => {
+                            compatible_initness(a, b)
+                        }
+                        (ScalarPair(a0, a1), Scalar(b)) => {
+                            compatible_initness(a0, b) && compatible_initness(a1, b)
+                        }
+                        (ScalarPair(a0, a1), ScalarPair(b0, b1)) => {
+                            compatible_initness(a0, b0) && compatible_initness(a1, b1)
+                        }
+                        _ => bug!("Mismatched layouts in analysis\nsrc: {src:?}\ntgt: {tgt:?}"),
                     }
                 }
-            }
 
-            if let mir::ProjectionElem::Deref = elem {
-                // Deref projections typically only read the pointer.
-                base_context = PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy);
-            }
+                match *elem {
+                    mir::PlaceElem::Field(fidx, ..) => {
+                        let field_layout = layout.field(self.fx.cx, fidx.as_usize());
+                        if compatible_projection(layout, field_layout) {
+                            layout = field_layout;
+                            continue;
+                        }
+                    }
+                    mir::PlaceElem::Downcast(_, vidx) => {
+                        let variant_layout = layout.for_variant(self.fx.cx, vidx);
+                        if compatible_projection(layout, variant_layout) {
+                            layout = variant_layout;
+                            continue;
+                        }
+                    }
 
-            self.process_place(&place_base, base_context, location);
-            // HACK(eddyb) this emulates the old `visit_projection_elem`, this
-            // entire `visit_place`-like `process_place` method should be rewritten,
-            // now that we have moved to the "slice of projections" representation.
-            if let mir::ProjectionElem::Index(local) = elem {
-                self.visit_local(
-                    local,
-                    PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy),
-                    location,
-                );
+                    mir::PlaceElem::Index(..)
+                    | mir::PlaceElem::ConstantIndex { .. }
+                    | mir::PlaceElem::Subslice { .. }
+                    | mir::PlaceElem::OpaqueCast(..)
+                    | mir::PlaceElem::UnwrapUnsafeBinder(..)
+                    | mir::PlaceElem::Subtype(..) => {}
+
+                    mir::PlaceElem::Deref => bug!("Deref after first position"),
+                }
+
+                // If the above didn't `continue`, we can't handle the projection.
+                self.locals[place_ref.local] = LocalKind::Memory;
+                return;
             }
-        } else {
-            self.visit_local(place_ref.local, context, location);
         }
+
+        // Even with supported projections, we still need to have `visit_local`
+        // check for things that can't be done in SSA (like `SharedBorrow`).
+        self.visit_local(place_ref.local, context, location);
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 
-use rustc_abi::{Align, BackendRepr, ExternAbi, HasDataLayout, Reg, Size, WrappingRange};
+use rustc_abi::{Align, BackendRepr, ExternAbi, FieldIdx, HasDataLayout, Reg, Size, WrappingRange};
 use rustc_ast as ast;
 use rustc_ast::{InlineAsmOptions, InlineAsmTemplatePiece};
 use rustc_data_structures::packed::Pu128;
@@ -1038,7 +1038,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             let (idx, _) = op.layout.non_1zst_field(bx).expect(
                                 "not exactly one non-1-ZST field in a `DispatchFromDyn` type",
                             );
-                            op = op.extract_field(self, bx, idx.as_usize());
+                            op = op.extract_field(self, bx, None, idx);
                         }
 
                         // Now that we have `*dyn Trait` or `&dyn Trait`, split it up into its
@@ -1598,7 +1598,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         } else {
             // If the tuple is immediate, the elements are as well.
             for i in 0..tuple.layout.fields.count() {
-                let op = tuple.extract_field(self, bx, i);
+                let op = tuple.extract_field(self, bx, None, FieldIdx::from_usize(i));
                 self.codegen_argument(bx, op, llargs, &args[i], lifetime_ends_after_call);
             }
         }

--- a/compiler/rustc_codegen_ssa/src/mir/locals.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/locals.rs
@@ -12,6 +12,7 @@ use tracing::{debug, warn};
 use crate::mir::{FunctionCx, LocalRef};
 use crate::traits::BuilderMethods;
 
+#[derive(Debug)]
 pub(super) struct Locals<'tcx, V> {
     values: IndexVec<mir::Local, LocalRef<'tcx, V>>,
 }

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -136,6 +136,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     }
 }
 
+#[derive(Debug)]
 enum LocalRef<'tcx, V> {
     Place(PlaceRef<'tcx, V>),
     /// `UnsizedPlace(p)`: `p` itself is a thin pointer (indirect place).

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -319,16 +319,40 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
         OperandRef { val, layout }
     }
 
+    /// Extracts field `field_idx` from `self`, after downcasting to
+    /// `downcast_variant` if it's specified.
+    ///
+    /// Reading from things like tuples or structs, which are always single-variant,
+    /// don't need to pass a downcast variant since downcasting them to
+    /// `FIRST_VARIANT` doesn't actually change anything.
+    /// Things like enums and coroutines, though, must pass the variant from which
+    /// they want to read unless they're specifically reading the tag field
+    /// (which is the index at the type level, not inside one of the variants).
     pub(crate) fn extract_field<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
         &self,
         fx: &mut FunctionCx<'a, 'tcx, Bx>,
         bx: &mut Bx,
-        i: usize,
+        downcast_variant: Option<VariantIdx>,
+        field_idx: FieldIdx,
     ) -> Self {
-        let field = self.layout.field(bx.cx(), i);
-        let offset = self.layout.fields.offset(i);
+        let layout = if let Some(vidx) = downcast_variant {
+            self.layout.for_variant(bx.cx(), vidx)
+        } else {
+            debug_assert!(
+                match self.layout.variants {
+                    Variants::Empty => true,
+                    Variants::Single { index } => index == FIRST_VARIANT,
+                    Variants::Multiple { tag_field, .. } => tag_field == field_idx,
+                },
+                "Should have specified a variant to read field {field_idx:?} of {self:?}",
+            );
+            self.layout
+        };
 
-        if !bx.is_backend_ref(self.layout) && bx.is_backend_ref(field) {
+        let field = layout.field(bx.cx(), field_idx.as_usize());
+        let offset = layout.fields.offset(field_idx.as_usize());
+
+        if !bx.is_backend_ref(layout) && bx.is_backend_ref(field) {
             // Part of https://github.com/rust-lang/compiler-team/issues/838
             span_bug!(
                 fx.mir.span,
@@ -338,18 +362,22 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
 
         let val = if field.is_zst() {
             OperandValue::ZeroSized
-        } else if let BackendRepr::SimdVector { .. } = self.layout.backend_repr {
+        } else if let BackendRepr::SimdVector { .. } = layout.backend_repr {
             // codegen_transmute_operand doesn't support SIMD, but since the previous
             // check handled ZSTs, the only possible field access into something SIMD
             // is to the `non_1zst_field` that's the same SIMD. (Other things, even
             // just padding, would change the wrapper's representation type.)
-            assert_eq!(field.size, self.layout.size);
+            assert_eq!(field.size, layout.size);
             self.val
-        } else if field.size == self.layout.size {
-            assert_eq!(offset.bytes(), 0);
-            fx.codegen_transmute_operand(bx, *self, field)
+        } else if field.size == layout.size {
+            debug_assert_eq!(offset.bytes(), 0);
+            if downcast_variant.is_some() {
+                fx.codegen_transmute_operand(bx, *self, field)
+            } else {
+                self.val
+            }
         } else {
-            let (in_scalar, imm) = match (self.val, self.layout.backend_repr) {
+            let (in_scalar, imm) = match (self.val, layout.backend_repr) {
                 // Extract a scalar component from a pair.
                 (OperandValue::Pair(a_llval, b_llval), BackendRepr::ScalarPair(a, b)) => {
                     // This needs to look at `offset`, rather than `i`, because
@@ -371,8 +399,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                 }
             };
             OperandValue::Immediate(match field.backend_repr {
-                BackendRepr::SimdVector { .. } => imm,
-                BackendRepr::Scalar(out_scalar) => {
+                BackendRepr::Scalar(out_scalar) if downcast_variant.is_some() => {
                     // For a type like `Result<usize, &u32>` the layout is `Pair(i64, ptr)`.
                     // But if we're reading the `Ok` payload, we need to turn that `ptr`
                     // back into an integer. To avoid repeating logic we do that by
@@ -380,10 +407,10 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
                     // assert we did when pulling it out of the pair.
                     transmute_scalar(bx, imm, in_scalar, out_scalar)
                 }
+                BackendRepr::Scalar(_) | BackendRepr::SimdVector { .. } => imm,
                 BackendRepr::ScalarPair(_, _) | BackendRepr::Memory { .. } => bug!(),
             })
         };
-
         OperandRef { val, layout: field }
     }
 
@@ -431,7 +458,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
         let tag_op = match self.val {
             OperandValue::ZeroSized => bug!(),
             OperandValue::Immediate(_) | OperandValue::Pair(_, _) => {
-                self.extract_field(fx, bx, tag_field.as_usize())
+                self.extract_field(fx, bx, None, tag_field)
             }
             OperandValue::Ref(place) => {
                 let tag = place.with_type(self.layout).project_field(bx, tag_field.as_usize());
@@ -922,6 +949,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     ) -> Option<OperandRef<'tcx, Bx::Value>> {
         debug!("maybe_codegen_consume_direct(place_ref={:?})", place_ref);
 
+        let mut downcast_variant = None;
         match self.locals[place_ref.local] {
             LocalRef::Operand(mut o) => {
                 // Moves out of scalar and scalar pair fields are trivial.
@@ -933,27 +961,16 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                 "Bad PlaceRef: destructing pointers should use cast/PtrMetadata, \
                                  but tried to access field {f:?} of pointer {o:?}",
                             );
-                            o = o.extract_field(self, bx, f.index());
+                            o = o.extract_field(self, bx, downcast_variant, f);
+                            downcast_variant = None;
                         }
                         mir::ProjectionElem::Downcast(_sym, variant_idx) => {
-                            let layout = o.layout.for_variant(bx.cx(), variant_idx);
-                            let val = match layout.backend_repr {
-                                // The transmute here handles cases like `Result<bool, u8>`
-                                // where the immediate values need to change for
-                                // the specific types in the cast-to variant.
-                                BackendRepr::Scalar(..) | BackendRepr::ScalarPair(..) => {
-                                    self.codegen_transmute_operand(bx, o, layout)
-                                }
-                                BackendRepr::SimdVector { .. } | BackendRepr::Memory { .. } => {
-                                    o.val
-                                }
-                            };
-
-                            o = OperandRef { val, layout };
+                            downcast_variant = Some(variant_idx);
                         }
                         _ => return None,
                     }
                 }
+                debug_assert_eq!(downcast_variant, None);
 
                 Some(o)
             }

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -371,7 +371,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
             self.val
         } else if field.size == layout.size {
             debug_assert_eq!(offset.bytes(), 0);
-            if downcast_variant.is_some() {
+            if downcast_variant.is_some() || self.layout.ty.is_union() {
                 fx.codegen_transmute_operand(bx, *self, field)
             } else {
                 self.val

--- a/tests/codegen/array-cmp.rs
+++ b/tests/codegen/array-cmp.rs
@@ -39,6 +39,10 @@ pub fn array_of_tuple_le(a: &[(i16, u16); 2], b: &[(i16, u16); 2]) -> bool {
     // CHECK: %[[EQ00:.+]] = icmp eq i16 %[[A00]], %[[B00]]
     // CHECK-NEXT: br i1 %[[EQ00]], label %[[L01:.+]], label %[[EXIT_S:.+]]
 
+    // CHECK: [[EXIT_S]]:
+    // CHECK: %[[RET_S:.+]] = icmp sle i16
+    // CHECK: br label
+
     // CHECK: [[L01]]:
     // CHECK: %[[PA01:.+]] = getelementptr{{.+}}i8, ptr %a, {{i32|i64}} 2
     // CHECK: %[[PB01:.+]] = getelementptr{{.+}}i8, ptr %b, {{i32|i64}} 2
@@ -66,8 +70,12 @@ pub fn array_of_tuple_le(a: &[(i16, u16); 2], b: &[(i16, u16); 2]) -> bool {
     // CHECK: %[[EQ11:.+]] = icmp eq i16 %[[A11]], %[[B11]]
     // CHECK-NEXT: br i1 %[[EQ11]], label %[[DONE:.+]], label %[[EXIT_U]]
 
+    // CHECK: [[EXIT_U]]:
+    // CHECK: %[[RET_U:.+]] = icmp ule i16
+    // CHECK: br label
+
     // CHECK: [[DONE]]:
-    // CHECK: %[[RET:.+]] = phi i1 [ %{{.+}}, %[[EXIT_S]] ], [ %{{.+}}, %[[EXIT_U]] ], [ true, %[[L11]] ]
+    // CHECK: %[[RET:.+]] = phi i1 [ true, %[[L11]] ], [ %[[RET_S]], %[[EXIT_S]] ], [ %[[RET_U]], %[[EXIT_U]] ]
     // CHECK: ret i1 %[[RET]]
 
     a <= b

--- a/tests/codegen/common_prim_int_ptr.rs
+++ b/tests/codegen/common_prim_int_ptr.rs
@@ -40,9 +40,13 @@ pub unsafe fn extract_int(x: Result<usize, Box<()>>) -> usize {
 }
 
 // CHECK-LABEL: @extract_box
-// CHECK-SAME: (i{{[0-9]+}} {{[^%]+}} [[DISCRIMINANT:%[0-9]+]], ptr {{[^%]+}} [[PAYLOAD:%[0-9]+]])
+// CHECK-SAME: (i{{[0-9]+}} {{[^%]+}} [[DISCRIMINANT:%x.0]], ptr {{[^%]+}} [[PAYLOAD:%x.1]])
 #[no_mangle]
 pub unsafe fn extract_box(x: Result<usize, Box<i32>>) -> Box<i32> {
+    // CHECK: [[NOT_OK:%.+]] = icmp ne i{{[0-9]+}} [[DISCRIMINANT]], 0
+    // CHECK: call void @llvm.assume(i1 [[NOT_OK]])
+    // CHECK: [[NOT_NULL:%.+]] = icmp ne ptr [[PAYLOAD]], null
+    // CHECK: call void @llvm.assume(i1 [[NOT_NULL]])
     // CHECK: ret ptr [[PAYLOAD]]
     match x {
         Ok(_) => std::intrinsics::unreachable(),

--- a/tests/codegen/enum/enum-extract.rs
+++ b/tests/codegen/enum/enum-extract.rs
@@ -1,0 +1,187 @@
+//@ revisions: OPT DBG
+//@ compile-flags: -Cno-prepopulate-passes -Cdebuginfo=0
+//@[OPT] compile-flags: -Copt-level=1
+//@[DBG] compile-flags: -Copt-level=0
+//@ min-llvm-version: 19
+//@ only-64bit
+
+#![crate_type = "lib"]
+
+// This tests various cases around consuming enums as SSA values in what we emit.
+// Importantly, it checks things like correct `i1` handling for `bool`
+// and for mixed integer/pointer payloads.
+
+use std::cmp::Ordering;
+use std::mem::MaybeUninit;
+use std::num::NonZero;
+use std::ptr::NonNull;
+
+// This doesn't actually end up in an SSA value because `extract_field`
+// doesn't know how to do the equivalent of `!noundef` without a load.
+#[no_mangle]
+fn use_option_u32(x: Option<u32>) -> u32 {
+    // CHECK-LABEL: @use_option_u32
+    // OPT-SAME: (i32 noundef range(i32 0, 2) %0, i32 %1)
+
+    // CHECK-NOT: alloca
+    // CHECK: %x = alloca [8 x i8]
+    // CHECK-NOT: alloca
+    // CHECK: %[[X0:.+]] = load i32, ptr %x
+    // CHECK: %[[DISCR:.+]] = zext i32 %[[X0]] to i64
+    // CHECK: %[[IS_SOME:.+]] = trunc nuw i64 %[[DISCR]] to i1
+    // OPT: %[[LIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_SOME]], i1 true)
+    // OPT: br i1 %[[LIKELY]], label %[[BLOCK:.+]],
+    // DBG: br i1 %[[IS_SOME]], label %[[BLOCK:.+]],
+
+    // CHECK: [[BLOCK]]:
+    // CHECK: %[[X1P:.+]] = getelementptr inbounds i8, ptr %x, i64 4
+    // CHECK: %[[X1:.+]] = load i32, ptr %[[X1P]]
+    // OPT-SAME: !noundef
+    // CHECK: ret i32 %[[X1]]
+
+    if let Some(val) = x { val } else { unreachable!() }
+}
+
+#[no_mangle]
+fn use_option_mu_i32(x: Option<MaybeUninit<i32>>) -> MaybeUninit<i32> {
+    // CHECK-LABEL: @use_option_mu_i32
+    // OPT-SAME: (i32 noundef range(i32 0, 2) %x.0, i32 %x.1)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[DISCR:.+]] = zext i32 %x.0 to i64
+    // CHECK: %[[IS_SOME:.+]] = trunc nuw i64 %[[DISCR]] to i1
+    // OPT: %[[LIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_SOME]], i1 true)
+    // OPT: br i1 %[[LIKELY]], label %[[BLOCK:.+]],
+    // DBG: br i1 %[[IS_SOME]], label %[[BLOCK:.+]],
+
+    // CHECK: [[BLOCK]]:
+    // CHECK: ret i32 %x.1
+
+    if let Some(val) = x { val } else { unreachable!() }
+}
+
+#[no_mangle]
+fn use_option_bool(x: Option<bool>) -> bool {
+    // CHECK-LABEL: @use_option_bool
+    // OPT-SAME: (i8 noundef range(i8 0, 3) %x)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[IS_NONE:.+]] = icmp eq i8 %x, 2
+    // CHECK: %[[DISCR:.+]] = select i1 %[[IS_NONE]], i64 0, i64 1
+    // CHECK: %[[IS_SOME:.+]] = trunc nuw i64 %[[DISCR]] to i1
+    // OPT: %[[LIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_SOME]], i1 true)
+    // OPT: br i1 %[[LIKELY]], label %[[BLOCK:.+]],
+    // DBG: br i1 %[[IS_SOME]], label %[[BLOCK:.+]],
+
+    // CHECK: [[BLOCK]]:
+    // CHECK: %val = trunc nuw i8 %x to i1
+    // CHECK: ret i1 %val
+
+    if let Some(val) = x { val } else { unreachable!() }
+}
+
+#[no_mangle]
+fn use_option_ordering(x: Option<Ordering>) -> Ordering {
+    // CHECK-LABEL: @use_option_ordering
+    // OPT-SAME: (i8 noundef range(i8 -1, 3) %x)
+
+    // CHECK: %[[IS_NONE:.+]] = icmp eq i8 %x, 2
+    // CHECK: %[[DISCR:.+]] = select i1 %[[IS_NONE]], i64 0, i64 1
+    // CHECK: %[[IS_SOME:.+]] = trunc nuw i64 %[[DISCR]] to i1
+    // OPT: %[[LIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_SOME]], i1 true)
+    // OPT: br i1 %[[LIKELY]], label %[[BLOCK:.+]],
+    // DBG: br i1 %[[IS_SOME]], label %[[BLOCK:.+]],
+
+    // CHECK: [[BLOCK]]:
+    // OPT: %[[SHIFTED:.+]] = sub i8 %x, -1
+    // OPT: %[[IN_WIDTH:.+]] = icmp ule i8 %[[SHIFTED]], 3
+    // OPT: call void @llvm.assume(i1 %[[IN_WIDTH]])
+    // DBG-NOT: assume
+    // CHECK: ret i8 %x
+
+    if let Some(val) = x { val } else { unreachable!() }
+}
+
+#[no_mangle]
+fn use_result_nzusize(x: Result<NonZero<usize>, NonNull<u32>>) -> NonZero<usize> {
+    // CHECK-LABEL: @use_result_nzusize
+    // OPT-SAME: (i64 noundef range(i64 0, 2) %x.0, ptr noundef %x.1)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[IS_ERR:.+]] = trunc nuw i64 %x.0 to i1
+    // OPT: %[[UNLIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_ERR]], i1 false)
+    // OPT: br i1 %[[UNLIKELY]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+    // DBG: br i1 %[[IS_ERR]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+
+    // CHECK: [[BLOCK]]:
+    // CHECK: %val = ptrtoint ptr %x.1 to i64
+    // CHECK: ret i64 %val
+
+    if let Ok(val) = x { val } else { unreachable!() }
+}
+
+#[no_mangle]
+fn use_result_i32_char(x: Result<i32, char>) -> char {
+    // CHECK-LABEL: @use_result_i32_char
+    // OPT-SAME: (i32 noundef range(i32 0, 2) %x.0, i32 noundef %x.1)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[IS_ERR_WIDE:.+]] = zext i32 %x.0 to i64
+    // CHECK: %[[IS_ERR:.+]] = trunc nuw i64 %[[IS_ERR_WIDE]] to i1
+    // OPT: %[[LIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_ERR]], i1 true)
+    // OPT: br i1 %[[LIKELY]], label %[[BLOCK:.+]], label %[[PANIC:.+]]
+    // DBG: br i1 %[[IS_ERR]], label %[[BLOCK:.+]], label %[[PANIC:.+]]
+
+    // CHECK: [[BLOCK]]:
+    // OPT: %[[RANGE:.+]] = icmp ule i32 %x.1, 1114111
+    // OPT: call void @llvm.assume(i1 %[[RANGE]])
+    // DBG-NOT: call
+    // CHECK: ret i32 %x.1
+
+    if let Err(val) = x { val } else { unreachable!() }
+}
+
+#[repr(u64)]
+enum BigEnum {
+    Foo = 100,
+    Bar = 200,
+}
+
+#[no_mangle]
+fn use_result_bigenum(x: Result<BigEnum, u64>) -> BigEnum {
+    // CHECK-LABEL: @use_result_bigenum
+    // OPT-SAME: (i64 noundef range(i64 0, 2) %x.0, i64 noundef %x.1)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[IS_ERR:.+]] = trunc nuw i64 %x.0 to i1
+    // OPT: %[[UNLIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_ERR]], i1 false)
+    // OPT: br i1 %[[UNLIKELY]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+    // DBG: br i1 %[[IS_ERR]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+
+    // CHECK: [[BLOCK]]:
+    // CHECK: ret i64 %x.1
+
+    if let Ok(val) = x { val } else { unreachable!() }
+}
+
+struct WhateverError;
+
+#[no_mangle]
+fn use_result_nonnull(x: Result<NonNull<u16>, WhateverError>) -> NonNull<u16> {
+    // CHECK-LABEL: @use_result_nonnull
+    // OPT-SAME: (ptr noundef %x)
+
+    // CHECK-NOT: alloca
+    // CHECK: %[[ADDR:.+]] = ptrtoint ptr %x to i64
+    // CHECK: %[[IS_NULL:.+]] = icmp eq i64 %[[ADDR]], 0
+    // CHECK: %[[DISCR:.+]] = select i1 %[[IS_NULL]], i64 1, i64 0
+    // CHECK: %[[IS_ERR:.+]] = trunc nuw i64 %[[DISCR]] to i1
+    // OPT: %[[UNLIKELY:.+]] = call i1 @llvm.expect.i1(i1 %[[IS_ERR]], i1 false)
+    // OPT: br i1 %[[UNLIKELY]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+    // DBG: br i1 %[[IS_ERR]], label %[[PANIC:.+]], label %[[BLOCK:.+]]
+
+    // CHECK: [[BLOCK]]:
+    // CHECK: ret ptr %x
+
+    if let Ok(val) = x { val } else { unreachable!() }
+}

--- a/tests/codegen/enum/enum-match.rs
+++ b/tests/codegen/enum/enum-match.rs
@@ -15,11 +15,10 @@ pub enum Enum0 {
     B,
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match0(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match0(i8{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[IS_B:.+]] = icmp eq i8 %0, 2
-// CHECK-NEXT: %[[TRUNC:.+]] = and i8 %0, 1
-// CHECK-NEXT: %[[R:.+]] = select i1 %[[IS_B]], i8 13, i8 %[[TRUNC]]
+// CHECK-NEXT: %[[IS_B:.+]] = icmp eq i8 %e, 2
+// CHECK-NEXT: %[[R:.+]] = select i1 %[[IS_B]], i8 13, i8 %e
 // CHECK-NEXT: ret i8 %[[R]]
 #[no_mangle]
 pub fn match0(e: Enum0) -> u8 {
@@ -37,11 +36,11 @@ pub enum Enum1 {
     C,
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match1(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match1(i8{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %0, -2
+// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %e, -2
 // CHECK-NEXT: %[[REL_VAR_WIDE:.+]] = zext i8 %[[REL_VAR]] to i64
-// CHECK-NEXT: %[[IS_NICHE:.+]] = icmp{{( samesign)?}} ugt i8 %0, 1
+// CHECK-NEXT: %[[IS_NICHE:.+]] = icmp{{( samesign)?}} ugt i8 %e, 1
 // CHECK-NEXT: %[[NICHE_DISCR:.+]] = add nuw nsw i64 %[[REL_VAR_WIDE]], 1
 // CHECK-NEXT: %[[DISCR:.+]] = select i1 %[[IS_NICHE]], i64 %[[NICHE_DISCR]], i64 0
 // CHECK-NEXT: switch i64 %[[DISCR]]
@@ -98,9 +97,9 @@ pub enum Enum2 {
     E,
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, -?[0-9]+\))?}} i8 @match2(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, -?[0-9]+\))?}} i8 @match2(i8{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[REL_VAR:.+]] = add i8 %0, 2
+// CHECK-NEXT: %[[REL_VAR:.+]] = add i8 %e, 2
 // CHECK-NEXT: %[[REL_VAR_WIDE:.+]] = zext i8 %[[REL_VAR]] to i64
 // CHECK-NEXT: %[[IS_NICHE:.+]] = icmp ult i8 %[[REL_VAR]], 4
 // CHECK-NEXT: %[[NICHE_DISCR:.+]] = add nuw nsw i64 %[[REL_VAR_WIDE]], 1
@@ -121,9 +120,9 @@ pub fn match2(e: Enum2) -> u8 {
 // And make sure it works even if the niched scalar is a pointer.
 // (For example, that we don't try to `sub` on pointers.)
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i16 -?[0-9]+, -?[0-9]+\))?}} i16 @match3(ptr{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i16 -?[0-9]+, -?[0-9]+\))?}} i16 @match3(ptr{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[IS_NULL:.+]] = icmp eq ptr %0, null
+// CHECK-NEXT: %[[IS_NULL:.+]] = icmp eq ptr %e, null
 // CHECK-NEXT: br i1 %[[IS_NULL]]
 #[no_mangle]
 pub fn match3(e: Option<&u8>) -> i16 {
@@ -145,12 +144,12 @@ pub enum MiddleNiche {
     E,
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 -?[0-9]+, -?[0-9]+\))?}} i8 @match4(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 -?[0-9]+, -?[0-9]+\))?}} i8 @match4(i8{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %0, -2
+// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %e, -2
 // CHECK-NEXT: %[[NOT_IMPOSSIBLE:.+]] = icmp ne i8 %[[REL_VAR]], 2
 // CHECK-NEXT: call void @llvm.assume(i1 %[[NOT_IMPOSSIBLE]])
-// CHECK-NEXT: %[[NOT_NICHE:.+]] = icmp{{( samesign)?}} ult i8 %0, 2
+// CHECK-NEXT: %[[NOT_NICHE:.+]] = icmp{{( samesign)?}} ult i8 %e, 2
 // CHECK-NEXT: %[[DISCR:.+]] = select i1 %[[NOT_NICHE]], i8 2, i8 %[[REL_VAR]]
 // CHECK-NEXT: switch i8 %[[DISCR]]
 #[no_mangle]
@@ -448,11 +447,11 @@ pub enum HugeVariantIndex {
     Possible259,
 }
 
-// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match5(i8{{.+}}%0)
+// CHECK-LABEL: define{{( dso_local)?}} noundef{{( range\(i8 [0-9]+, [0-9]+\))?}} i8 @match5(i8{{.+}}%e)
 // CHECK-NEXT: start:
-// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %0, -2
+// CHECK-NEXT: %[[REL_VAR:.+]] = add{{( nsw)?}} i8 %e, -2
 // CHECK-NEXT: %[[REL_VAR_WIDE:.+]] = zext i8 %[[REL_VAR]] to i64
-// CHECK-NEXT: %[[IS_NICHE:.+]] = icmp{{( samesign)?}} ugt i8 %0, 1
+// CHECK-NEXT: %[[IS_NICHE:.+]] = icmp{{( samesign)?}} ugt i8 %e, 1
 // CHECK-NEXT: %[[NICHE_DISCR:.+]] = add nuw nsw i64 %[[REL_VAR_WIDE]], 257
 // CHECK-NEXT: %[[NOT_IMPOSSIBLE:.+]] = icmp ne i64 %[[NICHE_DISCR]], 258
 // CHECK-NEXT: call void @llvm.assume(i1 %[[NOT_IMPOSSIBLE]])

--- a/tests/codegen/enum/enum-two-variants-match.rs
+++ b/tests/codegen/enum/enum-two-variants-match.rs
@@ -56,18 +56,16 @@ pub fn result_match(x: Result<u64, i64>) -> u16 {
     }
 }
 
-// CHECK-LABEL: @option_bool_match(
+// CHECK-LABEL: @option_bool_match(i8{{.+}}%x)
 #[no_mangle]
 pub fn option_bool_match(x: Option<bool>) -> char {
-    // CHECK: %[[RAW:.+]] = load i8, ptr %x
-    // CHECK: %[[IS_NONE:.+]] = icmp eq i8 %[[RAW]], 2
+    // CHECK: %[[IS_NONE:.+]] = icmp eq i8 %x, 2
     // CHECK: %[[OPT_DISCR:.+]] = select i1 %[[IS_NONE]], i64 0, i64 1
     // CHECK: %[[OPT_DISCR_T:.+]] = trunc nuw i64 %[[OPT_DISCR]] to i1
     // CHECK: br i1 %[[OPT_DISCR_T]], label %[[BB_SOME:.+]], label %[[BB_NONE:.+]]
 
     // CHECK: [[BB_SOME]]:
-    // CHECK: %[[FIELD:.+]] = load i8, ptr %x
-    // CHECK: %[[FIELD_T:.+]] = trunc nuw i8 %[[FIELD]] to i1
+    // CHECK: %[[FIELD_T:.+]] = trunc nuw i8 %x to i1
     // CHECK: br i1 %[[FIELD_T]]
     match x {
         None => 'n',
@@ -77,18 +75,16 @@ pub fn option_bool_match(x: Option<bool>) -> char {
 }
 
 use std::cmp::Ordering::{self, *};
-// CHECK-LABEL: @option_ordering_match(
+// CHECK-LABEL: @option_ordering_match(i8{{.+}}%x)
 #[no_mangle]
 pub fn option_ordering_match(x: Option<Ordering>) -> char {
-    // CHECK: %[[RAW:.+]] = load i8, ptr %x
-    // CHECK: %[[IS_NONE:.+]] = icmp eq i8 %[[RAW]], 2
+    // CHECK: %[[IS_NONE:.+]] = icmp eq i8 %x, 2
     // CHECK: %[[OPT_DISCR:.+]] = select i1 %[[IS_NONE]], i64 0, i64 1
     // CHECK: %[[OPT_DISCR_T:.+]] = trunc nuw i64 %[[OPT_DISCR]] to i1
     // CHECK: br i1 %[[OPT_DISCR_T]], label %[[BB_SOME:.+]], label %[[BB_NONE:.+]]
 
     // CHECK: [[BB_SOME]]:
-    // CHECK: %[[FIELD:.+]] = load i8, ptr %x
-    // CHECK: switch i8 %[[FIELD]], label %[[UNREACHABLE:.+]] [
+    // CHECK: switch i8 %x, label %[[UNREACHABLE:.+]] [
     // CHECK-NEXT: i8 -1, label
     // CHECK-NEXT: i8 0, label
     // CHECK-NEXT: i8 1, label

--- a/tests/codegen/intrinsics/cold_path3.rs
+++ b/tests/codegen/intrinsics/cold_path3.rs
@@ -44,8 +44,8 @@ pub fn test(x: Option<u32>) {
         _ => path_a(),
     }
 
-    // CHECK-LABEL: @test({{.+}} %0, {{.+}} %1)
-    // CHECK: switch i32 %1, label %bb1 [
+    // CHECK-LABEL: @test({{.+}} %x.0, {{.+}} %x.1)
+    // CHECK: switch i32 %x.1, label %bb1 [
     // CHECK: i32 0, label %bb6
     // CHECK: i32 1, label %bb5
     // CHECK: i32 2, label %bb4
@@ -75,8 +75,8 @@ pub fn test2(x: Option<u32>) {
         }
     }
 
-    // CHECK-LABEL: @test2({{.+}} %0, {{.+}} %1)
-    // CHECK: switch i32 %1, label %bb1 [
+    // CHECK-LABEL: @test2({{.+}} %x.0, {{.+}} %x.1)
+    // CHECK: switch i32 %x.1, label %bb1 [
     // CHECK: i32 10, label %bb5
     // CHECK: i32 11, label %bb4
     // CHECK: i32 13, label %bb3

--- a/tests/codegen/intrinsics/cold_path3.rs
+++ b/tests/codegen/intrinsics/cold_path3.rs
@@ -44,7 +44,7 @@ pub fn test(x: Option<u32>) {
         _ => path_a(),
     }
 
-    // CHECK-LABEL: @test(
+    // CHECK-LABEL: @test({{.+}} %0, {{.+}} %1)
     // CHECK: switch i32 %1, label %bb1 [
     // CHECK: i32 0, label %bb6
     // CHECK: i32 1, label %bb5
@@ -75,7 +75,7 @@ pub fn test2(x: Option<u32>) {
         }
     }
 
-    // CHECK-LABEL: @test2(
+    // CHECK-LABEL: @test2({{.+}} %0, {{.+}} %1)
     // CHECK: switch i32 %1, label %bb1 [
     // CHECK: i32 10, label %bb5
     // CHECK: i32 11, label %bb4

--- a/tests/codegen/range-loop.rs
+++ b/tests/codegen/range-loop.rs
@@ -14,7 +14,6 @@ pub fn call_for_zero_to_n(n: u32, f: fn(u32)) {
     // CHECK: start:
     // CHECK-NOT: alloca
     // CHECK: %[[IND:.+]] = alloca [4 x i8]
-    // CHECK-NEXT: %[[ALWAYS_SOME_OPTION:.+]] = alloca
     // CHECK-NOT: alloca
     // CHECK: store i32 0, ptr %[[IND]],
     // CHECK: br label %[[HEAD:.+]]
@@ -31,10 +30,7 @@ pub fn call_for_zero_to_n(n: u32, f: fn(u32)) {
     // CHECK: %[[T2:.+]] = load i32, ptr %[[IND]],
     // CHECK: %[[T3:.+]] = add nuw i32 %[[T2]], 1
     // CHECK: store i32 %[[T3]], ptr %[[IND]],
-
-    // CHECK: store i32 %[[T2]]
-    // CHECK: %[[T4:.+]] = load i32
-    // CHECK: call void %f(i32{{.+}}%[[T4]])
+    // CHECK: call void %f(i32{{.+}}%[[T2]])
 
     for i in 0..n {
         f(i);

--- a/tests/codegen/try_question_mark_nop.rs
+++ b/tests/codegen/try_question_mark_nop.rs
@@ -12,18 +12,18 @@
 use std::ops::ControlFlow::{self, Break, Continue};
 use std::ptr::NonNull;
 
-// CHECK-LABEL: @option_nop_match_32({{.+}} %0, {{.+}} %1)
+// CHECK-LABEL: @option_nop_match_32({{.+}} %x.0, {{.+}} %x.1)
 #[no_mangle]
 pub fn option_nop_match_32(x: Option<u32>) -> Option<u32> {
     // CHECK: start:
-    // CHECK-NEXT: [[TRUNC:%.*]] = trunc nuw i32 %0 to i1
+    // CHECK-NEXT: [[TRUNC:%.*]] = trunc nuw i32 %x.0 to i1
 
-    // NINETEEN-NEXT: [[SELECT:%.*]] = select i1 [[TRUNC]], i32 %0, i32 0
+    // NINETEEN-NEXT: [[SELECT:%.*]] = select i1 [[TRUNC]], i32 %x.0, i32 0
     // NINETEEN-NEXT: [[REG2:%.*]] = insertvalue { i32, i32 } poison, i32 [[SELECT]], 0
-    // NINETEEN-NEXT: [[REG3:%.*]] = insertvalue { i32, i32 } [[REG2]], i32 %1, 1
+    // NINETEEN-NEXT: [[REG3:%.*]] = insertvalue { i32, i32 } [[REG2]], i32 %x.1, 1
 
-    // TWENTY-NEXT: [[SELECT:%.*]] = select i1 [[TRUNC]], i32 %1, i32 undef
-    // TWENTY-NEXT: [[REG2:%.*]] = insertvalue { i32, i32 } poison, i32 %0, 0
+    // TWENTY-NEXT: [[SELECT:%.*]] = select i1 [[TRUNC]], i32 %x.1, i32 undef
+    // TWENTY-NEXT: [[REG2:%.*]] = insertvalue { i32, i32 } poison, i32 %x.0, 0
     // TWENTY-NEXT: [[REG3:%.*]] = insertvalue { i32, i32 } [[REG2]], i32 [[SELECT]], 1
 
     // CHECK-NEXT: ret { i32, i32 } [[REG3]]
@@ -33,12 +33,12 @@ pub fn option_nop_match_32(x: Option<u32>) -> Option<u32> {
     }
 }
 
-// CHECK-LABEL: @option_nop_traits_32({{.+}} %0, {{.+}} %1)
+// CHECK-LABEL: @option_nop_traits_32({{.+}} %x.0, {{.+}} %x.1)
 #[no_mangle]
 pub fn option_nop_traits_32(x: Option<u32>) -> Option<u32> {
     // CHECK: start:
-    // TWENTY-NEXT: %[[IS_SOME:.+]] = trunc nuw i32 %0 to i1
-    // TWENTY-NEXT: select i1 %[[IS_SOME]], i32 %1, i32 undef
+    // TWENTY-NEXT: %[[IS_SOME:.+]] = trunc nuw i32 %x.0 to i1
+    // TWENTY-NEXT: select i1 %[[IS_SOME]], i32 %x.1, i32 undef
     // CHECK-NEXT: insertvalue { i32, i32 }
     // CHECK-NEXT: insertvalue { i32, i32 }
     // CHECK-NEXT: ret { i32, i32 }
@@ -91,18 +91,18 @@ pub fn control_flow_nop_traits_32(x: ControlFlow<i32, u32>) -> ControlFlow<i32, 
     try { x? }
 }
 
-// CHECK-LABEL: @option_nop_match_64({{.+}} %0, {{.+}} %1)
+// CHECK-LABEL: @option_nop_match_64({{.+}} %x.0, {{.+}} %x.1)
 #[no_mangle]
 pub fn option_nop_match_64(x: Option<u64>) -> Option<u64> {
     // CHECK: start:
-    // CHECK-NEXT: [[TRUNC:%.*]] = trunc nuw i64 %0 to i1
+    // CHECK-NEXT: [[TRUNC:%.*]] = trunc nuw i64 %x.0 to i1
 
-    // NINETEEN-NEXT: [[SELECT:%.*]] = select i1 [[TRUNC]], i64 %0, i64 0
+    // NINETEEN-NEXT: [[SELECT:%.*]] = select i1 [[TRUNC]], i64 %x.0, i64 0
     // NINETEEN-NEXT: [[REG2:%.*]] = insertvalue { i64, i64 } poison, i64 [[SELECT]], 0
-    // NINETEEN-NEXT: [[REG3:%.*]] = insertvalue { i64, i64 } [[REG2]], i64 %1, 1
+    // NINETEEN-NEXT: [[REG3:%.*]] = insertvalue { i64, i64 } [[REG2]], i64 %x.1, 1
 
-    // TWENTY-NEXT: [[SELECT:%.*]] = select i1 [[TRUNC]], i64 %1, i64 undef
-    // TWENTY-NEXT: [[REG2:%.*]] = insertvalue { i64, i64 } poison, i64 %0, 0
+    // TWENTY-NEXT: [[SELECT:%.*]] = select i1 [[TRUNC]], i64 %x.1, i64 undef
+    // TWENTY-NEXT: [[REG2:%.*]] = insertvalue { i64, i64 } poison, i64 %x.0, 0
     // TWENTY-NEXT: [[REG3:%.*]] = insertvalue { i64, i64 } [[REG2]], i64 [[SELECT]], 1
 
     // CHECK-NEXT: ret { i64, i64 } [[REG3]]
@@ -112,12 +112,12 @@ pub fn option_nop_match_64(x: Option<u64>) -> Option<u64> {
     }
 }
 
-// CHECK-LABEL: @option_nop_traits_64({{.+}} %0, {{.+}} %1)
+// CHECK-LABEL: @option_nop_traits_64({{.+}} %x.0, {{.+}} %x.1)
 #[no_mangle]
 pub fn option_nop_traits_64(x: Option<u64>) -> Option<u64> {
     // CHECK: start:
-    // TWENTY-NEXT: %[[TRUNC:[0-9]+]] = trunc nuw i64 %0 to i1
-    // TWENTY-NEXT: %[[SEL:\.[0-9]+]] = select i1 %[[TRUNC]], i64 %1, i64 undef
+    // TWENTY-NEXT: %[[TRUNC:.+]] = trunc nuw i64 %x.0 to i1
+    // TWENTY-NEXT: %[[SEL:.+]] = select i1 %[[TRUNC]], i64 %x.1, i64 undef
     // CHECK-NEXT: insertvalue { i64, i64 }
     // CHECK-NEXT: insertvalue { i64, i64 }
     // CHECK-NEXT: ret { i64, i64 }

--- a/tests/codegen/union-abi.rs
+++ b/tests/codegen/union-abi.rs
@@ -137,20 +137,14 @@ pub fn test_CUnionU128(_: CUnionU128) {
 pub union UnionBool {
     b: bool,
 }
-// CHECK: define {{(dso_local )?}}noundef zeroext i1 @test_UnionBool(i8 %0)
+// CHECK: define {{(dso_local )?}}noundef zeroext i1 @test_UnionBool(i8 %b)
 #[no_mangle]
 pub fn test_UnionBool(b: UnionBool) -> bool {
     // Note the lack of `noundef` on the parameter, because (at least for now)
-    // all unions are allowed to be fully-uninitialized. We thus write it to
-    // memory and read it via `!noundef` when asserting validity.
+    // all unions are allowed to be fully-uninitialized.
 
     // CHECK-NOT: alloca
-    // CHECK: %b = alloca [1 x i8], align 1
-    // CHECK-NOT: alloca
-    // CHECK: store i8 %0, ptr %b, align 1
-    // CHECK: %[[WIDE:.+]] = load i8, ptr %b, align 1
-    // CHECK-SAME: !noundef
-    // CHECK: %[[BOOL:.+]] = trunc nuw i8 %[[WIDE]] to i1
+    // CHECK: %[[BOOL:.+]] = trunc nuw i8 %b to i1
     // CHECK: ret i1 %[[BOOL]]
 
     unsafe { b.b }

--- a/tests/codegen/union-abi.rs
+++ b/tests/codegen/union-abi.rs
@@ -137,9 +137,21 @@ pub fn test_CUnionU128(_: CUnionU128) {
 pub union UnionBool {
     b: bool,
 }
-// CHECK: define {{(dso_local )?}}noundef zeroext i1 @test_UnionBool(i8{{.*}} %b)
+// CHECK: define {{(dso_local )?}}noundef zeroext i1 @test_UnionBool(i8 %0)
 #[no_mangle]
 pub fn test_UnionBool(b: UnionBool) -> bool {
+    // Note the lack of `noundef` on the parameter, because (at least for now)
+    // all unions are allowed to be fully-uninitialized. We thus write it to
+    // memory and read it via `!noundef` when asserting validity.
+
+    // CHECK-NOT: alloca
+    // CHECK: %b = alloca [1 x i8], align 1
+    // CHECK-NOT: alloca
+    // CHECK: store i8 %0, ptr %b, align 1
+    // CHECK: %[[WIDE:.+]] = load i8, ptr %b, align 1
+    // CHECK-SAME: !noundef
+    // CHECK: %[[BOOL:.+]] = trunc nuw i8 %[[WIDE]] to i1
+    // CHECK: ret i1 %[[BOOL]]
+
     unsafe { b.b }
 }
-// CHECK: %_0 = trunc{{( nuw)?}} i8 %b to i1


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/138582)*

Well, 4 months later I'm finally back to this.

For example, if you pass an `Option<u32>` to a function, don't immediately write it to an `alloca` then read it again.