### PR TITLE
Remove cjgillot from automated review assignment

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1115,7 +1115,6 @@ compiler_leads = [
 ]
 compiler = [
     "@BoxyUwU",
-    "@cjgillot",
     "@compiler-errors",
     "@davidtwco",
     "@estebank",
@@ -1171,7 +1170,7 @@ codegen = [
     "@workingjubilee",
 ]
 query-system = [
-    "@cjgillot",
+    "@oli-obk",
 ]
 incremental = [
     "@wesleywiser",


### PR DESCRIPTION
As discussed [on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Review.20for.20.23137465/with/508540539).

To be clear, this is not a value judgement, it's just a way to improve our fairness when assigning reviews, trying to find a balance between leaving time to Rust contributors review on their terms and availability and avoid having PRs waiting for too long.

> [!IMPORTANT]
> This is not a final decision! Rust contributors are free to re-add themselves back to the active review rotation (if they feel like it) once they have more availability.

cc: @cjgillot 