### PR TITLE
Move FnWithoutBody error to ast_lowering.

### DIFF
--- a/compiler/rustc_ast_lowering/messages.ftl
+++ b/compiler/rustc_ast_lowering/messages.ftl
@@ -59,9 +59,15 @@ ast_lowering_default_field_in_tuple = default fields are not supported in tuple 
 ast_lowering_does_not_support_modifiers =
     the `{$class_name}` register class does not support template modifiers
 
+ast_lowering_extern_block_suggestion = if you meant to declare an externally defined function, use an `extern` block
+
 ast_lowering_extra_double_dot =
     `..` can only be used once per {$ctx} pattern
     .label = can only be used once per {$ctx} pattern
+
+ast_lowering_fn_without_body =
+    free function without a body
+    .suggestion = provide a definition for the function
 
 ast_lowering_functional_record_update_destructuring_assignment =
     functional record updates are not allowed in destructuring assignments

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -483,3 +483,33 @@ pub(crate) struct UseConstGenericArg {
     #[suggestion_part(code = "{other_args}")]
     pub call_args: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(ast_lowering_fn_without_body)]
+pub(crate) struct FnWithoutBody {
+    #[primary_span]
+    pub span: Span,
+    #[suggestion(code = " {{ <body> }}", applicability = "has-placeholders")]
+    pub replace_span: Span,
+    #[subdiagnostic]
+    pub extern_block_suggestion: Option<ExternBlockSuggestion>,
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum ExternBlockSuggestion {
+    #[multipart_suggestion(ast_lowering_extern_block_suggestion, applicability = "maybe-incorrect")]
+    Implicit {
+        #[suggestion_part(code = "extern {{")]
+        start_span: Span,
+        #[suggestion_part(code = " }}")]
+        end_span: Span,
+    },
+    #[multipart_suggestion(ast_lowering_extern_block_suggestion, applicability = "maybe-incorrect")]
+    Explicit {
+        #[suggestion_part(code = "extern \"{abi}\" {{")]
+        start_span: Span,
+        #[suggestion_part(code = " }}")]
+        end_span: Span,
+        abi: Symbol,
+    },
+}

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -216,15 +216,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 if body.is_none() && !is_instrinsic {
                     self.dcx().emit_err(FnWithoutBody {
                         span,
-                        replace_span: {
-                            let source_map = self.tcx.sess.source_map();
-                            let end = source_map.end_point(span);
-                            if source_map.span_to_snippet(end).is_ok_and(|s| s == ";") {
-                                end
-                            } else {
-                                span.shrink_to_hi()
-                            }
-                        },
+                        replace_span: self.tcx.sess.source_map().span_ending_semi_or_hi(span),
                         extern_block_suggestion: match header.ext {
                             Extern::None => None,
                             Extern::Implicit(start_span) => Some(ExternBlockSuggestion::Implicit {

--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -60,8 +60,6 @@ ast_passes_equality_in_where = equality constraints are not yet supported in `wh
     .suggestion_path = if `{$trait_segment}::{$potential_assoc}` is an associated type you're trying to set, use the associated type binding syntax
     .note = see issue #20041 <https://github.com/rust-lang/rust/issues/20041> for more information
 
-ast_passes_extern_block_suggestion = if you meant to declare an externally defined function, use an `extern` block
-
 ast_passes_extern_fn_qualifiers = functions in `extern` blocks cannot have `{$kw}` qualifier
     .label = in this `extern` block
     .suggestion = remove the `{$kw}` qualifier
@@ -108,10 +106,6 @@ ast_passes_fn_param_forbidden_self =
 
 ast_passes_fn_param_too_many =
     function can not have more than {$max_num_args} arguments
-
-ast_passes_fn_without_body =
-    free function without a body
-    .suggestion = provide a definition for the function
 
 ast_passes_forbidden_bound =
     bounds cannot be used in this context

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -918,36 +918,16 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 return; // Avoid visiting again.
             }
             ItemKind::Fn(
-                func
-                @ box Fn { defaultness, generics: _, sig, contract: _, body, define_opaque: _ },
+                func @ box Fn {
+                    defaultness,
+                    generics: _,
+                    sig: _,
+                    contract: _,
+                    body: _,
+                    define_opaque: _,
+                },
             ) => {
                 self.check_defaultness(item.span, *defaultness);
-
-                let is_intrinsic =
-                    item.attrs.iter().any(|a| a.name_or_empty() == sym::rustc_intrinsic);
-                if body.is_none() && !is_intrinsic {
-                    self.dcx().emit_err(errors::FnWithoutBody {
-                        span: item.span,
-                        replace_span: self.ending_semi_or_hi(item.span),
-                        extern_block_suggestion: match sig.header.ext {
-                            Extern::None => None,
-                            Extern::Implicit(start_span) => {
-                                Some(errors::ExternBlockSuggestion::Implicit {
-                                    start_span,
-                                    end_span: item.span.shrink_to_hi(),
-                                })
-                            }
-                            Extern::Explicit(abi, start_span) => {
-                                Some(errors::ExternBlockSuggestion::Explicit {
-                                    start_span,
-                                    end_span: item.span.shrink_to_hi(),
-                                    abi: abi.symbol_unescaped,
-                                })
-                            }
-                        },
-                    });
-                }
-
                 self.visit_vis(&item.vis);
                 self.visit_ident(&item.ident);
                 let kind = FnKind::Fn(FnCtxt::Free, &item.ident, &item.vis, &*func);

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -398,19 +398,6 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    /// If `sp` ends with a semicolon, returns it as a `Span`
-    /// Otherwise, returns `sp.shrink_to_hi()`
-    fn ending_semi_or_hi(&self, sp: Span) -> Span {
-        let source_map = self.sess.source_map();
-        let end = source_map.end_point(sp);
-
-        if source_map.span_to_snippet(end).is_ok_and(|s| s == ";") {
-            end
-        } else {
-            sp.shrink_to_hi()
-        }
-    }
-
     fn check_type_no_bounds(&self, bounds: &[GenericBound], ctx: &str) {
         let span = match bounds {
             [] => return,
@@ -1053,7 +1040,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 if expr.is_none() {
                     self.dcx().emit_err(errors::ConstWithoutBody {
                         span: item.span,
-                        replace_span: self.ending_semi_or_hi(item.span),
+                        replace_span: self.sess.source_map().span_ending_semi_or_hi(item.span),
                     });
                 }
             }
@@ -1066,7 +1053,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 if expr.is_none() {
                     self.dcx().emit_err(errors::StaticWithoutBody {
                         span: item.span,
-                        replace_span: self.ending_semi_or_hi(item.span),
+                        replace_span: self.sess.source_map().span_ending_semi_or_hi(item.span),
                     });
                 }
             }
@@ -1077,7 +1064,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 if ty.is_none() {
                     self.dcx().emit_err(errors::TyAliasWithoutBody {
                         span: item.span,
-                        replace_span: self.ending_semi_or_hi(item.span),
+                        replace_span: self.sess.source_map().span_ending_semi_or_hi(item.span),
                     });
                 }
                 self.check_type_no_bounds(bounds, "this context");
@@ -1398,14 +1385,14 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 AssocItemKind::Const(box ConstItem { expr: None, .. }) => {
                     self.dcx().emit_err(errors::AssocConstWithoutBody {
                         span: item.span,
-                        replace_span: self.ending_semi_or_hi(item.span),
+                        replace_span: self.sess.source_map().span_ending_semi_or_hi(item.span),
                     });
                 }
                 AssocItemKind::Fn(box Fn { body, .. }) => {
                     if body.is_none() {
                         self.dcx().emit_err(errors::AssocFnWithoutBody {
                             span: item.span,
-                            replace_span: self.ending_semi_or_hi(item.span),
+                            replace_span: self.sess.source_map().span_ending_semi_or_hi(item.span),
                         });
                     }
                 }
@@ -1413,7 +1400,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     if ty.is_none() {
                         self.dcx().emit_err(errors::AssocTypeWithoutBody {
                             span: item.span,
-                            replace_span: self.ending_semi_or_hi(item.span),
+                            replace_span: self.sess.source_map().span_ending_semi_or_hi(item.span),
                         });
                     }
                     self.check_type_no_bounds(bounds, "`impl`s");

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -178,36 +178,6 @@ pub(crate) struct TyAliasWithoutBody {
 }
 
 #[derive(Diagnostic)]
-#[diag(ast_passes_fn_without_body)]
-pub(crate) struct FnWithoutBody {
-    #[primary_span]
-    pub span: Span,
-    #[suggestion(code = " {{ <body> }}", applicability = "has-placeholders")]
-    pub replace_span: Span,
-    #[subdiagnostic]
-    pub extern_block_suggestion: Option<ExternBlockSuggestion>,
-}
-
-#[derive(Subdiagnostic)]
-pub(crate) enum ExternBlockSuggestion {
-    #[multipart_suggestion(ast_passes_extern_block_suggestion, applicability = "maybe-incorrect")]
-    Implicit {
-        #[suggestion_part(code = "extern {{")]
-        start_span: Span,
-        #[suggestion_part(code = " }}")]
-        end_span: Span,
-    },
-    #[multipart_suggestion(ast_passes_extern_block_suggestion, applicability = "maybe-incorrect")]
-    Explicit {
-        #[suggestion_part(code = "extern \"{abi}\" {{")]
-        start_span: Span,
-        #[suggestion_part(code = " }}")]
-        end_span: Span,
-        abi: Symbol,
-    },
-}
-
-#[derive(Diagnostic)]
 #[diag(ast_passes_extern_invalid_safety)]
 pub(crate) struct InvalidSafetyOnExtern {
     #[primary_span]

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -1080,6 +1080,13 @@ impl SourceMap {
         let span = self.next_point(span);
         if self.span_to_snippet(span).as_deref() == Ok(";") { Some(span) } else { None }
     }
+
+    /// If `sp` ends with a semicolon, returns it as a `Span`
+    /// Otherwise, returns `sp.shrink_to_hi()`
+    pub fn span_ending_semi_or_hi(&self, sp: Span) -> Span {
+        let end = self.end_point(sp);
+        if self.span_to_snippet(end).is_ok_and(|s| s == ";") { end } else { sp.shrink_to_hi() }
+    }
 }
 
 pub fn get_source_map() -> Option<Arc<SourceMap>> {

--- a/tests/ui/parser/fn-body-optional-semantic-fail.stderr
+++ b/tests/ui/parser/fn-body-optional-semantic-fail.stderr
@@ -1,19 +1,3 @@
-error: free function without a body
-  --> $DIR/fn-body-optional-semantic-fail.rs:7:5
-   |
-LL |     fn f1();
-   |     ^^^^^^^-
-   |            |
-   |            help: provide a definition for the function: `{ <body> }`
-
-error: free function without a body
-  --> $DIR/fn-body-optional-semantic-fail.rs:8:5
-   |
-LL |     fn f1_rpit() -> impl Trait;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   |                               |
-   |                               help: provide a definition for the function: `{ <body> }`
-
 error: associated function in `impl` without body
   --> $DIR/fn-body-optional-semantic-fail.rs:18:9
    |
@@ -43,6 +27,22 @@ LL |         fn f6() {}
    |
    = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: free function without a body
+  --> $DIR/fn-body-optional-semantic-fail.rs:7:5
+   |
+LL |     fn f1();
+   |     ^^^^^^^-
+   |            |
+   |            help: provide a definition for the function: `{ <body> }`
+
+error: free function without a body
+  --> $DIR/fn-body-optional-semantic-fail.rs:8:5
+   |
+LL |     fn f1_rpit() -> impl Trait;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |                               |
+   |                               help: provide a definition for the function: `{ <body> }`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/tests/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -1,11 +1,3 @@
-error: free function without a body
-  --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:3:1
-   |
-LL | async fn free();
-   | ^^^^^^^^^^^^^^^-
-   |                |
-   |                help: provide a definition for the function: `{ <body> }`
-
 error: associated function in `impl` without body
   --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:7:5
    |
@@ -21,6 +13,14 @@ LL |     async fn associated();
    |     ^^^^^^^^^^^^^^^^^^^^^-
    |                          |
    |                          help: provide a definition for the function: `{ <body> }`
+
+error: free function without a body
+  --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:3:1
+   |
+LL | async fn free();
+   | ^^^^^^^^^^^^^^^-
+   |                |
+   |                help: provide a definition for the function: `{ <body> }`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This moves the "missing function body" error from ast_passes to ast_lowering. This doesn't change much, except that it allows for builtin macro attributes to accept functions without a body.

We need this for externally implementable items:

```rust
// in core:
#[externally_implementable]
fn panic_handler();
```

Before this change, this would result in an error even before the (builtin) attribute macro gets expanded.
