### PR TITLE
Fix ICE in ParamConst::find_ty_from_env when handling None values

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -653,7 +653,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
         placeholder: Self::PlaceholderConst,
     ) -> Ty<'tcx> {
-        placeholder.find_const_ty_from_env(param_env)
+        placeholder.find_const_ty_from_env_unwrap(param_env)
     }
 
     fn anonymize_bound_vars<T: TypeFoldable<TyCtxt<'tcx>>>(

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -846,7 +846,7 @@ pub struct Placeholder<T> {
     pub bound: T,
 }
 impl Placeholder<BoundVar> {
-    pub fn find_const_ty_from_env<'tcx>(self, env: ParamEnv<'tcx>) -> Ty<'tcx> {
+    pub fn find_const_ty_from_env<'tcx>(self, env: ParamEnv<'tcx>) -> Option<Ty<'tcx>> {
         let mut candidates = env.caller_bounds().iter().filter_map(|clause| {
             // `ConstArgHasType` are never desugared to be higher ranked.
             match clause.kind().skip_binder() {
@@ -864,9 +864,17 @@ impl Placeholder<BoundVar> {
             }
         });
 
-        let ty = candidates.next().unwrap();
-        assert!(candidates.next().is_none());
+        let ty = candidates.next();
+        if ty.is_some() {
+            assert!(candidates.next().is_none());
+        }
         ty
+    }
+
+    /// Same as `find_const_ty_from_env` but unwraps the result.
+    /// This will panic if no type is found for the const parameter.
+    pub fn find_const_ty_from_env_unwrap<'tcx>(self, env: ParamEnv<'tcx>) -> Ty<'tcx> {
+        self.find_const_ty_from_env(env).unwrap()
     }
 }
 

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -342,7 +342,7 @@ impl ParamConst {
     }
 
     #[instrument(level = "debug")]
-    pub fn find_ty_from_env<'tcx>(self, env: ParamEnv<'tcx>) -> Ty<'tcx> {
+    pub fn find_ty_from_env<'tcx>(self, env: ParamEnv<'tcx>) -> Option<Ty<'tcx>> {
         let mut candidates = env.caller_bounds().iter().filter_map(|clause| {
             // `ConstArgHasType` are never desugared to be higher ranked.
             match clause.kind().skip_binder() {
@@ -358,9 +358,18 @@ impl ParamConst {
             }
         });
 
-        let ty = candidates.next().unwrap();
-        assert!(candidates.next().is_none());
+        let ty = candidates.next();
+        if ty.is_some() {
+            assert!(candidates.next().is_none());
+        }
         ty
+    }
+
+    /// Same as `find_ty_from_env` but unwraps the result.
+    /// This will panic if no type is found for the const parameter.
+    #[instrument(level = "debug")]
+    pub fn find_ty_from_env_unwrap<'tcx>(self, env: ParamEnv<'tcx>) -> Ty<'tcx> {
+        self.find_ty_from_env(env).unwrap()
     }
 }
 

--- a/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill/derive_errors.rs
@@ -36,7 +36,15 @@ pub(super) fn fulfillment_error_for_no_solution<'tcx>(
                 ty::ConstKind::Unevaluated(uv) => {
                     infcx.tcx.type_of(uv.def).instantiate(infcx.tcx, uv.args)
                 }
-                ty::ConstKind::Param(param_ct) => param_ct.find_ty_from_env(obligation.param_env),
+                ty::ConstKind::Param(param_ct) => {
+                    match param_ct.find_ty_from_env(obligation.param_env) {
+                        Some(ty) => ty,
+                        None => {
+                            // If we can't find the type, use error type
+                            Ty::new_misc_error(infcx.tcx)
+                        }
+                    }
+                },
                 ty::ConstKind::Value(cv) => cv.ty,
                 kind => span_bug!(
                     obligation.cause.span,

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -503,7 +503,15 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                         }
                         ty::ConstKind::Bound(_, _) => bug!("escaping bound vars in {:?}", ct),
                         ty::ConstKind::Param(param_ct) => {
-                            param_ct.find_ty_from_env(obligation.param_env)
+                            match param_ct.find_ty_from_env(obligation.param_env) {
+                                Some(ty) => ty,
+                                None => {
+                                    // If we can't find the type, return an error
+                                    return ProcessResult::Error(FulfillmentErrorCode::Select(
+                                        SelectionError::Unimplemented
+                                    ));
+                                }
+                            }
                         }
                     };
 

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -972,7 +972,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         }
                         ty::ConstKind::Bound(_, _) => bug!("escaping bound vars in {:?}", ct),
                         ty::ConstKind::Param(param_ct) => {
-                            param_ct.find_ty_from_env(obligation.param_env)
+                            match param_ct.find_ty_from_env(obligation.param_env) {
+                                Some(ty) => ty,
+                                None => {
+                                    // If we can't find the type, return an error
+                                    return Ok(EvaluatedToErr);
+                                }
+                            }
                         }
                     };
 

