### PR TITLE
std: make `cmath` functions safe

### DIFF
--- a/library/std/src/f128.rs
+++ b/library/std/src/f128.rs
@@ -666,7 +666,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn cbrt(self) -> f128 {
-        unsafe { cmath::cbrtf128(self) }
+        cmath::cbrtf128(self)
     }
 
     /// Compute the distance between the origin and a point (`x`, `y`) on the
@@ -703,7 +703,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn hypot(self, other: f128) -> f128 {
-        unsafe { cmath::hypotf128(self, other) }
+        cmath::hypotf128(self, other)
     }
 
     /// Computes the sine of a number (in radians).
@@ -789,7 +789,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn tan(self) -> f128 {
-        unsafe { cmath::tanf128(self) }
+        cmath::tanf128(self)
     }
 
     /// Computes the arcsine of a number. Return value is in radians in
@@ -824,7 +824,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn asin(self) -> f128 {
-        unsafe { cmath::asinf128(self) }
+        cmath::asinf128(self)
     }
 
     /// Computes the arccosine of a number. Return value is in radians in
@@ -859,7 +859,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn acos(self) -> f128 {
-        unsafe { cmath::acosf128(self) }
+        cmath::acosf128(self)
     }
 
     /// Computes the arctangent of a number. Return value is in radians in the
@@ -893,7 +893,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn atan(self) -> f128 {
-        unsafe { cmath::atanf128(self) }
+        cmath::atanf128(self)
     }
 
     /// Computes the four quadrant arctangent of `self` (`y`) and `other` (`x`) in radians.
@@ -939,7 +939,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn atan2(self, other: f128) -> f128 {
-        unsafe { cmath::atan2f128(self, other) }
+        cmath::atan2f128(self, other)
     }
 
     /// Simultaneously computes the sine and cosine of the number, `x`. Returns
@@ -1008,7 +1008,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn exp_m1(self) -> f128 {
-        unsafe { cmath::expm1f128(self) }
+        cmath::expm1f128(self)
     }
 
     /// Returns `ln(1+n)` (natural logarithm) more accurately than if
