### PR TITLE
Enable automatic cross-compilation in run-make tests

### DIFF
--- a/src/tools/run-make-support/src/external_deps/rustc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustc.rs
@@ -6,7 +6,7 @@ use crate::command::Command;
 use crate::env::env_var;
 use crate::path_helpers::cwd;
 use crate::util::set_host_compiler_dylib_path;
-use crate::{is_aix, is_darwin, is_msvc, is_windows, uname};
+use crate::{is_aix, is_darwin, is_msvc, is_windows, target, uname};
 
 /// Construct a new `rustc` invocation. This will automatically set the library
 /// search path as `-L cwd()`. Use [`bare_rustc`] to avoid this.
@@ -27,9 +27,15 @@ pub fn bare_rustc() -> Rustc {
 #[must_use]
 pub struct Rustc {
     cmd: Command,
+    target: Option<String>,
 }
 
-crate::macros::impl_common_helpers!(Rustc);
+// Only fill in the target just before execution, so that it can be overridden.
+crate::macros::impl_common_helpers!(Rustc, |rustc: &mut Rustc| {
+    if let Some(target) = &rustc.target {
+        rustc.cmd.arg(&format!("--target={target}"));
+    }
+});
 
 pub fn rustc_path() -> String {
     env_var("RUSTC")
@@ -46,19 +52,22 @@ impl Rustc {
     // `rustc` invocation constructor methods
 
     /// Construct a new `rustc` invocation. This will automatically set the library
-    /// search path as `-L cwd()`. Use [`bare_rustc`] to avoid this.
+    /// search path as `-L cwd()` and also the compilation target.
+    /// Use [`bare_rustc`] to avoid this.
     #[track_caller]
     pub fn new() -> Self {
         let mut cmd = setup_common();
         cmd.arg("-L").arg(cwd());
-        Self { cmd }
+
+        // Automatically default to cross-compilation
+        Self { cmd, target: Some(target()) }
     }
 
     /// Construct a bare `rustc` invocation with no flags set.
     #[track_caller]
     pub fn bare() -> Self {
         let cmd = setup_common();
-        Self { cmd }
+        Self { cmd, target: None }
     }
 
     // Argument provider methods
@@ -234,8 +243,9 @@ impl Rustc {
 
     /// Specify the target triple, or a path to a custom target json spec file.
     pub fn target<S: AsRef<str>>(&mut self, target: S) -> &mut Self {
-        let target = target.as_ref();
-        self.cmd.arg(format!("--target={target}"));
+        // We store the target as a separate field, so that it can be specified multiple times.
+        // This is in particular useful to override the default target set in Rustc::new().
+        self.target = Some(target.as_ref().to_string());
         self
     }
 

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -68,7 +68,7 @@ pub use llvm::{
 };
 pub use python::python_command;
 pub use rustc::{bare_rustc, rustc, rustc_path, Rustc};
-pub use rustdoc::{rustdoc, Rustdoc};
+pub use rustdoc::{bare_rustdoc, rustdoc, Rustdoc};
 
 /// [`diff`][mod@diff] is implemented in terms of the [similar] library.
 ///

--- a/src/tools/run-make-support/src/macros.rs
+++ b/src/tools/run-make-support/src/macros.rs
@@ -23,10 +23,16 @@
 /// }
 /// ```
 ///
+/// You can pass an optional second parameter which should be a function that is passed
+/// `&mut self` just before the command is executed.
+///
 /// [`Command`]: crate::command::Command
 /// [`CompletedProcess`]: crate::command::CompletedProcess
 macro_rules! impl_common_helpers {
     ($wrapper: ident) => {
+        $crate::macros::impl_common_helpers!($wrapper, |_| {});
+    };
+    ($wrapper: ident, $before_exec: expr) => {
         impl $wrapper {
             /// In very rare circumstances, you may need a e.g. `bare_rustc()` or `bare_rustdoc()`
             /// with host runtime libs configured, but want the underlying raw
@@ -130,12 +136,14 @@ macro_rules! impl_common_helpers {
             /// Run the constructed command and assert that it is successfully run.
             #[track_caller]
             pub fn run(&mut self) -> crate::command::CompletedProcess {
+                $before_exec(&mut *self);
                 self.cmd.run()
             }
 
             /// Run the constructed command and assert that it does not successfully run.
             #[track_caller]
             pub fn run_fail(&mut self) -> crate::command::CompletedProcess {
+                $before_exec(&mut *self);
                 self.cmd.run_fail()
             }
 
@@ -145,6 +153,7 @@ macro_rules! impl_common_helpers {
             /// whenever possible.
             #[track_caller]
             pub fn run_unchecked(&mut self) -> crate::command::CompletedProcess {
+                $before_exec(&mut *self);
                 self.cmd.run_unchecked()
             }
 

--- a/tests/run-make/allow-warnings-cmdline-stability/rmake.rs
+++ b/tests/run-make/allow-warnings-cmdline-stability/rmake.rs
@@ -1,4 +1,4 @@
-//@ needs-target-std
+//@ ignore-cross-compile
 // Test that `-Awarnings` suppresses warnings for unstable APIs.
 
 use run_make_support::rustc;

--- a/tests/run-make/apple-deployment-target/rmake.rs
+++ b/tests/run-make/apple-deployment-target/rmake.rs
@@ -41,7 +41,6 @@ fn main() {
 
     // Remove env vars to get `rustc`'s default
     let output = rustc()
-        .target(target())
         .env_remove("MACOSX_DEPLOYMENT_TARGET")
         .env_remove("IPHONEOS_DEPLOYMENT_TARGET")
         .env_remove("WATCHOS_DEPLOYMENT_TARGET")
@@ -58,7 +57,6 @@ fn main() {
     run_in_tmpdir(|| {
         let rustc = || {
             let mut rustc = rustc();
-            rustc.target(target());
             rustc.crate_type("lib");
             rustc.emit("obj");
             rustc.input("foo.rs");
@@ -82,7 +80,6 @@ fn main() {
 
         let rustc = || {
             let mut rustc = rustc();
-            rustc.target(target());
             rustc.crate_type("dylib");
             rustc.input("foo.rs");
             rustc.output("libfoo.dylib");
@@ -108,7 +105,6 @@ fn main() {
     run_in_tmpdir(|| {
         let rustc = || {
             let mut rustc = rustc();
-            rustc.target(target());
             rustc.crate_type("bin");
             rustc.input("foo.rs");
             rustc.output("foo");
@@ -147,7 +143,6 @@ fn main() {
     run_in_tmpdir(|| {
         let rustc = || {
             let mut rustc = rustc();
-            rustc.target(target());
             rustc.incremental("incremental");
             rustc.crate_type("lib");
             rustc.emit("obj");

--- a/tests/run-make/apple-sdk-version/rmake.rs
+++ b/tests/run-make/apple-sdk-version/rmake.rs
@@ -24,8 +24,7 @@ fn has_sdk_version(file: &str, version: &str) {
 
 fn main() {
     // Fetch rustc's inferred deployment target.
-    let current_deployment_target =
-        rustc().target(target()).print("deployment-target").run().stdout_utf8();
+    let current_deployment_target = rustc().print("deployment-target").run().stdout_utf8();
     let current_deployment_target = current_deployment_target.split('=').last().unwrap().trim();
 
     // Fetch current SDK version via. xcrun.
@@ -45,7 +44,7 @@ fn main() {
     let current_sdk_version = current_sdk_version.trim();
 
     // Check the SDK version in the object file produced by the codegen backend.
-    rustc().target(target()).crate_type("lib").emit("obj").input("foo.rs").output("foo.o").run();
+    rustc().crate_type("lib").emit("obj").input("foo.rs").output("foo.o").run();
     // Set to 0, which means not set or "n/a".
     has_sdk_version("foo.o", "n/a");
 
@@ -53,7 +52,7 @@ fn main() {
     //
     // This is just to ensure that we don't set some odd version in `create_object_file`,
     // if the rmeta file is packed in a different way in the future, this can safely be removed.
-    rustc().target(target()).crate_type("rlib").input("foo.rs").output("libfoo.rlib").run();
+    rustc().crate_type("rlib").input("foo.rs").output("libfoo.rlib").run();
     // Extra .rmeta file (which is encoded as an object file).
     cmd("ar").arg("-x").arg("libfoo.rlib").arg("lib.rmeta").run();
     has_sdk_version("lib.rmeta", "n/a");
@@ -69,7 +68,6 @@ fn main() {
         // Test with clang
         let file_name = format!("foo_cc{file_ext}");
         rustc()
-            .target(target())
             .crate_type("bin")
             .arg("-Clinker-flavor=gcc")
             .input("foo.rs")
@@ -80,7 +78,6 @@ fn main() {
         // Test with ld64
         let file_name = format!("foo_ld{file_ext}");
         rustc()
-            .target(target())
             .crate_type("bin")
             .arg("-Clinker-flavor=ld")
             .input("foo.rs")

--- a/tests/run-make/crate-circular-deps-link/rmake.rs
+++ b/tests/run-make/crate-circular-deps-link/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // Test that previously triggered a linker failure with root cause
 // similar to one found in the issue #69368.
 //

--- a/tests/run-make/doctests-merge/rmake.rs
+++ b/tests/run-make/doctests-merge/rmake.rs
@@ -1,4 +1,5 @@
-//@ needs-target-std
+//@ ignore-cross-compile (needs to run doctests)
+
 use std::path::Path;
 
 use run_make_support::{cwd, diff, rustc, rustdoc};

--- a/tests/run-make/doctests-runtool/rmake.rs
+++ b/tests/run-make/doctests-runtool/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile (needs to run host tool binary)
+
 // Tests behavior of rustdoc `--test-runtool`.
 
 use std::path::PathBuf;

--- a/tests/run-make/embed-metadata/rmake.rs
+++ b/tests/run-make/embed-metadata/rmake.rs
@@ -1,5 +1,6 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+//@ needs-crate-type: dylib
+
 // Tests the -Zembed-metadata compiler flag.
 // Tracking issue: https://github.com/rust-lang/rust/issues/139165
 

--- a/tests/run-make/embed-source-dwarf/rmake.rs
+++ b/tests/run-make/embed-source-dwarf/rmake.rs
@@ -1,6 +1,8 @@
 //@ needs-target-std
 //@ ignore-windows
 //@ ignore-apple
+//@ ignore-wasm (`object` doesn't handle wasm object files)
+//@ ignore-cross-compile
 
 // This test should be replaced with one in tests/debuginfo once we can easily
 // tell via GDB or LLDB if debuginfo contains source code. Cheap tricks in LLDB

--- a/tests/run-make/emit-shared-files/rmake.rs
+++ b/tests/run-make/emit-shared-files/rmake.rs
@@ -5,6 +5,8 @@
 // `all-shared` should only emit files that can be shared between crates.
 // See https://github.com/rust-lang/rust/pull/83478
 
+//@ needs-target-std
+
 use run_make_support::{has_extension, has_prefix, path, rustdoc, shallow_find_files};
 
 fn main() {

--- a/tests/run-make/emit-stack-sizes/rmake.rs
+++ b/tests/run-make/emit-stack-sizes/rmake.rs
@@ -7,8 +7,7 @@
 // See https://github.com/rust-lang/rust/pull/51946
 
 //@ needs-target-std
-//@ ignore-windows
-//@ ignore-apple
+//@ only-elf
 // Reason: this feature only works when the output object format is ELF.
 // This won't be the case on Windows/OSX - for example, OSX produces a Mach-O binary.
 

--- a/tests/run-make/env-dep-info/rmake.rs
+++ b/tests/run-make/env-dep-info/rmake.rs
@@ -1,5 +1,7 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+//@ needs-crate-type: proc-macro
+//@ ignore-musl (FIXME: can't find `-lunwind`)
+
 // Inside dep-info emit files, #71858 made it so all accessed environment
 // variables are usefully printed. This test checks that this feature works
 // as intended by checking if the environment variables used in compilation

--- a/tests/run-make/exit-code/rmake.rs
+++ b/tests/run-make/exit-code/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // Test that we exit with the correct exit code for successful / unsuccessful / ICE compilations
 
 use run_make_support::{rustc, rustdoc};

--- a/tests/run-make/export-executable-symbols/rmake.rs
+++ b/tests/run-make/export-executable-symbols/rmake.rs
@@ -8,9 +8,8 @@
 // Reason: the export-executable-symbols flag only works on Unix
 // due to hardcoded platform-specific implementation
 // (See #85673)
-//@ ignore-wasm32
-//@ ignore-wasm64
-//@ needs-target-std
+//@ ignore-cross-compile
+//@ ignore-wasm
 
 use run_make_support::{bin_name, llvm_readobj, rustc};
 

--- a/tests/run-make/export/disambiguator/rmake.rs
+++ b/tests/run-make/export/disambiguator/rmake.rs
@@ -1,4 +1,8 @@
-//@ needs-target-std
+//@ ignore-cross-compile
+
+// NOTE: `sdylib`'s platform support is basically just `dylib`'s platform support.
+//@ needs-crate-type: dylib
+
 use run_make_support::rustc;
 
 fn main() {

--- a/tests/run-make/export/extern-opt/rmake.rs
+++ b/tests/run-make/export/extern-opt/rmake.rs
@@ -1,4 +1,8 @@
-//@ needs-target-std
+//@ ignore-cross-compile
+
+// NOTE: `sdylib`'s platform support is basically that of `dylib`.
+//@ needs-crate-type: dylib
+
 use run_make_support::{dynamic_lib_name, rustc};
 
 fn main() {

--- a/tests/run-make/export/simple/rmake.rs
+++ b/tests/run-make/export/simple/rmake.rs
@@ -1,4 +1,8 @@
-//@ needs-target-std
+//@ ignore-cross-compile
+
+// NOTE: `sdylib`'s platform support is basically that of `dylib`.
+//@ needs-crate-type: dylib
+
 use run_make_support::rustc;
 
 fn main() {

--- a/tests/run-make/extern-diff-internal-name/rmake.rs
+++ b/tests/run-make/extern-diff-internal-name/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // In the following scenario:
 // 1. The crate foo, is referenced multiple times
 // 2. --extern foo=./path/to/libbar.rlib is specified to rustc

--- a/tests/run-make/extern-flag-fun/rmake.rs
+++ b/tests/run-make/extern-flag-fun/rmake.rs
@@ -1,4 +1,4 @@
-//@ needs-target-std
+//@ ignore-cross-compile
 //
 // The --extern flag can override the default crate search of
 // the compiler and directly fetch a given path. There are a few rules

--- a/tests/run-make/extern-multiple-copies/rmake.rs
+++ b/tests/run-make/extern-multiple-copies/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // In this test, the rust library foo1 exists in two different locations, but only one
 // is required by the --extern flag. This test checks that the copy is ignored (as --extern
 // demands fetching only the original instance of foo1) and that no error is emitted, resulting

--- a/tests/run-make/extern-multiple-copies2/rmake.rs
+++ b/tests/run-make/extern-multiple-copies2/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // Almost identical to `extern-multiple-copies`, but with a variation in the --extern calls
 // and the addition of #[macro_use] in the rust code files, which used to break --extern
 // until #33625.

--- a/tests/run-make/ice-dep-cannot-find-dep/rmake.rs
+++ b/tests/run-make/ice-dep-cannot-find-dep/rmake.rs
@@ -9,6 +9,7 @@
 
 //@ only-x86_64
 //@ only-linux
+//@ ignore-cross-compile
 // Reason: This is a platform-independent issue, no need to waste time testing
 // everywhere.
 

--- a/tests/run-make/include-all-symbols-linking/rmake.rs
+++ b/tests/run-make/include-all-symbols-linking/rmake.rs
@@ -7,7 +7,9 @@
 // See https://github.com/rust-lang/rust/pull/95604
 // See https://github.com/rust-lang/rust/issues/47384
 
-//@ needs-target-std
+//@ ignore-cross-compile
+//@ needs-crate-type: cdylib
+//@ needs-dynamic-linking
 //@ ignore-wasm differences in object file formats causes errors in the llvm_objdump step.
 //@ ignore-windows differences in object file formats causes errors in the llvm_objdump step.
 

--- a/tests/run-make/incr-prev-body-beyond-eof/rmake.rs
+++ b/tests/run-make/incr-prev-body-beyond-eof/rmake.rs
@@ -7,7 +7,7 @@
 // was hashed by rustc in addition to the span length, and the fix still
 // works.
 
-//@ needs-target-std
+//@ ignore-cross-compile
 
 use run_make_support::{rfs, rustc};
 

--- a/tests/run-make/incr-test-moved-file/rmake.rs
+++ b/tests/run-make/incr-test-moved-file/rmake.rs
@@ -9,7 +9,7 @@
 // for successful compilation.
 // See https://github.com/rust-lang/rust/issues/83112
 
-//@ needs-target-std
+//@ ignore-cross-compile
 
 use run_make_support::{rfs, rustc};
 

--- a/tests/run-make/intrinsic-unreachable/rmake.rs
+++ b/tests/run-make/intrinsic-unreachable/rmake.rs
@@ -4,6 +4,7 @@
 // which means the emitted artifacts should be shorter in length.
 // See https://github.com/rust-lang/rust/pull/16970
 
+//@ needs-target-std
 //@ needs-asm-support
 //@ ignore-windows
 // Reason: Because of Windows exception handling, the code is not necessarily any shorter.

--- a/tests/run-make/invalid-so/rmake.rs
+++ b/tests/run-make/invalid-so/rmake.rs
@@ -1,5 +1,7 @@
 //@ needs-target-std
-//
+//@ needs-crate-type: dylib
+//@ needs-dynamic-linking
+
 // When a fake library was given to the compiler, it would
 // result in an obscure and unhelpful error message. This test
 // creates a false "foo" dylib, and checks that the standard error

--- a/tests/run-make/issue-125484-used-dependencies/rmake.rs
+++ b/tests/run-make/issue-125484-used-dependencies/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // Non-regression test for issues #125474, #125484, #125646, with the repro taken from #125484. Some
 // queries use "used dependencies" while others use "speculatively loaded dependencies", and an
 // indexing ICE appeared in some cases when these were unexpectedly used in the same context.

--- a/tests/run-make/json-error-no-offset/rmake.rs
+++ b/tests/run-make/json-error-no-offset/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // The byte positions in json format error logging used to have a small, difficult
 // to predict offset. This was changed to be the top of the file every time in #42973,
 // and this test checks that the measurements appearing in the standard error are correct.

--- a/tests/run-make/link-args-order/rmake.rs
+++ b/tests/run-make/link-args-order/rmake.rs
@@ -1,5 +1,6 @@
 //@ needs-target-std
-//
+//@ ignore-wasm (explicit linker invocations)
+
 // Passing linker arguments to the compiler used to be lost or reordered in a messy way
 // as they were passed further to the linker. This was fixed in #70665, and this test
 // checks that linker arguments remain intact and in the order they were originally passed in.

--- a/tests/run-make/link-dedup/rmake.rs
+++ b/tests/run-make/link-dedup/rmake.rs
@@ -1,5 +1,5 @@
 //@ needs-target-std
-//
+//@ ignore-musl (not passed consecutively)
 // When native libraries are passed to the linker, there used to be an annoyance
 // where multiple instances of the same library in a row would cause duplication in
 // outputs. This has been fixed, and this test checks that it stays fixed.
@@ -9,7 +9,7 @@
 
 use std::fmt::Write;
 
-use run_make_support::{is_msvc, rustc};
+use run_make_support::{is_msvc, rustc, target};
 
 fn main() {
     rustc().input("depa.rs").run();
@@ -33,9 +33,11 @@ fn needle_from_libs(libs: &[&str]) -> String {
     let mut needle = String::new();
     for lib in libs {
         if is_msvc() {
-            let _ = needle.write_fmt(format_args!(r#""{lib}.lib" "#));
+            needle.write_fmt(format_args!(r#""{lib}.lib" "#)).unwrap();
+        } else if target().contains("wasm") {
+            needle.write_fmt(format_args!(r#""-l" "{lib}" "#)).unwrap();
         } else {
-            let _ = needle.write_fmt(format_args!(r#""-l{lib}" "#));
+            needle.write_fmt(format_args!(r#""-l{lib}" "#)).unwrap();
         }
     }
     needle.pop(); // remove trailing space

--- a/tests/run-make/linker-warning/rmake.rs
+++ b/tests/run-make/linker-warning/rmake.rs
@@ -1,4 +1,5 @@
-//@ needs-target-std
+//@ ignore-cross-compile (need to run fake linker)
+
 use run_make_support::{Rustc, diff, regex, rustc};
 
 fn run_rustc() -> Rustc {

--- a/tests/run-make/moved-src-dir-fingerprint-ice/rmake.rs
+++ b/tests/run-make/moved-src-dir-fingerprint-ice/rmake.rs
@@ -12,7 +12,7 @@
 // sessions.
 // See https://github.com/rust-lang/rust/issues/85019
 
-//@ needs-target-std
+//@ ignore-cross-compile
 
 use run_make_support::{rfs, rust_lib_name, rustc};
 

--- a/tests/run-make/mte-ffi/rmake.rs
+++ b/tests/run-make/mte-ffi/rmake.rs
@@ -22,11 +22,7 @@ fn run_test(variant: &str) {
         flags
     };
     println!("{variant} test...");
-    rustc()
-        .input(format!("foo_{variant}.rs"))
-        .target(target())
-        .linker("aarch64-linux-gnu-gcc")
-        .run();
+    rustc().input(format!("foo_{variant}.rs")).linker("aarch64-linux-gnu-gcc").run();
     gcc()
         .input(format!("bar_{variant}.c"))
         .input(dynamic_lib_name("foo"))

--- a/tests/run-make/naked-symbol-visibility/rmake.rs
+++ b/tests/run-make/naked-symbol-visibility/rmake.rs
@@ -1,5 +1,8 @@
 //@ ignore-windows
 //@ only-x86_64
+//@ needs-target-std
+//@ needs-crate-type: dylib
+
 use run_make_support::object::ObjectSymbol;
 use run_make_support::object::read::{File, Object, Symbol};
 use run_make_support::targets::is_windows;

--- a/tests/run-make/native-lib-alt-naming/rmake.rs
+++ b/tests/run-make/native-lib-alt-naming/rmake.rs
@@ -1,9 +1,7 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // On MSVC the alternative naming format for static libraries (`libfoo.a`) is accepted in addition
 // to the default format (`foo.lib`).
-
-//REMOVE@ only-msvc
 
 use run_make_support::rustc;
 

--- a/tests/run-make/native-link-modifier-verbatim-linker/rmake.rs
+++ b/tests/run-make/native-link-modifier-verbatim-linker/rmake.rs
@@ -3,8 +3,9 @@
 // This test is the same as native-link-modifier-rustc, but without rlibs.
 // See https://github.com/rust-lang/rust/issues/99425
 
-//@ needs-target-std
+//@ ignore-cross-compile
 //@ ignore-apple
+//@ ignore-wasm
 // Reason: linking fails due to the unusual ".ext" staticlib name.
 
 use run_make_support::rustc;

--- a/tests/run-make/no-builtins-attribute/filecheck.main.txt
+++ b/tests/run-make/no-builtins-attribute/filecheck.main.txt
@@ -1,5 +1,5 @@
-CHECK: declare void @foo()
+CHECK: declare{{.*}} void @foo()
 CHECK-SAME: #[[ATTR_3:[0-9]+]]
 
-CHECK: attributes #[[ATTR_3]] 
+CHECK: attributes #[[ATTR_3]]
 CHECK-SAME: no-builtins

--- a/tests/run-make/no-builtins-attribute/rmake.rs
+++ b/tests/run-make/no-builtins-attribute/rmake.rs
@@ -1,5 +1,4 @@
 //@ needs-target-std
-//
 // `no_builtins` is an attribute related to LLVM's optimizations. In order to ensure that it has an
 // effect on link-time optimizations (LTO), it should be added to function declarations in a crate.
 // This test uses the `llvm-filecheck` tool to determine that this attribute is successfully
@@ -11,5 +10,6 @@ use run_make_support::{llvm_filecheck, rfs, rustc};
 fn main() {
     rustc().input("no_builtins.rs").emit("link").run();
     rustc().input("main.rs").emit("llvm-ir").run();
+
     llvm_filecheck().patterns("filecheck.main.txt").stdin_buf(rfs::read("main.ll")).run();
 }

--- a/tests/run-make/no-builtins-lto/rmake.rs
+++ b/tests/run-make/no-builtins-lto/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // The rlib produced by a no_builtins crate should be explicitly linked
 // during compilation, and as a result be present in the linker arguments.
 // See the comments inside this file for more details.

--- a/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
+++ b/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
@@ -1,4 +1,4 @@
-//@ needs-target-std
+//@ ignore-cross-compile
 use run_make_support::{rfs, rustc};
 
 fn main() {

--- a/tests/run-make/proc-macro-three-crates/rmake.rs
+++ b/tests/run-make/proc-macro-three-crates/rmake.rs
@@ -1,5 +1,7 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+//@ needs-crate-type: proc-macro
+//@ ignore-musl (FIXME: can't find `-lunwind`)
+
 // A compiler bug caused the following issue:
 // If a crate A depends on crate B, and crate B
 // depends on crate C, and crate C contains a procedural

--- a/tests/run-make/relro-levels/rmake.rs
+++ b/tests/run-make/relro-levels/rmake.rs
@@ -1,6 +1,7 @@
 // This tests the different -Crelro-level values, and makes sure that they work properly.
 
 //@ only-linux
+//@ ignore-cross-compile
 
 use run_make_support::{llvm_readobj, rustc};
 

--- a/tests/run-make/repr128-dwarf/rmake.rs
+++ b/tests/run-make/repr128-dwarf/rmake.rs
@@ -1,4 +1,5 @@
-//@ needs-target-std
+//@ ignore-cross-compile
+//@ ignore-wasm (`object` can't handle wasm object files)
 //@ ignore-windows
 // This test should be replaced with one in tests/debuginfo once GDB or LLDB support 128-bit enums.
 

--- a/tests/run-make/reproducible-build-2/rmake.rs
+++ b/tests/run-make/reproducible-build-2/rmake.rs
@@ -6,7 +6,7 @@
 // Outputs should be identical.
 // See https://github.com/rust-lang/rust/issues/34902
 
-//@ needs-target-std
+//@ ignore-cross-compile
 //@ ignore-windows
 // Reasons:
 // 1. The object files are reproducible, but their paths are not, which causes

--- a/tests/run-make/rlib-format-packed-bundled-libs-2/rmake.rs
+++ b/tests/run-make/rlib-format-packed-bundled-libs-2/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // `-Z packed_bundled_libs` is an unstable rustc flag that makes the compiler
 // only require a native library and no supplementary object files to compile.
 // This test simply checks that this flag can be passed alongside verbatim syntax

--- a/tests/run-make/rustc-macro-dep-files/rmake.rs
+++ b/tests/run-make/rustc-macro-dep-files/rmake.rs
@@ -1,5 +1,7 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+//@ needs-crate-type: proc-macro
+//@ ignore-musl (FIXME: can't find `-lunwind`)
+
 // --emit dep-info used to print all macro-generated code it could
 // find as if it was part of a nonexistent file named "proc-macro source",
 // which is not a valid path. After this was fixed in #36776, this test checks

--- a/tests/run-make/rustc-macro-dep-files/rmake.rs
+++ b/tests/run-make/rustc-macro-dep-files/rmake.rs
@@ -10,7 +10,7 @@ use run_make_support::{diff, rustc, target};
 
 fn main() {
     rustc().input("foo.rs").run();
-    rustc().input("bar.rs").target(target()).emit("dep-info").run();
+    rustc().input("bar.rs").emit("dep-info").run();
     // The emitted file should not contain "proc-macro source".
     diff().expected_file("correct.d").actual_file("bar.d").run();
 }

--- a/tests/run-make/rustdoc-default-output/rmake.rs
+++ b/tests/run-make/rustdoc-default-output/rmake.rs
@@ -3,10 +3,10 @@
 // ensures the output of rustdoc's help menu is as expected.
 // See https://github.com/rust-lang/rust/issues/88756
 
-use run_make_support::{diff, rustdoc};
+use run_make_support::{bare_rustdoc, diff};
 
 fn main() {
-    let out = rustdoc().run().stdout_utf8();
+    let out = bare_rustdoc().run().stdout_utf8();
     diff()
         .expected_file("output-default.stdout")
         .actual_text("actual", out)

--- a/tests/run-make/rustdoc-dep-info/rmake.rs
+++ b/tests/run-make/rustdoc-dep-info/rmake.rs
@@ -1,6 +1,8 @@
 // This is a simple smoke test for rustdoc's `--emit dep-info` feature. It prints out
 // information about dependencies in a Makefile-compatible format, as a `.d` file.
 
+//@ needs-target-std
+
 use run_make_support::assertion_helpers::assert_contains;
 use run_make_support::{path, rfs, rustdoc};
 

--- a/tests/run-make/rustdoc-determinism/rmake.rs
+++ b/tests/run-make/rustdoc-determinism/rmake.rs
@@ -1,6 +1,8 @@
 // Assert that the search index is generated deterministically, regardless of the
 // order that crates are documented in.
 
+//@ needs-target-std
+
 use run_make_support::{diff, path, rustdoc};
 
 fn main() {

--- a/tests/run-make/rustdoc-error-lines/rmake.rs
+++ b/tests/run-make/rustdoc-error-lines/rmake.rs
@@ -1,6 +1,8 @@
 // Assert that the search index is generated deterministically, regardless of the
 // order that crates are documented in.
 
+//@ needs-target-std
+
 use run_make_support::rustdoc;
 
 fn main() {

--- a/tests/run-make/rustdoc-io-error/rmake.rs
+++ b/tests/run-make/rustdoc-io-error/rmake.rs
@@ -13,6 +13,7 @@
 // containers would use a non-root user, but this leads to issues with
 // `mkfs.ext4 -d`, as well as mounting a loop device for the rootfs.
 //@ ignore-windows - the `set_readonly` functions doesn't work on folders.
+//@ needs-target-std
 
 use run_make_support::{path, rfs, rustdoc};
 

--- a/tests/run-make/rustdoc-map-file/rmake.rs
+++ b/tests/run-make/rustdoc-map-file/rmake.rs
@@ -1,6 +1,8 @@
 // This test ensures that all items from `foo` are correctly generated into the `redirect-map.json`
 // file with `--generate-redirect-map` rustdoc option.
 
+//@ needs-target-std
+
 use run_make_support::rfs::read_to_string;
 use run_make_support::{path, rustdoc, serde_json};
 

--- a/tests/run-make/rustdoc-output-path/rmake.rs
+++ b/tests/run-make/rustdoc-output-path/rmake.rs
@@ -1,5 +1,7 @@
 // Checks that if the output folder doesn't exist, rustdoc will create it.
 
+//@ needs-target-std
+
 use run_make_support::{path, rustdoc};
 
 fn main() {

--- a/tests/run-make/rustdoc-output-stdout/rmake.rs
+++ b/tests/run-make/rustdoc-output-stdout/rmake.rs
@@ -1,6 +1,8 @@
 // This test verifies that rustdoc `-o -` prints JSON on stdout and doesn't generate
 // a JSON file.
 
+//@ needs-target-std
+
 use run_make_support::path_helpers::{cwd, has_extension, read_dir_entries_recursive};
 use run_make_support::{rustdoc, serde_json};
 

--- a/tests/run-make/rustdoc-test-args/rmake.rs
+++ b/tests/run-make/rustdoc-test-args/rmake.rs
@@ -1,3 +1,5 @@
+//@ ignore-cross-compile (needs to run doctest binary)
+
 use std::iter;
 use std::path::Path;
 

--- a/tests/run-make/rustdoc-themes/rmake.rs
+++ b/tests/run-make/rustdoc-themes/rmake.rs
@@ -1,5 +1,7 @@
 // Test that rustdoc will properly load in a theme file and display it in the theme selector.
 
+//@ needs-target-std
+
 use std::path::Path;
 
 use run_make_support::{htmldocck, rfs, rustdoc, source_root};

--- a/tests/run-make/rustdoc-verify-output-files/rmake.rs
+++ b/tests/run-make/rustdoc-verify-output-files/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+
 use std::path::{Path, PathBuf};
 
 use run_make_support::{assert_dirs_are_equal, rfs, rustdoc};

--- a/tests/run-make/rustdoc-with-out-dir-option/rmake.rs
+++ b/tests/run-make/rustdoc-with-out-dir-option/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+
 use run_make_support::{htmldocck, rustdoc};
 
 fn main() {

--- a/tests/run-make/rustdoc-with-output-option/rmake.rs
+++ b/tests/run-make/rustdoc-with-output-option/rmake.rs
@@ -1,3 +1,5 @@
+//@ needs-target-std
+
 use run_make_support::{htmldocck, rustdoc};
 
 fn main() {

--- a/tests/run-make/share-generics-dylib/rmake.rs
+++ b/tests/run-make/share-generics-dylib/rmake.rs
@@ -1,5 +1,7 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+//@ needs-dynamic-linking
+//@ needs-crate-type: dylib
+
 // This test makes sure all generic instances get re-exported from Rust dylibs for use by
 // `-Zshare-generics`. There are two rlibs (`instance_provider_a` and `instance_provider_b`)
 // which both provide an instance of `Cell<i32>::set`. There is `instance_user_dylib` which is

--- a/tests/run-make/static-pie/rmake.rs
+++ b/tests/run-make/static-pie/rmake.rs
@@ -49,7 +49,6 @@ fn test(compiler: &str) {
 
     rustc()
         .input("test-aslr.rs")
-        .target(target())
         .linker(compiler)
         .arg("-Clinker-flavor=gcc")
         .arg("-Ctarget-feature=+crt-static")

--- a/tests/run-make/staticlib-thin-archive/rmake.rs
+++ b/tests/run-make/staticlib-thin-archive/rmake.rs
@@ -1,5 +1,5 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+
 // Regression test for https://github.com/rust-lang/rust/issues/107407 which
 // checks that rustc can read thin archive. Before the object crate added thin
 // archive support rustc would add emit object files to the staticlib and after

--- a/tests/run-make/stdin-rustc/rmake.rs
+++ b/tests/run-make/stdin-rustc/rmake.rs
@@ -1,9 +1,9 @@
-//@ needs-target-std
+//@ ignore-cross-compile
 //! This test checks rustc `-` (stdin) support
 
 use std::path::PathBuf;
 
-use run_make_support::{is_windows, rustc};
+use run_make_support::{bin_name, rustc};
 
 const HELLO_WORLD: &str = r#"
 fn main() {
@@ -16,11 +16,7 @@ const NOT_UTF8: &[u8] = &[0xff, 0xff, 0xff];
 fn main() {
     // echo $HELLO_WORLD | rustc -
     rustc().arg("-").stdin_buf(HELLO_WORLD).run();
-    assert!(
-        PathBuf::from(if !is_windows() { "rust_out" } else { "rust_out.exe" })
-            .try_exists()
-            .unwrap()
-    );
+    assert!(PathBuf::from(bin_name("rust_out")).try_exists().unwrap());
 
     // echo $NOT_UTF8 | rustc -
     rustc().arg("-").stdin_buf(NOT_UTF8).run_fail().assert_stderr_contains(

--- a/tests/run-make/stdin-rustdoc/rmake.rs
+++ b/tests/run-make/stdin-rustdoc/rmake.rs
@@ -1,3 +1,5 @@
+//@ ignore-cross-compile (needs to run doctests)
+
 //! This test checks rustdoc `-` (stdin) handling
 
 use std::path::PathBuf;

--- a/tests/run-make/symbol-visibility/rmake.rs
+++ b/tests/run-make/symbol-visibility/rmake.rs
@@ -1,5 +1,7 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+//@ needs-crate-type: dylib, cdylib, proc-macro
+//@ needs-dynamic-linking
+
 // Dynamic libraries on Rust used to export a very high amount of symbols,
 // going as far as filling the output with mangled names and generic function
 // names. After the rework of #38117, this test checks that no mangled Rust symbols

--- a/tests/run-make/sysroot-crates-are-unstable/rmake.rs
+++ b/tests/run-make/sysroot-crates-are-unstable/rmake.rs
@@ -31,7 +31,6 @@ fn check_crate_is_unstable(cr: &Crate) {
     // Trying to use this crate from a user program should fail.
     let output = rustc()
         .crate_type("rlib")
-        .target(target())
         .extern_(name, path)
         .input("-")
         .stdin_buf(format!("extern crate {name};"))

--- a/tests/run-make/track-path-dep-info/rmake.rs
+++ b/tests/run-make/track-path-dep-info/rmake.rs
@@ -1,5 +1,7 @@
-//@ needs-target-std
-//
+//@ ignore-cross-compile
+//@ needs-crate-type: proc-macro
+//@ ignore-musl (FIXME: can't find `-lunwind`)
+
 // This test checks the functionality of `tracked_path::path`, a procedural macro
 // feature that adds a dependency to another file inside the procmacro. In this case,
 // the text file is added through this method, and the test checks that the compilation

--- a/tests/run-make/used/rmake.rs
+++ b/tests/run-make/used/rmake.rs
@@ -1,5 +1,6 @@
 //@ needs-target-std
-//
+//@ ignore-wasm (`object` can't handle wasm object files)
+
 // This test ensures that the compiler is keeping static variables, even if not referenced
 // by another part of the program, in the output object file.
 //


### PR DESCRIPTION
Supersedes rust-lang/rust#138066.

Blocker for rust-lang/rust#141856.

Based on rust-lang/rust#138066 plus `rustdoc()` cross-compile changes.

### Summary

This PR automatically specifies `--target` to `rustc()` and `rustdoc()` to have `rustc`/`rustdoc` produce cross-compiled artifacts in run-make tests by default, unless:

- `//@ ignore-cross-compile` is used, or
- `bare_{rustc,rustdoc}` are used, or
- Explicit `.target()` is specified, which overrides the default cross-compile target.

Some tests are necessarily modified:

- Tests that have `.target(target())` have that incantation removed (since this is now automatically the default).
- Some tests have `//@ needs-target-std`, but are a necessary-but-insufficient condition, and are changed to `//@ ignore-cross-compile` instead as host-only tests.
    - A few tests received `//@ ignore-musl` that fail against `x86_64-unknown-linux-musl` because of inability to find `-lunwind`. AFAICT, they don't *need* to test cross-compiled artifacts.
    - Some tests are constrained to host-only for now, because the effort to make them pass on cross-compile does not seem worth the complexity, and it's not really *meaningfully* improving test coverage.

try-job: dist-various-1