### PR TITLE
If a label is placed on the block of a loop instead of the header, suggest moving it to the header.

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -2529,7 +2529,7 @@ impl<'a> Parser<'a> {
             *sig_hi = self.prev_token.span;
             (AttrVec::new(), None)
         } else if self.check(exp!(OpenBrace)) || self.token.is_whole_block() {
-            self.parse_block_common(self.token.span, BlockCheckMode::Default, false)
+            self.parse_block_common(self.token.span, BlockCheckMode::Default, false, None)
                 .map(|(attrs, body)| (attrs, Some(body)))?
         } else if self.token == token::Eq {
             // Recover `fn foo() = $expr;`.

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -1374,7 +1374,7 @@ impl<'a> Parser<'a> {
             self.psess.gated_spans.gate(sym::inline_const_pat, span);
         }
         self.expect_keyword(exp!(Const))?;
-        let (attrs, blk) = self.parse_inner_attrs_and_block()?;
+        let (attrs, blk) = self.parse_inner_attrs_and_block(None)?;
         let anon_const = AnonConst {
             id: DUMMY_NODE_ID,
             value: self.mk_expr(blk.span, ExprKind::Block(blk, None)),

--- a/tests/ui/loops/label-on-block-suggest-move.rs
+++ b/tests/ui/loops/label-on-block-suggest-move.rs
@@ -1,0 +1,90 @@
+// see https://github.com/rust-lang/rust/issues/138585
+#![allow(break_with_label_and_loop)] // doesn't work locally
+
+fn main() {
+    loop 'a: {}
+    //~^ ERROR: block label not supported here
+    //~| HELP: if you meant to label the loop, move this label before the loop
+    while false 'a: {}
+    //~^ ERROR: block label not supported here
+    //~| HELP: if you meant to label the loop, move this label before the loop
+    for i in [0] 'a: {}
+    //~^ ERROR: block label not supported here
+    //~| HELP: if you meant to label the loop, move this label before the loop
+    'a: loop {
+        // first block is parsed as the break expr's value with or without parens
+        while break 'a 'b: {} 'c: {}
+        //~^ ERROR: block label not supported here
+        //~| HELP: if you meant to label the loop, move this label before the loop
+        while break 'a ('b: {}) 'c: {}
+        //~^ ERROR: block label not supported here
+        //~| HELP: if you meant to label the loop, move this label before the loop
+
+        // without the parens, the first block is parsed as the while-loop's body
+        // (see the 'no errors' section)
+        // #[allow(break_with_label_and_loop)] (doesn't work locally)
+        while (break 'a {}) 'c: {}
+        //~^ ERROR: block label not supported here
+        //~| HELP: if you meant to label the loop, move this label before the loop
+    }
+
+    // do not suggest moving the label if there is already a label on the loop
+    'a: loop 'b: {}
+    //~^ ERROR: block label not supported here
+    //~| HELP: remove this block label
+    'a: while false 'b: {}
+    //~^ ERROR: block label not supported here
+    //~| HELP: remove this block label
+    'a: for i in [0] 'b: {}
+    //~^ ERROR: block label not supported here
+    //~| HELP: remove this block label
+    'a: loop {
+        // first block is parsed as the break expr's value with or without parens
+        'd: while break 'a 'b: {} 'c: {}
+        //~^ ERROR: block label not supported here
+        //~| HELP: remove this block label
+        'd: while break 'a ('b: {}) 'c: {}
+        //~^ ERROR: block label not supported here
+        //~| HELP: remove this block label
+
+        // without the parens, the first block is parsed as the while-loop's body
+        // (see the 'no errors' section)
+        // #[allow(break_with_label_and_loop)] (doesn't work locally)
+        'd: while (break 'a {}) 'c: {}
+        //~^ ERROR: block label not supported here
+        //~| HELP: remove this block label
+    }
+
+    // no errors
+    loop { 'a: {} }
+    'a: loop { 'b: {} }
+    while false { 'a: {} }
+    'a: while false { 'b: {} }
+    for i in [0] { 'a: {} }
+    'a: for i in [0] { 'b: {} }
+    'a: {}
+    'a: { 'b: {} }
+    'a: loop {
+        // first block is parsed as the break expr's value if it is a labeled block
+        while break 'a 'b: {} {}
+        'd: while break 'a 'b: {} {}
+        while break 'a ('b: {}) {}
+        'd: while break 'a ('b: {}) {}
+        // first block is parsed as the while-loop's body if it has no label
+        // (the break expr is parsed as having no value),
+        // so the second block is a normal stmt-block, and the label is allowed
+        while break 'a {} 'c: {}
+        while break 'a {} {}
+        'd: while break 'a {} 'c: {}
+        'd: while break 'a {} {}
+    }
+
+    // unrelated errors that should not be affected
+    'a: 'b: {}
+    //~^ ERROR: expected `while`, `for`, `loop` or `{` after a label
+    //~| HELP: consider removing the label
+    loop { while break 'b: {} {} }
+    //~^ ERROR: parentheses are required around this expression to avoid confusion with a labeled break expression
+    //~| HELP: wrap the expression in parentheses
+    //~| ERROR: `break` or `continue` with no label in the condition of a `while` loop [E0590]
+}

