### PR TITLE
Polymorphize `array::IntoIter`'s iterator impl

### DIFF
--- a/library/core/src/array/iter/iter_inner.rs
+++ b/library/core/src/array/iter/iter_inner.rs
@@ -1,0 +1,281 @@
+//! Defines the `IntoIter` owned iterator for arrays.
+
+use crate::mem::MaybeUninit;
+use crate::num::NonZero;
+use crate::ops::{IndexRange, NeverShortCircuit, Try};
+use crate::{fmt, iter};
+
+#[allow(private_bounds)]
+trait PartialDrop {
+    /// # Safety
+    /// `self[alive]` are all initialized before the call,
+    /// then are never used (without reinitializing them) after it.
+    unsafe fn partial_drop(&mut self, alive: IndexRange);
+}
+impl<T> PartialDrop for [MaybeUninit<T>] {
+    unsafe fn partial_drop(&mut self, alive: IndexRange) {
+        // SAFETY: We know that all elements within `alive` are properly initialized.
+        unsafe { self.get_unchecked_mut(alive).assume_init_drop() }
+    }
+}
+impl<T, const N: usize> PartialDrop for [MaybeUninit<T>; N] {
+    unsafe fn partial_drop(&mut self, alive: IndexRange) {
+        let slice: &mut [MaybeUninit<T>] = self;
+        // SAFETY: Initialized elements in the array are also initialized in the slice.
+        unsafe { slice.partial_drop(alive) }
+    }
+}
+
+/// The internals of a by-value array iterator.
+///
+/// The real `array::IntoIter<T, N>` stores a `PolymorphicIter<[MaybeUninit<T>, N]>`
+/// which it unsizes to `PolymorphicIter<[MaybeUninit<T>]>` to iterate.
+#[allow(private_bounds)]
+pub(super) struct PolymorphicIter<TAIL: ?Sized>
+where
+    TAIL: PartialDrop,
+{
+    /// The elements in `data` that have not been yielded yet.
+    ///
+    /// Invariants:
+    /// - `alive.end <= N`
+    ///
+    /// (And the `IndexRange` type requires `alive.start <= alive.end`.)
+    alive: IndexRange,
+
+    /// This is the array we are iterating over.
+    ///
+    /// Elements with index `i` where `alive.start <= i < alive.end` have not
+    /// been yielded yet and are valid array entries. Elements with indices `i
+    /// < alive.start` or `i >= alive.end` have been yielded already and must
+    /// not be accessed anymore! Those dead elements might even be in a
+    /// completely uninitialized state!
+    ///
+    /// So the invariants are:
+    /// - `data[alive]` is alive (i.e. contains valid elements)
+    /// - `data[..alive.start]` and `data[alive.end..]` are dead (i.e. the
+    ///   elements were already read and must not be touched anymore!)
+    data: TAIL,
+}
+
+#[allow(private_bounds)]
+impl<TAIL: ?Sized> PolymorphicIter<TAIL>
+where
+    TAIL: PartialDrop,
+{
+    #[inline]
+    pub(super) const fn len(&self) -> usize {
+        self.alive.len()
+    }
+}
+
+#[allow(private_bounds)]
+impl<TAIL: ?Sized> Drop for PolymorphicIter<TAIL>
+where
+    TAIL: PartialDrop,
+{
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: by our type invariant `self.alive` is exactly the initialized
+        // items, and this is drop so nothing can use the items afterwards.
+        unsafe { self.data.partial_drop(self.alive.clone()) }
+    }
+}
+
+impl<T, const N: usize> PolymorphicIter<[MaybeUninit<T>; N]> {
+    #[inline]
+    pub(super) const fn empty() -> Self {
+        Self { alive: IndexRange::zero_to(0), data: [const { MaybeUninit::uninit() }; N] }
+    }
+
+    /// # Safety
+    /// `data[alive]` are all initialized.
+    #[inline]
+    pub(super) const unsafe fn new_unchecked(alive: IndexRange, data: [MaybeUninit<T>; N]) -> Self {
+        Self { alive, data }
+    }
+}
+
+impl<T: Clone, const N: usize> Clone for PolymorphicIter<[MaybeUninit<T>; N]> {
+    #[inline]
+    fn clone(&self) -> Self {
+        // Note, we don't really need to match the exact same alive range, so
+        // we can just clone into offset 0 regardless of where `self` is.
+        let mut new = Self::empty();
+
+        fn clone_into_new<U: Clone>(
+            source: &PolymorphicIter<[MaybeUninit<U>]>,
+            target: &mut PolymorphicIter<[MaybeUninit<U>]>,
+        ) {
+            // Clone all alive elements.
+            for (src, dst) in iter::zip(source.as_slice(), &mut target.data) {
+                // Write a clone into the new array, then update its alive range.
+                // If cloning panics, we'll correctly drop the previous items.
+                dst.write(src.clone());
+                // This addition cannot overflow as we're iterating a slice,
+                // the length of which always fits in usize.
+                target.alive = IndexRange::zero_to(target.alive.end() + 1);
+            }
+        }
+
+        clone_into_new(self, &mut new);
+        new
+    }
+}
+
+impl<T> PolymorphicIter<[MaybeUninit<T>]> {
+    #[inline]
+    pub(super) fn as_slice(&self) -> &[T] {
+        // SAFETY: We know that all elements within `alive` are properly initialized.
+        unsafe {
+            let slice = self.data.get_unchecked(self.alive.clone());
+            slice.assume_init_ref()
+        }
+    }
+
+    #[inline]
+    pub(super) fn as_mut_slice(&mut self) -> &mut [T] {
+        // SAFETY: We know that all elements within `alive` are properly initialized.
+        unsafe {
+            let slice = self.data.get_unchecked_mut(self.alive.clone());
+            slice.assume_init_mut()
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for PolymorphicIter<[MaybeUninit<T>]> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Only print the elements that were not yielded yet: we cannot
+        // access the yielded elements anymore.
+        f.debug_tuple("IntoIter").field(&self.as_slice()).finish()
+    }
+}
+
+/// Iterator-equivalent methods.
+///
+/// We don't implement the actual iterator traits because we want to implement
+/// things like `try_fold` that require `Self: Sized` (which we're not).
+impl<T> PolymorphicIter<[MaybeUninit<T>]> {
+    #[inline]
+    pub(super) fn next(&mut self) -> Option<T> {
+        // Get the next index from the front.
+        //
+        // Increasing `alive.start` by 1 maintains the invariant regarding
+        // `alive`. However, due to this change, for a short time, the alive
+        // zone is not `data[alive]` anymore, but `data[idx..alive.end]`.
+        self.alive.next().map(|idx| {
+            // Read the element from the array.
+            // SAFETY: `idx` is an index into the former "alive" region of the
+            // array. Reading this element means that `data[idx]` is regarded as
+            // dead now (i.e. do not touch). As `idx` was the start of the
+            // alive-zone, the alive zone is now `data[alive]` again, restoring
+            // all invariants.
+            unsafe { self.data.get_unchecked(idx).assume_init_read() }
+        })
+    }
+
+    #[inline]
+    pub(super) fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+
+    #[inline]
+    pub(super) fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        // This also moves the start, which marks them as conceptually "dropped",
+        // so if anything goes bad then our drop impl won't double-free them.
+        let range_to_drop = self.alive.take_prefix(n);
+        let remaining = n - range_to_drop.len();
+
+        // SAFETY: These elements are currently initialized, so it's fine to drop them.
+        unsafe {
+            let slice = self.data.get_unchecked_mut(range_to_drop);
+            slice.assume_init_drop();
+        }
+
+        NonZero::new(remaining).map_or(Ok(()), Err)
+    }
+
+    #[inline]
+    pub(super) fn fold<B>(&mut self, init: B, f: impl FnMut(B, T) -> B) -> B {
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2(f)).0
+    }
+
+    #[inline]
+    pub(super) fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R
+    where
+        F: FnMut(B, T) -> R,
+        R: Try<Output = B>,
+    {
+        // `alive` is an `IndexRange`, not an arbitrary iterator, so we can
+        // trust that its `try_rfold` isn't going to do something weird like
+        // call the fold-er multiple times for the same index.
+        let data = &mut self.data;
+        self.alive.try_fold(init, move |accum, idx| {
+            // SAFETY: `idx` has been removed from the alive range, so we're not
+            // going to drop it (even if `f` panics) and thus its ok to give
+            // out ownership of that item to `f` to handle.
+            let elem = unsafe { data.get_unchecked(idx).assume_init_read() };
+            f(accum, elem)
+        })
+    }
+
+    #[inline]
+    pub(super) fn next_back(&mut self) -> Option<T> {
+        // Get the next index from the back.
+        //
+        // Decreasing `alive.end` by 1 maintains the invariant regarding
+        // `alive`. However, due to this change, for a short time, the alive
+        // zone is not `data[alive]` anymore, but `data[alive.start..=idx]`.
+        self.alive.next_back().map(|idx| {
+            // Read the element from the array.
+            // SAFETY: `idx` is an index into the former "alive" region of the
+            // array. Reading this element means that `data[idx]` is regarded as
+            // dead now (i.e. do not touch). As `idx` was the end of the
+            // alive-zone, the alive zone is now `data[alive]` again, restoring
+            // all invariants.
+            unsafe { self.data.get_unchecked(idx).assume_init_read() }
+        })
+    }
+
+    #[inline]
+    pub(super) fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        // This also moves the end, which marks them as conceptually "dropped",
+        // so if anything goes bad then our drop impl won't double-free them.
+        let range_to_drop = self.alive.take_suffix(n);
+        let remaining = n - range_to_drop.len();
+
+        // SAFETY: These elements are currently initialized, so it's fine to drop them.
+        unsafe {
+            let slice = self.data.get_unchecked_mut(range_to_drop);
+            slice.assume_init_drop();
+        }
+
+        NonZero::new(remaining).map_or(Ok(()), Err)
+    }
+
+    #[inline]
+    pub(super) fn rfold<B>(&mut self, init: B, f: impl FnMut(B, T) -> B) -> B {
+        self.try_rfold(init, NeverShortCircuit::wrap_mut_2(f)).0
+    }
+
+    #[inline]
+    pub(super) fn try_rfold<B, F, R>(&mut self, init: B, mut f: F) -> R
+    where
+        F: FnMut(B, T) -> R,
+        R: Try<Output = B>,
+    {
+        // `alive` is an `IndexRange`, not an arbitrary iterator, so we can
+        // trust that its `try_rfold` isn't going to do something weird like
+        // call the fold-er multiple times for the same index.
+        let data = &mut self.data;
+        self.alive.try_rfold(init, move |accum, idx| {
+            // SAFETY: `idx` has been removed from the alive range, so we're not
+            // going to drop it (even if `f` panics) and thus its ok to give
+            // out ownership of that item to `f` to handle.
+            let elem = unsafe { data.get_unchecked(idx).assume_init_read() };
+            f(accum, elem)
+        })
+    }
+}