--- a/tests/ui/async-await/issue-139314-option-unwrap-none-regression.rs
+++ b/tests/ui/async-await/issue-139314-option-unwrap-none-regression.rs
@@ -1,0 +1,15 @@
+// Test for issue #139314
+// This test ensures that the compiler properly reports an error
+// instead of panicking with "called `Option::unwrap()` on a `None` value"
+// when processing async functions with const parameters.
+
+//@ edition:2018
+//@ error-pattern: the trait bound
+
+async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+    func(iter.map(|x| x + 1))
+}
+
+fn main() {
+    // Just make sure the function compiles, we don't need to call it
+}

--- a/tests/ui/async-await/issue-139314-option-unwrap-none-regression.stderr
+++ b/tests/ui/async-await/issue-139314-option-unwrap-none-regression.stderr
@@ -1,0 +1,80 @@
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-regression.rs:10:19: 10:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-regression.rs:10:10
+   |
+LL |     func(iter.map(|x| x + 1))
+   |     ---- ^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-regression.rs:10:19: 10:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none-regression.rs:9:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+help: consider removing this method call, as the receiver has type `T` and `T: Copy` trivially holds
+   |
+LL -     func(iter.map(|x| x + 1))
+LL +     func(iter)
+   |
+
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-regression.rs:10:19: 10:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-regression.rs:10:5
+   |
+LL |     func(iter.map(|x| x + 1))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-regression.rs:10:19: 10:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none-regression.rs:9:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+
+error[E0277]: the trait bound `impl Future<Output = impl Clone>: Clone` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-regression.rs:9:94
+   |
+LL |   async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |  ______________________________________________________________________________________________^
+LL | |     func(iter.map(|x| x + 1))
+LL | | }
+   | |_^ the trait `Clone` is not implemented for `impl Future<Output = impl Clone>`
+
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-regression.rs:10:19: 10:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-regression.rs:9:94
+   |
+LL |   async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |  ______________________________________________________________________________________________^
+LL | |     func(iter.map(|x| x + 1))
+LL | | }
+   | |_^ unsatisfied trait bound
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-regression.rs:10:19: 10:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none-regression.rs:9:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-regression.rs:10:19: 10:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-regression.rs:9:1
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-regression.rs:10:19: 10:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none-regression.rs:9:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+
+error[E0277]: the trait bound `impl Future<Output = impl Clone>: Clone` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-regression.rs:9:74
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                                                          ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `impl Future<Output = impl Clone>`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/issue-139314-option-unwrap-none-test.rs
+++ b/tests/ui/async-await/issue-139314-option-unwrap-none-test.rs
@@ -1,0 +1,16 @@
+// Test for issue #139314
+// This test ensures that the compiler doesn't panic with
+// "called `Option::unwrap()` on a `None` value" when processing
+// async functions with const parameters.
+
+//@ edition:2018
+//@ error-pattern: the trait bound
+
+// This is a simplified version of the test case that caused the ICE
+async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+    func(iter.map(|x| x + 1))
+}
+
+fn main() {
+    // Just make sure the function compiles, we don't need to call it
+}

--- a/tests/ui/async-await/issue-139314-option-unwrap-none-test.stderr
+++ b/tests/ui/async-await/issue-139314-option-unwrap-none-test.stderr
@@ -1,0 +1,80 @@
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-test.rs:11:19: 11:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-test.rs:11:10
+   |
+LL |     func(iter.map(|x| x + 1))
+   |     ---- ^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-test.rs:11:19: 11:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none-test.rs:10:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+help: consider removing this method call, as the receiver has type `T` and `T: Copy` trivially holds
+   |
+LL -     func(iter.map(|x| x + 1))
+LL +     func(iter)
+   |
+
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-test.rs:11:19: 11:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-test.rs:11:5
+   |
+LL |     func(iter.map(|x| x + 1))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-test.rs:11:19: 11:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none-test.rs:10:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+
+error[E0277]: the trait bound `impl Future<Output = impl Clone>: Clone` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-test.rs:10:94
+   |
+LL |   async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |  ______________________________________________________________________________________________^
+LL | |     func(iter.map(|x| x + 1))
+LL | | }
+   | |_^ the trait `Clone` is not implemented for `impl Future<Output = impl Clone>`
+
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-test.rs:11:19: 11:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-test.rs:10:94
+   |
+LL |   async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |  ______________________________________________________________________________________________^
+LL | |     func(iter.map(|x| x + 1))
+LL | | }
+   | |_^ unsatisfied trait bound
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-test.rs:11:19: 11:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none-test.rs:10:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-test.rs:11:19: 11:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-test.rs:10:1
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none-test.rs:11:19: 11:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none-test.rs:10:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+
+error[E0277]: the trait bound `impl Future<Output = impl Clone>: Clone` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none-test.rs:10:74
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                                                          ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `impl Future<Output = impl Clone>`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/async-await/issue-139314-option-unwrap-none.rs
+++ b/tests/ui/async-await/issue-139314-option-unwrap-none.rs
@@ -1,0 +1,15 @@
+// Test for issue #139314
+// This test ensures that the compiler doesn't panic with
+// "called `Option::unwrap()` on a `None` value" when processing
+// async functions with const parameters.
+
+//@ edition:2018
+//@ error-pattern: the trait bound
+
+async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+    func(iter.map(|x| x + 1))
+}
+
+fn main() {
+    // Just make sure the function compiles, we don't need to call it
+}

