### PR TITLE
Use delayed bug for normalization errors in drop elaboration

### DIFF
--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -266,19 +266,16 @@ where
                 let tcx = self.tcx();
 
                 assert_eq!(self.elaborator.typing_env().typing_mode, ty::TypingMode::PostAnalysis);
-                // The type error for normalization may have been in dropck: see
-                // `compute_drop_data` in rustc_borrowck, in which case we wouldn't have
-                // deleted the MIR body and could have an error here as well.
                 let field_ty = match tcx
                     .try_normalize_erasing_regions(self.elaborator.typing_env(), f.ty(tcx, args))
                 {
                     Ok(t) => t,
                     Err(_) => Ty::new_error(
                         self.tcx(),
-                        self.elaborator
-                            .body()
-                            .tainted_by_errors
-                            .expect("Error in drop elaboration not found by dropck."),
+                        self.tcx().dcx().span_delayed_bug(
+                            self.elaborator.body().span,
+                            "Error normalizing in drop elaboration.",
+                        ),
                     ),
                 };
 

--- a/tests/ui/drop/drop_elaboration_with_errors2.rs
+++ b/tests/ui/drop/drop_elaboration_with_errors2.rs
@@ -1,11 +1,14 @@
-//@ known-bug: #137287
+// Regression test for #137287
 
 mod defining_scope {
     use super::*;
     pub type Alias<T> = impl Sized;
+    //~^ ERROR unconstrained opaque type
+    //~| ERROR `impl Trait` in type aliases is unstable
 
     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
         x
+        //~^ ERROR mismatched types
     }
 }
 
@@ -21,6 +24,7 @@ impl<T> Trait<T> for T {
     type Assoc = Box<u32>;
 }
 impl<T> Trait<T> for defining_scope::Alias<T> {
+    //~^ ERROR conflicting implementations of trait `Trait<_>`
     type Assoc = usize;
 }
 

--- a/tests/ui/drop/drop_elaboration_with_errors2.stderr
+++ b/tests/ui/drop/drop_elaboration_with_errors2.stderr
@@ -1,0 +1,47 @@
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/drop_elaboration_with_errors2.rs:5:25
+   |
+LL |     pub type Alias<T> = impl Sized;
+   |                         ^^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0119]: conflicting implementations of trait `Trait<_>`
+  --> $DIR/drop_elaboration_with_errors2.rs:26:1
+   |
+LL | impl<T> Trait<T> for T {
+   | ---------------------- first implementation here
+...
+LL | impl<T> Trait<T> for defining_scope::Alias<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
+
+error: unconstrained opaque type
+  --> $DIR/drop_elaboration_with_errors2.rs:5:25
+   |
+LL |     pub type Alias<T> = impl Sized;
+   |                         ^^^^^^^^^^
+   |
+   = note: `Alias` must be used in combination with a concrete type within the same crate
+
+error[E0308]: mismatched types
+  --> $DIR/drop_elaboration_with_errors2.rs:10:9
+   |
+LL |     pub type Alias<T> = impl Sized;
+   |                         ---------- the found opaque type
+...
+LL |     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
+   |                 - expected this type parameter   --------------- expected `Container<T, T>` because of return type
+LL |         x
+   |         ^ expected `Container<T, T>`, found `Container<Alias<T>, T>`
+   |
+   = note: expected struct `Container<T, _>`
+              found struct `Container<Alias<T>, _>`
+   = help: type parameters must be constrained to match other types
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0119, E0308, E0658.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/drop/drop_elaboration_with_errors3.rs
+++ b/tests/ui/drop/drop_elaboration_with_errors3.rs
@@ -1,5 +1,6 @@
-//@ known-bug: #135668
+// Regression test for #135668
 //@ edition: 2021
+
 use std::future::Future;
 
 pub async fn foo() {
@@ -11,7 +12,8 @@ async fn create_task() -> impl Sized {
 }
 
 async fn documentation() {
-    include_str!("nonexistent");
+    compile_error!("bonjour");
+    //~^ ERROR bonjour
 }
 
 fn bind<F>(_filter: F) -> impl Sized
@@ -36,3 +38,5 @@ where
 {
     type Assoc = F;
 }
+
+fn main() {}

--- a/tests/ui/drop/drop_elaboration_with_errors3.stderr
+++ b/tests/ui/drop/drop_elaboration_with_errors3.stderr
@@ -1,0 +1,8 @@
+error: bonjour
+  --> $DIR/drop_elaboration_with_errors3.rs:15:5
+   |
+LL |     compile_error!("bonjour");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Normalization can fail due to a lot of different earlier errors, so just use span_delayed_bug if normalization failed.

Closes #137287 
Closes #135668

r? compiler-errors
