### PR TITLE
Use a more lightweight cache for `erase_regions`

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -660,20 +660,6 @@ rustc_queries! {
         separate_provide_extern
     }
 
-    /// Erases regions from `ty` to yield a new type.
-    /// Normally you would just use `tcx.erase_regions(value)`,
-    /// however, which uses this query as a kind of cache.
-    query erase_regions_ty(ty: Ty<'tcx>) -> Ty<'tcx> {
-        // This query is not expected to have input -- as a result, it
-        // is not a good candidates for "replay" because it is essentially a
-        // pure function of its input (and hence the expectation is that
-        // no caller would be green **apart** from just these
-        // queries). Making it anonymous avoids hashing the result, which
-        // may save a bit of time.
-        anon
-        desc { "erasing regions from `{}`", ty }
-    }
-
     query wasm_import_module_map(_: CrateNum) -> &'tcx DefIdMap<String> {
         arena_cache
         desc { "getting wasm import module map" }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1376,6 +1376,9 @@ pub struct GlobalCtxt<'tcx> {
     /// Common consts, pre-interned for your convenience.
     pub consts: CommonConsts<'tcx>,
 
+    /// A cache for the `erase_regions` function.
+    pub(in crate::ty) erased_region_cache: ShardedHashMap<Ty<'tcx>, Ty<'tcx>>,
+
     /// Hooks to be able to register functions in other crates that can then still
     /// be called from rustc_middle.
     pub(crate) hooks: crate::hooks::Providers,
@@ -1617,6 +1620,7 @@ impl<'tcx> TyCtxt<'tcx> {
             types: common_types,
             lifetimes: common_lifetimes,
             consts: common_consts,
+            erased_region_cache: Default::default(),
             untracked,
             query_system,
             query_kinds,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2129,7 +2129,6 @@ pub fn ast_uint_ty(uty: UintTy) -> ast::UintTy {
 pub fn provide(providers: &mut Providers) {
     closure::provide(providers);
     context::provide(providers);
-    erase_regions::provide(providers);
     inhabitedness::provide(providers);
     util::provide(providers);
     print::provide(providers);

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -268,6 +268,14 @@ impl<D: Deps> DepGraph<D> {
         D::with_deps(TaskDepsRef::Forbid, op)
     }
 
+    /// This checks that no dependencies are registered in `op` if debug assertions are enabled.
+    pub fn debug_assert_no_deps<OP, R>(op: OP) -> R
+    where
+        OP: FnOnce() -> R,
+    {
+        if cfg!(debug_assertions) { D::with_deps(TaskDepsRef::Forbid, op) } else { op() }
+    }
+
     #[inline(always)]
     pub fn with_task<Ctxt: HasDepContext<Deps = D>, A: Debug, R>(
         &self,


### PR DESCRIPTION
This changes `erase_regions` to use a global hashmap instead of a query to cache types with erased lifetimes. `erase_regions_ty` only depends on the input parameter so it doesn't need to be a query.

This is a rebase of https://github.com/rust-lang/rust/pull/59505.

<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th><td align="right">Physical Memory</td><td align="right">Physical Memory</td><td align="right">%</th><td align="right">Committed Memory</td><td align="right">Committed Memory</td><td align="right">%</th></tr><tr><td>🟣 <b>clap</b>:check</td><td align="right">1.3960s</td><td align="right">1.3883s</td><td align="right"> -0.55%</td><td align="right">147.66 MiB</td><td align="right">147.76 MiB</td><td align="right"> 0.07%</td><td align="right">199.83 MiB</td><td align="right">199.86 MiB</td><td align="right"> 0.01%</td></tr><tr><td>🟣 <b>hyper</b>:check</td><td align="right">0.2346s</td><td align="right">0.2337s</td><td align="right"> -0.38%</td><td align="right">80.35 MiB</td><td align="right">80.54 MiB</td><td align="right"> 0.24%</td><td align="right">129.99 MiB</td><td align="right">130.12 MiB</td><td align="right"> 0.10%</td></tr><tr><td>🟣 <b>regex</b>:check</td><td align="right">0.7811s</td><td align="right">0.7788s</td><td align="right"> -0.30%</td><td align="right">107.75 MiB</td><td align="right">108.07 MiB</td><td align="right"> 0.29%</td><td align="right">153.67 MiB</td><td align="right">153.99 MiB</td><td align="right"> 0.21%</td></tr><tr><td>🟣 <b>syn</b>:check</td><td align="right">1.2999s</td><td align="right">1.2978s</td><td align="right"> -0.17%</td><td align="right">140.24 MiB</td><td align="right">140.35 MiB</td><td align="right"> 0.08%</td><td align="right">188.59 MiB</td><td align="right">188.58 MiB</td><td align="right"> -0.01%</td></tr><tr><td>Total</td><td align="right">3.7117s</td><td align="right">3.6986s</td><td align="right"> -0.35%</td><td align="right">476.00 MiB</td><td align="right">476.72 MiB</td><td align="right"> 0.15%</td><td align="right">672.08 MiB</td><td align="right">672.55 MiB</td><td align="right"> 0.07%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">0.9965s</td><td align="right"> -0.35%</td><td align="right">1 byte</td><td align="right">1.00 bytes</td><td align="right"> 0.17%</td><td align="right">1 byte</td><td align="right">1.00 bytes</td><td align="right"> 0.08%</td></tr></table>
