### PR TITLE
compiletest: Support matching on diagnostics without a span

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/ui.md
+++ b/src/doc/rustc-dev-guide/src/tests/ui.md
@@ -202,6 +202,9 @@ several ways to match the message with the line (see the examples below):
 * `~|`: Associates the error level and message with the *same* line as the
   *previous comment*. This is more convenient than using multiple carets when
   there are multiple messages associated with the same line.
+* `~?`: Used to match error levels and messages with errors not having line
+  information. These can be placed on any line in the test file, but are
+  conventionally placed at the end.
 
 Example:
 
@@ -270,10 +273,23 @@ fn main() {
 //~| ERROR this pattern has 1 field, but the corresponding tuple struct has 3 fields [E0023]
 ```
 
+#### Error without line information
+
+Use `//~?` to match an error without line information.
+`//~?` is precise and will not match errors if their line information is available.
+It should be preferred to using `error-pattern`, which is imprecise and non-exhaustive.
+
+```rust,ignore
+//@ compile-flags: --print yyyy
+
+//~? ERROR unknown print request: `yyyy`
+```
+
 ### `error-pattern`
 
-The `error-pattern` [directive](directives.md) can be used for messages that don't
-have a specific span.
+The `error-pattern` [directive](directives.md) can be used for runtime messages, which don't
+have a specific span, or for compile time messages if imprecise matching is required due to
+multi-line platform specific diagnostics.
 
 Let's think about this test:
 
@@ -300,7 +316,9 @@ fn main() {
 }
 ```
 
-But for strict testing, try to use the `ERROR` annotation as much as possible.
+But for strict testing, try to use the `ERROR` annotation as much as possible,
+including `//~?` annotations for diagnostics without span.
+For compile time diagnostics `error-pattern` should very rarely be necessary.
 
 ### Error levels
 
@@ -353,7 +371,7 @@ would be a `.mir.stderr` and `.thir.stderr` file with the different outputs of
 the different revisions.
 
 > Note: cfg revisions also work inside the source code with `#[cfg]` attributes.
-> 
+>
 > By convention, the `FALSE` cfg is used to have an always-false config.
 
 ## Controlling pass/fail expectations

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -747,7 +747,7 @@ impl<'test> TestCx<'test> {
                         self.error(&format!(
                             "{}:{}: unexpected {}: '{}'",
                             file_name,
-                            actual_error.line_num,
+                            actual_error.line_num_str(),
                             actual_error
                                 .kind
                                 .as_ref()
@@ -767,7 +767,7 @@ impl<'test> TestCx<'test> {
                 self.error(&format!(
                     "{}:{}: expected {} not found: {}",
                     file_name,
-                    expected_error.line_num,
+                    expected_error.line_num_str(),
                     expected_error.kind.as_ref().map_or("message".into(), |k| k.to_string()),
                     expected_error.msg
                 ));

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -182,7 +182,7 @@ impl TestCx<'_> {
         } else if explicit && !expected_errors.is_empty() {
             let msg = format!(
                 "line {}: cannot combine `--error-format` with {} annotations; use `error-pattern` instead",
-                expected_errors[0].line_num,
+                expected_errors[0].line_num_str(),
                 expected_errors[0].kind.unwrap_or(ErrorKind::Error),
             );
             self.fatal(&msg);

--- a/tests/rustdoc-ui/coverage/html.rs
+++ b/tests/rustdoc-ui/coverage/html.rs
@@ -2,3 +2,5 @@
 
 /// Foo
 pub struct Xo;
+
+//~? ERROR `--output-format=html` is not supported for the `--show-coverage` option

--- a/tests/rustdoc-ui/deprecated-attrs.rs
+++ b/tests/rustdoc-ui/deprecated-attrs.rs
@@ -19,3 +19,7 @@
 //~| NOTE see issue #44136
 //~| NOTE no longer functions
 //~| NOTE `doc(plugins)` is now a no-op
+
+//~? WARN the `passes` flag no longer functions
+//~? NOTE see issue #44136
+//~? HELP you may want to use --document-private-items

--- a/tests/rustdoc-ui/doctest-output.rs
+++ b/tests/rustdoc-ui/doctest-output.rs
@@ -1,1 +1,3 @@
 //@ compile-flags:-Z unstable-options --show-coverage --output-format=doctest
+
+//~? ERROR `--output-format=doctest` is not supported for the `--show-coverage` option

--- a/tests/rustdoc-ui/generate-link-to-definition/generate-link-to-definition-opt.rs
+++ b/tests/rustdoc-ui/generate-link-to-definition/generate-link-to-definition-opt.rs
@@ -5,3 +5,5 @@
 //@ check-pass
 
 pub fn f() {}
+
+//~? WARN `--generate-link-to-definition` option can only be used with HTML output format

--- a/tests/rustdoc-ui/include-str-bare-urls.rs
+++ b/tests/rustdoc-ui/include-str-bare-urls.rs
@@ -13,3 +13,5 @@
 
 #![deny(rustdoc::bare_urls)]
 #![doc=include_str!("auxiliary/include-str-bare-urls.md")]
+
+//~? ERROR this URL is not a hyperlink

--- a/tests/rustdoc-ui/lints/check.rs
+++ b/tests/rustdoc-ui/lints/check.rs
@@ -12,3 +12,5 @@
 pub fn foo() {}
 //~^ WARN
 //~^^ WARN
+
+//~? WARN no documentation found for this crate's top-level module

--- a/tests/rustdoc-ui/remap-path-prefix-lint.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-lint.rs
@@ -8,3 +8,5 @@
 
 /// </script>
 pub struct Bar;
+
+//~? ERROR unopened HTML tag `script`

--- a/tests/rustdoc-ui/scrape-examples/scrape-examples-fail-if-type-error.rs
+++ b/tests/rustdoc-ui/scrape-examples/scrape-examples-fail-if-type-error.rs
@@ -5,3 +5,5 @@ pub fn foo() {
   INVALID_FUNC();
   //~^ ERROR could not resolve path
 }
+
+//~? ERROR Compilation failed, aborting rustdoc

--- a/tests/rustdoc-ui/scrape-examples/scrape-examples-wrong-options-1.rs
+++ b/tests/rustdoc-ui/scrape-examples/scrape-examples-wrong-options-1.rs
@@ -1,1 +1,3 @@
 //@ compile-flags: -Z unstable-options --scrape-examples-target-crate foobar
+
+//~? ERROR must use --scrape-examples-output-path and --scrape-examples-target-crate together

--- a/tests/rustdoc-ui/scrape-examples/scrape-examples-wrong-options-2.rs
+++ b/tests/rustdoc-ui/scrape-examples/scrape-examples-wrong-options-2.rs
@@ -1,1 +1,3 @@
 //@ compile-flags: -Z unstable-options --scrape-examples-output-path ex.calls
+
+//~? ERROR must use --scrape-examples-output-path and --scrape-examples-target-crate together

--- a/tests/rustdoc-ui/use_both_out_dir_and_output_options.rs
+++ b/tests/rustdoc-ui/use_both_out_dir_and_output_options.rs
@@ -1,1 +1,3 @@
 //@ compile-flags: --output ./foo
+
+//~? ERROR cannot use both 'out-dir' and 'output' at once

--- a/tests/ui/asm/inline-syntax.rs
+++ b/tests/ui/asm/inline-syntax.rs
@@ -58,3 +58,8 @@ pub fn main() {
 global_asm!(".intel_syntax noprefix", "nop");
 //[x86_64]~^ WARN avoid using `.intel_syntax`
 // Global assembly errors don't have line numbers, so no error on ARM.
+
+//[arm_llvm_18]~? ERROR unknown directive
+//[arm_llvm_18]~? ERROR unknown directive
+//[arm]~? ERROR unknown directive
+//[arm]~? ERROR unknown directive

--- a/tests/ui/cfg/disallowed-cli-cfgs.rs
+++ b/tests/ui/cfg/disallowed-cli-cfgs.rs
@@ -37,3 +37,5 @@
 //@ [emscripten_wasm_eh_]compile-flags: --cfg emscripten_wasm_eh
 
 fn main() {}
+
+//~? ERROR unexpected `--cfg

--- a/tests/ui/check-cfg/invalid-arguments.rs
+++ b/tests/ui/check-cfg/invalid-arguments.rs
@@ -36,3 +36,5 @@
 //@ [unsafe_attr]compile-flags: --check-cfg=unsafe(cfg(foo))
 
 fn main() {}
+
+//~? ERROR invalid `--check-cfg` argument

--- a/tests/ui/codegen/duplicated-path-in-error.rs
+++ b/tests/ui/codegen/duplicated-path-in-error.rs
@@ -5,3 +5,5 @@
 // the path of the dylib.
 
 fn main() {}
+
+//~? ERROR couldn't load codegen backend /non-existing-one.so

--- a/tests/ui/consts/const-eval/const_fn_ptr.rs
+++ b/tests/ui/consts/const-eval/const_fn_ptr.rs
@@ -34,3 +34,5 @@ fn main() {
     let z = foo(double, 2);
     assert_eq!(z, 4);
 }
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail.rs
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail.rs
@@ -10,3 +10,5 @@ const fn bar(x: usize) -> usize {
 }
 
 fn main() {}
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/const-eval/const_fn_ptr_fail2.rs
+++ b/tests/ui/consts/const-eval/const_fn_ptr_fail2.rs
@@ -24,3 +24,5 @@ fn main() {
     assert_eq!(Y, 4);
     assert_eq!(Z, 4);
 }
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/const-eval/issue-85155.rs
+++ b/tests/ui/consts/const-eval/issue-85155.rs
@@ -19,3 +19,6 @@ fn main() {
     post_monomorphization_error::stdarch_intrinsic::<2>();
     //~^ NOTE the above error was encountered while instantiating
 }
+
+//~? ERROR evaluation of `post_monomorphization_error::ValidateConstImm::<2, 0, 1>::VALID` failed
+//~? NOTE erroneous constant encountered

--- a/tests/ui/consts/miri_unleashed/abi-mismatch.rs
+++ b/tests/ui/consts/miri_unleashed/abi-mismatch.rs
@@ -13,3 +13,5 @@ static VAL: () = call_rust_fn(unsafe { std::mem::transmute(c_fn as extern "C" fn
 //~| NOTE calling a function with calling convention C using calling convention Rust
 
 fn main() {}
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/assoc_const.rs
+++ b/tests/ui/consts/miri_unleashed/assoc_const.rs
@@ -28,3 +28,5 @@ fn main() {
     // this test only causes errors due to the line below, so post-monomorphization
     let y = <String as Bar<Vec<u32>, String>>::F;
 }
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/box.rs
+++ b/tests/ui/consts/miri_unleashed/box.rs
@@ -9,3 +9,5 @@ static TEST_BAD: &mut i32 = {
     //~^ ERROR could not evaluate static initializer
     //~| NOTE calling non-const function `Box::<i32>::new`
 };
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -31,3 +31,5 @@ const REF_IMMUT: &u8 = &MY_STATIC;
 const READ_IMMUT: u8 = *REF_IMMUT;
 
 fn main() {}
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/inline_asm.rs
+++ b/tests/ui/consts/miri_unleashed/inline_asm.rs
@@ -11,3 +11,5 @@ static TEST_BAD: () = {
     //~^ ERROR could not evaluate static initializer
     //~| NOTE inline assembly is not supported
 };
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/mutable_references.rs
+++ b/tests/ui/consts/miri_unleashed/mutable_references.rs
@@ -114,3 +114,5 @@ fn main() {
     }
     *OH_YES = 99; //~ ERROR cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
 }
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/non_const_fn.rs
+++ b/tests/ui/consts/miri_unleashed/non_const_fn.rs
@@ -9,3 +9,5 @@ static C: () = foo();
 //~| NOTE calling non-const function `foo`
 
 fn main() {}
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/ptr_arith.rs
+++ b/tests/ui/consts/miri_unleashed/ptr_arith.rs
@@ -21,3 +21,5 @@ static PTR_INT_TRANSMUTE: () = unsafe {
 // their `PartialEq` impl is non-`const`.
 
 fn main() {}
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/static-no-inner-mut.rs
+++ b/tests/ui/consts/miri_unleashed/static-no-inner-mut.rs
@@ -38,3 +38,5 @@ static RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
 //~^ ERROR mutable pointer in final value
 
 fn main() {}
+
+//~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/tls.rs
+++ b/tests/ui/consts/miri_unleashed/tls.rs
@@ -23,3 +23,5 @@ static TEST_BAD_REF: () = {
 };
 
 fn main() {}
+
+//~? WARN skipping const checks

--- a/tests/ui/dep-graph/dep-graph-dump.rs
+++ b/tests/ui/dep-graph/dep-graph-dump.rs
@@ -4,3 +4,5 @@
 //@ compile-flags: -Z dump-dep-graph
 
 fn main() {}
+
+//~? ERROR can't dump dependency graph without `-Z query-dep-graph`

--- a/tests/ui/deprecation/deprecated_ar.rs
+++ b/tests/ui/deprecation/deprecated_ar.rs
@@ -2,3 +2,5 @@
 //@ compile-flags: -Car=foo
 
 fn main() {}
+
+//~? WARN `-C ar`: this option is deprecated and does nothing

--- a/tests/ui/deprecation/deprecated_inline_threshold.rs
+++ b/tests/ui/deprecation/deprecated_inline_threshold.rs
@@ -6,3 +6,9 @@
 //@[no_val] compile-flags: -Cinline-threshold
 
 fn main() {}
+
+//[good_val]~? WARN `-C inline-threshold`: this option is deprecated and does nothing
+//[bad_val]~? WARN `-C inline-threshold`: this option is deprecated and does nothing
+//[bad_val]~? ERROR incorrect value `asd` for codegen option `inline-threshold`
+//[no_val]~? WARN `-C inline-threshold`: this option is deprecated and does nothing
+//[no_val]~? ERROR codegen option `inline-threshold` requires a number

--- a/tests/ui/deprecation/deprecated_no_stack_check_opt.rs
+++ b/tests/ui/deprecation/deprecated_no_stack_check_opt.rs
@@ -2,3 +2,5 @@
 //@ compile-flags: -Cno-stack-check
 
 fn main() {}
+
+//~? WARN `-C no-stack-check`: this option is deprecated and does nothing

--- a/tests/ui/did_you_mean/recursion_limit_deref.rs
+++ b/tests/ui/did_you_mean/recursion_limit_deref.rs
@@ -51,3 +51,6 @@ fn main() {
     let x: &Bottom = &t; //~ ERROR mismatched types
     //~^ error recursion limit
 }
+
+//~? ERROR reached the recursion limit finding the struct tail for `K`
+//~? ERROR reached the recursion limit finding the struct tail for `Bottom`

--- a/tests/ui/editions/edition-keywords-2018-2015-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2018-2015-parsing.rs
@@ -28,3 +28,5 @@ pub fn check_async() {
 
     let _recovery_witness: () = 0; //~ ERROR mismatched types
 }
+
+//~? ERROR macro expansion ends with an incomplete expression

--- a/tests/ui/editions/edition-keywords-2018-2018-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2018-2018-parsing.rs
@@ -39,3 +39,5 @@ pub fn check_async() {
 
     let _recovery_witness: () = 0; //~ ERROR mismatched types
 }
+
+//~? ERROR macro expansion ends with an incomplete expression

--- a/tests/ui/entry-point/imported_main_from_extern_crate_wrong_type.rs
+++ b/tests/ui/entry-point/imported_main_from_extern_crate_wrong_type.rs
@@ -2,3 +2,5 @@
 
 extern crate bad_main_functions;
 pub use bad_main_functions::boilerplate as main;
+
+//~? ERROR `main` function has wrong type

--- a/tests/ui/errors/wrong-target-spec.rs
+++ b/tests/ui/errors/wrong-target-spec.rs
@@ -6,3 +6,5 @@
 //@ compile-flags: --target x86_64_unknown-linux-musl
 
 fn main() {}
+
+//~? ERROR Error loading target specification: Could not find specification for target "x86_64_unknown-linux-musl"

--- a/tests/ui/feature-gates/feature-gate-link-arg-attribute.rs
+++ b/tests/ui/feature-gates/feature-gate-link-arg-attribute.rs
@@ -7,3 +7,5 @@
 extern "C" {}
 
 fn main() {}
+
+//[in_flag]~? ERROR unknown linking modifier `link-arg`

--- a/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.rs
+++ b/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.rs
@@ -7,3 +7,5 @@
 extern "C" {}
 
 fn main() {}
+
+//[in_flag]~? ERROR linking modifier `as-needed` is unstable

--- a/tests/ui/fmt/fmt_debug/invalid.rs
+++ b/tests/ui/fmt/fmt_debug/invalid.rs
@@ -2,3 +2,5 @@
 //@ failure-status: 1
 fn main() {
 }
+
+//~? ERROR incorrect value `invalid-value` for unstable option `fmt-debug`

--- a/tests/ui/infinite/infinite-struct.rs
+++ b/tests/ui/infinite/infinite-struct.rs
@@ -15,3 +15,5 @@ struct Foo { //~ ERROR has infinite size
 struct Bar<T>([T; 1]);
 
 fn main() {}
+
+//~? ERROR reached the recursion limit finding the struct tail for `Take`

--- a/tests/ui/instrument-coverage/bad-value.rs
+++ b/tests/ui/instrument-coverage/bad-value.rs
@@ -3,3 +3,6 @@
 //@ [bad] compile-flags: -Cinstrument-coverage=bad-value
 
 fn main() {}
+
+//[blank]~? ERROR incorrect value `` for codegen option `instrument-coverage`
+//[bad]~? ERROR incorrect value `bad-value` for codegen option `instrument-coverage`

--- a/tests/ui/instrument-coverage/coverage-options.rs
+++ b/tests/ui/instrument-coverage/coverage-options.rs
@@ -17,3 +17,5 @@
 //@ [bad] compile-flags: -Zcoverage-options=bad
 
 fn main() {}
+
+//[bad]~? ERROR incorrect value `bad` for unstable option `coverage-options`

--- a/tests/ui/invalid-compile-flags/branch-protection-missing-pac-ret.rs
+++ b/tests/ui/invalid-compile-flags/branch-protection-missing-pac-ret.rs
@@ -15,3 +15,7 @@
 
 #[lang = "sized"]
 trait Sized {}
+
+//[BADFLAGS]~? ERROR incorrect value `leaf` for unstable option `branch-protection`
+//[BADFLAGSPC]~? ERROR incorrect value `pc` for unstable option `branch-protection`
+//[BADTARGET]~? ERROR `-Zbranch-protection` is only supported on aarch64

--- a/tests/ui/invalid-compile-flags/invalid-llvm-passes.rs
+++ b/tests/ui/invalid-compile-flags/invalid-llvm-passes.rs
@@ -2,3 +2,5 @@
 //@ compile-flags: -Cpasses=unknown-pass
 
 fn main() {}
+
+//~? ERROR failed to run LLVM passes: unknown pass name 'unknown-pass'

--- a/tests/ui/invalid-compile-flags/need-crate-arg-ignore-tidy$x.rs
+++ b/tests/ui/invalid-compile-flags/need-crate-arg-ignore-tidy$x.rs
@@ -1,2 +1,5 @@
 // issue: 113981
+
 pub fn main() {}
+
+//~? ERROR invalid character '$' in crate name: `need_crate_arg_ignore_tidy$x`

--- a/tests/ui/invalid-compile-flags/print.rs
+++ b/tests/ui/invalid-compile-flags/print.rs
@@ -1,1 +1,3 @@
 //@ compile-flags: --print yyyy
+
+//~? ERROR unknown print request: `yyyy`

--- a/tests/ui/invalid-module-declaration/invalid-module-declaration.rs
+++ b/tests/ui/invalid-module-declaration/invalid-module-declaration.rs
@@ -3,3 +3,5 @@ mod auxiliary {
 }
 
 fn main() {}
+
+//~? ERROR file not found for module `baz`

--- a/tests/ui/lang-items/lang-item-generic-requirements.rs
+++ b/tests/ui/lang-items/lang-item-generic-requirements.rs
@@ -59,3 +59,5 @@ fn ice() {
 
 // use `start`
 fn main() {}
+
+//~? ERROR requires `copy` lang_item

--- a/tests/ui/link-native-libs/modifiers-bad.rs
+++ b/tests/ui/link-native-libs/modifiers-bad.rs
@@ -9,3 +9,8 @@
 // Tests various illegal values for the "modifier" part of an `-l` flag.
 
 fn main() {}
+
+//[blank]~? ERROR invalid linking modifier syntax, expected '+' or '-' prefix
+//[no-prefix]~? ERROR invalid linking modifier syntax, expected '+' or '-' prefix
+//[prefix-only]~? ERROR unknown linking modifier ``
+//[unknown]~? ERROR unknown linking modifier `ferris`

--- a/tests/ui/link-native-libs/modifiers-override-2.rs
+++ b/tests/ui/link-native-libs/modifiers-override-2.rs
@@ -1,3 +1,5 @@
 //@ compile-flags:-lstatic:+whole-archive,-whole-archive=foo
 
 fn main() {}
+
+//~? ERROR multiple `whole-archive` modifiers in a single `-l` option

--- a/tests/ui/link-native-libs/msvc-non-utf8-output.rs
+++ b/tests/ui/link-native-libs/msvc-non-utf8-output.rs
@@ -3,3 +3,5 @@
 //@ only-msvc
 //@ normalize-stderr: "(?:.|\n)*(⦺ⅈ⽯⭏⽽◃⡽⚞)(?:.|\n)*" -> "$1"
 pub fn main() {}
+
+//~? ERROR linking with `

--- a/tests/ui/linkage-attr/link-self-contained-consistency.rs
+++ b/tests/ui/linkage-attr/link-self-contained-consistency.rs
@@ -8,3 +8,6 @@
 // ignore-tidy-linelength
 
 fn main() {}
+
+//[one]~? ERROR some `-C link-self-contained` components were both enabled and disabled: linker
+//[many]~? ERROR some `-C link-self-contained` components were both enabled and disabled: crto, linker

--- a/tests/ui/linkage-attr/linkage-detect-extern-generated-name-collision.rs
+++ b/tests/ui/linkage-attr/linkage-detect-extern-generated-name-collision.rs
@@ -22,3 +22,5 @@ fn main() {
        println!("{:p}", &dep1::collision);
     }
 }
+
+//~? ERROR symbol `collision` is already defined

--- a/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.rs
+++ b/tests/ui/linkage-attr/raw-dylib/windows/dlltool-failed.rs
@@ -19,3 +19,5 @@ extern "C" {
 pub fn lib_main() {
     unsafe { f(42); }
 }
+
+//~? ERROR Dlltool could not create import library with

--- a/tests/ui/linkage-attr/raw-dylib/windows/invalid-dlltool.rs
+++ b/tests/ui/linkage-attr/raw-dylib/windows/invalid-dlltool.rs
@@ -10,3 +10,5 @@ extern "C" {
 pub fn lib_main() {
     unsafe { f(42); }
 }
+
+//~? ERROR Error calling dlltool 'does_not_exist.exe': program not found

--- a/tests/ui/lint/expansion-time.rs
+++ b/tests/ui/lint/expansion-time.rs
@@ -31,3 +31,5 @@ fn main() {
     // WARN see in the stderr file, the warning points to the included file.
     include!("expansion-time-include.rs");
 }
+
+//~? WARN include macro expected single expression in source

--- a/tests/ui/lint/lint-unexported-no-mangle.rs
+++ b/tests/ui/lint/lint-unexported-no-mangle.rs
@@ -27,3 +27,10 @@ fn main() {
     foo();
     bar();
 }
+
+//~? WARN lint `private_no_mangle_fns` has been removed
+//~? WARN lint `private_no_mangle_statics` has been removed
+//~? WARN lint `private_no_mangle_fns` has been removed
+//~? WARN lint `private_no_mangle_statics` has been removed
+//~? WARN lint `private_no_mangle_fns` has been removed
+//~? WARN lint `private_no_mangle_statics` has been removed

--- a/tests/ui/lto/lto-and-no-bitcode-in-rlib.rs
+++ b/tests/ui/lto/lto-and-no-bitcode-in-rlib.rs
@@ -1,3 +1,5 @@
 //@ compile-flags: -C lto -C embed-bitcode=no
 
 fn main() {}
+
+//~? ERROR options `-C embed-bitcode=no` and `-C lto` are incompatible

--- a/tests/ui/macros/include-single-expr.rs
+++ b/tests/ui/macros/include-single-expr.rs
@@ -1,6 +1,6 @@
-//@ error-pattern include macro expected single expression
-
 fn main() {
     include!("include-single-expr-helper.rs");
     include!("include-single-expr-helper-1.rs");
 }
+
+//~? ERROR include macro expected single expression

--- a/tests/ui/mir-dataflow/inits-1.rs
+++ b/tests/ui/mir-dataflow/inits-1.rs
@@ -51,3 +51,5 @@ fn main() {
     foo(true, &mut S(13), S(14), S(15));
     foo(false, &mut S(13), S(14), S(15));
 }
+
+//~? ERROR stop_after_dataflow ended compilation

--- a/tests/ui/mir-dataflow/liveness-enum.rs
+++ b/tests/ui/mir-dataflow/liveness-enum.rs
@@ -20,3 +20,5 @@ fn foo() -> Option<i32> {
 }
 
 fn main() {}
+
+//~? ERROR stop_after_dataflow ended compilation

--- a/tests/ui/mir-dataflow/liveness-projection.rs
+++ b/tests/ui/mir-dataflow/liveness-projection.rs
@@ -30,3 +30,5 @@ fn foo() {
 }
 
 fn main() {}
+
+//~? ERROR stop_after_dataflow ended compilation

--- a/tests/ui/mir-dataflow/liveness-ptr.rs
+++ b/tests/ui/mir-dataflow/liveness-ptr.rs
@@ -26,3 +26,5 @@ fn foo() -> i32 {
 }
 
 fn main() {}
+
+//~? ERROR stop_after_dataflow ended compilation

--- a/tests/ui/mir-dataflow/uninits-1.rs
+++ b/tests/ui/mir-dataflow/uninits-1.rs
@@ -49,3 +49,5 @@ fn main() {
     foo(true, &mut S(13), S(14), S(15));
     foo(false, &mut S(13), S(14), S(15));
 }
+
+//~? ERROR stop_after_dataflow ended compilation

--- a/tests/ui/mir-dataflow/uninits-2.rs
+++ b/tests/ui/mir-dataflow/uninits-2.rs
@@ -22,3 +22,5 @@ fn main() {
     foo(&mut S(13));
     foo(&mut S(13));
 }
+
+//~? ERROR stop_after_dataflow ended compilation

--- a/tests/ui/mir/enable_passes_validation.rs
+++ b/tests/ui/mir/enable_passes_validation.rs
@@ -19,3 +19,6 @@
 //@[mixed] error-pattern: warning: MIR pass `ThisPassDoesNotExist` is unknown and will be ignored
 
 fn main() {}
+
+//[empty]~? ERROR incorrect value `` for unstable option `mir-enable-passes`
+//[unprefixed]~? ERROR incorrect value `CheckAlignment` for unstable option `mir-enable-passes`

--- a/tests/ui/missing/missing-allocator.rs
+++ b/tests/ui/missing/missing-allocator.rs
@@ -16,3 +16,5 @@ fn oom(_: core::alloc::Layout) -> ! {
 }
 
 extern crate alloc;
+
+//~? ERROR no global memory allocator found but one is required

--- a/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod.rs
+++ b/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod.rs
@@ -1,2 +1,4 @@
 mod foo;
 fn main() {}
+
+//~? ERROR file not found for module `missing`

--- a/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod_inline.rs
+++ b/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod_inline.rs
@@ -1,2 +1,4 @@
 mod foo_inline;
 fn main() {}
+
+//~? ERROR file not found for module `missing`

--- a/tests/ui/panic-handler/panic-handler-wrong-location.rs
+++ b/tests/ui/panic-handler/panic-handler-wrong-location.rs
@@ -6,3 +6,5 @@
 #[panic_handler] //~ ERROR `panic_impl` lang item must be applied to a function
 #[no_mangle]
 static X: u32 = 42;
+
+//~? ERROR `#[panic_handler]` function required, but not found

--- a/tests/ui/parser/issues/issue-94340.rs
+++ b/tests/ui/parser/issues/issue-94340.rs
@@ -6,3 +6,6 @@
 include!("auxiliary/issue-94340-inc.rs");
 
 fn main() {}
+
+//~? ERROR an inner attribute is not permitted in this context
+//~? ERROR an inner attribute is not permitted in this context

--- a/tests/ui/parser/unclosed-delimiter-in-dep.rs
+++ b/tests/ui/parser/unclosed-delimiter-in-dep.rs
@@ -3,3 +3,5 @@ mod unclosed_delim_mod;
 fn main() {
     let _: usize = unclosed_delim_mod::new();
 }
+
+//~? ERROR mismatched closing delimiter: `}`

--- a/tests/ui/patchable-function-entry/patchable-function-entry-flags.rs
+++ b/tests/ui/patchable-function-entry/patchable-function-entry-flags.rs
@@ -1,2 +1,5 @@
 //@ compile-flags: -Z patchable-function-entry=1,2
+
 fn main() {}
+
+//~? ERROR incorrect value `1,2` for unstable option `patchable-function-entry`

--- a/tests/ui/print-request/invalid-target.rs
+++ b/tests/ui/print-request/invalid-target.rs
@@ -2,3 +2,5 @@
 //@ needs-llvm-components: x86
 
 fn main() {}
+
+//~? ERROR only Apple targets currently support deployment version info

--- a/tests/ui/proc-macro/inner-attr-non-inline-mod.rs
+++ b/tests/ui/proc-macro/inner-attr-non-inline-mod.rs
@@ -1,6 +1,4 @@
 //@ compile-flags: -Z span-debug
-//@ error-pattern:custom inner attributes are unstable
-//@ error-pattern:inner macro attributes are unstable
 //@ proc-macro: test-macros.rs
 
 #![no_std] // Don't load unnecessary hygiene information from std
@@ -15,3 +13,6 @@ mod module_with_attrs;
 //~| ERROR custom inner attributes are unstable
 
 fn main() {}
+
+//~? ERROR custom inner attributes are unstable
+//~? ERROR inner macro attributes are unstable

--- a/tests/ui/proc-macro/inner-attr-non-inline-mod.stderr
+++ b/tests/ui/proc-macro/inner-attr-non-inline-mod.stderr
@@ -19,7 +19,7 @@ LL | #![print_attr]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: non-inline modules in proc macro input are unstable
-  --> $DIR/inner-attr-non-inline-mod.rs:13:1
+  --> $DIR/inner-attr-non-inline-mod.rs:11:1
    |
 LL | mod module_with_attrs;
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL | mod module_with_attrs;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom inner attributes are unstable
-  --> $DIR/inner-attr-non-inline-mod.rs:13:1
+  --> $DIR/inner-attr-non-inline-mod.rs:11:1
    |
 LL | mod module_with_attrs;
    | ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/proc-macro/inner-attr-non-inline-mod.stdout
+++ b/tests/ui/proc-macro/inner-attr-non-inline-mod.stdout
@@ -4,35 +4,35 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
         spacing: Alone,
-        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "deny",
-                span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+                span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "unused_attributes",
-                        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+                        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
                     },
                 ],
-                span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+                span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
             },
         ],
-        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
     },
     Ident {
         ident: "mod",
-        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
     },
     Ident {
         ident: "module_with_attrs",
-        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
     },
     Group {
         delimiter: Brace,
@@ -40,38 +40,38 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
             Punct {
                 ch: '#',
                 spacing: Joint,
-                span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+                span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+                span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "rustfmt",
-                        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+                        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
                     },
                     Punct {
                         ch: ':',
                         spacing: Joint,
-                        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+                        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
                     },
                     Punct {
                         ch: ':',
                         spacing: Alone,
-                        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+                        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
                     },
                     Ident {
                         ident: "skip",
-                        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+                        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
                     },
                 ],
-                span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+                span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
             },
         ],
-        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
+        span: $DIR/inner-attr-non-inline-mod.rs:11:1: 11:23 (#0),
     },
 ]

--- a/tests/ui/proc-macro/pretty-print-hack-show.rs
+++ b/tests/ui/proc-macro/pretty-print-hack-show.rs
@@ -18,3 +18,5 @@ mod second {
 }
 
 fn main() {}
+
+//~? ERROR using an old version of `rental`

--- a/tests/ui/resolve/parse-error-resolve.rs
+++ b/tests/ui/resolve/parse-error-resolve.rs
@@ -5,3 +5,5 @@ fn main() {
     let _ = "" + 1; //~ ERROR E0369
     parse_error::Canonical.foo(); // ok, `parse_error.rs` had parse errors
 }
+
+//~? ERROR expected one of `+`, `,`, `::`, `=`, or `>`, found `From`

--- a/tests/ui/rfcs/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/caller-location-fnptr-rt-ctfe-equiv.rs
@@ -30,3 +30,5 @@ fn main() {
         (CONSTANT.file(), CONSTANT.line(), CONSTANT.column()),
     );
 }
+
+//~? WARN skipping const checks

--- a/tests/ui/rmeta/no_optitimized_mir.rs
+++ b/tests/ui/rmeta/no_optitimized_mir.rs
@@ -9,3 +9,5 @@ extern crate rmeta_meta;
 fn main() {
     rmeta_meta::missing_optimized_mir();
 }
+
+//~? ERROR missing optimized MIR for an item in the crate `rmeta_meta`

--- a/tests/ui/runtime/on-broken-pipe/default.rs
+++ b/tests/ui/runtime/on-broken-pipe/default.rs
@@ -2,3 +2,5 @@
 //@ check-fail
 
 fn main() {}
+
+//~? ERROR incorrect value `default` for unstable option `on-broken-pipe`

--- a/tests/ui/runtime/on-broken-pipe/no-flag-arg.rs
+++ b/tests/ui/runtime/on-broken-pipe/no-flag-arg.rs
@@ -2,3 +2,5 @@
 //@ check-fail
 
 fn main() {}
+
+//~? ERROR unstable option `on-broken-pipe` requires either `kill`, `error`, or `inherit`

--- a/tests/ui/runtime/on-broken-pipe/wrong-flag-arg.rs
+++ b/tests/ui/runtime/on-broken-pipe/wrong-flag-arg.rs
@@ -2,3 +2,5 @@
 //@ check-fail
 
 fn main() {}
+
+//~? ERROR incorrect value `wrong` for unstable option `on-broken-pipe`

--- a/tests/ui/rustc-env/min-stack-banana.rs
+++ b/tests/ui/rustc-env/min-stack-banana.rs
@@ -1,2 +1,5 @@
 //@ rustc-env:RUST_MIN_STACK=banana
+
 fn main() {}
+
+//~? ERROR `RUST_MIN_STACK` should be a number of bytes, but was "banana"

--- a/tests/ui/sanitizer/cfi/canonical-jump-tables-requires-cfi.rs
+++ b/tests/ui/sanitizer/cfi/canonical-jump-tables-requires-cfi.rs
@@ -6,3 +6,5 @@
 #![feature(no_core)]
 #![no_core]
 #![no_main]
+
+//~? ERROR `-Zsanitizer-cfi-canonical-jump-tables` requires `-Zsanitizer=cfi`

--- a/tests/ui/sanitizer/cfi/generalize-pointers-requires-cfi.rs
+++ b/tests/ui/sanitizer/cfi/generalize-pointers-requires-cfi.rs
@@ -7,3 +7,5 @@
 #![feature(no_core)]
 #![no_core]
 #![no_main]
+
+//~? ERROR `-Zsanitizer-cfi-generalize-pointers` requires `-Zsanitizer=cfi` or `-Zsanitizer=kcfi`

--- a/tests/ui/sanitizer/cfi/is-incompatible-with-kcfi.rs
+++ b/tests/ui/sanitizer/cfi/is-incompatible-with-kcfi.rs
@@ -10,3 +10,6 @@
 #![feature(no_core)]
 #![no_core]
 #![no_main]
+
+//~? ERROR cfi sanitizer is not supported for this target
+//~? ERROR `-Zsanitizer=cfi` is incompatible with `-Zsanitizer=kcfi`

--- a/tests/ui/sanitizer/cfi/normalize-integers-requires-cfi.rs
+++ b/tests/ui/sanitizer/cfi/normalize-integers-requires-cfi.rs
@@ -7,3 +7,5 @@
 #![feature(no_core)]
 #![no_core]
 #![no_main]
+
+//~? ERROR `-Zsanitizer-cfi-normalize-integers` requires `-Zsanitizer=cfi` or `-Zsanitizer=kcfi`

--- a/tests/ui/sanitizer/cfi/requires-lto.rs
+++ b/tests/ui/sanitizer/cfi/requires-lto.rs
@@ -6,3 +6,5 @@
 #![feature(no_core)]
 #![no_core]
 #![no_main]
+
+//~? ERROR `-Zsanitizer=cfi` requires `-Clto` or `-Clinker-plugin-lto`

--- a/tests/ui/sanitizer/cfi/with-rustc-lto-requires-single-codegen-unit.rs
+++ b/tests/ui/sanitizer/cfi/with-rustc-lto-requires-single-codegen-unit.rs
@@ -6,3 +6,5 @@
 #![feature(no_core)]
 #![no_core]
 #![no_main]
+
+//~? ERROR `-Zsanitizer=cfi` with `-Clto` requires `-Ccodegen-units=1`

--- a/tests/ui/sanitizer/crt-static.rs
+++ b/tests/ui/sanitizer/crt-static.rs
@@ -4,3 +4,5 @@
 #![feature(no_core)]
 #![no_core]
 #![no_main]
+
+//~? ERROR sanitizer is incompatible with statically linked libc

--- a/tests/ui/sanitizer/split-lto-unit-requires-lto.rs
+++ b/tests/ui/sanitizer/split-lto-unit-requires-lto.rs
@@ -6,3 +6,5 @@
 #![feature(no_core)]
 #![no_core]
 #![no_main]
+
+//~? ERROR `-Zsplit-lto-unit` requires `-Clto`, `-Clto=thin`, or `-Clinker-plugin-lto`

--- a/tests/ui/stack-protector/warn-stack-protector-unsupported.rs
+++ b/tests/ui/stack-protector/warn-stack-protector-unsupported.rs
@@ -17,3 +17,7 @@ trait Sized {}
 trait Copy {}
 
 pub fn main(){}
+
+//[all]~? WARN `-Z stack-protector=all` is not supported for target nvptx64-nvidia-cuda and will be ignored
+//[strong]~? WARN `-Z stack-protector=strong` is not supported for target nvptx64-nvidia-cuda and will be ignored
+//[basic]~? WARN `-Z stack-protector=basic` is not supported for target nvptx64-nvidia-cuda and will be ignored

--- a/tests/ui/symbol-mangling-version/bad-value.rs
+++ b/tests/ui/symbol-mangling-version/bad-value.rs
@@ -4,3 +4,7 @@
 //@ [bad] compile-flags: -Csymbol-mangling-version=bad-value
 
 fn main() {}
+
+//[no-value]~? ERROR codegen option `symbol-mangling-version` requires one of
+//[blank]~? ERROR incorrect value `` for codegen option `symbol-mangling-version`
+//[bad]~? ERROR incorrect value `bad-value` for codegen option `symbol-mangling-version`

--- a/tests/ui/symbol-mangling-version/unstable.rs
+++ b/tests/ui/symbol-mangling-version/unstable.rs
@@ -7,3 +7,6 @@
 //@ [hashed-ok] compile-flags: -Zunstable-options -Csymbol-mangling-version=hashed
 
 fn main() {}
+
+//[legacy]~? ERROR `-C symbol-mangling-version=legacy` requires `-Z unstable-options`
+//[hashed]~? ERROR `-C symbol-mangling-version=hashed` requires `-Z unstable-options`

--- a/tests/ui/target-feature/allowed-softfloat-target-feature-flag-disable.rs
+++ b/tests/ui/target-feature/allowed-softfloat-target-feature-flag-disable.rs
@@ -7,3 +7,5 @@
 
 #[lang = "sized"]
 pub trait Sized {}
+
+//~? WARN unstable feature specified for `-Ctarget-feature`: `x87`

--- a/tests/ui/target-feature/missing-plusminus-2.rs
+++ b/tests/ui/target-feature/missing-plusminus-2.rs
@@ -4,3 +4,5 @@
 
 #![feature(no_core)]
 #![no_core]
+
+//~? WARN unknown feature specified for `-Ctarget-feature`: `rdrand`

--- a/tests/ui/target-feature/missing-plusminus.rs
+++ b/tests/ui/target-feature/missing-plusminus.rs
@@ -1,2 +1,4 @@
 //@ compile-flags: -Ctarget-feature=banana --crate-type=rlib
 //@ build-pass
+
+//~? WARN unknown feature specified for `-Ctarget-feature`: `banana`

--- a/tests/ui/target-feature/similar-feature-suggestion.rs
+++ b/tests/ui/target-feature/similar-feature-suggestion.rs
@@ -4,3 +4,5 @@
 
 #![feature(no_core)]
 #![no_core]
+
+//~? WARN unknown and unstable feature specified for `-Ctarget-feature`: `rdrnd`

--- a/tests/ui/target-feature/tied-features-cli.rs
+++ b/tests/ui/target-feature/tied-features-cli.rs
@@ -18,3 +18,7 @@
 trait Sized {}
 
 fn main() {}
+
+//[one]~? ERROR the target features paca, pacg must all be either enabled or disabled together
+//[two]~? ERROR the target features paca, pacg must all be either enabled or disabled together
+//[three]~? ERROR the target features paca, pacg must all be either enabled or disabled together

--- a/tests/ui/target-feature/tied-features-no-implication-1.rs
+++ b/tests/ui/target-feature/tied-features-no-implication-1.rs
@@ -18,3 +18,5 @@ trait Sized {}
 #[cfg(target_feature = "pacg")]
 pub unsafe fn foo() {
 }
+
+//~? ERROR the target features paca, pacg must all be either enabled or disabled together

--- a/tests/ui/target-feature/unstable-feature.rs
+++ b/tests/ui/target-feature/unstable-feature.rs
@@ -4,3 +4,5 @@
 
 #![feature(no_core)]
 #![no_core]
+
+//~? WARN unstable feature specified for `-Ctarget-feature`: `vaes`

--- a/tests/ui/target_modifiers/incompatible_regparm.rs
+++ b/tests/ui/target_modifiers/incompatible_regparm.rs
@@ -14,3 +14,5 @@
 #![no_core]
 
 extern crate wrong_regparm;
+
+//[allow_no_value]~? ERROR codegen option `unsafe-allow-abi-mismatch` requires a comma-separated list of strings

--- a/tests/ui/tool-attributes/duplicate-diagnostic.rs
+++ b/tests/ui/tool-attributes/duplicate-diagnostic.rs
@@ -1,13 +1,14 @@
 //@ aux-build: p1.rs
 //@ aux-build: p2.rs
 
-//@ error-pattern: duplicate diagnostic item in crate `p2`
-//@ error-pattern: note: the diagnostic item is first defined in crate `p1`
-
 #![feature(rustc_attrs)]
 extern crate p1;
 extern crate p2;
 
 #[rustc_diagnostic_item = "Foo"]
 pub struct Foo {} //~ ERROR duplicate diagnostic item in crate `duplicate_diagnostic`: `Foo`
+                  //~^ NOTE the diagnostic item is first defined in crate `p2`
 fn main() {}
+
+//~? ERROR duplicate diagnostic item in crate `p2`
+//~? NOTE the diagnostic item is first defined in crate `p1`

--- a/tests/ui/tool-attributes/duplicate-diagnostic.stderr
+++ b/tests/ui/tool-attributes/duplicate-diagnostic.stderr
@@ -3,7 +3,7 @@ error: duplicate diagnostic item in crate `p2`: `Foo`
    = note: the diagnostic item is first defined in crate `p1`
 
 error: duplicate diagnostic item in crate `duplicate_diagnostic`: `Foo`
-  --> $DIR/duplicate-diagnostic.rs:12:1
+  --> $DIR/duplicate-diagnostic.rs:9:1
    |
 LL | pub struct Foo {}
    | ^^^^^^^^^^^^^^

--- a/tests/ui/type/pattern_types/literals.rs
+++ b/tests/ui/type/pattern_types/literals.rs
@@ -134,3 +134,6 @@ fn lit_at_wraparound_range_start() -> pattern_type!(u32 is 2..1) {
 }
 
 fn main() {}
+
+//~? ERROR pattern type ranges cannot wrap: 1..=0
+//~? ERROR pattern type ranges cannot wrap: 2..=0

--- a/tests/ui/type/pattern_types/range_patterns.rs
+++ b/tests/ui/type/pattern_types/range_patterns.rs
@@ -40,3 +40,7 @@ type SignedWrap = pattern_type!(i8 is 120..=-120); //~ ERROR unknown layout
 fn main() {
     let x: pattern_type!(u32 is 1..) = unsafe { std::mem::transmute(42_u32) };
 }
+
+//~? ERROR pattern type ranges cannot wrap: 1..=0
+//~? ERROR pattern type ranges cannot wrap: 5..=1
+//~? ERROR pattern type ranges cannot wrap: 120..=-120

--- a/tests/ui/unpretty/avoid-crash.rs
+++ b/tests/ui/unpretty/avoid-crash.rs
@@ -2,3 +2,5 @@
 //@ compile-flags: -o. -Zunpretty=ast-tree
 
 fn main() {}
+
+//~? ERROR failed to write `.` due to error


### PR DESCRIPTION
Using `//~? ERROR my message` on any line of the test.

The new checks are exhaustive, like all other `//~` checks, and unlike the `error-pattern` directive that is sometimes used now to check for span-less diagnostics.

This will allow to eliminate most on `error-pattern` directives in compile-fail tests (except those that are intentionally imprecise due to platform-specific diagnostics).
I didn't migrate any of `error-pattern`s in this PR though, except those where the migration was necessary for the tests to pass.