### PR TITLE
[EXPERIMENTAL] Check `--print=native-static-libs` cross to `i686-unknown-linux-gnu`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1560,17 +1560,13 @@ fn print_native_static_libs(
     match out {
         OutFileName::Real(path) => {
             out.overwrite(&lib_args.join(" "), sess);
-            if !lib_args.is_empty() {
-                sess.dcx().emit_note(errors::StaticLibraryNativeArtifactsToFile { path });
-            }
+            sess.dcx().emit_note(errors::StaticLibraryNativeArtifactsToFile { path });
         }
         OutFileName::Stdout => {
-            if !lib_args.is_empty() {
-                sess.dcx().emit_note(errors::StaticLibraryNativeArtifacts);
-                // Prefix for greppability
-                // Note: This must not be translated as tools are allowed to depend on this exact string.
-                sess.dcx().note(format!("native-static-libs: {}", lib_args.join(" ")));
-            }
+            sess.dcx().emit_note(errors::StaticLibraryNativeArtifacts);
+            // Prefix for greppability
+            // Note: This must not be translated as tools are allowed to depend on this exact string.
+            sess.dcx().note(format!("native-static-libs: {}", lib_args.join(" ")));
         }
     }
 }

--- a/tests/ui/codegen/empty-static-libs-issue-108825.rs
+++ b/tests/ui/codegen/empty-static-libs-issue-108825.rs
@@ -5,7 +5,7 @@
 //@ build-pass
 //@ error-pattern: note: native-static-libs:
 //@ dont-check-compiler-stderr libcore links `/defaultlib:msvcrt` or `/defaultlib:libcmt` on MSVC
-//@ ignore-cross-compile doesn't produce any output on i686-unknown-linux-gnu for some reason?
+//-@ ignore-cross-compile doesn't produce any output on i686-unknown-linux-gnu for some reason?
 
 #![crate_type = "staticlib"]
 #![no_std]

--- a/tests/ui/codegen/empty-static-libs-issue-108825.rs
+++ b/tests/ui/codegen/empty-static-libs-issue-108825.rs
@@ -1,0 +1,16 @@
+//! Test that linking a no_std application still outputs the
+//! `native-static-libs: ` note, even though it's empty.
+
+//@ compile-flags: -Cpanic=abort --print=native-static-libs
+//@ build-pass
+//@ error-pattern: note: native-static-libs:
+//@ dont-check-compiler-stderr libcore links `/defaultlib:msvcrt` or `/defaultlib:libcmt` on MSVC
+//@ ignore-cross-compile doesn't produce any output on i686-unknown-linux-gnu for some reason?
+
+#![crate_type = "staticlib"]
+#![no_std]
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}


### PR DESCRIPTION
r? @ghost

try-job: `*i686*`