### PR TITLE
Move `fd` into `std::sys`

### DIFF
--- a/library/std/src/sys/fd/hermit.rs
+++ b/library/std/src/sys/fd/hermit.rs
@@ -1,8 +1,8 @@
 #![unstable(reason = "not public", issue = "none", feature = "fd")]
 
-use super::hermit_abi;
 use crate::cmp;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, Read, SeekFrom};
+use crate::os::hermit::hermit_abi;
 use crate::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use crate::sys::{cvt, unsupported};
 use crate::sys_common::{AsInner, FromInner, IntoInner};

--- a/library/std/src/sys/fd/mod.rs
+++ b/library/std/src/sys/fd/mod.rs
@@ -1,0 +1,19 @@
+//! Platform-dependent file descriptor abstraction.
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
+cfg_if::cfg_if! {
+    if #[cfg(target_family = "unix")] {
+        mod unix;
+        pub use unix::*;
+    } else if #[cfg(target_os = "hermit")] {
+        mod hermit;
+        pub use hermit::*;
+    } else if #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))] {
+        mod sgx;
+        pub use sgx::*;
+    } else if #[cfg(target_os = "wasi")] {
+        mod wasi;
+        pub use wasi::*;
+    }
+}

--- a/library/std/src/sys/fd/mod.rs
+++ b/library/std/src/sys/fd/mod.rs
@@ -1,6 +1,6 @@
 //! Platform-dependent file descriptor abstraction.
 
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 cfg_if::cfg_if! {
     if #[cfg(target_family = "unix")] {

--- a/library/std/src/sys/fd/sgx.rs
+++ b/library/std/src/sys/fd/sgx.rs
@@ -1,8 +1,8 @@
 use fortanix_sgx_abi::Fd;
 
-use super::abi::usercalls;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut};
 use crate::mem::ManuallyDrop;
+use crate::sys::pal::abi::usercalls;
 use crate::sys::{AsInner, FromInner, IntoInner};
 
 #[derive(Debug)]

--- a/library/std/src/sys/fd/unix.rs
+++ b/library/std/src/sys/fd/unix.rs
@@ -1,5 +1,4 @@
 #![unstable(reason = "not public", issue = "none", feature = "fd")]
-#![allow(unsafe_op_in_unsafe_fn)]
 
 #[cfg(test)]
 mod tests;
@@ -674,6 +673,6 @@ impl IntoRawFd for FileDesc {
 
 impl FromRawFd for FileDesc {
     unsafe fn from_raw_fd(raw_fd: RawFd) -> Self {
-        Self(FromRawFd::from_raw_fd(raw_fd))
+        Self(unsafe { FromRawFd::from_raw_fd(raw_fd) })
     }
 }

--- a/library/std/src/sys/fd/unix/tests.rs
+++ b/library/std/src/sys/fd/unix/tests.rs
@@ -1,6 +1,7 @@
 use core::mem::ManuallyDrop;
 
-use super::{FileDesc, IoSlice};
+use super::FileDesc;
+use crate::io::IoSlice;
 use crate::os::unix::io::FromRawFd;
 
 #[test]

--- a/library/std/src/sys/fd/wasi.rs
+++ b/library/std/src/sys/fd/wasi.rs
@@ -1,11 +1,10 @@
-#![forbid(unsafe_op_in_unsafe_fn)]
-#![allow(dead_code)]
+#![expect(dead_code)]
 
-use super::err2io;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, SeekFrom};
 use crate::mem;
 use crate::net::Shutdown;
 use crate::os::wasi::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+use crate::sys::pal::err2io;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
 #[derive(Debug)]

--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -9,8 +9,8 @@ use crate::os::hermit::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, Raw
 use crate::path::{Path, PathBuf};
 use crate::sync::Arc;
 use crate::sys::common::small_c_string::run_path_with_cstr;
+use crate::sys::fd::FileDesc;
 pub use crate::sys::fs::common::{copy, exists};
-use crate::sys::pal::fd::FileDesc;
 use crate::sys::time::SystemTime;
 use crate::sys::{cvt, unsupported};
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};

--- a/library/std/src/sys/mod.rs
+++ b/library/std/src/sys/mod.rs
@@ -12,6 +12,7 @@ pub mod anonymous_pipe;
 pub mod backtrace;
 pub mod cmath;
 pub mod exit_guard;
+pub mod fd;
 pub mod fs;
 pub mod io;
 pub mod net;

--- a/library/std/src/sys/pal/hermit/mod.rs
+++ b/library/std/src/sys/pal/hermit/mod.rs
@@ -20,7 +20,6 @@ use crate::os::raw::c_char;
 
 pub mod args;
 pub mod env;
