### PR TITLE
Make target maintainers more easily pingable

### DIFF
--- a/src/doc/rustc/src/platform-support/TEMPLATE.md
+++ b/src/doc/rustc/src/platform-support/TEMPLATE.md
@@ -6,7 +6,8 @@ One-sentence description of the target (e.g. CPU, OS)
 
 ## Target maintainers
 
-- Some Person, https://github.com/...
+[@Ghost](https://github.com/Ghost)
+[@octocat](https://github.com/octocat)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/aarch64-nintendo-switch-freestanding.md
+++ b/src/doc/rustc/src/platform-support/aarch64-nintendo-switch-freestanding.md
@@ -4,10 +4,10 @@
 
 Nintendo Switch with pure-Rust toolchain.
 
-## Designated Developers
+## Target Maintainers
 
-* [@leo60228](https://github.com/leo60228)
-* [@jam1garner](https://github.com/jam1garner)
+[@leo60228](https://github.com/leo60228)
+[@jam1garner](https://github.com/jam1garner)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/aarch64-unknown-teeos.md
+++ b/src/doc/rustc/src/platform-support/aarch64-unknown-teeos.md
@@ -20,8 +20,8 @@ TEEOS is open source in progress. [MORE about](https://gitee.com/opentrustee-gro
 
 ## Target maintainers
 
-- Petrochenkov Vadim
-- Sword-Destiny
+[@petrochenkov](https://github.com/petrochenkov)
+[@Sword-Destiny](https://github.com/Sword-Destiny)
 
 ## Setup
 We use OpenHarmony SDK for TEEOS.

--- a/src/doc/rustc/src/platform-support/aix.md
+++ b/src/doc/rustc/src/platform-support/aix.md
@@ -6,8 +6,8 @@ Rust for AIX operating system, currently only 64-bit PowerPC is supported.
 
 ## Target maintainers
 
-- David Tenty `daltenty@ibm.com`, https://github.com/daltenty
-- Chris Cambly, `ccambly@ca.ibm.com`, https://github.com/gilamn5tr
+[@daltenty](https://github.com/daltenty)
+[@gilamn5tr](https://github.com/gilamn5tr)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/amdgcn-amd-amdhsa.md
+++ b/src/doc/rustc/src/platform-support/amdgcn-amd-amdhsa.md
@@ -6,7 +6,7 @@ AMD GPU target for compute/HSA (Heterogeneous System Architecture).
 
 ## Target maintainers
 
-- [@Flakebi](https://github.com/Flakebi)
+[@Flakebi](https://github.com/Flakebi)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/android.md
+++ b/src/doc/rustc/src/platform-support/android.md
@@ -8,9 +8,9 @@
 
 ## Target maintainers
 
-- Chris Wailes ([@chriswailes](https://github.com/chriswailes))
-- Matthew Maurer ([@maurer](https://github.com/maurer))
-- Martin Geisler ([@mgeisler](https://github.com/mgeisler))
+[@chriswailes](https://github.com/chriswailes)
+[@maurer](https://github.com/maurer)
+[@mgeisler](https://github.com/mgeisler)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/apple-darwin.md
@@ -9,8 +9,8 @@ Apple macOS targets.
 
 ## Target maintainers
 
-- [@thomcc](https://github.com/thomcc)
-- [@madsmtm](https://github.com/madsmtm)
+[@thomcc](https://github.com/thomcc)
+[@madsmtm](https://github.com/madsmtm)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/apple-ios-macabi.md
+++ b/src/doc/rustc/src/platform-support/apple-ios-macabi.md
@@ -9,9 +9,9 @@ Apple Mac Catalyst targets.
 
 ## Target maintainers
 
-- [@badboy](https://github.com/badboy)
-- [@BlackHoleFox](https://github.com/BlackHoleFox)
-- [@madsmtm](https://github.com/madsmtm)
+[@badboy](https://github.com/badboy)
+[@BlackHoleFox](https://github.com/BlackHoleFox)
+[@madsmtm](https://github.com/madsmtm)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/apple-ios.md
+++ b/src/doc/rustc/src/platform-support/apple-ios.md
@@ -15,9 +15,9 @@ Apple iOS / iPadOS targets.
 
 ## Target maintainers
 
-- [@badboy](https://github.com/badboy)
-- [@deg4uss3r](https://github.com/deg4uss3r)
-- [@madsmtm](https://github.com/madsmtm)
+[@badboy](https://github.com/badboy)
+[@deg4uss3r](https://github.com/deg4uss3r)
+[@madsmtm](https://github.com/madsmtm)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/apple-tvos.md
+++ b/src/doc/rustc/src/platform-support/apple-tvos.md
@@ -10,8 +10,8 @@ Apple tvOS targets.
 
 ## Target maintainers
 
-- [@thomcc](https://github.com/thomcc)
-- [@madsmtm](https://github.com/madsmtm)
+[@thomcc](https://github.com/thomcc)
+[@madsmtm](https://github.com/madsmtm)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/apple-visionos.md
+++ b/src/doc/rustc/src/platform-support/apple-visionos.md
@@ -9,8 +9,8 @@ Apple visionOS / xrOS targets.
 
 ## Target maintainers
 
-- [@agg23](https://github.com/agg23)
-- [@madsmtm](https://github.com/madsmtm)
+[@agg23](https://github.com/agg23)
+[@madsmtm](https://github.com/madsmtm)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/apple-watchos.md
+++ b/src/doc/rustc/src/platform-support/apple-watchos.md
@@ -12,10 +12,10 @@ Apple watchOS targets.
 
 ## Target maintainers
 
-- [@deg4uss3r](https://github.com/deg4uss3r)
-- [@vladimir-ea](https://github.com/vladimir-ea)
-- [@leohowell](https://github.com/leohowell)
-- [@madsmtm](https://github.com/madsmtm)
+[@deg4uss3r](https://github.com/deg4uss3r)
+[@vladimir-ea](https://github.com/vladimir-ea)
+[@leohowell](https://github.com/leohowell)
+[@madsmtm](https://github.com/madsmtm)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/arm64e-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/arm64e-apple-darwin.md
@@ -6,7 +6,7 @@ ARM64e macOS (11.0+, Big Sur+)
 
 ## Target maintainers
 
-- Artyom Tetyukhin ([@arttet](https://github.com/arttet))
+[@arttet](https://github.com/arttet)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/arm64e-apple-ios.md
+++ b/src/doc/rustc/src/platform-support/arm64e-apple-ios.md
@@ -6,7 +6,7 @@ ARM64e iOS (14.0+)
 
 ## Target maintainers
 
-- Artyom Tetyukhin ([@arttet](https://github.com/arttet))
+[@arttet](https://github.com/arttet)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/arm64e-apple-tvos.md
+++ b/src/doc/rustc/src/platform-support/arm64e-apple-tvos.md
@@ -6,7 +6,7 @@ ARM64e tvOS (10.0+)
 
 ## Target maintainers
 
-- Artyom Tetyukhin ([@arttet](https://github.com/arttet))
+[@arttet](https://github.com/arttet)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/arm64ec-pc-windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/arm64ec-pc-windows-msvc.md
@@ -7,7 +7,7 @@ applications on AArch64 Windows 11. See <https://learn.microsoft.com/en-us/windo
 
 ## Target maintainers
 
-- [@dpaoliello](https://github.com/dpaoliello)
+[@dpaoliello](https://github.com/dpaoliello)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/armeb-unknown-linux-gnueabi.md
+++ b/src/doc/rustc/src/platform-support/armeb-unknown-linux-gnueabi.md
@@ -10,7 +10,8 @@ BE8 architecture retains the same little-endian ordered code-stream used by conv
 BE8 architecture is the default big-endian architecture for Arm since [Armv6](https://developer.arm.com/documentation/101754/0616/armlink-Reference/armlink-Command-line-Options/--be8?lang=en). It's predecessor, used for Armv4 and Armv5 devices was [BE32](https://developer.arm.com/documentation/dui0474/j/linker-command-line-options/--be32). On Armv6 architecture, endianness can be configured via [system registers](https://developer.arm.com/documentation/ddi0290/g/unaligned-and-mixed-endian-data-access-support/mixed-endian-access-support/interaction-between-the-bus-protocol-and-the-core-endianness). However, BE32 was withdrawn for [Armv7](https://developer.arm.com/documentation/ddi0406/cb/Appendixes/Deprecated-and-Obsolete-Features/Obsolete-features/Support-for-BE-32-endianness-model) onwards.
 
 ## Target Maintainers
-* [@WorksButNotTested](https://github.com/WorksButNotTested)
+
+[@WorksButNotTested](https://github.com/WorksButNotTested)
 
 ## Requirements
 The target is cross-compiled. This target supports `std` in the normal way (indeed only nominal changes are required from the standard Arm configuration).

--- a/src/doc/rustc/src/platform-support/armv4t-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv4t-none-eabi.md
@@ -11,8 +11,8 @@ overall performance.
 
 ## Target Maintainers
 
-* [@Lokathor](https://github.com/lokathor)
-* [@corwinkuiper](https://github.com/corwinkuiper)
+[@Lokathor](https://github.com/lokathor)
+[@corwinkuiper](https://github.com/corwinkuiper)
 
 ## Testing
 

--- a/src/doc/rustc/src/platform-support/armv5te-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv5te-none-eabi.md
@@ -13,7 +13,7 @@ See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
 
 ## Target Maintainers
 
-* [@QuinnPainter](https://github.com/QuinnPainter)
+[@QuinnPainter](https://github.com/QuinnPainter)
 
 ## Testing
 

--- a/src/doc/rustc/src/platform-support/armv6k-nintendo-3ds.md
+++ b/src/doc/rustc/src/platform-support/armv6k-nintendo-3ds.md
@@ -13,9 +13,9 @@ from nor used with any official Nintendo SDK.
 This target is maintained by members of the [@rust3ds](https://github.com/rust3ds)
 organization:
 
-- [@Meziu](https://github.com/Meziu)
-- [@AzureMarker](https://github.com/AzureMarker)
-- [@ian-h-chamberlain](https://github.com/ian-h-chamberlain)
+[@Meziu](https://github.com/Meziu)
+[@AzureMarker](https://github.com/AzureMarker)
+[@ian-h-chamberlain](https://github.com/ian-h-chamberlain)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/armv7-rtems-eabihf.md
+++ b/src/doc/rustc/src/platform-support/armv7-rtems-eabihf.md
@@ -6,7 +6,7 @@ ARM targets for the [RTEMS realtime operating system](https://www.rtems.org)  us
 
 ## Target maintainers
 
-- [@thesummer](https://github.com/thesummer)
+[@thesummer](https://github.com/thesummer)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/armv7-sony-vita-newlibeabihf.md
+++ b/src/doc/rustc/src/platform-support/armv7-sony-vita-newlibeabihf.md
@@ -9,9 +9,9 @@ from nor used with any official Sony SDK.
 
 ## Target maintainers
 
-* [@nikarh](https://github.com/nikarh)
-* [@pheki](https://github.com/pheki)
-* [@ZetaNumbers](https://github.com/ZetaNumbers)
+[@nikarh](https://github.com/nikarh)
+[@pheki](https://github.com/pheki)
+[@zetanumbers](https://github.com/zetanumbers)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/armv7-unknown-linux-uclibceabi.md
+++ b/src/doc/rustc/src/platform-support/armv7-unknown-linux-uclibceabi.md
@@ -6,7 +6,7 @@ This target supports Armv7-A softfloat CPUs and uses the uclibc-ng standard libr
 
 ## Target maintainers
 
-* [@lancethepants](https://github.com/lancethepants)
+[@lancethepants](https://github.com/lancethepants)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/armv7-unknown-linux-uclibceabihf.md
+++ b/src/doc/rustc/src/platform-support/armv7-unknown-linux-uclibceabihf.md
@@ -4,9 +4,9 @@
 
 This tier supports the Armv7-A processor running a Linux kernel and uClibc-ng standard library.  It provides full support for rust and the rust standard library.
 
-## Designated Developers
+## Target Maintainers
 
-* [@skrap](https://github.com/skrap)
+[@skrap](https://github.com/skrap)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/armv7r-none-eabi.md
+++ b/src/doc/rustc/src/platform-support/armv7r-none-eabi.md
@@ -16,7 +16,7 @@ See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
 
 ## Target maintainers
 
-- [Chris Copeland](https://github.com/chrisnc), `chris@chrisnc.net`
+[@chrisnc](https://github.com/chrisnc)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/armv8r-none-eabihf.md
+++ b/src/doc/rustc/src/platform-support/armv8r-none-eabihf.md
@@ -16,7 +16,7 @@ See [`arm-none-eabi`](arm-none-eabi.md) for information applicable to all
 
 ## Target maintainers
 
-- [Chris Copeland](https://github.com/chrisnc), `chris@chrisnc.net`
+[@chrisnc](https://github.com/chrisnc)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/avr-none.md
+++ b/src/doc/rustc/src/platform-support/avr-none.md
@@ -6,7 +6,7 @@ Series of microcontrollers from Atmel: ATmega8, ATmega328p etc.
 
 ## Target maintainers
 
-- [Patryk Wychowaniec](https://github.com/Patryk27) <pwychowaniec@pm.me>
+[@Patryk27](https://github.com/Patryk27)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/csky-unknown-linux-gnuabiv2.md
+++ b/src/doc/rustc/src/platform-support/csky-unknown-linux-gnuabiv2.md
@@ -22,7 +22,7 @@ other links:
 
 ## Target maintainers
 
-* [@Dirreke](https://github.com/Dirreke)
+[@Dirreke](https://github.com/Dirreke)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/esp-idf.md
+++ b/src/doc/rustc/src/platform-support/esp-idf.md
@@ -6,9 +6,9 @@ Targets for the [ESP-IDF](https://github.com/espressif/esp-idf) development fram
 
 ## Target maintainers
 
-- Ivan Markov [@ivmarkov](https://github.com/ivmarkov)
-- Scott Mabin [@MabezDev](https://github.com/MabezDev)
-- Sergio Gasquez [@SergioGasquez](https://github.com/SergioGasquez)
+[@ivmarkov](https://github.com/ivmarkov)
+[@MabezDev](https://github.com/MabezDev)
+[@SergioGasquez](https://github.com/SergioGasquez)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/freebsd.md
+++ b/src/doc/rustc/src/platform-support/freebsd.md
@@ -6,8 +6,8 @@
 
 ## Target maintainers
 
-- Alan Somers `asomers@FreeBSD.org`, https://github.com/asomers
-- Mikael Urankar `mikael@FreeBSD.org`, https://github.com/MikaelUrankar
+[@asomers](https://github.com/asomers)
+[@MikaelUrankar](https://github.com/MikaelUrankar)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/fuchsia.md
+++ b/src/doc/rustc/src/platform-support/fuchsia.md
@@ -7,9 +7,11 @@ updatable, and performant.
 
 ## Target maintainers
 
-See [`fuchsia.toml`] in the `team` repository for current target maintainers.
+[@erickt](https://github.com/erickt)
+[@Nashenas88](https://github.com/Nashenas88)
 
-[`fuchsia.toml`]: https://github.com/rust-lang/team/blob/master/teams/fuchsia.toml
+The up-to-date list can be also found via the
+[fuchsia marker team](https://github.com/rust-lang/team/blob/master/teams/fuchsia.toml).
 
 ## Table of contents
 

--- a/src/doc/rustc/src/platform-support/hermit.md
+++ b/src/doc/rustc/src/platform-support/hermit.md
@@ -14,8 +14,8 @@ Target triplets available so far:
 
 ## Target maintainers
 
-- Stefan Lankes ([@stlankes](https://github.com/stlankes))
-- Martin Kröning ([@mkroening](https://github.com/mkroening))
+[@stlankes](https://github.com/stlankes)
+[@mkroening](https://github.com/mkroening)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/hexagon-unknown-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/hexagon-unknown-linux-musl.md
@@ -11,7 +11,7 @@ DSP architecture.
 
 ## Target maintainers
 
-- [Brian Cain](https://github.com/androm3da), `bcain@quicinc.com`
+[@androm3da](https://github.com/androm3da)
 
 ## Requirements
 The target is cross-compiled. This target supports `std`.  By default, code

--- a/src/doc/rustc/src/platform-support/hexagon-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/hexagon-unknown-none-elf.md
@@ -10,7 +10,7 @@ Rust for baremetal Hexagon DSPs.
 
 ## Target maintainers
 
-- [Brian Cain](https://github.com/androm3da), `bcain@quicinc.com`
+[@androm3da](https://github.com/androm3da)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/hurd.md
+++ b/src/doc/rustc/src/platform-support/hurd.md
@@ -6,7 +6,7 @@
 
 ## Target maintainers
 
-- Samuel Thibault, `samuel.thibault@ens-lyon.org`, https://github.com/sthibaul/
+[@sthibaul](https://github.com/sthibaul)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/i686-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/i686-apple-darwin.md
@@ -4,8 +4,8 @@ Apple macOS on 32-bit x86.
 
 ## Target maintainers
 
-- [@thomcc](https://github.com/thomcc)
-- [@madsmtm](https://github.com/madsmtm)
+[@thomcc](https://github.com/thomcc)
+[@madsmtm](https://github.com/madsmtm)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/illumos.md
+++ b/src/doc/rustc/src/platform-support/illumos.md
@@ -7,8 +7,8 @@ including advanced system debugging, next generation filesystem, networking, and
 
 ## Target maintainers
 
-- Joshua M. Clulow ([@jclulow](https://github.com/jclulow))
-- Patrick Mooney ([@pfmooney](https://github.com/pfmooney))
+[@jclulow](https://github.com/jclulow)
+[@pfmooney](https://github.com/pfmooney)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/kmc-solid.md
+++ b/src/doc/rustc/src/platform-support/kmc-solid.md
@@ -14,9 +14,9 @@ The target names follow this format: `$ARCH-kmc-solid_$KERNEL-$ABI`, where `$ARC
 | `armv7a-kmc-solid_asp3-eabi`   | `arm`         | `kmc`           | `solid_asp3` |
 | `armv7a-kmc-solid_asp3-eabihf` | `arm`         | `kmc`           | `solid_asp3` |
 
-## Designated Developers
+## Target Maintainers
 
-- [@kawadakk](https://github.com/kawadakk)
+[@kawadakk](https://github.com/kawadakk)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/loongarch-linux.md
+++ b/src/doc/rustc/src/platform-support/loongarch-linux.md
@@ -22,10 +22,10 @@ Reference material:
 
 ## Target maintainers
 
-- [WANG Rui](https://github.com/heiher) `wangrui@loongson.cn`
-- [ZHAI Xiang](https://github.com/xiangzhai) `zhaixiang@loongson.cn`
-- [ZHAI Xiaojuan](https://github.com/zhaixiaojuan) `zhaixiaojuan@loongson.cn`
-- [WANG Xuerui](https://github.com/xen0n) `git@xen0n.name`
+[@heiher](https://github.com/heiher)
+[@xiangzhai](https://github.com/xiangzhai)
+[@zhaixiaojuan](https://github.com/zhaixiaojuan)
+[@xen0n](https://github.com/xen0n)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/loongarch-none.md
+++ b/src/doc/rustc/src/platform-support/loongarch-none.md
@@ -11,8 +11,8 @@ Freestanding/bare-metal LoongArch64 binaries in ELF format: firmware, kernels, e
 
 ## Target maintainers
 
-- [WANG Rui](https://github.com/heiher) `wangrui@loongson.cn`
-- [WANG Xuerui](https://github.com/xen0n) `git@xen0n.name`
+[@heiher](https://github.com/heiher)
+[@xen0n](https://github.com/xen0n)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/m68k-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/m68k-unknown-linux-gnu.md
@@ -4,10 +4,10 @@
 
 Motorola 680x0 Linux
 
-## Designated Developers
+## Target Maintainers
 
-* [@glaubitz](https://github.com/glaubitz)
-* [@ricky26](https://github.com/ricky26)
+[@glaubitz](https://github.com/glaubitz)
+[@ricky26](https://github.com/ricky26)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/m68k-unknown-none-elf.md
@@ -4,9 +4,9 @@
 
 Bare metal Motorola 680x0
 
-## Designated Developers
+## Target Maintainers
 
-* [@knickish](https://github.com/knickish)
+[@knickish](https://github.com/knickish)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/mips-mti-none-elf.md
+++ b/src/doc/rustc/src/platform-support/mips-mti-none-elf.md
@@ -9,7 +9,7 @@ MIPS32r2 baremetal softfloat, Big Endian or Little Endian.
 
 ## Target maintainers
 
-- YunQiang Su, `syq@debian.org`, https://github.com/wzssyqa
+[@wzssyqa](https://github.com/wzssyqa)
 
 ## Background
 

--- a/src/doc/rustc/src/platform-support/mips-release-6.md
+++ b/src/doc/rustc/src/platform-support/mips-release-6.md
@@ -16,10 +16,10 @@ The target name follow this format: `<machine>-<vendor>-<os><abi_suffix>`, where
 
 ## Target Maintainers
 
-- [Xuan Chen](https://github.com/chenx97) <henry.chen@oss.cipunited.com>
-- [Walter Ji](https://github.com/709924470) <walter.ji@oss.cipunited.com>
-- [Xinhui Yang](https://github.com/Cyanoxygen) <cyan@oss.cipunited.com>
-- [Lain Yang](https://github.com/Fearyncess) <lain.yang@oss.cipunited.com>
+[@chenx97](https://github.com/chenx97)
+[@709924470](https://github.com/709924470)
+[@Cyanoxygen](https://github.com/Cyanoxygen)
+[@Fearyncess](https://github.com/Fearyncess)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/mips64-openwrt-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/mips64-openwrt-linux-musl.md
@@ -2,7 +2,8 @@
 **Tier: 3**
 
 ## Target maintainers
-- Donald Hoskins `grommish@gmail.com`, https://github.com/Itus-Shield
+
+[@Itus-Shield](https://github.com/Itus-Shield)
 
 ## Requirements
 This target is cross-compiled. There is no support for `std`. There is no

--- a/src/doc/rustc/src/platform-support/mipsel-sony-psx.md
+++ b/src/doc/rustc/src/platform-support/mipsel-sony-psx.md
@@ -6,7 +6,7 @@ Sony PlayStation 1 (psx)
 
 ## Designated Developer
 
-* [@ayrtonm](https://github.com/ayrtonm)
+[@ayrtonm](https://github.com/ayrtonm)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/mipsel-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/mipsel-unknown-linux-gnu.md
@@ -6,7 +6,7 @@ Little-endian 32 bit MIPS for Linux with `glibc.
 
 ## Target maintainers
 
-- [@LukasWoodtli](https://github.com/LukasWoodtli)
+[@LukasWoodtli](https://github.com/LukasWoodtli)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/netbsd.md
+++ b/src/doc/rustc/src/platform-support/netbsd.md
@@ -31,9 +31,12 @@ are built for NetBSD 9.x, although some exceptions exist (some
 are built for NetBSD 8.x but also work on newer OS versions).
 
 
-## Designated Developers
+## Target Maintainers
 
-- [@he32](https://github.com/he32), `he@NetBSD.org`
+[@he32](https://github.com/he32)
+
+Further contacts:
+
 - [NetBSD/pkgsrc-wip's rust](https://github.com/NetBSD/pkgsrc-wip/blob/master/rust185/Makefile) maintainer (see MAINTAINER variable). This package is part of "pkgsrc work-in-progress" and is used for deployment and testing of new versions of rust
 - [NetBSD's pkgsrc lang/rust](https://github.com/NetBSD/pkgsrc/tree/trunk/lang/rust) for the "proper" package in pkgsrc.
 - [NetBSD's pkgsrc lang/rust-bin](https://github.com/NetBSD/pkgsrc/tree/trunk/lang/rust-bin) which re-uses the bootstrap kit as a binary distribution and therefore avoids the rather protracted native build time of rust itself
@@ -46,7 +49,7 @@ bug reporting system.
 The `x86_64-unknown-netbsd` artifacts is being distributed by the
 rust project.
 
-The other targets are built by the designated developers (see above),
+The other targets are built by the target maintainers (see above),
 and the targets are initially cross-compiled, but many if not most
 of them are also built natively as part of testing.
 

--- a/src/doc/rustc/src/platform-support/nto-qnx.md
+++ b/src/doc/rustc/src/platform-support/nto-qnx.md
@@ -13,10 +13,10 @@ and [QNX][qnx.com].
 
 ## Target maintainers
 
-- Florian Bartels, `Florian.Bartels@elektrobit.com`, https://github.com/flba-eb
-- Tristan Roach, `TRoach@blackberry.com`, https://github.com/gh-tr
-- Jonathan Pallant `Jonathan.Pallant@ferrous-systems.com`, https://github.com/jonathanpallant
-- Jorge Aparicio `Jorge.Aparicio@ferrous-systems.com`, https://github.com/japaric
+[@flba-eb](https://github.com/flba-eb)
+[@gh-tr](https://github.com/gh-tr)
+[@jonathanpallant](https://github.com/jonathanpallant)
+[@japaric](https://github.com/japaric)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/nuttx.md
+++ b/src/doc/rustc/src/platform-support/nuttx.md
@@ -12,7 +12,7 @@ For brevity, many parts of the documentation will refer to Apache NuttX as simpl
 
 ## Target maintainers
 
-- Qi Huang [@no1wudi](https://github.com/no1wudi)
+[@no1wudi](https://github.com/no1wudi)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/nvptx64-nvidia-cuda.md
+++ b/src/doc/rustc/src/platform-support/nvptx64-nvidia-cuda.md
@@ -7,8 +7,8 @@ platform.
 
 ## Target maintainers
 
-- Riccardo D'Ambrosio, https://github.com/RDambrosio016
-- Kjetil Kjeka, https://github.com/kjetilkjeka
+[@RDambrosio016](https://github.com/RDambrosio016)
+[@kjetilkjeka](https://github.com/kjetilkjeka)
 
 <!-- FIXME: fill this out
 

--- a/src/doc/rustc/src/platform-support/openbsd.md
+++ b/src/doc/rustc/src/platform-support/openbsd.md
@@ -20,9 +20,12 @@ The target names follow this format: `$ARCH-unknown-openbsd`, where `$ARCH` spec
 Note that all OS versions are *major* even if using X.Y notation (`6.8` and `6.9` are different major versions) and could be binary incompatibles (with breaking changes).
 
 
-## Designated Developers
+## Target Maintainers
 
-- [@semarie](https://github.com/semarie), `semarie@openbsd.org`
+[@semarie](https://github.com/semarie)
+
+Further contacts:
+
 - [lang/rust](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/lang/rust/Makefile?rev=HEAD&content-type=text/x-cvsweb-markup) maintainer (see MAINTAINER variable)
 
 Fallback to ports@openbsd.org, OpenBSD third parties public mailing-list (with openbsd developers readers)

--- a/src/doc/rustc/src/platform-support/openharmony.md
+++ b/src/doc/rustc/src/platform-support/openharmony.md
@@ -15,8 +15,8 @@ system.
 
 ## Target maintainers
 
-- Amanieu d'Antras ([@Amanieu](https://github.com/Amanieu))
-- Lu Binglun ([@lubinglun](https://github.com/lubinglun))
+[@Amanieu](https://github.com/Amanieu)
+[@lubinglun](https://github.com/lubinglun)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/powerpc-unknown-linux-muslspe.md
+++ b/src/doc/rustc/src/platform-support/powerpc-unknown-linux-muslspe.md
@@ -9,7 +9,7 @@ See also [platform support documentation of `powerpc-unknown-linux-gnuspe`](powe
 
 ## Target maintainers
 
-- [@BKPepe](https://github.com/BKPepe)
+[@BKPepe](https://github.com/BKPepe)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/powerpc64-unknown-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/powerpc64-unknown-linux-musl.md
@@ -7,9 +7,9 @@ This target uses the ELF v2 ABI.
 
 ## Target maintainers
 
-- [@Gelbpunkt](https://github.com/Gelbpunkt)
-- [@famfo](https://github.com/famfo)
-- [@neuschaefer](https://github.com/neuschaefer)
+[@Gelbpunkt](https://github.com/Gelbpunkt)
+[@famfo](https://github.com/famfo)
+[@neuschaefer](https://github.com/neuschaefer)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/powerpc64le-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/powerpc64le-unknown-linux-gnu.md
@@ -6,8 +6,8 @@ Target for 64-bit little endian PowerPC Linux programs
 
 ## Target maintainers
 
-- David Tenty `daltenty@ibm.com`, https://github.com/daltenty
-- Chris Cambly, `ccambly@ca.ibm.com`, https://github.com/gilamn5tr
+[@daltenty](https://github.com/daltenty)
+[@gilamn5tr](https://github.com/gilamn5tr)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/powerpc64le-unknown-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/powerpc64le-unknown-linux-musl.md
@@ -6,9 +6,9 @@ Target for 64-bit little endian PowerPC Linux programs using musl libc.
 
 ## Target maintainers
 
-- [@Gelbpunkt](https://github.com/Gelbpunkt)
-- [@famfo](https://github.com/famfo)
-- [@neuschaefer](https://github.com/neuschaefer)
+[@Gelbpunkt](https://github.com/Gelbpunkt)
+[@famfo](https://github.com/famfo)
+[@neuschaefer](https://github.com/neuschaefer)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/redox.md
+++ b/src/doc/rustc/src/platform-support/redox.md
@@ -13,7 +13,7 @@ Target triplets available so far:
 
 ## Target maintainers
 
-- Jeremy Soller ([@jackpot51](https://github.com/jackpot51))
+[@jackpot51](https://github.com/jackpot51)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/riscv32e-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/riscv32e-unknown-none-elf.md
@@ -6,7 +6,7 @@ Bare-metal target for RISC-V CPUs with the RV32E, RV32EM and RV32EMC ISAs.
 
 ## Target maintainers
 
-* Henri Lunnikivi, <henri.lunnikivi@gmail.com>, [@hegza](https://github.com/hegza)
+[@hegza](https://github.com/hegza)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/riscv32im-risc0-zkvm-elf.md
+++ b/src/doc/rustc/src/platform-support/riscv32im-risc0-zkvm-elf.md
@@ -6,9 +6,9 @@ RISC Zero's Zero Knowledge Virtual Machine (zkVM) implementing the RV32IM instru
 
 ## Target maintainers
 
-- Frank Laub, `frank@risczero.com`, https://github.com/flaub
-- Jeremy Bruestle, `jeremy@risczero.com`, https://github.com/jbruestle
-- Erik Kaneda, `erik@risczero.com`, https://github.com/SchmErik
+[@flaub](https://github.com/flaub)
+[@jbruestle](https://github.com/jbruestle)
+[@SchmErik](https://github.com/SchmErik)
 
 ## Background
 

--- a/src/doc/rustc/src/platform-support/riscv32imac-unknown-xous-elf.md
+++ b/src/doc/rustc/src/platform-support/riscv32imac-unknown-xous-elf.md
@@ -6,7 +6,7 @@ Xous microkernel, message-based operating system that powers devices such as Pre
 
 ## Target maintainers
 
-- [@xobs](https://github.com/xobs)
+[@xobs](https://github.com/xobs)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-gnu.md
@@ -7,10 +7,10 @@ RISC-V targets using the *RV64I* base instruction set with the *G* collection of
 
 ## Target maintainers
 
-- Kito Cheng, <kito.cheng@gmail.com>, [@kito-cheng](https://github.com/kito-cheng)
-- Michael Maitland, <michaeltmaitland@gmail.com>, [@michaelmaitland](https://github.com/michaelmaitland)
-- Robin Randhawa, <robin.randhawa@sifive.com>, [@robin-randhawa-sifive](https://github.com/robin-randhawa-sifive)
-- Craig Topper, <craig.topper@sifive.com>, [@topperc](https://github.com/topperc)
+[@kito-cheng](https://github.com/kito-cheng)
+[@michaelmaitland](https://github.com/michaelmaitland)
+[@robin-randhawa-sifive](https://github.com/robin-randhawa-sifive)
+[@topperc](https://github.com/topperc)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/riscv64gc-unknown-linux-musl.md
@@ -6,8 +6,8 @@ Target for RISC-V Linux programs using musl libc.
 
 ## Target maintainers
 
-- [@Amanieu](https://github.com/Amanieu)
-- [@kraj](https://github.com/kraj)
+[@Amanieu](https://github.com/Amanieu)
+[@kraj](https://github.com/kraj)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/s390x-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/s390x-unknown-linux-gnu.md
@@ -6,8 +6,8 @@ IBM z/Architecture (s390x) targets (including IBM Z and LinuxONE) running Linux.
 
 ## Target maintainers
 
-- Ulrich Weigand, <ulrich.weigand@de.ibm.com>, [@uweigand](https://github.com/uweigand)
-- Josh Stone, <jistone@redhat.com>, [@cuviper](https://github.com/cuviper)
+[@uweigand](https://github.com/uweigand)
+[@cuviper](https://github.com/cuviper)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/s390x-unknown-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/s390x-unknown-linux-musl.md
@@ -6,7 +6,7 @@ IBM z/Architecture (s390x) targets (including IBM Z and LinuxONE) running Linux.
 
 ## Target maintainers
 
-- Ulrich Weigand, <ulrich.weigand@de.ibm.com>, [@uweigand](https://github.com/uweigand)
+[@uweigand](https://github.com/uweigand)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/solaris.md
+++ b/src/doc/rustc/src/platform-support/solaris.md
@@ -7,7 +7,7 @@ Rust for Solaris operating system.
 
 ## Target maintainers
 
-- Petr Sumbera `sumbera@volny.cz`, https://github.com/psumbera
+[@psumbera](https://github.com/psumbera)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/sparc-unknown-none-elf.md
+++ b/src/doc/rustc/src/platform-support/sparc-unknown-none-elf.md
@@ -10,7 +10,7 @@ Rust for bare-metal 32-bit SPARC V7 and V8 systems, e.g. the Gaisler LEON3.
 
 ## Target maintainers
 
-- Jonathan Pallant, <jonathan.pallant@ferrous-systems.com>, https://ferrous-systems.com
+[@jonathanpallant](https://github.com/jonathanpallant)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/trusty.md
+++ b/src/doc/rustc/src/platform-support/trusty.md
@@ -7,10 +7,8 @@ Environment (TEE) for Android.
 
 ## Target maintainers
 
-- Nicole LeGare (@randomPoison)
-- Andrei Homescu (@ahomescu)
-- Chris Wailes (chriswailes@google.com)
-- As a fallback trusty-dev-team@google.com can be contacted
+[@randomPoison](https://github.com/randomPoison)
+[@ahomescu](https://github.com/ahomescu)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/unikraft-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/unikraft-linux-musl.md
@@ -12,7 +12,7 @@ Target triplets available so far:
 
 ## Target maintainers
 
-- Martin Kröning ([@mkroening](https://github.com/mkroening))
+[@mkroening](https://github.com/mkroening)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/unknown-uefi.md
+++ b/src/doc/rustc/src/platform-support/unknown-uefi.md
@@ -13,8 +13,8 @@ Available targets:
 
 ## Target maintainers
 
-- David Rheinsberg ([@dvdhrm](https://github.com/dvdhrm))
-- Nicholas Bishop ([@nicholasbishop](https://github.com/nicholasbishop))
+[@dvdhrm](https://github.com/dvdhrm)
+[@nicholasbishop](https://github.com/nicholasbishop)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/uwp-windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/uwp-windows-msvc.md
@@ -6,7 +6,7 @@ Windows targets for Universal Windows Platform (UWP) applications, using MSVC to
 
 ## Target maintainers
 
-- [@bdbai](https://github.com/bdbai)
+[@bdbai](https://github.com/bdbai)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/vxworks.md
+++ b/src/doc/rustc/src/platform-support/vxworks.md
@@ -19,7 +19,7 @@ Target triplets available:
 
 ## Target maintainers
 
-- B I Mohammed Abbas ([@biabbas](https://github.com/biabbas))
+[@biabbas](https://github.com/biabbas)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-emscripten.md
@@ -36,8 +36,8 @@ If you are only targeting the web and need to access web APIs, the
 
 ## Target maintainers
 
-- Hood Chatham, https://github.com/hoodmane
-- Juniper Tyree, https://github.com/juntyr
+[@hoodmane](https://github.com/hoodmane)
+[@juntyr](https://github.com/juntyr)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
@@ -34,7 +34,7 @@ was not maintained at that time. This means that the list below is not
 exhaustive, and there are more interested parties in this target. That being
 said, those interested in maintaining this target are:
 
-- Alex Crichton, https://github.com/alexcrichton
+[@alexcrichton](https://github.com/alexcrichton)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/wasm32-wali-linux.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wali-linux.md
@@ -10,7 +10,7 @@ From the wider Wasm ecosystem perspective, implementing WALI within engines allo
 
 ## Target maintainers
 
-- Arjun Ramesh [@arjunr2](https://github.com/arjunr2)
+[@arjunr2](https://github.com/arjunr2)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
@@ -18,10 +18,10 @@ with native multi threading capabilities.
 
 ## Target maintainers
 
-- Georgii Rylov, https://github.com/g0djan
-- Alex Crichton, https://github.com/alexcrichton
-- Andrew Brown, https://github.com/abrown
-- Marcin Kolny, https://github.com/loganek
+[@g0djan](https://github.com/g0djan)
+[@alexcrichton](https://github.com/alexcrichton)
+[@abrown](https://github.com/abrown)
+[@loganek](https://github.com/loganek)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1.md
@@ -43,7 +43,7 @@ exhaustive and there are more interested parties in this target. That being
 said since when this document was last updated those interested in maintaining
 this target are:
 
-- Alex Crichton, https://github.com/alexcrichton
+[@alexcrichton](https://github.com/alexcrichton)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/wasm32-wasip2.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip2.md
@@ -13,8 +13,8 @@ WebAssembly binaries with native host capabilities.
 
 ## Target maintainers
 
-- Alex Crichton, https://github.com/alexcrichton
-- Ryan Levick, https://github.com/rylev
+[@alexcrichton](https://github.com/alexcrichton)
+[@rylev](https://github.com/rylev)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/wasm32v1-none.md
+++ b/src/doc/rustc/src/platform-support/wasm32v1-none.md
@@ -19,8 +19,8 @@ The target is very similar to [`wasm32-unknown-unknown`](./wasm32-unknown-unknow
 
 ## Target maintainers
 
-- Alex Crichton, https://github.com/alexcrichton
-- Graydon Hoare, https://github.com/graydon
+[@alexcrichton](https://github.com/alexcrichton)
+[@graydon](https://github.com/graydon)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/wasm64-unknown-unknown.md
+++ b/src/doc/rustc/src/platform-support/wasm64-unknown-unknown.md
@@ -9,7 +9,7 @@ WebAssembly proposal.
 
 ## Target maintainers
 
-- Alex Crichton, https://github.com/alexcrichton
+[@alexcrichton](https://github.com/alexcrichton)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/win7-windows-gnu.md
+++ b/src/doc/rustc/src/platform-support/win7-windows-gnu.md
@@ -10,7 +10,7 @@ Target triples:
 
 ## Target maintainers
 
-- @tbu-
+[@tbu-](https://github.com/tbu-)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/win7-windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/win7-windows-msvc.md
@@ -10,7 +10,7 @@ Target triples:
 
 ## Target maintainers
 
-- @roblabla
+[@roblabla](https://github.com/roblabla)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/windows-gnullvm.md
+++ b/src/doc/rustc/src/platform-support/windows-gnullvm.md
@@ -11,8 +11,8 @@ Target triples available so far:
 
 ## Target maintainers
 
-- [@mati865](https://github.com/mati865)
-- [@thomcc](https://github.com/thomcc)
+[@mati865](https://github.com/mati865)
+[@thomcc](https://github.com/thomcc)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/x86_64-fortanix-unknown-sgx.md
+++ b/src/doc/rustc/src/platform-support/x86_64-fortanix-unknown-sgx.md
@@ -9,11 +9,13 @@ based on the ABI defined by Fortanix for the [Enclave Development Platform
 
 ## Target maintainers
 
-The [EDP team](mailto:edp.maintainers@fortanix.com) at Fortanix.
+[@jethrogb](https://github.com/jethrogb)
+[@raoulstrackx](https://github.com/raoulstrackx)
+[@mzohreva](https://github.com/mzohreva)
 
-- Jethro Beekman [@jethrogb](https://github.com/jethrogb)
-- Raoul Strackx [@raoulstrackx](https://github.com/raoulstrackx)
-- Mohsen Zohrevandi [@mzohreva](https://github.com/mzohreva)
+Further contacts:
+
+The [EDP team](mailto:edp.maintainers@fortanix.com) at Fortanix.
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/x86_64-pc-cygwin.md
+++ b/src/doc/rustc/src/platform-support/x86_64-pc-cygwin.md
@@ -10,7 +10,7 @@ Cygwin is only intended as an emulation layer for Unix-only programs which do no
 
 ## Target maintainers
 
-- [Berrysoft](https://github.com/Berrysoft)
+[@Berrysoft](https://github.com/Berrysoft)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/x86_64-unknown-linux-none.md
+++ b/src/doc/rustc/src/platform-support/x86_64-unknown-linux-none.md
@@ -6,7 +6,7 @@ Freestanding x86-64 linux binary with no dependency on libc.
 
 ## Target maintainers
 
-- [morr0ne](https://github.com/morr0ne/)
+[@morr0ne](https://github.com/morr0ne)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/x86_64-unknown-none.md
+++ b/src/doc/rustc/src/platform-support/x86_64-unknown-none.md
@@ -6,8 +6,8 @@ Freestanding/bare-metal x86-64 binaries in ELF format: firmware, kernels, etc.
 
 ## Target maintainers
 
-- Harald Hoyer `harald@profian.com`, https://github.com/haraldh
-- Mike Leany, https://github.com/mikeleany
+[@haraldh](https://github.com/haraldh)
+[@mikeleany](https://github.com/mikeleany)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/x86_64h-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/x86_64h-apple-darwin.md
@@ -8,7 +8,7 @@ Target for macOS on late-generation `x86_64` Apple chips, usable as the
 
 ## Target maintainers
 
-- Thom Chiovoloni `thom@shift.click` <https://github.com/thomcc>
+[@thomcc](https://github.com/thomcc)
 
 ## Requirements
 

--- a/src/doc/rustc/src/platform-support/xtensa.md
+++ b/src/doc/rustc/src/platform-support/xtensa.md
@@ -6,8 +6,8 @@ Targets for Xtensa CPUs.
 
 ## Target maintainers
 
-- Scott Mabin [@MabezDev](https://github.com/MabezDev)
-- Sergio Gasquez [@SergioGasquez](https://github.com/SergioGasquez)
+[@MabezDev](https://github.com/MabezDev)
+[@SergioGasquez](https://github.com/SergioGasquez)
 
 ## Requirements
 


### PR DESCRIPTION
Put them all on the same line with just their GitHub handles to make it very easy to copy and paste (with ctrl-shift-v!!!) the names.

We have no use for email, so I removed all the emails, we don't care about people's full names either.

This is a pretty big PR with lots of changes. I may have gotten one or two wrong, who knows. I went over it fairly aggressively, removing all information I deemed unnecessary.

> [!Caution]
> When copying these usernames, use **ctrl-shift-v** to avoid pasting them as links

r? RalfJung you indirectly asked for this :) (anyone is welcome to review)