### PR TITLE
Remove unused variables generated in merged doctests

### DIFF
--- a/src/librustdoc/doctest/runner.rs
+++ b/src/librustdoc/doctest/runner.rs
@@ -144,7 +144,6 @@ let tests = {{
     {ids}
     tests
 }};
-let test_marker = std::ffi::OsStr::new(__doctest_mod::RUN_OPTION);
 let test_args = &[{test_args}];
 const ENV_BIN: &'static str = \"RUSTDOC_DOCTEST_BIN_PATH\";
 


### PR DESCRIPTION
The variable is unused so no need to keep it around.

cc @notriddle 
r? @camelid 