### PR TITLE
Slightly reword triagebot ping message for `relnotes-interest-group`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -174,8 +174,8 @@ label = "O-emscripten"
 
 [ping.relnotes-interest-group]
 message = """\
-Hi relnotes-interest-group, this PR adds release notes. Could you review this PR
-if you have time? Thanks <3
+Hi relnotes-interest-group, this issue/PR could use some help in reviewing /
+adjusting release notes. Could you take a look if available? Thanks <3
 """
 
 [prioritize]


### PR DESCRIPTION
Now that there's also a meta relnotes tracking issue.

r? @cuviper (or release)