### PR TITLE
std: Add performance warnings to HashMap::get_disjoint_mut

### DIFF
--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -973,7 +973,7 @@ where
     /// Returns an array of length `N` with the results of each query. For soundness, at most one
     /// mutable reference will be returned to any value. `None` will be used if the key is missing.
     ///
-    /// This method performs a check to ensure there are no duplicate keys, which has time-complexity O(n^2),
+    /// This method performs a check to ensure there are no duplicate keys, which currently has a time-complexity of O(n^2),
     /// so be careful when passing many keys.
     ///
     /// # Panics

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -973,6 +973,9 @@ where
     /// Returns an array of length `N` with the results of each query. For soundness, at most one
     /// mutable reference will be returned to any value. `None` will be used if the key is missing.
     ///
+    /// This method performs a check to ensure there are no duplicate keys, which has time-complexity O(n^2),
+    /// so be careful when passing many keys.
+    ///
     /// # Panics
     ///
     /// Panics if any keys are overlapping.


### PR DESCRIPTION
Closes #139296 

The `get_disjoint_mut` in `HashMap` also performs a complexity O(n^2) check. So we need to be reminded of that as well.

https://github.com/rust-lang/hashbrown/blob/b5b0655a37e156f9798ac8dd7e970d4adba9bf90/src/raw/mod.rs#L1216-L1220