### PR TITLE
rustdoc: remove `ItemInner`.

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -115,19 +115,17 @@ fn synthesize_auto_trait_impl<'tcx>(
 
     Some(clean::Item {
         name: None,
-        inner: Box::new(clean::ItemInner {
-            attrs: Default::default(),
-            stability: None,
-            kind: clean::ImplItem(Box::new(clean::Impl {
-                safety: hir::Safety::Safe,
-                generics,
-                trait_: Some(clean_trait_ref_with_constraints(cx, trait_ref, ThinVec::new())),
-                for_: clean_middle_ty(ty::Binder::dummy(ty), cx, None, None),
-                items: Vec::new(),
-                polarity,
-                kind: clean::ImplKind::Auto,
-            })),
-        }),
+        attrs: Default::default(),
+        stability: None,
+        kind: clean::ImplItem(Box::new(clean::Impl {
+            safety: hir::Safety::Safe,
+            generics,
+            trait_: Some(clean_trait_ref_with_constraints(cx, trait_ref, ThinVec::new())),
+            for_: clean_middle_ty(ty::Binder::dummy(ty), cx, None, None),
+            items: Vec::new(),
+            polarity,
+            kind: clean::ImplKind::Auto,
+        })),
         item_id: clean::ItemId::Auto { trait_: trait_def_id, for_: item_def_id },
         cfg: None,
         inline_stmt_id: None,

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -85,44 +85,42 @@ pub(crate) fn synthesize_blanket_impls(
             blanket_impls.push(clean::Item {
                 name: None,
                 item_id: clean::ItemId::Blanket { impl_id: impl_def_id, for_: item_def_id },
-                inner: Box::new(clean::ItemInner {
-                    attrs: Default::default(),
-                    stability: None,
-                    kind: clean::ImplItem(Box::new(clean::Impl {
-                        safety: hir::Safety::Safe,
-                        generics: clean_ty_generics(
-                            cx,
-                            tcx.generics_of(impl_def_id),
-                            tcx.explicit_predicates_of(impl_def_id),
-                        ),
-                        // FIXME(eddyb) compute both `trait_` and `for_` from
-                        // the post-inference `trait_ref`, as it's more accurate.
-                        trait_: Some(clean_trait_ref_with_constraints(
-                            cx,
-                            ty::Binder::dummy(trait_ref.instantiate_identity()),
-                            ThinVec::new(),
-                        )),
-                        for_: clean_middle_ty(
-                            ty::Binder::dummy(ty.instantiate_identity()),
-                            cx,
-                            None,
-                            None,
-                        ),
-                        items: tcx
-                            .associated_items(impl_def_id)
-                            .in_definition_order()
-                            .filter(|item| !item.is_impl_trait_in_trait())
-                            .map(|item| clean_middle_assoc_item(item, cx))
-                            .collect(),
-                        polarity: ty::ImplPolarity::Positive,
-                        kind: clean::ImplKind::Blanket(Box::new(clean_middle_ty(
-                            ty::Binder::dummy(trait_ref.instantiate_identity().self_ty()),
-                            cx,
-                            None,
-                            None,
-                        ))),
-                    })),
-                }),
+                attrs: Default::default(),
+                stability: None,
+                kind: clean::ImplItem(Box::new(clean::Impl {
+                    safety: hir::Safety::Safe,
+                    generics: clean_ty_generics(
+                        cx,
+                        tcx.generics_of(impl_def_id),
+                        tcx.explicit_predicates_of(impl_def_id),
+                    ),
+                    // FIXME(eddyb) compute both `trait_` and `for_` from
+                    // the post-inference `trait_ref`, as it's more accurate.
+                    trait_: Some(clean_trait_ref_with_constraints(
+                        cx,
+                        ty::Binder::dummy(trait_ref.instantiate_identity()),
+                        ThinVec::new(),
+                    )),
+                    for_: clean_middle_ty(
+                        ty::Binder::dummy(ty.instantiate_identity()),
+                        cx,
+                        None,
+                        None,
+                    ),
+                    items: tcx
+                        .associated_items(impl_def_id)
+                        .in_definition_order()
+                        .filter(|item| !item.is_impl_trait_in_trait())
+                        .map(|item| clean_middle_assoc_item(item, cx))
+                        .collect(),
+                    polarity: ty::ImplPolarity::Positive,
+                    kind: clean::ImplKind::Blanket(Box::new(clean_middle_ty(
+                        ty::Binder::dummy(trait_ref.instantiate_identity().self_ty()),
+                        cx,
+                        None,
+                        None,
+                    ))),
+                })),
                 cfg: None,
                 inline_stmt_id: None,
             });

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -669,27 +669,25 @@ fn build_module_items(
                     // We can use the item's `DefId` directly since the only information ever used
                     // from it is `DefId.krate`.
                     item_id: ItemId::DefId(did),
-                    inner: Box::new(clean::ItemInner {
-                        attrs: Default::default(),
-                        stability: None,
-                        kind: clean::ImportItem(clean::Import::new_simple(
-                            item.ident.name,
-                            clean::ImportSource {
-                                path: clean::Path {
-                                    res,
-                                    segments: thin_vec![clean::PathSegment {
-                                        name: prim_ty.as_sym(),
-                                        args: clean::GenericArgs::AngleBracketed {
-                                            args: Default::default(),
-                                            constraints: ThinVec::new(),
-                                        },
-                                    }],
-                                },
-                                did: None,
+                    attrs: Default::default(),
+                    stability: None,
+                    kind: clean::ImportItem(clean::Import::new_simple(
+                        item.ident.name,
+                        clean::ImportSource {
+                            path: clean::Path {
+                                res,
+                                segments: thin_vec![clean::PathSegment {
+                                    name: prim_ty.as_sym(),
+                                    args: clean::GenericArgs::AngleBracketed {
+                                        args: Default::default(),
+                                        constraints: ThinVec::new(),
+                                    },
+                                }],
                             },
-                            true,
-                        )),
-                    }),
+                            did: None,
+                        },
+                        true,
+                    )),
                     cfg: None,
                     inline_stmt_id: None,
                 });

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -60,7 +60,7 @@ pub(crate) fn krate(cx: &mut DocContext<'_>) -> Crate {
     let primitives = local_crate.primitives(cx.tcx);
     let keywords = local_crate.keywords(cx.tcx);
     {
-        let ItemKind::ModuleItem(m) = &mut module.inner.kind else { unreachable!() };
+        let ItemKind::ModuleItem(m) = &mut module.kind else { unreachable!() };
         m.items.extend(primitives.iter().map(|&(def_id, prim)| {
             Item::from_def_id_and_parts(
                 def_id,

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -3,8 +3,8 @@ use std::mem;
 use crate::clean::*;
 
 pub(crate) fn strip_item(mut item: Item) -> Item {
-    if !matches!(item.inner.kind, StrippedItem(..)) {
-        item.inner.kind = StrippedItem(Box::new(item.inner.kind));
+    if !matches!(item.kind, StrippedItem(..)) {
+        item.kind = StrippedItem(Box::new(item.kind));
     }
     item
 }
@@ -102,9 +102,9 @@ pub(crate) trait DocFolder: Sized {
 
     /// don't override!
     fn fold_item_recur(&mut self, mut item: Item) -> Item {
-        item.inner.kind = match item.inner.kind {
+        item.kind = match item.kind {
             StrippedItem(box i) => StrippedItem(Box::new(self.fold_inner_recur(i))),
-            _ => self.fold_inner_recur(item.inner.kind),
+            _ => self.fold_inner_recur(item.kind),
         };
         item
     }

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -383,11 +383,7 @@ impl DocFolder for CacheBuilder<'_, '_> {
 
         // Once we've recursively found all the generics, hoard off all the
         // implementations elsewhere.
-        let ret = if let clean::Item {
-            inner: box clean::ItemInner { kind: clean::ImplItem(ref i), .. },
-            ..
-        } = item
-        {
+        let ret = if let clean::Item { kind: clean::ImplItem(ref i), .. } = item {
             // Figure out the id of this impl. This may map to a
             // primitive rather than always to a struct/enum.
             // Note: matching twice to restrict the lifetime of the `i` borrow.

--- a/src/librustdoc/formats/renderer.rs
+++ b/src/librustdoc/formats/renderer.rs
@@ -85,7 +85,7 @@ fn run_format_inner<'tcx, T: FormatRenderer<'tcx>>(
 
         cx.mod_item_in(&item)?;
         let (clean::StrippedItem(box clean::ModuleItem(module)) | clean::ModuleItem(module)) =
-            item.inner.kind
+            item.kind
         else {
             unreachable!()
         };

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -241,7 +241,7 @@ fn from_clean_item(item: clean::Item, renderer: &JsonRenderer<'_>) -> ItemEnum {
     let is_crate = item.is_crate();
     let header = item.fn_header(renderer.tcx);
 
-    match item.inner.kind {
+    match item.kind {
         ModuleItem(m) => {
             ItemEnum::Module(Module { is_crate, items: renderer.ids(m.items), is_stripped: false })
         }

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -210,7 +210,7 @@ pub(crate) fn collect_trait_impls(mut krate: Crate, cx: &mut DocContext<'_>) -> 
         }
     });
 
-    if let ModuleItem(Module { items, .. }) = &mut krate.module.inner.kind {
+    if let ModuleItem(Module { items, .. }) = &mut krate.module.kind {
         items.extend(synth_impls);
         items.extend(new_items_external);
         items.extend(new_items_local);
@@ -259,7 +259,7 @@ impl DocVisitor<'_> for ItemAndAliasCollector<'_> {
     fn visit_item(&mut self, i: &Item) {
         self.items.insert(i.item_id);
 
-        if let TypeAliasItem(alias) = &i.inner.kind
+        if let TypeAliasItem(alias) = &i.kind
             && let Some(did) = alias.type_.def_id(self.cache)
         {
             self.items.insert(ItemId::DefId(did));

--- a/src/librustdoc/passes/propagate_stability.rs
+++ b/src/librustdoc/passes/propagate_stability.rs
@@ -117,7 +117,7 @@ impl DocFolder for StabilityPropagator<'_, '_> {
             }
         };
 
-        item.inner.stability = stability;
+        item.stability = stability;
         self.parent_stability = stability;
         let item = self.fold_item_recur(item);
         self.parent_stability = parent_stability;


### PR DESCRIPTION
The `Item` struct is 48 bytes and contains a `Box<ItemInner>`; `ItemInner` is 104 bytes. This is an odd arrangement. Normally you'd have one of the following.

- A single large struct, which avoids the allocation for the `Box`, but can result in lots of wasted space in unused parts of a container like `Vec<Item>`, `HashSet<Item>`, etc.

- Or, something like struct `Item(Box<ItemInner>)`, which requires the `Box` allocation but gives a very small `Item` size, which is good for containers like `Vec<Item>`. (`Vec<Box<Item>>` would also work.)

`Item`/`ItemInner` currently gets the worst of both worlds: it always requires a `Box`, but `Item` is also pretty big and so wastes space in containers. It would make sense to push it in one direction or the other. This commit does the first option, a single large struct.

r? @ghost