### PR TITLE
Remove the regex dependency from coretests

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -85,7 +85,6 @@ version = "0.0.0"
 dependencies = [
  "rand",
  "rand_xorshift",
- "regex",
 ]
 
 [[package]]
@@ -311,31 +310,6 @@ checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"

--- a/library/coretests/Cargo.toml
+++ b/library/coretests/Cargo.toml
@@ -25,4 +25,3 @@ test = true
 [dev-dependencies]
 rand = { version = "0.9.0", default-features = false }
 rand_xorshift = { version = "0.4.0", default-features = false }
-regex = { version = "1.11.1", default-features = false }

--- a/library/coretests/tests/fmt/mod.rs
+++ b/library/coretests/tests/fmt/mod.rs
@@ -22,32 +22,24 @@ fn test_pointer_formats_data_pointer() {
 #[test]
 fn test_fmt_debug_of_raw_pointers() {
     use core::fmt::Debug;
+    use core::ptr;
 
-    fn check_fmt<T: Debug>(t: T, expected: &str) {
-        use std::sync::LazyLock;
-
-        use regex::Regex;
-
-        static ADDR_REGEX: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r"0x[0-9a-fA-F]+").unwrap());
-
+    fn check_fmt<T: Debug>(t: T, start: &str, contains: &str) {
         let formatted = format!("{:?}", t);
-        let normalized = ADDR_REGEX.replace_all(&formatted, "$$HEX");
-
-        assert_eq!(normalized, expected);
+        assert!(formatted.starts_with(start), "{formatted:?} doesn't start with {start:?}");
+        assert!(formatted.contains(contains), "{formatted:?} doesn't contain {contains:?}");
     }
 
-    let plain = &mut 100;
-    check_fmt(plain as *mut i32, "$HEX");
-    check_fmt(plain as *const i32, "$HEX");
+    assert_eq!(format!("{:?}", ptr::without_provenance_mut::<i32>(0x100)), "0x100");
+    assert_eq!(format!("{:?}", ptr::without_provenance::<i32>(0x100)), "0x100");
 
-    let slice = &mut [200, 300, 400][..];
-    check_fmt(slice as *mut [i32], "Pointer { addr: $HEX, metadata: 3 }");
-    check_fmt(slice as *const [i32], "Pointer { addr: $HEX, metadata: 3 }");
+    let slice = ptr::slice_from_raw_parts(ptr::without_provenance::<i32>(0x100), 3);
+    assert_eq!(format!("{:?}", slice as *mut [i32]), "Pointer { addr: 0x100, metadata: 3 }");
+    assert_eq!(format!("{:?}", slice as *const [i32]), "Pointer { addr: 0x100, metadata: 3 }");
 
     let vtable = &mut 500 as &mut dyn Debug;
-    check_fmt(vtable as *mut dyn Debug, "Pointer { addr: $HEX, metadata: DynMetadata($HEX) }");
-    check_fmt(vtable as *const dyn Debug, "Pointer { addr: $HEX, metadata: DynMetadata($HEX) }");
+    check_fmt(vtable as *mut dyn Debug, "Pointer { addr: ", ", metadata: DynMetadata(");
+    check_fmt(vtable as *const dyn Debug, "Pointer { addr: ", ", metadata: DynMetadata(");
 }
 
 #[test]


### PR DESCRIPTION
It is only used by a single test, yet would take up unnecessary space once stdlib deps get vendored.