### PR TITLE
What if we always run `ReorderBasicBlocks`?

### DIFF
--- a/tests/codegen/hint/cold_path.rs
+++ b/tests/codegen/hint/cold_path.rs
@@ -26,10 +26,10 @@ pub fn test1(x: bool) {
     }
 
     // CHECK-LABEL: @test1(
-    // CHECK: br i1 %x, label %bb1, label %bb2, !prof ![[NUM:[0-9]+]]
-    // CHECK: bb2:
-    // CHECK: path_b
+    // CHECK: br i1 %x, label %bb3, label %bb1, !prof ![[NUM:[0-9]+]]
     // CHECK: bb1:
+    // CHECK: path_b
+    // CHECK: bb3:
     // CHECK: path_a
 }
 
@@ -44,10 +44,11 @@ pub fn test2(x: i32) {
     }
 
     // CHECK-LABEL: @test2(
-    // CHECK: br i1 %_2, label %bb2, label %bb1, !prof ![[NUM]]
+    // CHECK: %_2 = icmp sgt i32 %x, 0
+    // CHECK: br i1 %_2, label %bb3, label %bb1, !prof ![[NUM]]
     // CHECK: bb1:
     // CHECK: path_b
-    // CHECK: bb2:
+    // CHECK: bb3:
     // CHECK: path_a
 }
 

--- a/tests/codegen/hint/likely.rs
+++ b/tests/codegen/hint/likely.rs
@@ -25,10 +25,10 @@ pub fn test1(x: bool) {
     }
 
     // CHECK-LABEL: @test1(
-    // CHECK: br i1 %x, label %bb2, label %bb3, !prof ![[NUM:[0-9]+]]
-    // CHECK: bb3:
+    // CHECK: br i1 %x, label %bb3, label %bb1, !prof ![[NUM:[0-9]+]]
+    // CHECK: bb1:
     // CHECK: path_b
-    // CHECK: bb2:
+    // CHECK: bb3:
     // CHECK: path_a
 }
 
@@ -40,10 +40,10 @@ pub fn test2(x: i32) {
     }
 
     // CHECK-LABEL: @test2(
-    // CHECK: br i1 %_2, label %bb2, label %bb3, !prof ![[NUM]]
-    // CHECK: bb3:
+    // CHECK: br i1 %_2, label %bb3, label %bb1, !prof ![[NUM]]
+    // CHECK: bb1:
     // CHECK: path_b
-    // CHECK: bb2:
+    // CHECK: bb3:
     // CHECK: path_a
 }
 
@@ -55,10 +55,10 @@ pub fn test3(x: i8) {
     }
 
     // CHECK-LABEL: @test3(
-    // CHECK: br i1 %_2, label %bb2, label %bb3, !prof ![[NUM]]
-    // CHECK: bb3:
+    // CHECK: br i1 %_2, label %bb3, label %bb1, !prof ![[NUM]]
+    // CHECK: bb1:
     // CHECK: path_b
-    // CHECK: bb2:
+    // CHECK: bb3:
     // CHECK: path_a
 }
 
@@ -69,11 +69,14 @@ pub fn test4(x: u64) {
         _ => path_b(),
     }
 
+    // Note that LLVM seems to flip this one, for some reason
+
     // CHECK-LABEL: @test4(
-    // CHECK: br i1 %0, label %bb3, label %bb2, !prof ![[NUM2:[0-9]+]]
-    // CHECK: bb3:
+    // CHECK: %0 = icmp eq i64 %x, 33
+    // CHECK: br i1 %0, label %bb1, label %bb3, !prof ![[NUM2:[0-9]+]]
+    // CHECK: bb1:
     // CHECK: path_a
-    // CHECK: bb2:
+    // CHECK: bb3:
     // CHECK: path_b
 }
 

