### PR TITLE
CI: mirror alpine and centos images to ghcr

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -5,6 +5,9 @@
 # Docker Hub has a rate limit, while ghcr.io doesn't.
 # Those images are pushed to ghcr.io by this job.
 #
+# While Docker Hub rate limit *shouldn't* be an issue on GitHub Actions,
+# it certainly is for AWS codebuild.
+#
 # Note that authenticating to DockerHub or other registries isn't possible
 # for PR jobs, because forks can't access secrets.
 # That's why we use ghcr.io: it has no rate limit and it doesn't require authentication.
@@ -54,6 +57,10 @@ jobs:
             "ubuntu:22.04"
             # Mirrored because used by all linux CI jobs, including mingw-check-tidy
             "moby/buildkit:buildx-stable-1"
+            # Mirrored because used when CI is running inside a Docker container
+            "alpine:3.4"
+            # Mirrored because used by dist-x86_64-linux
+            "centos:7"
           )
 
           # Mirror each image from DockerHub to ghcr.io


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
This week I will switch some jobs to aws codebuild to use some aws credits for CI. This PR mirrors more images, so that we don't hit the dockerhub rate limit in aws.
See https://github.com/rust-lang/rust/pull/133912/ if you are curious to know how these images are used.

r? @Kobzol 
<!-- homu-ignore:end -->
