### PR TITLE
Allow boolean literals in `check-cfg`

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -570,6 +570,14 @@ impl MetaItemInner {
         }
     }
 
+    /// Returns the bool if `self` is a boolean `MetaItemInner::Literal`.
+    pub fn boolean_literal(&self) -> Option<bool> {
+        match self {
+            MetaItemInner::Lit(MetaItemLit { kind: LitKind::Bool(b), .. }) => Some(*b),
+            _ => None,
+        }
+    }
+
     /// Returns the `MetaItem` if `self` is a `MetaItemInner::MetaItem` or if it's
     /// `MetaItemInner::Lit(MetaItemLit { kind: LitKind::Bool(_), .. })`.
     pub fn meta_item_or_bool(&self) -> Option<&MetaItemInner> {

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -204,6 +204,14 @@ pub(crate) fn parse_check_cfg(dcx: DiagCtxtHandle<'_>, specs: Vec<String>) -> Ch
                     error!("`cfg()` names cannot be after values");
                 }
                 names.push(ident);
+            } else if let Some(boolean) = arg.boolean_literal() {
+                if values_specified {
+                    error!("`cfg()` names cannot be after values");
+                }
+                names.push(rustc_span::Ident::new(
+                    if boolean { rustc_span::kw::True } else { rustc_span::kw::False },
+                    arg.span(),
+                ));
             } else if arg.has_name(sym::any)
                 && let Some(args) = arg.meta_item_list()
             {

--- a/tests/ui/cfg/raw-true-false.rs
+++ b/tests/ui/cfg/raw-true-false.rs
@@ -1,19 +1,11 @@
 //@ check-pass
-//@ compile-flags: --cfg false --check-cfg=cfg(r#false)
-
-#![deny(warnings)]
-
-#[expect(unexpected_cfgs)]
-mod a {
-  #[cfg(r#true)]
-  pub fn foo() {}
-}
-
-mod b {
-  #[cfg(r#false)]
-  pub fn bar() {}
-}
-
+//@ revisions: r0x0 r0x1 r1x0 r1x1
+//@[r0x0] compile-flags: --cfg false --check-cfg=cfg(false)
+//@[r0x1] compile-flags: --cfg false --check-cfg=cfg(r#false)
+//@[r1x0] compile-flags: --cfg r#false --check-cfg=cfg(false)
+//@[r1x1] compile-flags: --cfg r#false --check-cfg=cfg(r#false)
+#![deny(unexpected_cfgs)]
 fn main() {
-    b::bar()
+    #[cfg(not(r#false))]
+    compile_error!("");
 }

--- a/tests/ui/check-cfg/invalid-arguments.boolean.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.boolean.stderr
@@ -1,6 +1,0 @@
-error: invalid `--check-cfg` argument: `cfg(true)`
-   |
-   = note: `true` is a boolean literal
-   = note: `cfg()` arguments must be simple identifiers, `any()` or `values(...)`
-   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
-

--- a/tests/ui/check-cfg/invalid-arguments.boolean_after_values.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.boolean_after_values.stderr
@@ -1,0 +1,5 @@
+error: invalid `--check-cfg` argument: `cfg(values(),true)`
+   |
+   = note: `values()` cannot be specified before the names
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
+

--- a/tests/ui/check-cfg/invalid-arguments.rs
+++ b/tests/ui/check-cfg/invalid-arguments.rs
@@ -2,7 +2,7 @@
 //
 //@ check-fail
 //@ no-auto-check-cfg
-//@ revisions: anything_else boolean
+//@ revisions: anything_else boolean_after_values
 //@ revisions: string_for_name_1 string_for_name_2 multiple_any multiple_values
 //@ revisions: multiple_values_any not_empty_any not_empty_values_any
 //@ revisions: values_any_missing_values values_any_before_ident ident_in_values_1
@@ -11,7 +11,7 @@
 //@ revisions: none_not_empty cfg_none unsafe_attr
 //
 //@ [anything_else]compile-flags: --check-cfg=anything_else(...)
-//@ [boolean]compile-flags: --check-cfg=cfg(true)
+//@ [boolean_after_values]compile-flags: --check-cfg=cfg(values(),true)
 //@ [string_for_name_1]compile-flags: --check-cfg=cfg("NOT_IDENT")
 //@ [string_for_name_2]compile-flags: --check-cfg=cfg(foo,"NOT_IDENT",bar)
 //@ [multiple_any]compile-flags: --check-cfg=cfg(any(),any())


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/138632#issuecomment-2738114495
This makes it consistent with `--cfg`

We could alternatively add a forward-compatible lint against `--cfg true/false`
r? @Urgau 