### PR TITLE
Avoid double lowering of idents

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1757,7 +1757,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 })
             }
             GenericParamKind::Lifetime => {
-                let ident = self.lower_ident(ident);
                 let lt_id = self.next_node_id();
                 let lifetime = self.new_named_lifetime(id, lt_id, ident);
                 hir::WherePredicateKind::RegionPredicate(hir::WhereRegionPredicate {

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1720,7 +1720,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
         let bounds = self.lower_param_bounds(bounds, itctx);
 
-        let ident = self.lower_ident(ident);
         let param_span = ident.span;
 
         // Reconstruct the span of the entire predicate from the individual generic bounds.
@@ -1739,6 +1738,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let def_id = self.local_def_id(id).to_def_id();
                 let hir_id = self.next_id();
                 let res = Res::Def(DefKind::TyParam, def_id);
+                let ident = self.lower_ident(ident);
                 let ty_path = self.arena.alloc(hir::Path {
                     span: param_span,
                     res,

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1774,12 +1774,13 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     #[instrument(level = "debug", skip(self))]
-    fn new_named_lifetime_with_res(
+    fn new_named_lifetime(
         &mut self,
         id: NodeId,
+        new_id: NodeId,
         ident: Ident,
-        res: LifetimeRes,
     ) -> &'hir hir::Lifetime {
+        let res = self.resolver.get_lifetime_res(id).unwrap_or(LifetimeRes::Error);
         let res = match res {
             LifetimeRes::Param { param, .. } => hir::LifetimeName::Param(param),
             LifetimeRes::Fresh { param, .. } => {
@@ -1797,21 +1798,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
         debug!(?res);
         self.arena.alloc(hir::Lifetime {
-            hir_id: self.lower_node_id(id),
+            hir_id: self.lower_node_id(new_id),
             ident: self.lower_ident(ident),
             res,
         })
-    }
-
-    #[instrument(level = "debug", skip(self))]
-    fn new_named_lifetime(
-        &mut self,
-        id: NodeId,
-        new_id: NodeId,
-        ident: Ident,
-    ) -> &'hir hir::Lifetime {
-        let res = self.resolver.get_lifetime_res(id).unwrap_or(LifetimeRes::Error);
-        self.new_named_lifetime_with_res(new_id, ident, res)
     }
 
     fn lower_generic_params_mut(

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1769,8 +1769,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn lower_lifetime(&mut self, l: &Lifetime) -> &'hir hir::Lifetime {
-        let ident = self.lower_ident(l.ident);
-        self.new_named_lifetime(l.id, l.id, ident)
+        self.new_named_lifetime(l.id, l.id, l.ident)
     }
 
     #[instrument(level = "debug", skip(self))]

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1789,10 +1789,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             LifetimeRes::Infer => hir::LifetimeName::Infer,
             LifetimeRes::Static { .. } => hir::LifetimeName::Static,
             LifetimeRes::Error => hir::LifetimeName::Error,
-            res => panic!(
-                "Unexpected lifetime resolution {:?} for {:?} at {:?}",
-                res, ident, ident.span
-            ),
+            LifetimeRes::ElidedAnchor { .. } => {
+                panic!("Unexpected `ElidedAnchar` {:?} at {:?}", ident, ident.span);
+            }
         };
 
         debug!(?res);


### PR DESCRIPTION
It's easy to double lower idents and spans because they don't change type when lowered.

r? @cjgillot