### PR TITLE
Tweak type flags, fix missing flags from coroutine kind ty

### DIFF
--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -128,7 +128,6 @@ impl FlagComputation {
                 if should_remove_further_specializable {
                     self.flags -= TypeFlags::STILL_FURTHER_SPECIALIZABLE;
                 }
-                self.add_flags(TypeFlags::HAS_TY_COROUTINE);
             }
 
             &ty::Closure(_, args) => {

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -113,6 +113,7 @@ impl FlagComputation {
                     self.flags -= TypeFlags::STILL_FURTHER_SPECIALIZABLE;
                 }
 
+                self.add_ty(args.kind_ty());
                 self.add_ty(args.resume_ty());
                 self.add_ty(args.return_ty());
                 self.add_ty(args.witness());

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -101,63 +101,13 @@ impl FlagComputation {
 
             &ty::Param(_) => {
                 self.add_flags(TypeFlags::HAS_TY_PARAM);
-                self.add_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
             }
 
-            ty::Coroutine(_, args) => {
-                let args = args.as_coroutine();
-                let should_remove_further_specializable =
-                    !self.flags.contains(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
-                self.add_args(args.parent_args());
-                if should_remove_further_specializable {
-                    self.flags -= TypeFlags::STILL_FURTHER_SPECIALIZABLE;
-                }
-
-                self.add_ty(args.kind_ty());
-                self.add_ty(args.resume_ty());
-                self.add_ty(args.return_ty());
-                self.add_ty(args.witness());
-                self.add_ty(args.yield_ty());
-                self.add_ty(args.tupled_upvars_ty());
-            }
-
-            ty::CoroutineWitness(_, args) => {
-                let should_remove_further_specializable =
-                    !self.flags.contains(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
+            &ty::Closure(_, args)
+            | &ty::Coroutine(_, args)
+            | &ty::CoroutineClosure(_, args)
+            | &ty::CoroutineWitness(_, args) => {
                 self.add_args(args);
-                if should_remove_further_specializable {
-                    self.flags -= TypeFlags::STILL_FURTHER_SPECIALIZABLE;
-                }
-            }
-
-            &ty::Closure(_, args) => {
-                let args = args.as_closure();
-                let should_remove_further_specializable =
-                    !self.flags.contains(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
-                self.add_args(args.parent_args());
-                if should_remove_further_specializable {
-                    self.flags -= TypeFlags::STILL_FURTHER_SPECIALIZABLE;
-                }
-
-                self.add_ty(args.sig_as_fn_ptr_ty());
-                self.add_ty(args.kind_ty());
-                self.add_ty(args.tupled_upvars_ty());
-            }
-
-            &ty::CoroutineClosure(_, args) => {
-                let args = args.as_coroutine_closure();
-                let should_remove_further_specializable =
-                    !self.flags.contains(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
-                self.add_args(args.parent_args());
-                if should_remove_further_specializable {
-                    self.flags -= TypeFlags::STILL_FURTHER_SPECIALIZABLE;
-                }
-
-                self.add_ty(args.kind_ty());
-                self.add_ty(args.signature_parts_ty());
-                self.add_ty(args.tupled_upvars_ty());
-                self.add_ty(args.coroutine_captures_by_ref_ty());
-                self.add_ty(args.coroutine_witness_ty());
             }
 
             &ty::Bound(debruijn, _) => {
@@ -167,21 +117,17 @@ impl FlagComputation {
 
             &ty::Placeholder(..) => {
                 self.add_flags(TypeFlags::HAS_TY_PLACEHOLDER);
-                self.add_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
             }
 
-            &ty::Infer(infer) => {
-                self.add_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
-                match infer {
-                    ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => {
-                        self.add_flags(TypeFlags::HAS_TY_FRESH)
-                    }
-
-                    ty::TyVar(_) | ty::IntVar(_) | ty::FloatVar(_) => {
-                        self.add_flags(TypeFlags::HAS_TY_INFER)
-                    }
+            &ty::Infer(infer) => match infer {
+                ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_) => {
+                    self.add_flags(TypeFlags::HAS_TY_FRESH)
                 }
-            }
+
+                ty::TyVar(_) | ty::IntVar(_) | ty::FloatVar(_) => {
+                    self.add_flags(TypeFlags::HAS_TY_INFER)
+                }
+            },
 
             &ty::Adt(_, args) => {
                 self.add_args(args);
@@ -358,24 +304,19 @@ impl FlagComputation {
                 self.add_args(uv.args);
                 self.add_flags(TypeFlags::HAS_CT_PROJECTION);
             }
-            ty::ConstKind::Infer(infer) => {
-                self.add_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
-                match infer {
-                    InferConst::Fresh(_) => self.add_flags(TypeFlags::HAS_CT_FRESH),
-                    InferConst::Var(_) => self.add_flags(TypeFlags::HAS_CT_INFER),
-                }
-            }
+            ty::ConstKind::Infer(infer) => match infer {
+                InferConst::Fresh(_) => self.add_flags(TypeFlags::HAS_CT_FRESH),
+                InferConst::Var(_) => self.add_flags(TypeFlags::HAS_CT_INFER),
+            },
             ty::ConstKind::Bound(debruijn, _) => {
                 self.add_bound_var(debruijn);
                 self.add_flags(TypeFlags::HAS_CT_BOUND);
             }
             ty::ConstKind::Param(_) => {
                 self.add_flags(TypeFlags::HAS_CT_PARAM);
-                self.add_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
             }
             ty::ConstKind::Placeholder(_) => {
                 self.add_flags(TypeFlags::HAS_CT_PLACEHOLDER);
-                self.add_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
             }
             ty::ConstKind::Value(cv) => self.add_ty(cv.ty),
             ty::ConstKind::Expr(e) => self.add_args(e.args()),

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -119,10 +119,7 @@ bitflags::bitflags! {
         /// Does this value have `InferConst::Fresh`?
         const HAS_CT_FRESH                = 1 << 23;
 
-        /// Does this have `Coroutine` or `CoroutineWitness`?
-        const HAS_TY_COROUTINE            = 1 << 24;
-
         /// Does this have any binders with bound vars (e.g. that need to be anonymized)?
-        const HAS_BINDER_VARS             = 1 << 25;
+        const HAS_BINDER_VARS             = 1 << 24;
     }
 }

--- a/compiler/rustc_type_ir/src/flags.rs
+++ b/compiler/rustc_type_ir/src/flags.rs
@@ -111,15 +111,20 @@ bitflags::bitflags! {
 
         /// Does this value have parameters/placeholders/inference variables which could be
         /// replaced later, in a way that would change the results of `impl` specialization?
-        const STILL_FURTHER_SPECIALIZABLE = 1 << 21;
+        const STILL_FURTHER_SPECIALIZABLE = TypeFlags::HAS_TY_PARAM.bits()
+                                          | TypeFlags::HAS_TY_PLACEHOLDER.bits()
+                                          | TypeFlags::HAS_TY_INFER.bits()
+                                          | TypeFlags::HAS_CT_PARAM.bits()
+                                          | TypeFlags::HAS_CT_PLACEHOLDER.bits()
+                                          | TypeFlags::HAS_CT_INFER.bits();
 
         /// Does this value have `InferTy::FreshTy/FreshIntTy/FreshFloatTy`?
-        const HAS_TY_FRESH                = 1 << 22;
+        const HAS_TY_FRESH                = 1 << 21;
 
         /// Does this value have `InferConst::Fresh`?
-        const HAS_CT_FRESH                = 1 << 23;
+        const HAS_CT_FRESH                = 1 << 22;
 
         /// Does this have any binders with bound vars (e.g. that need to be anonymized)?
-        const HAS_BINDER_VARS             = 1 << 24;
+        const HAS_BINDER_VARS             = 1 << 23;
     }
 }

--- a/compiler/rustc_type_ir/src/visit.rs
+++ b/compiler/rustc_type_ir/src/visit.rs
@@ -269,10 +269,6 @@ pub trait TypeVisitableExt<I: Interner>: TypeVisitable<I> {
         self.has_type_flags(TypeFlags::HAS_TY_OPAQUE)
     }
 
-    fn has_coroutines(&self) -> bool {
-        self.has_type_flags(TypeFlags::HAS_TY_COROUTINE)
-    }
-
     fn references_error(&self) -> bool {
         self.has_type_flags(TypeFlags::HAS_ERROR)
     }


### PR DESCRIPTION
Firstly, make sure we visit the coroutine kind ty. Since this kind ty is either infer (before upvar computation), or `()` or `i8`/`i16`/`i32`, this isn't really that big of a deal, since other types in the coroutine will also be infer, so we're not misreporting `ty.has_infer()` or anything, but it's still wrong not to do this.

Furthermore, remove `HAS_TY_COROUTINE`, since nobody used it, and also remove special casing for `STILL_FURTHER_SPECIALIZABLE` since it's likely not important anymore? I have a vague recollection that it was important for polymorphization(?), but no tests seem to rely on this behavior.

r? lcnr or reassign