### PR TITLE
[bootstrap] Use llvm_runtimes for compiler-rt

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -479,7 +479,6 @@ impl Step for Llvm {
 
         if helpers::forcing_clang_based_tests() {
             enabled_llvm_projects.push("clang");
-            enabled_llvm_projects.push("compiler-rt");
         }
 
         if builder.config.llvm_polly {
@@ -501,6 +500,10 @@ impl Step for Llvm {
         }
 
         let mut enabled_llvm_runtimes = Vec::new();
+
+        if helpers::forcing_clang_based_tests() {
+            enabled_llvm_runtimes.push("compiler-rt");
+        }
 
         if builder.config.llvm_offload {
             enabled_llvm_runtimes.push("offload");


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Trying to enable `compiler-rt` via `LLVM_ENABLE_PROJECTS` is no longer a supported option in LLVM, and gives you nasty warnings:
```
Using LLVM_ENABLE_PROJECTS=compiler-rt is deprecated now, and will become a
  fatal error in the LLVM 21 release.  Please use
  -DLLVM_ENABLE_RUNTIMES=compiler-rt or see the instructions at
  https://compiler-rt.llvm.org/ for building the runtimes.
```

try-job: aarch64-gnu-debug
try-job: x86_64-gnu-debug