### PR TITLE
Revert "Disable `f16` on Aarch64 without `neon`"

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -12,11 +12,6 @@ fn main() {
         .expect("CARGO_CFG_TARGET_POINTER_WIDTH was not set")
         .parse()
         .unwrap();
-    let target_features: Vec<_> = env::var("CARGO_CFG_TARGET_FEATURE")
-        .unwrap_or_default()
-        .split(",")
-        .map(ToOwned::to_owned)
-        .collect();
     let is_miri = env::var_os("CARGO_CFG_MIRI").is_some();
 
     println!("cargo:rustc-check-cfg=cfg(netbsd10)");
@@ -108,8 +103,6 @@ fn main() {
         ("s390x", _) => false,
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         ("arm64ec", _) => false,
-        // LLVM crash <https://github.com/llvm/llvm-project/issues/129394>
-        ("aarch64", _) if !target_features.iter().any(|f| f == "neon") => false,
         // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
         ("x86_64", "windows") if target_env == "gnu" && target_abi != "llvm" => false,
         // Infinite recursion <https://github.com/llvm/llvm-project/issues/97981>


### PR DESCRIPTION
The LLVM issue [1] was resolved and the fix was synced to rust-lang/rust in [2].

This reverts commit c51b229140c885cac757a405a328a07e90d5bca9.

[1]: https://github.com/llvm/llvm-project/issues/129394
[2]: https://github.com/rust-lang/rust/pull/138695

try-job: aarch64-gnu
try-job: aarch64-gnu-debug
try-job: armhf-gnu
try-job: dist-various-1