### PR TITLE
expand: Do not report `cfg_attr` traces on macros as unused attributes

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1941,7 +1941,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                 let attr_name = attr.ident().unwrap().name;
                 // `#[cfg]` and `#[cfg_attr]` are special - they are
                 // eagerly evaluated.
-                if attr_name != sym::cfg && attr_name != sym::cfg_attr {
+                if attr_name != sym::cfg && attr_name != sym::cfg_attr_trace {
                     self.cx.sess.psess.buffer_lint(
                         UNUSED_ATTRIBUTES,
                         attr.span,

--- a/tests/ui/lint/inert-attr-macro.rs
+++ b/tests/ui/lint/inert-attr-macro.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 
+#![feature(cfg_boolean_literals)]
 #![warn(unused)]
 
 macro_rules! foo {
@@ -17,4 +18,10 @@ fn main() {
     // This does work, since the attribute is on a parent
     // of the macro invocation.
     #[allow(warnings)] { #[inline] foo!(); }
+
+    // Ok, `cfg` and `cfg_attr` are expanded eagerly and do not warn.
+    #[cfg(true)] foo!();
+    #[cfg(false)] foo!();
+    #[cfg_attr(true, cfg(true))] foo!();
+    #[cfg_attr(false, nonexistent)] foo!();
 }

--- a/tests/ui/lint/inert-attr-macro.stderr
+++ b/tests/ui/lint/inert-attr-macro.stderr
@@ -1,41 +1,41 @@
 warning: unused attribute `inline`
-  --> $DIR/inert-attr-macro.rs:10:5
+  --> $DIR/inert-attr-macro.rs:11:5
    |
 LL |     #[inline] foo!();
    |     ^^^^^^^^^
    |
 note: the built-in attribute `inline` will be ignored, since it's applied to the macro invocation `foo`
-  --> $DIR/inert-attr-macro.rs:10:15
+  --> $DIR/inert-attr-macro.rs:11:15
    |
 LL |     #[inline] foo!();
    |               ^^^
 note: the lint level is defined here
-  --> $DIR/inert-attr-macro.rs:3:9
+  --> $DIR/inert-attr-macro.rs:4:9
    |
 LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unused_attributes)]` implied by `#[warn(unused)]`
 
 warning: unused attribute `allow`
-  --> $DIR/inert-attr-macro.rs:14:5
+  --> $DIR/inert-attr-macro.rs:15:5
    |
 LL |     #[allow(warnings)] #[inline] foo!();
    |     ^^^^^^^^^^^^^^^^^^
    |
 note: the built-in attribute `allow` will be ignored, since it's applied to the macro invocation `foo`
-  --> $DIR/inert-attr-macro.rs:14:34
+  --> $DIR/inert-attr-macro.rs:15:34
    |
 LL |     #[allow(warnings)] #[inline] foo!();
    |                                  ^^^
 
 warning: unused attribute `inline`
-  --> $DIR/inert-attr-macro.rs:14:24
+  --> $DIR/inert-attr-macro.rs:15:24
    |
 LL |     #[allow(warnings)] #[inline] foo!();
    |                        ^^^^^^^^^
    |
 note: the built-in attribute `inline` will be ignored, since it's applied to the macro invocation `foo`
-  --> $DIR/inert-attr-macro.rs:14:34
+  --> $DIR/inert-attr-macro.rs:15:34
    |
 LL |     #[allow(warnings)] #[inline] foo!();
    |                                  ^^^


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/138779