### PR TITLE
Use the span of the whole bound when the diagnostic talks about a bound

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -838,7 +838,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 | PredicateFilter::SelfOnly
                 | PredicateFilter::SelfAndAssociatedTypeBounds => {
                     match constness {
-                        hir::BoundConstness::Always(span) => {
+                        hir::BoundConstness::Always(_) => {
                             if polarity == ty::PredicatePolarity::Positive {
                                 bounds.push((
                                     poly_trait_ref
@@ -864,7 +864,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 // in `lower_assoc_item_constraint`.
                 PredicateFilter::ConstIfConst | PredicateFilter::SelfConstIfConst => {
                     match constness {
-                        hir::BoundConstness::Maybe(span) => {
+                        hir::BoundConstness::Maybe(_) => {
                             if polarity == ty::PredicatePolarity::Positive {
                                 bounds.push((
                                     poly_trait_ref

--- a/tests/ui/consts/const-block-const-bound.stderr
+++ b/tests/ui/consts/const-block-const-bound.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `f`
   --> $DIR/const-block-const-bound.rs:6:15
    |
 LL | const fn f<T: ~const Destruct>(x: T) {}
-   |               ^^^^^^ required by this bound in `f`
+   |               ^^^^^^^^^^^^^^^ required by this bound in `f`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/assoc-type.current.stderr
+++ b/tests/ui/traits/const-traits/assoc-type.current.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `Foo::Bar`
   --> $DIR/assoc-type.rs:33:15
    |
 LL |     type Bar: ~const Add;
-   |               ^^^^^^ required by this bound in `Foo::Bar`
+   |               ^^^^^^^^^^ required by this bound in `Foo::Bar`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/assoc-type.next.stderr
+++ b/tests/ui/traits/const-traits/assoc-type.next.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `Foo::Bar`
   --> $DIR/assoc-type.rs:33:15
    |
 LL |     type Bar: ~const Add;
-   |               ^^^^^^ required by this bound in `Foo::Bar`
+   |               ^^^^^^^^^^ required by this bound in `Foo::Bar`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/call-generic-method-nonconst.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-nonconst.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `equals_self`
   --> $DIR/call-generic-method-nonconst.rs:17:25
    |
 LL | const fn equals_self<T: ~const Foo>(t: &T) -> bool {
-   |                         ^^^^^^ required by this bound in `equals_self`
+   |                         ^^^^^^^^^^ required by this bound in `equals_self`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/const-drop-fail-2.precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.precise.stderr
@@ -8,14 +8,14 @@ note: required for `ConstDropImplWithBounds<NonTrivialDrop>` to implement `const
   --> $DIR/const-drop-fail-2.rs:25:25
    |
 LL | impl<T: ~const A> const Drop for ConstDropImplWithBounds<T> {
-   |         ------          ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         --------        ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         unsatisfied trait bound introduced here
 note: required by a bound in `check`
   --> $DIR/const-drop-fail-2.rs:21:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                   ^^^^^^ required by this bound in `check`
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/const-drop-fail-2.stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.stock.stderr
@@ -8,14 +8,14 @@ note: required for `ConstDropImplWithBounds<NonTrivialDrop>` to implement `const
   --> $DIR/const-drop-fail-2.rs:25:25
    |
 LL | impl<T: ~const A> const Drop for ConstDropImplWithBounds<T> {
-   |         ------          ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         --------        ^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         unsatisfied trait bound introduced here
 note: required by a bound in `check`
   --> $DIR/const-drop-fail-2.rs:21:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                   ^^^^^^ required by this bound in `check`
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/const-drop-fail.new_precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.new_precise.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `check`
   --> $DIR/const-drop-fail.rs:24:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                   ^^^^^^ required by this bound in `check`
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
   --> $DIR/const-drop-fail.rs:35:5
@@ -26,7 +26,7 @@ note: required by a bound in `check`
   --> $DIR/const-drop-fail.rs:24:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                   ^^^^^^ required by this bound in `check`
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/const-drop-fail.new_stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.new_stock.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `check`
   --> $DIR/const-drop-fail.rs:24:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                   ^^^^^^ required by this bound in `check`
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
   --> $DIR/const-drop-fail.rs:35:5
@@ -26,7 +26,7 @@ note: required by a bound in `check`
   --> $DIR/const-drop-fail.rs:24:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                   ^^^^^^ required by this bound in `check`
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/const-drop-fail.old_precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.old_precise.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `check`
   --> $DIR/const-drop-fail.rs:24:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                   ^^^^^^ required by this bound in `check`
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
   --> $DIR/const-drop-fail.rs:35:5
@@ -26,7 +26,7 @@ note: required by a bound in `check`
   --> $DIR/const-drop-fail.rs:24:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                   ^^^^^^ required by this bound in `check`
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/const-drop-fail.old_stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.old_stock.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `check`
   --> $DIR/const-drop-fail.rs:24:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                   ^^^^^^ required by this bound in `check`
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
   --> $DIR/const-drop-fail.rs:35:5
@@ -26,7 +26,7 @@ note: required by a bound in `check`
   --> $DIR/const-drop-fail.rs:24:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                   ^^^^^^ required by this bound in `check`
+   |                   ^^^^^^^^^^^^^^^ required by this bound in `check`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/const-opaque.no.stderr
+++ b/tests/ui/traits/const-traits/const-opaque.no.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `bar`
   --> $DIR/const-opaque.rs:26:17
    |
 LL | const fn bar<T: ~const Foo>(t: T) -> impl ~const Foo {
-   |                 ^^^^^^ required by this bound in `bar`
+   |                 ^^^^^^^^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): const Foo` is not satisfied
   --> $DIR/const-opaque.rs:33:12

--- a/tests/ui/traits/const-traits/default-method-body-is-const-body-checking.stderr
+++ b/tests/ui/traits/const-traits/default-method-body-is-const-body-checking.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `foo`
   --> $DIR/default-method-body-is-const-body-checking.rs:7:28
    |
 LL | const fn foo<T>() where T: ~const Tr {}
-   |                            ^^^^^^ required by this bound in `foo`
+   |                            ^^^^^^^^^ required by this bound in `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/item-bound-entailment-fails.stderr
+++ b/tests/ui/traits/const-traits/item-bound-entailment-fails.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `Foo::Assoc`
   --> $DIR/item-bound-entailment-fails.rs:5:20
    |
 LL |     type Assoc<T>: ~const Bar
-   |                    ^^^^^^ required by this bound in `Foo::Assoc`
+   |                    ^^^^^^^^^^ required by this bound in `Foo::Assoc`
 
 error[E0277]: the trait bound `T: ~const Bar` is not satisfied
   --> $DIR/item-bound-entailment-fails.rs:24:21
@@ -20,12 +20,12 @@ note: required for `C<T>` to implement `~const Bar`
   --> $DIR/item-bound-entailment-fails.rs:14:15
    |
 LL | impl<T> const Bar for C<T> where T: ~const Bar {}
-   |               ^^^     ^^^^          ------ unsatisfied trait bound introduced here
+   |               ^^^     ^^^^          ---------- unsatisfied trait bound introduced here
 note: required by a bound in `Foo::Assoc`
   --> $DIR/item-bound-entailment-fails.rs:5:20
    |
 LL |     type Assoc<T>: ~const Bar
-   |                    ^^^^^^ required by this bound in `Foo::Assoc`
+   |                    ^^^^^^^^^^ required by this bound in `Foo::Assoc`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/minicore-fn-fail.stderr
+++ b/tests/ui/traits/const-traits/minicore-fn-fail.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `call_indirect`
   --> $DIR/minicore-fn-fail.rs:11:27
    |
 LL | const fn call_indirect<T: ~const Fn()>(t: &T) { t() }
-   |                           ^^^^^^ required by this bound in `call_indirect`
+   |                           ^^^^^^^^^^^ required by this bound in `call_indirect`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/predicate-entailment-fails.stderr
+++ b/tests/ui/traits/const-traits/predicate-entailment-fails.stderr
@@ -5,7 +5,7 @@ LL |     type Bar<T> where T: ~const Bar;
    |     ----------- definition of `Bar` from trait
 ...
 LL |     type Bar<T> = () where T: const Bar;
-   |                               ^^^^^ impl has extra requirement `T: const Bar`
+   |                               ^^^^^^^^^ impl has extra requirement `T: const Bar`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/predicate-entailment-fails.rs:17:26
@@ -14,7 +14,7 @@ LL |     fn foo<T>() where T: ~const Bar;
    |     -------------------------------- definition of `foo` from trait
 ...
 LL |     fn foo<T>() where T: const Bar {}
-   |                          ^^^^^ impl has extra requirement `T: const Bar`
+   |                          ^^^^^^^^^ impl has extra requirement `T: const Bar`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/predicate-entailment-fails.rs:28:31
@@ -23,7 +23,7 @@ LL |     type Bar<T> where T: Bar;
    |     ----------- definition of `Bar` from trait
 ...
 LL |     type Bar<T> = () where T: const Bar;
-   |                               ^^^^^ impl has extra requirement `T: const Bar`
+   |                               ^^^^^^^^^ impl has extra requirement `T: const Bar`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/predicate-entailment-fails.rs:31:26
@@ -32,7 +32,7 @@ LL |     fn foo<T>() where T: Bar;
    |     ------------------------- definition of `foo` from trait
 ...
 LL |     fn foo<T>() where T: const Bar {}
-   |                          ^^^^^ impl has extra requirement `T: const Bar`
+   |                          ^^^^^^^^^ impl has extra requirement `T: const Bar`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/predicate-entailment-fails.rs:35:31
@@ -41,7 +41,7 @@ LL |     type Bar<T> where T: Bar;
    |     ----------- definition of `Bar` from trait
 ...
 LL |     type Bar<T> = () where T: ~const Bar;
-   |                               ^^^^^^ impl has extra requirement `T: ~const Bar`
+   |                               ^^^^^^^^^^ impl has extra requirement `T: ~const Bar`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/predicate-entailment-fails.rs:38:26
@@ -50,7 +50,7 @@ LL |     fn foo<T>() where T: Bar;
    |     ------------------------- definition of `foo` from trait
 ...
 LL |     fn foo<T>() where T: ~const Bar {}
-   |                          ^^^^^^ impl has extra requirement `T: ~const Bar`
+   |                          ^^^^^^^^^^ impl has extra requirement `T: ~const Bar`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/traits/const-traits/trait-where-clause-const.stderr
+++ b/tests/ui/traits/const-traits/trait-where-clause-const.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `Foo::b`
   --> $DIR/trait-where-clause-const.rs:15:24
    |
 LL |     fn b() where Self: ~const Bar;
-   |                        ^^^^^^ required by this bound in `Foo::b`
+   |                        ^^^^^^^^^^ required by this bound in `Foo::b`
 
 error[E0277]: the trait bound `T: ~const Bar` is not satisfied
   --> $DIR/trait-where-clause-const.rs:23:12
@@ -20,7 +20,7 @@ note: required by a bound in `Foo::c`
   --> $DIR/trait-where-clause-const.rs:16:13
    |
 LL |     fn c<T: ~const Bar>();
-   |             ^^^^^^ required by this bound in `Foo::c`
+   |             ^^^^^^^^^^ required by this bound in `Foo::c`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
+++ b/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
@@ -28,7 +28,7 @@ note: required by a bound in `require`
   --> $DIR/unsatisfied-const-trait-bound.rs:8:15
    |
 LL | fn require<T: const Trait>() {}
-   |               ^^^^^ required by this bound in `require`
+   |               ^^^^^^^^^^^ required by this bound in `require`
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
While it makes sense that the host predicate only points to the `~const` part, as whether the actual trait bound is satisfied is checked separately, the user facing diagnostic is talking about the entire trait bound, at which point it makes more sense to just highlight the entire bound

r? @compiler-errors or @fee1-dead 