### PR TITLE
tidy: Fix paths to `coretests` and `alloctests`

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -3016,6 +3016,6 @@ impl<T: ?Sized> Debug for SyncUnsafeCell<T> {
     }
 }
 
-// If you expected tests to be here, look instead at the core/tests/fmt.rs file,
+// If you expected tests to be here, look instead at coretests/tests/fmt/;
 // it's a lot easier than creating all of the rt::Piece structures here.
-// There are also tests in the alloc crate, for those that need allocations.
+// There are also tests in alloctests/tests/fmt.rs, for those that need allocations.

--- a/library/coretests/tests/str.rs
+++ b/library/coretests/tests/str.rs
@@ -1,1 +1,1 @@
-// All `str` tests live in library/alloc/tests/str.rs
+// All `str` tests live in library/alloctests/tests/str.rs

--- a/src/tools/tidy/src/unit_tests.rs
+++ b/src/tools/tidy/src/unit_tests.rs
@@ -1,11 +1,13 @@
-//! Tidy check to ensure `#[test]` and `#[bench]` are not used directly inside `core`.
+//! Tidy check to ensure `#[test]` and `#[bench]` are not used directly inside
+//! `core` or `alloc`.
 //!
-//! `#![no_core]` libraries cannot be tested directly due to duplicating lang
-//! items. All tests and benchmarks must be written externally in `core/{tests,benches}`.
+//! `core` and `alloc` cannot be tested directly due to duplicating lang items.
+//! All tests and benchmarks must be written externally in
+//! `{coretests,alloctests}/{tests,benches}`.
 //!
-//! Outside of core tests and benchmarks should be outlined into separate files
-//! named `tests.rs` or `benches.rs`, or directories named `tests` or `benches` unconfigured
-//! during normal build.
+//! Outside of `core` and `alloc`, tests and benchmarks should be outlined into
+//! separate files named `tests.rs` or `benches.rs`, or directories named
+//! `tests` or `benches` unconfigured during normal build.
 
 use std::path::Path;
 
@@ -14,40 +16,51 @@ use crate::walk::{filter_dirs, walk};
 pub fn check(root_path: &Path, bad: &mut bool) {
     let core = root_path.join("core");
     let core_copy = core.clone();
-    let core_tests = core.join("tests");
-    let core_benches = core.join("benches");
-    let is_core = move |path: &Path| {
-        path.starts_with(&core)
-            && !(path.starts_with(&core_tests) || path.starts_with(&core_benches))
-    };
+    let is_core = move |path: &Path| path.starts_with(&core);
+    let alloc = root_path.join("alloc");
+    let alloc_copy = alloc.clone();
+    let is_alloc = move |path: &Path| path.starts_with(&alloc);
 
     let skip = move |path: &Path, is_dir| {
         let file_name = path.file_name().unwrap_or_default();
         if is_dir {
             filter_dirs(path)
                 || path.ends_with("src/doc")
-                || (file_name == "tests" || file_name == "benches") && !is_core(path)
+                || (file_name == "tests" || file_name == "benches")
+                    && !is_core(path)
+                    && !is_alloc(path)
         } else {
             let extension = path.extension().unwrap_or_default();
             extension != "rs"
-                || (file_name == "tests.rs" || file_name == "benches.rs") && !is_core(path)
-                // UI tests with different names
-                || path.ends_with("src/thread/local/dynamic_tests.rs")
-                || path.ends_with("src/sync/mpsc/sync_tests.rs")
+                || (file_name == "tests.rs" || file_name == "benches.rs")
+                    && !is_core(path)
+                    && !is_alloc(path)
+                // Tests which use non-public internals and, as such, need to
+                // have the types in the same crate as the tests themselves. See
+                // the comment in alloctests/lib.rs.
+                || path.ends_with("library/alloc/src/collections/btree/borrow/tests.rs")
+                || path.ends_with("library/alloc/src/collections/btree/map/tests.rs")
+                || path.ends_with("library/alloc/src/collections/btree/node/tests.rs")
+                || path.ends_with("library/alloc/src/collections/btree/set/tests.rs")
+                || path.ends_with("library/alloc/src/collections/linked_list/tests.rs")
+                || path.ends_with("library/alloc/src/collections/vec_deque/tests.rs")
+                || path.ends_with("library/alloc/src/raw_vec/tests.rs")
         }
     };
 
     walk(root_path, skip, &mut |entry, contents| {
         let path = entry.path();
         let is_core = path.starts_with(&core_copy);
+        let is_alloc = path.starts_with(&alloc_copy);
         for (i, line) in contents.lines().enumerate() {
             let line = line.trim();
             let is_test = || line.contains("#[test]") && !line.contains("`#[test]");
             let is_bench = || line.contains("#[bench]") && !line.contains("`#[bench]");
             if !line.starts_with("//") && (is_test() || is_bench()) {
                 let explanation = if is_core {
-                    "core unit tests and benchmarks must be placed into \
-                         `core/tests` or `core/benches`"
+                    "`core` unit tests and benchmarks must be placed into `coretests`"
+                } else if is_alloc {
+                    "`alloc` unit tests and benchmarks must be placed into `alloctests`"
                 } else {
                     "unit tests and benchmarks must be placed into \
                          separate files or directories named \


### PR DESCRIPTION
Following `#135937` and `#136642`, tests for core and alloc are in coretests and alloctests. Fix tidy to lint for the new paths. Also, update comments referring to the old locations.

Some context for changes which don't match that pattern:
- `library/std/src/thread/local/dynamic_tests.rs` and `library/std/src/sync/mpsc/sync_tests.rs` were moved under `library/std/tests/` in 332fb7e6f1d (Move std::thread_local unit tests to integration tests, 2025-01-17) and b8ae372e483 (Move std::sync unit tests to integration tests, 2025-01-17), respectively, so are no longer special cases.
- There never was a `library/core/tests/fmt.rs` file. That comment previously referred to `src/test/ui/ifmt.rs`, which was folded into `library/alloc/tests/fmt.rs` in 949c96660c3 (move format! interface tests, 2020-09-08).

Now, the only matches for `(alloc|core)/tests` are in `compiler/rustc_codegen_{cranelift,gcc}/patches`. I don't know why CI hasn't broken because those patches can't apply. Or maybe they somehow still can apply?

r? @bjorn3