### PR TITLE
Revert "fix download-llvm logic for subtree sync branches #137593"

### DIFF
--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -140,7 +140,6 @@ pub fn get_closest_merge_commit(
             //    cd \"/checkout\" && \"git\" \"merge-base\" \"origin/master\" \"HEAD\"\nexpected success, got: exit status: 1\n"
             // ```
             // Investigate and resolve this issue instead of skipping it like this.
-            // NOTE (2025-03): this is probably caused by CI using a sparse checkout.
             (channel == "nightly" || !CiEnv::is_rust_lang_managed_ci_job())
         {
             git_upstream_merge_base(config, git_dir).unwrap()
@@ -151,18 +150,11 @@ pub fn get_closest_merge_commit(
         }
     };
 
-    // Now that rust-lang/rust is the only repo using bors, we can search the entire
-    // history for a bors commit, not just "first parents". This is crucial to make
-    // this logic work when the user has currently checked out a subtree sync branch.
-    // At the same time, we use this logic in CI where only a tiny part of the history
-    // is even checked out, making this kind of history search very fragile. It turns
-    // out that by adding `--diff-merges=first-parent`, we get a usable reply
-    // even for sparse checkouts: it will just return the most recent bors commit.
     git.args([
         "rev-list",
         &format!("--author={}", config.git_merge_commit_email),
         "-n1",
-        "--diff-merges=first-parent",
+        "--first-parent",
         &merge_base,
     ]);
 


### PR DESCRIPTION
Reverts #137593.

It's likely because the perf machine has an old `git` version that doesn't have the `--diff-merges` option or its forwarding in `git rev-list` yet...

This reverts commit 95994f94ff5c9335426af4dec19afb5024f82fab, reversing changes made to 7290b04b0a46de2118968aa556bfc0970aac6661.

This will unfortunately re-open https://github.com/rust-lang/rust/issues/101907.

cc @RalfJung @Mark-Simulacrum for FYI
r? @onur-ozkan (or bootstrap or infra or anyone really)