### PR TITLE
arbitrary_self_type: insert implied Receiver bound on Deref

### DIFF
--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -128,6 +128,7 @@
 /// let x = DerefExample { value: 'a' };
 /// assert_eq!('a', *x);
 /// ```
+#[cfg(bootstrap)]
 #[lang = "deref"]
 #[doc(alias = "*")]
 #[doc(alias = "&*")]
@@ -147,6 +148,158 @@ pub trait Deref {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "deref_method"]
     fn deref(&self) -> &Self::Target;
+}
+
+/// Used for immutable dereferencing operations, like `*v`.
+///
+/// In addition to being used for explicit dereferencing operations with the
+/// (unary) `*` operator in immutable contexts, `Deref` is also used implicitly
+/// by the compiler in many circumstances. This mechanism is called
+/// ["`Deref` coercion"][coercion]. In mutable contexts, [`DerefMut`] is used and
+/// mutable deref coercion similarly occurs.
+///
+/// **Warning:** Deref coercion is a powerful language feature which has
+/// far-reaching implications for every type that implements `Deref`. The
+/// compiler will silently insert calls to `Deref::deref`. For this reason, one
+/// should be careful about implementing `Deref` and only do so when deref
+/// coercion is desirable. See [below][implementing] for advice on when this is
+/// typically desirable or undesirable.
+///
+/// Types that implement `Deref` or `DerefMut` are often called "smart
+/// pointers" and the mechanism of deref coercion has been specifically designed
+/// to facilitate the pointer-like behavior that name suggests. Often, the
+/// purpose of a "smart pointer" type is to change the ownership semantics
+/// of a contained value (for example, [`Rc`][rc] or [`Cow`][cow]) or the
+/// storage semantics of a contained value (for example, [`Box`][box]).
+///
+/// # Deref coercion
+///
+/// If `T` implements `Deref<Target = U>`, and `v` is a value of type `T`, then:
+///
+/// * In immutable contexts, `*v` (where `T` is neither a reference nor a raw
+///   pointer) is equivalent to `*Deref::deref(&v)`.
+/// * Values of type `&T` are coerced to values of type `&U`
+/// * `T` implicitly implements all the methods of the type `U` which take the
+///   `&self` receiver.
+///
+/// For more details, visit [the chapter in *The Rust Programming Language*][book]
+/// as well as the reference sections on [the dereference operator][ref-deref-op],
+/// [method resolution], and [type coercions].
+///
+/// # When to implement `Deref` or `DerefMut`
+///
+/// The same advice applies to both deref traits. In general, deref traits
+/// **should** be implemented if:
+///
+/// 1. a value of the type transparently behaves like a value of the target
+///    type;
+/// 1. the implementation of the deref function is cheap; and
+/// 1. users of the type will not be surprised by any deref coercion behavior.
+///
+/// In general, deref traits **should not** be implemented if:
+///
+/// 1. the deref implementations could fail unexpectedly; or
+/// 1. the type has methods that are likely to collide with methods on the
+///    target type; or
+/// 1. committing to deref coercion as part of the public API is not desirable.
+///
+/// Note that there's a large difference between implementing deref traits
+/// generically over many target types, and doing so only for specific target
+/// types.
+///
+/// Generic implementations, such as for [`Box<T>`][box] (which is generic over
+/// every type and dereferences to `T`) should be careful to provide few or no
+/// methods, since the target type is unknown and therefore every method could
+/// collide with one on the target type, causing confusion for users.
+/// `impl<T> Box<T>` has no methods (though several associated functions),
+/// partly for this reason.
+///
+/// Specific implementations, such as for [`String`][string] (whose `Deref`
+/// implementation has `Target = str`) can have many methods, since avoiding
+/// collision is much easier. `String` and `str` both have many methods, and
+/// `String` additionally behaves as if it has every method of `str` because of
+/// deref coercion. The implementing type may also be generic while the
+/// implementation is still specific in this sense; for example, [`Vec<T>`][vec]
+/// dereferences to `[T]`, so methods of `T` are not applicable.
+///
+/// Consider also that deref coercion means that deref traits are a much larger
+/// part of a type's public API than any other trait as it is implicitly called
+/// by the compiler. Therefore, it is advisable to consider whether this is
+/// something you are comfortable supporting as a public API.
+///
+/// The [`AsRef`] and [`Borrow`][core::borrow::Borrow] traits have very similar
+/// signatures to `Deref`. It may be desirable to implement either or both of
+/// these, whether in addition to or rather than deref traits. See their
+/// documentation for details.
+///
+/// # Fallibility
+///
+/// **This trait's method should never unexpectedly fail**. Deref coercion means
+/// the compiler will often insert calls to `Deref::deref` implicitly. Failure
+/// during dereferencing can be extremely confusing when `Deref` is invoked
+/// implicitly. In the majority of uses it should be infallible, though it may
+/// be acceptable to panic if the type is misused through programmer error, for
+/// example.
+///
+/// However, infallibility is not enforced and therefore not guaranteed.
+/// As such, `unsafe` code should not rely on infallibility in general for
+/// soundness.
+///
+/// [book]: ../../book/ch15-02-deref.html
+/// [coercion]: #deref-coercion
+/// [implementing]: #when-to-implement-deref-or-derefmut
+/// [ref-deref-op]: ../../reference/expressions/operator-expr.html#the-dereference-operator
+/// [method resolution]: ../../reference/expressions/method-call-expr.html
+/// [type coercions]: ../../reference/type-coercions.html
+/// [box]: ../../alloc/boxed/struct.Box.html
+/// [string]: ../../alloc/string/struct.String.html
+/// [vec]: ../../alloc/vec/struct.Vec.html
+/// [rc]: ../../alloc/rc/struct.Rc.html
+/// [cow]: ../../alloc/borrow/enum.Cow.html
+///
+/// # Examples
+///
+/// A struct with a single field which is accessible by dereferencing the
+/// struct.
+///
+/// ```
+/// use std::ops::Deref;
+///
+/// struct DerefExample<T> {
+///     value: T
+/// }
+///
+/// impl<T> Deref for DerefExample<T> {
+///     type Target = T;
+///
+///     fn deref(&self) -> &Self::Target {
+///         &self.value
+///     }
+/// }
+///
+/// let x = DerefExample { value: 'a' };
+/// assert_eq!('a', *x);
+/// ```
+#[cfg(not(bootstrap))]
+#[lang = "deref"]
+#[doc(alias = "*")]
+#[doc(alias = "&*")]
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_diagnostic_item = "Deref"]
+#[const_trait]
+#[rustc_const_unstable(feature = "const_deref", issue = "88955")]
+pub trait Deref: Receiver<Target = <Self as Deref>::Target> {
+    /// The resulting type after dereferencing.
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_diagnostic_item = "deref_target"]
+    #[lang = "deref_target"]
+    type Target: ?Sized;
+
+    /// Dereferences the value.
+    #[must_use]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_diagnostic_item = "deref_method"]
+    fn deref(&self) -> &<Self as Deref>::Target;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -271,7 +424,7 @@ pub trait DerefMut: ~const Deref {
     /// Mutably dereferences the value.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "deref_mut_method"]
-    fn deref_mut(&mut self) -> &mut Self::Target;
+    fn deref_mut(&mut self) -> &mut <Self as Deref>::Target;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/tests/ui/associated-types/defaults-unsound-62211-1.current.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.current.stderr
@@ -1,68 +1,14 @@
-error[E0277]: `Self` doesn't implement `std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-1.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
-   |
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:24:86
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + std::fmt::Display {
-   |                            +++++++++++++++++++
-
-error[E0277]: cannot add-assign `&'static str` to `Self`
-  --> $DIR/defaults-unsound-62211-1.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ no implementation for `Self += &'static str`
-   |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:24:47
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
-   |                            +++++++++++++++++++++++++
-
 error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:24:96
+  --> $DIR/defaults-unsound-62211-1.rs:22:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:24:25
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + Deref {
    |                            +++++++
 
-error[E0277]: the trait bound `Self: Copy` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
-   |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:24:18
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                  ^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + Copy {
-   |                            ++++++
-
-error: aborting due to 4 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.next.stderr
@@ -1,68 +1,14 @@
-error[E0277]: `Self` doesn't implement `std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-1.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
-   |
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:24:86
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + std::fmt::Display {
-   |                            +++++++++++++++++++
-
-error[E0277]: cannot add-assign `&'static str` to `Self`
-  --> $DIR/defaults-unsound-62211-1.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ no implementation for `Self += &'static str`
-   |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:24:47
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
-   |                            +++++++++++++++++++++++++
-
 error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:24:96
+  --> $DIR/defaults-unsound-62211-1.rs:22:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:24:31
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                               ^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + Deref {
    |                            +++++++
 
-error[E0277]: the trait bound `Self: Copy` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
-   |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-1.rs:24:18
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                  ^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + Copy {
-   |                            ++++++
-
-error: aborting due to 4 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/defaults-unsound-62211-1.rs
+++ b/tests/ui/associated-types/defaults-unsound-62211-1.rs
@@ -13,19 +13,14 @@
 
 #![feature(associated_type_defaults)]
 
-use std::{
-    fmt::Display,
-    ops::{AddAssign, Deref},
-};
+use std::fmt::Display;
+use std::ops::{AddAssign, Deref};
 
 trait UncheckedCopy: Sized {
     // This Output is said to be Copy. Yet we default to Self
-    // and it's accepted, not knowing if Self ineed is Copy
+    // and it's accepted, not knowing if Self indeed is Copy
     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-    //~^ ERROR the trait bound `Self: Copy` is not satisfied
-    //~| ERROR the trait bound `Self: Deref` is not satisfied
-    //~| ERROR cannot add-assign `&'static str` to `Self`
-    //~| ERROR `Self` doesn't implement `std::fmt::Display`
+    //~^ ERROR the trait bound `Self: Deref` is not satisfied
 
     // We said the Output type was Copy, so we can Copy it freely!
     fn unchecked_copy(other: &Self::Output) -> Self::Output {

--- a/tests/ui/associated-types/defaults-unsound-62211-2.current.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.current.stderr
@@ -1,68 +1,14 @@
-error[E0277]: `Self` doesn't implement `std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-2.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
-   |
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:24:86
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + std::fmt::Display {
-   |                            +++++++++++++++++++
-
-error[E0277]: cannot add-assign `&'static str` to `Self`
-  --> $DIR/defaults-unsound-62211-2.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ no implementation for `Self += &'static str`
-   |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:24:47
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
-   |                            +++++++++++++++++++++++++
-
 error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:24:96
+  --> $DIR/defaults-unsound-62211-2.rs:22:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:24:25
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                         ^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + Deref {
    |                            +++++++
 
-error[E0277]: the trait bound `Self: Copy` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
-   |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:24:18
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                  ^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + Copy {
-   |                            ++++++
-
-error: aborting due to 4 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.next.stderr
@@ -1,68 +1,14 @@
-error[E0277]: `Self` doesn't implement `std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-2.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
-   |
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:24:86
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                      ^^^^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + std::fmt::Display {
-   |                            +++++++++++++++++++
-
-error[E0277]: cannot add-assign `&'static str` to `Self`
-  --> $DIR/defaults-unsound-62211-2.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ no implementation for `Self += &'static str`
-   |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:24:47
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
-   |                            +++++++++++++++++++++++++
-
 error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:24:96
+  --> $DIR/defaults-unsound-62211-2.rs:22:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
    |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:24:31
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                               ^^^^^^^^^^^^ required by this bound in `UncheckedCopy::Output`
 help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + Deref {
    |                            +++++++
 
-error[E0277]: the trait bound `Self: Copy` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:24:96
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
-   |
-note: required by a bound in `UncheckedCopy::Output`
-  --> $DIR/defaults-unsound-62211-2.rs:24:18
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |                  ^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + Copy {
-   |                            ++++++
-
-error: aborting due to 4 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-types/defaults-unsound-62211-2.rs
+++ b/tests/ui/associated-types/defaults-unsound-62211-2.rs
@@ -13,19 +13,14 @@
 
 #![feature(associated_type_defaults)]
 
-use std::{
-    fmt::Display,
-    ops::{AddAssign, Deref},
-};
+use std::fmt::Display;
+use std::ops::{AddAssign, Deref};
 
 trait UncheckedCopy: Sized {
     // This Output is said to be Copy. Yet we default to Self
-    // and it's accepted, not knowing if Self ineed is Copy
+    // and it's accepted, not knowing if Self indeed is Copy
     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-    //~^ ERROR the trait bound `Self: Copy` is not satisfied
-    //~| ERROR the trait bound `Self: Deref` is not satisfied
-    //~| ERROR cannot add-assign `&'static str` to `Self`
-    //~| ERROR `Self` doesn't implement `std::fmt::Display`
+    //~^ ERROR the trait bound `Self: Deref` is not satisfied
 
     // We said the Output type was Copy, so we can Copy it freely!
     fn unchecked_copy(other: &Self::Output) -> Self::Output {

--- a/tests/ui/attributes/dump-preds.stderr
+++ b/tests/ui/attributes/dump-preds.stderr
@@ -33,6 +33,8 @@ LL |     type Assoc<P: Eq>: std::ops::Deref<Target = ()>
    |
    = note: Binder { value: ProjectionPredicate(AliasTerm { args: [Alias(Projection, AliasTy { args: [Self/#0, T/#1, P/#2], def_id: DefId(..), .. })], def_id: DefId(..), .. }, Term::Ty(())), bound_vars: [] }
    = note: Binder { value: TraitPredicate(<<Self as Trait<T>>::Assoc<P> as std::ops::Deref>, polarity:Positive), bound_vars: [] }
+   = note: Binder { value: ProjectionPredicate(AliasTerm { args: [Alias(Projection, AliasTy { args: [Self/#0, T/#1, P/#2], def_id: DefId(..), .. })], def_id: DefId(..), .. }, Term::Ty(Alias(Projection, AliasTy { args: [Alias(Projection, AliasTy { args: [Self/#0, T/#1, P/#2], def_id: DefId(..), .. })], def_id: DefId(..), .. }))), bound_vars: [] }
+   = note: Binder { value: TraitPredicate(<<Self as Trait<T>>::Assoc<P> as std::ops::Receiver>, polarity:Positive), bound_vars: [] }
    = note: Binder { value: TraitPredicate(<<Self as Trait<T>>::Assoc<P> as std::marker::Sized>, polarity:Positive), bound_vars: [] }
 
 error: aborting due to 3 previous errors


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
r? @nikomatsakis 

This is an experimental setup which allows us to assess the impact from inserting an implied supertrait bound `Deref: Receiver`.

The observations are as follows.
- Thanks to the trait solver, not too many hacks are needed to implement the idea behind [this comment](https://github.com/rust-lang/rust/pull/135881#issuecomment-2718417230), where inductive cycles are admissible.
- We want to allow users to continue use the `dyn Deref` type as `Deref` has been `dyn`-compatible. Following the current `dyn`-compatibility rule, it would have been impossible to use `dyn Deref<Target = ..>` because one would need to write `dyn Deref<..> + Receiver<..>` while neither `Deref` nor `Receiver` is an `auto` trait. This is the main change that this PR proposes: we fill in the missing projection bound that `Receiver` demands from a `dyn Deref` and this will remain the only exception.
- Finally, the type (pretty-)printing is adjusted so as to not present the frivolous `Receiver::Target = ..` bound. It will always be the same term as `Deref::Target`.

I am proposing a crater experiment to see the extent of impact on the existing ecosystem and explore corner cases that I have missed.