### PR TITLE
Add target-specific NaN payloads for the missing tier 2 targets

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1309,10 +1309,12 @@ mod prim_f16 {}
 // FIXME: Is there a better place to put this?
 ///
 /// | `target_arch` | Extra payloads possible on this platform |
-/// |---------------|---------|
-/// | `x86`, `x86_64`, `arm`, `aarch64`, `riscv32`, `riscv64` | None |
+/// |---------------|------------------------------------------|
+// Sorted alphabetically
+/// | `aarch64`, `arm`, `arm64ec`, `loongarch64`, `powerpc` (except when `target_abi = "spe"`), `powerpc64`, `riscv32`, `riscv64`, `s390x`, `x86`, `x86_64` | None |
+/// | `nvptx64` | All payloads |
 /// | `sparc`, `sparc64` | The all-one payload |
-/// | `wasm32`, `wasm64` | If all input NaNs are quiet with all-zero payload: None.<br> Otherwise: all possible payloads. |
+/// | `wasm32`, `wasm64` | If all input NaNs are quiet with all-zero payload: None.<br> Otherwise: all payloads. |
 ///
 /// For targets not in this table, all payloads are possible.
 


### PR DESCRIPTION
This PR adds target-specific NaN payloads for the remaining tier 2 targets:

- `arm64ec`: This target is a mix of `x86_64` and `aarch64`, meaning as they both have no extra payloads `arm64ec` also has no extra payloads.
- `loongarch64`: Per [LoongArch Reference Manual - Volume 1: Basic Architecture](https://github.com/loongson/LoongArch-Documentation/releases/download/2023.04.20/LoongArch-Vol1-v1.10-EN.pdf) section 3.1.1.3, LoongArch does quieting NaN propagation with the Rust preferred NaN as its default NaN, meaning it has no extra payloads.
- `nvptx64`: Per [PTX ISA documentation](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#floating-point-instructions) section 9.7.3 (and section 9.7.4 for `f16`), all payloads are possible. The documentation explicitly states that `f16` and `f32` operations result in an unspecified NaN payload, while for `f64` it states "NaN payloads are supported" without specifying how or what payload will be generated if there are no input NaNs.
- `powerpc` and `powerpc64`: Per [Power Instruction Set Architecture](https://files.openpower.foundation/s/9izgC5Rogi5Ywmm/download/OPF_PowerISA_v3.1C.pdf) Book I section 4.3.2, PowerPC does quieting NaN propagation with the Rust preferred NaN being generated if no there are no input NaNs, meaning it has no extra payloads.
- `s390x`: Per [IBM z/Architecture Principles of Operation](https://www.vm.ibm.com/library/other/22783213.pdf#page=965) page 9-3, s390x does quieting NaN propagation with the Rust's preferred NaN as its default NaN, meaning it has no extra payloads.

Tracking issue: #128288

cc @RalfJung
@rustbot label +T-lang

Also cc relevant target maintainers of tier 2 targets:
- `arm64ec`: @dpaoliello
- `loongarch64`: @heiher @xiangzhai @zhaixiaojuan @xen0n
- `nvptx64`: @RDambrosio016 @kjetilkjeka
- `powerpc`: the only documented maintainer is @BKPepe for the tier 3 `powerpc-unknown-linux-muslspe`.
- `powerpc64`: @daltenty @gilamn5tr @Gelbpunkt @famfo @neuschaefer
- `s390x`: @uweigand @cuviper