### PR TITLE
Implement `AsRef<OsStr>` for `Cow<'_, Path>`

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -3173,6 +3173,14 @@ impl AsRef<OsStr> for Path {
     }
 }
 
+#[stable(feature = "cow_path_as_ref_os_str", since = "CURRENT_RUSTC_VERSION")]
+impl AsRef<OsStr> for Cow<'_, Path> {
+    #[inline]
+    fn as_ref(&self) -> &OsStr {
+        self.as_os_str()
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for Path {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -941,7 +941,7 @@ impl<'test> TestCx<'test> {
             .arg("-L")
             .arg(aux_dir)
             .arg("-o")
-            .arg(out_dir.as_ref())
+            .arg(out_dir)
             .arg("--deny")
             .arg("warnings")
             .arg(&self.testpaths.file)


### PR DESCRIPTION
In #31751, `impl AsRef<Path> for Cow<'_, OsStr>` was added, but the converse was omitted and it wasn't mentioned in discussion. This seems to have been a simple oversight, as it otherwise implemented traits mutually between `OsStr` and `Path`.

Tracked in #139429.

r? libs-api