### PR TITLE
Revert "Mention style for new syntax in tracking issue template"

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -41,13 +41,10 @@ for larger features an implementation could be broken up into multiple PRs.
 - [ ] Implement the RFC (cc @rust-lang/XXX -- can anyone write up mentoring
       instructions?)
 - [ ] Adjust documentation ([see instructions on rustc-dev-guide][doc-guide])
-- [ ] Formatting for new syntax has been added to the [Style Guide] ([nightly-style-procedure])
 - [ ] Stabilization PR ([see instructions on rustc-dev-guide][stabilization-guide])
 
 [stabilization-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#stabilization-pr
 [doc-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#documentation-prs
-[nightly-style-procedure]: https://github.com/rust-lang/style-team/blob/main/nightly-style-procedure.md 
-[Style Guide]: https://github.com/rust-lang/rust/tree/master/src/doc/style-guide
 
 ### Unresolved Questions
 <!--


### PR DESCRIPTION
As per [#t-lang > style specification as a blocker for stabilization @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/style.20specification.20as.20a.20blocker.20for.20stabilization/near/510450873), I believe we should stop making style guide a requirement for stabilizing new syntax features such as #132833. The previous decision on this was based on the assumption that the style team had a reasonable bandwidth to do this without significant time lags. This is not the case now.

Open to other suggestions such as placing this bullet point after the stabilization PR and/or requiring an _issue_ created on the style team's repo just to get into their radar, i.e. have some form of the existing process but still stop it from being a strict requirement.