--- a/tests/codegen/hint/unlikely.rs
+++ b/tests/codegen/hint/unlikely.rs
@@ -25,8 +25,8 @@ pub fn test1(x: bool) {
     }
 
     // CHECK-LABEL: @test1(
-    // CHECK: br i1 %x, label %bb2, label %bb4, !prof ![[NUM:[0-9]+]]
-    // CHECK: bb4:
+    // CHECK: br i1 %x, label %bb2, label %bb1, !prof ![[NUM:[0-9]+]]
+    // CHECK: bb1:
     // CHECK: path_b
     // CHECK: bb2:
     // CHECK: path_a
@@ -40,8 +40,8 @@ pub fn test2(x: i32) {
     }
 
     // CHECK-LABEL: @test2(
-    // CHECK: br i1 %_2, label %bb2, label %bb4, !prof ![[NUM]]
-    // CHECK: bb4:
+    // CHECK: br i1 %_2, label %bb2, label %bb1, !prof ![[NUM]]
+    // CHECK: bb1:
     // CHECK: path_b
     // CHECK: bb2:
     // CHECK: path_a
@@ -55,8 +55,8 @@ pub fn test3(x: i8) {
     }
 
     // CHECK-LABEL: @test3(
-    // CHECK: br i1 %_2, label %bb2, label %bb4, !prof ![[NUM]]
-    // CHECK: bb4:
+    // CHECK: br i1 %_2, label %bb2, label %bb1, !prof ![[NUM]]
+    // CHECK: bb1:
     // CHECK: path_b
     // CHECK: bb2:
     // CHECK: path_a
@@ -69,12 +69,16 @@ pub fn test4(x: u64) {
         _ => path_b(),
     }
 
+    // Note that LLVM seems to flip this one, for some reason
+
     // CHECK-LABEL: @test4(
-    // CHECK: br i1 %0, label %bb4, label %bb2, !prof ![[NUM2:[0-9]+]]
-    // CHECK: bb4:
+    // CHECK: %0 = icmp eq i64 %x, 33
+    // CHECK: br i1 %0, label %bb1, label %bb2, !prof ![[NUM2:[0-9]+]]
+    // CHECK: bb1:
     // CHECK: path_a
     // CHECK: bb2:
     // CHECK: path_b
 }
 
 // CHECK: ![[NUM]] = !{!"branch_weights", {{(!"expected", )?}}i32 1, i32 2000}
+// CHECK: ![[NUM2]] = !{!"branch_weights", {{(!"expected", )?}}i32 2000, i32 1}

--- a/tests/codegen/intrinsics/cold_path3.rs
+++ b/tests/codegen/intrinsics/cold_path3.rs
@@ -45,11 +45,11 @@ pub fn test(x: Option<u32>) {
     }
 
     // CHECK-LABEL: @test(
-    // CHECK: switch i32 %1, label %bb1 [
-    // CHECK: i32 0, label %bb6
-    // CHECK: i32 1, label %bb5
-    // CHECK: i32 2, label %bb4
-    // CHECK: i32 3, label %bb3
+    // CHECK: switch i32 %1, label %bb8 [
+    // CHECK: i32 0, label %bb2
+    // CHECK: i32 1, label %bb3
+    // CHECK: i32 2, label %bb5
+    // CHECK: i32 3, label %bb6
     // CHECK: ], !prof ![[NUM1:[0-9]+]]
 }
 
@@ -76,10 +76,10 @@ pub fn test2(x: Option<u32>) {
     }
 
     // CHECK-LABEL: @test2(
-    // CHECK: switch i32 %1, label %bb1 [
-    // CHECK: i32 10, label %bb5
-    // CHECK: i32 11, label %bb4
-    // CHECK: i32 13, label %bb3
+    // CHECK: switch i32 %1, label %bb7 [
+    // CHECK: i32 10, label %bb2
+    // CHECK: i32 11, label %bb3
+    // CHECK: i32 13, label %bb5
     // CHECK: ], !prof ![[NUM2:[0-9]+]]
 }
 

