### PR TITLE
Mark .pp files as Rust

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 *.h rust
 *.rs rust diff=rust
 *.fixed linguist-language=Rust
+*.pp linguist-language=Rust
 *.mir linguist-language=Rust
 src/etc/installer/gfx/* binary
 src/vendor/** -text


### PR DESCRIPTION
Pretty-printing tests generate `.pp` files, but GitHub classify and highlight them as Pascal:
[https://github.com/search?q=repo:rust-lang/rust+path:*.pp&type=code](https://github.com/search?q=repo%3Arust-lang%2Frust+path%3A*.pp&type=code)

@rustbot label +A-meta +A-testsuite