### PR TITLE
Implement `AsRef<ByteStr>` for `[u8]`

### DIFF
--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -90,7 +90,7 @@ macro_rules! specialize_for_lengths {
                 $num => {
                     for s in iter {
                         copy_slice_and_advance!(target, sep_bytes);
-                        let content_bytes = s.borrow().as_ref();
+                        let content_bytes: &[_] = s.borrow().as_ref();
                         copy_slice_and_advance!(target, content_bytes);
                     }
                 },
@@ -99,7 +99,7 @@ macro_rules! specialize_for_lengths {
                 // arbitrary non-zero size fallback
                 for s in iter {
                     copy_slice_and_advance!(target, sep_bytes);
-                    let content_bytes = s.borrow().as_ref();
+                    let content_bytes: &[_] = s.borrow().as_ref();
                     copy_slice_and_advance!(target, content_bytes);
                 }
             }

--- a/library/core/src/bstr/mod.rs
+++ b/library/core/src/bstr/mod.rs
@@ -200,7 +200,13 @@ impl AsRef<ByteStr> for ByteStr {
     }
 }
 
-// `impl AsRef<ByteStr> for [u8]` omitted to avoid widespread inference failures
+#[unstable(feature = "bstr", issue = "134915")]
+impl AsRef<ByteStr> for [u8] {
+    #[inline]
+    fn as_ref(&self) -> &ByteStr {
+        ByteStr::new(self)
+    }
+}
 
 #[unstable(feature = "bstr", issue = "134915")]
 impl AsRef<ByteStr> for str {

--- a/src/tools/clippy/tests/ui/useful_asref.rs
+++ b/src/tools/clippy/tests/ui/useful_asref.rs
@@ -7,7 +7,7 @@ trait Trait {
     fn as_ptr(&self);
 }
 
-impl<'a> Trait for &'a [u8] {
+impl<'a> Trait for &'a [u32] {
     fn as_ptr(&self) {
         self.as_ref().as_ptr();
     }


### PR DESCRIPTION
This impl was omitted from #135073 due to inference failures. Add it separately to judge its impact.

Tracked in https://github.com/rust-lang/rust/issues/139429.

r? libs-api

cc @joshtriplett