--- a/tests/ui/loops/label-on-block-suggest-move.stderr
+++ b/tests/ui/loops/label-on-block-suggest-move.stderr
@@ -1,0 +1,140 @@
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:5:10
+   |
+LL |     loop 'a: {}
+   |          ^^^ not supported here
+   |
+help: if you meant to label the loop, move this label before the loop
+   |
+LL -     loop 'a: {}
+LL +     'a: loop {}
+   |
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:8:17
+   |
+LL |     while false 'a: {}
+   |                 ^^^ not supported here
+   |
+help: if you meant to label the loop, move this label before the loop
+   |
+LL -     while false 'a: {}
+LL +     'a: while false {}
+   |
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:11:18
+   |
+LL |     for i in [0] 'a: {}
+   |                  ^^^ not supported here
+   |
+help: if you meant to label the loop, move this label before the loop
+   |
+LL -     for i in [0] 'a: {}
+LL +     'a: for i in [0] {}
+   |
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:16:31
+   |
+LL |         while break 'a 'b: {} 'c: {}
+   |                               ^^^ not supported here
+   |
+help: if you meant to label the loop, move this label before the loop
+   |
+LL -         while break 'a 'b: {} 'c: {}
+LL +         'c: while break 'a 'b: {} {}
+   |
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:19:33
+   |
+LL |         while break 'a ('b: {}) 'c: {}
+   |                                 ^^^ not supported here
+   |
+help: if you meant to label the loop, move this label before the loop
+   |
+LL -         while break 'a ('b: {}) 'c: {}
+LL +         'c: while break 'a ('b: {}) {}
+   |
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:26:29
+   |
+LL |         while (break 'a {}) 'c: {}
+   |                             ^^^ not supported here
+   |
+help: if you meant to label the loop, move this label before the loop
+   |
+LL -         while (break 'a {}) 'c: {}
+LL +         'c: while (break 'a {}) {}
+   |
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:32:14
+   |
+LL |     'a: loop 'b: {}
+   |              ^^^ not supported here
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:35:21
+   |
+LL |     'a: while false 'b: {}
+   |                     ^^^ not supported here
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:38:22
+   |
+LL |     'a: for i in [0] 'b: {}
+   |                      ^^^ not supported here
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:43:35
+   |
+LL |         'd: while break 'a 'b: {} 'c: {}
+   |                                   ^^^ not supported here
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:46:37
+   |
+LL |         'd: while break 'a ('b: {}) 'c: {}
+   |                                     ^^^ not supported here
+
+error: block label not supported here
+  --> $DIR/label-on-block-suggest-move.rs:53:33
+   |
+LL |         'd: while (break 'a {}) 'c: {}
+   |                                 ^^^ not supported here
+
+error: expected `while`, `for`, `loop` or `{` after a label
+  --> $DIR/label-on-block-suggest-move.rs:83:9
+   |
+LL |     'a: 'b: {}
+   |         ^^ expected `while`, `for`, `loop` or `{` after a label
+   |
+help: consider removing the label
+   |
+LL -     'a: 'b: {}
+LL +     'b: {}
+   |
+
+error: parentheses are required around this expression to avoid confusion with a labeled break expression
+  --> $DIR/label-on-block-suggest-move.rs:86:24
+   |
+LL |     loop { while break 'b: {} {} }
+   |                        ^^^^^^
+   |
+help: wrap the expression in parentheses
+   |
+LL |     loop { while break ('b: {}) {} }
+   |                        +      +
+
+error[E0590]: `break` or `continue` with no label in the condition of a `while` loop
+  --> $DIR/label-on-block-suggest-move.rs:86:18
+   |
+LL |     loop { while break 'b: {} {} }
+   |                  ^^^^^^^^^^^^ unlabeled `break` in the condition of a `while` loop
+
+error: aborting due to 15 previous errors
+
+For more information about this error, try `rustc --explain E0590`.


### PR DESCRIPTION
Fixes #138585

If a label is placed on the block of a loop instead of the header, suggest to the user moving it to the loop header instead of ~~suggesting to remove it~~ emitting a tool-only suggestion to remove it.

```rs
fn main() {
    loop 'a: { return; }
}
```

```diff
 error: block label not supported here
  --> src/main.rs:2:10
   |
 2 |     loop 'a: { return; }
   |          ^^^ not supported here
+  |
+help: if you meant to label the loop, move this label before the loop
+  |
+2 -     loop 'a: { return; }
+2 +     'a: loop { return; }
+  |
```
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Questions for reviewer:

* The "desired output" in the linked issue had the main diagnostic be "misplaced loop label". Should the main diagnostic message the changed instead of leaving it as "block label not supported here"?
* Should this be `Applicability::MachineApplicable`?
