### PR TITLE
Prevent a test from seeing forbidden numbers in the rustc version

### DIFF
--- a/tests/codegen/issues/issue-122600-ptr-discriminant-update.rs
+++ b/tests/codegen/issues/issue-122600-ptr-discriminant-update.rs
@@ -37,6 +37,8 @@ pub unsafe fn update(s: *mut State) {
     // CHECK-NOT: store
     // CHECK-NOT: memcpy
     // CHECK-NOT: 75{{3|4}}
+
+    // CHECK: ret
     let State::A(v) = s.read() else { std::hint::unreachable_unchecked() };
     s.write(State::B(v));
 }


### PR DESCRIPTION
The final CHECK-NOT directive in this test was able to see past the end of the enclosing function, and find the substring `753` or `754` in the git hash in the rustc version number, causing false failures in CI whenever the git hash happens to contain those digits in sequence.

Adding an explicit check for `ret` prevents the CHECK-NOT directive from seeing past the end of the function.

---

Manually tested by adding `// CHECK-NOT: rustc` after the existing CHECK-NOT directives, and demonstrating that the new check prevents it from seeing the rustc version string.
