### PR TITLE
Do not treat lifetimes from parent items as influencing child items

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1833,13 +1833,16 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 }
                 LifetimeRibKind::StaticIfNoLifetimeInScope { lint_id: node_id, emit_lint } => {
                     let mut lifetimes_in_scope = vec![];
-                    for rib in &self.lifetime_ribs[..i] {
+                    for rib in self.lifetime_ribs[..i].iter().rev() {
                         lifetimes_in_scope.extend(rib.bindings.iter().map(|(ident, _)| ident.span));
                         // Consider any anonymous lifetimes, too
                         if let LifetimeRibKind::AnonymousCreateParameter { binder, .. } = rib.kind
                             && let Some(extra) = self.r.extra_lifetime_params_map.get(&binder)
                         {
                             lifetimes_in_scope.extend(extra.iter().map(|(ident, _, _)| ident.span));
+                        }
+                        if let LifetimeRibKind::Item = rib.kind {
+                            break;
                         }
                     }
                     if lifetimes_in_scope.is_empty() {

--- a/tests/ui/consts/static-default-lifetime/static-trait-impl.rs
+++ b/tests/ui/consts/static-default-lifetime/static-trait-impl.rs
@@ -17,4 +17,17 @@ impl Bar<'static> for B {
     const STATIC: &str = "";
 }
 
+struct C;
+impl Bar<'_> for C {
+    // make  ^^ not cause
+    const STATIC: &'static str = {
+        struct B;
+        impl Bar<'static> for B {
+            const STATIC: &str = "";
+            //            ^ to emit a future incompat warning
+        }
+        ""
+    };
+}
+
 fn main() {}


### PR DESCRIPTION
```rust
struct A;
impl Bar<'static> for A {
    const STATIC: &str = "";
    //            ^ no future incompat warning
}
```

has no future incompat warning, because there is no ambiguity. But

```rust
struct C;
impl Bar<'_> for C {
//       ^^ this lifeimte
    const STATIC: &'static str = {
        struct B;
        impl Bar<'static> for B {
            const STATIC: &str = "";
            // causes     ^ to emit a future incompat warning
        }
        ""
    };
}
```

had one before this PR, because the impl for `B` (which is just a copy of `A`) thought it was influenced by a lifetime on the impl for `C`.

I double checked all other `lifetime_ribs` iterations and all of them do check for `Item` boundaries. This feels very fragile tho, and ~~I think we should do not even be able to see ribs from parent items, but that's a different refactoring that I'd rather not do at the same time as a bugfix~~. EDIT: ah nevermind, this is needed for improving diagnostics like "use of undeclared lifetime" being "can't use generic parameters from outer item" instead.

r? @compiler-errors 