--- a/tests/codegen/intrinsics/likely.rs
+++ b/tests/codegen/intrinsics/likely.rs
@@ -26,10 +26,10 @@ pub fn test_likely(x: bool) {
 }
 
 // CHECK-LABEL: @test_likely(
-// CHECK: br i1 %x, label %bb2, label %bb3, !prof ![[NUM:[0-9]+]]
-// CHECK: bb3:
+// CHECK: br i1 %x, label %bb3, label %bb1, !prof ![[NUM:[0-9]+]]
+// CHECK: bb1:
 // CHECK-NOT: cold_path
 // CHECK: path_b
-// CHECK: bb2:
+// CHECK: bb3:
 // CHECK: path_a
 // CHECK: ![[NUM]] = !{!"branch_weights", {{(!"expected", )?}}i32 2000, i32 1}

--- a/tests/codegen/intrinsics/unlikely.rs
+++ b/tests/codegen/intrinsics/unlikely.rs
@@ -26,8 +26,8 @@ pub fn test_unlikely(x: bool) {
 }
 
 // CHECK-LABEL: @test_unlikely(
-// CHECK: br i1 %x, label %bb2, label %bb4, !prof ![[NUM:[0-9]+]]
-// CHECK: bb4:
+// CHECK: br i1 %x, label %bb2, label %bb1, !prof ![[NUM:[0-9]+]]
+// CHECK: bb1:
 // CHECK: path_b
 // CHECK: bb2:
 // CHECK-NOT: cold_path

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.32bit.panic-abort.diff
@@ -84,8 +84,8 @@
           StorageLive(_17);
           StorageLive(_19);
           _19 = const false;
--         switchInt(move _19) -> [0: bb6, otherwise: bb5];
-+         switchInt(const false) -> [0: bb6, otherwise: bb5];
+-         switchInt(move _19) -> [0: bb3, otherwise: bb2];
++         switchInt(const false) -> [0: bb3, otherwise: bb2];
       }
   
       bb1: {
@@ -95,15 +95,29 @@
       }
   
       bb2: {
-          unreachable;
+-         _20 = Layout::from_size_align_unchecked::precondition_check(copy _11, copy _12) -> [return: bb3, unwind unreachable];
++         _20 = Layout::from_size_align_unchecked::precondition_check(const 0_usize, const 1_usize) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {
--         _18 = handle_alloc_error(move _14) -> unwind unreachable;
-+         _18 = handle_alloc_error(const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}) -> unwind unreachable;
+          StorageDead(_19);
+          StorageLive(_21);
+-         _21 = copy _12 as std::ptr::Alignment (Transmute);
+-         _14 = Layout { size: copy _11, align: move _21 };
++         _21 = const std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0);
++         _14 = const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }};
+          StorageDead(_21);
+          StorageLive(_15);
+-         _15 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], copy _14, const false) -> [return: bb4, unwind unreachable];
++         _15 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}, const false) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {
+          _16 = discriminant(_15);
+          switchInt(move _16) -> [0: bb5, 1: bb6, otherwise: bb7];
+      }
+  
+      bb5: {
           _17 = copy ((_15 as Ok).0: std::ptr::NonNull<[u8]>);
           StorageLive(_22);
           _22 = copy _17 as *mut [u8] (Transmute);
@@ -150,27 +164,13 @@
           drop(_3) -> [return: bb1, unwind unreachable];
       }
   
