### PR TITLE
move autodiff from EnzymeAD/Enzyme to our rust-lang/Enzyme soft-fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,7 +45,7 @@
 	shallow = true
 [submodule "src/tools/enzyme"]
 	path = src/tools/enzyme
-	url = https://github.com/EnzymeAD/Enzyme.git
+	url = https://github.com/rust-lang/Enzyme.git
 	shallow = true
 [submodule "src/gcc"]
 	path = src/gcc


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

In https://github.com/rust-lang/team/pull/1665 we decided to have a soft-fork of Enzyme, to be able to merge e.g. CI, docs, or cmake improvements if upstream is not interested in them. We don't intend to merge logic/code changes. It also seems generally preferable if we clone submodules from a rust-lang repo, instead of an external org. We don't build or checkout Enzyme yet by default, so this should be a safe rollup.

