### PR TITLE
rustdoc: remove useless `Symbol::is_empty` checks.

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -211,17 +211,7 @@ pub(crate) fn load_attrs<'hir>(cx: &DocContext<'hir>, did: DefId) -> &'hir [hir:
 }
 
 pub(crate) fn item_relative_path(tcx: TyCtxt<'_>, def_id: DefId) -> Vec<Symbol> {
-    tcx.def_path(def_id)
-        .data
-        .into_iter()
-        .filter_map(|elem| {
-            // extern blocks (and a few others things) have an empty name.
-            match elem.data.get_opt_name() {
-                Some(s) if !s.is_empty() => Some(s),
-                _ => None,
-            }
-        })
-        .collect()
+    tcx.def_path(def_id).data.into_iter().filter_map(|elem| elem.data.get_opt_name()).collect()
 }
 
 /// Record an external fully qualified name in the external_paths cache.

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -288,7 +288,7 @@ impl DocFolder for CacheBuilder<'_, '_> {
 
         // Keep track of the fully qualified path for this item.
         let pushed = match item.name {
-            Some(n) if !n.is_empty() => {
+            Some(n) => {
                 self.cache.stack.push(n);
                 true
             }

--- a/src/librustdoc/html/render/sidebar.rs
+++ b/src/librustdoc/html/render/sidebar.rs
@@ -731,20 +731,20 @@ fn get_methods<'a>(
 ) -> Vec<Link<'a>> {
     i.items
         .iter()
-        .filter_map(|item| match item.name {
-            Some(ref name) if !name.is_empty() && item.is_method() => {
-                if !for_deref || super::should_render_item(item, deref_mut, tcx) {
-                    Some(Link::new(
-                        get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::Method)),
-                        name.as_str(),
-                    ))
-                } else {
-                    None
-                }
+        .filter_map(|item| {
+            if let Some(ref name) = item.name
+                && item.is_method()
+                && (!for_deref || super::should_render_item(item, deref_mut, tcx))
+            {
+                Some(Link::new(
+                    get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::Method)),
+                    name.as_str(),
+                ))
+            } else {
+                None
             }
-            _ => None,
         })
-        .collect::<Vec<_>>()
+        .collect()
 }
 
 fn get_associated_constants<'a>(
@@ -753,14 +753,19 @@ fn get_associated_constants<'a>(
 ) -> Vec<Link<'a>> {
     i.items
         .iter()
-        .filter_map(|item| match item.name {
-            Some(ref name) if !name.is_empty() && item.is_associated_const() => Some(Link::new(
-                get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::AssocConst)),
-                name.as_str(),
-            )),
-            _ => None,
+        .filter_map(|item| {
+            if let Some(ref name) = item.name
+                && item.is_associated_const()
+            {
+                Some(Link::new(
+                    get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::AssocConst)),
+                    name.as_str(),
+                ))
+            } else {
+                None
+            }
         })
-        .collect::<Vec<_>>()
+        .collect()
 }
 
 fn get_associated_types<'a>(
@@ -769,12 +774,17 @@ fn get_associated_types<'a>(
 ) -> Vec<Link<'a>> {
     i.items
         .iter()
-        .filter_map(|item| match item.name {
-            Some(ref name) if !name.is_empty() && item.is_associated_type() => Some(Link::new(
-                get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::AssocType)),
-                name.as_str(),
-            )),
-            _ => None,
+        .filter_map(|item| {
+            if let Some(ref name) = item.name
+                && item.is_associated_type()
+            {
+                Some(Link::new(
+                    get_next_url(used_links, format!("{typ}.{name}", typ = ItemType::AssocType)),
+                    name.as_str(),
+                ))
+            } else {
+                None
+            }
         })
-        .collect::<Vec<_>>()
+        .collect()
 }


### PR DESCRIPTION
There are a number of `is_empty` checks that can never fail. This commit removes them, in support of #137978.

r? @GuillaumeGomez 