### PR TITLE
Provide cross-compiling guidance when Apple SDK is missing

### DIFF
--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -404,6 +404,23 @@ codegen_ssa_visual_studio_not_installed = you may need to install Visual Studio 
 codegen_ssa_xcrun_command_line_tools_insufficient =
     when compiling for iOS, tvOS, visionOS or watchOS, you need a full installation of Xcode
 
+codegen_ssa_xcrun_cross_download_sdk =
+    the SDK can be downloaded and extracted from https://developer.apple.com/download/all/?q=xcode (requires an Apple ID).
+
+    The full Xcode bundle should contain the SDK in Xcode.app/Contents/Developer/Platforms/{$sdk_name}.platform/Developer/SDKs/{$sdk_name}.sdk{ $sdk_name ->
+        [MacOSX] , but downloading just the "Command Line Tools for Xcode" should also be sufficient to obtain the macOS SDK.
+        *[other] .
+    }
+
+codegen_ssa_xcrun_cross_env_var =
+    pass the path to the SDK using the SDKROOT environment variable
+
+codegen_ssa_xcrun_cross_ill_supported_target =
+    cross-compiling to iOS, tvOS, visionOS or watchOS (in particular the linking step) is ill supported on non-macOS hosts
+
+codegen_ssa_xcrun_cross_linker_not_explicitly_set =
+    you will also need to use a linker capable of linking Mach-O files, consider using the bundled `lld` with `-Clinker=rust-lld`
+
 codegen_ssa_xcrun_failed_invoking = invoking `{$command_formatted}` to find {$sdk_name}.sdk failed: {$error}
 
 codegen_ssa_xcrun_found_developer_dir = found active developer directory at "{$developer_dir}"

--- a/compiler/rustc_codegen_ssa/src/back/apple.rs
+++ b/compiler/rustc_codegen_ssa/src/back/apple.rs
@@ -172,16 +172,29 @@ pub(super) fn get_sdk_root(sess: &Session) -> Option<PathBuf> {
             let mut diag = sess.dcx().create_err(err);
 
             // Recognize common error cases, and give more Rust-specific error messages for those.
-            if let Some(developer_dir) = xcode_select_developer_dir() {
-                diag.arg("developer_dir", &developer_dir);
-                diag.note(fluent::codegen_ssa_xcrun_found_developer_dir);
-                if developer_dir.as_os_str().to_string_lossy().contains("CommandLineTools") {
-                    if sdk_name != "MacOSX" {
-                        diag.help(fluent::codegen_ssa_xcrun_command_line_tools_insufficient);
+            if sess.host.os == "macos" {
+                if let Some(developer_dir) = xcode_select_developer_dir() {
+                    diag.arg("developer_dir", &developer_dir);
+                    diag.note(fluent::codegen_ssa_xcrun_found_developer_dir);
+                    if developer_dir.as_os_str().to_string_lossy().contains("CommandLineTools") {
+                        if sdk_name != "MacOSX" {
+                            diag.help(fluent::codegen_ssa_xcrun_command_line_tools_insufficient);
+                        }
                     }
+                } else {
+                    diag.help(fluent::codegen_ssa_xcrun_no_developer_dir);
                 }
             } else {
-                diag.help(fluent::codegen_ssa_xcrun_no_developer_dir);
+                diag.help(fluent::codegen_ssa_xcrun_cross_env_var);
+                diag.help(fluent::codegen_ssa_xcrun_cross_download_sdk);
+
+                if sess.opts.cg.linker.is_none() {
+                    diag.warn(fluent::codegen_ssa_xcrun_cross_linker_not_explicitly_set);
+                }
+
+                if sess.target.os != "macos" {
+                    diag.warn(fluent::codegen_ssa_xcrun_cross_ill_supported_target);
+                }
             }
 
             diag.emit();


### PR DESCRIPTION
Emit more guided warnings when cross-compiling to Apple platforms from non-host macOS.

Note that in the common cross-compilation case (to macOS while linking with `cc`-like compiler), users won't actually hit this, since `xcrun` isn't invoked in that case. But I intend to change that in https://github.com/rust-lang/rust/pull/131477, and then the error message here will start to matter a lot more.

The message now looks something like:
```console
$ rustc +stage1 example.rs --target aarch64-apple-ios
warning: invoking `"xcrun" "--sdk" "iphoneos" "--show-sdk-path"` to find iPhoneOS.sdk failed: No such file or directory (os error 2)
  |
  = note: the SDK is needed by the linker to know where to find symbols in system libraries and for embedding the SDK version in the final object file
  = help: pass the path to the SDK using the SDKROOT environment variable
  = help: the SDK can be downloaded and extracted from https://developer.apple.com/download/all/?q=xcode (requires an Apple ID).
          
          The full Xcode bundle should contain the SDK in Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk.
  = warning: you will also need to use a linker capable of linking Mach-O files, consider using the bundled `lld` with `-Clinker=rust-lld`
  = warning: cross-compiling on iOS, tvOS, visionOS or watchOS (in particular the linking step) is ill supported on non-macOS hosts
```

Suggestions on how to improve it welcome!

Might also make sense to emit some of these help messages if the linker invocation itself fails? Unsure, but I'll work on that in a different PR.

(I originally considered not even attempting to invoke `xcrun`, but decided to continue doing that, since an `xcrun`-compatible interface _can_ be present on other platforms, it's just unusual (e.g. Facebook developed [`xcbuild`](https://github.com/facebookarchive/xcbuild) for a while, similar probably exist)).

Follow-up to https://github.com/rust-lang/rust/pull/139010.
Part of https://github.com/rust-lang/rust/issues/129432.
Related to https://github.com/rust-lang/rustup/issues/1483 in that we now document the steps required for cross-compilation in the error message.

@rustbot label O-apple
r? wesleywiser since you just reviewed rust-lang/rust#139010
CC @BlackHoleFox @thomcc
