### PR TITLE
Collect items referenced from var_debug_info

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -231,7 +231,7 @@ use rustc_middle::ty::{
 use rustc_middle::util::Providers;
 use rustc_middle::{bug, span_bug};
 use rustc_session::Limit;
-use rustc_session::config::EntryFnType;
+use rustc_session::config::{DebugInfo, EntryFnType};
 use rustc_span::source_map::{Spanned, dummy_spanned, respan};
 use rustc_span::{DUMMY_SP, Span};
 use tracing::{debug, instrument, trace};
@@ -1235,6 +1235,11 @@ fn collect_items_of_instance<'tcx>(
     };
 
     if mode == CollectionMode::UsedItems {
+        if tcx.sess.opts.debuginfo == DebugInfo::Full {
+            for var_debug_info in &body.var_debug_info {
+                collector.visit_var_debug_info(var_debug_info);
+            }
+        }
         for (bb, data) in traversal::mono_reachable(body, tcx, instance) {
             collector.visit_basic_block_data(bb, data)
         }

--- a/tests/ui/mir/var_debug_ref.rs
+++ b/tests/ui/mir/var_debug_ref.rs
@@ -1,0 +1,24 @@
+// Regression test for #138942, where a function was incorrectly internalized, despite the fact
+// that it was referenced by a var debug info from another code generation unit.
+//
+//@ build-pass
+//@ revisions: limited full
+//@ compile-flags: -Ccodegen-units=4
+//@[limited] compile-flags: -Cdebuginfo=limited
+//@[full]    compile-flags: -Cdebuginfo=full
+trait Fun {
+    const FUN: &'static fn();
+}
+impl Fun for () {
+    const FUN: &'static fn() = &(detail::f as fn());
+}
+mod detail {
+    // Place `f` in a distinct module to generate a separate code generation unit.
+    #[inline(never)]
+    pub(super) fn f() {}
+}
+fn main() {
+    // SingleUseConsts represents "x" using VarDebugInfoContents::Const.
+    // It is the only reference to `f` remaining.
+    let x = <() as ::Fun>::FUN;
+}


### PR DESCRIPTION
The collection is limited to full debuginfo builds to match behavior of FunctionCx::compute_per_local_var_debug_info.

Fixes #138942.