### PR TITLE
Folder experiment: Account for TypeFlags in OpportunisticRegionResolver

### DIFF
--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -107,6 +107,10 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for OpportunisticRegionResolver<'a, 'tcx
             ct.super_fold_with(self)
         }
     }
+
+    fn fold_predicate(&mut self, p: ty::Predicate<'tcx>) -> ty::Predicate<'tcx> {
+        if !p.has_infer_regions() { p } else { p.super_fold_with(self) }
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**NOTE:** This is one of a series of perf experiments that I've come up with while sick in bed. I'm assigning them to lqd b/c you're a good reviewer and you'll hopefully be awake when these experiments finish, lol.

r? lqd

The `OpportunisticRegionResolver` is hot, so let's avoid unnecessarily folding predicates. This will likey end up being a noop, so close this if it's perf neutral.