### PR TITLE
Folder experiment: Account for type flags in `fold_predicate` in `Canonicalizer`

### DIFF
--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -515,6 +515,10 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
             ct
         }
     }
+
+    fn fold_predicate(&mut self, p: ty::Predicate<'tcx>) -> ty::Predicate<'tcx> {
+        if p.flags().intersects(self.needs_canonical_flags) { p.super_fold_with(self) } else { p }
+    }
 }
 
 impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {


### PR DESCRIPTION
**NOTE:** This is one of a series of perf experiments that I've come up with while sick in bed. I'm assigning them to lqd b/c you're a good reviewer and you'll hopefully be awake when these experiments finish, lol.

r? lqd

The canonicalizer is used a lot in borrowck and in the eval-flavor of the trait solver. Let's avoid doing unnecessary work when folding predicates, which I would assume are a very important input to the canonicalizer as the main "type" of all goals and such.