### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -28,6 +28,7 @@ use tracing::instrument;
 use crate::middle::region;
 use crate::mir::interpret::AllocId;
 use crate::mir::{self, BinOp, BorrowKind, FakeReadCause, UnOp};
+use crate::thir::visit::for_each_immediate_subpat;
 use crate::ty::adjustment::PointerCoercion;
 use crate::ty::layout::IntegerExt;
 use crate::ty::{
@@ -672,27 +673,7 @@ impl<'tcx> Pat<'tcx> {
             return;
         }
 
-        use PatKind::*;
-        match &self.kind {
-            Wild
-            | Never
-            | Range(..)
-            | Binding { subpattern: None, .. }
-            | Constant { .. }
-            | Error(_) => {}
-            AscribeUserType { subpattern, .. }
-            | Binding { subpattern: Some(subpattern), .. }
-            | Deref { subpattern }
-            | DerefPattern { subpattern, .. }
-            | ExpandedConstant { subpattern, .. } => subpattern.walk_(it),
-            Leaf { subpatterns } | Variant { subpatterns, .. } => {
-                subpatterns.iter().for_each(|field| field.pattern.walk_(it))
-            }
-            Or { pats } => pats.iter().for_each(|p| p.walk_(it)),
-            Array { box prefix, slice, box suffix } | Slice { box prefix, slice, box suffix } => {
-                prefix.iter().chain(slice.as_deref()).chain(suffix.iter()).for_each(|p| p.walk_(it))
-            }
-        }
+        for_each_immediate_subpat(self, |p| p.walk_(it));
     }
 
     /// Whether the pattern has a `PatKind::Error` nested within.

--- a/compiler/rustc_transmute/src/layout/dfa.rs
+++ b/compiler/rustc_transmute/src/layout/dfa.rs
@@ -55,6 +55,7 @@ where
 #[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Copy, Clone)]
 pub(crate) struct State(u32);
 
+#[cfg(test)]
 #[derive(Hash, Eq, PartialEq, Clone, Copy)]
 pub(crate) enum Transition<R>
 where
@@ -70,6 +71,7 @@ impl fmt::Debug for State {
     }
 }
 
+#[cfg(test)]
 impl<R> fmt::Debug for Transition<R>
 where
     R: Ref,
@@ -166,6 +168,7 @@ impl State {
     }
 }
 
