### PR TITLE
Add target maintainer information for powerpc64-unknown-linux-musl

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -250,6 +250,11 @@ v(
     "mips64el-unknown-linux-muslabi64 install directory",
 )
 v(
+    "musl-root-powerpc64",
+    "target.powerpc64-unknown-linux-musl.musl-root",
+    "powerpc64-unknown-linux-musl install directory",
+)
+v(
     "musl-root-powerpc64le",
     "target.powerpc64le-unknown-linux-musl.musl-root",
     "powerpc64le-unknown-linux-musl install directory",

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -72,6 +72,7 @@
     - [powerpc-unknown-linux-gnuspe](platform-support/powerpc-unknown-linux-gnuspe.md)
     - [powerpc-unknown-linux-muslspe](platform-support/powerpc-unknown-linux-muslspe.md)
     - [powerpc64-ibm-aix](platform-support/aix.md)
+    - [powerpc64-unknown-linux-musl](platform-support/powerpc64-unknown-linux-musl.md)
     - [powerpc64le-unknown-linux-gnu](platform-support/powerpc64le-unknown-linux-gnu.md)
     - [powerpc64le-unknown-linux-musl](platform-support/powerpc64le-unknown-linux-musl.md)
     - [riscv32e\*-unknown-none-elf](platform-support/riscv32e-unknown-none-elf.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -356,7 +356,7 @@ target | std | host | notes
 [`powerpc-wrs-vxworks-spe`](platform-support/vxworks.md) | ✓ |  |
 [`powerpc64-ibm-aix`](platform-support/aix.md) | ? |  | 64-bit AIX (7.2 and newer)
 [`powerpc64-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | PPC64 FreeBSD (ELFv2)
-`powerpc64-unknown-linux-musl` | ? |  | 64-bit PowerPC Linux with musl 1.2.3
+[`powerpc64-unknown-linux-musl`](platform-support/powerpc64-unknown-linux-musl.md) | ✓ | ✓ | PPC64 Linux (kernel 4.19, musl 1.2.3)
 [`powerpc64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | OpenBSD/powerpc64
 [`powerpc64-wrs-vxworks`](platform-support/vxworks.md) | ✓ |  |
 [`powerpc64le-unknown-freebsd`](platform-support/freebsd.md) | ✓ | ✓ | PPC64LE FreeBSD

--- a/src/doc/rustc/src/platform-support/powerpc64-unknown-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/powerpc64-unknown-linux-musl.md
@@ -1,0 +1,52 @@
+# powerpc64-unknown-linux-musl
+
+**Tier: 3**
+
+Target for 64-bit big endian PowerPC Linux programs using musl libc.
+This target uses the ELF v2 ABI.
+
+## Target maintainers
+
+- [@Gelbpunkt](https://github.com/Gelbpunkt)
+- [@famfo](https://github.com/famfo)
+- [@neuschaefer](https://github.com/neuschaefer)
+
+## Requirements
+
+Building the target itself requires a 64-bit big endian PowerPC compiler that
+is supported by `cc-rs`.
+
+## Building the target
+
+The target can be built by enabling it for a `rustc` build.
+
+```toml
+[build]
+target = ["powerpc64-unknown-linux-musl"]
+```
+
+Make sure your C compiler is included in `$PATH`, then add it to the
+`bootstrap.toml`:
+
+```toml
+[target.powerpc64-unknown-linux-musl]
+cc = "powerpc64-linux-musl-gcc"
+cxx = "powerpc64-linux-musl-g++"
+ar = "powerpc64-linux-musl-ar"
+linker = "powerpc64-linux-musl-gcc"
+```
+
+## Building Rust programs
+
+Rust does not yet ship pre-compiled artifacts for this target. To compile for
+this target, you will first need to build Rust with the target enabled (see
+"Building the target" above).
+
+## Cross-compilation
+
+This target can be cross-compiled from any host.
+
+## Testing
+
+This target can be tested as normal with `x.py` on a 64-bit big endian PowerPC
+host or via QEMU emulation.


### PR DESCRIPTION
We intend to fix the outstanding issues on the target and eventually promote it to tier 2. We have the capacity to maintain this target in the future and already perform regular builds of rustc for this target.

Currently, all host tools except miri build fine, but I have a patch for libffi-sys to make miri also compile fine for this target that is [pending review](https://github.com/tov/libffi-rs/pull/100).

While at it, add an option for the musl root for this target.

I also added a kernel version requirement, which is rather arbitrarily chosen, but it matches our tier 2 powerpc64le-unknown-linux-musl target so I think it is a good fit.