--- a/tests/ui/async-await/issue-139314-option-unwrap-none.stderr
+++ b/tests/ui/async-await/issue-139314-option-unwrap-none.stderr
@@ -1,0 +1,80 @@
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none.rs:10:19: 10:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none.rs:10:10
+   |
+LL |     func(iter.map(|x| x + 1))
+   |     ---- ^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none.rs:10:19: 10:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none.rs:9:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+help: consider removing this method call, as the receiver has type `T` and `T: Copy` trivially holds
+   |
+LL -     func(iter.map(|x| x + 1))
+LL +     func(iter)
+   |
+
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none.rs:10:19: 10:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none.rs:10:5
+   |
+LL |     func(iter.map(|x| x + 1))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none.rs:10:19: 10:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none.rs:9:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+
+error[E0277]: the trait bound `impl Future<Output = impl Clone>: Clone` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none.rs:9:94
+   |
+LL |   async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |  ______________________________________________________________________________________________^
+LL | |     func(iter.map(|x| x + 1))
+LL | | }
+   | |_^ the trait `Clone` is not implemented for `impl Future<Output = impl Clone>`
+
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none.rs:10:19: 10:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none.rs:9:94
+   |
+LL |   async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |  ______________________________________________________________________________________________^
+LL | |     func(iter.map(|x| x + 1))
+LL | | }
+   | |_^ unsatisfied trait bound
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none.rs:10:19: 10:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none.rs:9:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+
+error[E0277]: the trait bound `Map<T, {closure@$DIR/issue-139314-option-unwrap-none.rs:10:19: 10:22}>: Copy` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none.rs:9:1
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `Copy` is not implemented for `Map<T, {closure@$DIR/issue-139314-option-unwrap-none.rs:10:19: 10:22}>`
+note: required by a bound in `func`
+  --> $DIR/issue-139314-option-unwrap-none.rs:9:40
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                        ^^^^ required by this bound in `func`
+
+error[E0277]: the trait bound `impl Future<Output = impl Clone>: Clone` is not satisfied
+  --> $DIR/issue-139314-option-unwrap-none.rs:9:74
+   |
+LL | async fn func<T: Iterator<Item = u8> + Copy, const N: usize>(iter: T) -> impl for<'a1> Clone {
+   |                                                                          ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `impl Future<Output = impl Clone>`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
# Fix ICE in ParamConst::find_ty_from_env when handling None values

This PR fixes issue #139314 where the compiler would panic with "called `Option::unwrap()` on a `None` value" when processing async functions with const parameters.

## Problem

When processing async functions with const parameters, the compiler would try to find the type of a const parameter by looking through the environment's caller bounds. If no matching type was found, it would call `unwrap()` on a `None` value, causing the compiler to panic.

## Solution

The fix modifies `ParamConst::find_ty_from_env` to return an `Option<Ty<'tcx>>` instead of unwrapping the result directly. A new method `find_ty_from_env_unwrap` is added for backward compatibility.

All call sites are updated to handle the `Option` return type appropriately:
- In `rustc_trait_selection/src/traits/fulfill.rs`: Return a `ProcessResult::Error` when no type is found
- In `rustc_trait_selection/src/solve/fulfill/derive_errors.rs`: Use an error type when no type is found
- In `rustc_trait_selection/src/traits/select/mod.rs`: Return `EvaluatedToErr` when no type is found

Similar changes are made to `Placeholder::find_const_ty_from_env` for consistency.

## Testing

Test cases are added to verify the fix and prevent regression. The compiler now properly reports type errors instead of panicking with an ICE.

Fixes #139314