--- a/library/core/src/array/iter/iter_inner.rs
+++ b/library/core/src/array/iter/iter_inner.rs
@@ -31,9 +31,9 @@ impl<T, const N: usize> PartialDrop for [MaybeUninit<T>; N] {
 /// The real `array::IntoIter<T, N>` stores a `PolymorphicIter<[MaybeUninit<T>, N]>`
 /// which it unsizes to `PolymorphicIter<[MaybeUninit<T>]>` to iterate.
 #[allow(private_bounds)]
-pub(super) struct PolymorphicIter<TAIL: ?Sized>
+pub(super) struct PolymorphicIter<DATA: ?Sized>
 where
-    TAIL: PartialDrop,
+    DATA: PartialDrop,
 {
     /// The elements in `data` that have not been yielded yet.
     ///
@@ -55,13 +55,13 @@ where
     /// - `data[alive]` is alive (i.e. contains valid elements)
     /// - `data[..alive.start]` and `data[alive.end..]` are dead (i.e. the
     ///   elements were already read and must not be touched anymore!)
-    data: TAIL,
+    data: DATA,
 }
 
 #[allow(private_bounds)]
-impl<TAIL: ?Sized> PolymorphicIter<TAIL>
+impl<DATA: ?Sized> PolymorphicIter<DATA>
 where
-    TAIL: PartialDrop,
+    DATA: PartialDrop,
 {
     #[inline]
     pub(super) const fn len(&self) -> usize {
@@ -70,9 +70,9 @@ where
 }
 
 #[allow(private_bounds)]
-impl<TAIL: ?Sized> Drop for PolymorphicIter<TAIL>
+impl<DATA: ?Sized> Drop for PolymorphicIter<DATA>
 where
-    TAIL: PartialDrop,
+    DATA: PartialDrop,
 {
     #[inline]
     fn drop(&mut self) {
@@ -209,7 +209,7 @@ impl<T> PolymorphicIter<[MaybeUninit<T>]> {
         R: Try<Output = B>,
     {
         // `alive` is an `IndexRange`, not an arbitrary iterator, so we can
-        // trust that its `try_rfold` isn't going to do something weird like
+        // trust that its `try_fold` isn't going to do something weird like
         // call the fold-er multiple times for the same index.
         let data = &mut self.data;
         self.alive.try_fold(init, move |accum, idx| {

--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -1,5 +1,6 @@
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::num::NonZero;
+use crate::ops::{NeverShortCircuit, Try};
 use crate::ub_checks;
 
 /// Like a `Range<usize>`, but with a safety invariant that `start <= end`.
@@ -112,6 +113,12 @@ impl IndexRange {
         self.end = mid;
         suffix
     }
+
+    #[inline]
+    fn assume_range(&self) {
+        // SAFETY: This is the type invariant
+        unsafe { crate::hint::assert_unchecked(self.start <= self.end) }
+    }
 }
 
 impl Iterator for IndexRange {
@@ -138,6 +145,30 @@ impl Iterator for IndexRange {
         let taken = self.take_prefix(n);
         NonZero::new(n - taken.len()).map_or(Ok(()), Err)
     }
+
+    #[inline]
+    fn fold<B, F: FnMut(B, usize) -> B>(mut self, init: B, f: F) -> B {
+        self.try_fold(init, NeverShortCircuit::wrap_mut_2(f)).0
+    }
+
+    #[inline]
+    fn try_fold<B, F, R>(&mut self, mut accum: B, mut f: F) -> R
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> R,
+        R: Try<Output = B>,
+    {
+        // `Range` needs to check `start < end`, but thanks to our type invariant
+        // we can loop on the stricter `start != end`.
+
+        self.assume_range();
+        while self.start != self.end {
+            // SAFETY: We just checked that the range is non-empty
+            let i = unsafe { self.next_unchecked() };
+            accum = f(accum, i)?;
+        }
+        try { accum }
+    }
 }
 
 impl DoubleEndedIterator for IndexRange {
@@ -155,6 +186,30 @@ impl DoubleEndedIterator for IndexRange {
     fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
         let taken = self.take_suffix(n);
         NonZero::new(n - taken.len()).map_or(Ok(()), Err)
+    }
+
+    #[inline]
+    fn rfold<B, F: FnMut(B, usize) -> B>(mut self, init: B, f: F) -> B {
+        self.try_rfold(init, NeverShortCircuit::wrap_mut_2(f)).0
+    }
+
+    #[inline]
+    fn try_rfold<B, F, R>(&mut self, mut accum: B, mut f: F) -> R
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> R,
+        R: Try<Output = B>,
+    {
+        // `Range` needs to check `start < end`, but thanks to our type invariant
+        // we can loop on the stricter `start != end`.
+
+        self.assume_range();
+        while self.start != self.end {
+            // SAFETY: We just checked that the range is non-empty
+            let i = unsafe { self.next_back_unchecked() };
+            accum = f(accum, i)?;
+        }
+        try { accum }
     }
 }
 

--- a/tests/codegen/issues/issue-101082.rs
+++ b/tests/codegen/issues/issue-101082.rs
@@ -1,8 +1,16 @@
 //@ compile-flags: -Copt-level=3
-//@ revisions: host x86-64-v3
+//@ revisions: host x86-64 x86-64-v3
 //@ min-llvm-version: 20
 
-// This particular CPU regressed in #131563
+//@[host] ignore-x86_64
+
+// Set the base cpu explicitly, in case the default has been changed.
+//@[x86-64] only-x86_64
+//@[x86-64] compile-flags: -Ctarget-cpu=x86-64
+
+// FIXME(cuviper) x86-64-v3 in particular regressed in #131563, and the workaround
+// at the time still sometimes fails, so only verify it for the power-of-two size
+// - https://github.com/llvm/llvm-project/issues/134735
 //@[x86-64-v3] only-x86_64
 //@[x86-64-v3] compile-flags: -Ctarget-cpu=x86-64-v3
 
@@ -12,16 +20,14 @@
 pub fn test() -> usize {
     // CHECK-LABEL: @test(
     // host: ret {{i64|i32}} 165
+    // x86-64: ret {{i64|i32}} 165
 
     // FIXME: Now that this autovectorizes via a masked load, it doesn't actually
     // const-fold for certain widths.  The `test_eight` case below shows that, yes,
     // what we're emitting *can* be const-folded, except that the way LLVM does it
     // for certain widths doesn't today.  We should be able to put this back to
     // the same check after <https://github.com/llvm/llvm-project/issues/134513>
-    // x86-64-v3: <i64 23, i64 16, i64 54, i64 3>
-    // x86-64-v3: llvm.masked.load
-    // x86-64-v3: %[[R:.+]] = {{.+}}llvm.vector.reduce.add.v4i64
-    // x86-64-v3: ret i64 %[[R]]
+    // x86-64-v3: masked.load
 
     let values = [23, 16, 54, 3, 60, 9];
     let mut acc = 0;

--- a/tests/codegen/issues/issue-101082.rs
+++ b/tests/codegen/issues/issue-101082.rs
@@ -11,8 +11,31 @@
 #[no_mangle]
 pub fn test() -> usize {
     // CHECK-LABEL: @test(
-    // CHECK: ret {{i64|i32}} 165
+    // host: ret {{i64|i32}} 165
+
+    // FIXME: Now that this autovectorizes via a masked load, it doesn't actually
+    // const-fold for certain widths.  The `test_eight` case below shows that, yes,
+    // what we're emitting *can* be const-folded, except that the way LLVM does it
+    // for certain widths doesn't today.  We should be able to put this back to
+    // the same check after <https://github.com/llvm/llvm-project/issues/134513>
+    // x86-64-v3: <i64 23, i64 16, i64 54, i64 3>
+    // x86-64-v3: llvm.masked.load
+    // x86-64-v3: %[[R:.+]] = {{.+}}llvm.vector.reduce.add.v4i64
+    // x86-64-v3: ret i64 %[[R]]
+
     let values = [23, 16, 54, 3, 60, 9];
+    let mut acc = 0;
+    for item in values {
+        acc += item;
+    }
+    acc
+}
+
+#[no_mangle]
+pub fn test_eight() -> usize {
+    // CHECK-LABEL: @test_eight(
+    // CHECK: ret {{i64|i32}} 220
+    let values = [23, 16, 54, 3, 60, 9, 13, 42];
     let mut acc = 0;
     for item in values {
         acc += item;


### PR DESCRIPTION
Today we emit all the iterator methods for every different array width.  That's wasteful since the actual array length never even comes into it -- the indices used are from the separate `alive: IndexRange` field, not even the `N` const param.

This PR switches things so that an `array::IntoIter<T, N>` stores a `PolymorphicIter<[MaybeUninit<T>; N]>`, which we *unsize* to `PolymorphicIter<[MaybeUninit<T>]>` and call methods on that non-`Sized` type for all the iterator methods.

That also necessarily makes the layout consistent between the different lengths of arrays, because of the unsizing.  Compare that to today <https://rust.godbolt.org/z/Prb4xMPrb>, where different widths can't even be deduped because the offset to the indices is different for different array widths.