### PR TITLE
bootstrap: update `test_find` test

### DIFF
--- a/src/bootstrap/src/utils/cc_detect/tests.rs
+++ b/src/bootstrap/src/utils/cc_detect/tests.rs
@@ -264,7 +264,7 @@ fn test_find_target_without_config() {
 fn test_find() {
     let mut build = Build::new(Config { ..Config::parse(Flags::parse(&["check".to_owned()])) });
     let target1 = TargetSelection::from_user("x86_64-unknown-linux-gnu");
-    let target2 = TargetSelection::from_user("arm-linux-androideabi");
+    let target2 = TargetSelection::from_user("x86_64-unknown-openbsd");
     build.targets.push(target1.clone());
     build.hosts.push(target2.clone());
     find(&build);


### PR DESCRIPTION
`cc::Build::get_archiver` is noisy on the `arm-linux-androideabi` target and constantly printing `llvm-ar --version` output during bootstrap tests on all platforms.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
