### PR TITLE
Use -C target-cpu=z13 on s390x vector test

### DIFF
--- a/tests/codegen/dont-shuffle-bswaps.rs
+++ b/tests/codegen/dont-shuffle-bswaps.rs
@@ -1,8 +1,11 @@
-//@ revisions: OPT2 OPT3
+//@ revisions: OPT2 OPT3 OPT3_S390X
 //@[OPT2] compile-flags: -Copt-level=2
 //@[OPT3] compile-flags: -C opt-level=3
 // some targets don't do the opt we are looking for
 //@[OPT3] only-64bit
+//@[OPT3] ignore-s390x
+//@[OPT3_S390X] compile-flags: -C opt-level=3 -C target-cpu=z13
+//@[OPT3_S390X] only-s390x
 
 #![crate_type = "lib"]
 #![no_std]
@@ -17,6 +20,10 @@
 // OPT3-NEXT: call <8 x i16> @llvm.bswap
 // OPT3-NEXT: store <8 x i16>
 // OPT3-NEXT: ret void
+// OPT3_S390X: load <8 x i16>
+// OPT3_S390X-NEXT: call <8 x i16> @llvm.bswap
+// OPT3_S390X-NEXT: store <8 x i16>
+// OPT3_S390X-NEXT: ret void
 #[no_mangle]
 pub fn convert(value: [u16; 8]) -> [u8; 16] {
     #[cfg(target_endian = "little")]


### PR DESCRIPTION
currently we see a regression in the `dont-shuffle-bswaps.rs` on s390x. This is due to, the default s390x cpu is set to z10 [here](https://github.com/rust-lang/rust/blob/master/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_gnu.rs#L9) which does not have vector instructions implemented. To make the test pass we need to create an extra test revision and set target-cpu at least to `z13`.


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
