### PR TITLE
Make the compiler suggest actual paths instead of visible paths if the visible paths are through any doc hidden path.

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -25,6 +25,7 @@ use rustc_middle::bug;
 use rustc_middle::ty::fast_reject::{DeepRejectCtxt, TreatParams, simplify_type};
 use rustc_middle::ty::print::{
     PrintTraitRefExt as _, with_crate_prefix, with_forced_trimmed_paths,
+    with_no_visible_paths_if_doc_hidden,
 };
 use rustc_middle::ty::{self, GenericArgKind, IsSuggestable, Ty, TyCtxt, TypeVisitableExt};
 use rustc_span::def_id::DefIdSet;
@@ -3328,7 +3329,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let path_strings = candidates.iter().map(|trait_did| {
                 format!(
                     "{prefix}{}{postfix}\n",
-                    with_crate_prefix!(self.tcx.def_path_str(*trait_did)),
+                    with_no_visible_paths_if_doc_hidden!(with_crate_prefix!(
+                        self.tcx.def_path_str(*trait_did)
+                    )),
                 )
             });
 
@@ -3336,7 +3339,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let parent_did = parent_map.get(trait_did).unwrap();
                 format!(
                     "{prefix}{}::*{postfix} // trait {}\n",
-                    with_crate_prefix!(self.tcx.def_path_str(*parent_did)),
+                    with_no_visible_paths_if_doc_hidden!(with_crate_prefix!(
+                        self.tcx.def_path_str(*parent_did)
+                    )),
                     self.tcx.item_name(*trait_did),
                 )
             });

--- a/tests/ui/typeck/auxiliary/suggest-trait-reexported-as-not-doc-visible-a.rs
+++ b/tests/ui/typeck/auxiliary/suggest-trait-reexported-as-not-doc-visible-a.rs
@@ -1,0 +1,5 @@
+//@ edition: 2021
+
+pub trait Foo {
+    fn foo();
+}

--- a/tests/ui/typeck/auxiliary/suggest-trait-reexported-as-not-doc-visible-b.rs
+++ b/tests/ui/typeck/auxiliary/suggest-trait-reexported-as-not-doc-visible-b.rs
@@ -1,0 +1,14 @@
+// ignore-tidy-linelength
+//@ edition: 2021
+//@ aux-crate:suggest_trait_reexported_as_not_doc_visible_a=suggest-trait-reexported-as-not-doc-visible-a.rs
+
+pub struct Bar;
+
+impl __DocHidden::Foo for Bar {
+    fn foo() {}
+}
+
+#[doc(hidden)]
+pub mod __DocHidden {
+    pub use suggest_trait_reexported_as_not_doc_visible_a::Foo;
+}

--- a/tests/ui/typeck/suggest-trait-reexported-as-not-doc-visible.rs
+++ b/tests/ui/typeck/suggest-trait-reexported-as-not-doc-visible.rs
@@ -1,0 +1,11 @@
+// ignore-tidy-linelength
+//@ edition: 2021
+//@ aux-crate:suggest_trait_reexported_as_not_doc_visible_a=suggest-trait-reexported-as-not-doc-visible-a.rs
+//@ aux-crate:suggest_trait_reexported_as_not_doc_visible_b=suggest-trait-reexported-as-not-doc-visible-b.rs
+
+use suggest_trait_reexported_as_not_doc_visible_b::Bar;
+
+fn main() {
+    Bar::foo();
+    //~^ ERROR: no function or associated item named `foo` found for struct `Bar` in the current scope [E0599]
+}

--- a/tests/ui/typeck/suggest-trait-reexported-as-not-doc-visible.stderr
+++ b/tests/ui/typeck/suggest-trait-reexported-as-not-doc-visible.stderr
@@ -1,0 +1,15 @@
+error[E0599]: no function or associated item named `foo` found for struct `Bar` in the current scope
+  --> $DIR/suggest-trait-reexported-as-not-doc-visible.rs:9:10
+   |
+LL |     Bar::foo();
+   |          ^^^ function or associated item not found in `Bar`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: trait `Foo` which provides `foo` is implemented but not in scope; perhaps you want to import it
+   |
+LL + use suggest_trait_reexported_as_not_doc_visible_a::Foo;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
close #127011
Currently, when emitting a diagnostic about a valid trait, the compiler suggestes using visible paths of the trait even if they are through a doc hidden path. This PR updates the compiler to suggest actual paths in these cases.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
