### PR TITLE
Reintroduce remote-test support in run-make tests

### DIFF
--- a/src/tools/run-make-support/src/run.rs
+++ b/src/tools/run-make-support/src/run.rs
@@ -12,7 +12,20 @@ fn run_common(name: &str, args: Option<&[&str]>) -> Command {
     bin_path.push(cwd());
     bin_path.push(name);
     let ld_lib_path_envvar = env_var("LD_LIB_PATH_ENVVAR");
-    let mut cmd = Command::new(bin_path);
+
+    let mut cmd = if let Some(rtc) = env::var_os("REMOTE_TEST_CLIENT") {
+        let mut cmd = Command::new(rtc);
+        cmd.arg("run");
+        // FIXME: the "0" indicates how many support files should be uploaded along with the binary
+        // to execute. If a test requires additional files to be pushed to the remote machine, this
+        // will have to be changed (and the support files will have to be uploaded).
+        cmd.arg("0");
+        cmd.arg(bin_path);
+        cmd
+    } else {
+        Command::new(bin_path)
+    };
+
     if let Some(args) = args {
         for arg in args {
             cmd.arg(arg);

--- a/tests/run-make/doctests-keep-binaries/rmake.rs
+++ b/tests/run-make/doctests-keep-binaries/rmake.rs
@@ -1,3 +1,5 @@
+//@ ignore-cross-compile attempts to run the doctests
+
 // Check that valid binaries are persisted by running them, regardless of whether the
 // --run or --no-run option is used.
 

--- a/tests/run-make/target-cpu-native/rmake.rs
+++ b/tests/run-make/target-cpu-native/rmake.rs
@@ -3,6 +3,8 @@
 // warnings when used, and that binaries produced by it can also be successfully executed.
 // See https://github.com/rust-lang/rust/pull/23238
 
+//@ ignore-cross-compile target-cpu=native doesn't work well when cross compiling
+
 use run_make_support::{run, rustc};
 
 fn main() {


### PR DESCRIPTION
The old Makefile-based infrastructure included support for executing binaries with remote-test-client if configured, but that didn't get ported to run_make_support as part of the rmake migration.

This PR re-introduces back that support, with the same implementation (and limitations) of the original Makefile-based support.

[Old Makefile-based implementation of this](https://github.com/rust-lang/rust/blob/9b8accbeb6336fa24d02b2a8bcaecaf44fe2bb65/tests/run-make/tools.mk#L65-L74)

try-job: armhf-gnu
