### PR TITLE
Skip suggest impl or dyn when poly trait is not a real trait

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
@@ -86,6 +86,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 "expected a type, found a trait"
             );
             if self_ty.span.can_be_used_for_suggestions()
+                && poly_trait_ref.trait_ref.trait_def_id().is_some()
                 && !self.maybe_suggest_impl_trait(self_ty, &mut diag)
                 && !self.maybe_suggest_dyn_trait(self_ty, sugg, &mut diag)
             {

--- a/tests/ui/traits/object/suggestion-trait-object-issue-139174.rs
+++ b/tests/ui/traits/object/suggestion-trait-object-issue-139174.rs
@@ -1,0 +1,24 @@
+//@compile-flags: --edition 2021
+
+fn f<'a>(x: Box<dyn Fn() -> Option<usize + 'a>>) -> usize {
+    //~^ ERROR expected trait, found builtin type `usize`
+    //~| ERROR expected a type, found a trait [E0782]
+    0
+}
+
+fn create_adder<'a>(x: i32) -> usize + 'a {
+    //~^ ERROR expected trait, found builtin type `usize`
+    //~| ERROR expected a type, found a trait [E0782]
+    move |y| x + y
+}
+
+struct Struct<'a>{
+    x: usize + 'a,
+    //~^ ERROR expected trait, found builtin type `usize`
+    //~| ERROR expected a type, found a trait [E0782]
+}
+
+
+fn main() {
+
+}

--- a/tests/ui/traits/object/suggestion-trait-object-issue-139174.stderr
+++ b/tests/ui/traits/object/suggestion-trait-object-issue-139174.stderr
@@ -21,33 +21,18 @@ error[E0782]: expected a type, found a trait
    |
 LL | fn f<'a>(x: Box<dyn Fn() -> Option<usize + 'a>>) -> usize {
    |                                    ^^^^^^^^^^
-   |
-help: you can add the `dyn` keyword if you want a trait object
-   |
-LL | fn f<'a>(x: Box<dyn Fn() -> Option<dyn usize + 'a>>) -> usize {
-   |                                    +++
 
 error[E0782]: expected a type, found a trait
   --> $DIR/suggestion-trait-object-issue-139174.rs:9:32
    |
 LL | fn create_adder<'a>(x: i32) -> usize + 'a {
    |                                ^^^^^^^^^^
-   |
-help: `usize + 'a` is dyn-incompatible, use `impl usize + 'a` to return an opaque type, as long as you return a single underlying type
-   |
-LL | fn create_adder<'a>(x: i32) -> impl usize + 'a {
-   |                                ++++
 
 error[E0782]: expected a type, found a trait
   --> $DIR/suggestion-trait-object-issue-139174.rs:16:8
    |
 LL |     x: usize + 'a,
    |        ^^^^^^^^^^
-   |
-help: you can add the `dyn` keyword if you want a trait object
-   |
-LL |     x: dyn usize + 'a,
-   |        +++
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/traits/object/suggestion-trait-object-issue-139174.stderr
+++ b/tests/ui/traits/object/suggestion-trait-object-issue-139174.stderr
@@ -1,0 +1,55 @@
+error[E0404]: expected trait, found builtin type `usize`
+  --> $DIR/suggestion-trait-object-issue-139174.rs:3:36
+   |
+LL | fn f<'a>(x: Box<dyn Fn() -> Option<usize + 'a>>) -> usize {
+   |                                    ^^^^^ not a trait
+
+error[E0404]: expected trait, found builtin type `usize`
+  --> $DIR/suggestion-trait-object-issue-139174.rs:9:32
+   |
+LL | fn create_adder<'a>(x: i32) -> usize + 'a {
+   |                                ^^^^^ not a trait
+
+error[E0404]: expected trait, found builtin type `usize`
+  --> $DIR/suggestion-trait-object-issue-139174.rs:16:8
+   |
+LL |     x: usize + 'a,
+   |        ^^^^^ not a trait
+
+error[E0782]: expected a type, found a trait
+  --> $DIR/suggestion-trait-object-issue-139174.rs:3:36
+   |
+LL | fn f<'a>(x: Box<dyn Fn() -> Option<usize + 'a>>) -> usize {
+   |                                    ^^^^^^^^^^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL | fn f<'a>(x: Box<dyn Fn() -> Option<dyn usize + 'a>>) -> usize {
+   |                                    +++
+
+error[E0782]: expected a type, found a trait
+  --> $DIR/suggestion-trait-object-issue-139174.rs:9:32
+   |
+LL | fn create_adder<'a>(x: i32) -> usize + 'a {
+   |                                ^^^^^^^^^^
+   |
+help: `usize + 'a` is dyn-incompatible, use `impl usize + 'a` to return an opaque type, as long as you return a single underlying type
+   |
+LL | fn create_adder<'a>(x: i32) -> impl usize + 'a {
+   |                                ++++
+
+error[E0782]: expected a type, found a trait
+  --> $DIR/suggestion-trait-object-issue-139174.rs:16:8
+   |
+LL |     x: usize + 'a,
+   |        ^^^^^^^^^^
+   |
+help: you can add the `dyn` keyword if you want a trait object
+   |
+LL |     x: dyn usize + 'a,
+   |        +++
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0404, E0782.
+For more information about an error, try `rustc --explain E0404`.


### PR DESCRIPTION
Fixes #139174
When `poly_trait_ref` is not a real trait, we should stop suggesting `impl` and `dyn` to avoid false positives. 3 cases were added to the ui test.
https://github.com/rust-lang/rust/blob/0b45675cfcec57f30a3794e1a1e18423aa9cf200/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs#L88-L93

In the first commit, I submitted the test and passed it. In the second commit, I modified the code and we can see the changes in the test.

r? compiler