### PR TITLE
Remove Amanieu from the libs review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1161,7 +1161,6 @@ compiler = [
 ]
 libs = [
     "@Mark-Simulacrum",
-    "@Amanieu",
     "@Noratrieb",
     "@workingjubilee",
     "@joboet",


### PR DESCRIPTION
Unfortunately I've accumulated a large backlog of PRs to review, both in rust-lang and my own repos. Until I've cleared the backlog, I will remove myself from the review rotation for rust-lang/rust.