### PR TITLE
linker: Move native library search from linker to rustc

### DIFF
--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -96,13 +96,14 @@ pub fn try_find_native_static_library(
     verbatim: bool,
 ) -> Option<PathBuf> {
     let default = sess.staticlib_components(verbatim);
+    let unix = ("lib", ".a");
     let formats = if verbatim {
         vec![default]
+    } else if default != unix && sess.target.is_like_msvc {
+        // On Windows MSVC naming scheme `libfoo.a` is used as a fallback from default `foo.lib`.
+        vec![default, unix]
     } else {
-        // On Windows, static libraries sometimes show up as libfoo.a and other
-        // times show up as foo.lib
-        let unix = ("lib", ".a");
-        if default == unix { vec![default] } else { vec![default, unix] }
+        vec![default]
     };
 
     walk_native_lib_search_dirs(sess, None, |dir, is_framework| {

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -82,6 +82,12 @@ The name used in a `link` attribute may be overridden using the form `-l
 ATTR_NAME:LINK_NAME` where `ATTR_NAME` is the name in the `link` attribute,
 and `LINK_NAME` is the name of the actual library that will be linked.
 
+The compiler may attempt to search for the library in native library search directories
+(controlled by `-L`), and pass it to linker by full path if the search is successful.
+Otherwise the library will be passed to linker by name, so it can perform its own search.
+In some cases this enables use of alternative library naming schemes or `+verbatim` modifier
+even if they are not natively supported by linker.
+
 [link-attribute]: ../reference/items/external-blocks.html#the-link-attribute
 
 ### Linking modifiers: `whole-archive`

--- a/tests/run-make/native-link-modifier-bundle/rmake.rs
+++ b/tests/run-make/native-link-modifier-bundle/rmake.rs
@@ -68,7 +68,7 @@ fn main() {
             .crate_type("cdylib")
             .print("link-args")
             .run()
-            .assert_stdout_not_contains(r#"-l[" ]*native-staticlib"#);
+            .assert_stdout_not_contains("libnative-staticlib.a");
         llvm_nm()
             .input(dynamic_lib_name("cdylib_bundled"))
             .run()
@@ -81,7 +81,7 @@ fn main() {
             .crate_type("cdylib")
             .print("link-args")
             .run()
-            .assert_stdout_contains_regex(r#"-l[" ]*native-staticlib"#);
+            .assert_stdout_contains_regex(r"libnative-staticlib.a");
         llvm_nm()
             .input(dynamic_lib_name("cdylib_non_bundled"))
             .run()

--- a/tests/run-make/native-link-modifier-verbatim-linker/rmake.rs
+++ b/tests/run-make/native-link-modifier-verbatim-linker/rmake.rs
@@ -4,9 +4,6 @@
 // See https://github.com/rust-lang/rust/issues/99425
 
 //@ ignore-cross-compile
-//@ ignore-apple
-//@ ignore-wasm
-// Reason: linking fails due to the unusual ".ext" staticlib name.
 
 use run_make_support::rustc;
 

--- a/tests/run-make/rlib-format-packed-bundled-libs-3/rmake.rs
+++ b/tests/run-make/rlib-format-packed-bundled-libs-3/rmake.rs
@@ -16,6 +16,7 @@ use run_make_support::{
 //@ only-linux
 // Reason: differences in the native lib compilation process causes differences
 // in the --print link-args output
+// FIXME: The test actually passes on windows-gnu, enable it there.
 
 fn main() {
     build_native_static_lib("native_dep_1");
@@ -77,8 +78,10 @@ fn main() {
         .stdout_utf8();
 
     let re = regex::Regex::new(
-"--whole-archive.*native_dep_1.*--whole-archive.*lnative_dep_2.*no-whole-archive.*lnative_dep_4"
-    ).unwrap();
+        "--whole-archive.*native_dep_1.*--whole-archive.*libnative_dep_2.a\
+                                .*no-whole-archive.*libnative_dep_4.a",
+    )
+    .unwrap();
 
     assert!(re.is_match(&out));
 }


### PR DESCRIPTION
For static libraries only, for now.

Linker's search by name is still used if rustc's search fails, because linker may search in additional platform-specific directories in addition to directories known to rustc.
So we are basically doing something like https://github.com/rust-lang/rust/pull/123436 for all targets.

This way we provide best effort support for `+verbatim` modifier even on targets with linkers not supporting it natively.
This closes https://github.com/rust-lang/rust/issues/132264 in particular.

If this is supported for dynamic libraries as well (which is nontrivial), this may also allow us to not pass `-L` options to the linker at all, although it may cause some breakage from libraries passed to linker directly, without rustc knowing about it.

TODO: Some more tests for `+verbatim` and library naming fallback on Windows, if they are missing.