### PR TITLE
Suppress missing field error when autoderef bottoms out in infer

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2915,8 +2915,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
         // We failed to check the expression, report an error.
 
-        // Emits an error if we deref an infer variable, like calling `.field` on a base type of &_.
-        self.structurally_resolve_type(autoderef.span(), autoderef.final_ty(false));
+        // Emits an error if we deref an infer variable, like calling `.field` on a base type
+        // of `&_`. We can also use this to suppress unnecessary "missing field" errors that
+        // will follow ambiguity errors.
+        let final_ty = self.structurally_resolve_type(autoderef.span(), autoderef.final_ty(false));
+        if let ty::Error(_) = final_ty.kind() {
+            return final_ty;
+        }
 
         if let Some((adjustments, did)) = private_candidate {
             // (#90483) apply adjustments to avoid ExprUseVisitor from

--- a/tests/ui/typeck/issue-65611.rs
+++ b/tests/ui/typeck/issue-65611.rs
@@ -58,6 +58,5 @@ fn main() {
     let mut buffer = ArrayVec::new();
     let x = buffer.last().unwrap().0.clone();
     //~^ ERROR type annotations needed
-    //~| ERROR no field `0` on type `&_`
     buffer.reverse();
 }

--- a/tests/ui/typeck/issue-65611.stderr
+++ b/tests/ui/typeck/issue-65611.stderr
@@ -4,13 +4,6 @@ error[E0282]: type annotations needed
 LL |     let x = buffer.last().unwrap().0.clone();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
 
-error[E0609]: no field `0` on type `&_`
-  --> $DIR/issue-65611.rs:59:36
-   |
-LL |     let x = buffer.last().unwrap().0.clone();
-   |                                    ^ unknown field
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0282, E0609.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
I see this error repeatedly when doing refactorings, and it's pretty misleading b/c it's not the source of the error.