### PR TITLE
Allow for missing invisible close delim when reparsing an expression.

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -793,7 +793,10 @@ impl<'a> Parser<'a> {
                 self.bump();
                 Some(res)
             } else {
-                panic!("no close delim when reparsing {mv_kind:?}");
+                // This can occur when invalid syntax is passed to a decl macro. E.g. see #139248,
+                // where the reparse attempt of an invalid expr consumed the trailing invisible
+                // delimiter.
+                None
             }
         } else {
             None

--- a/tests/ui/macros/no-close-delim-issue-139248.rs
+++ b/tests/ui/macros/no-close-delim-issue-139248.rs
@@ -1,0 +1,14 @@
+// This code caused a "no close delim when reparsing Expr" ICE in #139248.
+
+macro_rules! m {
+    (static a : () = $e:expr) => {
+        static a : () = $e;
+        //~^ ERROR macro expansion ends with an incomplete expression: expected expression
+    }
+}
+
+m! { static a : () = (if b) }
+//~^ error: expected `{`, found `)`
+//~| error: expected `{`, found `)`
+
+fn main() {}

--- a/tests/ui/macros/no-close-delim-issue-139248.stderr
+++ b/tests/ui/macros/no-close-delim-issue-139248.stderr
@@ -1,0 +1,33 @@
+error: expected `{`, found `)`
+  --> $DIR/no-close-delim-issue-139248.rs:10:27
+   |
+LL | m! { static a : () = (if b) }
+   |                           ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/no-close-delim-issue-139248.rs:10:26
+   |
+LL | m! { static a : () = (if b) }
+   |                          ^
+
+error: expected `{`, found `)`
+  --> $DIR/no-close-delim-issue-139248.rs:10:27
+   |
+LL | m! { static a : () = (if b) }
+   |                           ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/no-close-delim-issue-139248.rs:10:26
+   |
+LL | m! { static a : () = (if b) }
+   |                          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: macro expansion ends with an incomplete expression: expected expression
+  --> $DIR/no-close-delim-issue-139248.rs:5:28
+   |
+LL |         static a : () = $e;
+   |                            ^ expected expression
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
This can happen when invalid syntax is passed to a declarative macro. We shouldn't be too strict about the token stream position once the parser has rejected the invalid syntax.

Fixes #139248.

r? @petrochenkov 

---
try-job: test-various