### PR TITLE
Fix closure recovery for missing block when return type is specified

### DIFF
--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -810,16 +810,16 @@ pub(crate) enum WrapInParentheses {
 
 #[derive(Diagnostic)]
 #[diag(parse_array_brackets_instead_of_braces)]
-pub(crate) struct ArrayBracketsInsteadOfSpaces {
+pub(crate) struct ArrayBracketsInsteadOfBraces {
     #[primary_span]
     pub span: Span,
     #[subdiagnostic]
-    pub sub: ArrayBracketsInsteadOfSpacesSugg,
+    pub sub: ArrayBracketsInsteadOfBracesSugg,
 }
 
 #[derive(Subdiagnostic)]
 #[multipart_suggestion(parse_suggestion, applicability = "maybe-incorrect")]
-pub(crate) struct ArrayBracketsInsteadOfSpacesSugg {
+pub(crate) struct ArrayBracketsInsteadOfBracesSugg {
     #[suggestion_part(code = "[")]
     pub left: Span,
     #[suggestion_part(code = "]")]

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2190,7 +2190,9 @@ impl<'a> Parser<'a> {
     }
 
     fn is_array_like_block(&mut self) -> bool {
-        self.look_ahead(1, |t| matches!(t.kind, TokenKind::Ident(..) | TokenKind::Literal(_)))
+        matches!(self.token.kind, TokenKind::OpenDelim(Delimiter::Brace))
+            && self
+                .look_ahead(1, |t| matches!(t.kind, TokenKind::Ident(..) | TokenKind::Literal(_)))
             && self.look_ahead(2, |t| t == &token::Comma)
             && self.look_ahead(3, |t| t.can_begin_expr())
     }
@@ -2202,9 +2204,9 @@ impl<'a> Parser<'a> {
         let mut snapshot = self.create_snapshot_for_diagnostic();
         match snapshot.parse_expr_array_or_repeat(exp!(CloseBrace)) {
             Ok(arr) => {
-                let guar = self.dcx().emit_err(errors::ArrayBracketsInsteadOfSpaces {
+                let guar = self.dcx().emit_err(errors::ArrayBracketsInsteadOfBraces {
                     span: arr.span,
-                    sub: errors::ArrayBracketsInsteadOfSpacesSugg {
+                    sub: errors::ArrayBracketsInsteadOfBracesSugg {
                         left: lo,
                         right: snapshot.prev_token.span,
                     },

--- a/tests/ui/parser/closure-return-syntax.rs
+++ b/tests/ui/parser/closure-return-syntax.rs
@@ -1,7 +1,21 @@
 // Test that we cannot parse a closure with an explicit return type
 // unless it uses braces.
 
-fn main() {
+fn needs_braces_1() {
     let x = || -> i32 22;
     //~^ ERROR expected `{`, found `22`
 }
+
+// Check other delimiters too.
+
+fn needs_braces_2() {
+        let x = || -> (i32, i32) (1, 2);
+        //~^ ERROR expected `{`, found `(`
+}
+
+fn needs_braces_3() {
+        let c = || -> [i32; 2] [1, 2];
+        //~^ ERROR expected `{`, found `[`
+}
+
+fn main() {}

--- a/tests/ui/parser/closure-return-syntax.stderr
+++ b/tests/ui/parser/closure-return-syntax.stderr
@@ -9,5 +9,27 @@ help: you might have meant to write this as part of a block
 LL |     let x = || -> i32 { 22 };
    |                       +    +
 
-error: aborting due to 1 previous error
+error: expected `{`, found `(`
+  --> $DIR/closure-return-syntax.rs:12:34
+   |
+LL |         let x = || -> (i32, i32) (1, 2);
+   |                                  ^ expected `{`
+   |
+help: you might have meant to write this as part of a block
+   |
+LL |         let x = || -> (i32, i32) { (1, 2) };
+   |                                  +        +
+
+error: expected `{`, found `[`
+  --> $DIR/closure-return-syntax.rs:17:32
+   |
+LL |         let c = || -> [i32; 2] [1, 2];
+   |                                ^ expected `{`
+   |
+help: you might have meant to write this as part of a block
+   |
+LL |         let c = || -> [i32; 2] { [1, 2] };
+   |                                +        +
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/closure-return-syntax.stderr
+++ b/tests/ui/parser/closure-return-syntax.stderr
@@ -2,9 +2,11 @@ error: expected `{`, found `22`
   --> $DIR/closure-return-syntax.rs:5:23
    |
 LL |     let x = || -> i32 22;
-   |                       ^^ expected `{`
+   |                   --- ^^
+   |                   |
+   |                   explicit return type requires closure body to be enclosed in braces
    |
-help: you might have meant to write this as part of a block
+help: wrap the expression in curly braces
    |
 LL |     let x = || -> i32 { 22 };
    |                       +    +
@@ -13,9 +15,11 @@ error: expected `{`, found `(`
   --> $DIR/closure-return-syntax.rs:12:34
    |
 LL |         let x = || -> (i32, i32) (1, 2);
-   |                                  ^ expected `{`
+   |                       ---------- ^
+   |                       |
+   |                       explicit return type requires closure body to be enclosed in braces
    |
-help: you might have meant to write this as part of a block
+help: wrap the expression in curly braces
    |
 LL |         let x = || -> (i32, i32) { (1, 2) };
    |                                  +        +
@@ -24,9 +28,11 @@ error: expected `{`, found `[`
   --> $DIR/closure-return-syntax.rs:17:32
    |
 LL |         let c = || -> [i32; 2] [1, 2];
-   |                                ^ expected `{`
+   |                       -------- ^
+   |                       |
+   |                       explicit return type requires closure body to be enclosed in braces
    |
-help: you might have meant to write this as part of a block
+help: wrap the expression in curly braces
    |
 LL |         let c = || -> [i32; 2] { [1, 2] };
    |                                +        +


### PR DESCRIPTION
Firstly, fix the `is_array_like_block` condition to make sure we're actually recovering a mistyped *block* rather than some other delimited expression. This fixes #138748.

Secondly, split out the recovery of missing braces on a closure body into a separate recovery. Right now, the suggestion `"you might have meant to write this as part of a block"` originates from `suggest_fixes_misparsed_for_loop_head`, which feels kinda brittle and coincidental since AFAICT that recovery wasn't ever really intended to fix this.

We also can make this `MachineApplicable` in this case.

Fixes #138748

r? @fmease or reassign if you're busy/don't wanna review this