### PR TITLE
Fix up partial res of segment in primitive resolution hack

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4598,6 +4598,11 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     }
                 };
 
+                // Fix up partial res of segment from `resolve_path` call.
+                if let Some(id) = path[0].id {
+                    self.r.partial_res_map.insert(id, PartialRes::new(Res::PrimTy(prim)));
+                }
+
                 PartialRes::with_unresolved_segments(Res::PrimTy(prim), path.len() - 1)
             }
             PathResult::Module(ModuleOrUniformRoot::Module(module)) => {

--- a/tests/ui/resolve/auxiliary/empty.rs
+++ b/tests/ui/resolve/auxiliary/empty.rs
@@ -1,0 +1,1 @@
+// Intentionally empty.

--- a/tests/ui/resolve/prim-crate-partial-res.rs
+++ b/tests/ui/resolve/prim-crate-partial-res.rs
@@ -1,0 +1,8 @@
+//@ aux-build: empty.rs
+
+extern crate empty as usize;
+
+fn foo() -> usize<()> { 0 }
+//~^ ERROR type arguments are not allowed on builtin type `usize`
+
+fn main() {}

--- a/tests/ui/resolve/prim-crate-partial-res.stderr
+++ b/tests/ui/resolve/prim-crate-partial-res.stderr
@@ -1,0 +1,17 @@
+error[E0109]: type arguments are not allowed on builtin type `usize`
+  --> $DIR/prim-crate-partial-res.rs:5:19
+   |
+LL | fn foo() -> usize<()> { 0 }
+   |             ----- ^^ type argument not allowed
+   |             |
+   |             not allowed on builtin type `usize`
+   |
+help: primitive type `usize` doesn't have generic parameters
+   |
+LL - fn foo() -> usize<()> { 0 }
+LL + fn foo() -> usize { 0 }
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0109`.


### PR DESCRIPTION
There is a hack in the resolver:

```
// In `a(::assoc_item)*` `a` cannot be a module. If `a` does resolve to a module we
// don't report an error right away, but try to fallback to a primitive type.
```

This fixes up the resolution for primitives which would otherwise resolve to a module, but we weren't also updating the res of the path segment, leading to weird diagnostics.

We explicitly call `self.r.partial_res_map.insert` instead of `record_partial_res` b/c we have recorded a partial res already, and we specifically want to override it.

cc https://github.com/rust-lang/rust/issues/139095#issuecomment-2764371934