### PR TITLE
Use target-agnostic LLD flags in bootstrap for `use-lld`

### DIFF
--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -474,13 +474,13 @@ pub fn linker_flags(
                 if stage == 0 && target.is_windows() {
                     args.push("-Clink-arg=-fuse-ld=lld".to_string());
                 } else {
-                    args.push("-Clinker-flavor=gnu-lld-cc".to_string());
+                    args.push("-Zlinker-features=+lld".to_string());
                 }
                 // FIXME(kobzol): remove this flag once MCP510 gets stabilized
                 args.push("-Zunstable-options".to_string());
             }
             LldMode::SelfContained => {
-                args.push("-Clinker-flavor=gnu-lld-cc".to_string());
+                args.push("-Zlinker-features=+lld".to_string());
                 args.push("-Clink-self-contained=+linker".to_string());
                 // FIXME(kobzol): remove this flag once MCP510 gets stabilized
                 args.push("-Zunstable-options".to_string());


### PR DESCRIPTION
[Before](https://github.com/rust-lang/rust/pull/135001), I hardcoded LLD flags that pretty much only worked on GNU. The right way is to use `-Zlinker-features` instead though.

I *think* that this should also make this work on Windows mingw, and thus @petrochenkov's workaround is no longer necessary.

Fixes: https://github.com/rust-lang/rust/issues/139372
Closes: https://github.com/rust-lang/rust/pull/139375

r? @lqd