### PR TITLE
fix docs for `Peekable::next_if{_eq}`

### DIFF
--- a/library/core/src/iter/adapters/peekable.rs
+++ b/library/core/src/iter/adapters/peekable.rs
@@ -271,7 +271,7 @@ impl<I: Iterator> Peekable<I> {
     /// assert_eq!(iter.next_if(|&x| x == 0), Some(0));
     /// // The next item returned is now 1, so `next_if` will return `None`.
     /// assert_eq!(iter.next_if(|&x| x == 0), None);
-    /// // `next_if` saves the value of the next item if it was not equal to `expected`.
+    /// // `next_if` retains the next item if the predicate evaluates to `false` for it.
     /// assert_eq!(iter.next(), Some(1));
     /// ```
     ///
@@ -304,9 +304,9 @@ impl<I: Iterator> Peekable<I> {
     /// let mut iter = (0..5).peekable();
     /// // The first item of the iterator is 0; consume it.
     /// assert_eq!(iter.next_if_eq(&0), Some(0));
-    /// // The next item returned is now 1, so `next_if` will return `None`.
+    /// // The next item returned is now 1, so `next_if_eq` will return `None`.
     /// assert_eq!(iter.next_if_eq(&0), None);
-    /// // `next_if_eq` saves the value of the next item if it was not equal to `expected`.
+    /// // `next_if_eq` retains the next item if it was not equal to `expected`.
     /// assert_eq!(iter.next(), Some(1));
     /// ```
     #[stable(feature = "peekable_next_if", since = "1.51.0")]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
These seem like copy-paste errors

(except `saves the value of` 👉 `retains` which just sounds better to me)