### PR TITLE
Use `abs_diff` where applicable

### DIFF
--- a/compiler/rustc_errors/src/snippet.rs
+++ b/compiler/rustc_errors/src/snippet.rs
@@ -159,11 +159,7 @@ impl Annotation {
     /// Length of this annotation as displayed in the stderr output
     pub(crate) fn len(&self) -> usize {
         // Account for usize underflows
-        if self.end_col.display > self.start_col.display {
-            self.end_col.display - self.start_col.display
-        } else {
-            self.start_col.display - self.end_col.display
-        }
+        self.end_col.display.abs_diff(self.start_col.display)
     }
 
     pub(crate) fn has_label(&self) -> bool {

--- a/compiler/rustc_span/src/edit_distance.rs
+++ b/compiler/rustc_span/src/edit_distance.rs
@@ -118,7 +118,7 @@ pub fn edit_distance_with_substrings(a: &str, b: &str, limit: usize) -> Option<u
     // Check one isn't less than half the length of the other. If this is true then there is a
     // big difference in length.
     let big_len_diff = (n * 2) < m || (m * 2) < n;
-    let len_diff = if n < m { m - n } else { n - m };
+    let len_diff = m.abs_diff(n);
     let distance = edit_distance(a, b, limit + len_diff)?;
 
     // This is the crux, subtracting length difference means exact substring matches will now be 0


### PR DESCRIPTION
Very small cleanup, dogfooding a [new clippy lint](https://github.com/rust-lang/rust-clippy/pull/14482) I'm trying to add