### PR TITLE
Fix build failure on Trusty

### DIFF
--- a/library/std/src/sys/random/trusty.rs
+++ b/library/std/src/sys/random/trusty.rs
@@ -1,4 +1,4 @@
-extern "C" {
+unsafe extern "C" {
     fn trusty_rng_secure_rand(randomBuffer: *mut core::ffi::c_void, randomBufferLen: libc::size_t);
 }
 


### PR DESCRIPTION
This target is currently broken due to update to 2024 editon.

```console
$ cargo new --lib repro
$ cd repro
$ cargo check -Z build-std=std --target aarch64-unknown-trusty
   Compiling std v0.0.0 ($HOME/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std)
error: extern blocks must be unsafe
 --> $HOME/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/random/trusty.rs:1:1
  |
1 | / extern "C" {
2 | |     fn trusty_rng_secure_rand(randomBuffer: *mut core::ffi::c_void, randomBufferLen: libc::size_t);
3 | | }
  | |_^

error: could not compile `std` (lib) due to 1 previous error
```

cc @randomPoison @ahomescu ([target maintainers](https://doc.rust-lang.org/nightly/rustc/platform-support/trusty.html#target-maintainers))