### PR TITLE
Change notifications for Exploit Mitigations PG

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1002,7 +1002,7 @@ message = "Changes to the size of AST and/or HIR nodes."
 cc = ["@nnethercote"]
 
 [mentions."compiler/rustc_sanitizers"]
-cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
+cc = ["@rcvalle"]
 
 [mentions."src/doc/rustc/src/exploit-mitigations.md"]
 cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
@@ -1038,7 +1038,7 @@ cc = ["@Urgau"]
 cc = ["@Noratrieb"]
 
 [mentions."tests/codegen/sanitizer"]
-cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
+cc = ["@rcvalle"]
 
 [mentions."tests/codegen/split-lto-unit.rs"]
 cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
@@ -1050,7 +1050,7 @@ cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 
 [mentions."tests/ui/sanitizer"]
-cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
+cc = ["@rcvalle"]
 
 [mentions."tests/ui/stack-protector"]
 cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]


### PR DESCRIPTION
Reduce the amount of notifications sent to all the Exploit Mitigations PG by removing it from some of the paths.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
