### PR TITLE
Ensure `define_opaque` attrs are accounted for in HIR hash

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -625,7 +625,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
         // Don't hash unless necessary, because it's expensive.
         let (opt_hash_including_bodies, attrs_hash) =
-            self.tcx.hash_owner_nodes(node, &bodies, &attrs);
+            self.tcx.hash_owner_nodes(node, &bodies, &attrs, define_opaque);
         let num_nodes = self.item_local_id_counter.as_usize();
         let (nodes, parenting) = index::index_hir(self.tcx, node, &bodies, num_nodes);
         let nodes = hir::OwnerNodes { opt_hash_including_bodies, nodes, bodies };

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1288,7 +1288,8 @@ impl<'tcx> TyCtxtFeed<'tcx, LocalDefId> {
         let bodies = Default::default();
         let attrs = hir::AttributeMap::EMPTY;
 
-        let (opt_hash_including_bodies, _) = self.tcx.hash_owner_nodes(node, &bodies, &attrs.map);
+        let (opt_hash_including_bodies, _) =
+            self.tcx.hash_owner_nodes(node, &bodies, &attrs.map, attrs.define_opaque);
         let node = node.into();
         self.opt_hir_owner_nodes(Some(self.tcx.arena.alloc(hir::OwnerNodes {
             opt_hash_including_bodies,

--- a/tests/incremental/define-opaques.rs
+++ b/tests/incremental/define-opaques.rs
@@ -1,0 +1,19 @@
+//@ revisions: rpass1 cfail2
+
+#![feature(type_alias_impl_trait)]
+
+pub type Foo = impl Sized;
+
+#[cfg_attr(rpass1, define_opaque())]
+#[cfg_attr(cfail2, define_opaque(Foo))]
+fn a() {
+    //[cfail2]~^ ERROR item does not constrain `Foo::{opaque#0}`
+    let _: Foo = b();
+}
+
+#[define_opaque(Foo)]
+fn b() -> Foo {
+    ()
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #138948

r? oli-obk