### PR TITLE
Temporarily disable Fuchsia test job to unblock queue

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -262,13 +262,16 @@ auto:
   - name: test-various
     <<: *job-linux-4c
 
-  - name: x86_64-fuchsia
-    # Only run this job on the nightly channel. Fuchsia requires
-    # nightly features to compile, and this job would fail if
-    # executed on beta and stable.
-    only_on_channel: nightly
-    doc_url: https://rustc-dev-guide.rust-lang.org/tests/fuchsia.html
-    <<: *job-linux-8c
+  # FIXME: temporarily disabled due to fuchsia server rate limits. See
+  # <https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/fuchsia.20failure/with/506637259>.
+  #
+  #- name: x86_64-fuchsia
+  #  # Only run this job on the nightly channel. Fuchsia requires
+  #  # nightly features to compile, and this job would fail if
+  #  # executed on beta and stable.
+  #  only_on_channel: nightly
+  #  doc_url: https://rustc-dev-guide.rust-lang.org/tests/fuchsia.html
+  #  <<: *job-linux-8c
 
   # Tests integration with Rust for Linux.
   # Builds stage 1 compiler and tries to compile a few RfL examples with it.


### PR DESCRIPTION
See <https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/fuchsia.20failure/with/506637259> for efforts to fix the test job.

This PR temporarily disables the Fuchsia test job to unblock the queue, so that neither the Fuchsia maintainers nor T-infra maintainers should feel pressured to fix the job ASAP.

Please feel free to re-enable once the test job is fixed.
FYI @erickt since you or other Fuchsia maintainers will need to revert this change to merge Fuchsia test job fixes in the future.

r? infra-ci
