### PR TITLE
Remove unneeded LLVM CI test assertions

### DIFF
--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -24,31 +24,11 @@ pub(crate) fn parse(config: &str) -> Config {
 
 #[test]
 fn download_ci_llvm() {
-    let config = parse("");
-    let is_available = llvm::is_ci_llvm_available_for_target(&config, config.llvm_assertions);
-    if is_available {
-        assert!(config.llvm_from_ci);
-    }
-
-    let config = Config::parse_inner(
-        Flags::parse(&[
-            "check".to_string(),
-            "--config=/does/not/exist".to_string(),
-            "--ci".to_string(),
-            "false".to_string(),
-        ]),
-        |&_| toml::from_str("llvm.download-ci-llvm = true"),
-    );
-    let is_available = llvm::is_ci_llvm_available_for_target(&config, config.llvm_assertions);
-    if is_available {
-        assert!(config.llvm_from_ci);
-    }
-
     let config = parse("llvm.download-ci-llvm = false");
     assert!(!config.llvm_from_ci);
 
     let if_unchanged_config = parse("llvm.download-ci-llvm = \"if-unchanged\"");
-    if if_unchanged_config.llvm_from_ci {
+    if if_unchanged_config.llvm_from_ci && if_unchanged_config.is_running_on_ci {
         let has_changes = if_unchanged_config
             .last_modified_commit(LLVM_INVALIDATION_PATHS, "download-ci-llvm", true)
             .is_none();


### PR DESCRIPTION
The `download_ci_llvm` bootstrap test was checking implementation details of the LLVM CI download check, which isn't very useful. It was essentially testing "if function_that_checks_if_llvm_ci_is_available returns true, we enable CI LLVM", but the usage of the function was an implementation detail. After https://github.com/rust-lang/rust/pull/138704, the inner implementation has changed, so the test now breaks if LLVM is updated.

I don't think that it's very useful to test implementation details like this, without taking the outside git state into account. Ideally, we should mock the git state for the test, otherwise the test will randomly break when executed in environments which the test does not control (e.g. on CI when a LLVM change happens).

I only kept the part of the test that checks that LLVM CI isn't used when we specify `download-ci-llvm = false`, as that should hold under all conditions, CI/local, and all git states.

I also kept the `if-unchanged` assertion, but only on CI, and as a temporary measure. After https://github.com/rust-lang/rust/pull/138591, we should have a proper way of mocking the git state to make the test robust, and make it test what we actually want.

Fixes [this](https://github.com/rust-lang/rust/pull/138784#issuecomment-2751460456).

r? @ghost