### PR TITLE
Folder experiment: Account for flags in ArgFolder

### DIFF
--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -697,11 +697,23 @@ impl<'a, I: Interner> TypeFolder<I> for ArgFolder<'a, I> {
     }
 
     fn fold_const(&mut self, c: I::Const) -> I::Const {
+        if !c.has_param() {
+            return c;
+        }
+
         if let ty::ConstKind::Param(p) = c.kind() {
             self.const_for_param(p, c)
         } else {
             c.super_fold_with(self)
         }
+    }
+
+    fn fold_predicate(&mut self, p: I::Predicate) -> I::Predicate {
+        if !p.has_param() {
+            return p;
+        }
+
+        p.super_fold_with(self)
     }
 }
 


### PR DESCRIPTION
**NOTE:** This is one of a series of perf experiments that I've come up with while sick in bed. I'm assigning them to lqd b/c you're a good reviewer and you'll hopefully be awake when these experiments finish, lol.

r? lqd

The arg folder is very hot and this hopefully avoids unnecessarily substituting predicates and consts when they have no consts in them :>