### PR TITLE
test(ui): add tuple-struct-where-clause-suggestion ui test for #91520

### DIFF
--- a/tests/ui/suggestions/tuple-struct-where-clause-suggestion-91520.rs
+++ b/tests/ui/suggestions/tuple-struct-where-clause-suggestion-91520.rs
@@ -1,0 +1,17 @@
+// Verify that the `where` clause suggestion is in the correct place
+// Previously, the suggestion to add `where` clause was placed inside the derive
+// like `#[derive(Clone where Inner<T>: Clone)]`
+// instead of `struct Outer<T>(Inner<T>) where Inner<T>: Clone`
+
+#![crate_type = "lib"]
+
+struct Inner<T>(T);
+//~^ HELP consider annotating `Inner<T>` with `#[derive(Clone)]`
+impl Clone for Inner<()> {
+    fn clone(&self) -> Self { todo!() }
+}
+
+#[derive(Clone)]
+struct Outer<T>(Inner<T>);
+//~^ ERROR the trait bound `Inner<T>: Clone` is not satisfied [E0277]
+//~| HELP consider introducing a `where` clause

--- a/tests/ui/suggestions/tuple-struct-where-clause-suggestion-91520.stderr
+++ b/tests/ui/suggestions/tuple-struct-where-clause-suggestion-91520.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `Inner<T>: Clone` is not satisfied
+  --> $DIR/tuple-struct-where-clause-suggestion-91520.rs:15:17
+   |
+LL | #[derive(Clone)]
+   |          ----- in this derive macro expansion
+LL | struct Outer<T>(Inner<T>);
+   |                 ^^^^^^^^ the trait `Clone` is not implemented for `Inner<T>`
+   |
+help: consider annotating `Inner<T>` with `#[derive(Clone)]`
+   |
+LL + #[derive(Clone)]
+LL | struct Inner<T>(T);
+   |
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | struct Outer<T>(Inner<T>) where Inner<T>: Clone;
+   |                           +++++++++++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #91520 

I tried to also make it a .fixed test, but I failed to accomplish that.
That's because of the 'consider annotating `Inner<T>` with `#[derive(Clone)]`' suggestion does not compile (conflicting Clone implementations), and I can't isolate them with `rustfix-only-machine-applicable` as both suggestions are not marked as `MachineApplicable`.
Instead I just test that the where clause suggestion is applied to the correct line.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
