### PR TITLE
Check if merged attributes list is empty in expr

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -74,14 +74,16 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     // Merge attributes into the inner expression.
                     if !e.attrs.is_empty() {
                         let old_attrs = self.attrs.get(&ex.hir_id.local_id).copied().unwrap_or(&[]);
-                        self.attrs.insert(
-                            ex.hir_id.local_id,
-                            &*self.arena.alloc_from_iter(
-                                self.lower_attrs_vec(&e.attrs, e.span)
-                                    .into_iter()
-                                    .chain(old_attrs.iter().cloned()),
-                            ),
+                        let attrs = &*self.arena.alloc_from_iter(
+                            self.lower_attrs_vec(&e.attrs, e.span)
+                                .into_iter()
+                                .chain(old_attrs.iter().cloned()),
                         );
+                        if attrs.is_empty() {
+                            return ex;
+                        }
+
+                        self.attrs.insert(ex.hir_id.local_id, attrs);
                     }
                     return ex;
                 }

--- a/tests/ui/attributes/invalid-reprs.rs
+++ b/tests/ui/attributes/invalid-reprs.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let y = #[repr(uwu(4))]
+    //~^ ERROR attributes on expressions are experimental
+    //~| ERROR unrecognized representation hint
+    (&id(5)); //~ ERROR: cannot find function `id` in this scope
+}

--- a/tests/ui/attributes/invalid-reprs.stderr
+++ b/tests/ui/attributes/invalid-reprs.stderr
@@ -1,0 +1,33 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/invalid-reprs.rs:2:13
+   |
+LL |     let y = #[repr(uwu(4))]
+   |             ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0425]: cannot find function `id` in this scope
+  --> $DIR/invalid-reprs.rs:5:7
+   |
+LL |     (&id(5));
+   |       ^^ not found in this scope
+   |
+help: consider importing this function
+   |
+LL + use std::process::id;
+   |
+
+error[E0552]: unrecognized representation hint
+  --> $DIR/invalid-reprs.rs:2:20
+   |
+LL |     let y = #[repr(uwu(4))]
+   |                    ^^^^^^
+   |
+   = help: valid reprs are `Rust` (default), `C`, `align`, `packed`, `transparent`, `simd`, `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0425, E0552, E0658.
+For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes #139373

In the example code, an [`UnrecognizedReprHint`](https://github.com/rust-lang/rust/blob/6b5ccfc87f59ab017032e430d4d358b4989735da/compiler/rustc_attr_parsing/src/attributes/repr.rs#L155) error is output, and the list of merged attributes becomes empty. This causes a [panic](https://github.com/rust-lang/rust/blob/6b5ccfc87f59ab017032e430d4d358b4989735da/compiler/rustc_ast_lowering/src/lib.rs#L618) to occur. So, it's necessary to check if merged attributes list is empty as other functions do.

ref: https://github.com/rust-lang/rust/blob/6b5ccfc87f59ab017032e430d4d358b4989735da/compiler/rustc_ast_lowering/src/lib.rs#L896