### PR TITLE
Adapt `pin!` to the new lifespan-extension rules of 2024 edition

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -2100,10 +2100,10 @@ pub macro pin($value:expr $(,)?) {
 /// hinges on the following observation:
 ///
 /// > `&mut Wrapper { field: $value }` happens to preserve the lifespan-of-temps-extending
-/// > rules of 2021 edition `&mut $value`, and also funnels `$value` through a value expression.
+/// > rules of 2021 edition `&mut { $value }`, and also funnels `$value` through a value expression.
 ///
-/// But we get a `&mut Wrapper<typeof<$value>>` rather than a `&mut typeof<$value>`.
-/// So now the challenge is to get `DerefMut` to take place here, and we are good!
+/// But of course, we now have a `&mut Wrapper<typeof<$value>>` rather than a `&mut typeof<$value>`.
+/// So now the challenge is to get `DerefMut` to take place here, and we will be good to go!
 ///
 /// Only…, so far, lifespan-extension rules get broken by _explicit_ `Deref{,Mut}` such as `*`,
 /// `&*`, or, in our case, `&mut *`!! 😩

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -2037,7 +2037,7 @@ pub macro pin($value:expr $(,)?) {
             }
             pin
         },
-    }
+    } as $crate::pin::Pin<&mut _> // allow unsized coërcions
 }
 
 /// Since the 2024 edition, the rules for lifespan-of-temporaries extension have changed,


### PR DESCRIPTION
Fixes #138596

See the docs of the `lifetime_extension` module for info about the implementation and the, alas, hacks involved.

The hackiest part is the need to add a `PhantomData` field to `Pin`, alongside dead code, to guide type inference so as to force a sorely needed `DerefMut` coërcion to happen.

Therefore, let's keep in mind possible:

<span id="alternatives-to-this-pr"></span>

# Alternatives to this PR

In order, imho, of simplicity-and-shipping-velocity:

 1. **Language tweak**: get explicit `Deref{,Mut}`, _i.e._, `&*` and `&mut *`, to preserve lifespan-of-temps extension.

    Indeed, it is not currently the case, whereas _implicit_ `Deref{,Mut}` (through deref-coërcions from type constraints) does preserve it!

    In other words, currently, we have the following silly disparity:

    ```rs
    use ::std::borrow::Cow;
    let b: &String = &Cow::Borrowed { 0: &String::from("…") } /* as &*… */;
    let _some_use = (&b, ); // OK
    // vs.
    let b /*: &String*/ = &*Cow::Borrowed { 0: &String::from("…") };
    let _some_use = (&b, ); // Error!
    ```

      - [Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=43861eea59ca44b0e7a6638e037e9c8c)

    With this, the implementation of this PR gets significantly reduced, insofar anything `__phantom` related disappears, and we'd just have:

    ```rs
    Pin { __pointer: &mut *__Pinned { value…: $value } }
    ```

 1. **Lib/compiler hack**: expose a way for the `pin!` macro (or a helper macro thereof) to emit code using 2021 edition (for its braces) so that the emitted code benefits from the 2021 edition rules for lifespan-of-temps extension.

    What I dislike about this: it becomes an utter acknowledgment of edition 2024 having regressed in expressibility; we ought rather to try and find ways to be able to express 2021 edition semantics without actually needing to be using that edition, I'd say.

 1. **Language feature** (and proper solution): have the language offer `super let`.

    This is _the_ proper tool through which the `pin!` macro and the like ought to be implemented:

    ```rs
    macro_rules! pin {( $value:expr $(,)? ) => ({
     // extends the life-span of this `anon` local.
     // vvvvv
        super let mut anon = $value;
        // No need for field privacy hacks, or brittle braced constructions.
        // For instance, anybody could implement this, not just the stdlib.
        unsafe { Pin::new_unchecked(&mut anon) }
    })}
    ```

    The problem is that I don't see this happening quick enough w.r.t. fixing issues such as #138596 (unless we temporarily reverted the edition of `core` back to 2021 in the meantime?).