-      bb5: {
--         _20 = Layout::from_size_align_unchecked::precondition_check(copy _11, copy _12) -> [return: bb6, unwind unreachable];
-+         _20 = Layout::from_size_align_unchecked::precondition_check(const 0_usize, const 1_usize) -> [return: bb6, unwind unreachable];
-      }
-  
       bb6: {
-          StorageDead(_19);
-          StorageLive(_21);
--         _21 = copy _12 as std::ptr::Alignment (Transmute);
--         _14 = Layout { size: copy _11, align: move _21 };
-+         _21 = const std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0);
-+         _14 = const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }};
-          StorageDead(_21);
-          StorageLive(_15);
--         _15 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], copy _14, const false) -> [return: bb7, unwind unreachable];
-+         _15 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}, const false) -> [return: bb7, unwind unreachable];
+-         _18 = handle_alloc_error(move _14) -> unwind unreachable;
++         _18 = handle_alloc_error(const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}) -> unwind unreachable;
       }
   
       bb7: {
-          _16 = discriminant(_15);
-          switchInt(move _16) -> [0: bb4, 1: bb3, otherwise: bb2];
+          unreachable;
       }
 + }
 + 

--- a/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/dont_reset_cast_kind_without_updating_operand.test.GVN.64bit.panic-abort.diff
@@ -84,8 +84,8 @@
           StorageLive(_17);
           StorageLive(_19);
           _19 = const false;
--         switchInt(move _19) -> [0: bb6, otherwise: bb5];
-+         switchInt(const false) -> [0: bb6, otherwise: bb5];
+-         switchInt(move _19) -> [0: bb3, otherwise: bb2];
++         switchInt(const false) -> [0: bb3, otherwise: bb2];
       }
   
       bb1: {
@@ -95,15 +95,29 @@
       }
   
       bb2: {
-          unreachable;
+-         _20 = Layout::from_size_align_unchecked::precondition_check(copy _11, copy _12) -> [return: bb3, unwind unreachable];
++         _20 = Layout::from_size_align_unchecked::precondition_check(const 0_usize, const 1_usize) -> [return: bb3, unwind unreachable];
       }
   
       bb3: {
--         _18 = handle_alloc_error(move _14) -> unwind unreachable;
-+         _18 = handle_alloc_error(const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}) -> unwind unreachable;
+          StorageDead(_19);
+          StorageLive(_21);
+-         _21 = copy _12 as std::ptr::Alignment (Transmute);
+-         _14 = Layout { size: copy _11, align: move _21 };
++         _21 = const std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0);
++         _14 = const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }};
+          StorageDead(_21);
+          StorageLive(_15);
+-         _15 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], copy _14, const false) -> [return: bb4, unwind unreachable];
++         _15 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}, const false) -> [return: bb4, unwind unreachable];
       }
   
       bb4: {
+          _16 = discriminant(_15);
+          switchInt(move _16) -> [0: bb5, 1: bb6, otherwise: bb7];
+      }
+  
+      bb5: {
           _17 = copy ((_15 as Ok).0: std::ptr::NonNull<[u8]>);
           StorageLive(_22);
           _22 = copy _17 as *mut [u8] (Transmute);
@@ -150,27 +164,13 @@
           drop(_3) -> [return: bb1, unwind unreachable];
       }
   
-      bb5: {
--         _20 = Layout::from_size_align_unchecked::precondition_check(copy _11, copy _12) -> [return: bb6, unwind unreachable];
-+         _20 = Layout::from_size_align_unchecked::precondition_check(const 0_usize, const 1_usize) -> [return: bb6, unwind unreachable];
-      }
-  
       bb6: {
-          StorageDead(_19);
-          StorageLive(_21);
--         _21 = copy _12 as std::ptr::Alignment (Transmute);
--         _14 = Layout { size: copy _11, align: move _21 };
-+         _21 = const std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0);
-+         _14 = const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }};
-          StorageDead(_21);
-          StorageLive(_15);
--         _15 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], copy _14, const false) -> [return: bb7, unwind unreachable];
-+         _15 = std::alloc::Global::alloc_impl(const alloc::alloc::exchange_malloc::promoted[0], const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}, const false) -> [return: bb7, unwind unreachable];
+-         _18 = handle_alloc_error(move _14) -> unwind unreachable;
++         _18 = handle_alloc_error(const Layout {{ size: 0_usize, align: std::ptr::Alignment(std::ptr::alignment::AlignmentEnum::_Align1Shl0) }}) -> unwind unreachable;
       }
   
       bb7: {
-          _16 = discriminant(_15);
-          switchInt(move _16) -> [0: bb4, 1: bb3, otherwise: bb2];
+          unreachable;
       }
 + }
 + 

