### PR TITLE
Added `get_unchecked` and `get_unchecked_mut` to `OnceLock` and `LazyLock`

### DIFF
--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -288,7 +288,7 @@ impl<T, F> LazyLock<T, F> {
     ///
     /// The lazy must be initialized
     #[inline]
-    #[unstable(feature = "once_lazy_lock_get_unchecked", issue = "1")]
+    #[unstable(feature = "once_lazy_lock_get_unchecked", issue = "138914")]
     pub unsafe fn get_unchecked(this: &LazyLock<T, F>) -> &T {
         debug_assert!(this.once.is_completed());
         unsafe { &*(*this.data.get()).value }
@@ -298,7 +298,7 @@ impl<T, F> LazyLock<T, F> {
     ///
     /// The lazy must be initialized
     #[inline]
-    #[unstable(feature = "once_lazy_lock_get_unchecked", issue = "1")]
+    #[unstable(feature = "once_lazy_lock_get_unchecked", issue = "138914")]
     pub unsafe fn get_unchecked_mut(this: &mut LazyLock<T, F>) -> &mut T {
         debug_assert!(this.once.is_completed());
         unsafe { &mut *this.data.get_mut().value }

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -535,7 +535,8 @@ impl<T> OnceLock<T> {
     ///
     /// The cell must be initialized
     #[inline]
-    unsafe fn get_unchecked(&self) -> &T {
+    #[unstable(feature = "once_lazy_lock_get_unchecked", issue = "1")]
+    pub unsafe fn get_unchecked(&self) -> &T {
         debug_assert!(self.is_initialized());
         unsafe { (&*self.value.get()).assume_init_ref() }
     }
@@ -544,7 +545,8 @@ impl<T> OnceLock<T> {
     ///
     /// The cell must be initialized
     #[inline]
-    unsafe fn get_unchecked_mut(&mut self) -> &mut T {
+    #[unstable(feature = "once_lazy_lock_get_unchecked", issue = "1")]
+    pub unsafe fn get_unchecked_mut(&mut self) -> &mut T {
         debug_assert!(self.is_initialized());
         unsafe { (&mut *self.value.get()).assume_init_mut() }
     }

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -535,7 +535,7 @@ impl<T> OnceLock<T> {
     ///
     /// The cell must be initialized
     #[inline]
-    #[unstable(feature = "once_lazy_lock_get_unchecked", issue = "1")]
+    #[unstable(feature = "once_lazy_lock_get_unchecked", issue = "138914")]
     pub unsafe fn get_unchecked(&self) -> &T {
         debug_assert!(self.is_initialized());
         unsafe { (&*self.value.get()).assume_init_ref() }
@@ -545,7 +545,7 @@ impl<T> OnceLock<T> {
     ///
     /// The cell must be initialized
     #[inline]
-    #[unstable(feature = "once_lazy_lock_get_unchecked", issue = "1")]
+    #[unstable(feature = "once_lazy_lock_get_unchecked", issue = "138914")]
     pub unsafe fn get_unchecked_mut(&mut self) -> &mut T {
         debug_assert!(self.is_initialized());
         unsafe { (&mut *self.value.get()).assume_init_mut() }


### PR DESCRIPTION
This adds methods for avoiding the atomic checks when accessing the value in a `OnceLock` or `LazyLock`