### PR TITLE
use then in docs for `fuse` to enhance readability

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1704,11 +1704,7 @@ pub trait Iterator {
     ///         self.state = self.state + 1;
     ///
     ///         // if it's even, Some(i32), else None
-    ///         if val % 2 == 0 {
-    ///             Some(val)
-    ///         } else {
-    ///             None
-    ///         }
+    ///         (val % 2 == 0).then_some(val)
     ///     }
     /// }
     ///


### PR DESCRIPTION
use the more-idiomatic `then_some` rather than an `if { some } else { none }` for `fused` docs