--- a/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
@@ -72,7 +72,7 @@
 +         StorageLive(_13);
 +         StorageLive(_14);
 +         _12 = const 0_usize;
-+         goto -> bb4;
++         goto -> bb2;
       }
   
       bb1: {
@@ -90,23 +90,23 @@
       }
   
       bb2: {
++         _14 = Eq(copy _12, copy _10);
++         switchInt(move _14) -> [0: bb3, otherwise: bb4];
++     }
++ 
++     bb3: {
++         _13 = &raw mut (*_8)[_12];
++         _12 = Add(move _12, const 1_usize);
++         drop((*_13)) -> [return: bb2, unwind unreachable];
++     }
++ 
++     bb4: {
 +         StorageDead(_14);
 +         StorageDead(_13);
 +         StorageDead(_12);
 +         StorageDead(_8);
 +         StorageDead(_10);
 +         drop(((*_4).0: alloc::raw_vec::RawVec<A>)) -> [return: bb1, unwind unreachable];
-+     }
-+ 
-+     bb3: {
-+         _13 = &raw mut (*_8)[_12];
-+         _12 = Add(move _12, const 1_usize);
-+         drop((*_13)) -> [return: bb4, unwind unreachable];
-+     }
-+ 
-+     bb4: {
-+         _14 = Eq(copy _12, copy _10);
-+         switchInt(move _14) -> [0: bb3, otherwise: bb2];
 +     }
 + 
 +     bb5: {

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
@@ -26,26 +26,26 @@
 +         StorageLive(_3);
 +         StorageLive(_5);
 +         _3 = discriminant(_2);
-+         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(move _3) -> [0: bb1, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
-+         unreachable;
-+     }
-+ 
-+     bb2: {
 +         StorageLive(_4);
 +         _4 = UbChecks();
 +         assume(copy _4);
-+         _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
++         _5 = unreachable_unchecked::precondition_check() -> [return: bb3, unwind unreachable];
 +     }
 + 
-+     bb3: {
++     bb2: {
 +         _0 = move ((_2 as Some).0: T);
 +         StorageDead(_5);
 +         StorageDead(_3);
           StorageDead(_2);
           return;
++     }
++ 
++     bb3: {
++         unreachable;
       }
   }
   

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
@@ -26,30 +26,28 @@
 +         StorageLive(_3);
 +         StorageLive(_5);
 +         _3 = discriminant(_2);
-+         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(move _3) -> [0: bb1, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
--         StorageDead(_2);
--         return;
-+         unreachable;
++         StorageLive(_4);
++         _4 = UbChecks();
++         assume(copy _4);
++         _5 = unreachable_unchecked::precondition_check() -> [return: bb3, unwind unreachable];
++     }
++ 
++     bb2: {
++         _0 = move ((_2 as Some).0: T);
++         StorageDead(_5);
++         StorageDead(_3);
+          StorageDead(_2);
+          return;
       }
   
 -     bb2 (cleanup): {
 -         resume;
-+     bb2: {
-+         StorageLive(_4);
-+         _4 = UbChecks();
-+         assume(copy _4);
-+         _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
-+     }
-+ 
 +     bb3: {
-+         _0 = move ((_2 as Some).0: T);
-+         StorageDead(_5);
-+         StorageDead(_3);
-+         StorageDead(_2);
-+         return;
++         unreachable;
       }
   }
   

--- a/tests/mir-opt/instsimplify/ub_check.unwrap_unchecked.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/ub_check.unwrap_unchecked.InstSimplify-after-simplifycfg.diff
@@ -25,27 +25,27 @@
           StorageLive(_3);
           StorageLive(_5);
           _3 = discriminant(_2);
-          switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
+          switchInt(move _3) -> [0: bb1, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
-          unreachable;
-      }
-  
-      bb2: {
           StorageLive(_4);
 -         _4 = UbChecks();
 +         _4 = const false;
           assume(copy _4);
-          _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
+          _5 = unreachable_unchecked::precondition_check() -> [return: bb3, unwind unreachable];
       }
   
-      bb3: {
+      bb2: {
           _0 = move ((_2 as Some).0: i32);
           StorageDead(_5);
           StorageDead(_3);
           StorageDead(_2);
           return;
+      }
+  
+      bb3: {
+          unreachable;
       }
   }
   

--- a/tests/mir-opt/jump_threading.identity.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.identity.JumpThreading.panic-abort.diff
@@ -50,7 +50,7 @@
           StorageLive(_11);
           StorageLive(_12);
           _10 = discriminant(_4);
-          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb1];
+          switchInt(move _10) -> [0: bb6, 1: bb7, otherwise: bb1];
       }
   
       bb1: {
@@ -98,22 +98,22 @@
           StorageDead(_4);
           _5 = discriminant(_3);
 -         switchInt(move _5) -> [0: bb2, 1: bb3, otherwise: bb1];
-+         goto -> bb2;
++         goto -> bb3;
       }
   
       bb6: {
-          _12 = move ((_4 as Err).0: i32);
-          StorageLive(_13);
-          _13 = Result::<Infallible, i32>::Err(copy _12);
-          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _13);
-          StorageDead(_13);
+          _11 = move ((_4 as Ok).0: i32);
+          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _11);
 -         goto -> bb5;
 +         goto -> bb8;
       }
   
       bb7: {
-          _11 = move ((_4 as Ok).0: i32);
-          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _11);
+          _12 = move ((_4 as Err).0: i32);
+          StorageLive(_13);
+          _13 = Result::<Infallible, i32>::Err(copy _12);
+          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _13);
+          StorageDead(_13);
           goto -> bb5;
 +     }
 + 
