### PR TITLE
Lower to a memset(undef) when Rvalue::Repeat repeats uninit

### DIFF
--- a/tests/codegen/uninit-repeat-in-aggregate.rs
+++ b/tests/codegen/uninit-repeat-in-aggregate.rs
@@ -1,0 +1,21 @@
+//@ compile-flags: -Copt-level=3
+
+#![crate_type = "lib"]
+
+use std::mem::MaybeUninit;
+
+// We need to make sure len is at offset 0, otherwise codegen needs an extra instruction
+#[repr(C)]
+pub struct SmallVec<T> {
+    pub len: u64,
+    pub arr: [MaybeUninit<T>; 24],
+}
+
+// CHECK-LABEL: @uninit_arr_via_const
+#[no_mangle]
+pub fn uninit_arr_via_const() -> SmallVec<String> {
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: store i64 0,
+    // CHECK-NEXT: ret
+    SmallVec { len: 0, arr: [const { MaybeUninit::uninit() }; 24] }
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/138625.

It is technically correct to just do nothing. But if we actually do nothing, we may miss that this is de-initializing something, so instead we just lower to a single memset that writes undef. This is still superior to the memcpy loop, in both quality of code we hand to the backend and LLVM's final output.