### PR TITLE
Suppress swapping equality suggestion in extern macro when check overloaded binop

### DIFF
--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -249,7 +249,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             rhs_ty_var,
             Some(lhs_expr),
             |err, ty| {
-                if let Op::BinOp(binop) = op
+                if !expr.span.in_external_macro(self.tcx.sess.source_map())
+                    && let Op::BinOp(binop) = op
                     && binop.node == hir::BinOpKind::Eq
                 {
                     self.suggest_swapping_lhs_and_rhs(err, ty, lhs_ty, rhs_expr, lhs_expr);


### PR DESCRIPTION
Fixes #139050 

I didn't add a ui test because I couldn't see the difference in the ui test before and after modifying the code.

r? @fmease 