-pub mod fd;
 pub mod futex;
 pub mod os;
 #[path = "../unsupported/pipe.rs"]

--- a/library/std/src/sys/pal/sgx/mod.rs
+++ b/library/std/src/sys/pal/sgx/mod.rs
@@ -11,7 +11,6 @@ use crate::sync::atomic::{AtomicBool, Ordering};
 pub mod abi;
 pub mod args;
 pub mod env;
-pub mod fd;
 mod libunwind_integration;
 pub mod os;
 #[path = "../unsupported/pipe.rs"]

--- a/library/std/src/sys/pal/unix/linux/pidfd.rs
+++ b/library/std/src/sys/pal/unix/linux/pidfd.rs
@@ -1,7 +1,7 @@
 use crate::io;
 use crate::os::fd::{AsRawFd, FromRawFd, RawFd};
 use crate::sys::cvt;
-use crate::sys::pal::unix::fd::FileDesc;
+use crate::sys::fd::FileDesc;
 use crate::sys::process::ExitStatus;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 

--- a/library/std/src/sys/pal/unix/mod.rs
+++ b/library/std/src/sys/pal/unix/mod.rs
@@ -8,7 +8,6 @@ pub mod weak;
 
 pub mod args;
 pub mod env;
-pub mod fd;
 #[cfg(target_os = "fuchsia")]
 pub mod fuchsia;
 pub mod futex;

--- a/library/std/src/sys/pal/wasi/mod.rs
+++ b/library/std/src/sys/pal/wasi/mod.rs
@@ -15,7 +15,6 @@
 
 pub mod args;
 pub mod env;
-pub mod fd;
 #[allow(unused)]
 #[path = "../wasm/atomics/futex.rs"]
 pub mod futex;

--- a/library/std/src/sys/pal/wasip2/mod.rs
+++ b/library/std/src/sys/pal/wasip2/mod.rs
@@ -10,8 +10,6 @@
 pub mod args;
 #[path = "../wasi/env.rs"]
 pub mod env;
-#[path = "../wasi/fd.rs"]
-pub mod fd;
 #[allow(unused)]
 #[path = "../wasm/atomics/futex.rs"]
 pub mod futex;
@@ -39,7 +37,6 @@ mod helpers;
 // import conflict rules. If we glob export `helpers` and `common` together,
 // then the compiler complains about conflicts.
 
-use helpers::err2io;
-pub use helpers::{abort_internal, decode_error_kind, is_interrupted};
+pub(crate) use helpers::{abort_internal, decode_error_kind, err2io, is_interrupted};
 
 mod cabi_realloc;

--- a/library/std/src/sys/stdio/wasi.rs
+++ b/library/std/src/sys/stdio/wasi.rs
@@ -4,7 +4,7 @@ use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut};
 use crate::mem::ManuallyDrop;
 use crate::os::raw;
 use crate::os::wasi::io::{AsRawFd, FromRawFd};
-use crate::sys::pal::fd::WasiFd;
+use crate::sys::fd::WasiFd;
 
 pub struct Stdin;
 pub struct Stdout;

--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -73,12 +73,12 @@ check-aux:
 		$(BOOTSTRAP) miri --stage 2 library/std \
 		$(BOOTSTRAP_ARGS) \
 		--no-doc -- \
-		--skip fs:: --skip net:: --skip process:: --skip sys::pal::
+		--skip fs:: --skip net:: --skip process:: --skip sys::fd:: --skip sys::pal::
 	$(Q)MIRIFLAGS="-Zmiri-disable-isolation" \
 		$(BOOTSTRAP) miri --stage 2 library/std \
 		$(BOOTSTRAP_ARGS) \
 		--doc -- \
-		--skip fs:: --skip net:: --skip process:: --skip sys::pal::
+		--skip fs:: --skip net:: --skip process:: --skip sys::fd:: --skip sys::pal::
 	# Also test some very target-specific modules on other targets
 	# (making sure to cover an i686 target as well).
 	$(Q)MIRIFLAGS="-Zmiri-disable-isolation" BOOTSTRAP_SKIP_TARGET_SANITY=1 \


### PR DESCRIPTION
Move platform definitions of `fd` into `std::sys`, as part of https://github.com/rust-lang/rust/issues/117276.

Unlike other modules directly under `std::sys`, this is only available on some platforms and I have not provided a fallback abstraction for unsupported platforms. That is similar to how `std::os::fd` is gated to only supported platforms.

Also, fix the `unsafe_op_in_unsafe_fn` lint, which was allowed for the Unix fd impl. Since macro expansions from `std::sys::pal::unix::weak` trigger this lint, fix it there too.

cc @joboet, @ChrisDenton

try-job: x86_64-gnu-aux