### PR TITLE
make `Arguments::as_statically_known_str` doc(hidden)

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -743,6 +743,7 @@ impl<'a> Arguments<'a> {
     #[unstable(feature = "fmt_internals", reason = "internal to standard library", issue = "none")]
     #[must_use]
     #[inline]
+    #[doc(hidden)]
     pub fn as_statically_known_str(&self) -> Option<&'static str> {
         let s = self.as_str();
         if core::intrinsics::is_val_statically_known(s.is_some()) { s } else { None }


### PR DESCRIPTION
Fixes `as_statically_known_str` being [visible](https://doc.rust-lang.org/nightly/std/fmt/struct.Arguments.html#method.as_statically_known_str) ([Rendered](https://github.com/user-attachments/assets/45482d9f-2ec5-4610-be9c-b231bd2850c6))

This snuck in with https://github.com/rust-lang/rust/pull/138650, cc @thaliaarchi 

This is also visible in the beta docs.

@rustbot label +beta-nominated