@@ -123,7 +123,7 @@
 +         StorageDead(_10);
 +         StorageDead(_4);
 +         _5 = discriminant(_3);
-+         goto -> bb3;
++         goto -> bb2;
       }
   }
   

--- a/tests/mir-opt/jump_threading.identity.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.identity.JumpThreading.panic-unwind.diff
@@ -50,7 +50,7 @@
           StorageLive(_11);
           StorageLive(_12);
           _10 = discriminant(_4);
-          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb1];
+          switchInt(move _10) -> [0: bb6, 1: bb7, otherwise: bb1];
       }
   
       bb1: {
@@ -98,22 +98,22 @@
           StorageDead(_4);
           _5 = discriminant(_3);
 -         switchInt(move _5) -> [0: bb2, 1: bb3, otherwise: bb1];
-+         goto -> bb2;
++         goto -> bb3;
       }
   
       bb6: {
-          _12 = move ((_4 as Err).0: i32);
-          StorageLive(_13);
-          _13 = Result::<Infallible, i32>::Err(copy _12);
-          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _13);
-          StorageDead(_13);
+          _11 = move ((_4 as Ok).0: i32);
+          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _11);
 -         goto -> bb5;
 +         goto -> bb8;
       }
   
       bb7: {
-          _11 = move ((_4 as Ok).0: i32);
-          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _11);
+          _12 = move ((_4 as Err).0: i32);
+          StorageLive(_13);
+          _13 = Result::<Infallible, i32>::Err(copy _12);
+          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _13);
+          StorageDead(_13);
           goto -> bb5;
 +     }
 + 
@@ -123,7 +123,7 @@
 +         StorageDead(_10);
 +         StorageDead(_4);
 +         _5 = discriminant(_3);
