### PR TITLE
Slim `rustc_parse_format` dependencies down

### DIFF
--- a/compiler/rustc_parse_format/Cargo.toml
+++ b/compiler/rustc_parse_format/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2024"
 rustc_lexer = { path = "../rustc_lexer" }
 # tidy-alphabetical-end
 
-[target.'cfg(target_pointer_width = "64")'.dependencies]
+[target.'cfg(target_pointer_width = "64")'.dev-dependencies]
+# tidy-alphabetical-start
 rustc_index = { path = "../rustc_index", default-features = false }
+# tidy-alphabetical-end

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -1105,7 +1105,7 @@ fn unescape_string(string: &str) -> Option<String> {
 }
 
 // Assert a reasonable size for `Piece`
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(test, target_pointer_width = "64"))]
 rustc_index::static_assert_size!(Piece<'_>, 16);
 
 #[cfg(test)]


### PR DESCRIPTION
`rustc_index` is only used for its size assertion macro, so demote it to a dev-dependency gated under testing instead. This allows the crate to built without having to wait for `syn` (pulled in by `rustc_index_macros`)

Alternatively we could inline the macro, though from the looks of it that will run into trouble with `rustc_randomized_layouts`
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
