### PR TITLE
run-make-support: Calculate artifact names for target platform, not host platform

### DIFF
--- a/src/tools/run-make-support/src/artifact_names.rs
+++ b/src/tools/run-make-support/src/artifact_names.rs
@@ -1,11 +1,11 @@
 //! A collection of helpers to construct artifact names, such as names of dynamic or static
-//! librarys which are target-dependent.
+//! libraries which are target-dependent.
 
-// FIXME(jieyouxu): convert these to return `PathBuf`s instead of strings!
-
+use crate::target;
 use crate::targets::is_msvc;
 
 /// Construct the static library name based on the target.
+#[track_caller]
 #[must_use]
 pub fn static_lib_name(name: &str) -> String {
     assert!(!name.contains(char::is_whitespace), "static library name cannot contain whitespace");
@@ -14,15 +14,34 @@ pub fn static_lib_name(name: &str) -> String {
 }
 
 /// Construct the dynamic library name based on the target.
+#[track_caller]
 #[must_use]
 pub fn dynamic_lib_name(name: &str) -> String {
     assert!(!name.contains(char::is_whitespace), "dynamic library name cannot contain whitespace");
 
-    format!("{}{name}.{}", std::env::consts::DLL_PREFIX, std::env::consts::DLL_EXTENSION)
+    format!("{}{name}.{}", dynamic_lib_prefix(), dynamic_lib_extension())
 }
 
-/// Construct the name of the import library for the dynamic library, exclusive to MSVC and
-/// accepted by link.exe.
+fn dynamic_lib_prefix() -> &'static str {
+    if target().contains("windows") { "" } else { "lib" }
+}
+
+/// Construct the dynamic library extension based on the target.
+#[must_use]
+pub fn dynamic_lib_extension() -> &'static str {
+    let target = target();
+
+    if target.contains("apple") {
+        "dylib"
+    } else if target.contains("windows") {
+        "dll"
+    } else {
+        "so"
+    }
+}
+
+/// Construct the name of the import library for the dynamic library, exclusive to MSVC and accepted
+/// by link.exe.
 #[track_caller]
 #[must_use]
 pub fn msvc_import_dynamic_lib_name(name: &str) -> String {
@@ -32,20 +51,28 @@ pub fn msvc_import_dynamic_lib_name(name: &str) -> String {
     format!("{name}.dll.lib")
 }
 
-/// Construct the dynamic library extension based on the target.
-#[must_use]
-pub fn dynamic_lib_extension() -> &'static str {
-    std::env::consts::DLL_EXTENSION
-}
-
 /// Construct the name of a rust library (rlib).
+#[track_caller]
 #[must_use]
 pub fn rust_lib_name(name: &str) -> String {
     format!("lib{name}.rlib")
 }
 
 /// Construct the binary (executable) name based on the target.
+#[track_caller]
 #[must_use]
 pub fn bin_name(name: &str) -> String {
-    format!("{name}{}", std::env::consts::EXE_SUFFIX)
+    let target = target();
+
+    if target.contains("windows") {
+        format!("{name}.exe")
+    } else if target.contains("uefi") {
+        format!("{name}.efi")
+    } else if target.contains("wasm") {
+        format!("{name}.wasm")
+    } else if target.contains("nvptx") {
+        format!("{name}.ptx")
+    } else {
+        name.to_string()
+    }
 }

