### PR TITLE
Folder experiment: Account for type flags in fold_predicate in OpportunisticVarResolver

### DIFF
--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -56,6 +56,10 @@ impl<'a, 'tcx> TypeFolder<TyCtxt<'tcx>> for OpportunisticVarResolver<'a, 'tcx> {
             ct.super_fold_with(self)
         }
     }
+
+    fn fold_predicate(&mut self, p: ty::Predicate<'tcx>) -> ty::Predicate<'tcx> {
+        if !p.has_non_region_infer() { p } else { p.super_fold_with(self) }
+    }
 }
 
 /// The opportunistic region resolver opportunistically resolves regions


### PR DESCRIPTION
**NOTE:** This is one of a series of perf experiments that I've come up with while sick in bed. I'm assigning them to lqd b/c you're a good reviewer and you'll hopefully be awake when these experiments finish, lol.

r? lqd

Same as #139288, but for the var resolver. I could've probably merged these into one, but I want to test these things in parallel. Close this if it ends up neutral.