-+         goto -> bb3;
++         goto -> bb2;
       }
   }
   

--- a/tests/mir-opt/jump_threading.rs
+++ b/tests/mir-opt/jump_threading.rs
@@ -49,7 +49,7 @@ fn identity(x: Result<i32, i32>) -> Result<i32, i32> {
     // CHECK-LABEL: fn identity(
     // CHECK: bb0: {
     // CHECK:     [[x:_.*]] = copy _1;
-    // CHECK:     switchInt(move {{_.*}}) -> [0: bb7, 1: bb6, otherwise: bb1];
+    // CHECK:     switchInt(move {{_.*}}) -> [0: bb6, 1: bb7, otherwise: bb1];
     // CHECK: bb1: {
     // CHECK:     unreachable;
     // CHECK: bb2: {
@@ -63,17 +63,17 @@ fn identity(x: Result<i32, i32>) -> Result<i32, i32> {
     // CHECK: bb4: {
     // CHECK:     return;
     // CHECK: bb5: {
-    // CHECK:     goto -> bb2;
+    // CHECK:     goto -> bb3;
     // CHECK: bb6: {
-    // CHECK:     {{_.*}} = move (([[x]] as Err).0: i32);
-    // CHECK:     [[controlflow]] = ControlFlow::<Result<Infallible, i32>, i32>::Break(
-    // CHECK:     goto -> bb8;
-    // CHECK: bb7: {
     // CHECK:     {{_.*}} = move (([[x]] as Ok).0: i32);
     // CHECK:     [[controlflow]] = ControlFlow::<Result<Infallible, i32>, i32>::Continue(
+    // CHECK:     goto -> bb8;
+    // CHECK: bb7: {
+    // CHECK:     {{_.*}} = move (([[x]] as Err).0: i32);
+    // CHECK:     [[controlflow]] = ControlFlow::<Result<Infallible, i32>, i32>::Break(
     // CHECK:     goto -> bb5;
     // CHECK: bb8: {
-    // CHECK:     goto -> bb3;
+    // CHECK:     goto -> bb2;
     Ok(x?)
 }
 

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -48,20 +48,16 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _10) -> [0: bb1, 1: bb2, otherwise: bb3];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(const 0_isize) -> [0: bb1, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
-          unreachable;
-      }
-  
-      bb2: {
           _11 = option::unwrap_failed() -> unwind unreachable;
       }
   
-      bb3: {
+      bb2: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -80,23 +76,20 @@
 +         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb4, unwind unreachable];
       }
   
+      bb3: {
+          unreachable;
+      }
+  
       bb4: {
           StorageDead(_8);
           StorageDead(_7);
           StorageLive(_12);
           StorageLive(_16);
           _12 = discriminant(_6);
-          switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb1];
+          switchInt(move _12) -> [0: bb5, 1: bb6, otherwise: bb3];
       }
   
       bb5: {
-          StorageLive(_15);
-          _16 = &_13;
-          _15 = copy _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
-          _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
-      }
-  
-      bb6: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
           StorageDead(_16);
           StorageDead(_12);
@@ -109,6 +102,13 @@
 -         StorageDead(_1);
 +         nop;
           return;
+      }
+  
+      bb6: {
+          StorageLive(_15);
+          _16 = &_13;
+          _15 = copy _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
+          _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
       }
 + }
 + 

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -37,9 +37,9 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb3, 1: bb4, otherwise: bb2];
+-         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb4];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb4, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb4];
       }
   
       bb1: {
@@ -55,14 +55,10 @@
       }
   
       bb2: {
-          unreachable;
-      }
-  
-      bb3: {
           _11 = option::unwrap_failed() -> unwind continue;
       }
   
-      bb4: {
+      bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -79,6 +75,10 @@
 -         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb5, unwind continue];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
 +         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb5, unwind continue];
