### PR TITLE
Fix derive bounds for fully-qualified field types

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -183,7 +183,7 @@ pub(crate) use SubstructureFields::*;
 use rustc_ast::ptr::P;
 use rustc_ast::{
     self as ast, AnonConst, BindingMode, ByRef, EnumDef, Expr, GenericArg, GenericParamKind,
-    Generics, Mutability, PatKind, VariantData,
+    Generics, Mutability, PatKind, QSelf, VariantData,
 };
 use rustc_attr_parsing::{AttributeKind, AttributeParser, ReprPacked};
 use rustc_expand::base::{Annotatable, ExtCtxt};
@@ -409,6 +409,22 @@ fn find_type_parameters(
         type_params: Vec<TypeParameter>,
     }
 
+    impl Visitor<'_, '_> {
+        fn is_path_from_ty_param(&self, qself: &Option<P<QSelf>>, path: &ast::Path) -> bool {
+            if let Some(qself) = qself
+                && let ast::TyKind::Path(qself, path) = &qself.ty.kind
+            {
+                self.is_path_from_ty_param(&qself, &path)
+            } else if let Some(segment) = path.segments.first()
+                && self.ty_param_names.contains(&segment.ident.name)
+            {
+                true
+            } else {
+                false
+            }
+        }
+    }
+
     impl<'a, 'b> visit::Visitor<'a> for Visitor<'a, 'b> {
         fn visit_ty(&mut self, ty: &'a ast::Ty) {
             let stack_len = self.bound_generic_params_stack.len();
@@ -420,14 +436,13 @@ fn find_type_parameters(
                 self.bound_generic_params_stack.extend(bare_fn.generic_params.iter().cloned());
             }
 
-            if let ast::TyKind::Path(_, path) = &ty.kind
-                && let Some(segment) = path.segments.first()
-                && self.ty_param_names.contains(&segment.ident.name)
-            {
-                self.type_params.push(TypeParameter {
-                    bound_generic_params: self.bound_generic_params_stack.clone(),
-                    ty: P(ty.clone()),
-                });
+            if let ast::TyKind::Path(qself, path) = &ty.kind {
+                if self.is_path_from_ty_param(qself, path) {
+                    self.type_params.push(TypeParameter {
+                        bound_generic_params: self.bound_generic_params_stack.clone(),
+                        ty: P(ty.clone()),
+                    });
+                }
             }
 
             visit::walk_ty(self, ty);

--- a/tests/ui/deriving/deriving-associated-types.rs
+++ b/tests/ui/deriving/deriving-associated-types.rs
@@ -44,6 +44,16 @@ struct TupleStruct<A, B: DeclaredTrait, C>(
 ) where C: WhereTrait;
 
 #[derive(PartialEq, Debug)]
+struct TupleStructJustQSelf<B: DeclaredTrait, C>(
+    <B>::Type,
+    <B as DeclaredTrait>::Type,
+    Option<<B as DeclaredTrait>::Type>,
+    <C as WhereTrait>::Type,
+    Option<<C as WhereTrait>::Type>,
+    <i32 as DeclaredTrait>::Type,
+) where C: WhereTrait;
+
+#[derive(PartialEq, Debug)]
 pub struct Struct<A, B: DeclaredTrait, C> where C: WhereTrait {
     m1: module::Type,
     m2: Option<module::Type>,
@@ -57,6 +67,16 @@ pub struct Struct<A, B: DeclaredTrait, C> where C: WhereTrait {
     c: C,
     c1: C::Type,
     c2: Option<C::Type>,
+    c3: <C as WhereTrait>::Type,
+    c4: Option<<C as WhereTrait>::Type>,
+    d: <i32 as DeclaredTrait>::Type,
+}
+
+#[derive(PartialEq, Debug)]
+pub struct StructJustQSelf<B: DeclaredTrait, C> where C: WhereTrait {
+    b1: <B>::Type,
+    b3: <B as DeclaredTrait>::Type,
+    b4: Option<<B as DeclaredTrait>::Type>,
     c3: <C as WhereTrait>::Type,
     c4: Option<<C as WhereTrait>::Type>,
     d: <i32 as DeclaredTrait>::Type,
@@ -101,6 +121,29 @@ enum Enum<A, B: DeclaredTrait, C> where C: WhereTrait {
     },
 }
 
+#[derive(PartialEq, Debug)]
+enum EnumJustQSelf<B: DeclaredTrait, C> where C: WhereTrait {
+    Unit,
+    Seq(
+        <B>::Type,
+        <B as DeclaredTrait>::Type,
+        Option<<B as DeclaredTrait>::Type>,
+        <C>::Type,
+        <C as WhereTrait>::Type,
+        Option<<C as WhereTrait>::Type>,
+        <i32 as DeclaredTrait>::Type,
+    ),
+    Map {
+        b1: <B>::Type,
+        b3: <B as DeclaredTrait>::Type,
+        b4: Option<<B as DeclaredTrait>::Type>,
+        c1: <C>::Type,
+        c3: <C as WhereTrait>::Type,
+        c4: Option<<C as WhereTrait>::Type>,
+        d: <i32 as DeclaredTrait>::Type,
+    },
+}
+
 fn main() {
     let e: TupleStruct<
         i32,
@@ -116,6 +159,19 @@ fn main() {
         None,
         0,
         None,
+        0,
+        0,
+        None,
+        0,
+        None,
+        0,
+    );
+    assert_eq!(e, e);
+
+    let e: TupleStructJustQSelf<
+        i32,
+        i32,
+    > = TupleStructJustQSelf(
         0,
         0,
         None,
@@ -142,6 +198,19 @@ fn main() {
         c: 0,
         c1: 0,
         c2: None,
+        c3: 0,
+        c4: None,
+        d: 0,
+    };
+    assert_eq!(e, e);
+
+    let e: StructJustQSelf<
+        i32,
+        i32,
+    > = StructJustQSelf {
+        b1: 0,
+        b3: 0,
+        b4: None,
         c3: 0,
         c4: None,
         d: 0,
@@ -191,6 +260,40 @@ fn main() {
         c: 0,
         c1: 0,
         c2: None,
+        c3: 0,
+        c4: None,
+        d: 0,
+    };
+    assert_eq!(e, e);
+
+    let e: EnumJustQSelf<
+        i32,
+        i32,
+    > = EnumJustQSelf::Unit;
+    assert_eq!(e, e);
+
+    let e: EnumJustQSelf<
+        i32,
+        i32,
+    > = EnumJustQSelf::Seq(
+        0,
+        0,
+        None,
+        0,
+        0,
+        None,
+        0,
+    );
+    assert_eq!(e, e);
+
+    let e: EnumJustQSelf<
+        i32,
+        i32,
+    > = EnumJustQSelf::Map {
+        b1: 0,
+        b3: 0,
+        b4: None,
+        c1: 0,
         c3: 0,
         c4: None,
         d: 0,


### PR DESCRIPTION
Builtin traits like `Clone`, `Debug`, and `PartialEq` which can be derived look for uses of generics when adding type bounds. However, the procedure for adding these trait bounds did not account for fully-qualified type paths. This causes code which does not fully-qualify paths to generate correct derive bounds, while fully-qualified paths do not receive correct bounds. For example:

```
#[derive(Clone)]
struct Foo<T: MyTrait>(T::MyType);
```

Will receive the correct `T::MyType: Clone` bound, but:

```
#[derive(Clone)]
struct Foo<T: MyTrait>(<T>::MyType);
```

Does not. This change modifies generic parameter detection to walk up the chain of `QSelf`s in path types when looking for type parameters, rather than only looking at the outermost type.

Related issues:
- #50730
- https://github.com/rkyv/rkyv/issues/602

Note that there are existing tests for this behavior. However, the existing tests accidentally include fields with the working syntax (`T::MyType`) alongside fields with the broken syntax (`<T>::MyType`) and so this issue has gone undiscovered.

This is a conservative fix; it aims only to make previously-invalid code valid. It does not attempt to move the builtin derive macros closer to a perfect derive.