### PR TITLE
Add `#[cfg(test)]` for Transition in dfa in `rustc_transmute`

### DIFF
--- a/compiler/rustc_transmute/src/layout/dfa.rs
+++ b/compiler/rustc_transmute/src/layout/dfa.rs
@@ -55,6 +55,7 @@ where
 #[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Copy, Clone)]
 pub(crate) struct State(u32);
 
+#[cfg(test)]
 #[derive(Hash, Eq, PartialEq, Clone, Copy)]
 pub(crate) enum Transition<R>
 where
@@ -70,6 +71,7 @@ impl fmt::Debug for State {
     }
 }
 
+#[cfg(test)]
 impl<R> fmt::Debug for Transition<R>
 where
     R: Ref,
@@ -166,6 +168,7 @@ impl State {
     }
 }
 
+#[cfg(test)]
 impl<R> From<nfa::Transition<R>> for Transition<R>
 where
     R: Ref,


### PR DESCRIPTION
`Transition` is only used in the `Transitions::insert` in test after #137776

Detected by #128637