### PR TITLE
Deduplicate & clean up Nix shell

### DIFF
--- a/src/tools/nix-dev-shell/flake.nix
+++ b/src/tools/nix-dev-shell/flake.nix
@@ -1,32 +1,24 @@
 {
   description = "rustc dev shell";
 
-  inputs = {
-    nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url  = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
-	flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        x = import ./x { inherit pkgs; };
-      in
-      {
-        devShells.default = with pkgs; mkShell {
-          name = "rustc-dev-shell";
-          nativeBuildInputs = with pkgs; [
-            binutils cmake ninja pkg-config python3 git curl cacert patchelf nix
-          ];
-          buildInputs = with pkgs; [
-            openssl glibc.out glibc.static x
-          ];
-          # Avoid creating text files for ICEs.
-          RUSTC_ICE = "0";
-          # Provide `libstdc++.so.6` for the self-contained lld.
-          # Provide `libz.so.1`.
-          LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [stdenv.cc.cc.lib zlib]}";
-        };
-      }
-    );
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      inherit (nixpkgs) lib;
+      forEachSystem = lib.genAttrs lib.systems.flakeExposed;
+    in
+    {
+      devShells = forEachSystem (system: {
+        default = nixpkgs.legacyPackages.${system}.callPackage ./shell.nix { };
+      });
+
+      packages = forEachSystem (system: {
+        default = nixpkgs.legacyPackages.${system}.callPackage ./x { };
+      });
+    };
 }

--- a/src/tools/nix-dev-shell/shell.nix
+++ b/src/tools/nix-dev-shell/shell.nix
@@ -1,18 +1,26 @@
-{ pkgs ? import <nixpkgs> {} }:
-let 
-  x = import ./x { inherit pkgs; };
+{
+  pkgs ? import <nixpkgs> { },
+}:
+let
+  inherit (pkgs.lib) lists attrsets;
+
+  x = pkgs.callPackage ./x { };
+  inherit (x.passthru) cacert env;
 in
 pkgs.mkShell {
-  name = "rustc";
-  nativeBuildInputs = with pkgs; [
-    binutils cmake ninja pkg-config python3 git curl cacert patchelf nix
-  ];
-  buildInputs = with pkgs; [
-    openssl glibc.out glibc.static x
-  ];
-  # Avoid creating text files for ICEs.
-  RUSTC_ICE = "0";
-  # Provide `libstdc++.so.6` for the self-contained lld.
-  # Provide `libz.so.1`
-  LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [stdenv.cc.cc.lib zlib]}";
+  name = "rustc-shell";
+
+  inputsFrom = [ x ];
+  packages = [
+    pkgs.git
+    pkgs.nix
+    x
+    # Get the runtime deps of the x wrapper
+  ] ++ lists.flatten (attrsets.attrValues env);
+
+  env = {
+    # Avoid creating text files for ICEs.
+    RUSTC_ICE = 0;
+    SSL_CERT_FILE = cacert;
+  };
 }

--- a/src/tools/nix-dev-shell/x/default.nix
+++ b/src/tools/nix-dev-shell/x/default.nix
@@ -1,22 +1,83 @@
 {
-  pkgs ? import <nixpkgs> { },
+  pkgs,
+  lib,
+  stdenv,
+  rustc,
+  python3,
+  makeBinaryWrapper,
+  # Bootstrap
+  curl,
+  pkg-config,
+  libiconv,
+  openssl,
+  patchelf,
+  cacert,
+  zlib,
+  # LLVM Deps
+  ninja,
+  cmake,
+  glibc,
 }:
-pkgs.stdenv.mkDerivation {
-  name = "x";
+stdenv.mkDerivation (self: {
+  strictDeps = true;
+  name = "x-none";
+
+  outputs = [
+    "out"
+    "unwrapped"
+  ];
 
   src = ./x.rs;
   dontUnpack = true;
 
-  nativeBuildInputs = with pkgs; [ rustc ];
+  nativeBuildInputs = [
+    rustc
+    makeBinaryWrapper
+  ];
 
+  env.PYTHON = python3.interpreter;
   buildPhase = ''
-    PYTHON=${pkgs.lib.getExe pkgs.python3} rustc -Copt-level=3 --crate-name x $src --out-dir $out/bin
+    rustc -Copt-level=3 --crate-name x $src --out-dir $unwrapped/bin
   '';
 
-  meta = with pkgs.lib; {
+  installPhase =
+    let
+      inherit (self.passthru) cacert env;
+    in
+    ''
+      makeWrapper $unwrapped/bin/x $out/bin/x \
+        --set-default SSL_CERT_FILE ${cacert} \
+        --prefix CPATH ";" "${lib.makeSearchPath "include" env.cpath}" \
+        --prefix PATH : ${lib.makeBinPath env.path} \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath env.ldLib}
+    '';
+
+  # For accessing them in the devshell
+  passthru = {
+    env = {
+      cpath = [ libiconv ];
+      path = [
+        python3
+        patchelf
+        curl
+        pkg-config
+        cmake
+        ninja
+        stdenv.cc
+      ];
+      ldLib = [
+        openssl
+        zlib
+        stdenv.cc.cc.lib
+      ];
+    };
+    cacert = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  };
+
+  meta = {
     description = "Helper for rust-lang/rust x.py";
     homepage = "https://github.com/rust-lang/rust/blob/master/src/tools/x";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "x";
   };
-}
+})


### PR DESCRIPTION
1. Deduplicate the flake and shell files
2. Remove flake-utils
3. Remove `with` statements
They are considered bad practice nowadays because the slow down the evalulator and have weird shadowing rules.
4. Use `env`
:3 
5. use `callPackage`
It's the recommended way for derivations like these.
6. Use `packages` in the shell
There is no reason to use `buildInputs` for a mkShell (except in funny cases that will not be seen here), so the  `packages` attr is recommended now days. 

r? WaffleLapkin