### PR TITLE
make abi_unsupported_vector_types a hard error

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/std_example.rs
+++ b/compiler/rustc_codegen_cranelift/example/std_example.rs
@@ -8,9 +8,6 @@
     unboxed_closures
 )]
 #![allow(internal_features)]
-// FIXME once abi_unsupported_vector_types is a hard error disable the foo test when the respective
-// target feature is not enabled.
-#![allow(abi_unsupported_vector_types)]
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -608,6 +608,11 @@ fn register_builtins(store: &mut LintStore) {
         "converted into hard error, see PR #139001 \
          <https://github.com/rust-lang/rust/issues/139001> for more information",
     );
+    store.register_removed(
+        "abi_unsupported_vector_types",
+        "converted into hard error, \
+         see <https://github.com/rust-lang/rust/issues/116558> for more information",
+    );
 }
 
 fn register_internals(store: &mut LintStore) {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -16,7 +16,6 @@ declare_lint_pass! {
     /// that are used by other parts of the compiler.
     HardwiredLints => [
         // tidy-alphabetical-start
-        ABI_UNSUPPORTED_VECTOR_TYPES,
         ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
         AMBIGUOUS_ASSOCIATED_ITEMS,
         AMBIGUOUS_GLOB_IMPORTS,
@@ -5025,74 +5024,6 @@ declare_lint! {
         reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>",
     };
     crate_level_only
-}
-
-declare_lint! {
-    /// The `abi_unsupported_vector_types` lint detects function definitions and calls
-    /// whose ABI depends on enabling certain target features, but those features are not enabled.
-    ///
-    /// ### Example
-    ///
-    /// ```rust,ignore (fails on non-x86_64)
-    /// extern "C" fn missing_target_feature(_: std::arch::x86_64::__m256) {
-    ///   todo!()
-    /// }
-    ///
-    /// #[target_feature(enable = "avx")]
-    /// unsafe extern "C" fn with_target_feature(_: std::arch::x86_64::__m256) {
-    ///   todo!()
-    /// }
-    ///
-    /// fn main() {
-    ///   let v = unsafe { std::mem::zeroed() };
-    ///   unsafe { with_target_feature(v); }
-    /// }
-    /// ```
-    ///
-    /// This will produce:
-    ///
-    /// ```text
-    /// warning: ABI error: this function call uses a avx vector type, which is not enabled in the caller
-    ///  --> lint_example.rs:18:12
-    ///   |
-    ///   |   unsafe { with_target_feature(v); }
-    ///   |            ^^^^^^^^^^^^^^^^^^^^^^ function called here
-    ///   |
-    ///   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    ///   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-    ///   = help: consider enabling it globally (-C target-feature=+avx) or locally (#[target_feature(enable="avx")])
-    ///   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-    ///
-    ///
-    /// warning: ABI error: this function definition uses a avx vector type, which is not enabled
-    ///  --> lint_example.rs:3:1
-    ///   |
-    ///   | pub extern "C" fn with_target_feature(_: std::arch::x86_64::__m256) {
-    ///   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-    ///   |
-    ///   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    ///   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-    ///   = help: consider enabling it globally (-C target-feature=+avx) or locally (#[target_feature(enable="avx")])
-    /// ```
-    ///
-    ///
-    ///
-    /// ### Explanation
-    ///
-    /// The C ABI for `__m256` requires the value to be passed in an AVX register,
-    /// which is only possible when the `avx` target feature is enabled.
-    /// Therefore, `missing_target_feature` cannot be compiled without that target feature.
-    /// A similar (but complementary) message is triggered when `with_target_feature` is called
-    /// by a function that does not enable the `avx` target feature.
-    ///
-    /// Note that this lint is very similar to the `-Wpsabi` warning in `gcc`/`clang`.
-    pub ABI_UNSUPPORTED_VECTOR_TYPES,
-    Warn,
-    "this function call or definition uses a vector type which is not enabled",
-    @future_incompatible = FutureIncompatibleInfo {
-        reason: FutureIncompatibilityReason::FutureReleaseErrorReportInDeps,
-        reference: "issue #116558 <https://github.com/rust-lang/rust/issues/116558>",
-    };
 }
 
 declare_lint! {

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -70,10 +70,11 @@ pub(crate) struct UnknownCguCollectionMode<'a> {
     pub mode: &'a str,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(monomorphize_abi_error_disabled_vector_type)]
 #[help]
 pub(crate) struct AbiErrorDisabledVectorType<'a> {
+    #[primary_span]
     #[label]
     pub span: Span,
     pub required_feature: &'a str,
@@ -82,9 +83,10 @@ pub(crate) struct AbiErrorDisabledVectorType<'a> {
     pub is_call: bool,
 }
 
-#[derive(LintDiagnostic)]
+#[derive(Diagnostic)]
 #[diag(monomorphize_abi_error_unsupported_vector_type)]
 pub(crate) struct AbiErrorUnsupportedVectorType<'a> {
+    #[primary_span]
     #[label]
     pub span: Span,
     pub ty: Ty<'a>,

--- a/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
@@ -5,7 +5,7 @@ use rustc_hir::{CRATE_HIR_ID, HirId};
 use rustc_middle::mir::{self, Location, traversal};
 use rustc_middle::ty::layout::LayoutCx;
 use rustc_middle::ty::{self, Instance, InstanceKind, Ty, TyCtxt, TypingEnv};
-use rustc_session::lint::builtin::{ABI_UNSUPPORTED_VECTOR_TYPES, WASM_C_ABI};
+use rustc_session::lint::builtin::WASM_C_ABI;
 use rustc_span::def_id::DefId;
 use rustc_span::{DUMMY_SP, Span, Symbol, sym};
 use rustc_target::callconv::{ArgAbi, Conv, FnAbi, PassMode};
@@ -50,34 +50,24 @@ fn do_check_simd_vector_abi<'tcx>(
             let feature = match feature_def.iter().find(|(bits, _)| size.bits() <= *bits) {
                 Some((_, feature)) => feature,
                 None => {
-                    let (span, hir_id) = loc();
-                    tcx.emit_node_span_lint(
-                        ABI_UNSUPPORTED_VECTOR_TYPES,
-                        hir_id,
+                    let (span, _hir_id) = loc();
+                    tcx.dcx().emit_err(errors::AbiErrorUnsupportedVectorType {
                         span,
-                        errors::AbiErrorUnsupportedVectorType {
-                            span,
-                            ty: arg_abi.layout.ty,
-                            is_call,
-                        },
-                    );
+                        ty: arg_abi.layout.ty,
+                        is_call,
+                    });
                     continue;
                 }
             };
             if !have_feature(Symbol::intern(feature)) {
                 // Emit error.
-                let (span, hir_id) = loc();
-                tcx.emit_node_span_lint(
-                    ABI_UNSUPPORTED_VECTOR_TYPES,
-                    hir_id,
+                let (span, _hir_id) = loc();
+                tcx.dcx().emit_err(errors::AbiErrorDisabledVectorType {
                     span,
-                    errors::AbiErrorDisabledVectorType {
-                        span,
-                        required_feature: feature,
-                        ty: arg_abi.layout.ty,
-                        is_call,
-                    },
-                );
+                    required_feature: feature,
+                    ty: arg_abi.layout.ty,
+                    is_call,
+                });
             }
         }
     }

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -775,7 +775,7 @@ const RISCV_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[
     (32768, "zvl32768b"),
     (65536, "zvl65536b"),
 ];
