### PR TITLE
Remove `aux_build` run-make rustc helpers

### DIFF
--- a/src/tools/run-make-support/src/external_deps/rustc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustc.rs
@@ -22,12 +22,6 @@ pub fn bare_rustc() -> Rustc {
     Rustc::bare()
 }
 
-/// Construct a new `rustc` aux-build invocation.
-#[track_caller]
-pub fn aux_build() -> Rustc {
-    Rustc::new_aux_build()
-}
-
 /// A `rustc` invocation builder.
 #[derive(Debug)]
 #[must_use]
@@ -64,14 +58,6 @@ impl Rustc {
     #[track_caller]
     pub fn bare() -> Self {
         let cmd = setup_common();
-        Self { cmd }
-    }
-
-    /// Construct a new `rustc` invocation with `aux_build` preset (setting `--crate-type=lib`).
-    #[track_caller]
-    pub fn new_aux_build() -> Self {
-        let mut cmd = setup_common();
-        cmd.arg("--crate-type=lib");
         Self { cmd }
     }
 

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -68,7 +68,7 @@ pub use llvm::{
     LlvmFilecheck, LlvmNm, LlvmObjcopy, LlvmObjdump, LlvmProfdata, LlvmReadobj,
 };
 pub use python::python_command;
-pub use rustc::{aux_build, bare_rustc, rustc, rustc_path, Rustc};
+pub use rustc::{bare_rustc, rustc, rustc_path, Rustc};
 pub use rustdoc::{rustdoc, Rustdoc};
 
 /// [`diff`][mod@diff] is implemented in terms of the [similar] library.

--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -3,10 +3,10 @@
 // Check that the `CURRENT_RUSTC_VERSION` placeholder is correctly replaced by the current
 // `rustc` version and the `since` property in feature stability gating is properly respected.
 
-use run_make_support::{aux_build, rfs, rustc, source_root};
+use run_make_support::{rfs, rustc, source_root};
 
 fn main() {
-    aux_build().input("stable.rs").emit("metadata").run();
+    rustc().crate_type("lib").input("stable.rs").emit("metadata").run();
 
     let output =
         rustc().input("main.rs").emit("metadata").extern_("stable", "libstable.rmeta").run();

--- a/tests/run-make/issue-107495-archive-permissions/rmake.rs
+++ b/tests/run-make/issue-107495-archive-permissions/rmake.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 #[cfg(unix)]
 use run_make_support::libc;
-use run_make_support::{aux_build, rfs};
+use run_make_support::{rfs, rustc};
 
 fn main() {
     #[cfg(unix)]
@@ -12,7 +12,7 @@ fn main() {
         libc::umask(0o002);
     }
 
-    aux_build().arg("foo.rs").run();
+    rustc().crate_type("lib").arg("foo.rs").run();
     verify(Path::new("libfoo.rlib"));
 }
 


### PR DESCRIPTION
They provide very little value and makes it more confusing than is
helpful.

Helps with #138066.

r? @Kobzol 