--- a/tests/run-make/crate-data-smoke/rmake.rs
+++ b/tests/run-make/crate-data-smoke/rmake.rs
@@ -1,9 +1,20 @@
-use run_make_support::{bin_name, rust_lib_name, rustc};
+use run_make_support::{bin_name, rust_lib_name, rustc, target};
 
 fn main() {
-    rustc().print("crate-name").input("crate.rs").run().assert_stdout_equals("foo");
-    rustc().print("file-names").input("crate.rs").run().assert_stdout_equals(bin_name("foo"));
     rustc()
+        .target(target())
+        .print("crate-name")
+        .input("crate.rs")
+        .run()
+        .assert_stdout_equals("foo");
+    rustc()
+        .target(target())
+        .print("file-names")
+        .input("crate.rs")
+        .run()
+        .assert_stdout_equals(bin_name("foo"));
+    rustc()
+        .target(target())
         .print("file-names")
         .crate_type("lib")
         .arg("--test")
@@ -11,11 +22,22 @@ fn main() {
         .run()
         .assert_stdout_equals(bin_name("foo"));
     rustc()
+        .target(target())
         .print("file-names")
         .arg("--test")
         .input("lib.rs")
         .run()
         .assert_stdout_equals(bin_name("mylib"));
-    rustc().print("file-names").input("lib.rs").run().assert_stdout_equals(rust_lib_name("mylib"));
-    rustc().print("file-names").input("rlib.rs").run().assert_stdout_equals(rust_lib_name("mylib"));
+    rustc()
+        .target(target())
+        .print("file-names")
+        .input("lib.rs")
+        .run()
+        .assert_stdout_equals(rust_lib_name("mylib"));
+    rustc()
+        .target(target())
+        .print("file-names")
+        .input("rlib.rs")
+        .run()
+        .assert_stdout_equals(rust_lib_name("mylib"));
 }

--- a/tests/run-make/crate-name-priority/rmake.rs
+++ b/tests/run-make/crate-name-priority/rmake.rs
@@ -4,6 +4,8 @@
 // and the compiler flags, and checks that the flag is favoured each time.
 // See https://github.com/rust-lang/rust/pull/15518
 
+//@ ignore-cross-compile (relocations in generic ELF against `arm-unknown-linux-gnueabihf`)
+
 use run_make_support::{bin_name, rfs, rustc};
 
 fn main() {

--- a/tests/run-make/extra-filename-with-temp-outputs/rmake.rs
+++ b/tests/run-make/extra-filename-with-temp-outputs/rmake.rs
@@ -6,6 +6,8 @@
 // are named as expected.
 // See https://github.com/rust-lang/rust/pull/15686
 
+//@ ignore-cross-compile (relocations in generic ELF against `arm-unknown-linux-gnueabihf`)
+
 use run_make_support::{bin_name, cwd, has_prefix, has_suffix, rfs, rustc, shallow_find_files};
 
 fn main() {

--- a/tests/run-make/output-type-permutations/rmake.rs
+++ b/tests/run-make/output-type-permutations/rmake.rs
@@ -4,6 +4,9 @@
 // files are exactly what is expected, no more, no less.
 // See https://github.com/rust-lang/rust/pull/12020
 
+//@ ignore-cross-compile
+// Reason: some cross-compiled targets don't support various crate types and fail to link.
+
 use std::path::PathBuf;
 
 use run_make_support::{
@@ -17,6 +20,7 @@ use run_make_support::{
 // `dir`: the name of the directory where the test happens
 // `rustc_invocation`: the rustc command being tested
 // Any unexpected output files not listed in `must_exist` or `can_exist` will cause a failure.
+#[track_caller]
 fn assert_expected_output_files(expectations: Expectations, rustc_invocation: impl Fn()) {
     let Expectations { expected_files: must_exist, allowed_files: can_exist, test_dir: dir } =
         expectations;

--- a/tests/run-make/reproducible-build/rmake.rs
+++ b/tests/run-make/reproducible-build/rmake.rs
@@ -20,6 +20,8 @@
 // See https://github.com/rust-lang/rust/pull/32293
 // Tracking Issue: https://github.com/rust-lang/rust/issues/129080
 
+//@ ignore-cross-compile (linker binary needs to run)
+
 use run_make_support::{
     bin_name, cwd, diff, is_darwin, is_windows, regex, rfs, run_in_tmpdir, rust_lib_name, rustc,
 };

--- a/tests/run-make/strip/rmake.rs
+++ b/tests/run-make/strip/rmake.rs
@@ -1,4 +1,5 @@
-//@ ignore-windows Windows does not actually strip
+//@ ignore-windows (Windows does not actually strip)
+//@ ignore-cross-compile (relocations in generic ELF against `arm-unknown-linux-gnueabihf`)
 
 // Test that -Cstrip correctly strips/preserves debuginfo and symbols.
 

--- a/tests/run-make/symbols-all-mangled/rmake.rs
+++ b/tests/run-make/symbols-all-mangled/rmake.rs
@@ -1,5 +1,7 @@
 // Check that all symbols in cdylibs, staticlibs and bins are mangled
 //@ only-elf some object file formats create multiple symbols for each function with different names
+//@ ignore-nvptx64 (needs target std)
+//@ ignore-cross-compile (host-only)
 
 use run_make_support::object::read::{Object, ObjectSymbol};
 use run_make_support::{bin_name, dynamic_lib_name, object, rfs, rustc, static_lib_name};


### PR DESCRIPTION
This was implemented incorrectly during the porting process, where we relied on std consts. However, `run-make-support` is a host-only library, which meant that these artifact names were for the *host* and not the *target*.

Helps with #138066.

r? @Kobzol 

try-job: armhf-gnu
try-job: test-various
try-job: x86_64-msvc-1
try-job: i686-msvc-1
try-job: x86_64-mingw-1
try-job: aarch64-apple
try-job: x86_64-apple-1
