### PR TITLE
Remove `llvm` and `llvms` triagebot ping aliases for `icebreakers-llvm` ping group

### DIFF
--- a/src/doc/rustc-dev-guide/src/notification-groups/about.md
+++ b/src/doc/rustc-dev-guide/src/notification-groups/about.md
@@ -23,7 +23,7 @@ Here's the list of the notification groups:
 - [ARM](./arm.md)
 - [Cleanup Crew](./cleanup-crew.md)
 - [Emscripten](./emscripten.md)
-- [LLVM](./llvm.md)
+- [LLVM Icebreakers](./llvm.md)
 - [RISC-V](./risc-v.md)
 - [WASI](./wasi.md)
 - [WebAssembly](./wasm.md)
@@ -83,7 +83,7 @@ group. For example:
 @rustbot ping arm
 @rustbot ping cleanup-crew
 @rustbot ping emscripten
-@rustbot ping llvm
+@rustbot ping icebreakers-llvm
 @rustbot ping risc-v
 @rustbot ping wasi
 @rustbot ping wasm

--- a/src/doc/rustc-dev-guide/src/notification-groups/llvm.md
+++ b/src/doc/rustc-dev-guide/src/notification-groups/llvm.md
@@ -1,13 +1,16 @@
-# LLVM Notification group
+# LLVM Icebreakers Notification group
 
 **Github Label:** [A-LLVM] <br>
-**Ping command:** `@rustbot ping llvm`
+**Ping command:** `@rustbot ping icebreakers-llvm`
 
 [A-LLVM]: https://github.com/rust-lang/rust/labels/A-LLVM
 
-The "LLVM Notification Group" are focused on bugs that center around LLVM.
-These bugs often arise because of LLVM optimizations gone awry, or as
-the result of an LLVM upgrade. The goal here is:
+*Note*: this notification group is *not* the same as the LLVM working group
+(WG-llvm).
+
+The "LLVM Icebreakers Notification Group" are focused on bugs that center around
+LLVM. These bugs often arise because of LLVM optimizations gone awry, or as the
+result of an LLVM upgrade. The goal here is:
 
 - to determine whether the bug is a result of us generating invalid LLVM IR,
   or LLVM misoptimizing;

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -47,7 +47,6 @@ add_labels = ["S-waiting-on-review"]
 [glacier]
 
 [ping.icebreakers-llvm]
-alias = ["llvm", "llvms"]
 message = """\
 Hey LLVM ICE-breakers! This bug has been identified as a good
 "LLVM ICE-breaking candidate". In case it's useful, here are some


### PR DESCRIPTION
Because it's way too easy to confuse LLVM Icebreakers ping group versus trying to ping WG-llvm.
And AFAIK, icebreakers-llvm isn't really used in a good while.

I also fixed the rustc-dev-guide docs about `@rustbot ping llvm` (and changed that to the raw ping group name `@rustbot icebreakers-llvm`) because it's very confusing.

Previously discussed in [#t-compiler/wg-llvm > Ping group renaming](https://rust-lang.zulipchat.com/#narrow/channel/187780-t-compiler.2Fwg-llvm/topic/Ping.20group.20renaming/with/453005029).

FYI @rust-lang/wg-llvm
FYI @RalfJung (since you asked in https://github.com/rust-lang/rust/pull/138120#issuecomment-2710466874)
r? @nikic (or wg-llvm)