### PR TITLE
Use the bootstrap compiler for `x check` on bootstrap tools

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -78,7 +78,7 @@ impl Builder<'_> {
                 *target,
             ),
             // doesn't depend on compiler, same as host compiler
-            _ => self.msg(Kind::Build, build_stage, format_args!("tool {tool}"), *host, *target),
+            _ => self.msg(kind, build_stage, format_args!("tool {tool}"), *host, *target),
         }
     }
 }


### PR DESCRIPTION
The existing implementation of `tool_check_step!` uses the specified `--stage` compiler, assumes `Mode::ToolRustc`, and unconditionally performs a check build of the compiler before checking the tool.

That behaviour makes sense for tools like rustdoc, but is inappropriate for checking things like bootstrap itself, or compiletest. Bootstrap tools are built the bootstrap compiler, and should be checked with that same compiler. And they have no reason to check the compiler crates.

This PR therefore adds support for specifying a mode in `tool_check_step!`, and using that mode to determine which compiler to use.