### PR TITLE
Fix autofix for `self` and `self as …` in `unused_imports` lint

### DIFF
--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -337,7 +337,8 @@ fn calc_unused_spans(
                     }
                 }
                 contains_self |= use_tree.prefix == kw::SelfLower
-                    && matches!(use_tree.kind, ast::UseTreeKind::Simple(None));
+                    && matches!(use_tree.kind, ast::UseTreeKind::Simple(_))
+                    && !unused_import.unused.contains(&use_tree_id);
                 previous_unused = remove.is_some();
             }
             if unused_spans.is_empty() {

--- a/tests/ui/lint/unused/lint-unused-imports-self-single.fixed
+++ b/tests/ui/lint/unused/lint-unused-imports-self-single.fixed
@@ -1,0 +1,29 @@
+//@ run-rustfix
+
+#![deny(unused_imports)]
+#![allow(unreachable_code)]
+
+use std::collections::{self as coll};
+//~^ ERROR unused import: `HashMap`
+
+//~^ ERROR unused import: `self as std_io`
+
+use std::sync::Mutex;
+//~^ ERROR unused import: `self as std_sync`
+
+use std::sync::mpsc::Sender;
+//~^ ERROR unused import: `self as std_sync_mpsc`
+
+use std::collections::hash_map::{self as std_coll_hm};
+//~^ ERROR unused import: `Keys`
+
+use std::borrow::Cow;
+//~^ ERROR unused import: `self`
+
+fn main() {
+    let _ = coll::BTreeSet::<String>::default();
+    let _ = Mutex::new(String::new());
+    let _: Cow<'static, str> = "foo".into();
+    let _: Sender<u32> = todo!();
+    let _: std_coll_hm::Entry<'static, u32, u32> = todo!();
+}

--- a/tests/ui/lint/unused/lint-unused-imports-self-single.rs
+++ b/tests/ui/lint/unused/lint-unused-imports-self-single.rs
@@ -1,0 +1,30 @@
+//@ run-rustfix
+
+#![deny(unused_imports)]
+#![allow(unreachable_code)]
+
+use std::collections::{HashMap, self as coll};
+//~^ ERROR unused import: `HashMap`
+
+use std::io::{self as std_io};
+//~^ ERROR unused import: `self as std_io`
+
+use std::sync::{Mutex, self as std_sync};
+//~^ ERROR unused import: `self as std_sync`
+
+use std::sync::{mpsc::{self as std_sync_mpsc, Sender}};
+//~^ ERROR unused import: `self as std_sync_mpsc`
+
+use std::collections::{hash_map::{self as std_coll_hm, Keys}};
+//~^ ERROR unused import: `Keys`
+
+use std::borrow::{self, Cow};
+//~^ ERROR unused import: `self`
+
+fn main() {
+    let _ = coll::BTreeSet::<String>::default();
+    let _ = Mutex::new(String::new());
+    let _: Cow<'static, str> = "foo".into();
+    let _: Sender<u32> = todo!();
+    let _: std_coll_hm::Entry<'static, u32, u32> = todo!();
+}

--- a/tests/ui/lint/unused/lint-unused-imports-self-single.stderr
+++ b/tests/ui/lint/unused/lint-unused-imports-self-single.stderr
@@ -1,0 +1,44 @@
+error: unused import: `HashMap`
+  --> $DIR/lint-unused-imports-self-single.rs:6:24
+   |
+LL | use std::collections::{HashMap, self as coll};
+   |                        ^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-unused-imports-self-single.rs:3:9
+   |
+LL | #![deny(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+error: unused import: `self as std_io`
+  --> $DIR/lint-unused-imports-self-single.rs:9:15
+   |
+LL | use std::io::{self as std_io};
+   |               ^^^^^^^^^^^^^^
+
+error: unused import: `self as std_sync`
+  --> $DIR/lint-unused-imports-self-single.rs:12:24
+   |
+LL | use std::sync::{Mutex, self as std_sync};
+   |                        ^^^^^^^^^^^^^^^^
+
+error: unused import: `self as std_sync_mpsc`
+  --> $DIR/lint-unused-imports-self-single.rs:15:24
+   |
+LL | use std::sync::{mpsc::{self as std_sync_mpsc, Sender}};
+   |                        ^^^^^^^^^^^^^^^^^^^^^
+
+error: unused import: `Keys`
+  --> $DIR/lint-unused-imports-self-single.rs:18:56
+   |
+LL | use std::collections::{hash_map::{self as std_coll_hm, Keys}};
+   |                                                        ^^^^
+
+error: unused import: `self`
+  --> $DIR/lint-unused-imports-self-single.rs:21:19
+   |
+LL | use std::borrow::{self, Cow};
+   |                   ^^^^
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
This fixes two problems with the autofixes for the `unused_imports` lint:

- `use std::collections::{HashMap, self as coll};` would suggest, when `HashMap` is unused, the incorrect `use std::collections::self as coll;` which does not compile.
- `use std::borrow::{self, Cow};` would suggest, when `self` is unused, `use std::borrow::{Cow};`, which contains unnecessary brackets.

The first problem was reported in rust-lang/rust-clippy#14450, the second found while fixing the first one.

Fix #133750
(thanks to @richardsamuels for spotting the duplicate)