### PR TITLE
Do not mix normalized and unnormalized caller bounds when constructing param-env for `receiver_is_dispatchable`

### DIFF
--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -36,21 +36,6 @@ LL | |
 LL | |         &self,
 LL | |     ) -> Self::AssocType;
    | |_________________________^ the trait `Foo` is not implemented for `Bug`
-   |
-help: consider further restricting type parameter `Bug` with trait `Foo`
-   |
-LL | pub trait ThriftService<Bug: NotFoo + Foo>:
-   |                                     +++++
-
-error[E0277]: the trait bound `Bug: Foo` is not satisfied
-  --> $DIR/issue-59324.rs:16:5
-   |
-LL | /     fn get_service(
-LL | |
-LL | |
-LL | |         &self,
-LL | |     ) -> Self::AssocType;
-   | |_________________________^ the trait `Foo` is not implemented for `Bug`
 
 error[E0277]: the trait bound `(): Foo` is not satisfied
   --> $DIR/issue-59324.rs:24:29
@@ -63,6 +48,21 @@ help: this trait has no implementations, consider adding one
    |
 LL | pub trait Foo: NotFoo {
    | ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Bug: Foo` is not satisfied
+  --> $DIR/issue-59324.rs:16:5
+   |
+LL | /     fn get_service(
+LL | |
+LL | |
+LL | |         &self,
+LL | |     ) -> Self::AssocType;
+   | |_________________________^ the trait `Foo` is not implemented for `Bug`
+   |
+help: consider further restricting type parameter `Bug` with trait `Foo`
+   |
+LL | pub trait ThriftService<Bug: NotFoo + Foo>:
+   |                                     +++++
 
 error[E0277]: the trait bound `Bug: Foo` is not satisfied
   --> $DIR/issue-59324.rs:20:10

--- a/tests/ui/self/dyn-dispatch-do-not-mix-normalized-and-unnormalized.rs
+++ b/tests/ui/self/dyn-dispatch-do-not-mix-normalized-and-unnormalized.rs
@@ -1,0 +1,26 @@
+//@ check-pass
+
+// Regression test for <https://github.com/rust-lang/rust/issues/138937>.
+
+// Previously, we'd take the normalized param env's clauses which included
+// `<PF as TraitC>::Value = i32`, which comes from the supertraits of `TraitD`
+// after normalizing `<PF as TraitC>::Value = <PF as TraitD>::Scalar`. Since
+// `normalize_param_env_or_error` ends up re-elaborating `PF: TraitD`, we'd
+// end up with both versions of this predicate (normalized and unnormalized).
+// Since these projections preds are not equal, we'd fail with ambiguity.
+
+trait TraitB<T> {}
+
+trait TraitC: TraitB<Self::Value> {
+    type Value;
+}
+
+trait TraitD: TraitC<Value = Self::Scalar> {
+    type Scalar;
+}
+
+trait TraitE {
+    fn apply<PF: TraitD<Scalar = i32>>(&self);
+}
+
+fn main() {}


### PR DESCRIPTION
See comments in code and in test I added.

r? @BoxyUwU since you reviewed the last PR, or reassign

Fixes #138937