### PR TITLE
std: use the address of `errno` to identify threads in `unique_thread_exit`

### DIFF
--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -61,7 +61,7 @@ unsafe extern "C" {
     #[cfg_attr(target_os = "aix", link_name = "_Errno")]
     // SAFETY: this will always return the same pointer on a given thread.
     #[unsafe(ffi_const)]
-    fn errno_location() -> *mut c_int;
+    pub safe fn errno_location() -> *mut c_int;
 }
 
 /// Returns the platform-specific value of errno


### PR DESCRIPTION
Getting the address of `errno` should be just as cheap as `pthread_self()` and avoids having to use the expensive `Mutex` logic because it always results in a pointer.