### PR TITLE
io: Avoid marking some bytes as uninit

### DIFF
--- a/library/std/src/io/buffered/bufreader/buffer.rs
+++ b/library/std/src/io/buffered/bufreader/buffer.rs
@@ -123,7 +123,6 @@ impl Buffer {
     /// Remove bytes that have already been read from the buffer.
     pub fn backshift(&mut self) {
         self.buf.copy_within(self.pos.., 0);
-        self.initialized -= self.pos;
         self.filled -= self.pos;
         self.pos = 0;
     }

--- a/library/std/src/io/copy.rs
+++ b/library/std/src/io/copy.rs
@@ -248,8 +248,11 @@ impl<I: Write + ?Sized> BufferedWriterSpec for BufWriter<I> {
                     Err(e) => return Err(e),
                 }
             } else {
+                // All the bytes that were already in the buffer are initialized,
+                // treat them as such when the buffer is flushed.
+                init += buf.len();
+
                 self.flush_buf()?;
-                init = 0;
             }
         }
     }


### PR DESCRIPTION
These bytes were marked as uninit, which would cause them to be initialized multiple times even though it was not necessary.