### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_codegen_cranelift/patches/0029-stdlib-Disable-f16-and-f128-in-compiler-builtins.patch
+++ b/compiler/rustc_codegen_cranelift/patches/0029-stdlib-Disable-f16-and-f128-in-compiler-builtins.patch
@@ -16,8 +16,8 @@ index 7165c3e48af..968552ad435 100644
  
  [dependencies]
  core = { path = "../core", public = true }
--compiler_builtins = { version = "=0.1.151", features = ['rustc-dep-of-std'] }
-+compiler_builtins = { version = "=0.1.151", features = ['rustc-dep-of-std', 'no-f16-f128'] }
+-compiler_builtins = { version = "=0.1.152", features = ['rustc-dep-of-std'] }
++compiler_builtins = { version = "=0.1.152", features = ['rustc-dep-of-std', 'no-f16-f128'] }
  
  [features]
  compiler-builtins-mem = ['compiler_builtins/mem']

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1782,7 +1782,10 @@ fn exported_symbols_for_non_proc_macro(tcx: TyCtxt<'_>, crate_type: CrateType) -
     let mut symbols = Vec::new();
     let export_threshold = symbol_export::crates_export_threshold(&[crate_type]);
     for_each_exported_symbols_include_dep(tcx, crate_type, |symbol, info, cnum| {
-        if info.level.is_below_threshold(export_threshold) {
+        // Do not export mangled symbols from cdylibs and don't attempt to export compiler-builtins
+        // from any cdylib. The latter doesn't work anyway as we use hidden visibility for
+        // compiler-builtins. Most linkers silently ignore it, but ld64 gives a warning.
+        if info.level.is_below_threshold(export_threshold) && !tcx.is_compiler_builtins(cnum) {
             symbols.push(symbol_export::exporting_symbol_name_for_instance_in_crate(
                 tcx, symbol, cnum,
             ));

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1824,7 +1824,9 @@ pub(crate) fn linked_symbols(
 
     let export_threshold = symbol_export::crates_export_threshold(&[crate_type]);
     for_each_exported_symbols_include_dep(tcx, crate_type, |symbol, info, cnum| {
-        if info.level.is_below_threshold(export_threshold) || info.used {
+        if info.level.is_below_threshold(export_threshold) && !tcx.is_compiler_builtins(cnum)
+            || info.used
+        {
             symbols.push((
                 symbol_export::linking_symbol_name_for_instance_in_crate(tcx, symbol, cnum),
                 info.kind,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -1,7 +1,7 @@
 //! A utility module to inspect currently ambiguous obligations in the current context.
 
 use rustc_infer::traits::{self, ObligationCause, PredicateObligations};
-use rustc_middle::traits::solve::{Goal, GoalSource};
+use rustc_middle::traits::solve::GoalSource;
 use rustc_middle::ty::{self, Ty, TypeVisitableExt};
 use rustc_span::Span;
 use rustc_trait_selection::solve::inspect::{
@@ -85,7 +85,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 root_cause: &obligation.cause,
             };
 
-            let goal = Goal::new(self.tcx, obligation.param_env, obligation.predicate);
+            let goal = obligation.as_goal();
             self.visit_proof_tree(goal, &mut visitor);
         }
 

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -864,10 +864,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Resolver<'cx, 'tcx> {
     }
 
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
-        self.handle_term(ct, ty::Const::outer_exclusive_binder, |tcx, guar| {
-            ty::Const::new_error(tcx, guar)
-        })
-        .super_fold_with(self)
+        self.handle_term(ct, ty::Const::outer_exclusive_binder, ty::Const::new_error)
     }
 
     fn fold_predicate(&mut self, predicate: ty::Predicate<'tcx>) -> ty::Predicate<'tcx> {

--- a/compiler/rustc_hir_typeck/src/writeback.rs
+++ b/compiler/rustc_hir_typeck/src/writeback.rs
@@ -548,7 +548,8 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         let fcx_typeck_results = self.fcx.typeck_results.borrow();
         assert_eq!(fcx_typeck_results.hir_owner, self.typeck_results.hir_owner);
         for (predicate, cause) in &fcx_typeck_results.coroutine_stalled_predicates {
-            let (predicate, cause) = self.resolve((*predicate, cause.clone()), &cause.span);
+            let (predicate, cause) =
+                self.resolve_coroutine_predicate((*predicate, cause.clone()), &cause.span);
             self.typeck_results.coroutine_stalled_predicates.insert((predicate, cause));
         }
     }
@@ -730,7 +731,25 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
         let value = self.fcx.resolve_vars_if_possible(value);
-        let value = value.fold_with(&mut Resolver::new(self.fcx, span, self.body));
+        let value = value.fold_with(&mut Resolver::new(self.fcx, span, self.body, true));
+        assert!(!value.has_infer());
+
+        // We may have introduced e.g. `ty::Error`, if inference failed, make sure
+        // to mark the `TypeckResults` as tainted in that case, so that downstream
+        // users of the typeck results don't produce extra errors, or worse, ICEs.
+        if let Err(guar) = value.error_reported() {
+            self.typeck_results.tainted_by_errors = Some(guar);
+        }
+
+        value
+    }
+
+    fn resolve_coroutine_predicate<T>(&mut self, value: T, span: &dyn Locatable) -> T
+    where
+        T: TypeFoldable<TyCtxt<'tcx>>,
+    {
+        let value = self.fcx.resolve_vars_if_possible(value);
+        let value = value.fold_with(&mut Resolver::new(self.fcx, span, self.body, false));
         assert!(!value.has_infer());
 
         // We may have introduced e.g. `ty::Error`, if inference failed, make sure
@@ -774,8 +793,9 @@ impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
         fcx: &'cx FnCtxt<'cx, 'tcx>,
         span: &'cx dyn Locatable,
         body: &'tcx hir::Body<'tcx>,
+        should_normalize: bool,
     ) -> Resolver<'cx, 'tcx> {
-        Resolver { fcx, span, body, should_normalize: fcx.next_trait_solver() }
+        Resolver { fcx, span, body, should_normalize }
     }
 
     fn report_error(&self, p: impl Into<ty::GenericArg<'tcx>>) -> ErrorGuaranteed {
@@ -805,10 +825,9 @@ impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
         T: Into<ty::GenericArg<'tcx>> + TypeSuperFoldable<TyCtxt<'tcx>> + Copy,
     {
         let tcx = self.fcx.tcx;
-        // We must deeply normalize in the new solver, since later lints
-        // expect that types that show up in the typeck are fully
-        // normalized.
-        let mut value = if self.should_normalize {
+        // We must deeply normalize in the new solver, since later lints expect
+        // that types that show up in the typeck are fully normalized.
+        let mut value = if self.should_normalize && self.fcx.next_trait_solver() {
             let body_id = tcx.hir_body_owner_def_id(self.body.id());
             let cause = ObligationCause::misc(self.span.to_span(tcx), body_id);
             let at = self.fcx.at(&cause, self.fcx.param_env);
@@ -868,13 +887,11 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Resolver<'cx, 'tcx> {
     }
 
     fn fold_predicate(&mut self, predicate: ty::Predicate<'tcx>) -> ty::Predicate<'tcx> {
-        // Do not normalize predicates in the new solver. The new solver is
-        // supposed to handle unnormalized predicates and incorrectly normalizing
-        // them can be unsound, e.g. for `WellFormed` predicates.
-        let prev = mem::replace(&mut self.should_normalize, false);
-        let predicate = predicate.super_fold_with(self);
-        self.should_normalize = prev;
-        predicate
+        assert!(
+            !self.should_normalize,
+            "normalizing predicates in writeback is not generally sound"
+        );
+        predicate.super_fold_with(self)
     }
 }
 

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -246,8 +246,7 @@ impl<'tcx> InferCtxt<'tcx> {
                             .eq(DefineOpaqueTypes::Yes, prev, hidden_ty)?
                             .obligations
                             .into_iter()
-                            // FIXME: Shuttling between obligations and goals is awkward.
-                            .map(Goal::from),
+                            .map(|obligation| obligation.as_goal()),
                     );
                 }
             }

--- a/compiler/rustc_infer/src/traits/mod.rs
+++ b/compiler/rustc_infer/src/traits/mod.rs
@@ -54,6 +54,12 @@ pub struct Obligation<'tcx, T> {
     pub recursion_depth: usize,
 }
 
+impl<'tcx, T: Copy> Obligation<'tcx, T> {
+    pub fn as_goal(&self) -> solve::Goal<'tcx, T> {
+        solve::Goal { param_env: self.param_env, predicate: self.predicate }
+    }
+}
+
 impl<'tcx, T: PartialEq> PartialEq<Obligation<'tcx, T>> for Obligation<'tcx, T> {
     #[inline]
     fn eq(&self, other: &Obligation<'tcx, T>) -> bool {
@@ -72,12 +78,6 @@ impl<T: Hash> Hash for Obligation<'_, T> {
         // See the comment on `Obligation::eq`.
         self.param_env.hash(state);
         self.predicate.hash(state);
-    }
-}
-
-impl<'tcx, P> From<Obligation<'tcx, P>> for solve::Goal<'tcx, P> {
-    fn from(value: Obligation<'tcx, P>) -> Self {
-        solve::Goal { param_env: value.param_env, predicate: value.predicate }
     }
 }
 

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -60,66 +60,76 @@ pub fn make_target_bin_path(sysroot: &Path, target_triple: &str) -> PathBuf {
 
 #[cfg(unix)]
 fn current_dll_path() -> Result<PathBuf, String> {
-    use std::ffi::{CStr, OsStr};
-    use std::os::unix::prelude::*;
+    use std::sync::OnceLock;
 
-    #[cfg(not(target_os = "aix"))]
-    unsafe {
-        let addr = current_dll_path as usize as *mut _;
-        let mut info = std::mem::zeroed();
-        if libc::dladdr(addr, &mut info) == 0 {
-            return Err("dladdr failed".into());
-        }
-        if info.dli_fname.is_null() {
-            return Err("dladdr returned null pointer".into());
-        }
-        let bytes = CStr::from_ptr(info.dli_fname).to_bytes();
-        let os = OsStr::from_bytes(bytes);
-        Ok(PathBuf::from(os))
-    }
+    // This is somewhat expensive relative to other work when compiling `fn main() {}` as `dladdr`
+    // needs to iterate over the symbol table of librustc_driver.so until it finds a match.
+    // As such cache this to avoid recomputing if we try to get the sysroot in multiple places.
+    static CURRENT_DLL_PATH: OnceLock<Result<PathBuf, String>> = OnceLock::new();
+    CURRENT_DLL_PATH
+        .get_or_init(|| {
+            use std::ffi::{CStr, OsStr};
+            use std::os::unix::prelude::*;
 
-    #[cfg(target_os = "aix")]
-    unsafe {
-        // On AIX, the symbol `current_dll_path` references a function descriptor.
-        // A function descriptor is consisted of (See https://reviews.llvm.org/D62532)
-        // * The address of the entry point of the function.
-        // * The TOC base address for the function.
-        // * The environment pointer.
-        // The function descriptor is in the data section.
-        let addr = current_dll_path as u64;
-        let mut buffer = vec![std::mem::zeroed::<libc::ld_info>(); 64];
-        loop {
-            if libc::loadquery(
-                libc::L_GETINFO,
-                buffer.as_mut_ptr() as *mut u8,
-                (size_of::<libc::ld_info>() * buffer.len()) as u32,
-            ) >= 0
-            {
-                break;
-            } else {
-                if std::io::Error::last_os_error().raw_os_error().unwrap() != libc::ENOMEM {
-                    return Err("loadquery failed".into());
+            #[cfg(not(target_os = "aix"))]
+            unsafe {
+                let addr = current_dll_path as usize as *mut _;
+                let mut info = std::mem::zeroed();
+                if libc::dladdr(addr, &mut info) == 0 {
+                    return Err("dladdr failed".into());
                 }
-                buffer.resize(buffer.len() * 2, std::mem::zeroed::<libc::ld_info>());
-            }
-        }
-        let mut current = buffer.as_mut_ptr() as *mut libc::ld_info;
-        loop {
-            let data_base = (*current).ldinfo_dataorg as u64;
-            let data_end = data_base + (*current).ldinfo_datasize;
-            if (data_base..data_end).contains(&addr) {
-                let bytes = CStr::from_ptr(&(*current).ldinfo_filename[0]).to_bytes();
+                if info.dli_fname.is_null() {
+                    return Err("dladdr returned null pointer".into());
+                }
+                let bytes = CStr::from_ptr(info.dli_fname).to_bytes();
                 let os = OsStr::from_bytes(bytes);
-                return Ok(PathBuf::from(os));
+                Ok(PathBuf::from(os))
             }
-            if (*current).ldinfo_next == 0 {
-                break;
+
+            #[cfg(target_os = "aix")]
+            unsafe {
+                // On AIX, the symbol `current_dll_path` references a function descriptor.
+                // A function descriptor is consisted of (See https://reviews.llvm.org/D62532)
+                // * The address of the entry point of the function.
+                // * The TOC base address for the function.
+                // * The environment pointer.
+                // The function descriptor is in the data section.
+                let addr = current_dll_path as u64;
+                let mut buffer = vec![std::mem::zeroed::<libc::ld_info>(); 64];
+                loop {
+                    if libc::loadquery(
+                        libc::L_GETINFO,
+                        buffer.as_mut_ptr() as *mut u8,
+                        (size_of::<libc::ld_info>() * buffer.len()) as u32,
+                    ) >= 0
+                    {
+                        break;
+                    } else {
+                        if std::io::Error::last_os_error().raw_os_error().unwrap() != libc::ENOMEM {
+                            return Err("loadquery failed".into());
+                        }
+                        buffer.resize(buffer.len() * 2, std::mem::zeroed::<libc::ld_info>());
+                    }
+                }
+                let mut current = buffer.as_mut_ptr() as *mut libc::ld_info;
+                loop {
+                    let data_base = (*current).ldinfo_dataorg as u64;
+                    let data_end = data_base + (*current).ldinfo_datasize;
+                    if (data_base..data_end).contains(&addr) {
+                        let bytes = CStr::from_ptr(&(*current).ldinfo_filename[0]).to_bytes();
+                        let os = OsStr::from_bytes(bytes);
+                        return Ok(PathBuf::from(os));
+                    }
+                    if (*current).ldinfo_next == 0 {
+                        break;
+                    }
+                    current = (current as *mut i8).offset((*current).ldinfo_next as isize)
+                        as *mut libc::ld_info;
+                }
+                return Err(format!("current dll's address {} is not in the load map", addr));
             }
-            current =
-                (current as *mut i8).offset((*current).ldinfo_next as isize) as *mut libc::ld_info;
-        }
-        return Err(format!("current dll's address {} is not in the load map", addr));
-    }
+        })
+        .clone()
 }
 
 #[cfg(windows)]

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -96,7 +96,7 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
     ) -> Option<Vec<Goal<'tcx, ty::Predicate<'tcx>>>> {
         crate::traits::wf::unnormalized_obligations(&self.0, param_env, arg, DUMMY_SP, CRATE_DEF_ID)
             .map(|obligations| {
-                obligations.into_iter().map(|obligation| obligation.into()).collect()
+                obligations.into_iter().map(|obligation| obligation.as_goal()).collect()
             })
     }
 

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -80,7 +80,7 @@ impl<'tcx> ObligationStorage<'tcx> {
             // change.
             // FIXME: <https://github.com/Gankra/thin-vec/pull/66> is merged, this can be removed.
             self.overflowed.extend(ExtractIf::new(&mut self.pending, |o| {
-                let goal = o.clone().into();
+                let goal = o.as_goal();
                 let result = <&SolverDelegate<'tcx>>::from(infcx)
                     .evaluate_root_goal(goal, GenerateProofTree::No, o.cause.span)
                     .0;
@@ -161,7 +161,7 @@ where
 
             let mut has_changed = false;
             for obligation in self.obligations.unstalled_for_select() {
-                let goal = obligation.clone().into();
+                let goal = obligation.as_goal();
                 let result = <&SolverDelegate<'tcx>>::from(infcx)
                     .evaluate_root_goal(goal, GenerateProofTree::No, obligation.cause.span)
                     .0;

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -625,7 +625,7 @@ fn compute_intercrate_ambiguity_causes<'tcx>(
     let mut causes: FxIndexSet<IntercrateAmbiguityCause<'tcx>> = Default::default();
 
     for obligation in obligations {
-        search_ambiguity_causes(infcx, obligation.clone().into(), &mut causes);
+        search_ambiguity_causes(infcx, obligation.as_goal(), &mut causes);
     }
 
     causes

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.151"
+version = "0.1.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc30f1766d387c35f2405e586d3e7a88230dc728ff78cd1d0bc59ae0b63154b"
+checksum = "2153cf213eb259361567720ce55f6446f17acd0ccca87fb6dc05360578228a58"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 
 [dependencies]
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.151", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "=0.1.152", features = ['rustc-dep-of-std'] }
 
 [features]
 compiler-builtins-mem = ['compiler_builtins/mem']

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -29,6 +29,7 @@ mod bytewise;
 pub(crate) use bytewise::BytewiseEq;
 
 use self::Ordering::*;
+use crate::ops::ControlFlow::{self, Break, Continue};
 
 /// Trait for comparisons using the equality operator.
 ///
@@ -1446,6 +1447,54 @@ pub macro PartialOrd($item:item) {
     /* compiler built-in */
 }
 
+/// Helpers for chaining together field PartialOrds into the full type's ordering.
+///
+/// If the two values are equal, returns `ControlFlow::Continue`.
+/// If the two values are not equal, returns `ControlFlow::Break(self OP other)`.
+///
+/// This allows simple types like `i32` and `f64` to just emit two comparisons
+/// directly, instead of needing to optimize the 3-way comparison.
+///
+/// Currently this is done using specialization, but it doesn't need that:
+/// it could be provided methods on `PartialOrd` instead and work fine.
+pub(crate) trait SpecChainingPartialOrd<Rhs>: PartialOrd<Rhs> {
+    fn spec_chain_lt(&self, other: &Rhs) -> ControlFlow<bool>;
+    fn spec_chain_le(&self, other: &Rhs) -> ControlFlow<bool>;
+    fn spec_chain_gt(&self, other: &Rhs) -> ControlFlow<bool>;
+    fn spec_chain_ge(&self, other: &Rhs) -> ControlFlow<bool>;
+}
+
+impl<T: PartialOrd<U>, U> SpecChainingPartialOrd<U> for T {
+    #[inline]
+    default fn spec_chain_lt(&self, other: &U) -> ControlFlow<bool> {
+        match PartialOrd::partial_cmp(self, other) {
+            Some(Equal) => Continue(()),
+            c => Break(c.is_some_and(Ordering::is_lt)),
+        }
+    }
+    #[inline]
+    default fn spec_chain_le(&self, other: &U) -> ControlFlow<bool> {
+        match PartialOrd::partial_cmp(self, other) {
+            Some(Equal) => Continue(()),
+            c => Break(c.is_some_and(Ordering::is_le)),
+        }
+    }
+    #[inline]
+    default fn spec_chain_gt(&self, other: &U) -> ControlFlow<bool> {
+        match PartialOrd::partial_cmp(self, other) {
+            Some(Equal) => Continue(()),
+            c => Break(c.is_some_and(Ordering::is_gt)),
+        }
+    }
+    #[inline]
+    default fn spec_chain_ge(&self, other: &U) -> ControlFlow<bool> {
+        match PartialOrd::partial_cmp(self, other) {
+            Some(Equal) => Continue(()),
+            c => Break(c.is_some_and(Ordering::is_ge)),
+        }
+    }
+}
+
 /// Compares and returns the minimum of two values.
 ///
 /// Returns the first argument if the comparison determines them to be equal.
@@ -1741,6 +1790,7 @@ where
 mod impls {
     use crate::cmp::Ordering::{self, Equal, Greater, Less};
     use crate::hint::unreachable_unchecked;
+    use crate::ops::ControlFlow::{self, Break, Continue};
 
     macro_rules! partial_eq_impl {
         ($($t:ty)*) => ($(
@@ -1779,6 +1829,36 @@ mod impls {
 
     eq_impl! { () bool char usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 
+    macro_rules! chaining_impl {
+        ($t:ty) => {
+            // These implementations are the same for `Ord` or `PartialOrd` types
+            // because if either is NAN the `==` test will fail so we end up in
+            // the `Break` case and the comparison will correctly return `false`.
+            impl super::SpecChainingPartialOrd<$t> for $t {
+                #[inline]
+                fn spec_chain_lt(&self, other: &Self) -> ControlFlow<bool> {
+                    let (lhs, rhs) = (*self, *other);
+                    if lhs == rhs { Continue(()) } else { Break(lhs < rhs) }
+                }
+                #[inline]
+                fn spec_chain_le(&self, other: &Self) -> ControlFlow<bool> {
+                    let (lhs, rhs) = (*self, *other);
+                    if lhs == rhs { Continue(()) } else { Break(lhs <= rhs) }
+                }
+                #[inline]
+                fn spec_chain_gt(&self, other: &Self) -> ControlFlow<bool> {
+                    let (lhs, rhs) = (*self, *other);
+                    if lhs == rhs { Continue(()) } else { Break(lhs > rhs) }
+                }
+                #[inline]
+                fn spec_chain_ge(&self, other: &Self) -> ControlFlow<bool> {
+                    let (lhs, rhs) = (*self, *other);
+                    if lhs == rhs { Continue(()) } else { Break(lhs >= rhs) }
+                }
+            }
+        };
+    }
+
     macro_rules! partial_ord_impl {
         ($($t:ty)*) => ($(
             #[stable(feature = "rust1", since = "1.0.0")]
@@ -1801,6 +1881,8 @@ mod impls {
                 #[inline(always)]
                 fn gt(&self, other: &$t) -> bool { (*self) > (*other) }
             }
+
+            chaining_impl!($t);
         )*)
     }
 
@@ -1839,6 +1921,8 @@ mod impls {
                 #[inline(always)]
                 fn gt(&self, other: &$t) -> bool { (*self) > (*other) }
             }
+
+            chaining_impl!($t);
 
             #[stable(feature = "rust1", since = "1.0.0")]
             impl Ord for $t {

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -1,7 +1,6 @@
 // See core/src/primitive_docs.rs for documentation.
 
 use crate::cmp::Ordering::{self, *};
-use crate::cmp::SpecChainingPartialOrd;
 use crate::marker::{ConstParamTy_, StructuralPartialEq, UnsizedConstParamTy};
 use crate::ops::ControlFlow::{Break, Continue};
 
@@ -82,19 +81,19 @@ macro_rules! tuple_impls {
                 }
                 #[inline]
                 fn lt(&self, other: &($($T,)+)) -> bool {
-                    lexical_ord!(lt, spec_chain_lt, $( ${ignore($T)} self.${index()}, other.${index()} ),+)
+                    lexical_ord!(lt, __chaining_lt, $( ${ignore($T)} self.${index()}, other.${index()} ),+)
                 }
                 #[inline]
                 fn le(&self, other: &($($T,)+)) -> bool {
-                    lexical_ord!(le, spec_chain_le, $( ${ignore($T)} self.${index()}, other.${index()} ),+)
+                    lexical_ord!(le, __chaining_le, $( ${ignore($T)} self.${index()}, other.${index()} ),+)
                 }
                 #[inline]
                 fn ge(&self, other: &($($T,)+)) -> bool {
-                    lexical_ord!(ge, spec_chain_ge, $( ${ignore($T)} self.${index()}, other.${index()} ),+)
+                    lexical_ord!(ge, __chaining_ge, $( ${ignore($T)} self.${index()}, other.${index()} ),+)
                 }
                 #[inline]
                 fn gt(&self, other: &($($T,)+)) -> bool {
-                    lexical_ord!(gt, spec_chain_gt, $( ${ignore($T)} self.${index()}, other.${index()} ),+)
+                    lexical_ord!(gt, __chaining_gt, $( ${ignore($T)} self.${index()}, other.${index()} ),+)
                 }
             }
         }
@@ -173,11 +172,11 @@ macro_rules! maybe_tuple_doc {
 // `(a1, a2, a3) < (b1, b2, b3)` would be `lexical_ord!(lt, opt_is_lt, a1, b1,
 // a2, b2, a3, b3)` (and similarly for `lexical_cmp`)
 //
-// `$chain_rel` is the method from `SpecChainingPartialOrd` to use for all but the
+// `$chain_rel` is the chaining method from `PartialOrd` to use for all but the
 // final value, to produce better results for simple primitives.
 macro_rules! lexical_ord {
     ($rel: ident, $chain_rel: ident, $a:expr, $b:expr, $($rest_a:expr, $rest_b:expr),+) => {{
-        match SpecChainingPartialOrd::$chain_rel(&$a, &$b) {
+        match PartialOrd::$chain_rel(&$a, &$b) {
             Break(val) => val,
             Continue(()) => lexical_ord!($rel, $chain_rel, $($rest_a, $rest_b),+),
         }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.151" }
+compiler_builtins = { version = "=0.1.152" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1719,6 +1719,23 @@ fn test_eq_direntry_metadata() {
     }
 }
 
+/// Test that windows file type equality is not affected by attributes unrelated
+/// to the file type.
+#[test]
+#[cfg(target_os = "windows")]
+fn test_eq_windows_file_type() {
+    let tmpdir = tmpdir();
+    let file1 = File::create(tmpdir.join("file1")).unwrap();
+    let file2 = File::create(tmpdir.join("file2")).unwrap();
+    assert_eq!(file1.metadata().unwrap().file_type(), file2.metadata().unwrap().file_type());
+
+    // Change the readonly attribute of one file.
+    let mut perms = file1.metadata().unwrap().permissions();
+    perms.set_readonly(true);
+    file1.set_permissions(perms).unwrap();
+    assert_eq!(file1.metadata().unwrap().file_type(), file2.metadata().unwrap().file_type());
+}
+
 /// Regression test for https://github.com/rust-lang/rust/issues/50619.
 #[test]
 #[cfg(target_os = "linux")]

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -33,7 +33,7 @@ use crate::utils::exec::command;
 use crate::utils::helpers::{
     exe, get_clang_cl_resource_dir, is_debug_info, is_dylib, symlink_dir, t, up_to_date,
 };
-use crate::{CLang, Compiler, DependencyType, GitRepo, LLVM_TOOLS, Mode, debug, trace};
+use crate::{CLang, Compiler, DependencyType, FileType, GitRepo, LLVM_TOOLS, Mode, debug, trace};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Std {
@@ -321,7 +321,7 @@ fn copy_and_stamp(
     dependency_type: DependencyType,
 ) {
     let target = libdir.join(name);
-    builder.copy_link(&sourcedir.join(name), &target);
+    builder.copy_link(&sourcedir.join(name), &target, FileType::Regular);
 
     target_deps.push((target, dependency_type));
 }
@@ -330,7 +330,7 @@ fn copy_llvm_libunwind(builder: &Builder<'_>, target: TargetSelection, libdir: &
     let libunwind_path = builder.ensure(llvm::Libunwind { target });
     let libunwind_source = libunwind_path.join("libunwind.a");
     let libunwind_target = libdir.join("libunwind.a");
-    builder.copy_link(&libunwind_source, &libunwind_target);
+    builder.copy_link(&libunwind_source, &libunwind_target, FileType::NativeLibrary);
     libunwind_target
 }
 
@@ -401,7 +401,7 @@ fn copy_self_contained_objects(
             for &obj in &["crtbegin.o", "crtbeginS.o", "crtend.o", "crtendS.o"] {
                 let src = crt_path.join(obj);
                 let target = libdir_self_contained.join(obj);
-                builder.copy_link(&src, &target);
+                builder.copy_link(&src, &target, FileType::NativeLibrary);
                 target_deps.push((target, DependencyType::TargetSelfContained));
             }
         } else {
@@ -443,9 +443,9 @@ fn copy_self_contained_objects(
     } else if target.is_windows_gnu() {
         for obj in ["crt2.o", "dllcrt2.o"].iter() {
             let src = compiler_file(builder, &builder.cc(target), target, CLang::C, obj);
-            let target = libdir_self_contained.join(obj);
-            builder.copy_link(&src, &target);
-            target_deps.push((target, DependencyType::TargetSelfContained));
+            let dst = libdir_self_contained.join(obj);
+            builder.copy_link(&src, &dst, FileType::NativeLibrary);
+            target_deps.push((dst, DependencyType::TargetSelfContained));
         }
     }
 
@@ -790,8 +790,11 @@ impl Step for StdLink {
                     let file = t!(file);
                     let path = file.path();
                     if path.is_file() {
-                        builder
-                            .copy_link(&path, &sysroot.join("lib").join(path.file_name().unwrap()));
+                        builder.copy_link(
+                            &path,
+                            &sysroot.join("lib").join(path.file_name().unwrap()),
+                            FileType::Regular,
+                        );
                     }
                 }
             }
@@ -829,7 +832,7 @@ fn copy_sanitizers(
 
     for runtime in &runtimes {
         let dst = libdir.join(&runtime.name);
-        builder.copy_link(&runtime.path, &dst);
+        builder.copy_link(&runtime.path, &dst, FileType::NativeLibrary);
 
         // The `aarch64-apple-ios-macabi` and `x86_64-apple-ios-macabi` are also supported for
         // sanitizers, but they share a sanitizer runtime with `${arch}-apple-darwin`, so we do
@@ -934,9 +937,9 @@ impl Step for StartupObjects {
                     .run(builder);
             }
 
-            let target = sysroot_dir.join((*file).to_string() + ".o");
-            builder.copy_link(dst_file, &target);
-            target_deps.push((target, DependencyType::Target));
+            let obj = sysroot_dir.join((*file).to_string() + ".o");
+            builder.copy_link(dst_file, &obj, FileType::NativeLibrary);
+            target_deps.push((obj, DependencyType::Target));
         }
 
         target_deps
@@ -952,7 +955,7 @@ fn cp_rustc_component_to_ci_sysroot(builder: &Builder<'_>, sysroot: &Path, conte
         if src.is_dir() {
             t!(fs::create_dir_all(dst));
         } else {
-            builder.copy_link(&src, &dst);
+            builder.copy_link(&src, &dst, FileType::Regular);
         }
     }
 }
@@ -1707,7 +1710,7 @@ fn copy_codegen_backends_to_sysroot(
             let dot = filename.find('.').unwrap();
             format!("{}-{}{}", &filename[..dash], builder.rust_release(), &filename[dot..])
         };
-        builder.copy_link(file, &dst.join(target_filename));
+        builder.copy_link(file, &dst.join(target_filename), FileType::NativeLibrary);
     }
 }
 
@@ -2011,7 +2014,11 @@ impl Step for Assemble {
                         extra_features: vec![],
                     });
                 let tool_exe = exe("llvm-bitcode-linker", target_compiler.host);
-                builder.copy_link(&llvm_bitcode_linker.tool_path, &libdir_bin.join(tool_exe));
+                builder.copy_link(
+                    &llvm_bitcode_linker.tool_path,
+                    &libdir_bin.join(tool_exe),
+                    FileType::Executable,
+                );
             }
         };
 
@@ -2072,8 +2079,8 @@ impl Step for Assemble {
                 builder.sysroot_target_libdir(target_compiler, target_compiler.host);
             let dst_lib = libdir.join(&libenzyme).with_extension(lib_ext);
             let target_dst_lib = target_libdir.join(&libenzyme).with_extension(lib_ext);
-            builder.copy_link(&src_lib, &dst_lib);
-            builder.copy_link(&src_lib, &target_dst_lib);
+            builder.copy_link(&src_lib, &dst_lib, FileType::NativeLibrary);
+            builder.copy_link(&src_lib, &target_dst_lib, FileType::NativeLibrary);
         }
 
         // Build the libraries for this compiler to link to (i.e., the libraries
@@ -2168,7 +2175,7 @@ impl Step for Assemble {
             };
 
             if is_dylib_or_debug && can_be_rustc_dynamic_dep && !is_proc_macro {
-                builder.copy_link(&f.path(), &rustc_libdir.join(&filename));
+                builder.copy_link(&f.path(), &rustc_libdir.join(&filename), FileType::Regular);
             }
         }
 
@@ -2196,7 +2203,11 @@ impl Step for Assemble {
             // See <https://github.com/rust-lang/rust/issues/132719>.
             let src_exe = exe("llvm-objcopy", target_compiler.host);
             let dst_exe = exe("rust-objcopy", target_compiler.host);
-            builder.copy_link(&libdir_bin.join(src_exe), &libdir_bin.join(dst_exe));
+            builder.copy_link(
+                &libdir_bin.join(src_exe),
+                &libdir_bin.join(dst_exe),
+                FileType::Executable,
+            );
         }
 
         // In addition to `rust-lld` also install `wasm-component-ld` when
@@ -2212,6 +2223,7 @@ impl Step for Assemble {
             builder.copy_link(
                 &wasm_component.tool_path,
                 &libdir_bin.join(wasm_component.tool_path.file_name().unwrap()),
+                FileType::Executable,
             );
         }
 
@@ -2234,7 +2246,7 @@ impl Step for Assemble {
         t!(fs::create_dir_all(bindir));
         let compiler = builder.rustc(target_compiler);
         debug!(src = ?rustc, dst = ?compiler, "linking compiler binary itself");
-        builder.copy_link(&rustc, &compiler);
+        builder.copy_link(&rustc, &compiler, FileType::Executable);
 
         target_compiler
     }
@@ -2260,7 +2272,7 @@ pub fn add_to_sysroot(
             DependencyType::Target => sysroot_dst,
             DependencyType::TargetSelfContained => self_contained_dst,
         };
-        builder.copy_link(&path, &dst.join(path.file_name().unwrap()));
+        builder.copy_link(&path, &dst.join(path.file_name().unwrap()), FileType::Regular);
     }
 }
 

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -32,7 +32,7 @@ use crate::utils::helpers::{
     exe, is_dylib, move_file, t, target_supports_cranelift_backend, timeit,
 };
 use crate::utils::tarball::{GeneratedTarball, OverlayKind, Tarball};
-use crate::{Compiler, DependencyType, LLVM_TOOLS, Mode, trace};
+use crate::{Compiler, DependencyType, FileType, LLVM_TOOLS, Mode, trace};
 
 pub fn pkgname(builder: &Builder<'_>, component: &str) -> String {
     format!("{}-{}", component, builder.rust_package_vers())
@@ -81,7 +81,7 @@ impl Step for Docs {
         let mut tarball = Tarball::new(builder, "rust-docs", &host.triple);
         tarball.set_product_name("Rust Documentation");
         tarball.add_bulk_dir(builder.doc_out(host), dest);
-        tarball.add_file(builder.src.join("src/doc/robots.txt"), dest, 0o644);
+        tarball.add_file(builder.src.join("src/doc/robots.txt"), dest, FileType::Regular);
         Some(tarball.generate())
     }
 }
@@ -418,7 +418,7 @@ impl Step for Rustc {
                 .is_none_or(|tools| tools.iter().any(|tool| tool == "rustdoc"))
             {
                 let rustdoc = builder.rustdoc(compiler);
-                builder.install(&rustdoc, &image.join("bin"), 0o755);
+                builder.install(&rustdoc, &image.join("bin"), FileType::Executable);
             }
 
             if let Some(ra_proc_macro_srv) = builder.ensure_if_default(
@@ -432,7 +432,8 @@ impl Step for Rustc {
                 },
                 builder.kind,
             ) {
-                builder.install(&ra_proc_macro_srv.tool_path, &image.join("libexec"), 0o755);
+                let dst = image.join("libexec");
+                builder.install(&ra_proc_macro_srv.tool_path, &dst, FileType::Executable);
             }
 
             let libdir_relative = builder.libdir_relative(compiler);
@@ -444,7 +445,7 @@ impl Step for Rustc {
                     if is_dylib(&entry.path()) {
                         // Don't use custom libdir here because ^lib/ will be resolved again
                         // with installer
-                        builder.install(&entry.path(), &image.join("lib"), 0o644);
+                        builder.install(&entry.path(), &image.join("lib"), FileType::NativeLibrary);
                     }
                 }
             }
@@ -463,7 +464,11 @@ impl Step for Rustc {
             if builder.config.lld_enabled {
                 let src_dir = builder.sysroot_target_bindir(compiler, host);
                 let rust_lld = exe("rust-lld", compiler.host);
-                builder.copy_link(&src_dir.join(&rust_lld), &dst_dir.join(&rust_lld));
+                builder.copy_link(
+                    &src_dir.join(&rust_lld),
+                    &dst_dir.join(&rust_lld),
+                    FileType::Executable,
+                );
                 let self_contained_lld_src_dir = src_dir.join("gcc-ld");
                 let self_contained_lld_dst_dir = dst_dir.join("gcc-ld");
                 t!(fs::create_dir(&self_contained_lld_dst_dir));
@@ -472,6 +477,7 @@ impl Step for Rustc {
                     builder.copy_link(
                         &self_contained_lld_src_dir.join(&exe_name),
                         &self_contained_lld_dst_dir.join(&exe_name),
+                        FileType::Executable,
                     );
                 }
             }
@@ -480,13 +486,17 @@ impl Step for Rustc {
                 let src_dir = builder.sysroot_target_bindir(compiler, host);
                 let llvm_objcopy = exe("llvm-objcopy", compiler.host);
                 let rust_objcopy = exe("rust-objcopy", compiler.host);
-                builder.copy_link(&src_dir.join(&llvm_objcopy), &dst_dir.join(&rust_objcopy));
+                builder.copy_link(
+                    &src_dir.join(&llvm_objcopy),
+                    &dst_dir.join(&rust_objcopy),
+                    FileType::Executable,
+                );
             }
 
             if builder.tool_enabled("wasm-component-ld") {
                 let src_dir = builder.sysroot_target_bindir(compiler, host);
                 let ld = exe("wasm-component-ld", compiler.host);
-                builder.copy_link(&src_dir.join(&ld), &dst_dir.join(&ld));
+                builder.copy_link(&src_dir.join(&ld), &dst_dir.join(&ld), FileType::Executable);
             }
 
             // Man pages
@@ -511,15 +521,19 @@ impl Step for Rustc {
             // HTML copyright files
             let file_list = builder.ensure(super::run::GenerateCopyright);
             for file in file_list {
-                builder.install(&file, &image.join("share/doc/rust"), 0o644);
+                builder.install(&file, &image.join("share/doc/rust"), FileType::Regular);
             }
 
             // README
-            builder.install(&builder.src.join("README.md"), &image.join("share/doc/rust"), 0o644);
+            builder.install(
+                &builder.src.join("README.md"),
+                &image.join("share/doc/rust"),
+                FileType::Regular,
+            );
 
             // The REUSE-managed license files
             let license = |path: &Path| {
-                builder.install(path, &image.join("share/doc/rust/licenses"), 0o644);
+                builder.install(path, &image.join("share/doc/rust/licenses"), FileType::Regular);
             };
             for entry in t!(std::fs::read_dir(builder.src.join("LICENSES"))).flatten() {
                 license(&entry.path());
@@ -548,14 +562,14 @@ impl Step for DebuggerScripts {
         let dst = sysroot.join("lib/rustlib/etc");
         t!(fs::create_dir_all(&dst));
         let cp_debugger_script = |file: &str| {
-            builder.install(&builder.src.join("src/etc/").join(file), &dst, 0o644);
+            builder.install(&builder.src.join("src/etc/").join(file), &dst, FileType::Regular);
         };
         if host.contains("windows-msvc") {
             // windbg debugger scripts
             builder.install(
                 &builder.src.join("src/etc/rust-windbg.cmd"),
                 &sysroot.join("bin"),
-                0o755,
+                FileType::Script,
             );
 
             cp_debugger_script("natvis/intrinsic.natvis");
@@ -567,15 +581,27 @@ impl Step for DebuggerScripts {
         cp_debugger_script("rust_types.py");
 
         // gdb debugger scripts
-        builder.install(&builder.src.join("src/etc/rust-gdb"), &sysroot.join("bin"), 0o755);
-        builder.install(&builder.src.join("src/etc/rust-gdbgui"), &sysroot.join("bin"), 0o755);
+        builder.install(
+            &builder.src.join("src/etc/rust-gdb"),
+            &sysroot.join("bin"),
+            FileType::Script,
+        );
+        builder.install(
+            &builder.src.join("src/etc/rust-gdbgui"),
+            &sysroot.join("bin"),
+            FileType::Script,
+        );
 
         cp_debugger_script("gdb_load_rust_pretty_printers.py");
         cp_debugger_script("gdb_lookup.py");
         cp_debugger_script("gdb_providers.py");
 
         // lldb debugger scripts
-        builder.install(&builder.src.join("src/etc/rust-lldb"), &sysroot.join("bin"), 0o755);
+        builder.install(
+            &builder.src.join("src/etc/rust-lldb"),
+            &sysroot.join("bin"),
+            FileType::Script,
+        );
 
         cp_debugger_script("lldb_lookup.py");
         cp_debugger_script("lldb_providers.py");
@@ -640,9 +666,13 @@ fn copy_target_libs(
     t!(fs::create_dir_all(&self_contained_dst));
     for (path, dependency_type) in builder.read_stamp_file(stamp) {
         if dependency_type == DependencyType::TargetSelfContained {
-            builder.copy_link(&path, &self_contained_dst.join(path.file_name().unwrap()));
+            builder.copy_link(
+                &path,
+                &self_contained_dst.join(path.file_name().unwrap()),
+                FileType::NativeLibrary,
+            );
         } else if dependency_type == DependencyType::Target || builder.is_builder_target(target) {
-            builder.copy_link(&path, &dst.join(path.file_name().unwrap()));
+            builder.copy_link(&path, &dst.join(path.file_name().unwrap()), FileType::NativeLibrary);
         }
     }
 }
@@ -750,7 +780,11 @@ impl Step for RustcDev {
             &tarball.image_dir().join("lib/rustlib/rustc-src/rust"),
         );
         for file in src_files {
-            tarball.add_file(builder.src.join(file), "lib/rustlib/rustc-src/rust", 0o644);
+            tarball.add_file(
+                builder.src.join(file),
+                "lib/rustlib/rustc-src/rust",
+                FileType::Regular,
+            );
         }
 
         Some(tarball.generate())
@@ -1045,7 +1079,11 @@ impl Step for PlainSourceTarball {
 
         // Copy the files normally
         for item in &src_files {
-            builder.copy_link(&builder.src.join(item), &plain_dst_src.join(item));
+            builder.copy_link(
+                &builder.src.join(item),
+                &plain_dst_src.join(item),
+                FileType::Regular,
+            );
         }
 
         // Create the version file
@@ -1147,9 +1185,14 @@ impl Step for Cargo {
         let mut tarball = Tarball::new(builder, "cargo", &target.triple);
         tarball.set_overlay(OverlayKind::Cargo);
 
-        tarball.add_file(cargo.tool_path, "bin", 0o755);
-        tarball.add_file(etc.join("_cargo"), "share/zsh/site-functions", 0o644);
-        tarball.add_renamed_file(etc.join("cargo.bashcomp.sh"), "etc/bash_completion.d", "cargo");
+        tarball.add_file(&cargo.tool_path, "bin", FileType::Executable);
+        tarball.add_file(etc.join("_cargo"), "share/zsh/site-functions", FileType::Regular);
+        tarball.add_renamed_file(
+            etc.join("cargo.bashcomp.sh"),
+            "etc/bash_completion.d",
+            "cargo",
+            FileType::Regular,
+        );
         tarball.add_dir(etc.join("man"), "share/man/man1");
         tarball.add_legal_and_readme_to("share/doc/cargo");
 
@@ -1193,7 +1236,7 @@ impl Step for RustAnalyzer {
         let mut tarball = Tarball::new(builder, "rust-analyzer", &target.triple);
         tarball.set_overlay(OverlayKind::RustAnalyzer);
         tarball.is_preview(true);
-        tarball.add_file(rust_analyzer.tool_path, "bin", 0o755);
+        tarball.add_file(&rust_analyzer.tool_path, "bin", FileType::Executable);
         tarball.add_legal_and_readme_to("share/doc/rust-analyzer");
         Some(tarball.generate())
     }
@@ -1239,8 +1282,8 @@ impl Step for Clippy {
         let mut tarball = Tarball::new(builder, "clippy", &target.triple);
         tarball.set_overlay(OverlayKind::Clippy);
         tarball.is_preview(true);
-        tarball.add_file(clippy.tool_path, "bin", 0o755);
-        tarball.add_file(cargoclippy.tool_path, "bin", 0o755);
+        tarball.add_file(&clippy.tool_path, "bin", FileType::Executable);
+        tarball.add_file(&cargoclippy.tool_path, "bin", FileType::Executable);
         tarball.add_legal_and_readme_to("share/doc/clippy");
         Some(tarball.generate())
     }
@@ -1289,8 +1332,8 @@ impl Step for Miri {
         let mut tarball = Tarball::new(builder, "miri", &target.triple);
         tarball.set_overlay(OverlayKind::Miri);
         tarball.is_preview(true);
-        tarball.add_file(miri.tool_path, "bin", 0o755);
-        tarball.add_file(cargomiri.tool_path, "bin", 0o755);
+        tarball.add_file(&miri.tool_path, "bin", FileType::Executable);
+        tarball.add_file(&cargomiri.tool_path, "bin", FileType::Executable);
         tarball.add_legal_and_readme_to("share/doc/miri");
         Some(tarball.generate())
     }
@@ -1374,7 +1417,11 @@ impl Step for CodegenBackend {
         for backend in fs::read_dir(&backends_src).unwrap() {
             let file_name = backend.unwrap().file_name();
             if file_name.to_str().unwrap().contains(&backend_name) {
-                tarball.add_file(backends_src.join(file_name), &backends_dst, 0o644);
+                tarball.add_file(
+                    backends_src.join(file_name),
+                    &backends_dst,
+                    FileType::NativeLibrary,
+                );
                 found_backend = true;
             }
         }
@@ -1420,8 +1467,8 @@ impl Step for Rustfmt {
         let mut tarball = Tarball::new(builder, "rustfmt", &target.triple);
         tarball.set_overlay(OverlayKind::Rustfmt);
         tarball.is_preview(true);
-        tarball.add_file(rustfmt.tool_path, "bin", 0o755);
-        tarball.add_file(cargofmt.tool_path, "bin", 0o755);
+        tarball.add_file(&rustfmt.tool_path, "bin", FileType::Executable);
+        tarball.add_file(&cargofmt.tool_path, "bin", FileType::Executable);
         tarball.add_legal_and_readme_to("share/doc/rustfmt");
         Some(tarball.generate())
     }
@@ -1578,7 +1625,7 @@ impl Step for Extended {
                     &work.join(format!("{}-{}", pkgname(builder, name), target.triple)),
                     &pkg.join(name),
                 );
-                builder.install(&etc.join("pkg/postinstall"), &pkg.join(name), 0o755);
+                builder.install(&etc.join("pkg/postinstall"), &pkg.join(name), FileType::Script);
                 pkgbuild(name);
             };
             prepare("rustc");
@@ -1593,12 +1640,12 @@ impl Step for Extended {
                 }
             }
             // create an 'uninstall' package
-            builder.install(&etc.join("pkg/postinstall"), &pkg.join("uninstall"), 0o755);
+            builder.install(&etc.join("pkg/postinstall"), &pkg.join("uninstall"), FileType::Script);
             pkgbuild("uninstall");
 
             builder.create_dir(&pkg.join("res"));
             builder.create(&pkg.join("res/LICENSE.txt"), &license);
-            builder.install(&etc.join("gfx/rust-logo.png"), &pkg.join("res"), 0o644);
+            builder.install(&etc.join("gfx/rust-logo.png"), &pkg.join("res"), FileType::Regular);
             let mut cmd = command("productbuild");
             cmd.arg("--distribution")
                 .arg(xform(&etc.join("pkg/Distribution.xml")))
@@ -1655,7 +1702,7 @@ impl Step for Extended {
                 prepare("rust-mingw");
             }
 
-            builder.install(&etc.join("gfx/rust-logo.ico"), &exe, 0o644);
+            builder.install(&etc.join("gfx/rust-logo.ico"), &exe, FileType::Regular);
 
             // Generate msi installer
             let wix_path = env::var_os("WIX")
@@ -1874,8 +1921,8 @@ impl Step for Extended {
             }
 
             builder.create(&exe.join("LICENSE.rtf"), &rtf);
-            builder.install(&etc.join("gfx/banner.bmp"), &exe, 0o644);
-            builder.install(&etc.join("gfx/dialogbg.bmp"), &exe, 0o644);
+            builder.install(&etc.join("gfx/banner.bmp"), &exe, FileType::Regular);
+            builder.install(&etc.join("gfx/dialogbg.bmp"), &exe, FileType::Regular);
 
             builder.info(&format!("building `msi` installer with {light:?}"));
             let filename = format!("{}-{}.msi", pkgname(builder, "rust"), target.triple);
@@ -1961,13 +2008,13 @@ fn install_llvm_file(
     if source.is_symlink() {
         // If we have a symlink like libLLVM-18.so -> libLLVM.so.18.1, install the target of the
         // symlink, which is what will actually get loaded at runtime.
-        builder.install(&t!(fs::canonicalize(source)), destination, 0o644);
+        builder.install(&t!(fs::canonicalize(source)), destination, FileType::NativeLibrary);
 
         let full_dest = destination.join(source.file_name().unwrap());
         if install_symlink {
             // For download-ci-llvm, also install the symlink, to match what LLVM does. Using a
             // symlink is fine here, as this is not a rustup component.
-            builder.copy_link(source, &full_dest);
+            builder.copy_link(source, &full_dest, FileType::NativeLibrary);
         } else {
             // Otherwise, replace the symlink with an equivalent linker script. This is used when
             // projects like miri link against librustc_driver.so. We don't use a symlink, as
@@ -1984,7 +2031,7 @@ fn install_llvm_file(
             }
         }
     } else {
-        builder.install(source, destination, 0o644);
+        builder.install(source, destination, FileType::NativeLibrary);
     }
 }
 
@@ -2036,7 +2083,7 @@ fn maybe_install_llvm(
         let src_libdir = builder.llvm_out(target).join("lib");
         let llvm_dylib_path = src_libdir.join("libLLVM.dylib");
         if llvm_dylib_path.exists() {
-            builder.install(&llvm_dylib_path, dst_libdir, 0o644);
+            builder.install(&llvm_dylib_path, dst_libdir, FileType::NativeLibrary);
         }
         !builder.config.dry_run()
     } else if let llvm::LlvmBuildStatus::AlreadyBuilt(llvm::LlvmResult { llvm_config, .. }) =
@@ -2186,7 +2233,7 @@ impl Step for LlvmTools {
             let dst_bindir = format!("lib/rustlib/{}/bin", target.triple);
             for tool in tools_to_install(&builder.paths) {
                 let exe = src_bindir.join(exe(tool, target));
-                tarball.add_file(&exe, &dst_bindir, 0o755);
+                tarball.add_file(&exe, &dst_bindir, FileType::Executable);
             }
         }
 
@@ -2241,7 +2288,7 @@ impl Step for LlvmBitcodeLinker {
         tarball.set_overlay(OverlayKind::LlvmBitcodeLinker);
         tarball.is_preview(true);
 
-        tarball.add_file(llbc_linker.tool_path, self_contained_bin_dir, 0o755);
+        tarball.add_file(&llbc_linker.tool_path, self_contained_bin_dir, FileType::Executable);
 
         Some(tarball.generate())
     }
@@ -2302,7 +2349,7 @@ impl Step for RustDev {
                 let entry = t!(entry);
                 if entry.file_type().is_file() && !entry.path_is_symlink() {
                     let name = entry.file_name().to_str().unwrap();
-                    tarball.add_file(src_bindir.join(name), "bin", 0o755);
+                    tarball.add_file(src_bindir.join(name), "bin", FileType::Executable);
                 }
             }
         }
@@ -2314,11 +2361,11 @@ impl Step for RustDev {
             // We don't build LLD on some platforms, so only add it if it exists
             let lld_path = lld_out.join("bin").join(exe("lld", target));
             if lld_path.exists() {
-                tarball.add_file(lld_path, "bin", 0o755);
+                tarball.add_file(&lld_path, "bin", FileType::Executable);
             }
         }
 
-        tarball.add_file(builder.llvm_filecheck(target), "bin", 0o755);
+        tarball.add_file(builder.llvm_filecheck(target), "bin", FileType::Executable);
 
         // Copy the include directory as well; needed mostly to build
         // librustc_llvm properly (e.g., llvm-config.h is in here). But also
@@ -2379,7 +2426,11 @@ impl Step for Bootstrap {
 
         let bootstrap_outdir = &builder.bootstrap_out;
         for file in &["bootstrap", "rustc", "rustdoc"] {
-            tarball.add_file(bootstrap_outdir.join(exe(file, target)), "bootstrap/bin", 0o755);
+            tarball.add_file(
+                bootstrap_outdir.join(exe(file, target)),
+                "bootstrap/bin",
+                FileType::Executable,
+            );
         }
 
         Some(tarball.generate())
@@ -2412,7 +2463,7 @@ impl Step for BuildManifest {
         let build_manifest = builder.tool_exe(Tool::BuildManifest);
 
         let tarball = Tarball::new(builder, "build-manifest", &self.target.triple);
-        tarball.add_file(build_manifest, "bin", 0o755);
+        tarball.add_file(&build_manifest, "bin", FileType::Executable);
         tarball.generate()
     }
 }
@@ -2444,15 +2495,15 @@ impl Step for ReproducibleArtifacts {
         let mut added_anything = false;
         let tarball = Tarball::new(builder, "reproducible-artifacts", &self.target.triple);
         if let Some(path) = builder.config.rust_profile_use.as_ref() {
-            tarball.add_file(path, ".", 0o644);
+            tarball.add_file(path, ".", FileType::Regular);
             added_anything = true;
         }
         if let Some(path) = builder.config.llvm_profile_use.as_ref() {
-            tarball.add_file(path, ".", 0o644);
+            tarball.add_file(path, ".", FileType::Regular);
             added_anything = true;
         }
         for profile in &builder.config.reproducible_artifacts {
-            tarball.add_file(profile, ".", 0o644);
+            tarball.add_file(profile, ".", FileType::Regular);
             added_anything = true;
         }
         if added_anything { Some(tarball.generate()) } else { None }
@@ -2481,7 +2532,7 @@ impl Step for Gcc {
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let tarball = Tarball::new(builder, "gcc", &self.target.triple);
         let output = builder.ensure(super::gcc::Gcc { target: self.target });
-        tarball.add_file(output.libgccjit, "lib", 0o644);
+        tarball.add_file(&output.libgccjit, "lib", FileType::NativeLibrary);
         tarball.generate()
     }
 }

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1856,7 +1856,7 @@ impl Step for Extended {
                     .arg("-out")
                     .arg(&output)
                     .arg(input);
-                add_env(builder, &mut cmd, target);
+                add_env(builder, &mut cmd, target, &built_tools);
 
                 if built_tools.contains("clippy") {
                     cmd.arg("-dClippyDir=clippy");
@@ -1960,7 +1960,14 @@ impl Step for Extended {
     }
 }
 
-fn add_env(builder: &Builder<'_>, cmd: &mut BootstrapCommand, target: TargetSelection) {
+fn add_env(
+    builder: &Builder<'_>,
+    cmd: &mut BootstrapCommand,
+    target: TargetSelection,
+    built_tools: &HashSet<&'static str>,
+) {
+    // envs for wix should be always defined, even if not used
+    // FIXME: is they affect ccache?
     let mut parts = builder.version.split('.');
     cmd.env("CFG_RELEASE_INFO", builder.rust_version())
         .env("CFG_RELEASE_NUM", &builder.version)
@@ -1980,6 +1987,27 @@ fn add_env(builder: &Builder<'_>, cmd: &mut BootstrapCommand, target: TargetSele
         cmd.env("CFG_MINGW", "1").env("CFG_ABI", "GNU");
     } else {
         cmd.env("CFG_MINGW", "0").env("CFG_ABI", "MSVC");
+    }
+
+    if built_tools.contains("rustfmt") {
+        cmd.env("CFG_RUSTFMT", "1");
+    } else {
+        cmd.env("CFG_RUSTFMT", "0");
+    }
+    if built_tools.contains("clippy") {
+        cmd.env("CFG_CLIPPY", "1");
+    } else {
+        cmd.env("CFG_CLIPPY", "0");
+    }
+    if built_tools.contains("miri") {
+        cmd.env("CFG_MIRI", "1");
+    } else {
+        cmd.env("CFG_MIRI", "0");
+    }
+    if built_tools.contains("rust-analyzer") {
+        cmd.env("CFG_RA", "1");
+    } else {
+        cmd.env("CFG_RA", "0");
     }
 }
 

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1585,9 +1585,15 @@ impl Step for Extended {
             prepare("cargo");
             prepare("rust-std");
             prepare("rust-analysis");
-            prepare("clippy");
-            prepare("rust-analyzer");
-            for tool in &["rust-docs", "miri", "rustc-codegen-cranelift"] {
+
+            for tool in &[
+                "clippy",
+                "rustfmt",
+                "rust-analyzer",
+                "rust-docs",
+                "miri",
+                "rustc-codegen-cranelift",
+            ] {
                 if built_tools.contains(tool) {
                     prepare(tool);
                 }

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1966,8 +1966,6 @@ fn add_env(
     target: TargetSelection,
     built_tools: &HashSet<&'static str>,
 ) {
-    // envs for wix should be always defined, even if not used
-    // FIXME: is they affect ccache?
     let mut parts = builder.version.split('.');
     cmd.env("CFG_RELEASE_INFO", builder.rust_version())
         .env("CFG_RELEASE_NUM", &builder.version)
@@ -1989,26 +1987,14 @@ fn add_env(
         cmd.env("CFG_MINGW", "0").env("CFG_ABI", "MSVC");
     }
 
-    if built_tools.contains("rustfmt") {
-        cmd.env("CFG_RUSTFMT", "1");
-    } else {
-        cmd.env("CFG_RUSTFMT", "0");
-    }
-    if built_tools.contains("clippy") {
-        cmd.env("CFG_CLIPPY", "1");
-    } else {
-        cmd.env("CFG_CLIPPY", "0");
-    }
-    if built_tools.contains("miri") {
-        cmd.env("CFG_MIRI", "1");
-    } else {
-        cmd.env("CFG_MIRI", "0");
-    }
-    if built_tools.contains("rust-analyzer") {
-        cmd.env("CFG_RA", "1");
-    } else {
-        cmd.env("CFG_RA", "0");
-    }
+    // ensure these variables are defined
+    let mut define_optional_tool = |tool_name: &str, env_name: &str| {
+        cmd.env(env_name, if built_tools.contains(tool_name) { "1" } else { "0" });
+    };
+    define_optional_tool("rustfmt", "CFG_RUSTFMT");
+    define_optional_tool("clippy", "CFG_CLIPPY");
+    define_optional_tool("miri", "CFG_MIRI");
+    define_optional_tool("rust-analyzer", "CFG_RA");
 }
 
 fn install_llvm_file(

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1627,6 +1627,8 @@ impl Step for Extended {
                     "rust-analyzer-preview".to_string()
                 } else if name == "clippy" {
                     "clippy-preview".to_string()
+                } else if name == "rustfmt" {
+                    "rustfmt-preview".to_string()
                 } else if name == "miri" {
                     "miri-preview".to_string()
                 } else if name == "rustc-codegen-cranelift" {
@@ -1646,7 +1648,7 @@ impl Step for Extended {
             prepare("cargo");
             prepare("rust-analysis");
             prepare("rust-std");
-            for tool in &["clippy", "rust-analyzer", "rust-docs", "miri"] {
+            for tool in &["clippy", "rustfmt", "rust-analyzer", "rust-docs", "miri"] {
                 if built_tools.contains(tool) {
                     prepare(tool);
                 }
@@ -1764,6 +1766,24 @@ impl Step for Extended {
                     .arg(etc.join("msi/remove-duplicates.xsl"))
                     .run(builder);
             }
+            if built_tools.contains("rustfmt") {
+                command(&heat)
+                    .current_dir(&exe)
+                    .arg("dir")
+                    .arg("rustfmt")
+                    .args(heat_flags)
+                    .arg("-cg")
+                    .arg("RustFmtGroup")
+                    .arg("-dr")
+                    .arg("RustFmt")
+                    .arg("-var")
+                    .arg("var.RustFmtDir")
+                    .arg("-out")
+                    .arg(exe.join("RustFmtGroup.wxs"))
+                    .arg("-t")
+                    .arg(etc.join("msi/remove-duplicates.xsl"))
+                    .run(builder);
+            }
             if built_tools.contains("miri") {
                 command(&heat)
                     .current_dir(&exe)
@@ -1835,6 +1855,9 @@ impl Step for Extended {
                 if built_tools.contains("clippy") {
                     cmd.arg("-dClippyDir=clippy");
                 }
+                if built_tools.contains("rustfmt") {
+                    cmd.arg("-dRustFmtDir=rustfmt");
+                }
                 if built_tools.contains("rust-docs") {
                     cmd.arg("-dDocsDir=rust-docs");
                 }
@@ -1860,6 +1883,9 @@ impl Step for Extended {
             candle("StdGroup.wxs".as_ref());
             if built_tools.contains("clippy") {
                 candle("ClippyGroup.wxs".as_ref());
+            }
+            if built_tools.contains("rustfmt") {
+                candle("RustFmtGroup.wxs".as_ref());
             }
             if built_tools.contains("miri") {
                 candle("MiriGroup.wxs".as_ref());
@@ -1898,6 +1924,9 @@ impl Step for Extended {
 
             if built_tools.contains("clippy") {
                 cmd.arg("ClippyGroup.wixobj");
+            }
+            if built_tools.contains("rustfmt") {
+                cmd.arg("RustFmtGroup.wixobj");
             }
             if built_tools.contains("miri") {
                 cmd.arg("MiriGroup.wixobj");

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -11,7 +11,6 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::{env, fs, mem};
 
-use crate::Mode;
 use crate::core::build_steps::compile;
 use crate::core::build_steps::tool::{self, SourceType, Tool, prepare_tool_cargo};
 use crate::core::builder::{
@@ -19,6 +18,7 @@ use crate::core::builder::{
 };
 use crate::core::config::{Config, TargetSelection};
 use crate::helpers::{submodule_path_of, symlink_dir, t, up_to_date};
+use crate::{FileType, Mode};
 
 macro_rules! book {
     ($($name:ident, $path:expr, $book_name:expr, $lang:expr ;)+) => {
@@ -546,6 +546,7 @@ impl Step for SharedAssets {
         builder.copy_link(
             &builder.src.join("src").join("doc").join("rust.css"),
             &out.join("rust.css"),
+            FileType::Regular,
         );
 
         SharedAssetsPaths { version_info }

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -36,7 +36,9 @@ use crate::core::builder;
 use crate::core::builder::Kind;
 use crate::core::config::{DryRun, LldMode, LlvmLibunwind, Target, TargetSelection, flags};
 use crate::utils::exec::{BehaviorOnFailure, BootstrapCommand, CommandOutput, OutputMode, command};
-use crate::utils::helpers::{self, dir_is_empty, exe, libdir, output, set_file_times, symlink_dir};
+use crate::utils::helpers::{
+    self, dir_is_empty, exe, libdir, output, set_file_times, split_debuginfo, symlink_dir,
+};
 
 mod core;
 mod utils;
@@ -272,6 +274,35 @@ impl Mode {
 pub enum CLang {
     C,
     Cxx,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileType {
+    /// An executable binary file (like a `.exe`).
+    Executable,
+    /// A native, binary library file (like a `.so`, `.dll`, `.a`, `.lib` or `.o`).
+    NativeLibrary,
+    /// An executable (non-binary) script file (like a `.py` or `.sh`).
+    Script,
+    /// Any other regular file that is non-executable.
+    Regular,
+}
+
+impl FileType {
+    /// Get Unix permissions appropriate for this file type.
+    pub fn perms(self) -> u32 {
+        match self {
+            FileType::Executable | FileType::Script => 0o755,
+            FileType::Regular | FileType::NativeLibrary => 0o644,
+        }
+    }
+
+    pub fn could_have_split_debuginfo(self) -> bool {
+        match self {
+            FileType::Executable | FileType::NativeLibrary => true,
+            FileType::Script | FileType::Regular => false,
+        }
+    }
 }
 
 macro_rules! forward {
@@ -1744,8 +1775,18 @@ Executed at: {executed_at}"#,
     /// Attempts to use hard links if possible, falling back to copying.
     /// You can neither rely on this being a copy nor it being a link,
     /// so do not write to dst.
-    pub fn copy_link(&self, src: &Path, dst: &Path) {
+    pub fn copy_link(&self, src: &Path, dst: &Path, file_type: FileType) {
         self.copy_link_internal(src, dst, false);
+
+        if file_type.could_have_split_debuginfo() {
+            if let Some(dbg_file) = split_debuginfo(src) {
+                self.copy_link_internal(
+                    &dbg_file,
+                    &dst.with_extension(dbg_file.extension().unwrap()),
+                    false,
+                );
+            }
+        }
     }
 
     fn copy_link_internal(&self, src: &Path, dst: &Path, dereference_symlinks: bool) {
@@ -1808,7 +1849,7 @@ Executed at: {executed_at}"#,
                 t!(fs::create_dir_all(&dst));
                 self.cp_link_r(&path, &dst);
             } else {
-                self.copy_link(&path, &dst);
+                self.copy_link(&path, &dst, FileType::Regular);
             }
         }
     }
@@ -1844,7 +1885,7 @@ Executed at: {executed_at}"#,
                     self.cp_link_filtered_recurse(&path, &dst, &relative, filter);
                 } else {
                     let _ = fs::remove_file(&dst);
-                    self.copy_link(&path, &dst);
+                    self.copy_link(&path, &dst, FileType::Regular);
                 }
             }
         }
@@ -1853,10 +1894,10 @@ Executed at: {executed_at}"#,
     fn copy_link_to_folder(&self, src: &Path, dest_folder: &Path) {
         let file_name = src.file_name().unwrap();
         let dest = dest_folder.join(file_name);
-        self.copy_link(src, &dest);
+        self.copy_link(src, &dest, FileType::Regular);
     }
 
-    fn install(&self, src: &Path, dstdir: &Path, perms: u32) {
+    fn install(&self, src: &Path, dstdir: &Path, file_type: FileType) {
         if self.config.dry_run() {
             return;
         }
@@ -1866,8 +1907,16 @@ Executed at: {executed_at}"#,
         if !src.exists() {
             panic!("ERROR: File \"{}\" not found!", src.display());
         }
+
         self.copy_link_internal(src, &dst, true);
-        chmod(&dst, perms);
+        chmod(&dst, file_type.perms());
+
+        // If this file can have debuginfo, look for split debuginfo and install it too.
+        if file_type.could_have_split_debuginfo() {
+            if let Some(dbg_file) = split_debuginfo(src) {
+                self.install(&dbg_file, dstdir, FileType::Regular);
+            }
+        }
     }
 
     fn read(&self, path: &Path) -> String {

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -52,6 +52,23 @@ pub fn exe(name: &str, target: TargetSelection) -> String {
     crate::utils::shared_helpers::exe(name, &target.triple)
 }
 
+/// Returns the path to the split debug info for the specified file if it exists.
+pub fn split_debuginfo(name: impl Into<PathBuf>) -> Option<PathBuf> {
+    // FIXME: only msvc is currently supported
+
+    let path = name.into();
+    let pdb = path.with_extension("pdb");
+    if pdb.exists() {
+        return Some(pdb);
+    }
+
+    // pdbs get named with '-' replaced by '_'
+    let file_name = pdb.file_name()?.to_str()?.replace("-", "_");
+
+    let pdb: PathBuf = [path.parent()?, Path::new(&file_name)].into_iter().collect();
+    pdb.exists().then_some(pdb)
+}
+
 /// Returns `true` if the file name given looks like a dynamic library.
 pub fn is_dylib(path: &Path) -> bool {
     path.extension().and_then(|ext| ext.to_str()).is_some_and(|ext| {

--- a/src/bootstrap/src/utils/tarball.rs
+++ b/src/bootstrap/src/utils/tarball.rs
@@ -7,6 +7,7 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::FileType;
 use crate::core::build_steps::dist::distdir;
 use crate::core::builder::{Builder, Kind};
 use crate::core::config::BUILDER_CONFIG_FILENAME;
@@ -182,7 +183,12 @@ impl<'a> Tarball<'a> {
         &self.image_dir
     }
 
-    pub(crate) fn add_file(&self, src: impl AsRef<Path>, destdir: impl AsRef<Path>, perms: u32) {
+    pub(crate) fn add_file(
+        &self,
+        src: impl AsRef<Path>,
+        destdir: impl AsRef<Path>,
+        file_type: FileType,
+    ) {
         // create_dir_all fails to create `foo/bar/.`, so when the destination is "." this simply
         // uses the base directory as the destination directory.
         let destdir = if destdir.as_ref() == Path::new(".") {
@@ -192,7 +198,7 @@ impl<'a> Tarball<'a> {
         };
 
         t!(std::fs::create_dir_all(&destdir));
-        self.builder.install(src.as_ref(), &destdir, perms);
+        self.builder.install(src.as_ref(), &destdir, file_type);
     }
 
     pub(crate) fn add_renamed_file(
@@ -200,15 +206,16 @@ impl<'a> Tarball<'a> {
         src: impl AsRef<Path>,
         destdir: impl AsRef<Path>,
         new_name: &str,
+        file_type: FileType,
     ) {
         let destdir = self.image_dir.join(destdir.as_ref());
         t!(std::fs::create_dir_all(&destdir));
-        self.builder.copy_link(src.as_ref(), &destdir.join(new_name));
+        self.builder.copy_link(src.as_ref(), &destdir.join(new_name), file_type);
     }
 
     pub(crate) fn add_legal_and_readme_to(&self, destdir: impl AsRef<Path>) {
         for file in self.overlay.legal_and_readme() {
-            self.add_file(self.builder.src.join(file), destdir.as_ref(), 0o644);
+            self.add_file(self.builder.src.join(file), destdir.as_ref(), FileType::Regular);
         }
     }
 
@@ -318,11 +325,20 @@ impl<'a> Tarball<'a> {
 
         // Add config file if present.
         if let Some(config) = &self.builder.config.config {
-            self.add_renamed_file(config, &self.overlay_dir, BUILDER_CONFIG_FILENAME);
+            self.add_renamed_file(
+                config,
+                &self.overlay_dir,
+                BUILDER_CONFIG_FILENAME,
+                FileType::Regular,
+            );
         }
 
         for file in self.overlay.legal_and_readme() {
-            self.builder.install(&self.builder.src.join(file), &self.overlay_dir, 0o644);
+            self.builder.install(
+                &self.builder.src.join(file),
+                &self.overlay_dir,
+                FileType::Regular,
+            );
         }
 
         let mut cmd = self.builder.tool_cmd(crate::core::build_steps::tool::Tool::RustInstaller);

--- a/src/etc/installer/msi/rust.wxs
+++ b/src/etc/installer/msi/rust.wxs
@@ -172,6 +172,11 @@
                     <!-- tool-rust-docs-end -->
                     <Directory Id="Cargo" Name="." />
                     <Directory Id="Std" Name="." />
+                    <Directory Id="RustFmt" Name="." />
+                    <Directory Id="RustAnalyzer" Name="." />
+                    <Directory Id="Miri" Name="." />
+                    <Directory Id="Analysis" Name="." />
+                    <Directory Id="Clippy" Name="." />
                 </Directory>
             </Directory>
 
@@ -279,7 +284,41 @@
                  <ComponentRef Id="PathEnvPerMachine" />
                  <ComponentRef Id="PathEnvPerUser" />
         </Feature>
-
+        <Feature Id="RustFmt"
+                 Title="Formatter for rust"
+                 Display="7"
+                 Level="1"
+                 AllowAdvertise="no">
+                 <ComponentGroupRef Id="RustFmtGroup" />
+        </Feature>
+        <Feature Id="Clippy"
+                 Title="Formatter and checker for rust"
+                 Display="8"
+                 Level="1"
+                 AllowAdvertise="no">
+                 <ComponentGroupRef Id="ClippyGroup" />
+        </Feature>
+        <Feature Id="Miri"
+                 Title="Soundness checker for rust"
+                 Display="9"
+                 Level="1"
+                 AllowAdvertise="no">
+                 <ComponentGroupRef Id="MiriGroup" />
+        </Feature>
+        <Feature Id="RustAnalyzer"
+                 Title="Analyzer for rust"
+                 Display="10"
+                 Level="1"
+                 AllowAdvertise="no">
+                 <ComponentGroupRef Id="RustAnalyzerGroup" />
+        </Feature>
+        <Feature Id="Analysis"
+                 Title="Analysis for rust"
+                 Display="11"
+                 Level="1"
+                 AllowAdvertise="no">
+                 <ComponentGroupRef Id="AnalysisGroup" />
+        </Feature>
         <UIRef Id="RustUI" />
     </Product>
 </Wix>

--- a/src/etc/installer/msi/rust.wxs
+++ b/src/etc/installer/msi/rust.wxs
@@ -172,11 +172,19 @@
                     <!-- tool-rust-docs-end -->
                     <Directory Id="Cargo" Name="." />
                     <Directory Id="Std" Name="." />
-                    <Directory Id="RustFmt" Name="." />
-                    <Directory Id="RustAnalyzer" Name="." />
-                    <Directory Id="Miri" Name="." />
+                    <?if $(env.CFG_RUSTFMT)="1" ?>
+                        <Directory Id="RustFmt" Name="." />
+                    <?endif?>
+                    <?if $(env.CFG_RA)="1" ?>
+                        <Directory Id="RustAnalyzer" Name="." />
+                    <?endif?>
+                    <?if $(env.CFG_MIRI)="1" ?>
+                        <Directory Id="Miri" Name="." />
+                    <?endif?>
                     <Directory Id="Analysis" Name="." />
-                    <Directory Id="Clippy" Name="." />
+                    <?if $(env.CFG_CLIPPY)="1" ?>
+                        <Directory Id="Clippy" Name="." />
+                    <?endif?>
                 </Directory>
             </Directory>
 
@@ -284,34 +292,42 @@
                  <ComponentRef Id="PathEnvPerMachine" />
                  <ComponentRef Id="PathEnvPerUser" />
         </Feature>
-        <Feature Id="RustFmt"
-                 Title="Formatter for rust"
-                 Display="7"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="RustFmtGroup" />
-        </Feature>
-        <Feature Id="Clippy"
-                 Title="Formatter and checker for rust"
-                 Display="8"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="ClippyGroup" />
-        </Feature>
-        <Feature Id="Miri"
-                 Title="Soundness checker for rust"
-                 Display="9"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="MiriGroup" />
-        </Feature>
-        <Feature Id="RustAnalyzer"
-                 Title="Analyzer for rust"
-                 Display="10"
-                 Level="1"
-                 AllowAdvertise="no">
-                 <ComponentGroupRef Id="RustAnalyzerGroup" />
-        </Feature>
+        <?if $(env.CFG_RUSTFMT)="1" ?>
+            <Feature Id="RustFmt"
+                     Title="Formatter for rust"
+                     Display="7"
+                     Level="1"
+                     AllowAdvertise="no">
+                     <ComponentGroupRef Id="RustFmtGroup" />
+            </Feature>
+        <?endif?>
+        <?if $(env.CFG_CLIPPY)="1" ?>
+            <Feature Id="Clippy"
+                     Title="Formatter and checker for rust"
+                     Display="8"
+                     Level="1"
+                     AllowAdvertise="no">
+                     <ComponentGroupRef Id="ClippyGroup" />
+            </Feature>
+        <?endif?>
+        <?if $(env.CFG_MIRI)="1" ?>
+            <Feature Id="Miri"
+                     Title="Soundness checker for rust"
+                     Display="9"
+                     Level="1"
+                     AllowAdvertise="no">
+                     <ComponentGroupRef Id="MiriGroup" />
+            </Feature>
+        <?endif?>
+        <?if $(env.CFG_RA)="1" ?>
+            <Feature Id="RustAnalyzer"
+                     Title="Analyzer for rust"
+                     Display="10"
+                     Level="1"
+                     AllowAdvertise="no">
+                     <ComponentGroupRef Id="RustAnalyzerGroup" />
+            </Feature>
+        <?endif?>
         <Feature Id="Analysis"
                  Title="Analysis for rust"
                  Display="11"

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1533,6 +1533,10 @@ impl Type {
         matches!(self, Type::BorrowedRef { .. })
     }
 
+    fn is_type_alias(&self) -> bool {
+        matches!(self, Type::Path { path: Path { res: Res::Def(DefKind::TyAlias, _), .. } })
+    }
+
     /// Check if two types are "the same" for documentation purposes.
     ///
     /// This is different from `Eq`, because it knows that things like
@@ -1561,6 +1565,16 @@ impl Type {
         } else {
             (self, other)
         };
+
+        // FIXME: `Cache` does not have the data required to unwrap type aliases,
+        // so we just assume they are equal.
+        // This is only remotely acceptable because we were previously
+        // assuming all types were equal when used
+        // as a generic parameter of a type in `Deref::Target`.
+        if self_cleared.is_type_alias() || other_cleared.is_type_alias() {
+            return true;
+        }
+
         match (self_cleared, other_cleared) {
             // Recursive cases.
             (Type::Tuple(a), Type::Tuple(b)) => {

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -533,7 +533,10 @@ fn sidebar_deref_methods<'a>(
             debug!("found inner_impl: {impls:?}");
             let mut ret = impls
                 .iter()
-                .filter(|i| i.inner_impl().trait_.is_none())
+                .filter(|i| {
+                    i.inner_impl().trait_.is_none()
+                        && real_target.is_doc_subtype_of(&i.inner_impl().for_, &c)
+                })
                 .flat_map(|i| get_methods(i.inner_impl(), true, used_links, deref_mut, cx.tcx()))
                 .collect::<Vec<_>>();
             if !ret.is_empty() {

--- a/tests/mir-opt/pre-codegen/tuple_ord.demo_ge_partial.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/tuple_ord.demo_ge_partial.PreCodegen.after.mir
@@ -10,7 +10,7 @@ fn demo_ge_partial(_1: &(f32, f32), _2: &(f32, f32)) -> bool {
             let _8: bool;
             scope 3 {
             }
-            scope 4 (inlined std::cmp::impls::<impl std::cmp::SpecChainingPartialOrd<f32> for f32>::spec_chain_ge) {
+            scope 4 (inlined std::cmp::impls::<impl PartialOrd for f32>::__chaining_ge) {
                 let mut _3: f32;
                 let mut _4: f32;
                 let mut _5: bool;

--- a/tests/mir-opt/pre-codegen/tuple_ord.demo_ge_partial.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/tuple_ord.demo_ge_partial.PreCodegen.after.mir
@@ -1,0 +1,237 @@
+// MIR for `demo_ge_partial` after PreCodegen
+
+fn demo_ge_partial(_1: &(f32, f32), _2: &(f32, f32)) -> bool {
+    debug a => _1;
+    debug b => _2;
+    let mut _0: bool;
+    scope 1 (inlined std::cmp::impls::<impl PartialOrd for &(f32, f32)>::le) {
+        scope 2 (inlined core::tuple::<impl PartialOrd for (f32, f32)>::le) {
+            let mut _12: bool;
+            let _15: std::option::Option<std::cmp::Ordering>;
+            let _19: &f32;
+            let _20: &f32;
+            scope 3 {
+                let mut _9: &std::option::Option<std::cmp::Ordering>;
+                let mut _13: &std::option::Option<std::cmp::Ordering>;
+                scope 4 (inlined <Option<std::cmp::Ordering> as PartialEq>::ne) {
+                    let mut _11: bool;
+                    scope 5 (inlined <Option<std::cmp::Ordering> as PartialEq>::eq) {
+                        let mut _10: isize;
+                        let mut _16: isize;
+                        scope 6 {
+                            scope 7 (inlined <std::cmp::Ordering as PartialEq>::eq) {
+                                let _17: i8;
+                                scope 8 {
+                                    let _18: i8;
+                                    scope 9 {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                scope 10 (inlined <Option<std::cmp::Ordering> as PartialEq>::eq) {
+                    let mut _14: isize;
+                    let mut _21: isize;
+                    scope 11 {
+                        scope 12 (inlined <std::cmp::Ordering as PartialEq>::eq) {
+                            let _22: i8;
+                            scope 13 {
+                                let _23: i8;
+                                scope 14 {
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            scope 15 (inlined std::cmp::impls::<impl PartialOrd for f32>::partial_cmp) {
+                let mut _3: f32;
+                let mut _4: f32;
+                let mut _5: bool;
+                let mut _6: f32;
+                let mut _7: f32;
+                let mut _8: bool;
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_19);
+        StorageLive(_20);
+        StorageLive(_13);
+        StorageLive(_9);
+        StorageLive(_15);
+        StorageLive(_5);
+        StorageLive(_8);
+        StorageLive(_3);
+        _3 = copy ((*_1).0: f32);
+        StorageLive(_4);
+        _4 = copy ((*_2).0: f32);
+        _5 = Le(move _3, move _4);
+        StorageDead(_4);
+        StorageDead(_3);
+        StorageLive(_6);
+        _6 = copy ((*_1).0: f32);
+        StorageLive(_7);
+        _7 = copy ((*_2).0: f32);
+        _8 = Ge(move _6, move _7);
+        StorageDead(_7);
+        StorageDead(_6);
+        switchInt(copy _5) -> [0: bb1, otherwise: bb5];
+    }
+
+    bb1: {
+        switchInt(copy _8) -> [0: bb2, otherwise: bb4];
+    }
+
+    bb2: {
+        StorageDead(_8);
+        StorageDead(_5);
+        StorageLive(_12);
+        _9 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[1];
+        StorageLive(_11);
+        StorageLive(_16);
+        StorageLive(_10);
+        _10 = discriminant((*_9));
+        _11 = Eq(copy _10, const 0_isize);
+        StorageDead(_10);
+        StorageDead(_16);
+        _12 = Not(move _11);
+        StorageDead(_11);
+        switchInt(move _12) -> [0: bb11, otherwise: bb3];
+    }
+
+    bb3: {
+        _13 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[0];
+        StorageLive(_21);
+        StorageLive(_14);
+        _14 = discriminant((*_13));
+        _0 = Eq(copy _14, const 0_isize);
+        goto -> bb16;
+    }
+
+    bb4: {
+        _15 = const Option::<std::cmp::Ordering>::Some(Greater);
+        StorageDead(_8);
+        StorageDead(_5);
+        StorageLive(_12);
+        _9 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[1];
+        StorageLive(_11);
+        StorageLive(_16);
+        StorageLive(_10);
+        goto -> bb8;
+    }
+
+    bb5: {
+        switchInt(copy _8) -> [0: bb6, otherwise: bb7];
+    }
+
+    bb6: {
+        _15 = const Option::<std::cmp::Ordering>::Some(Less);
+        StorageDead(_8);
+        StorageDead(_5);
+        StorageLive(_12);
+        _9 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[1];
+        StorageLive(_11);
+        StorageLive(_16);
+        StorageLive(_10);
+        goto -> bb8;
+    }
+
+    bb7: {
+        _15 = const Option::<std::cmp::Ordering>::Some(Equal);
+        StorageDead(_8);
+        StorageDead(_5);
+        StorageLive(_12);
+        _9 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[1];
+        StorageLive(_11);
+        StorageLive(_16);
+        StorageLive(_10);
+        goto -> bb8;
+    }
+
+    bb8: {
+        _16 = discriminant((*_9));
+        switchInt(move _16) -> [0: bb9, 1: bb10, otherwise: bb18];
+    }
+
+    bb9: {
+        StorageDead(_10);
+        StorageDead(_16);
+        StorageDead(_11);
+        _13 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[0];
+        StorageLive(_21);
+        StorageLive(_14);
+        goto -> bb13;
+    }
+
+    bb10: {
+        StorageLive(_17);
+        StorageLive(_18);
+        _17 = discriminant(((_15 as Some).0: std::cmp::Ordering));
+        _18 = discriminant((((*_9) as Some).0: std::cmp::Ordering));
+        _11 = Eq(copy _17, copy _18);
+        StorageDead(_18);
+        StorageDead(_17);
+        StorageDead(_10);
+        StorageDead(_16);
+        _12 = Not(move _11);
+        StorageDead(_11);
+        switchInt(move _12) -> [0: bb11, otherwise: bb12];
+    }
+
+    bb11: {
+        _19 = &((*_1).1: f32);
+        _20 = &((*_2).1: f32);
+        _0 = <f32 as PartialOrd>::le(move _19, move _20) -> [return: bb17, unwind continue];
+    }
+
+    bb12: {
+        _13 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[0];
+        StorageLive(_21);
+        StorageLive(_14);
+        goto -> bb13;
+    }
+
+    bb13: {
+        _21 = discriminant((*_13));
+        switchInt(move _21) -> [0: bb14, 1: bb15, otherwise: bb18];
+    }
+
+    bb14: {
+        _0 = const false;
+        goto -> bb16;
+    }
+
+    bb15: {
+        StorageLive(_22);
+        StorageLive(_23);
+        _22 = discriminant(((_15 as Some).0: std::cmp::Ordering));
+        _23 = discriminant((((*_13) as Some).0: std::cmp::Ordering));
+        _0 = Eq(copy _22, copy _23);
+        StorageDead(_23);
+        StorageDead(_22);
+        goto -> bb16;
+    }
+
+    bb16: {
+        StorageDead(_14);
+        StorageDead(_21);
+        goto -> bb17;
+    }
+
+    bb17: {
+        StorageDead(_12);
+        StorageDead(_15);
+        StorageDead(_9);
+        StorageDead(_13);
+        StorageDead(_20);
+        StorageDead(_19);
+        return;
+    }
+
+    bb18: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/pre-codegen/tuple_ord.demo_ge_partial.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/tuple_ord.demo_ge_partial.PreCodegen.after.mir
@@ -4,234 +4,67 @@ fn demo_ge_partial(_1: &(f32, f32), _2: &(f32, f32)) -> bool {
     debug a => _1;
     debug b => _2;
     let mut _0: bool;
-    scope 1 (inlined std::cmp::impls::<impl PartialOrd for &(f32, f32)>::le) {
-        scope 2 (inlined core::tuple::<impl PartialOrd for (f32, f32)>::le) {
-            let mut _12: bool;
-            let _15: std::option::Option<std::cmp::Ordering>;
-            let _19: &f32;
-            let _20: &f32;
+    scope 1 (inlined std::cmp::impls::<impl PartialOrd for &(f32, f32)>::ge) {
+        scope 2 (inlined core::tuple::<impl PartialOrd for (f32, f32)>::ge) {
+            let mut _7: std::ops::ControlFlow<bool>;
+            let _8: bool;
             scope 3 {
-                let mut _9: &std::option::Option<std::cmp::Ordering>;
-                let mut _13: &std::option::Option<std::cmp::Ordering>;
-                scope 4 (inlined <Option<std::cmp::Ordering> as PartialEq>::ne) {
-                    let mut _11: bool;
-                    scope 5 (inlined <Option<std::cmp::Ordering> as PartialEq>::eq) {
-                        let mut _10: isize;
-                        let mut _16: isize;
-                        scope 6 {
-                            scope 7 (inlined <std::cmp::Ordering as PartialEq>::eq) {
-                                let _17: i8;
-                                scope 8 {
-                                    let _18: i8;
-                                    scope 9 {
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                scope 10 (inlined <Option<std::cmp::Ordering> as PartialEq>::eq) {
-                    let mut _14: isize;
-                    let mut _21: isize;
-                    scope 11 {
-                        scope 12 (inlined <std::cmp::Ordering as PartialEq>::eq) {
-                            let _22: i8;
-                            scope 13 {
-                                let _23: i8;
-                                scope 14 {
-                                }
-                            }
-                        }
-                    }
-                }
             }
-            scope 15 (inlined std::cmp::impls::<impl PartialOrd for f32>::partial_cmp) {
+            scope 4 (inlined std::cmp::impls::<impl std::cmp::SpecChainingPartialOrd<f32> for f32>::spec_chain_ge) {
                 let mut _3: f32;
                 let mut _4: f32;
                 let mut _5: bool;
-                let mut _6: f32;
-                let mut _7: f32;
-                let mut _8: bool;
+                let mut _6: bool;
+                scope 5 {
+                }
+            }
+            scope 6 (inlined std::cmp::impls::<impl PartialOrd for f32>::ge) {
+                let mut _9: f32;
+                let mut _10: f32;
             }
         }
     }
 
     bb0: {
-        StorageLive(_19);
-        StorageLive(_20);
-        StorageLive(_13);
-        StorageLive(_9);
-        StorageLive(_15);
-        StorageLive(_5);
-        StorageLive(_8);
-        StorageLive(_3);
-        _3 = copy ((*_1).0: f32);
-        StorageLive(_4);
-        _4 = copy ((*_2).0: f32);
-        _5 = Le(move _3, move _4);
-        StorageDead(_4);
-        StorageDead(_3);
-        StorageLive(_6);
-        _6 = copy ((*_1).0: f32);
         StorageLive(_7);
-        _7 = copy ((*_2).0: f32);
-        _8 = Ge(move _6, move _7);
-        StorageDead(_7);
-        StorageDead(_6);
-        switchInt(copy _5) -> [0: bb1, otherwise: bb5];
+        StorageLive(_3);
+        StorageLive(_4);
+        _3 = copy ((*_1).0: f32);
+        _4 = copy ((*_2).0: f32);
+        StorageLive(_5);
+        _5 = Eq(copy _3, copy _4);
+        switchInt(move _5) -> [0: bb1, otherwise: bb2];
     }
 
     bb1: {
-        switchInt(copy _8) -> [0: bb2, otherwise: bb4];
+        StorageLive(_6);
+        _6 = Ge(copy _3, copy _4);
+        _7 = ControlFlow::<bool>::Break(move _6);
+        StorageDead(_6);
+        StorageDead(_5);
+        StorageDead(_4);
+        StorageDead(_3);
+        _8 = copy ((_7 as Break).0: bool);
+        _0 = copy _8;
+        goto -> bb3;
     }
 
     bb2: {
-        StorageDead(_8);
         StorageDead(_5);
-        StorageLive(_12);
-        _9 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[1];
-        StorageLive(_11);
-        StorageLive(_16);
+        StorageDead(_4);
+        StorageDead(_3);
+        StorageLive(_9);
+        _9 = copy ((*_1).1: f32);
         StorageLive(_10);
-        _10 = discriminant((*_9));
-        _11 = Eq(copy _10, const 0_isize);
+        _10 = copy ((*_2).1: f32);
+        _0 = Ge(move _9, move _10);
         StorageDead(_10);
-        StorageDead(_16);
-        _12 = Not(move _11);
-        StorageDead(_11);
-        switchInt(move _12) -> [0: bb11, otherwise: bb3];
+        StorageDead(_9);
+        goto -> bb3;
     }
 
     bb3: {
-        _13 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[0];
-        StorageLive(_21);
-        StorageLive(_14);
-        _14 = discriminant((*_13));
-        _0 = Eq(copy _14, const 0_isize);
-        goto -> bb16;
-    }
-
-    bb4: {
-        _15 = const Option::<std::cmp::Ordering>::Some(Greater);
-        StorageDead(_8);
-        StorageDead(_5);
-        StorageLive(_12);
-        _9 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[1];
-        StorageLive(_11);
-        StorageLive(_16);
-        StorageLive(_10);
-        goto -> bb8;
-    }
-
-    bb5: {
-        switchInt(copy _8) -> [0: bb6, otherwise: bb7];
-    }
-
-    bb6: {
-        _15 = const Option::<std::cmp::Ordering>::Some(Less);
-        StorageDead(_8);
-        StorageDead(_5);
-        StorageLive(_12);
-        _9 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[1];
-        StorageLive(_11);
-        StorageLive(_16);
-        StorageLive(_10);
-        goto -> bb8;
-    }
-
-    bb7: {
-        _15 = const Option::<std::cmp::Ordering>::Some(Equal);
-        StorageDead(_8);
-        StorageDead(_5);
-        StorageLive(_12);
-        _9 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[1];
-        StorageLive(_11);
-        StorageLive(_16);
-        StorageLive(_10);
-        goto -> bb8;
-    }
-
-    bb8: {
-        _16 = discriminant((*_9));
-        switchInt(move _16) -> [0: bb9, 1: bb10, otherwise: bb18];
-    }
-
-    bb9: {
-        StorageDead(_10);
-        StorageDead(_16);
-        StorageDead(_11);
-        _13 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[0];
-        StorageLive(_21);
-        StorageLive(_14);
-        goto -> bb13;
-    }
-
-    bb10: {
-        StorageLive(_17);
-        StorageLive(_18);
-        _17 = discriminant(((_15 as Some).0: std::cmp::Ordering));
-        _18 = discriminant((((*_9) as Some).0: std::cmp::Ordering));
-        _11 = Eq(copy _17, copy _18);
-        StorageDead(_18);
-        StorageDead(_17);
-        StorageDead(_10);
-        StorageDead(_16);
-        _12 = Not(move _11);
-        StorageDead(_11);
-        switchInt(move _12) -> [0: bb11, otherwise: bb12];
-    }
-
-    bb11: {
-        _19 = &((*_1).1: f32);
-        _20 = &((*_2).1: f32);
-        _0 = <f32 as PartialOrd>::le(move _19, move _20) -> [return: bb17, unwind continue];
-    }
-
-    bb12: {
-        _13 = const core::tuple::<impl std::cmp::PartialOrd for (f32, f32)>::le::promoted[0];
-        StorageLive(_21);
-        StorageLive(_14);
-        goto -> bb13;
-    }
-
-    bb13: {
-        _21 = discriminant((*_13));
-        switchInt(move _21) -> [0: bb14, 1: bb15, otherwise: bb18];
-    }
-
-    bb14: {
-        _0 = const false;
-        goto -> bb16;
-    }
-
-    bb15: {
-        StorageLive(_22);
-        StorageLive(_23);
-        _22 = discriminant(((_15 as Some).0: std::cmp::Ordering));
-        _23 = discriminant((((*_13) as Some).0: std::cmp::Ordering));
-        _0 = Eq(copy _22, copy _23);
-        StorageDead(_23);
-        StorageDead(_22);
-        goto -> bb16;
-    }
-
-    bb16: {
-        StorageDead(_14);
-        StorageDead(_21);
-        goto -> bb17;
-    }
-
-    bb17: {
-        StorageDead(_12);
-        StorageDead(_15);
-        StorageDead(_9);
-        StorageDead(_13);
-        StorageDead(_20);
-        StorageDead(_19);
+        StorageDead(_7);
         return;
-    }
-
-    bb18: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/tuple_ord.demo_le_total.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/tuple_ord.demo_le_total.PreCodegen.after.mir
@@ -10,7 +10,7 @@ fn demo_le_total(_1: &(u16, i16), _2: &(u16, i16)) -> bool {
             let _8: bool;
             scope 3 {
             }
-            scope 4 (inlined std::cmp::impls::<impl std::cmp::SpecChainingPartialOrd<u16> for u16>::spec_chain_le) {
+            scope 4 (inlined std::cmp::impls::<impl PartialOrd for u16>::__chaining_le) {
                 let mut _3: u16;
                 let mut _4: u16;
                 let mut _5: bool;

--- a/tests/mir-opt/pre-codegen/tuple_ord.demo_le_total.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/tuple_ord.demo_le_total.PreCodegen.after.mir
@@ -6,140 +6,65 @@ fn demo_le_total(_1: &(u16, i16), _2: &(u16, i16)) -> bool {
     let mut _0: bool;
     scope 1 (inlined std::cmp::impls::<impl PartialOrd for &(u16, i16)>::le) {
         scope 2 (inlined core::tuple::<impl PartialOrd for (u16, i16)>::le) {
-            let mut _12: bool;
-            let _13: &i16;
-            let _14: &i16;
+            let mut _7: std::ops::ControlFlow<bool>;
+            let _8: bool;
             scope 3 {
-                let mut _6: &std::option::Option<std::cmp::Ordering>;
-                let mut _8: &std::option::Option<std::cmp::Ordering>;
-                scope 4 (inlined <Option<std::cmp::Ordering> as PartialEq>::ne) {
-                    let mut _11: bool;
-                    scope 5 (inlined <Option<std::cmp::Ordering> as PartialEq>::eq) {
-                        let mut _7: isize;
-                        scope 6 {
-                            scope 7 (inlined <std::cmp::Ordering as PartialEq>::eq) {
-                                let _9: i8;
-                                scope 8 {
-                                    let _10: i8;
-                                    scope 9 {
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                scope 10 (inlined <Option<std::cmp::Ordering> as PartialEq>::eq) {
-                    let mut _15: isize;
-                    scope 11 {
-                        scope 12 (inlined <std::cmp::Ordering as PartialEq>::eq) {
-                            let _16: i8;
-                            scope 13 {
-                                let _17: i8;
-                                scope 14 {
-                                }
-                            }
-                        }
-                    }
-                }
             }
-            scope 15 (inlined std::cmp::impls::<impl PartialOrd for u16>::partial_cmp) {
+            scope 4 (inlined std::cmp::impls::<impl std::cmp::SpecChainingPartialOrd<u16> for u16>::spec_chain_le) {
                 let mut _3: u16;
                 let mut _4: u16;
-                let mut _5: std::cmp::Ordering;
+                let mut _5: bool;
+                let mut _6: bool;
+                scope 5 {
+                }
+            }
+            scope 6 (inlined std::cmp::impls::<impl PartialOrd for i16>::le) {
+                let mut _9: i16;
+                let mut _10: i16;
             }
         }
     }
 
     bb0: {
-        StorageLive(_13);
-        StorageLive(_14);
-        StorageLive(_8);
-        StorageLive(_6);
-        StorageLive(_3);
-        _3 = copy ((*_1).0: u16);
-        StorageLive(_4);
-        _4 = copy ((*_2).0: u16);
-        _5 = Cmp(move _3, move _4);
-        StorageDead(_4);
-        StorageDead(_3);
-        StorageLive(_12);
-        _6 = const core::tuple::<impl std::cmp::PartialOrd for (u16, i16)>::le::promoted[1];
-        StorageLive(_11);
         StorageLive(_7);
-        _7 = discriminant((*_6));
-        switchInt(move _7) -> [0: bb1, 1: bb2, otherwise: bb10];
+        StorageLive(_3);
+        StorageLive(_4);
+        _3 = copy ((*_1).0: u16);
+        _4 = copy ((*_2).0: u16);
+        StorageLive(_5);
+        _5 = Eq(copy _3, copy _4);
+        switchInt(move _5) -> [0: bb1, otherwise: bb2];
     }
 
     bb1: {
-        StorageDead(_7);
-        StorageDead(_11);
-        _8 = const core::tuple::<impl std::cmp::PartialOrd for (u16, i16)>::le::promoted[0];
-        StorageLive(_15);
-        goto -> bb5;
+        StorageLive(_6);
+        _6 = Le(copy _3, copy _4);
+        _7 = ControlFlow::<bool>::Break(move _6);
+        StorageDead(_6);
+        StorageDead(_5);
+        StorageDead(_4);
+        StorageDead(_3);
+        _8 = copy ((_7 as Break).0: bool);
+        _0 = copy _8;
+        goto -> bb3;
     }
 
     bb2: {
+        StorageDead(_5);
+        StorageDead(_4);
+        StorageDead(_3);
         StorageLive(_9);
+        _9 = copy ((*_1).1: i16);
         StorageLive(_10);
-        _9 = discriminant(_5);
-        _10 = discriminant((((*_6) as Some).0: std::cmp::Ordering));
-        _11 = Eq(copy _9, copy _10);
+        _10 = copy ((*_2).1: i16);
+        _0 = Le(move _9, move _10);
         StorageDead(_10);
         StorageDead(_9);
-        StorageDead(_7);
-        _12 = Not(move _11);
-        StorageDead(_11);
-        switchInt(move _12) -> [0: bb3, otherwise: bb4];
+        goto -> bb3;
     }
 
     bb3: {
-        _13 = &((*_1).1: i16);
-        _14 = &((*_2).1: i16);
-        _0 = <i16 as PartialOrd>::le(move _13, move _14) -> [return: bb9, unwind continue];
-    }
-
-    bb4: {
-        _8 = const core::tuple::<impl std::cmp::PartialOrd for (u16, i16)>::le::promoted[0];
-        StorageLive(_15);
-        goto -> bb5;
-    }
-
-    bb5: {
-        _15 = discriminant((*_8));
-        switchInt(move _15) -> [0: bb6, 1: bb7, otherwise: bb10];
-    }
-
-    bb6: {
-        _0 = const false;
-        goto -> bb8;
-    }
-
-    bb7: {
-        StorageLive(_16);
-        StorageLive(_17);
-        _16 = discriminant(_5);
-        _17 = discriminant((((*_8) as Some).0: std::cmp::Ordering));
-        _0 = Eq(copy _16, copy _17);
-        StorageDead(_17);
-        StorageDead(_16);
-        goto -> bb8;
-    }
-
-    bb8: {
-        StorageDead(_15);
-        goto -> bb9;
-    }
-
-    bb9: {
-        StorageDead(_12);
-        StorageDead(_6);
-        StorageDead(_8);
-        StorageDead(_14);
-        StorageDead(_13);
+        StorageDead(_7);
         return;
-    }
-
-    bb10: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/tuple_ord.demo_le_total.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/tuple_ord.demo_le_total.PreCodegen.after.mir
@@ -1,0 +1,145 @@
+// MIR for `demo_le_total` after PreCodegen
+
+fn demo_le_total(_1: &(u16, i16), _2: &(u16, i16)) -> bool {
+    debug a => _1;
+    debug b => _2;
+    let mut _0: bool;
+    scope 1 (inlined std::cmp::impls::<impl PartialOrd for &(u16, i16)>::le) {
+        scope 2 (inlined core::tuple::<impl PartialOrd for (u16, i16)>::le) {
+            let mut _12: bool;
+            let _13: &i16;
+            let _14: &i16;
+            scope 3 {
+                let mut _6: &std::option::Option<std::cmp::Ordering>;
+                let mut _8: &std::option::Option<std::cmp::Ordering>;
+                scope 4 (inlined <Option<std::cmp::Ordering> as PartialEq>::ne) {
+                    let mut _11: bool;
+                    scope 5 (inlined <Option<std::cmp::Ordering> as PartialEq>::eq) {
+                        let mut _7: isize;
+                        scope 6 {
+                            scope 7 (inlined <std::cmp::Ordering as PartialEq>::eq) {
+                                let _9: i8;
+                                scope 8 {
+                                    let _10: i8;
+                                    scope 9 {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                scope 10 (inlined <Option<std::cmp::Ordering> as PartialEq>::eq) {
+                    let mut _15: isize;
+                    scope 11 {
+                        scope 12 (inlined <std::cmp::Ordering as PartialEq>::eq) {
+                            let _16: i8;
+                            scope 13 {
+                                let _17: i8;
+                                scope 14 {
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            scope 15 (inlined std::cmp::impls::<impl PartialOrd for u16>::partial_cmp) {
+                let mut _3: u16;
+                let mut _4: u16;
+                let mut _5: std::cmp::Ordering;
+            }
+        }
+    }
+
+    bb0: {
+        StorageLive(_13);
+        StorageLive(_14);
+        StorageLive(_8);
+        StorageLive(_6);
+        StorageLive(_3);
+        _3 = copy ((*_1).0: u16);
+        StorageLive(_4);
+        _4 = copy ((*_2).0: u16);
+        _5 = Cmp(move _3, move _4);
+        StorageDead(_4);
+        StorageDead(_3);
+        StorageLive(_12);
+        _6 = const core::tuple::<impl std::cmp::PartialOrd for (u16, i16)>::le::promoted[1];
+        StorageLive(_11);
+        StorageLive(_7);
+        _7 = discriminant((*_6));
+        switchInt(move _7) -> [0: bb1, 1: bb2, otherwise: bb10];
+    }
+
+    bb1: {
+        StorageDead(_7);
+        StorageDead(_11);
+        _8 = const core::tuple::<impl std::cmp::PartialOrd for (u16, i16)>::le::promoted[0];
+        StorageLive(_15);
+        goto -> bb5;
+    }
+
+    bb2: {
+        StorageLive(_9);
+        StorageLive(_10);
+        _9 = discriminant(_5);
+        _10 = discriminant((((*_6) as Some).0: std::cmp::Ordering));
+        _11 = Eq(copy _9, copy _10);
+        StorageDead(_10);
+        StorageDead(_9);
+        StorageDead(_7);
+        _12 = Not(move _11);
+        StorageDead(_11);
+        switchInt(move _12) -> [0: bb3, otherwise: bb4];
+    }
+
+    bb3: {
+        _13 = &((*_1).1: i16);
+        _14 = &((*_2).1: i16);
+        _0 = <i16 as PartialOrd>::le(move _13, move _14) -> [return: bb9, unwind continue];
+    }
+
+    bb4: {
+        _8 = const core::tuple::<impl std::cmp::PartialOrd for (u16, i16)>::le::promoted[0];
+        StorageLive(_15);
+        goto -> bb5;
+    }
+
+    bb5: {
+        _15 = discriminant((*_8));
+        switchInt(move _15) -> [0: bb6, 1: bb7, otherwise: bb10];
+    }
+
+    bb6: {
+        _0 = const false;
+        goto -> bb8;
+    }
+
+    bb7: {
+        StorageLive(_16);
+        StorageLive(_17);
+        _16 = discriminant(_5);
+        _17 = discriminant((((*_8) as Some).0: std::cmp::Ordering));
+        _0 = Eq(copy _16, copy _17);
+        StorageDead(_17);
+        StorageDead(_16);
+        goto -> bb8;
+    }
+
+    bb8: {
+        StorageDead(_15);
+        goto -> bb9;
+    }
+
+    bb9: {
+        StorageDead(_12);
+        StorageDead(_6);
+        StorageDead(_8);
+        StorageDead(_14);
+        StorageDead(_13);
+        return;
+    }
+
+    bb10: {
+        unreachable;
+    }
+}

--- a/tests/mir-opt/pre-codegen/tuple_ord.rs
+++ b/tests/mir-opt/pre-codegen/tuple_ord.rs
@@ -1,0 +1,16 @@
+//@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=0 -Z inline-mir-hint-threshold=9999
+//@ needs-unwind
+
+#![crate_type = "lib"]
+
+// EMIT_MIR tuple_ord.demo_le_total.PreCodegen.after.mir
+pub fn demo_le_total(a: &(u16, i16), b: &(u16, i16)) -> bool {
+    // CHECK-LABEL: demo_le_total
+    a <= b
+}
+
+// EMIT_MIR tuple_ord.demo_ge_partial.PreCodegen.after.mir
+pub fn demo_ge_partial(a: &(f32, f32), b: &(f32, f32)) -> bool {
+    // CHECK-LABEL: demo_ge_partial
+    a <= b
+}

--- a/tests/mir-opt/pre-codegen/tuple_ord.rs
+++ b/tests/mir-opt/pre-codegen/tuple_ord.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=0 -Z inline-mir-hint-threshold=9999
+//@ compile-flags: -O -Zmir-opt-level=2 -Cdebuginfo=0
 //@ needs-unwind
 
 #![crate_type = "lib"]
@@ -12,5 +12,5 @@ pub fn demo_le_total(a: &(u16, i16), b: &(u16, i16)) -> bool {
 // EMIT_MIR tuple_ord.demo_ge_partial.PreCodegen.after.mir
 pub fn demo_ge_partial(a: &(f32, f32), b: &(f32, f32)) -> bool {
     // CHECK-LABEL: demo_ge_partial
-    a <= b
+    a >= b
 }

--- a/tests/rustdoc/deref/deref-methods-24686-target.rs
+++ b/tests/rustdoc/deref/deref-methods-24686-target.rs
@@ -1,0 +1,27 @@
+#![crate_name = "foo"]
+
+// test for https://github.com/rust-lang/rust/issues/24686
+use std::ops::Deref;
+
+pub struct Foo<T>(T);
+impl Foo<i32> {
+    pub fn get_i32(&self) -> i32 { self.0 }
+}
+impl Foo<u32> {
+    pub fn get_u32(&self) -> u32 { self.0 }
+}
+
+// Note that the same href is used both on the method itself,
+// and on the sidebar items.
+//@ has foo/struct.Bar.html
+//@ has - '//a[@href="#method.get_i32"]' 'get_i32'
+//@ !has - '//a[@href="#method.get_u32"]' 'get_u32'
+//@ count - '//ul[@class="block deref-methods"]//a' 1
+//@ count - '//a[@href="#method.get_i32"]' 2
+pub struct Bar(Foo<i32>);
+impl Deref for Bar {
+    type Target = Foo<i32>;
+    fn deref(&self) -> &Foo<i32> {
+        &self.0
+    }
+}


### PR DESCRIPTION
Successful merges:

 - #137593 (fix download-llvm logic for subtree sync branches)
 - #137736 (Don't attempt to export compiler-builtins symbols from rust dylibs)
 - #138135 (Simplify `PartialOrd` on tuples containing primitives)
 - #138321 ([bootstrap] Distribute split debuginfo if present)
 - #138574 (rustdoc: be more strict about "Methods from Deref")
 - #138606 (Fix missing rustfmt in msi installer - cont)
 - #138671 (Fix `FileType` `PartialEq` implementation on Windows)
 - #138728 (Update `compiler-builtins` to 0.1.152)
 - #138783 (Cache current_dll_path output)
 - #138846 (Tweaks to writeback and `Obligation -> Goal` conversion)

Failed merges:

 - #138755 ([rustdoc] Remove duplicated loop when computing doc cfgs)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=137593,137736,138135,138321,138574,138606,138671,138728,138783,138846)
<!-- homu-ignore:end -->