### PR TITLE
Remove double nesting in post-merge workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -35,12 +35,11 @@ jobs:
 
           cd src/ci/citool
 
-          printf "*This is an experimental post-merge analysis report. You can ignore it.*\n\n" > output.log
-          printf "<details>\n<summary>Post-merge report</summary>\n\n" >> output.log
+          printf "<details>\n<summary>What is this?</summary>\n" >> output.log
+          printf "This is an experimental post-merge analysis report that shows differences in test outcomes between the merged PR and its parent PR.\n" >> output.log
+          printf "</details>\n\n" >> output.log
 
           cargo run --release post-merge-report ${PARENT_COMMIT} ${{ github.sha }} >> output.log
-
-          printf "</details>\n" >> output.log
 
           cat output.log
 

--- a/src/ci/citool/src/main.rs
+++ b/src/ci/citool/src/main.rs
@@ -20,7 +20,7 @@ use crate::cpu_usage::load_cpu_usage;
 use crate::datadog::upload_datadog_metric;
 use crate::jobs::RunType;
 use crate::metrics::{JobMetrics, download_auto_job_metrics, download_job_metrics, load_metrics};
-use crate::utils::{load_env_var, output_details};
+use crate::utils::load_env_var;
 
 const CI_DIRECTORY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
 const DOCKER_DIRECTORY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../docker");
@@ -174,13 +174,6 @@ fn postprocess_metrics(
 
 fn post_merge_report(db: JobDatabase, current: String, parent: String) -> anyhow::Result<()> {
     let metrics = download_auto_job_metrics(&db, &parent, &current)?;
-
-    output_details("What is this?", || {
-        println!(
-            r#"This is an experimental post-merge analysis report that shows differences in
-test outcomes between the merged PR and its parent PR."#
-        );
-    });
 
     println!("\nComparing {parent} (parent) -> {current} (this PR)\n");
     output_test_diffs(metrics);


### PR DESCRIPTION
See [this](https://github.com/rust-lang/rust/pull/138630#issuecomment-2732224491) :)

Can be tested with:
```bash
#!/bin/bash

PARENT_COMMIT=493c38ba371929579fe136df26eccd9516347c7a
SHA=259fdb521200c9abba547302fc2c826479ef26b2

printf "<details>\n<summary>What is this?</summary>\n" >> output.log
printf "This is an experimental post-merge analysis report that shows differences in test outcomes between the merged PR and its parent PR.\n" >> output.log
printf "</details>\n\n" >> output.log

cargo run --release post-merge-report ${PARENT_COMMIT} ${SHA} >> output.log
```

I think that it's better to leave the notice in CI, to avoid generating it in citool, which can also be executed locally.

r? @marcoieni