### PR TITLE
Fix `ProvenVia` for global where clauses

### DIFF
--- a/tests/ui/codegen/mono-impossible-drop.rs
+++ b/tests/ui/codegen/mono-impossible-drop.rs
@@ -1,3 +1,6 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
 //@ compile-flags: -Clink-dead-code=on --crate-type=lib
 //@ build-pass
 


### PR DESCRIPTION
When we're merging one (or more) global where clauses in the presence of no other candidates, ensure that we return `TraitGoalProvenVia::ParamEnv` so that rigid projections work correctly. This fixes some tests with `feature(trivial_bounds)`.

Fixes #139408