+#[cfg(test)]
 impl<R> From<nfa::Transition<R>> for Transition<R>
 where
     R: Ref,

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -330,7 +330,7 @@ impl Error for VarError {
 ///
 /// Discussion of this unsafety on Unix may be found in:
 ///
-///  - [Austin Group Bugzilla](https://austingroupbugs.net/view.php?id=188)
+///  - [Austin Group Bugzilla (for POSIX)](https://austingroupbugs.net/view.php?id=188)
 ///  - [GNU C library Bugzilla](https://sourceware.org/bugzilla/show_bug.cgi?id=15607#c2)
 ///
 /// To pass an environment variable to a child process, you can instead use [`Command::env`].

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2003,9 +2003,9 @@ impl ExitCode {
     ///
     /// Note that this has the same caveats as [`process::exit()`][exit], namely that this function
     /// terminates the process immediately, so no destructors on the current stack or any other
-    /// thread's stack will be run. If a clean shutdown is needed, it is recommended to simply
-    /// return this ExitCode from the `main` function, as demonstrated in the [type
-    /// documentation](#examples).
+    /// thread's stack will be run. Also see those docs for some important notes on interop with C
+    /// code. If a clean shutdown is needed, it is recommended to simply return this ExitCode from
+    /// the `main` function, as demonstrated in the [type documentation](#examples).
     ///
     /// # Differences from `process::exit()`
     ///
@@ -2296,6 +2296,34 @@ impl Child {
 /// threads. (The alternative to this requirement would be to not run exit handlers at all, which is
 /// considered undesirable. Note that returning from `main` also calls `exit`, so making `exit` an
 /// unsafe operation is not an option.)
+///
+/// ## Safe interop with C code
+///
+/// This function is safe to call as long as `exit` is only ever invoked from Rust. However, on some
+/// platforms this function is implemented by calling the C function [`exit`][C-exit]. As of C23,
+/// the C standard does not permit multiple threads to call `exit` concurrently. Rust mitigates this
+/// with a lock, but if C code calls `exit`, that can still cause undefined behavior. Note that
+/// returning from `main` is equivalent to calling `exit`.
+///
+/// Therefore, it is undefined behavior to have two concurrent threads perform the following
+/// without synchronization:
+/// - One thread calls Rust's `exit` function or returns from Rust's `main` function
+/// - Another thread calls the C function `exit` or `quick_exit`, or returns from C's `main` function
+///
+/// Note that if a binary contains multiple copies of the Rust runtime (e.g., when combining
+/// multiple `cdylib` or `staticlib`), they each have their own separate lock, so from the
+/// perspective of code running in one of the Rust runtimes, the "outside" Rust code is basically C
+/// code, and concurrent `exit` again causes undefined behavior.
+///
+/// Individual C implementations might provide more guarantees than the standard and permit concurrent
+/// calls to `exit`; consult the documentation of your C implementation for details.
+///
+/// For some of the on-going discussion to make `exit` thread-safe in C, see:
+/// - [Rust issue #126600](https://github.com/rust-lang/rust/issues/126600)
+/// - [Austin Group Bugzilla (for POSIX)](https://austingroupbugs.net/view.php?id=1845)
+/// - [GNU C library Bugzilla](https://sourceware.org/bugzilla/show_bug.cgi?id=31997)
+///
+/// [C-exit]: https://en.cppreference.com/w/c/program/exit
 ///
 /// ## Platform-specific behavior
 ///

--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -396,7 +396,7 @@ impl File {
     }
 
     pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
-        crate::io::default_read_buf(|buf| self.read(buf), cursor)
+        self.0.read_buf(cursor)
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {

--- a/library/std/src/sys/stdio/unix.rs
+++ b/library/std/src/sys/stdio/unix.rs
@@ -3,9 +3,7 @@ use hermit_abi::{EBADF, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 #[cfg(target_family = "unix")]
 use libc::{EBADF, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 
-#[cfg(target_family = "unix")]
-use crate::io::BorrowedCursor;
-use crate::io::{self, IoSlice, IoSliceMut};
+use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut};
 use crate::mem::ManuallyDrop;
 #[cfg(target_os = "hermit")]
 use crate::os::hermit::io::FromRawFd;
@@ -28,7 +26,6 @@ impl io::Read for Stdin {
         unsafe { ManuallyDrop::new(FileDesc::from_raw_fd(STDIN_FILENO)).read(buf) }
     }
 
-    #[cfg(not(target_os = "hermit"))]
     fn read_buf(&mut self, buf: BorrowedCursor<'_>) -> io::Result<()> {
         unsafe { ManuallyDrop::new(FileDesc::from_raw_fd(STDIN_FILENO)).read_buf(buf) }
     }

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -216,8 +216,9 @@ fn setup_config_toml(path: &Path, profile: Profile, config: &Config) {
 
     let latest_change_id = CONFIG_CHANGE_HISTORY.last().unwrap().change_id;
     let settings = format!(
-        "# Includes one of the default files in {PROFILE_DIR}\n\
-    profile = \"{profile}\"\n\
+        "# See bootstrap.example.toml for documentation of available options\n\
+    #\n\
+    profile = \"{profile}\"  # Includes one of the default files in {PROFILE_DIR}\n\
     change-id = {latest_change_id}\n"
     );
 

--- a/tests/rustdoc-json/attrs/repr_align.rs
+++ b/tests/rustdoc-json/attrs/repr_align.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+//@ is "$.index[*][?(@.name=='Aligned')].attrs" '["#[attr = Repr([ReprAlign(Align(4 bytes))])]\n"]'
+#[repr(align(4))]
+pub struct Aligned {
+    a: i8,
+    b: i64,
+}

--- a/tests/rustdoc-json/attrs/repr_c.rs
+++ b/tests/rustdoc-json/attrs/repr_c.rs
@@ -1,0 +1,18 @@
+#![no_std]
+
+//@ is "$.index[*][?(@.name=='ReprCStruct')].attrs" '["#[attr = Repr([ReprC])]\n"]'
+#[repr(C)]
+pub struct ReprCStruct(pub i64);
+
+//@ is "$.index[*][?(@.name=='ReprCEnum')].attrs" '["#[attr = Repr([ReprC])]\n"]'
+#[repr(C)]
+pub enum ReprCEnum {
+    First,
+}
+
+//@ is "$.index[*][?(@.name=='ReprCUnion')].attrs" '["#[attr = Repr([ReprC])]\n"]'
+#[repr(C)]
+pub union ReprCUnion {
+    pub left: i64,
+    pub right: u64,
+}

--- a/tests/rustdoc-json/attrs/repr_combination.rs
+++ b/tests/rustdoc-json/attrs/repr_combination.rs
@@ -1,0 +1,78 @@
+#![no_std]
+
+// Combinations of `#[repr(..)]` attributes.
+
+//@ is "$.index[*][?(@.name=='ReprCI8')].attrs" '["#[attr = Repr([ReprC, ReprInt(SignedInt(I8))])]\n"]'
+#[repr(C, i8)]
+pub enum ReprCI8 {
+    First,
+}
+
+//@ is "$.index[*][?(@.name=='SeparateReprCI16')].attrs" '["#[attr = Repr([ReprC, ReprInt(SignedInt(I16))])]\n"]'
+#[repr(C)]
+#[repr(i16)]
+pub enum SeparateReprCI16 {
+    First,
+}
+
+//@ is "$.index[*][?(@.name=='ReversedReprCUsize')].attrs" '["#[attr = Repr([ReprInt(UnsignedInt(Usize)), ReprC])]\n"]'
+#[repr(usize, C)]
+pub enum ReversedReprCUsize {
+    First,
+}
+
+//@ is "$.index[*][?(@.name=='ReprCPacked')].attrs" '["#[attr = Repr([ReprC, ReprPacked(Align(1 bytes))])]\n"]'
+#[repr(C, packed)]
+pub struct ReprCPacked {
+    a: i8,
+    b: i64,
+}
+
+//@ is "$.index[*][?(@.name=='SeparateReprCPacked')].attrs" '["#[attr = Repr([ReprC, ReprPacked(Align(2 bytes))])]\n"]'
+#[repr(C)]
+#[repr(packed(2))]
+pub struct SeparateReprCPacked {
+    a: i8,
+    b: i64,
+}
+
+//@ is "$.index[*][?(@.name=='ReversedReprCPacked')].attrs" '["#[attr = Repr([ReprPacked(Align(2 bytes)), ReprC])]\n"]'
+#[repr(packed(2), C)]
+pub struct ReversedReprCPacked {
+    a: i8,
+    b: i64,
+}
+
+//@ is "$.index[*][?(@.name=='ReprCAlign')].attrs" '["#[attr = Repr([ReprC, ReprAlign(Align(16 bytes))])]\n"]'
+#[repr(C, align(16))]
+pub struct ReprCAlign {
+    a: i8,
+    b: i64,
+}
+
+//@ is "$.index[*][?(@.name=='SeparateReprCAlign')].attrs" '["#[attr = Repr([ReprC, ReprAlign(Align(2 bytes))])]\n"]'
+#[repr(C)]
+#[repr(align(2))]
+pub struct SeparateReprCAlign {
+    a: i8,
+    b: i64,
+}
+
+//@ is "$.index[*][?(@.name=='ReversedReprCAlign')].attrs" '["#[attr = Repr([ReprAlign(Align(2 bytes)), ReprC])]\n"]'
+#[repr(align(2), C)]
+pub struct ReversedReprCAlign {
+    a: i8,
+    b: i64,
+}
+
+//@ is "$.index[*][?(@.name=='AlignedExplicitRepr')].attrs" '["#[attr = Repr([ReprC, ReprAlign(Align(16 bytes)), ReprInt(SignedInt(Isize))])]\n"]'
+#[repr(C, align(16), isize)]
+pub enum AlignedExplicitRepr {
+    First,
+}
+
+//@ is "$.index[*][?(@.name=='ReorderedAlignedExplicitRepr')].attrs" '["#[attr = Repr([ReprInt(SignedInt(Isize)), ReprC, ReprAlign(Align(16 bytes))])]\n"]'
+#[repr(isize, C, align(16))]
+pub enum ReorderedAlignedExplicitRepr {
+    First,
+}

--- a/tests/rustdoc-json/attrs/repr_int_enum.rs
+++ b/tests/rustdoc-json/attrs/repr_int_enum.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+//@ is "$.index[*][?(@.name=='I8')].attrs" '["#[attr = Repr([ReprInt(SignedInt(I8))])]\n"]'
+#[repr(i8)]
+pub enum I8 {
+    First,
+}
+
+//@ is "$.index[*][?(@.name=='I32')].attrs" '["#[attr = Repr([ReprInt(SignedInt(I32))])]\n"]'
+#[repr(i32)]
+pub enum I32 {
+    First,
+}
+
+//@ is "$.index[*][?(@.name=='Usize')].attrs" '["#[attr = Repr([ReprInt(UnsignedInt(Usize))])]\n"]'
+#[repr(usize)]
+pub enum Usize {
+    First,
+}

--- a/tests/rustdoc-json/attrs/repr_packed.rs
+++ b/tests/rustdoc-json/attrs/repr_packed.rs
@@ -1,0 +1,18 @@
+#![no_std]
+
+// Note the normalization:
+// `#[repr(packed)]` in has the implict "1" in rustdoc JSON.
+
+//@ is "$.index[*][?(@.name=='Packed')].attrs" '["#[attr = Repr([ReprPacked(Align(1 bytes))])]\n"]'
+#[repr(packed)]
+pub struct Packed {
+    a: i8,
+    b: i64,
+}
+
+//@ is "$.index[*][?(@.name=='PackedAligned')].attrs" '["#[attr = Repr([ReprPacked(Align(4 bytes))])]\n"]'
+#[repr(packed(4))]
+pub struct PackedAligned {
+    a: i8,
+    b: i64,
+}

--- a/tests/rustdoc-json/attrs/repr_transparent.rs
+++ b/tests/rustdoc-json/attrs/repr_transparent.rs
@@ -1,0 +1,22 @@
+#![no_std]
+
+// Rustdoc JSON currently includes `#[repr(transparent)]`
+// even if the transparency is not part of the public API
+//
+// https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent
+
+//@ is "$.index[*][?(@.name=='Transparent')].attrs" '["#[attr = Repr([ReprTransparent])]\n"]'
+#[repr(transparent)]
+pub struct Transparent(pub i64);
+
+//@ is "$.index[*][?(@.name=='TransparentNonPub')].attrs" '["#[attr = Repr([ReprTransparent])]\n"]'
+#[repr(transparent)]
+pub struct TransparentNonPub(i64);
+
+//@ is "$.index[*][?(@.name=='AllZst')].attrs" '["#[attr = Repr([ReprTransparent])]\n"]'
+#[repr(transparent)]
+pub struct AllZst<'a>(pub core::marker::PhantomData<&'a ()>, ());
+
+//@ is "$.index[*][?(@.name=='AllZstNotPublic')].attrs" '["#[attr = Repr([ReprTransparent])]\n"]'
+#[repr(transparent)]
+pub struct AllZstNotPublic<'a>(core::marker::PhantomData<&'a ()>, ());

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1082,7 +1082,6 @@ contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
 users_on_vacation = [
     "jyn514",
     "ChrisDenton",
-    "jieyouxu",
 ]
 
 [[assign.warn_non_default_branch.exceptions]]


### PR DESCRIPTION
Successful merges:

 - #136320 (exit: document interaction with C)
 - #138080 (Leave a breadcrumb towards bootstrap config documentation in `bootstrap.toml`)
 - #138301 (Implement `read_buf` for Hermit)
 - #138569 (rustdoc-json: Add tests for `#[repr(...)]`)
 - #138635 (Extract `for_each_immediate_subpat` from THIR pattern visitors)
 - #138642 (Unvacation myself)
 - #138644 (Add `#[cfg(test)]` for Transition in dfa in `rustc_transmute`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=136320,138080,138301,138569,138635,138642,138644)
<!-- homu-ignore:end -->