+      }
+  
+      bb4: {
+          unreachable;
       }
   
       bb5: {

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -48,20 +48,16 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _10) -> [0: bb1, 1: bb2, otherwise: bb3];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(const 0_isize) -> [0: bb1, 1: bb2, otherwise: bb3];
       }
   
       bb1: {
-          unreachable;
-      }
-  
-      bb2: {
           _11 = option::unwrap_failed() -> unwind unreachable;
       }
   
-      bb3: {
+      bb2: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -80,23 +76,20 @@
 +         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb4, unwind unreachable];
       }
   
+      bb3: {
+          unreachable;
+      }
+  
       bb4: {
           StorageDead(_8);
           StorageDead(_7);
           StorageLive(_12);
           StorageLive(_16);
           _12 = discriminant(_6);
-          switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb1];
+          switchInt(move _12) -> [0: bb5, 1: bb6, otherwise: bb3];
       }
   
       bb5: {
-          StorageLive(_15);
-          _16 = &_13;
-          _15 = copy _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
-          _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
-      }
-  
-      bb6: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
           StorageDead(_16);
           StorageDead(_12);
@@ -109,6 +102,13 @@
 -         StorageDead(_1);
 +         nop;
           return;
+      }
+  
+      bb6: {
+          StorageLive(_15);
+          _16 = &_13;
+          _15 = copy _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize, Implicit));
+          _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
       }
 + }
 + 

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -37,9 +37,9 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb3, 1: bb4, otherwise: bb2];
+-         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb4];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb4, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb4];
       }
   
       bb1: {
@@ -55,14 +55,10 @@
       }
   
       bb2: {
-          unreachable;
-      }
-  
-      bb3: {
           _11 = option::unwrap_failed() -> unwind continue;
       }
   
-      bb4: {
+      bb3: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -79,6 +75,10 @@
 -         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb5, unwind continue];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
 +         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb5, unwind continue];
+      }
+  
+      bb4: {
+          unreachable;
       }
   
       bb5: {

--- a/tests/mir-opt/separate_const_switch.identity.JumpThreading.diff
+++ b/tests/mir-opt/separate_const_switch.identity.JumpThreading.diff
@@ -42,7 +42,7 @@
           StorageLive(_7);
           StorageLive(_8);
           _6 = discriminant(_1);
-          switchInt(move _6) -> [0: bb6, 1: bb5, otherwise: bb1];
+          switchInt(move _6) -> [0: bb5, 1: bb6, otherwise: bb1];
       }
   
       bb1: {
@@ -70,22 +70,22 @@
           StorageDead(_6);
           _3 = discriminant(_2);
 -         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
-+         goto -> bb2;
++         goto -> bb3;
       }
   
       bb5: {
-          _8 = copy ((_1 as Err).0: i32);
-          StorageLive(_9);
-          _9 = Result::<Infallible, i32>::Err(copy _8);
-          _2 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _9);
-          StorageDead(_9);
+          _7 = copy ((_1 as Ok).0: i32);
+          _2 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _7);
 -         goto -> bb4;
 +         goto -> bb7;
       }
   
       bb6: {
-          _7 = copy ((_1 as Ok).0: i32);
-          _2 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _7);
+          _8 = copy ((_1 as Err).0: i32);
+          StorageLive(_9);
+          _9 = Result::<Infallible, i32>::Err(copy _8);
+          _2 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _9);
+          StorageDead(_9);
           goto -> bb4;
 +     }
 + 
@@ -94,7 +94,7 @@
 +         StorageDead(_7);
 +         StorageDead(_6);
 +         _3 = discriminant(_2);
-+         goto -> bb3;
++         goto -> bb2;
       }
   }
   


### PR DESCRIPTION
Obviously we don't *need* to run this, but I keep being sad when I look at MIR on the playground that it's really awkward to read because you have to jump around all over because whenever something's inlined it's put at the end.

So what if we just do it when we're optimizing anyway?  Can we afford it?