### PR TITLE
Add `#[must_use]` annotation to `Result::ok`

### DIFF
--- a/compiler/rustc_data_structures/src/jobserver.rs
+++ b/compiler/rustc_data_structures/src/jobserver.rs
@@ -47,7 +47,7 @@ fn default_client() -> Client {
     let client = Client::new(32).expect("failed to create jobserver");
 
     // Acquire a token for the main thread which we can release later
-    client.acquire_raw().ok();
+    let _ = client.acquire_raw().ok();
 
     client
 }
@@ -62,7 +62,7 @@ pub fn initialize_checked(report_warning: impl FnOnce(&'static str)) {
             default_client()
         }
     };
-    GLOBAL_CLIENT_CHECKED.set(client_checked).ok();
+    let _ = GLOBAL_CLIENT_CHECKED.set(client_checked);
 }
 
 const ACCESS_ERROR: &str = "jobserver check should have been called earlier";
@@ -72,9 +72,9 @@ pub fn client() -> Client {
 }
 
 pub fn acquire_thread() {
-    GLOBAL_CLIENT_CHECKED.get().expect(ACCESS_ERROR).acquire_raw().ok();
+    let _ = GLOBAL_CLIENT_CHECKED.get().expect(ACCESS_ERROR).acquire_raw();
 }
 
 pub fn release_thread() {
-    GLOBAL_CLIENT_CHECKED.get().expect(ACCESS_ERROR).release_raw().ok();
+    let _ = GLOBAL_CLIENT_CHECKED.get().expect(ACCESS_ERROR).release_raw();
 }

--- a/compiler/rustc_data_structures/src/sync/worker_local.rs
+++ b/compiler/rustc_data_structures/src/sync/worker_local.rs
@@ -79,7 +79,7 @@ impl Registry {
                     drop(threads);
                     panic!("Thread already has a registry");
                 }
-                registry.set(self.clone()).ok();
+                let _ = registry.set(self.clone());
                 THREAD_DATA.with(|data| {
                     data.registry_id.set(self.id());
                     data.index.set(*threads);

--- a/compiler/rustc_query_system/src/query/caches.rs
+++ b/compiler/rustc_query_system/src/query/caches.rs
@@ -99,7 +99,7 @@ where
 
     #[inline]
     fn complete(&self, _key: (), value: V, index: DepNodeIndex) {
-        self.cache.set((value, index)).ok();
+        let _ = self.cache.set((value, index));
     }
 
     fn iter(&self, f: &mut dyn FnMut(&Self::Key, &Self::Value, DepNodeIndex)) {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -655,6 +655,7 @@ impl<T, E> Result<T, E> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "result_ok_method"]
+    #[must_use]
     pub fn ok(self) -> Option<T> {
         match self {
             Ok(x) => Some(x),

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -322,7 +322,7 @@ fn default_hook(info: &PanicHookInfo<'_>) {
 
     if let Ok(Some(local)) = try_set_output_capture(None) {
         write(&mut *local.lock().unwrap_or_else(|e| e.into_inner()));
-        try_set_output_capture(Some(local)).ok();
+        let _ = try_set_output_capture(Some(local));
     } else if let Some(mut out) = panic_output() {
         write(&mut out);
     }

--- a/src/tools/miri/src/shims/unix/fd.rs
+++ b/src/tools/miri/src/shims/unix/fd.rs
@@ -88,7 +88,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // If old_fd and new_fd point to the same description, then `dup_fd` ensures we keep the underlying file description alive.
             if let Some(old_new_fd) = this.machine.fds.fds.insert(new_fd_num, fd) {
                 // Ignore close error (not interpreter's) according to dup2() doc.
-                old_new_fd.close_ref(this.machine.communicate(), this)?.ok();
+                let _ = old_new_fd.close_ref(this.machine.communicate(), this)?;
             }
         }
         interp_ok(Scalar::from_i32(new_fd_num))


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
I've encountered a few instances of people (@ work) writing these types of snippets:
```rust
some_fallible_op().inspect_err(|e| eprintln!("Got an error: {e}")).ok();
```
IMHO the idiomatic way to write this would be:
```rust
if let Err(e) = some_fallible_op() { eprintln!("Got an error: {e}"); }
```
or, if you're just discarding the error and don't need to log it
```rust
let _ = some_fallible_op();
```

I think using `.ok()` for discarding an error is misleading and makes the code harder to read. I wouldn't propose adding `#[must_use]` to `Option` itself (as opposed to `Result`) is wrong, but it makes a lot of sense to me that `.ok()` is missing its purpose if you're not using its return value!

Let's see what people feel about this...

(Edit: fixes #66116 , which I missed before opening this)