### PR TITLE
Detect and provide suggestion for `&raw EXPR`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -120,6 +120,17 @@ impl Path {
         Path { segments: thin_vec![PathSegment::from_ident(ident)], span: ident.span, tokens: None }
     }
 
+    pub fn is_ident(&self, name: Symbol) -> bool {
+        if let [segment] = self.segments.as_ref()
+            && segment.args.is_none()
+            && segment.ident.name == name
+        {
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn is_global(&self) -> bool {
         self.segments.first().is_some_and(|segment| segment.ident.name == kw::PathRoot)
     }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -829,6 +829,18 @@ impl<'a> Parser<'a> {
         if let Some(lt) = lifetime {
             self.error_remove_borrow_lifetime(span, lt.ident.span.until(expr.span));
         }
+
+        // Add expected tokens if we parsed `&raw` as an expression.
+        // This will make sure we see "expected `const`, `mut`", and
+        // guides recovery in case we write `&raw expr`.
+        if borrow_kind == ast::BorrowKind::Ref
+            && mutbl == ast::Mutability::Not
+            && matches!(&expr.kind, ExprKind::Path(None, p) if p.is_ident(kw::Raw))
+        {
+            self.expected_token_types.insert(TokenType::KwMut);
+            self.expected_token_types.insert(TokenType::KwConst);
+        }
+
         Ok((span, ExprKind::AddrOf(borrow_kind, mutbl, expr)))
     }
 

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -516,7 +516,11 @@ impl<'a> Parser<'a> {
         let prev = self.prev_token.span;
         let sp = self.token.span;
         let mut e = self.dcx().struct_span_err(sp, msg);
-        let do_not_suggest_help = self.token.is_keyword(kw::In) || self.token == token::Colon;
+        self.label_expected_raw_ref(&mut e);
+
+        let do_not_suggest_help = self.token.is_keyword(kw::In)
+            || self.token == token::Colon
+            || self.prev_token.is_keyword(kw::Raw);
 
         // Check to see if the user has written something like
         //

--- a/tests/ui/parser/recover/raw-no-const-mut.rs
+++ b/tests/ui/parser/recover/raw-no-const-mut.rs
@@ -1,0 +1,31 @@
+fn a() {
+    let x = &raw 1;
+    //~^ ERROR expected one of
+}
+
+fn b() {
+    [&raw const 1, &raw 2]
+    //~^ ERROR expected one of
+    //~| ERROR cannot find value `raw` in this scope
+    //~| ERROR cannot take address of a temporary
+}
+
+fn c() {
+    if x == &raw z {}
+    //~^ ERROR expected `{`
+}
+
+fn d() {
+    f(&raw 2);
+    //~^ ERROR expected one of
+    //~| ERROR cannot find value `raw` in this scope
+    //~| ERROR cannot find function `f` in this scope
+}
+
+fn e() {
+    let x;
+    x = &raw 1;
+    //~^ ERROR expected one of
+}
+
+fn main() {}

--- a/tests/ui/parser/recover/raw-no-const-mut.stderr
+++ b/tests/ui/parser/recover/raw-no-const-mut.stderr
@@ -1,0 +1,109 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `const`, `else`, `mut`, `{`, or an operator, found `1`
+  --> $DIR/raw-no-const-mut.rs:2:18
+   |
+LL |     let x = &raw 1;
+   |                  ^ expected one of 10 possible tokens
+   |
+help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
+   |
+LL |     let x = &raw const 1;
+   |                  +++++
+LL |     let x = &raw mut 1;
+   |                  +++
+
+error: expected one of `!`, `,`, `.`, `::`, `?`, `]`, `const`, `mut`, `{`, or an operator, found `2`
+  --> $DIR/raw-no-const-mut.rs:7:25
+   |
+LL |     [&raw const 1, &raw 2]
+   |                         ^ expected one of 10 possible tokens
+   |
+help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
+   |
+LL |     [&raw const 1, &raw const 2]
+   |                         +++++
+LL |     [&raw const 1, &raw mut 2]
+   |                         +++
+help: missing `,`
+   |
+LL |     [&raw const 1, &raw, 2]
+   |                        +
+
+error: expected `{`, found `z`
+  --> $DIR/raw-no-const-mut.rs:14:18
+   |
+LL |     if x == &raw z {}
+   |                  ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/raw-no-const-mut.rs:14:8
+   |
+LL |     if x == &raw z {}
+   |        ^^^^^^^^^
+help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
+   |
+LL |     if x == &raw const z {}
+   |                  +++++
+LL |     if x == &raw mut z {}
+   |                  +++
+
+error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `const`, `mut`, `{`, or an operator, found `2`
+  --> $DIR/raw-no-const-mut.rs:19:12
+   |
+LL |     f(&raw 2);
+   |            ^ expected one of 10 possible tokens
+   |
+help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
+   |
+LL |     f(&raw const 2);
+   |            +++++
+LL |     f(&raw mut 2);
+   |            +++
+help: missing `,`
+   |
+LL |     f(&raw, 2);
+   |           +
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `const`, `mut`, `{`, `}`, or an operator, found `1`
+  --> $DIR/raw-no-const-mut.rs:27:14
+   |
+LL |     x = &raw 1;
+   |              ^ expected one of 10 possible tokens
+   |
+help: `&raw` must be followed by `const` or `mut` to be a raw reference expression
+   |
+LL |     x = &raw const 1;
+   |              +++++
+LL |     x = &raw mut 1;
+   |              +++
+
+error[E0425]: cannot find value `raw` in this scope
+  --> $DIR/raw-no-const-mut.rs:7:21
+   |
+LL |     [&raw const 1, &raw 2]
+   |                     ^^^ not found in this scope
+
+error[E0425]: cannot find value `raw` in this scope
+  --> $DIR/raw-no-const-mut.rs:19:8
+   |
+LL |     f(&raw 2);
+   |        ^^^ not found in this scope
+
+error[E0745]: cannot take address of a temporary
+  --> $DIR/raw-no-const-mut.rs:7:17
+   |
+LL |     [&raw const 1, &raw 2]
+   |                 ^ temporary value
+
+error[E0425]: cannot find function `f` in this scope
+  --> $DIR/raw-no-const-mut.rs:19:5
+   |
+LL | fn a() {
+   | ------ similarly named function `a` defined here
+...
+LL |     f(&raw 2);
+   |     ^ help: a function with a similar name exists: `a`
+
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0425, E0745.
+For more information about an error, try `rustc --explain E0425`.


### PR DESCRIPTION
When emitting an error in the parser, and we detect that the previous token was `raw` and we *could* have consumed `const`/`mut`, suggest that this may have been a mistyped raw ref expr. To do this, we add `const`/`mut` to the expected token set when parsing `&raw` as an expression (which does not affect the "good path" of parsing, for the record).

This is kind of a rudimentary error improvement, since it doesn't actually attempt to recover anything, leading to some other knock-on errors b/c we still treat `&raw` as the expression that was parsed... but at least we add the suggestion! I don't think the parser grammar means we can faithfully recover `&raw EXPR` early, i.e. during `parse_expr_borrow`.

Fixes #133231