### PR TITLE
Fix the "used_with_archive" test on Fuchsia

### DIFF
--- a/tests/ui/attributes/auxiliary/used_pre_main_constructor.rs
+++ b/tests/ui/attributes/auxiliary/used_pre_main_constructor.rs
@@ -19,6 +19,7 @@
         target_os = "netbsd",
         target_os = "nto",
         target_os = "openbsd",
+        target_os = "fuchsia",
     ),
     link_section = ".init_array"
 )]


### PR DESCRIPTION
This change adds Fuchsia OS as a target to the cfg_attr in the pre_main_constructor external declaration. This allows the "tests/ui/attributes/used_with_archive.rs" to pass against Fuchsia.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
