### PR TITLE
Update wg-prio triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -581,12 +581,12 @@ trigger_files = [
 ]
 
 [notify-zulip."I-prioritize"]
-zulip_stream = 245100 # #t-compiler/wg-prioritization/alerts
+zulip_stream = 245100 # #t-compiler/prioritization/alerts
 topic = "#{number} {title}"
 message_on_add = """\
 @*WG-prioritization/alerts* issue #{number} has been requested for prioritization.
 
-# [Procedure](https://forge.rust-lang.org/compiler/prioritization/procedure.html#assign-priority-to-unprioritized-issues-with-i-prioritize-label)
+# [Procedure](https://forge.rust-lang.org/compiler/prioritization.html)
 - Priority?
 - Regression?
 - Notify people/groups?


### PR DESCRIPTION
This completes the Zulip channel renaming after https://github.com/rust-lang/compiler-team/issues/848

Just nits: fixed a documentation link and the name of the Zulip channel for prioritization alerts.

r? @davidtwco 