@@ -1055,7 +1055,7 @@ impl f128 {
     #[rustc_allow_incoherent_impl]
     #[unstable(feature = "f128", issue = "116909")]
     pub fn ln_1p(self) -> f128 {
-        unsafe { cmath::log1pf128(self) }
+        cmath::log1pf128(self)
     }
 
     /// Hyperbolic sine function.
@@ -1090,7 +1090,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn sinh(self) -> f128 {
-        unsafe { cmath::sinhf128(self) }
+        cmath::sinhf128(self)
     }
 
     /// Hyperbolic cosine function.
@@ -1125,7 +1125,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn cosh(self) -> f128 {
-        unsafe { cmath::coshf128(self) }
+        cmath::coshf128(self)
     }
 
     /// Hyperbolic tangent function.
@@ -1160,7 +1160,7 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn tanh(self) -> f128 {
-        unsafe { cmath::tanhf128(self) }
+        cmath::tanhf128(self)
     }
 
     /// Inverse hyperbolic sine function.
@@ -1289,7 +1289,7 @@ impl f128 {
     // #[unstable(feature = "float_gamma", issue = "99842")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn gamma(self) -> f128 {
-        unsafe { cmath::tgammaf128(self) }
+        cmath::tgammaf128(self)
     }
 
     /// Natural logarithm of the absolute value of the gamma function
@@ -1325,7 +1325,7 @@ impl f128 {
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn ln_gamma(self) -> (f128, i32) {
         let mut signgamp: i32 = 0;
-        let x = unsafe { cmath::lgammaf128_r(self, &mut signgamp) };
+        let x = cmath::lgammaf128_r(self, &mut signgamp);
         (x, signgamp)
     }
 
@@ -1365,7 +1365,7 @@ impl f128 {
     // #[unstable(feature = "float_erf", issue = "136321")]
     #[inline]
     pub fn erf(self) -> f128 {
-        unsafe { cmath::erff128(self) }
+        cmath::erff128(self)
     }
 
     /// Complementary error function.
@@ -1398,6 +1398,6 @@ impl f128 {
     // #[unstable(feature = "float_erf", issue = "136321")]
     #[inline]
     pub fn erfc(self) -> f128 {
-        unsafe { cmath::erfcf128(self) }
+        cmath::erfcf128(self)
     }
 }

--- a/library/std/src/f16.rs
+++ b/library/std/src/f16.rs
@@ -665,7 +665,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn cbrt(self) -> f16 {
-        (unsafe { cmath::cbrtf(self as f32) }) as f16
+        cmath::cbrtf(self as f32) as f16
     }
 
     /// Compute the distance between the origin and a point (`x`, `y`) on the
@@ -701,7 +701,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn hypot(self, other: f16) -> f16 {
-        (unsafe { cmath::hypotf(self as f32, other as f32) }) as f16
+        cmath::hypotf(self as f32, other as f32) as f16
     }
 
     /// Computes the sine of a number (in radians).
@@ -787,7 +787,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn tan(self) -> f16 {
-        (unsafe { cmath::tanf(self as f32) }) as f16
+        cmath::tanf(self as f32) as f16
     }
 
     /// Computes the arcsine of a number. Return value is in radians in
@@ -822,7 +822,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn asin(self) -> f16 {
-        (unsafe { cmath::asinf(self as f32) }) as f16
+        cmath::asinf(self as f32) as f16
     }
 
     /// Computes the arccosine of a number. Return value is in radians in
@@ -857,7 +857,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn acos(self) -> f16 {
-        (unsafe { cmath::acosf(self as f32) }) as f16
+        cmath::acosf(self as f32) as f16
     }
 
     /// Computes the arctangent of a number. Return value is in radians in the
@@ -891,7 +891,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn atan(self) -> f16 {
-        (unsafe { cmath::atanf(self as f32) }) as f16
+        cmath::atanf(self as f32) as f16
     }
 
     /// Computes the four quadrant arctangent of `self` (`y`) and `other` (`x`) in radians.
@@ -937,7 +937,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn atan2(self, other: f16) -> f16 {
-        (unsafe { cmath::atan2f(self as f32, other as f32) }) as f16
+        cmath::atan2f(self as f32, other as f32) as f16
     }
 
     /// Simultaneously computes the sine and cosine of the number, `x`. Returns
@@ -1006,7 +1006,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn exp_m1(self) -> f16 {
-        (unsafe { cmath::expm1f(self as f32) }) as f16
+        cmath::expm1f(self as f32) as f16
     }
 
     /// Returns `ln(1+n)` (natural logarithm) more accurately than if
@@ -1053,7 +1053,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn ln_1p(self) -> f16 {
-        (unsafe { cmath::log1pf(self as f32) }) as f16
+        cmath::log1pf(self as f32) as f16
     }
 
     /// Hyperbolic sine function.
@@ -1088,7 +1088,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn sinh(self) -> f16 {
-        (unsafe { cmath::sinhf(self as f32) }) as f16
+        cmath::sinhf(self as f32) as f16
     }
 
     /// Hyperbolic cosine function.
@@ -1123,7 +1123,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn cosh(self) -> f16 {
-        (unsafe { cmath::coshf(self as f32) }) as f16
+        cmath::coshf(self as f32) as f16
     }
 
     /// Hyperbolic tangent function.
@@ -1158,7 +1158,7 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn tanh(self) -> f16 {
-        (unsafe { cmath::tanhf(self as f32) }) as f16
+        cmath::tanhf(self as f32) as f16
     }
 
     /// Inverse hyperbolic sine function.
@@ -1287,7 +1287,7 @@ impl f16 {
     // #[unstable(feature = "float_gamma", issue = "99842")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn gamma(self) -> f16 {
-        (unsafe { cmath::tgammaf(self as f32) }) as f16
+        cmath::tgammaf(self as f32) as f16
     }
 
     /// Natural logarithm of the absolute value of the gamma function
@@ -1323,7 +1323,7 @@ impl f16 {
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn ln_gamma(self) -> (f16, i32) {
         let mut signgamp: i32 = 0;
-        let x = (unsafe { cmath::lgammaf_r(self as f32, &mut signgamp) }) as f16;
+        let x = cmath::lgammaf_r(self as f32, &mut signgamp) as f16;
         (x, signgamp)
     }
 
@@ -1363,7 +1363,7 @@ impl f16 {
     // #[unstable(feature = "float_erf", issue = "136321")]
     #[inline]
     pub fn erf(self) -> f16 {
-        (unsafe { cmath::erff(self as f32) }) as f16
+        cmath::erff(self as f32) as f16
     }
 
     /// Complementary error function.
@@ -1396,6 +1396,6 @@ impl f16 {
     // #[unstable(feature = "float_erf", issue = "136321")]
     #[inline]
     pub fn erfc(self) -> f16 {
-        (unsafe { cmath::erfcf(self as f32) }) as f16
+        cmath::erfcf(self as f32) as f16
     }
 }

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -599,7 +599,7 @@ impl f32 {
                 filing an issue describing your use-case too)."
     )]
     pub fn abs_sub(self, other: f32) -> f32 {
-        unsafe { cmath::fdimf(self, other) }
+        cmath::fdimf(self, other)
     }
 
     /// Returns the cube root of a number.
@@ -626,7 +626,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cbrt(self) -> f32 {
-        unsafe { cmath::cbrtf(self) }
+        cmath::cbrtf(self)
     }
 
     /// Compute the distance between the origin and a point (`x`, `y`) on the
@@ -657,7 +657,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn hypot(self, other: f32) -> f32 {
-        unsafe { cmath::hypotf(self, other) }
+        cmath::hypotf(self, other)
     }
 
     /// Computes the sine of a number (in radians).
@@ -730,7 +730,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tan(self) -> f32 {
-        unsafe { cmath::tanf(self) }
+        cmath::tanf(self)
     }
 
     /// Computes the arcsine of a number. Return value is in radians in
@@ -760,7 +760,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asin(self) -> f32 {
-        unsafe { cmath::asinf(self) }
+        cmath::asinf(self)
     }
 
     /// Computes the arccosine of a number. Return value is in radians in
@@ -790,7 +790,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acos(self) -> f32 {
-        unsafe { cmath::acosf(self) }
+        cmath::acosf(self)
     }
 
     /// Computes the arctangent of a number. Return value is in radians in the
@@ -819,7 +819,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atan(self) -> f32 {
-        unsafe { cmath::atanf(self) }
+        cmath::atanf(self)
     }
 
     /// Computes the four quadrant arctangent of `self` (`y`) and `other` (`x`) in radians.
@@ -860,7 +860,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atan2(self, other: f32) -> f32 {
-        unsafe { cmath::atan2f(self, other) }
+        cmath::atan2f(self, other)
     }
 
     /// Simultaneously computes the sine and cosine of the number, `x`. Returns
@@ -919,7 +919,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp_m1(self) -> f32 {
-        unsafe { cmath::expm1f(self) }
+        cmath::expm1f(self)
     }
 
     /// Returns `ln(1+n)` (natural logarithm) more accurately than if
@@ -957,7 +957,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln_1p(self) -> f32 {
-        unsafe { cmath::log1pf(self) }
+        cmath::log1pf(self)
     }
 
     /// Hyperbolic sine function.
@@ -987,7 +987,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sinh(self) -> f32 {
-        unsafe { cmath::sinhf(self) }
+        cmath::sinhf(self)
     }
 
     /// Hyperbolic cosine function.
@@ -1017,7 +1017,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cosh(self) -> f32 {
-        unsafe { cmath::coshf(self) }
+        cmath::coshf(self)
     }
 
     /// Hyperbolic tangent function.
@@ -1047,7 +1047,7 @@ impl f32 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tanh(self) -> f32 {
-        unsafe { cmath::tanhf(self) }
+        cmath::tanhf(self)
     }
 
     /// Inverse hyperbolic sine function.
@@ -1158,7 +1158,7 @@ impl f32 {
     #[unstable(feature = "float_gamma", issue = "99842")]
     #[inline]
     pub fn gamma(self) -> f32 {
-        unsafe { cmath::tgammaf(self) }
+        cmath::tgammaf(self)
     }
 
     /// Natural logarithm of the absolute value of the gamma function
@@ -1188,7 +1188,7 @@ impl f32 {
     #[inline]
     pub fn ln_gamma(self) -> (f32, i32) {
         let mut signgamp: i32 = 0;
-        let x = unsafe { cmath::lgammaf_r(self, &mut signgamp) };
+        let x = cmath::lgammaf_r(self, &mut signgamp);
         (x, signgamp)
     }
 
@@ -1224,7 +1224,7 @@ impl f32 {
     #[unstable(feature = "float_erf", issue = "136321")]
     #[inline]
     pub fn erf(self) -> f32 {
-        unsafe { cmath::erff(self) }
+        cmath::erff(self)
     }
 
     /// Complementary error function.
@@ -1253,6 +1253,6 @@ impl f32 {
     #[unstable(feature = "float_erf", issue = "136321")]
     #[inline]
     pub fn erfc(self) -> f32 {
-        unsafe { cmath::erfcf(self) }
+        cmath::erfcf(self)
     }
 }

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -599,7 +599,7 @@ impl f64 {
                 filing an issue describing your use-case too)."
     )]
     pub fn abs_sub(self, other: f64) -> f64 {
-        unsafe { cmath::fdim(self, other) }
+        cmath::fdim(self, other)
     }
 
     /// Returns the cube root of a number.
@@ -626,7 +626,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cbrt(self) -> f64 {
-        unsafe { cmath::cbrt(self) }
+        cmath::cbrt(self)
     }
 
     /// Compute the distance between the origin and a point (`x`, `y`) on the
@@ -657,7 +657,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn hypot(self, other: f64) -> f64 {
-        unsafe { cmath::hypot(self, other) }
+        cmath::hypot(self, other)
     }
 
     /// Computes the sine of a number (in radians).
@@ -730,7 +730,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tan(self) -> f64 {
-        unsafe { cmath::tan(self) }
+        cmath::tan(self)
     }
 
     /// Computes the arcsine of a number. Return value is in radians in
@@ -760,7 +760,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asin(self) -> f64 {
-        unsafe { cmath::asin(self) }
+        cmath::asin(self)
     }
 
     /// Computes the arccosine of a number. Return value is in radians in
@@ -790,7 +790,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acos(self) -> f64 {
-        unsafe { cmath::acos(self) }
+        cmath::acos(self)
     }
 
     /// Computes the arctangent of a number. Return value is in radians in the
@@ -819,7 +819,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atan(self) -> f64 {
-        unsafe { cmath::atan(self) }
+        cmath::atan(self)
     }
 
     /// Computes the four quadrant arctangent of `self` (`y`) and `other` (`x`) in radians.
@@ -860,7 +860,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atan2(self, other: f64) -> f64 {
-        unsafe { cmath::atan2(self, other) }
+        cmath::atan2(self, other)
     }
 
     /// Simultaneously computes the sine and cosine of the number, `x`. Returns
@@ -919,7 +919,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp_m1(self) -> f64 {
-        unsafe { cmath::expm1(self) }
+        cmath::expm1(self)
     }
 
     /// Returns `ln(1+n)` (natural logarithm) more accurately than if
@@ -957,7 +957,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln_1p(self) -> f64 {
-        unsafe { cmath::log1p(self) }
+        cmath::log1p(self)
     }
 
     /// Hyperbolic sine function.
@@ -987,7 +987,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sinh(self) -> f64 {
-        unsafe { cmath::sinh(self) }
+        cmath::sinh(self)
     }
 
     /// Hyperbolic cosine function.
@@ -1017,7 +1017,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cosh(self) -> f64 {
-        unsafe { cmath::cosh(self) }
+        cmath::cosh(self)
     }
 
     /// Hyperbolic tangent function.
@@ -1047,7 +1047,7 @@ impl f64 {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tanh(self) -> f64 {
-        unsafe { cmath::tanh(self) }
+        cmath::tanh(self)
     }
 
     /// Inverse hyperbolic sine function.
@@ -1158,7 +1158,7 @@ impl f64 {
     #[unstable(feature = "float_gamma", issue = "99842")]
     #[inline]
     pub fn gamma(self) -> f64 {
-        unsafe { cmath::tgamma(self) }
+        cmath::tgamma(self)
     }
 
     /// Natural logarithm of the absolute value of the gamma function
@@ -1188,7 +1188,7 @@ impl f64 {
     #[inline]
     pub fn ln_gamma(self) -> (f64, i32) {
         let mut signgamp: i32 = 0;
-        let x = unsafe { cmath::lgamma_r(self, &mut signgamp) };
+        let x = cmath::lgamma_r(self, &mut signgamp);
         (x, signgamp)
     }
 
@@ -1224,7 +1224,7 @@ impl f64 {
     #[unstable(feature = "float_erf", issue = "136321")]
     #[inline]
     pub fn erf(self) -> f64 {
-        unsafe { cmath::erf(self) }
+        cmath::erf(self)
     }
 
     /// Complementary error function.
@@ -1253,6 +1253,6 @@ impl f64 {
     #[unstable(feature = "float_erf", issue = "136321")]
     #[inline]
     pub fn erfc(self) -> f64 {
-        unsafe { cmath::erfc(self) }
+        cmath::erfc(self)
     }
 }

--- a/library/std/src/sys/cmath.rs
+++ b/library/std/src/sys/cmath.rs
@@ -3,70 +3,70 @@
 // These symbols are all defined by `libm`,
 // or by `compiler-builtins` on unsupported platforms.
 unsafe extern "C" {
-    pub fn acos(n: f64) -> f64;
-    pub fn asin(n: f64) -> f64;
-    pub fn atan(n: f64) -> f64;
-    pub fn atan2(a: f64, b: f64) -> f64;
-    pub fn cbrt(n: f64) -> f64;
-    pub fn cbrtf(n: f32) -> f32;
-    pub fn cosh(n: f64) -> f64;
-    pub fn expm1(n: f64) -> f64;
-    pub fn expm1f(n: f32) -> f32;
-    pub fn fdim(a: f64, b: f64) -> f64;
-    pub fn fdimf(a: f32, b: f32) -> f32;
+    pub safe fn acos(n: f64) -> f64;
+    pub safe fn asin(n: f64) -> f64;
+    pub safe fn atan(n: f64) -> f64;
+    pub safe fn atan2(a: f64, b: f64) -> f64;
+    pub safe fn cbrt(n: f64) -> f64;
+    pub safe fn cbrtf(n: f32) -> f32;
+    pub safe fn cosh(n: f64) -> f64;
+    pub safe fn expm1(n: f64) -> f64;
+    pub safe fn expm1f(n: f32) -> f32;
+    pub safe fn fdim(a: f64, b: f64) -> f64;
+    pub safe fn fdimf(a: f32, b: f32) -> f32;
     #[cfg_attr(target_env = "msvc", link_name = "_hypot")]
-    pub fn hypot(x: f64, y: f64) -> f64;
+    pub safe fn hypot(x: f64, y: f64) -> f64;
     #[cfg_attr(target_env = "msvc", link_name = "_hypotf")]
-    pub fn hypotf(x: f32, y: f32) -> f32;
-    pub fn log1p(n: f64) -> f64;
-    pub fn log1pf(n: f32) -> f32;
-    pub fn sinh(n: f64) -> f64;
-    pub fn tan(n: f64) -> f64;
-    pub fn tanh(n: f64) -> f64;
-    pub fn tgamma(n: f64) -> f64;
-    pub fn tgammaf(n: f32) -> f32;
-    pub fn lgamma_r(n: f64, s: &mut i32) -> f64;
+    pub safe fn hypotf(x: f32, y: f32) -> f32;
+    pub safe fn log1p(n: f64) -> f64;
+    pub safe fn log1pf(n: f32) -> f32;
+    pub safe fn sinh(n: f64) -> f64;
+    pub safe fn tan(n: f64) -> f64;
+    pub safe fn tanh(n: f64) -> f64;
+    pub safe fn tgamma(n: f64) -> f64;
+    pub safe fn tgammaf(n: f32) -> f32;
+    pub safe fn lgamma_r(n: f64, s: &mut i32) -> f64;
     #[cfg(not(target_os = "aix"))]
-    pub fn lgammaf_r(n: f32, s: &mut i32) -> f32;
-    pub fn erf(n: f64) -> f64;
-    pub fn erff(n: f32) -> f32;
-    pub fn erfc(n: f64) -> f64;
-    pub fn erfcf(n: f32) -> f32;
+    pub safe fn lgammaf_r(n: f32, s: &mut i32) -> f32;
+    pub safe fn erf(n: f64) -> f64;
+    pub safe fn erff(n: f32) -> f32;
+    pub safe fn erfc(n: f64) -> f64;
+    pub safe fn erfcf(n: f32) -> f32;
 
-    pub fn acosf128(n: f128) -> f128;
-    pub fn asinf128(n: f128) -> f128;
-    pub fn atanf128(n: f128) -> f128;
-    pub fn atan2f128(a: f128, b: f128) -> f128;
-    pub fn cbrtf128(n: f128) -> f128;
-    pub fn coshf128(n: f128) -> f128;
-    pub fn expm1f128(n: f128) -> f128;
-    pub fn hypotf128(x: f128, y: f128) -> f128;
-    pub fn log1pf128(n: f128) -> f128;
-    pub fn sinhf128(n: f128) -> f128;
-    pub fn tanf128(n: f128) -> f128;
-    pub fn tanhf128(n: f128) -> f128;
-    pub fn tgammaf128(n: f128) -> f128;
-    pub fn lgammaf128_r(n: f128, s: &mut i32) -> f128;
-    pub fn erff128(n: f128) -> f128;
-    pub fn erfcf128(n: f128) -> f128;
+    pub safe fn acosf128(n: f128) -> f128;
+    pub safe fn asinf128(n: f128) -> f128;
+    pub safe fn atanf128(n: f128) -> f128;
+    pub safe fn atan2f128(a: f128, b: f128) -> f128;
+    pub safe fn cbrtf128(n: f128) -> f128;
+    pub safe fn coshf128(n: f128) -> f128;
+    pub safe fn expm1f128(n: f128) -> f128;
+    pub safe fn hypotf128(x: f128, y: f128) -> f128;
+    pub safe fn log1pf128(n: f128) -> f128;
+    pub safe fn sinhf128(n: f128) -> f128;
+    pub safe fn tanf128(n: f128) -> f128;
+    pub safe fn tanhf128(n: f128) -> f128;
+    pub safe fn tgammaf128(n: f128) -> f128;
+    pub safe fn lgammaf128_r(n: f128, s: &mut i32) -> f128;
+    pub safe fn erff128(n: f128) -> f128;
+    pub safe fn erfcf128(n: f128) -> f128;
 
     cfg_if::cfg_if! {
     if #[cfg(not(all(target_os = "windows", target_env = "msvc", target_arch = "x86")))] {
-        pub fn acosf(n: f32) -> f32;
-        pub fn asinf(n: f32) -> f32;
-        pub fn atan2f(a: f32, b: f32) -> f32;
-        pub fn atanf(n: f32) -> f32;
-        pub fn coshf(n: f32) -> f32;
-        pub fn sinhf(n: f32) -> f32;
-        pub fn tanf(n: f32) -> f32;
-        pub fn tanhf(n: f32) -> f32;
+        pub safe fn acosf(n: f32) -> f32;
+        pub safe fn asinf(n: f32) -> f32;
+        pub safe fn atan2f(a: f32, b: f32) -> f32;
+        pub safe fn atanf(n: f32) -> f32;
+        pub safe fn coshf(n: f32) -> f32;
+        pub safe fn sinhf(n: f32) -> f32;
+        pub safe fn tanf(n: f32) -> f32;
+        pub safe fn tanhf(n: f32) -> f32;
     }}
 }
 
 // On AIX, we don't have lgammaf_r only the f64 version, so we can
 // use the f64 version lgamma_r
 #[cfg(target_os = "aix")]
-pub unsafe fn lgammaf_r(n: f32, s: &mut i32) -> f32 {
+pub fn lgammaf_r(n: f32, s: &mut i32) -> f32 {
     lgamma_r(n.into(), s) as f32
 }
 
@@ -76,42 +76,42 @@ pub unsafe fn lgammaf_r(n: f32, s: &mut i32) -> f32 {
 cfg_if::cfg_if! {
 if #[cfg(all(target_os = "windows", target_env = "msvc", target_arch = "x86"))] {
     #[inline]
-    pub unsafe fn acosf(n: f32) -> f32 {
+    pub fn acosf(n: f32) -> f32 {
         f64::acos(n as f64) as f32
     }
 
     #[inline]
-    pub unsafe fn asinf(n: f32) -> f32 {
+    pub fn asinf(n: f32) -> f32 {
         f64::asin(n as f64) as f32
     }
 
     #[inline]
-    pub unsafe fn atan2f(n: f32, b: f32) -> f32 {
+    pub fn atan2f(n: f32, b: f32) -> f32 {
         f64::atan2(n as f64, b as f64) as f32
     }
 
     #[inline]
-    pub unsafe fn atanf(n: f32) -> f32 {
+    pub fn atanf(n: f32) -> f32 {
         f64::atan(n as f64) as f32
     }
 
     #[inline]
-    pub unsafe fn coshf(n: f32) -> f32 {
+    pub fn coshf(n: f32) -> f32 {
         f64::cosh(n as f64) as f32
     }
 
     #[inline]
-    pub unsafe fn sinhf(n: f32) -> f32 {
+    pub fn sinhf(n: f32) -> f32 {
         f64::sinh(n as f64) as f32
     }
 
     #[inline]
-    pub unsafe fn tanf(n: f32) -> f32 {
+    pub fn tanf(n: f32) -> f32 {
         f64::tan(n as f64) as f32
     }
 
     #[inline]
-    pub unsafe fn tanhf(n: f32) -> f32 {
+    pub fn tanhf(n: f32) -> f32 {
         f64::tanh(n as f64) as f32
     }
 }}


### PR DESCRIPTION
The floating point intrinsics are more difficult, I'll probably wait until #119899 has merged before making them safe as well.