-// Always warn on SPARC, as the necessary target features cannot be enabled in Rust at the moment.
+// Always error on SPARC, as the necessary target features cannot be enabled in Rust at the moment.
 const SPARC_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[/*(64, "vis")*/];
 
 const HEXAGON_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] =

--- a/tests/assembly/simd-bitmask.rs
+++ b/tests/assembly/simd-bitmask.rs
@@ -65,8 +65,9 @@ pub unsafe extern "C" fn bitmask_m8x16(mask: m8x16) -> u16 {
     simd_bitmask(mask)
 }
 
-// CHECK-LABEL: bitmask_m8x64
+// x86-avx512-LABEL: bitmask_m8x64
 #[no_mangle]
+#[cfg(x86_avx512)]
 pub unsafe extern "C" fn bitmask_m8x64(mask: m8x64) -> u64 {
     // The simd_bitmask intrinsic already uses the most significant bit, so no shift is necessary.
     // Note that x86 has no byte shift, llvm uses a word shift to move the least significant bit
@@ -128,8 +129,10 @@ pub unsafe extern "C" fn bitmask_m64x2(mask: m64x2) -> u8 {
     simd_bitmask(mask)
 }
 
-// CHECK-LABEL: bitmask_m64x4
+// x86-avx2-LABEL: bitmask_m64x4
+// x86-avx512-LABEL: bitmask_m64x4
 #[no_mangle]
+#[cfg(any(x86_avx2, x86_avx512))]
 pub unsafe extern "C" fn bitmask_m64x4(mask: m64x4) -> u8 {
     // The simd_bitmask intrinsic already uses the most significant bit, so no shift is necessary.
     //

--- a/tests/assembly/simd-intrinsic-select.rs
+++ b/tests/assembly/simd-intrinsic-select.rs
@@ -99,8 +99,10 @@ pub unsafe extern "C" fn select_f64x2(mask: m64x2, a: f64x2, b: f64x2) -> f64x2 
     simd_select(mask, a, b)
 }
 
-// CHECK-LABEL: select_f64x4
+// x86-avx2-LABEL: select_f64x4
+// x86-avx512-LABEL: select_f64x4
 #[no_mangle]
+#[cfg(any(x86_avx2, x86_avx512))]
 pub unsafe extern "C" fn select_f64x4(mask: m64x4, a: f64x4, b: f64x4) -> f64x4 {
     // The parameter is a 256 bit vector which in the C abi is only valid for avx targets.
     //
@@ -113,8 +115,9 @@ pub unsafe extern "C" fn select_f64x4(mask: m64x4, a: f64x4, b: f64x4) -> f64x4 
     simd_select(mask, a, b)
 }
 
-// CHECK-LABEL: select_f64x8
+// x86-avx512-LABEL: select_f64x8
 #[no_mangle]
+#[cfg(x86_avx512)]
 pub unsafe extern "C" fn select_f64x8(mask: m64x8, a: f64x8, b: f64x8) -> f64x8 {
     // The parameter is a 256 bit vector which in the C abi is only valid for avx512 targets.
     //

--- a/tests/codegen/const-vector.rs
+++ b/tests/codegen/const-vector.rs
@@ -8,6 +8,7 @@
 #![feature(repr_simd)]
 #![feature(rustc_attrs)]
 #![feature(simd_ffi)]
+#![feature(arm_target_feature)]
 #![allow(non_camel_case_types)]
 
 // Setting up structs that can be used as const vectors
@@ -28,33 +29,12 @@ pub struct Simd<T, const N: usize>([T; N]);
 
 extern "unadjusted" {
     fn test_i8x2(a: i8x2);
-}
-
-extern "unadjusted" {
     fn test_i8x2_two_args(a: i8x2, b: i8x2);
-}
-
-extern "unadjusted" {
     fn test_i8x2_mixed_args(a: i8x2, c: i32, b: i8x2);
-}
-
-extern "unadjusted" {
     fn test_i8x2_arr(a: i8x2);
-}
-
-extern "unadjusted" {
     fn test_f32x2(a: f32x2);
-}
-
-extern "unadjusted" {
     fn test_f32x2_arr(a: f32x2);
-}
-
-extern "unadjusted" {
     fn test_simd(a: Simd<i32, 4>);
-}
-
-extern "unadjusted" {
     fn test_simd_unaligned(a: Simd<i32, 3>);
 }
 
@@ -62,6 +42,9 @@ extern "unadjusted" {
 // if the size is not a power of 2
 // CHECK: %"Simd<i32, 3>" = type { [3 x i32] }
 
+#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+#[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 pub fn do_call() {
     unsafe {
         // CHECK: call void @test_i8x2(<2 x i8> <i8 32, i8 64>

--- a/tests/codegen/regparm-inreg.rs
+++ b/tests/codegen/regparm-inreg.rs
@@ -3,7 +3,7 @@
 // x86 only.
 
 //@ add-core-stubs
-//@ compile-flags: --target i686-unknown-linux-gnu -Cno-prepopulate-passes -Copt-level=3
+//@ compile-flags: --target i686-unknown-linux-gnu -Cno-prepopulate-passes -Copt-level=3 -Ctarget-feature=+avx
 //@ needs-llvm-components: x86
 
 //@ revisions:regparm0 regparm1 regparm2 regparm3

--- a/tests/codegen/repr/transparent.rs
+++ b/tests/codegen/repr/transparent.rs
@@ -9,7 +9,7 @@
 // For LoongArch: see codegen/loongarch-abi
 
 #![crate_type = "lib"]
-#![feature(repr_simd, transparent_unions)]
+#![feature(repr_simd, transparent_unions, arm_target_feature)]
 
 use std::marker::PhantomData;
 
@@ -139,6 +139,9 @@ pub struct Vector(f32x4);
 
 // CHECK: define{{.*}}<4 x float> @test_Vector(<4 x float> %_1)
 #[no_mangle]
+#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+#[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 pub extern "C" fn test_Vector(_: Vector) -> Vector {
     loop {}
 }

--- a/tests/codegen/simd/extract-insert-dyn.rs
+++ b/tests/codegen/simd/extract-insert-dyn.rs
@@ -1,6 +1,6 @@
 //@compile-flags: -C opt-level=3 -C no-prepopulate-passes
 
-#![feature(core_intrinsics, repr_simd)]
+#![feature(core_intrinsics, repr_simd, arm_target_feature)]
 #![no_std]
 #![crate_type = "lib"]
 #![allow(non_camel_case_types)]
@@ -21,6 +21,9 @@ pub struct i8x16([i8; 16]);
 // CHECK-LABEL: dyn_simd_extract
 // CHECK: extractelement <16 x i8> %x, i32 %idx
 #[no_mangle]
+#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+#[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 unsafe extern "C" fn dyn_simd_extract(x: i8x16, idx: u32) -> i8 {
     simd_extract_dyn(x, idx)
 }
@@ -28,6 +31,9 @@ unsafe extern "C" fn dyn_simd_extract(x: i8x16, idx: u32) -> i8 {
 // CHECK-LABEL: literal_dyn_simd_extract
 // CHECK: extractelement <16 x i8> %x, i32 7
 #[no_mangle]
+#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+#[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 unsafe extern "C" fn literal_dyn_simd_extract(x: i8x16) -> i8 {
     simd_extract_dyn(x, 7)
 }
@@ -35,6 +41,9 @@ unsafe extern "C" fn literal_dyn_simd_extract(x: i8x16) -> i8 {
 // CHECK-LABEL: const_dyn_simd_extract
 // CHECK: extractelement <16 x i8> %x, i32 7
 #[no_mangle]
+#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+#[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 unsafe extern "C" fn const_dyn_simd_extract(x: i8x16) -> i8 {
     simd_extract_dyn(x, const { 3 + 4 })
 }
@@ -42,6 +51,9 @@ unsafe extern "C" fn const_dyn_simd_extract(x: i8x16) -> i8 {
 // CHECK-LABEL: const_simd_extract
 // CHECK: extractelement <16 x i8> %x, i32 7
 #[no_mangle]
+#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+#[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 unsafe extern "C" fn const_simd_extract(x: i8x16) -> i8 {
     simd_extract(x, const { 3 + 4 })
 }
@@ -49,6 +61,9 @@ unsafe extern "C" fn const_simd_extract(x: i8x16) -> i8 {
 // CHECK-LABEL: dyn_simd_insert
 // CHECK: insertelement <16 x i8> %x, i8 %e, i32 %idx
 #[no_mangle]
+#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+#[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 unsafe extern "C" fn dyn_simd_insert(x: i8x16, e: i8, idx: u32) -> i8x16 {
     simd_insert_dyn(x, idx, e)
 }
@@ -56,6 +71,9 @@ unsafe extern "C" fn dyn_simd_insert(x: i8x16, e: i8, idx: u32) -> i8x16 {
 // CHECK-LABEL: literal_dyn_simd_insert
 // CHECK: insertelement <16 x i8> %x, i8 %e, i32 7
 #[no_mangle]
+#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+#[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 unsafe extern "C" fn literal_dyn_simd_insert(x: i8x16, e: i8) -> i8x16 {
     simd_insert_dyn(x, 7, e)
 }
@@ -63,6 +81,9 @@ unsafe extern "C" fn literal_dyn_simd_insert(x: i8x16, e: i8) -> i8x16 {
 // CHECK-LABEL: const_dyn_simd_insert
 // CHECK: insertelement <16 x i8> %x, i8 %e, i32 7
 #[no_mangle]
+#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+#[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 unsafe extern "C" fn const_dyn_simd_insert(x: i8x16, e: i8) -> i8x16 {
     simd_insert_dyn(x, const { 3 + 4 }, e)
 }
@@ -70,6 +91,9 @@ unsafe extern "C" fn const_dyn_simd_insert(x: i8x16, e: i8) -> i8x16 {
 // CHECK-LABEL: const_simd_insert
 // CHECK: insertelement <16 x i8> %x, i8 %e, i32 7
 #[no_mangle]
+#[cfg_attr(target_family = "wasm", target_feature(enable = "simd128"))]
+#[cfg_attr(target_arch = "arm", target_feature(enable = "neon"))]
+#[cfg_attr(target_arch = "x86", target_feature(enable = "sse"))]
 unsafe extern "C" fn const_simd_insert(x: i8x16, e: i8) -> i8x16 {
     simd_insert(x, const { 3 + 4 }, e)
 }

--- a/tests/run-make/simd-ffi/rmake.rs
+++ b/tests/run-make/simd-ffi/rmake.rs
@@ -52,11 +52,20 @@ fn main() {
         // enabled by-default for i686 and ARM; these features will be invalid
         // on some platforms, but LLVM just prints a warning so that's fine for
         // now.
+        let target_feature = if target.starts_with("i686") || target.starts_with("x86") {
+            "+sse2"
+        } else if target.starts_with("arm") || target.starts_with("aarch64") {
+            "-soft-float,+neon"
+        } else if target.starts_with("mips") {
+            "+msa,+fp64"
+        } else {
+            panic!("missing target_feature case for {target}");
+        };
         rustc()
             .target(&target)
             .emit("llvm-ir,asm")
             .input("simd.rs")
-            .arg("-Ctarget-feature=-soft-float,+neon,+sse")
+            .arg(format!("-Ctarget-feature={target_feature}"))
             .arg(&format!("-Cextra-filename=-{target}"))
             .run();
     }

--- a/tests/ui/abi/simd-abi-checks-avx.rs
+++ b/tests/ui/abi/simd-abi-checks-avx.rs
@@ -1,6 +1,5 @@
 //@ only-x86_64
-//@ build-pass
-//@ ignore-pass (test emits codegen-time warnings)
+//@ build-fail
 //@ compile-flags: -C target-feature=-avx
 
 #![feature(avx512_target_feature)]
@@ -14,20 +13,17 @@ use std::arch::x86_64::*;
 struct Wrapper(__m256);
 
 unsafe extern "C" fn w(_: Wrapper) {
-    //~^ WARN requires the `avx` target feature, which is not enabled
-    //~| WARNING this was previously accepted by the compiler
+    //~^ ERROR: requires the `avx` target feature, which is not enabled
     todo!()
 }
 
 unsafe extern "C" fn f(_: __m256) {
-    //~^ WARN requires the `avx` target feature, which is not enabled
-    //~| WARNING this was previously accepted by the compiler
+    //~^ ERROR: requires the `avx` target feature, which is not enabled
     todo!()
 }
 
 unsafe extern "C" fn g() -> __m256 {
-    //~^ WARN requires the `avx` target feature, which is not enabled
-    //~| WARNING this was previously accepted by the compiler
+    //~^ ERROR: requires the `avx` target feature, which is not enabled
     todo!()
 }
 
@@ -56,25 +52,20 @@ unsafe fn test() {
 unsafe fn in_closure() -> impl FnOnce() -> __m256 {
     #[inline(always)] // this disables target-feature inheritance
     || g()
-    //~^ WARNING requires the `avx` target feature, which is not enabled in the caller
-    //~| WARNING this was previously accepted by the compiler
+    //~^ ERROR requires the `avx` target feature, which is not enabled in the caller
 }
 
 fn main() {
     unsafe {
         f(g());
-        //~^ WARNING requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING this was previously accepted by the compiler
-        //~| WARNING this was previously accepted by the compiler
+        //~^ ERROR requires the `avx` target feature, which is not enabled in the caller
+        //~| ERROR requires the `avx` target feature, which is not enabled in the caller
     }
 
     unsafe {
         gavx(favx());
-        //~^ WARNING requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING this was previously accepted by the compiler
-        //~| WARNING this was previously accepted by the compiler
+        //~^ ERROR requires the `avx` target feature, which is not enabled in the caller
+        //~| ERROR requires the `avx` target feature, which is not enabled in the caller
     }
 
     unsafe {
@@ -83,10 +74,8 @@ fn main() {
 
     unsafe {
         w(Wrapper(g()));
-        //~^ WARNING requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING this was previously accepted by the compiler
-        //~| WARNING this was previously accepted by the compiler
+        //~^ ERROR requires the `avx` target feature, which is not enabled in the caller
+        //~| ERROR requires the `avx` target feature, which is not enabled in the caller
     }
 
     unsafe {
@@ -99,8 +88,7 @@ fn main() {
             fn some_extern() -> __m256;
         }
         some_extern();
-        //~^ WARNING requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING this was previously accepted by the compiler
+        //~^ ERROR requires the `avx` target feature, which is not enabled in the caller
     }
 }
 

--- a/tests/ui/abi/simd-abi-checks-avx.stderr
+++ b/tests/ui/abi/simd-abi-checks-avx.stderr
@@ -1,245 +1,96 @@
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:65:11
+error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+  --> $DIR/simd-abi-checks-avx.rs:60:11
    |
 LL |         f(g());
    |           ^^^ function called here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:65:9
+error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+  --> $DIR/simd-abi-checks-avx.rs:60:9
    |
 LL |         f(g());
    |         ^^^^^^ function called here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:73:14
+error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+  --> $DIR/simd-abi-checks-avx.rs:66:14
    |
 LL |         gavx(favx());
    |              ^^^^^^ function called here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:73:9
+error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+  --> $DIR/simd-abi-checks-avx.rs:66:9
    |
 LL |         gavx(favx());
    |         ^^^^^^^^^^^^ function called here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:85:19
+error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+  --> $DIR/simd-abi-checks-avx.rs:76:19
    |
 LL |         w(Wrapper(g()));
    |                   ^^^ function called here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:85:9
+error: this function call uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+  --> $DIR/simd-abi-checks-avx.rs:76:9
    |
 LL |         w(Wrapper(g()));
    |         ^^^^^^^^^^^^^^^ function called here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:101:9
+error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+  --> $DIR/simd-abi-checks-avx.rs:90:9
    |
 LL |         some_extern();
    |         ^^^^^^^^^^^^^ function called here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-avx.rs:28:1
+error: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-avx.rs:25:1
    |
 LL | unsafe extern "C" fn g() -> __m256 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-avx.rs:22:1
+error: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-avx.rs:20:1
    |
 LL | unsafe extern "C" fn f(_: __m256) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function definition uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-avx.rs:16:1
+error: this function definition uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-avx.rs:15:1
    |
 LL | unsafe extern "C" fn w(_: Wrapper) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:58:8
+error: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+  --> $DIR/simd-abi-checks-avx.rs:54:8
    |
 LL |     || g()
    |        ^^^ function called here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: 11 warnings emitted
+note: the above error was encountered while instantiating `fn in_closure::{closure#0}`
+  --> $DIR/simd-abi-checks-avx.rs:82:9
+   |
+LL |         in_closure()();
+   |         ^^^^^^^^^^^^^^
 
-Future incompatibility report: Future breakage diagnostic:
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:65:11
-   |
-LL |         f(g());
-   |           ^^^ function called here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-
-Future breakage diagnostic:
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:65:9
-   |
-LL |         f(g());
-   |         ^^^^^^ function called here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-
-Future breakage diagnostic:
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:73:14
-   |
-LL |         gavx(favx());
-   |              ^^^^^^ function called here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-
-Future breakage diagnostic:
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:73:9
-   |
-LL |         gavx(favx());
-   |         ^^^^^^^^^^^^ function called here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-
-Future breakage diagnostic:
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:85:19
-   |
-LL |         w(Wrapper(g()));
-   |                   ^^^ function called here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-
-Future breakage diagnostic:
-warning: this function call uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:85:9
-   |
-LL |         w(Wrapper(g()));
-   |         ^^^^^^^^^^^^^^^ function called here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-
-Future breakage diagnostic:
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:101:9
-   |
-LL |         some_extern();
-   |         ^^^^^^^^^^^^^ function called here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-
-Future breakage diagnostic:
-warning: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-avx.rs:28:1
-   |
-LL | unsafe extern "C" fn g() -> __m256 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-
-Future breakage diagnostic:
-warning: this function definition uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-avx.rs:22:1
-   |
-LL | unsafe extern "C" fn f(_: __m256) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-
-Future breakage diagnostic:
-warning: this function definition uses SIMD vector type `Wrapper` which (with the chosen ABI) requires the `avx` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-avx.rs:16:1
-   |
-LL | unsafe extern "C" fn w(_: Wrapper) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
-
-Future breakage diagnostic:
-warning: this function call uses SIMD vector type `std::arch::x86_64::__m256` which (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
-  --> $DIR/simd-abi-checks-avx.rs:58:8
-   |
-LL |     || g()
-   |        ^^^ function called here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
+error: aborting due to 11 previous errors
 

--- a/tests/ui/abi/simd-abi-checks-empty-list.rs
+++ b/tests/ui/abi/simd-abi-checks-empty-list.rs
@@ -1,8 +1,9 @@
+//! At the time of writing, the list of "which target feature enables which vector size" is empty
+//! for SPARC. Ensure that this leads to all vector sizes causing an error.
 //@ add-core-stubs
 //@ needs-llvm-components: sparc
 //@ compile-flags: --target=sparc-unknown-none-elf --crate-type=rlib
-//@ build-pass
-//@ ignore-pass (test emits codegen-time warnings)
+//@ build-fail
 #![no_core]
 #![feature(no_core, repr_simd)]
 #![allow(improper_ctypes_definitions)]
@@ -14,5 +15,4 @@ use minicore::*;
 pub struct SimdVec([i32; 4]);
 
 pub extern "C" fn pass_by_vec(_: SimdVec) {}
-//~^ WARN this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
-//~| WARNING this was previously accepted by the compiler
+//~^ ERROR: this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI

--- a/tests/ui/abi/simd-abi-checks-empty-list.stderr
+++ b/tests/ui/abi/simd-abi-checks-empty-list.stderr
@@ -1,23 +1,8 @@
-warning: this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
-  --> $DIR/simd-abi-checks-empty-list.rs:16:1
+error: this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
+  --> $DIR/simd-abi-checks-empty-list.rs:17:1
    |
 LL | pub extern "C" fn pass_by_vec(_: SimdVec) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
-warning: 1 warning emitted
-
-Future incompatibility report: Future breakage diagnostic:
-warning: this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
-  --> $DIR/simd-abi-checks-empty-list.rs:16:1
-   |
-LL | pub extern "C" fn pass_by_vec(_: SimdVec) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
+error: aborting due to 1 previous error
 

--- a/tests/ui/abi/simd-abi-checks-s390x.rs
+++ b/tests/ui/abi/simd-abi-checks-s390x.rs
@@ -13,7 +13,6 @@
 #![no_core]
 #![crate_type = "lib"]
 #![allow(non_camel_case_types, improper_ctypes_definitions)]
-#![deny(abi_unsupported_vector_types)]
 
 extern crate minicore;
 use minicore::*;
@@ -38,13 +37,11 @@ impl<T: Copy> Copy for TransparentWrapper<T> {}
 #[no_mangle]
 extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
     //~^ ERROR requires the `vector` target feature, which is not enabled
-    //~^^ WARN this was previously accepted
     *x
 }
 #[no_mangle]
 extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
     //~^ ERROR requires the `vector` target feature, which is not enabled
-    //~^^ WARN this was previously accepted
     *x
 }
 #[no_mangle]
@@ -93,7 +90,6 @@ extern "C" fn vector_transparent_wrapper_ret_small(
     x: &TransparentWrapper<i8x8>,
 ) -> TransparentWrapper<i8x8> {
     //~^^^ ERROR requires the `vector` target feature, which is not enabled
-    //~^^^^ WARN this was previously accepted
     *x
 }
 #[no_mangle]
@@ -101,7 +97,6 @@ extern "C" fn vector_transparent_wrapper_ret(
     x: &TransparentWrapper<i8x16>,
 ) -> TransparentWrapper<i8x16> {
     //~^^^ ERROR requires the `vector` target feature, which is not enabled
-    //~^^^^ WARN this was previously accepted
     *x
 }
 #[no_mangle]
@@ -115,13 +110,11 @@ extern "C" fn vector_transparent_wrapper_ret_large(
 #[no_mangle]
 extern "C" fn vector_arg_small(x: i8x8) -> i64 {
     //~^ ERROR requires the `vector` target feature, which is not enabled
-    //~^^ WARN this was previously accepted
     unsafe { *(&x as *const i8x8 as *const i64) }
 }
 #[no_mangle]
 extern "C" fn vector_arg(x: i8x16) -> i64 {
     //~^ ERROR requires the `vector` target feature, which is not enabled
-    //~^^ WARN this was previously accepted
     unsafe { *(&x as *const i8x16 as *const i64) }
 }
 #[no_mangle]
@@ -133,13 +126,11 @@ extern "C" fn vector_arg_large(x: i8x32) -> i64 {
 #[no_mangle]
 extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
     //~^ ERROR requires the `vector` target feature, which is not enabled
-    //~^^ WARN this was previously accepted
     unsafe { *(&x as *const Wrapper<i8x8> as *const i64) }
 }
 #[no_mangle]
 extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
     //~^ ERROR requires the `vector` target feature, which is not enabled
-    //~^^ WARN this was previously accepted
     unsafe { *(&x as *const Wrapper<i8x16> as *const i64) }
 }
 #[no_mangle]
@@ -151,13 +142,11 @@ extern "C" fn vector_wrapper_arg_large(x: Wrapper<i8x32>) -> i64 {
 #[no_mangle]
 extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
     //~^ ERROR requires the `vector` target feature, which is not enabled
-    //~^^ WARN this was previously accepted
     unsafe { *(&x as *const TransparentWrapper<i8x8> as *const i64) }
 }
 #[no_mangle]
 extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
     //~^ ERROR requires the `vector` target feature, which is not enabled
-    //~^^ WARN this was previously accepted
     unsafe { *(&x as *const TransparentWrapper<i8x16> as *const i64) }
 }
 #[no_mangle]

--- a/tests/ui/abi/simd-abi-checks-s390x.z10.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z10.stderr
@@ -1,275 +1,86 @@
 error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:39:1
+  --> $DIR/simd-abi-checks-s390x.rs:38:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:45:1
+  --> $DIR/simd-abi-checks-s390x.rs:43:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:92:1
+  --> $DIR/simd-abi-checks-s390x.rs:89:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
 LL | |     x: &TransparentWrapper<i8x8>,
 LL | | ) -> TransparentWrapper<i8x8> {
    | |_____________________________^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:100:1
+  --> $DIR/simd-abi-checks-s390x.rs:96:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
 LL | |     x: &TransparentWrapper<i8x16>,
 LL | | ) -> TransparentWrapper<i8x16> {
    | |______________________________^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:116:1
+  --> $DIR/simd-abi-checks-s390x.rs:111:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:122:1
+  --> $DIR/simd-abi-checks-s390x.rs:116:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:134:1
+  --> $DIR/simd-abi-checks-s390x.rs:127:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:140:1
+  --> $DIR/simd-abi-checks-s390x.rs:132:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:152:1
+  --> $DIR/simd-abi-checks-s390x.rs:143:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:158:1
+  --> $DIR/simd-abi-checks-s390x.rs:148:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: aborting due to 10 previous errors
-
-Future incompatibility report: Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:39:1
-   |
-LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:45:1
-   |
-LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:92:1
-   |
-LL | / extern "C" fn vector_transparent_wrapper_ret_small(
-LL | |     x: &TransparentWrapper<i8x8>,
-LL | | ) -> TransparentWrapper<i8x8> {
-   | |_____________________________^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:100:1
-   |
-LL | / extern "C" fn vector_transparent_wrapper_ret(
-LL | |     x: &TransparentWrapper<i8x16>,
-LL | | ) -> TransparentWrapper<i8x16> {
-   | |______________________________^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:116:1
-   |
-LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:122:1
-   |
-LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:134:1
-   |
-LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:140:1
-   |
-LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:152:1
-   |
-LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:158:1
-   |
-LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/abi/simd-abi-checks-s390x.z13_no_vector.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z13_no_vector.stderr
@@ -1,275 +1,86 @@
 error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:39:1
+  --> $DIR/simd-abi-checks-s390x.rs:38:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:45:1
+  --> $DIR/simd-abi-checks-s390x.rs:43:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:92:1
+  --> $DIR/simd-abi-checks-s390x.rs:89:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
 LL | |     x: &TransparentWrapper<i8x8>,
 LL | | ) -> TransparentWrapper<i8x8> {
    | |_____________________________^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:100:1
+  --> $DIR/simd-abi-checks-s390x.rs:96:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
 LL | |     x: &TransparentWrapper<i8x16>,
 LL | | ) -> TransparentWrapper<i8x16> {
    | |______________________________^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:116:1
+  --> $DIR/simd-abi-checks-s390x.rs:111:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:122:1
+  --> $DIR/simd-abi-checks-s390x.rs:116:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:134:1
+  --> $DIR/simd-abi-checks-s390x.rs:127:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:140:1
+  --> $DIR/simd-abi-checks-s390x.rs:132:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:152:1
+  --> $DIR/simd-abi-checks-s390x.rs:143:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:158:1
+  --> $DIR/simd-abi-checks-s390x.rs:148:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: aborting due to 10 previous errors
-
-Future incompatibility report: Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:39:1
-   |
-LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:45:1
-   |
-LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:92:1
-   |
-LL | / extern "C" fn vector_transparent_wrapper_ret_small(
-LL | |     x: &TransparentWrapper<i8x8>,
-LL | | ) -> TransparentWrapper<i8x8> {
-   | |_____________________________^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:100:1
-   |
-LL | / extern "C" fn vector_transparent_wrapper_ret(
-LL | |     x: &TransparentWrapper<i8x16>,
-LL | | ) -> TransparentWrapper<i8x16> {
-   | |______________________________^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:116:1
-   |
-LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:122:1
-   |
-LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:134:1
-   |
-LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:140:1
-   |
-LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:152:1
-   |
-LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:158:1
-   |
-LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/abi/simd-abi-checks-s390x.z13_soft_float.stderr
+++ b/tests/ui/abi/simd-abi-checks-s390x.z13_soft_float.stderr
@@ -1,275 +1,86 @@
 error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:39:1
+  --> $DIR/simd-abi-checks-s390x.rs:38:1
    |
 LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:45:1
+  --> $DIR/simd-abi-checks-s390x.rs:43:1
    |
 LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:92:1
+  --> $DIR/simd-abi-checks-s390x.rs:89:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret_small(
 LL | |     x: &TransparentWrapper<i8x8>,
 LL | | ) -> TransparentWrapper<i8x8> {
    | |_____________________________^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:100:1
+  --> $DIR/simd-abi-checks-s390x.rs:96:1
    |
 LL | / extern "C" fn vector_transparent_wrapper_ret(
 LL | |     x: &TransparentWrapper<i8x16>,
 LL | | ) -> TransparentWrapper<i8x16> {
    | |______________________________^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:116:1
+  --> $DIR/simd-abi-checks-s390x.rs:111:1
    |
 LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:122:1
+  --> $DIR/simd-abi-checks-s390x.rs:116:1
    |
 LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:134:1
+  --> $DIR/simd-abi-checks-s390x.rs:127:1
    |
 LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:140:1
+  --> $DIR/simd-abi-checks-s390x.rs:132:1
    |
 LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:152:1
+  --> $DIR/simd-abi-checks-s390x.rs:143:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:158:1
+  --> $DIR/simd-abi-checks-s390x.rs:148:1
    |
 LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
 
 error: aborting due to 10 previous errors
-
-Future incompatibility report: Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:39:1
-   |
-LL | extern "C" fn vector_ret_small(x: &i8x8) -> i8x8 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:45:1
-   |
-LL | extern "C" fn vector_ret(x: &i8x16) -> i8x16 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:92:1
-   |
-LL | / extern "C" fn vector_transparent_wrapper_ret_small(
-LL | |     x: &TransparentWrapper<i8x8>,
-LL | | ) -> TransparentWrapper<i8x8> {
-   | |_____________________________^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:100:1
-   |
-LL | / extern "C" fn vector_transparent_wrapper_ret(
-LL | |     x: &TransparentWrapper<i8x16>,
-LL | | ) -> TransparentWrapper<i8x16> {
-   | |______________________________^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x8` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:116:1
-   |
-LL | extern "C" fn vector_arg_small(x: i8x8) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `i8x16` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:122:1
-   |
-LL | extern "C" fn vector_arg(x: i8x16) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `Wrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:134:1
-   |
-LL | extern "C" fn vector_wrapper_arg_small(x: Wrapper<i8x8>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `Wrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:140:1
-   |
-LL | extern "C" fn vector_wrapper_arg(x: Wrapper<i8x16>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x8>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:152:1
-   |
-LL | extern "C" fn vector_transparent_wrapper_arg_small(x: TransparentWrapper<i8x8>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: this function definition uses SIMD vector type `TransparentWrapper<i8x16>` which (with the chosen ABI) requires the `vector` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-s390x.rs:158:1
-   |
-LL | extern "C" fn vector_transparent_wrapper_arg(x: TransparentWrapper<i8x16>) -> i64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+vector`) or locally (`#[target_feature(enable="vector")]`)
-note: the lint level is defined here
-  --> $DIR/simd-abi-checks-s390x.rs:16:9
-   |
-LL | #![deny(abi_unsupported_vector_types)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/abi/simd-abi-checks-sse.rs
+++ b/tests/ui/abi/simd-abi-checks-sse.rs
@@ -3,8 +3,7 @@
 //@ compile-flags: --crate-type=rlib --target=i586-unknown-linux-gnu
 //@ compile-flags: -Ctarget-cpu=pentium4 -C target-feature=-sse,-sse2
 //@ add-core-stubs
-//@ build-pass
-//@ ignore-pass (test emits codegen-time warnings)
+//@ build-fail
 //@ needs-llvm-components: x86
 #![feature(no_core, repr_simd)]
 #![no_core]
@@ -18,6 +17,5 @@ pub struct SseVector([i64; 2]);
 
 #[no_mangle]
 pub unsafe extern "C" fn f(_: SseVector) {
-    //~^ WARN this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
-    //~| WARNING this was previously accepted by the compiler
+    //~^ ERROR: this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
 }

--- a/tests/ui/abi/simd-abi-checks-sse.stderr
+++ b/tests/ui/abi/simd-abi-checks-sse.stderr
@@ -1,25 +1,10 @@
-warning: this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-sse.rs:20:1
+error: this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
+  --> $DIR/simd-abi-checks-sse.rs:19:1
    |
 LL | pub unsafe extern "C" fn f(_: SseVector) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+sse`) or locally (`#[target_feature(enable="sse")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
-warning: 1 warning emitted
-
-Future incompatibility report: Future breakage diagnostic:
-warning: this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
-  --> $DIR/simd-abi-checks-sse.rs:20:1
-   |
-LL | pub unsafe extern "C" fn f(_: SseVector) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
-   = help: consider enabling it globally (`-C target-feature=+sse`) or locally (`#[target_feature(enable="sse")]`)
-   = note: `#[warn(abi_unsupported_vector_types)]` on by default
+error: aborting due to 1 previous error
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/116558 by completing the transition; see that issue for context. The lint was introduced with Rust 1.84 and this has been shown in cargo's future breakage reports since Rust 1.85, released 6 weeks ago, and so far we got 0 complaints by users. There's not even a backlink on the tracking issue. We did a [crater run](https://github.com/rust-lang/rust/pull/127731#issuecomment-2286736295) when the lint was originally added and found no breakage. So I don't think we need another crater run now, but I can do one if the team prefers that.

https://github.com/rust-lang/rust/issues/131800 is done, so for most current targets (in particular, all tier 1 and tier 2 targets) we have the information to implement this check (modulo the targets where we don't properly support SIMD vectors yet, see the sub-issues of https://github.com/rust-lang/rust/issues/116558). If a new target gets added in the future, it will default to reject all SIMD vector types until proper information is added, which is the default we want.


This will need approval by for @rust-lang/lang. Cc @workingjubilee @veluca93 

try-job: test-various
try-job: armhf-gnu
try-job: dist-i586-gnu-i586-i686-musl