### PR TITLE
Stop dirtying incremental with span access when computing region scope span

### DIFF
--- a/compiler/rustc_middle/src/ty/significant_drop_order.rs
+++ b/compiler/rustc_middle/src/ty/significant_drop_order.rs
@@ -143,25 +143,11 @@ pub fn ty_dtor_span<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Span> {
         | ty::UnsafeBinder(_) => None,
 
         ty::Adt(adt_def, _) => {
-            let did = adt_def.did();
-            let try_local_did_span = |did: DefId| {
-                if let Some(local) = did.as_local() {
-                    tcx.source_span(local)
-                } else {
-                    tcx.def_span(did)
-                }
-            };
-            let dtor = if let Some(dtor) = tcx.adt_destructor(did) {
-                dtor.did
-            } else if let Some(dtor) = tcx.adt_async_destructor(did) {
-                return Some(tcx.source_span(dtor.impl_did));
+            if let Some(dtor) = tcx.adt_destructor(adt_def.did()) {
+                Some(tcx.def_span(tcx.parent(dtor.did)))
             } else {
-                return Some(try_local_did_span(did));
-            };
-            let def_key = tcx.def_key(dtor);
-            let Some(parent_index) = def_key.parent else { return Some(try_local_did_span(dtor)) };
-            let parent_did = DefId { index: parent_index, krate: dtor.krate };
-            Some(try_local_did_span(parent_did))
+                Some(tcx.def_span(adt_def.did()))
+            }
         }
         ty::Coroutine(did, _)
         | ty::CoroutineWitness(did, _)

--- a/compiler/rustc_mir_build/src/builder/scope.rs
+++ b/compiler/rustc_mir_build/src/builder/scope.rs
@@ -1135,11 +1135,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             if scope.region_scope == region_scope {
                 let region_scope_span = region_scope.span(self.tcx, self.region_scope_tree);
-                // Attribute scope exit drops to scope's closing brace.
-                let scope_end = self.tcx.sess.source_map().end_point(region_scope_span);
 
                 scope.drops.push(DropData {
-                    source_info: SourceInfo { span: scope_end, scope: scope.source_scope },
+                    source_info: SourceInfo {
+                        span: region_scope_span.shrink_to_hi(),
+                        scope: scope.source_scope,
+                    },
                     local,
                     kind: drop_kind,
                 });

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.stderr
@@ -27,7 +27,7 @@ LL |     outlives::<'a>(c());
    |     argument requires that `c` is borrowed for `'a`
 LL |     outlives::<'a>(call_once(c));
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/without-precise-captures-we-are-powerless.rs:26:13
@@ -72,7 +72,7 @@ LL |     outlives::<'a>(c());
    |     argument requires that `c` is borrowed for `'a`
 LL |     outlives::<'a>(call_once(c));
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0505]: cannot move out of `c` because it is borrowed
   --> $DIR/without-precise-captures-we-are-powerless.rs:32:30
@@ -126,7 +126,7 @@ LL |     outlives::<'a>(c());
    |     argument requires that `c` is borrowed for `'a`
 LL |     outlives::<'a>(call_once(c));
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/without-precise-captures-we-are-powerless.rs:44:5

--- a/tests/ui/async-await/feature-self-return-type.stderr
+++ b/tests/ui/async-await/feature-self-return-type.stderr
@@ -9,7 +9,7 @@ LL |         Foo::new(&bar).await
    |                  ^^^^ borrowed value does not live long enough
 LL |
 LL |     };
-   |     - `bar` dropped here while still borrowed
+   |      - `bar` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
+++ b/tests/ui/async-await/issue-74072-lifetime-name-annotations.stderr
@@ -57,7 +57,7 @@ LL | ||     })()
    | |_______|
    |         creates a temporary value which is freed while still in use
 LL |    }
-   |    - temporary value is freed at the end of this statement
+   |     - temporary value is freed at the end of this statement
 
 error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:27:9
@@ -106,7 +106,7 @@ LL | ||     })()
    | |_______|
    |         creates a temporary value which is freed while still in use
 LL |    }
-   |    - temporary value is freed at the end of this statement
+   |     - temporary value is freed at the end of this statement
 
 error[E0506]: cannot assign to `*x` because it is borrowed
   --> $DIR/issue-74072-lifetime-name-annotations.rs:35:9

--- a/tests/ui/borrowck/alias-liveness/escaping-bounds-2.stderr
+++ b/tests/ui/borrowck/alias-liveness/escaping-bounds-2.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/escaping-bounds-2.rs:10:31
    |
 LL |     let func = get_func::<T>(&String::new());
-   |                               ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                               ^^^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |                               |
    |                               creates a temporary value which is freed while still in use
 LL |     drop(func);

--- a/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.stderr
+++ b/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.stderr
@@ -7,7 +7,7 @@ LL |     test(&vec![])
    |     |     creates a temporary value which is freed while still in use
    |     argument requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/borrowck/already-borrowed-as-mutable-if-let-133941.stderr
+++ b/tests/ui/borrowck/already-borrowed-as-mutable-if-let-133941.stderr
@@ -11,7 +11,7 @@ LL |         foo.g();
    |         ^^^ second mutable borrow occurs here
 LL |
 LL |     }
-   |     - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<Bar<'_>>`
+   |      - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<Bar<'_>>`
    |
 help: consider using the `matches!` macro
    |
@@ -32,7 +32,7 @@ LL |         foo.g();
    |         ^^^ second mutable borrow occurs here
 LL |
 LL |     }
-   |     - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<Bar<'_>>`
+   |      - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<Bar<'_>>`
    |
 help: consider using the `matches!` macro
    |
@@ -52,7 +52,7 @@ LL |         foo.g();
    |         ^^^ second mutable borrow occurs here
 LL |
 LL |     }
-   |     - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<Bar<'_>>`
+   |      - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<Bar<'_>>`
 
 error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/already-borrowed-as-mutable-if-let-133941.rs:37:9
@@ -66,13 +66,13 @@ LL |         foo.g();
    |         ^^^ second mutable borrow occurs here
 LL |
 LL |     }
-   |     - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<Bar<'_>>`
+   |      - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<Bar<'_>>`
 
 error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/already-borrowed-as-mutable-if-let-133941.rs:40:45
    |
 LL |     while let Some(_x) = {let _x = foo.f(); foo.g(); None::<()>} {
-   |                                    ---      ^^^                - first borrow might be used here, when `_x` is dropped and runs the destructor for type `Option<Bar<'_>>`
+   |                                    ---      ^^^                 - first borrow might be used here, when `_x` is dropped and runs the destructor for type `Option<Bar<'_>>`
    |                                    |        |
    |                                    |        second mutable borrow occurs here
    |                                    first mutable borrow occurs here
@@ -81,7 +81,7 @@ error[E0499]: cannot borrow `foo` as mutable more than once at a time
   --> $DIR/already-borrowed-as-mutable-if-let-133941.rs:43:42
    |
 LL |     if let Some(_x) = {let _x = foo.f(); foo.g(); None::<()>} {
-   |                                 ---      ^^^                - first borrow might be used here, when `_x` is dropped and runs the destructor for type `Option<Bar<'_>>`
+   |                                 ---      ^^^                 - first borrow might be used here, when `_x` is dropped and runs the destructor for type `Option<Bar<'_>>`
    |                                 |        |
    |                                 |        second mutable borrow occurs here
    |                                 first mutable borrow occurs here

--- a/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
+++ b/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/borrowck-borrowed-uniq-rvalue-2.rs:20:20
    |
 LL |     let x = defer(&vec!["Goodbye", "world!"]);
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |                    |
    |                    creates a temporary value which is freed while still in use
 LL |     x.x[0];

--- a/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue.stderr
+++ b/tests/ui/borrowck/borrowck-borrowed-uniq-rvalue.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/borrowck-borrowed-uniq-rvalue.rs:8:28
    |
 LL |     buggy_map.insert(42, &*Box::new(1));
-   |                            ^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                            ^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |                            |
    |                            creates a temporary value which is freed while still in use
 ...

--- a/tests/ui/borrowck/borrowck-fn-in-const-c.stderr
+++ b/tests/ui/borrowck/borrowck-fn-in-const-c.stderr
@@ -4,7 +4,7 @@ error[E0713]: borrow may still be in use when destructor runs
 LL |         return &local.inner;
    |                ^^^^^^^^^^^^ returning this value requires that `local.inner` is borrowed for `'static`
 LL |     }
-   |     - here, drop of `local` needs exclusive access to `local.inner`, because the type `DropString` implements the `Drop` trait
+   |      - here, drop of `local` needs exclusive access to `local.inner`, because the type `DropString` implements the `Drop` trait
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/fn-item-check-trait-ref.stderr
+++ b/tests/ui/borrowck/fn-item-check-trait-ref.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/fn-item-check-trait-ref.rs:13:7
    |
 LL |     (&String::new()).assert_static();
-   |     --^^^^^^^^^^^^^------------------ temporary value is freed at the end of this statement
+   |     --^^^^^^^^^^^^^----------------- - temporary value is freed at the end of this statement
    |     | |
    |     | creates a temporary value which is freed while still in use
    |     argument requires that borrow lasts for `'static`

--- a/tests/ui/borrowck/fn-item-check-type-params.stderr
+++ b/tests/ui/borrowck/fn-item-check-type-params.stderr
@@ -23,7 +23,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/fn-item-check-type-params.rs:48:11
    |
 LL |     want(&String::new(), extend_lt);
-   |     ------^^^^^^^^^^^^^------------- temporary value is freed at the end of this statement
+   |     ------^^^^^^^^^^^^^------------ - temporary value is freed at the end of this statement
    |     |     |
    |     |     creates a temporary value which is freed while still in use
    |     argument requires that borrow lasts for `'static`
@@ -32,7 +32,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/fn-item-check-type-params.rs:54:26
    |
 LL |     let val = extend_lt(&String::from("blah blah blah"));
-   |               -----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+   |               -----------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- - temporary value is freed at the end of this statement
    |               |          |
    |               |          creates a temporary value which is freed while still in use
    |               argument requires that borrow lasts for `'static`

--- a/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
+++ b/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
@@ -21,7 +21,7 @@ LL |         force_send(async_load(&not_static));
    |         argument requires that `not_static` is borrowed for `'1`
 ...
 LL |     }
-   |     - `not_static` dropped here while still borrowed
+   |      - `not_static` dropped here while still borrowed
    |
 note: due to current limitations in the borrow checker, this implies a `'static` lifetime
   --> $DIR/implementation-not-general-enough-ice-133252.rs:16:18

--- a/tests/ui/borrowck/issue-114374-invalid-help-fmt-args.stderr
+++ b/tests/ui/borrowck/issue-114374-invalid-help-fmt-args.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-114374-invalid-help-fmt-args.rs:5:13
    |
 LL |     let x = format_args!("a {} {} {}.", 1, format_args!("b{}!", 2), 3);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
    |             |
    |             creates a temporary value which is freed while still in use
 ...
@@ -16,7 +16,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-114374-invalid-help-fmt-args.rs:10:15
    |
 LL |     let foo = format_args!("{}", "hi");
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
    |               |
    |               creates a temporary value which is freed while still in use
 LL |

--- a/tests/ui/borrowck/issue-11493.stderr
+++ b/tests/ui/borrowck/issue-11493.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-11493.rs:6:35
    |
 LL |     let y = x.as_ref().unwrap_or(&id(5));
-   |                                   ^^^^^ - temporary value is freed at the end of this statement
+   |                                   ^^^^^  - temporary value is freed at the end of this statement
    |                                   |
    |                                   creates a temporary value which is freed while still in use
 LL |     let _ = &y;

--- a/tests/ui/borrowck/issue-17545.stderr
+++ b/tests/ui/borrowck/issue-17545.stderr
@@ -7,7 +7,7 @@ LL | /     bar.call((
 LL | |         &id(()),
    | |          ^^^^^^ creates a temporary value which is freed while still in use
 LL | |     ));
-   | |      -- temporary value is freed at the end of this statement
+   | |      - - temporary value is freed at the end of this statement
    | |______|
    |        argument requires that borrow lasts for `'a`
 

--- a/tests/ui/borrowck/issue-36082.stderr
+++ b/tests/ui/borrowck/issue-36082.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-36082.rs:9:19
    |
 LL |     let val: &_ = x.borrow().0;
-   |                   ^^^^^^^^^^  - temporary value is freed at the end of this statement
+   |                   ^^^^^^^^^^   - temporary value is freed at the end of this statement
    |                   |
    |                   creates a temporary value which is freed while still in use
 ...

--- a/tests/ui/borrowck/issue-47646.stderr
+++ b/tests/ui/borrowck/issue-47646.stderr
@@ -11,7 +11,7 @@ LL |             println!("{:?}", heap);
    |                              ^^^^ immutable borrow occurs here
 ...
 LL |     };
-   |      - ... and the mutable borrow might be used here, when that temporary is dropped and runs the destructor for type `(Option<PeekMut<'_, i32>>, ())`
+   |       - ... and the mutable borrow might be used here, when that temporary is dropped and runs the destructor for type `(Option<PeekMut<'_, i32>>, ())`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/borrowck/issue-82462.stderr
+++ b/tests/ui/borrowck/issue-82462.stderr
@@ -10,7 +10,7 @@ LL |         v.push(*x);
    |         ^^^^^^^^^^ mutable borrow occurs here
 LL |         break;
 LL |     }
-   |     - ... and the immutable borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `DroppingSlice`
+   |      - ... and the immutable borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `DroppingSlice`
    |
 help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
    |

--- a/tests/ui/borrowck/issue-85581.stderr
+++ b/tests/ui/borrowck/issue-85581.stderr
@@ -10,7 +10,7 @@ LL |         Some(_) => { heap.pop(); },
    |                      ^^^^ second mutable borrow occurs here
 ...
 LL | }
-   | - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<PeekMut<'_, i32>>`
+   |  - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<PeekMut<'_, i32>>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/let_underscore_temporary.stderr
+++ b/tests/ui/borrowck/let_underscore_temporary.stderr
@@ -7,7 +7,7 @@ LL |         &a
    |         ^^ borrowed value does not live long enough
 LL |
 LL |     };
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 
 error[E0597]: `a` does not live long enough
   --> $DIR/let_underscore_temporary.rs:26:9
@@ -18,7 +18,7 @@ LL |         &a
    |         ^^ borrowed value does not live long enough
 LL |
 LL |     };
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 
 error[E0597]: `a` does not live long enough
   --> $DIR/let_underscore_temporary.rs:39:9
@@ -29,7 +29,7 @@ LL |         &a
    |         ^^ borrowed value does not live long enough
 LL |
 LL |     };
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 
 error[E0597]: `a` does not live long enough
   --> $DIR/let_underscore_temporary.rs:54:9
@@ -40,7 +40,7 @@ LL |         &a
    |         ^^ borrowed value does not live long enough
 LL |
 LL |     };
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 
 error[E0597]: `a` does not live long enough
   --> $DIR/let_underscore_temporary.rs:71:9
@@ -51,7 +51,7 @@ LL |         &a
    |         ^^ borrowed value does not live long enough
 LL |
 LL |     } {
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 
 error[E0597]: `a` does not live long enough
   --> $DIR/let_underscore_temporary.rs:92:9
@@ -62,7 +62,7 @@ LL |         &a
    |         ^^ borrowed value does not live long enough
 LL |
 LL |     } {
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/btreemap/btreemap_dropck.stderr
+++ b/tests/ui/btreemap/btreemap_dropck.stderr
@@ -8,7 +8,7 @@ LL |     let _map = BTreeMap::from_iter([((), PrintOnDrop(&s))]);
 LL |     drop(s);
    |          ^ move out of `s` occurs here
 LL | }
-   | - borrow might be used here, when `_map` is dropped and runs the `Drop` code for type `BTreeMap`
+   |  - borrow might be used here, when `_map` is dropped and runs the `Drop` code for type `BTreeMap`
    |
 help: consider cloning the value if the performance cost is acceptable
    |

--- a/tests/ui/c-variadic/variadic-ffi-4.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-4.stderr
@@ -117,7 +117,7 @@ LL |     ap0 = &mut ap1;
    |     assignment requires that `ap1` is borrowed for `'3`
 ...
 LL | }
-   | - `ap1` dropped here while still borrowed
+   |  - `ap1` dropped here while still borrowed
 
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:35:5

--- a/tests/ui/cleanup-rvalue-scopes-cf.stderr
+++ b/tests/ui/cleanup-rvalue-scopes-cf.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/cleanup-rvalue-scopes-cf.rs:26:19
    |
 LL |     let x1 = arg(&AddFlags(1));
-   |                   ^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                   ^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |                   |
    |                   creates a temporary value which is freed while still in use
 ...
@@ -19,7 +19,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/cleanup-rvalue-scopes-cf.rs:27:14
    |
 LL |     let x2 = AddFlags(1).get();
-   |              ^^^^^^^^^^^      - temporary value is freed at the end of this statement
+   |              ^^^^^^^^^^^       - temporary value is freed at the end of this statement
    |              |
    |              creates a temporary value which is freed while still in use
 ...
@@ -36,7 +36,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/cleanup-rvalue-scopes-cf.rs:28:21
    |
 LL |     let x3 = &*arg(&AddFlags(1));
-   |                     ^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                     ^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |                     |
    |                     creates a temporary value which is freed while still in use
 ...
@@ -53,7 +53,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/cleanup-rvalue-scopes-cf.rs:29:24
    |
 LL |     let ref x4 = *arg(&AddFlags(1));
-   |                        ^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                        ^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |                        |
    |                        creates a temporary value which is freed while still in use
 ...
@@ -70,7 +70,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/cleanup-rvalue-scopes-cf.rs:30:24
    |
 LL |     let &ref x5 = arg(&AddFlags(1));
-   |                        ^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                        ^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |                        |
    |                        creates a temporary value which is freed while still in use
 ...
@@ -87,7 +87,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/cleanup-rvalue-scopes-cf.rs:31:14
    |
 LL |     let x6 = AddFlags(1).get();
-   |              ^^^^^^^^^^^      - temporary value is freed at the end of this statement
+   |              ^^^^^^^^^^^       - temporary value is freed at the end of this statement
    |              |
    |              creates a temporary value which is freed while still in use
 ...
@@ -104,7 +104,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/cleanup-rvalue-scopes-cf.rs:32:44
    |
 LL |     let StackBox { f: x7 } = StackBox { f: AddFlags(1).get() };
-   |                                            ^^^^^^^^^^^        - temporary value is freed at the end of this statement
+   |                                            ^^^^^^^^^^^         - temporary value is freed at the end of this statement
    |                                            |
    |                                            creates a temporary value which is freed while still in use
 LL |

--- a/tests/ui/closures/issue-113087.stderr
+++ b/tests/ui/closures/issue-113087.stderr
@@ -9,7 +9,7 @@ LL |             some_closure(c);
    |             ------------ borrow later captured here by closure
 LL |         });
 LL |     }
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/bad-array-size-in-type-err.stderr
+++ b/tests/ui/consts/bad-array-size-in-type-err.stderr
@@ -54,7 +54,7 @@ error[E0493]: destructor of `Wrap` cannot be evaluated at compile-time
   --> $DIR/bad-array-size-in-type-err.rs:21:16
    |
 LL | pub const fn i(_: Wrap) {}
-   |                ^         - value is dropped here
+   |                ^          - value is dropped here
    |                |
    |                the destructor for this type cannot be evaluated in constant functions
 

--- a/tests/ui/consts/const-eval/const-eval-intrinsic-promotion.stderr
+++ b/tests/ui/consts/const-eval/const-eval-intrinsic-promotion.stderr
@@ -6,7 +6,7 @@ LL |     let x: &'static usize =
 LL |         &std::intrinsics::size_of::<i32>();
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/const_let.stderr
+++ b/tests/ui/consts/const-eval/const_let.stderr
@@ -18,7 +18,7 @@ error[E0493]: destructor of `Option<FakeNeedsDrop>` cannot be evaluated at compi
   --> $DIR/const_let.rs:24:21
    |
 LL | const Z: () = { let mut x = None; x = Some(FakeNeedsDrop); };
-   |                     ^^^^^                                  - value is dropped here
+   |                     ^^^^^                                   - value is dropped here
    |                     |
    |                     the destructor for this type cannot be evaluated in constants
 
@@ -26,7 +26,7 @@ error[E0493]: destructor of `Option<FakeNeedsDrop>` cannot be evaluated at compi
   --> $DIR/const_let.rs:28:22
    |
 LL | const Z2: () = { let mut x; x = None; x = Some(FakeNeedsDrop); };
-   |                      ^^^^^                                     - value is dropped here
+   |                      ^^^^^                                      - value is dropped here
    |                      |
    |                      the destructor for this type cannot be evaluated in constants
 

--- a/tests/ui/consts/const-eval/dont_promote_unstable_const_fn.stderr
+++ b/tests/ui/consts/const-eval/dont_promote_unstable_const_fn.stderr
@@ -24,7 +24,7 @@ LL |     let _: &'static u32 = &foo();
    |            |
    |            type annotation requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn.rs:21:28
@@ -35,7 +35,7 @@ LL |     let _: &'static u32 = &meh();
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn.rs:22:26
@@ -46,7 +46,7 @@ LL |     let x: &'static _ = &std::time::Duration::from_millis(42).subsec_millis
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/const-eval/dont_promote_unstable_const_fn_cross_crate.stderr
+++ b/tests/ui/consts/const-eval/dont_promote_unstable_const_fn_cross_crate.stderr
@@ -7,7 +7,7 @@ LL |     let _: &'static u32 = &foo();
    |            type annotation requires that borrow lasts for `'static`
 LL |     let _x: &'static u32 = &foo();
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/dont_promote_unstable_const_fn_cross_crate.rs:9:29
@@ -17,7 +17,7 @@ LL |     let _x: &'static u32 = &foo();
    |             |
    |             type annotation requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/generic-slice.stderr
+++ b/tests/ui/consts/const-eval/generic-slice.stderr
@@ -10,7 +10,7 @@ LL |     &x
    |     using this value as a static requires that `x` is borrowed for `'static`
 LL |
 LL | };
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/generic-slice.rs:15:9
@@ -27,7 +27,7 @@ LL |         &x
    |         using this value as a constant requires that `x` is borrowed for `'a`
 LL |
 LL |     };
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-eval/issue-65394.stock.stderr
+++ b/tests/ui/consts/const-eval/issue-65394.stock.stderr
@@ -5,7 +5,7 @@ LL |     let mut x = Vec::<i32>::new();
    |         ^^^^^ the destructor for this type cannot be evaluated in constants
 ...
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/promoted_raw_ptr_ops.stderr
+++ b/tests/ui/consts/const-eval/promoted_raw_ptr_ops.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static bool = &(42 as *const i32 == 43 as *const i32);
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_raw_ptr_ops.rs:4:30
@@ -18,7 +18,7 @@ LL |     let y: &'static usize = &(&1 as *const i32 as usize + 1);
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_raw_ptr_ops.rs:6:28
@@ -29,7 +29,7 @@ LL |     let z: &'static i32 = &(unsafe { *(42 as *const i32) });
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_raw_ptr_ops.rs:8:29
@@ -40,7 +40,7 @@ LL |     let a: &'static bool = &(main as fn() == main as fn());
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/const-eval/transmute-const-promotion.stderr
+++ b/tests/ui/consts/const-eval/transmute-const-promotion.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static u32 = unsafe { &mem::transmute(3.0f32) };
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-eval/union_promotion.stderr
+++ b/tests/ui/consts/const-eval/union_promotion.stderr
@@ -9,7 +9,7 @@ LL | |         Foo { a: &1 }.b == Foo { a: &2 }.b
 LL | |     };
    | |_____^ creates a temporary value which is freed while still in use
 LL |   }
-   |   - temporary value is freed at the end of this statement
+   |    - temporary value is freed at the end of this statement
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/const-int-conversion.stderr
+++ b/tests/ui/consts/const-int-conversion.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static i32 = &(5_i32.reverse_bits());
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:4:28
@@ -18,7 +18,7 @@ LL |     let y: &'static i32 = &(i32::from_be_bytes([0x12, 0x34, 0x56, 0x78]));
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:6:28
@@ -29,7 +29,7 @@ LL |     let z: &'static i32 = &(i32::from_le_bytes([0x12, 0x34, 0x56, 0x78]));
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:8:28
@@ -40,7 +40,7 @@ LL |     let a: &'static i32 = &(i32::from_be(i32::from_ne_bytes([0x80, 0, 0, 0]
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:10:29
@@ -51,7 +51,7 @@ LL |     let b: &'static [u8] = &(0x12_34_56_78_i32.to_be_bytes());
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:12:29
@@ -62,7 +62,7 @@ LL |     let c: &'static [u8] = &(0x12_34_56_78_i32.to_le_bytes());
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-conversion.rs:14:29
@@ -73,7 +73,7 @@ LL |     let d: &'static [u8] = &(i32::MIN.to_be().to_ne_bytes());
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/consts/const-int-overflowing.stderr
+++ b/tests/ui/consts/const-int-overflowing.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static (i32, bool) = &(5_i32.overflowing_add(3));
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-overflowing.rs:4:36
@@ -18,7 +18,7 @@ LL |     let y: &'static (i32, bool) = &(5_i32.overflowing_sub(3));
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-overflowing.rs:6:36
@@ -29,7 +29,7 @@ LL |     let z: &'static (i32, bool) = &(5_i32.overflowing_mul(3));
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/const-int-rotate.stderr
+++ b/tests/ui/consts/const-int-rotate.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static i32 = &(5_i32.rotate_left(3));
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-rotate.rs:4:28
@@ -18,7 +18,7 @@ LL |     let y: &'static i32 = &(5_i32.rotate_right(3));
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-int-sign.stderr
+++ b/tests/ui/consts/const-int-sign.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static bool = &(5_i32.is_negative());
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-sign.rs:4:29
@@ -18,7 +18,7 @@ LL |     let y: &'static bool = &(5_i32.is_positive());
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-int-wrapping.stderr
+++ b/tests/ui/consts/const-int-wrapping.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static i32 = &(5_i32.wrapping_add(3));
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:4:28
@@ -18,7 +18,7 @@ LL |     let y: &'static i32 = &(5_i32.wrapping_sub(3));
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:6:28
@@ -29,7 +29,7 @@ LL |     let z: &'static i32 = &(5_i32.wrapping_mul(3));
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:8:28
@@ -40,7 +40,7 @@ LL |     let a: &'static i32 = &(5_i32.wrapping_shl(3));
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-int-wrapping.rs:10:28
@@ -51,7 +51,7 @@ LL |     let b: &'static i32 = &(5_i32.wrapping_shr(3));
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
@@ -8,9 +8,8 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/mut_ref_in_final.rs:20:40
    |
 LL | const B3: Option<&mut i32> = Some(&mut 42);
-   |                              ----------^^-
-   |                              |         | |
-   |                              |         | temporary value is freed at the end of this statement
+   |                              ----------^^-- temporary value is freed at the end of this statement
+   |                              |         |
    |                              |         creates a temporary value which is freed while still in use
    |                              using this value as a constant requires that borrow lasts for `'static`
 
@@ -18,9 +17,8 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/mut_ref_in_final.rs:23:42
    |
 LL | const B4: Option<&mut i32> = helper(&mut 42);
-   |                              ------------^^-
-   |                              |           | |
-   |                              |           | temporary value is freed at the end of this statement
+   |                              ------------^^-- temporary value is freed at the end of this statement
+   |                              |           |
    |                              |           creates a temporary value which is freed while still in use
    |                              using this value as a constant requires that borrow lasts for `'static`
 
@@ -39,9 +37,8 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/mut_ref_in_final.rs:50:65
    |
 LL | const FOO: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
-   |                                  -------------------------------^^--
-   |                                  |                              |  |
-   |                                  |                              |  temporary value is freed at the end of this statement
+   |                                  -------------------------------^^--- temporary value is freed at the end of this statement
+   |                                  |                              |
    |                                  |                              creates a temporary value which is freed while still in use
    |                                  using this value as a constant requires that borrow lasts for `'static`
 
@@ -49,9 +46,8 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/mut_ref_in_final.rs:53:67
    |
 LL | static FOO2: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
-   |                                    -------------------------------^^--
-   |                                    |                              |  |
-   |                                    |                              |  temporary value is freed at the end of this statement
+   |                                    -------------------------------^^--- temporary value is freed at the end of this statement
+   |                                    |                              |
    |                                    |                              creates a temporary value which is freed while still in use
    |                                    using this value as a static requires that borrow lasts for `'static`
 
@@ -59,9 +55,8 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/mut_ref_in_final.rs:56:71
    |
 LL | static mut FOO3: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
-   |                                        -------------------------------^^--
-   |                                        |                              |  |
-   |                                        |                              |  temporary value is freed at the end of this statement
+   |                                        -------------------------------^^--- temporary value is freed at the end of this statement
+   |                                        |                              |
    |                                        |                              creates a temporary value which is freed while still in use
    |                                        using this value as a static requires that borrow lasts for `'static`
 

--- a/tests/ui/consts/const-promoted-opaque.atomic.stderr
+++ b/tests/ui/consts/const-promoted-opaque.atomic.stderr
@@ -5,7 +5,7 @@ LL |     let _: &'static _ = &FOO;
    |                          ^^^ the destructor for this type cannot be evaluated in constants
 LL |
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0492]: constants cannot refer to interior mutable data
   --> $DIR/const-promoted-opaque.rs:36:19
@@ -22,7 +22,7 @@ LL |     let _: &'static _ = &FOO;
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/const-promoted-opaque.string.stderr
+++ b/tests/ui/consts/const-promoted-opaque.string.stderr
@@ -5,7 +5,7 @@ LL |     let _: &'static _ = &FOO;
    |                          ^^^ the destructor for this type cannot be evaluated in constants
 LL |
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-promoted-opaque.rs:40:26
@@ -16,7 +16,7 @@ LL |     let _: &'static _ = &FOO;
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-promoted-opaque.unit.stderr
+++ b/tests/ui/consts/const-promoted-opaque.unit.stderr
@@ -5,7 +5,7 @@ LL |     let _: &'static _ = &FOO;
    |                          ^^^ the destructor for this type cannot be evaluated in constants
 LL |
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-promoted-opaque.rs:40:26
@@ -16,7 +16,7 @@ LL |     let _: &'static _ = &FOO;
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-ptr-nonnull.stderr
+++ b/tests/ui/consts/const-ptr-nonnull.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static NonNull<u32> = &(NonNull::dangling());
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-ptr-nonnull.rs:9:37
@@ -18,7 +18,7 @@ LL |     let x: &'static NonNull<u32> = &(non_null.cast());
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/const-ptr-unique.stderr
+++ b/tests/ui/consts/const-ptr-unique.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static *mut u32 = &(unique.as_ptr());
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/control-flow/drop-fail.precise.stderr
+++ b/tests/ui/consts/control-flow/drop-fail.precise.stderr
@@ -5,7 +5,7 @@ LL |     let x = Some(Vec::new());
    |         ^ the destructor for this type cannot be evaluated in constants
 ...
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `Option<Vec<i32>>` cannot be evaluated at compile-time
   --> $DIR/drop-fail.rs:40:9
@@ -14,7 +14,7 @@ LL |     let mut tmp = None;
    |         ^^^^^^^ the destructor for this type cannot be evaluated in constants
 ...
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/control-flow/drop-fail.stock.stderr
+++ b/tests/ui/consts/control-flow/drop-fail.stock.stderr
@@ -5,7 +5,7 @@ LL |     let x = Some(Vec::new());
    |         ^ the destructor for this type cannot be evaluated in constants
 ...
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `(Vec<i32>,)` cannot be evaluated at compile-time
   --> $DIR/drop-fail.rs:22:9
@@ -14,7 +14,7 @@ LL |     let vec_tuple = (Vec::new(),);
    |         ^^^^^^^^^ the destructor for this type cannot be evaluated in constants
 ...
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `Result<Vec<i32>, Vec<i32>>` cannot be evaluated at compile-time
   --> $DIR/drop-fail.rs:30:9
@@ -23,7 +23,7 @@ LL |     let x: Result<_, Vec<i32>> = Ok(Vec::new());
    |         ^ the destructor for this type cannot be evaluated in constants
 ...
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `Option<Vec<i32>>` cannot be evaluated at compile-time
   --> $DIR/drop-fail.rs:40:9
@@ -32,7 +32,7 @@ LL |     let mut tmp = None;
    |         ^^^^^^^ the destructor for this type cannot be evaluated in constants
 ...
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/control-flow/interior-mutability.stderr
+++ b/tests/ui/consts/control-flow/interior-mutability.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static _ = &X;
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/interior-mutability.rs:41:26
@@ -18,7 +18,7 @@ LL |     let y: &'static _ = &Y;
    |            type annotation requires that borrow lasts for `'static`
 LL |     let z: &'static _ = &Z;
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/interior-mutability.rs:42:26
@@ -28,7 +28,7 @@ LL |     let z: &'static _ = &Z;
    |            |
    |            type annotation requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/drop_box.stderr
+++ b/tests/ui/consts/drop_box.stderr
@@ -2,7 +2,7 @@ error[E0493]: destructor of `Box<T>` cannot be evaluated at compile-time
   --> $DIR/drop_box.rs:1:15
    |
 LL | const fn f<T>(_: Box<T>) {}
-   |               ^           - value is dropped here
+   |               ^            - value is dropped here
    |               |
    |               the destructor for this type cannot be evaluated in constant functions
 

--- a/tests/ui/consts/drop_zst.stderr
+++ b/tests/ui/consts/drop_zst.stderr
@@ -4,7 +4,7 @@ error[E0493]: destructor of `S` cannot be evaluated at compile-time
 LL |     let s = S;
    |         ^ the destructor for this type cannot be evaluated in constant functions
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-54224.stderr
+++ b/tests/ui/consts/issue-54224.stderr
@@ -2,9 +2,8 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-54224.rs:1:39
    |
 LL | const FOO: Option<&[[u8; 3]]> = Some(&[*b"foo"]);
-   |                                 ------^^^^^^^^^-
-   |                                 |     |        |
-   |                                 |     |        temporary value is freed at the end of this statement
+   |                                 ------^^^^^^^^^-- temporary value is freed at the end of this statement
+   |                                 |     |
    |                                 |     creates a temporary value which is freed while still in use
    |                                 using this value as a constant requires that borrow lasts for `'static`
 
@@ -12,9 +11,8 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-54224.rs:9:57
    |
 LL | pub const Z: Cow<'static, [ [u8; 3] ]> = Cow::Borrowed(&[*b"ABC"]);
-   |                                          ---------------^^^^^^^^^-
-   |                                          |              |        |
-   |                                          |              |        temporary value is freed at the end of this statement
+   |                                          ---------------^^^^^^^^^-- temporary value is freed at the end of this statement
+   |                                          |              |
    |                                          |              creates a temporary value which is freed while still in use
    |                                          using this value as a constant requires that borrow lasts for `'static`
 

--- a/tests/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/tests/ui/consts/min_const_fn/min_const_fn.stderr
@@ -2,7 +2,7 @@ error[E0493]: destructor of `Foo<T>` cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:37:25
    |
 LL |     const fn into_inner(self) -> T { self.0 }
-   |                         ^^^^                - value is dropped here
+   |                         ^^^^                 - value is dropped here
    |                         |
    |                         the destructor for this type cannot be evaluated in constant functions
 
@@ -10,7 +10,7 @@ error[E0493]: destructor of `Foo<T>` cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:43:28
    |
 LL |     const fn into_inner_lt(self) -> T { self.0 }
-   |                            ^^^^                - value is dropped here
+   |                            ^^^^                 - value is dropped here
    |                            |
    |                            the destructor for this type cannot be evaluated in constant functions
 
@@ -18,7 +18,7 @@ error[E0493]: destructor of `Foo<T>` cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:49:27
    |
 LL |     const fn into_inner_s(self) -> T { self.0 }
-   |                           ^^^^                - value is dropped here
+   |                           ^^^^                 - value is dropped here
    |                           |
    |                           the destructor for this type cannot be evaluated in constant functions
 
@@ -62,7 +62,7 @@ error[E0493]: destructor of `AlanTuring<impl std::fmt::Debug>` cannot be evaluat
   --> $DIR/min_const_fn.rs:109:19
    |
 LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
-   |                   ^^                                     - value is dropped here
+   |                   ^^                                      - value is dropped here
    |                   |
    |                   the destructor for this type cannot be evaluated in constant functions
 
@@ -70,7 +70,7 @@ error[E0493]: destructor of `impl std::fmt::Debug` cannot be evaluated at compil
   --> $DIR/min_const_fn.rs:111:18
    |
 LL | const fn no_apit(_x: impl std::fmt::Debug) {}
-   |                  ^^                         - value is dropped here
+   |                  ^^                          - value is dropped here
    |                  |
    |                  the destructor for this type cannot be evaluated in constant functions
 

--- a/tests/ui/consts/min_const_fn/promotion.stderr
+++ b/tests/ui/consts/min_const_fn/promotion.stderr
@@ -7,7 +7,7 @@ LL |     let x: &'static () = &foo1();
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:12:28
@@ -18,7 +18,7 @@ LL |     let y: &'static i32 = &foo2(42);
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:13:28
@@ -29,7 +29,7 @@ LL |     let z: &'static i32 = &foo3();
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:14:34
@@ -40,7 +40,7 @@ LL |     let a: &'static Cell<i32> = &foo4();
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:15:42
@@ -51,7 +51,7 @@ LL |     let a: &'static Option<Cell<i32>> = &foo5();
    |            type annotation requires that borrow lasts for `'static`
 LL |     let a: &'static Option<Cell<i32>> = &foo6();
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promotion.rs:16:42
@@ -61,7 +61,7 @@ LL |     let a: &'static Option<Cell<i32>> = &foo6();
    |            |
    |            type annotation requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -1,8 +1,8 @@
 error[E0080]: evaluation of `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))` failed
-  --> $DIR/assoc_const.rs:12:31
+  --> $DIR/assoc_const.rs:12:32
    |
 LL |     const F: u32 = (U::X, 42).1;
-   |                               ^ calling non-const function `<Vec<u32> as Drop>::drop`
+   |                                ^ calling non-const function `<Vec<u32> as Drop>::drop`
    |
 note: inside `std::ptr::drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/tests/ui/consts/miri_unleashed/drop.stderr
+++ b/tests/ui/consts/miri_unleashed/drop.stderr
@@ -1,8 +1,8 @@
 error[E0080]: could not evaluate static initializer
-  --> $DIR/drop.rs:17:1
+  --> $DIR/drop.rs:17:2
    |
 LL | };
-   | ^ calling non-const function `<Vec<i32> as Drop>::drop`
+   |  ^ calling non-const function `<Vec<i32> as Drop>::drop`
    |
 note: inside `std::ptr::drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/tests/ui/consts/miri_unleashed/feature-gate-unleash_the_miri_inside_of_you.stderr
+++ b/tests/ui/consts/miri_unleashed/feature-gate-unleash_the_miri_inside_of_you.stderr
@@ -2,7 +2,7 @@ error[E0493]: destructor of `(T, u32)` cannot be evaluated at compile-time
   --> $DIR/feature-gate-unleash_the_miri_inside_of_you.rs:9:20
    |
 LL |     const F: u32 = (U::X, 42).1;
-   |                    ^^^^^^^^^^ - value is dropped here
+   |                    ^^^^^^^^^^  - value is dropped here
    |                    |
    |                    the destructor for this type cannot be evaluated in constants
 

--- a/tests/ui/consts/precise-drop-allow-const-fn-unstable.not_allow.stderr
+++ b/tests/ui/consts/precise-drop-allow-const-fn-unstable.not_allow.stderr
@@ -5,7 +5,7 @@ LL | pub const fn unwrap<T>(this: Option<T>) -> T {
    |                        ^^^^ the destructor for this type cannot be evaluated in constant functions
 ...
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/promote-not.stderr
+++ b/tests/ui/consts/promote-not.stderr
@@ -2,9 +2,8 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:9:50
    |
 LL | static mut TEST1: Option<&mut [i32]> = Some(&mut [1, 2, 3]);
-   |                                        ----------^^^^^^^^^-
-   |                                        |         |        |
-   |                                        |         |        temporary value is freed at the end of this statement
+   |                                        ----------^^^^^^^^^-- temporary value is freed at the end of this statement
+   |                                        |         |
    |                                        |         creates a temporary value which is freed while still in use
    |                                        using this value as a static requires that borrow lasts for `'static`
 
@@ -16,7 +15,7 @@ LL |     let x = &mut [1,2,3];
 LL |     x
    |     - using this value as a static requires that borrow lasts for `'static`
 LL | };
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:34:29
@@ -26,7 +25,7 @@ LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
    |             |
    |             type annotation requires that borrow lasts for `'static`
 LL | };
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:40:29
@@ -36,7 +35,7 @@ LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
    |               |
    |               type annotation requires that borrow lasts for `'static`
 LL | };
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0493]: destructor of `String` cannot be evaluated at compile-time
   --> $DIR/promote-not.rs:47:14
@@ -45,7 +44,7 @@ LL |     let x = &String::new();
    |              ^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constants
 ...
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:59:33
@@ -55,7 +54,7 @@ LL |         let _x: &'static u32 = &mk_panic();
    |                 |
    |                 type annotation requires that borrow lasts for `'static`
 LL |     }
-   |     - temporary value is freed at the end of this statement
+   |      - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:21:32
@@ -65,7 +64,7 @@ LL |         let _x: &'static () = &foo();
    |                 |
    |                 type annotation requires that borrow lasts for `'static`
 LL |     }
-   |     - temporary value is freed at the end of this statement
+   |      - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:29:29
@@ -75,7 +74,7 @@ LL |     let _x: &'static i32 = &unsafe { U { x: 0 }.x };
    |             |
    |             type annotation requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:65:29
@@ -86,7 +85,7 @@ LL |     let _val: &'static _ = &(Cell::new(1), 2).0;
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:66:29
@@ -97,7 +96,7 @@ LL |     let _val: &'static _ = &(Cell::new(1), 2).1;
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:69:29
@@ -108,7 +107,7 @@ LL |     let _val: &'static _ = &(1/0);
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:70:29
@@ -119,7 +118,7 @@ LL |     let _val: &'static _ = &(1/(1-1));
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:71:29
@@ -130,7 +129,7 @@ LL |     let _val: &'static _ = &((1+1)/(1-1));
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:72:29
@@ -141,7 +140,7 @@ LL |     let _val: &'static _ = &(i32::MIN/-1);
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:73:29
@@ -152,7 +151,7 @@ LL |     let _val: &'static _ = &(i32::MIN/(0-1));
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:74:29
@@ -163,7 +162,7 @@ LL |     let _val: &'static _ = &(-128i8/-1);
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:75:29
@@ -174,7 +173,7 @@ LL |     let _val: &'static _ = &(1%0);
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:76:29
@@ -185,7 +184,7 @@ LL |     let _val: &'static _ = &(1%(1-1));
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:77:29
@@ -196,7 +195,7 @@ LL |     let _val: &'static _ = &([1,2,3][4]+1);
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:81:29
@@ -207,7 +206,7 @@ LL |     let _val: &'static _ = &TEST_DROP;
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:83:29
@@ -218,7 +217,7 @@ LL |     let _val: &'static _ = &&TEST_DROP;
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:83:30
@@ -229,7 +228,7 @@ LL |     let _val: &'static _ = &&TEST_DROP;
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:86:29
@@ -240,7 +239,7 @@ LL |     let _val: &'static _ = &(&TEST_DROP,);
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:86:31
@@ -251,7 +250,7 @@ LL |     let _val: &'static _ = &(&TEST_DROP,);
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:89:29
@@ -262,13 +261,13 @@ LL |     let _val: &'static _ = &[&TEST_DROP; 1];
    |               type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote-not.rs:89:31
    |
 LL |     let _val: &'static _ = &[&TEST_DROP; 1];
-   |               ----------      ^^^^^^^^^    - temporary value is freed at the end of this statement
+   |               ----------      ^^^^^^^^^     - temporary value is freed at the end of this statement
    |               |               |
    |               |               creates a temporary value which is freed while still in use
    |               type annotation requires that borrow lasts for `'static`
@@ -282,7 +281,7 @@ LL |     let x: &'static _ = &UnionWithCell { f1: 0 };
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 27 previous errors
 

--- a/tests/ui/consts/promote_const_let.stderr
+++ b/tests/ui/consts/promote_const_let.stderr
@@ -8,7 +8,7 @@ LL |         let y = 42;
 LL |         &y
    |         ^^ borrowed value does not live long enough
 LL |     };
-   |     - `y` dropped here while still borrowed
+   |      - `y` dropped here while still borrowed
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promote_const_let.rs:6:28
@@ -22,7 +22,7 @@ LL | |         y
 LL | |     };
    | |_____^ creates a temporary value which is freed while still in use
 LL |   }
-   |   - temporary value is freed at the end of this statement
+   |    - temporary value is freed at the end of this statement
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/promoted-const-drop.stderr
+++ b/tests/ui/consts/promoted-const-drop.stderr
@@ -7,7 +7,7 @@ LL |     let _: &'static A = &A();
    |            type annotation requires that borrow lasts for `'static`
 LL |     let _: &'static [A] = &[C];
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted-const-drop.rs:13:28
@@ -17,7 +17,7 @@ LL |     let _: &'static [A] = &[C];
    |            |
    |            type annotation requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/promoted_const_call.stderr
+++ b/tests/ui/consts/promoted_const_call.stderr
@@ -7,13 +7,13 @@ LL |     let _: &'static _ = &id(&Panic);
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | };
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call.rs:8:30
    |
 LL |     let _: &'static _ = &id(&Panic);
-   |            ----------        ^^^^^ - temporary value is freed at the end of this statement
+   |            ----------        ^^^^^  - temporary value is freed at the end of this statement
    |            |                 |
    |            |                 creates a temporary value which is freed while still in use
    |            type annotation requires that borrow lasts for `'static`
@@ -27,13 +27,13 @@ LL |     let _: &'static _ = &id(&Panic);
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call.rs:14:30
    |
 LL |     let _: &'static _ = &id(&Panic);
-   |            ----------        ^^^^^ - temporary value is freed at the end of this statement
+   |            ----------        ^^^^^  - temporary value is freed at the end of this statement
    |            |                 |
    |            |                 creates a temporary value which is freed while still in use
    |            type annotation requires that borrow lasts for `'static`
@@ -47,7 +47,7 @@ LL |     let _: &'static _ = &&(Panic, 0).1;
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call.rs:17:27
@@ -58,7 +58,7 @@ LL |     let _: &'static _ = &&(Panic, 0).1;
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/consts/promoted_const_call2.stderr
+++ b/tests/ui/consts/promoted_const_call2.stderr
@@ -7,13 +7,13 @@ LL |     let _: &'static _ = &id(&String::new());
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | };
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call2.rs:4:30
    |
 LL |     let _: &'static _ = &id(&String::new());
-   |            ----------        ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |            ----------        ^^^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |            |                 |
    |            |                 creates a temporary value which is freed while still in use
    |            type annotation requires that borrow lasts for `'static`
@@ -22,7 +22,7 @@ error[E0493]: destructor of `String` cannot be evaluated at compile-time
   --> $DIR/promoted_const_call2.rs:4:30
    |
 LL |     let _: &'static _ = &id(&String::new());
-   |                              ^^^^^^^^^^^^^ - value is dropped here
+   |                              ^^^^^^^^^^^^^  - value is dropped here
    |                              |
    |                              the destructor for this type cannot be evaluated in constants
 
@@ -35,13 +35,13 @@ LL |     let _: &'static _ = &id(&String::new());
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call2.rs:11:30
    |
 LL |     let _: &'static _ = &id(&String::new());
-   |            ----------        ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |            ----------        ^^^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |            |                 |
    |            |                 creates a temporary value which is freed while still in use
    |            type annotation requires that borrow lasts for `'static`

--- a/tests/ui/consts/promoted_const_call3.stderr
+++ b/tests/ui/consts/promoted_const_call3.stderr
@@ -5,13 +5,13 @@ LL |     let _: &'static _ = &String::new();
    |                          ^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constants
 LL |
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `String` cannot be evaluated at compile-time
   --> $DIR/promoted_const_call3.rs:8:30
    |
 LL |     let _: &'static _ = &id(&String::new());
-   |                              ^^^^^^^^^^^^^ - value is dropped here
+   |                              ^^^^^^^^^^^^^  - value is dropped here
    |                              |
    |                              the destructor for this type cannot be evaluated in constants
 
@@ -24,7 +24,7 @@ LL |     let _: &'static _ = &std::mem::ManuallyDrop::new(String::new());
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | };
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call3.rs:18:26
@@ -35,7 +35,7 @@ LL |     let _: &'static _ = &String::new();
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call3.rs:21:26
@@ -46,13 +46,13 @@ LL |     let _: &'static _ = &id(&String::new());
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call3.rs:21:30
    |
 LL |     let _: &'static _ = &id(&String::new());
-   |            ----------        ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |            ----------        ^^^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |            |                 |
    |            |                 creates a temporary value which is freed while still in use
    |            type annotation requires that borrow lasts for `'static`
@@ -66,7 +66,7 @@ LL |     let _: &'static _ = &std::mem::ManuallyDrop::new(String::new());
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/consts/promoted_const_call5.stderr
+++ b/tests/ui/consts/promoted_const_call5.stderr
@@ -2,7 +2,7 @@ error[E0493]: destructor of `String` cannot be evaluated at compile-time
   --> $DIR/promoted_const_call5.rs:26:30
    |
 LL |     let _: &'static _ = &id(&new_string());
-   |                              ^^^^^^^^^^^^ - value is dropped here
+   |                              ^^^^^^^^^^^^  - value is dropped here
    |                              |
    |                              the destructor for this type cannot be evaluated in constants
 
@@ -15,7 +15,7 @@ LL |     let _: &'static _ = &new_manually_drop(new_string());
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | };
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call5.rs:36:26
@@ -26,13 +26,13 @@ LL |     let _: &'static _ = &id(&new_string());
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call5.rs:36:30
    |
 LL |     let _: &'static _ = &id(&new_string());
-   |                          ----^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+   |                          ----^^^^^^^^^^^^- - temporary value is freed at the end of this statement
    |                          |   |
    |                          |   creates a temporary value which is freed while still in use
    |                          argument requires that borrow lasts for `'static`
@@ -46,7 +46,7 @@ LL |     let _: &'static _ = &new_manually_drop(new_string());
    |            type annotation requires that borrow lasts for `'static`
 LL |
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/consts/qualif-indirect-mutation-fail.stderr
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.stderr
@@ -5,13 +5,13 @@ LL |     let mut x = None;
    |         ^^^^^ the destructor for this type cannot be evaluated in constants
 ...
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/qualif-indirect-mutation-fail.rs:18:1
+  --> $DIR/qualif-indirect-mutation-fail.rs:18:2
    |
 LL | };
-   | ^ calling non-const function `<Vec<u8> as Drop>::drop`
+   |  ^ calling non-const function `<Vec<u8> as Drop>::drop`
    |
 note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
@@ -26,13 +26,13 @@ error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
 LL |     let _z = x;
    |         ^^ the destructor for this type cannot be evaluated in constants
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/qualif-indirect-mutation-fail.rs:29:1
+  --> $DIR/qualif-indirect-mutation-fail.rs:29:2
    |
 LL | };
-   | ^ calling non-const function `<Vec<u8> as Drop>::drop`
+   |  ^ calling non-const function `<Vec<u8> as Drop>::drop`
    |
 note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
@@ -48,7 +48,7 @@ LL |     let mut a: (u32, Option<String>) = (0, None);
    |         ^^^^^ the destructor for this type cannot be evaluated in constant functions
 LL |     let _ = &mut a.1;
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `Option<T>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:33:9
@@ -57,7 +57,7 @@ LL |     let x: Option<T> = None;
    |         ^ the destructor for this type cannot be evaluated in constant functions
 LL |     let _ = x.is_some();
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `Option<T>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:41:9
@@ -65,7 +65,7 @@ error[E0493]: destructor of `Option<T>` cannot be evaluated at compile-time
 LL |     let _y = x;
    |         ^^ the destructor for this type cannot be evaluated in constant functions
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:49:9
@@ -74,7 +74,7 @@ LL |     let mut y: Option<String> = None;
    |         ^^^^^ the destructor for this type cannot be evaluated in constant functions
 LL |     std::ptr::addr_of_mut!(y);
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:46:9
@@ -83,7 +83,7 @@ LL |     let mut x: Option<String> = None;
    |         ^^^^^ the destructor for this type cannot be evaluated in constant functions
 ...
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:59:9
@@ -92,7 +92,7 @@ LL |     let y: Option<String> = None;
    |         ^ the destructor for this type cannot be evaluated in constant functions
 LL |     std::ptr::addr_of!(y);
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:56:9
@@ -101,7 +101,7 @@ LL |     let x: Option<String> = None;
    |         ^ the destructor for this type cannot be evaluated in constant functions
 ...
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/consts/qualif-union.stderr
+++ b/tests/ui/consts/qualif-union.stderr
@@ -7,7 +7,7 @@ LL |     let _: &'static _ = &C1;
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/qualif-union.rs:29:26
@@ -18,7 +18,7 @@ LL |     let _: &'static _ = &C2;
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/qualif-union.rs:30:26
@@ -29,7 +29,7 @@ LL |     let _: &'static _ = &C3;
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/qualif-union.rs:31:26
@@ -40,7 +40,7 @@ LL |     let _: &'static _ = &C4;
    |            type annotation requires that borrow lasts for `'static`
 LL |     let _: &'static _ = &C5;
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/qualif-union.rs:32:26
@@ -50,7 +50,7 @@ LL |     let _: &'static _ = &C5;
    |            |
    |            type annotation requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/consts/stable-precise-live-drops-in-libcore.stderr
+++ b/tests/ui/consts/stable-precise-live-drops-in-libcore.stderr
@@ -5,7 +5,7 @@ LL |     pub const fn unwrap(self) -> T {
    |                         ^^^^ the destructor for this type cannot be evaluated in constant functions
 ...
 LL |     }
-   |     - value is dropped here
+   |      - value is dropped here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/tests/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -32,7 +32,7 @@ LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T>(self, f: F) -> T {
    |                                                            ^ the destructor for this type cannot be evaluated in constant functions
 ...
 LL |     }
-   |     - value is dropped here
+   |      - value is dropped here
 
 error[E0493]: destructor of `Opt<T>` cannot be evaluated at compile-time
   --> $DIR/unstable-const-fn-in-libcore.rs:19:54
@@ -41,7 +41,7 @@ LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T>(self, f: F) -> T {
    |                                                      ^^^^ the destructor for this type cannot be evaluated in constant functions
 ...
 LL |     }
-   |     - value is dropped here
+   |      - value is dropped here
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/coroutine/auto-trait-regions.stderr
+++ b/tests/ui/coroutine/auto-trait-regions.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/auto-trait-regions.rs:45:24
    |
 LL |         let a = A(&mut true, &mut true, No);
-   |                        ^^^^                - temporary value is freed at the end of this statement
+   |                        ^^^^                 - temporary value is freed at the end of this statement
    |                        |
    |                        creates a temporary value which is freed while still in use
 ...
@@ -19,7 +19,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/auto-trait-regions.rs:45:35
    |
 LL |         let a = A(&mut true, &mut true, No);
-   |                                   ^^^^     - temporary value is freed at the end of this statement
+   |                                   ^^^^      - temporary value is freed at the end of this statement
    |                                   |
    |                                   creates a temporary value which is freed while still in use
 ...

--- a/tests/ui/coroutine/borrowing.stderr
+++ b/tests/ui/coroutine/borrowing.stderr
@@ -11,7 +11,7 @@ LL |         Pin::new(&mut #[coroutine] || yield &a).resume(())
    |                                    value captured here by coroutine
 LL |
 LL |     };
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 
 error[E0597]: `a` does not live long enough
   --> $DIR/borrowing.rs:16:20
@@ -26,7 +26,7 @@ LL |             yield &a
    |                    ^ borrowed value does not live long enough
 ...
 LL |     };
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/coroutine/dropck-resume.stderr
+++ b/tests/ui/coroutine/dropck-resume.stderr
@@ -8,7 +8,7 @@ LL |         r = y.as_ref().unwrap();
    |             ^ immutable borrow occurs here
 LL |
 LL |     }
-   |     - mutable borrow might be used here, when `g` is dropped and runs the destructor for coroutine
+   |      - mutable borrow might be used here, when `g` is dropped and runs the destructor for coroutine
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/dropck.stderr
+++ b/tests/ui/coroutine/dropck.stderr
@@ -8,10 +8,10 @@ LL |     let ref_ = Box::leak(Box::new(Some(cell.borrow_mut())));
    |                                        ^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `*cell` dropped here while still borrowed
-   | borrow might be used here, when `gen` is dropped and runs the destructor for coroutine
+   |  -
+   |  |
+   |  `*cell` dropped here while still borrowed
+   |  borrow might be used here, when `gen` is dropped and runs the destructor for coroutine
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -28,10 +28,10 @@ LL |         let _d = ref_.take();
    |                  ^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `ref_` dropped here while still borrowed
-   | borrow might be used here, when `gen` is dropped and runs the destructor for coroutine
+   |  -
+   |  |
+   |  `ref_` dropped here while still borrowed
+   |  borrow might be used here, when `gen` is dropped and runs the destructor for coroutine
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/drop/drop-order-comparisons.e2021.stderr
+++ b/tests/ui/drop/drop-order-comparisons.e2021.stderr
@@ -31,39 +31,23 @@ LL | |     }, e.mark(3), e.ok(4));
 note: `#3` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `_v` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 note: the lint level is defined here
   --> $DIR/drop-order-comparisons.rs:28:25
@@ -95,21 +79,13 @@ LL | |     }, e.mark(1), e.ok(4));
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: relative drop order changing in Rust 2024
@@ -135,21 +111,13 @@ LL | |     }, e.mark(1), e.ok(4));
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: relative drop order changing in Rust 2024
@@ -175,21 +143,13 @@ LL | |     }, e.mark(2), e.ok(3));
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: relative drop order changing in Rust 2024
@@ -215,21 +175,13 @@ LL | |     }, e.mark(2), e.ok(3));
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
@@ -245,12 +197,8 @@ LL |     _ = (if let Ok(_) = e.ok(4).as_ref() {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:127:5
    |
@@ -279,12 +227,8 @@ LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:145:44
    |
@@ -312,12 +256,8 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:247:43
    |
@@ -345,12 +285,8 @@ LL |         if let true = e.err(9).is_ok() {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:352:41
    |
@@ -378,12 +314,8 @@ LL |         if let Ok(_v) = e.err(8) {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:355:35
    |
@@ -411,12 +343,8 @@ LL |         if let Ok(_) = e.err(7) {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:358:34
    |
@@ -444,12 +372,8 @@ LL |         if let Ok(_) = e.err(6).as_ref() {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:361:43
    |
@@ -477,12 +401,8 @@ LL |         if let Ok(_v) = e.err(5) {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:365:35
    |
@@ -510,12 +430,8 @@ LL |         if let Ok(_) = e.err(4) {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:368:34
    |
@@ -543,12 +459,8 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:404:43
    |

--- a/tests/ui/drop/drop-order-comparisons.e2021.stderr
+++ b/tests/ui/drop/drop-order-comparisons.e2021.stderr
@@ -20,9 +20,8 @@ LL | |         e.ok(5).is_ok()
    | |         up until Edition 2021 `#3` is dropped last but will be dropped earlier in Edition 2024
 ...  |
 LL | |     }, e.mark(3), e.ok(4));
-   | |                          -
+   | |                          -- now the temporary value is dropped here, before the local variables in the block or statement
    | |                          |
-   | |                          now the temporary value is dropped here, before the local variables in the block or statement
    | |__________________________this value will be stored in a temporary; let us call it `#1`
    |                            `#1` will be dropped later as of Edition 2024
    |
@@ -68,9 +67,8 @@ LL | |         (e.ok(2), e.ok(6).is_ok(), e.ok(3), e.ok(5).is_ok())
    | |                                             up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
 ...  |
 LL | |     }, e.mark(1), e.ok(4));
-   | |                          -
+   | |                          -- now the temporary value is dropped here, before the local variables in the block or statement
    | |                          |
-   | |                          now the temporary value is dropped here, before the local variables in the block or statement
    | |__________________________this value will be stored in a temporary; let us call it `#1`
    |                            `#1` will be dropped later as of Edition 2024
    |
@@ -100,9 +98,8 @@ LL | |         (e.ok(2), e.ok(6).is_ok(), e.ok(3), e.ok(5).is_ok())
    | |                   up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
 ...  |
 LL | |     }, e.mark(1), e.ok(4));
-   | |                          -
+   | |                          -- now the temporary value is dropped here, before the local variables in the block or statement
    | |                          |
-   | |                          now the temporary value is dropped here, before the local variables in the block or statement
    | |__________________________this value will be stored in a temporary; let us call it `#1`
    |                            `#1` will be dropped later as of Edition 2024
    |
@@ -132,9 +129,8 @@ LL | |         if let Ok(_) = e.ok(4).as_ref() {
    | |                        up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
 ...  |
 LL | |     }, e.mark(2), e.ok(3));
-   | |                          -
+   | |                          -- now the temporary value is dropped here, before the local variables in the block or statement
    | |                          |
-   | |                          now the temporary value is dropped here, before the local variables in the block or statement
    | |__________________________this value will be stored in a temporary; let us call it `#1`
    |                            `#1` will be dropped later as of Edition 2024
    |
@@ -164,9 +160,8 @@ LL | |         if let Ok(_) = e.err(4).as_ref() {} else {
    | |                        up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
 ...  |
 LL | |     }, e.mark(2), e.ok(3));
-   | |                          -
+   | |                          -- now the temporary value is dropped here, before the local variables in the block or statement
    | |                          |
-   | |                          now the temporary value is dropped here, before the local variables in the block or statement
    | |__________________________this value will be stored in a temporary; let us call it `#1`
    |                            `#1` will be dropped later as of Edition 2024
    |

--- a/tests/ui/drop/if-let-rescope-borrowck-suggestions.stderr
+++ b/tests/ui/drop/if-let-rescope-borrowck-suggestions.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/if-let-rescope-borrowck-suggestions.rs:21:39
    |
 LL |     do_something(if let Some(value) = Droppy.get_ref() { value } else { &0 });
-   |                                       ^^^^^^                   - temporary value is freed at the end of this statement
+   |                                       ^^^^^^                    - temporary value is freed at the end of this statement
    |                                       |
    |                                       creates a temporary value which is freed while still in use
    |
@@ -29,7 +29,7 @@ LL |     do_something(if let Some(value) = Droppy.get_ref() {
    |                                       ^^^^^^ creates a temporary value which is freed while still in use
 ...
 LL |     } else if let Some(value) = Droppy.get_ref() {
-   |     - temporary value is freed at the end of this statement
+   |      - temporary value is freed at the end of this statement
    |
 note: lifetimes for temporaries generated in `if let`s have been shortened in Edition 2024 so that they are dropped here instead
   --> $DIR/if-let-rescope-borrowck-suggestions.rs:26:5
@@ -60,7 +60,7 @@ LL |     } else if let Some(value) = Droppy.get_ref() {
    |                                 ^^^^^^ creates a temporary value which is freed while still in use
 ...
 LL |     } else {
-   |     - temporary value is freed at the end of this statement
+   |      - temporary value is freed at the end of this statement
    |
 note: lifetimes for temporaries generated in `if let`s have been shortened in Edition 2024 so that they are dropped here instead
   --> $DIR/if-let-rescope-borrowck-suggestions.rs:29:5

--- a/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
@@ -11,12 +11,8 @@ LL |     if let Some(_value) = Droppy.get() {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope-gated.rs:14:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope-gated.rs:30:5
    |

--- a/tests/ui/drop/lint-if-let-rescope-with-macro.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-with-macro.stderr
@@ -18,12 +18,8 @@ LL | |     };
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope-with-macro.rs:22:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope-with-macro.rs:12:38
    |

--- a/tests/ui/drop/lint-if-let-rescope.stderr
+++ b/tests/ui/drop/lint-if-let-rescope.stderr
@@ -11,12 +11,8 @@ LL |     if let Some(_value) = droppy().get() {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:32:5
    |
@@ -55,21 +51,13 @@ LL |     } else if let Some(_value) = droppy().get() {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:42:5
    |
@@ -105,12 +93,8 @@ LL |     } else if let Some(_value) = droppy().get() {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:54:5
    |
@@ -140,12 +124,8 @@ LL |     if let Some(1) = { if let Some(_value) = Droppy.get() { Some(1) } else 
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:58:69
    |
@@ -170,12 +150,8 @@ LL |     if (if let Some(_value) = droppy().get() { true } else { false }) {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:72:53
    |
@@ -200,12 +176,8 @@ LL |     } else if (((if let Some(_value) = droppy().get() { true } else { false
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:78:62
    |
@@ -230,12 +202,8 @@ LL |     while (if let Some(_value) = droppy().get() { false } else { true }) {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:90:57
    |

--- a/tests/ui/drop/lint-tail-expr-drop-order.stderr
+++ b/tests/ui/drop/lint-tail-expr-drop-order.stderr
@@ -21,17 +21,13 @@ LL | }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 note: the lint level is defined here
   --> $DIR/lint-tail-expr-drop-order.rs:6:9
@@ -62,17 +58,13 @@ LL |     }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -98,17 +90,13 @@ LL | }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -134,10 +122,8 @@ LL | }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -185,17 +171,13 @@ LL | }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -221,23 +203,13 @@ LL | }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:193:5
    |
-LL | /     impl Drop for LoudDropper3 {
-LL | |
-LL | |         fn drop(&mut self) {
-LL | |             println!("loud drop");
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl Drop for LoudDropper3 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:205:5
    |
-LL | /     impl Drop for LoudDropper2 {
-LL | |
-LL | |         fn drop(&mut self) {
-LL | |             println!("loud drop");
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl Drop for LoudDropper2 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -263,17 +235,13 @@ LL |     ));
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `_x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: aborting due to 8 previous errors

--- a/tests/ui/drop/lint-tail-expr-drop-order.stderr
+++ b/tests/ui/drop/lint-tail-expr-drop-order.stderr
@@ -14,7 +14,7 @@ LL |     x.get() + LoudDropper.get()
    |               up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
 ...
 LL | }
-   | - now the temporary value is dropped here, before the local variables in the block or statement
+   |  - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
@@ -51,7 +51,7 @@ LL |         x.get() + LoudDropper.get()
    |                   up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
 ...
 LL |     }
-   |     - now the temporary value is dropped here, before the local variables in the block or statement
+   |      - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
@@ -83,7 +83,7 @@ LL |     { LoudDropper.get() }
    |       up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
 ...
 LL | }
-   | - now the temporary value is dropped here, before the local variables in the block or statement
+   |  - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
@@ -115,7 +115,7 @@ LL |     LoudDropper.get()
    |     up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
 ...
 LL | }
-   | - now the temporary value is dropped here, before the local variables in the block or statement
+   |  - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
@@ -142,7 +142,7 @@ LL |     extract(&T::default())
    |              up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
 ...
 LL | }
-   | - now the temporary value is dropped here, before the local variables in the block or statement
+   |  - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
@@ -164,7 +164,7 @@ LL |     LoudDropper.get()
    |     up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
 ...
 LL | }
-   | - now the temporary value is dropped here, before the local variables in the block or statement
+   |  - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
@@ -196,7 +196,7 @@ LL |     LoudDropper3.get()
    |     up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
 ...
 LL | }
-   | - now the temporary value is dropped here, before the local variables in the block or statement
+   |  - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
@@ -228,7 +228,7 @@ LL |             let _x = LoudDropper;
    |                 `_x` will be dropped later as of Edition 2024
 ...
 LL |     ));
-   |       - now the temporary value is dropped here, before the local variables in the block or statement
+   |        - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>

--- a/tests/ui/drop/tail-expr-drop-order-negative.edition2024.stderr
+++ b/tests/ui/drop/tail-expr-drop-order-negative.edition2024.stderr
@@ -2,12 +2,12 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/tail-expr-drop-order-negative.rs:8:15
    |
 LL |     x.replace(std::cell::RefCell::new(123).borrow()).is_some()
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                   - temporary value is freed at the end of this statement
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                    - temporary value is freed at the end of this statement
    |               |
    |               creates a temporary value which is freed while still in use
 LL |
 LL | }
-   | - borrow might be used here, when `x` is dropped and runs the destructor for type `Option<Ref<'_, i32>>`
+   |  - borrow might be used here, when `x` is dropped and runs the destructor for type `Option<Ref<'_, i32>>`
    |
    = note: consider using a `let` binding to create a longer lived value
 

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
@@ -27,24 +27,18 @@ LL |     }
 note: `#2` invokes this custom destructor
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
-LL | / impl std::ops::Drop for Drop {
-LL | |     fn drop(&mut self) {}
-LL | | }
-   | |_^
+LL | impl std::ops::Drop for Drop {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
-LL | / impl std::ops::Drop for Drop {
-LL | |     fn drop(&mut self) {}
-LL | | }
-   | |_^
+LL | impl std::ops::Drop for Drop {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `e` invokes this custom destructor
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
-LL | / impl std::ops::Drop for Drop {
-LL | |     fn drop(&mut self) {}
-LL | | }
-   | |_^
+LL | impl std::ops::Drop for Drop {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 note: the lint level is defined here
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:6:9

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
@@ -20,7 +20,7 @@ LL |             Err(e) => {}
    |                 `e` will be dropped later as of Edition 2024
 LL |         }
 LL |     }
-   |     - now the temporary value is dropped here, before the local variables in the block or statement
+   |      - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>

--- a/tests/ui/dropck/dropck-eyepatch-extern-crate.stderr
+++ b/tests/ui/dropck/dropck-eyepatch-extern-crate.stderr
@@ -8,10 +8,10 @@ LL |         dt = Dt("dt", &c_shortest);
    |                       ^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     -
-   |     |
-   |     `c_shortest` dropped here while still borrowed
-   |     borrow might be used here, when `dt` is dropped and runs the `Drop` code for type `Dt`
+   |      -
+   |      |
+   |      `c_shortest` dropped here while still borrowed
+   |      borrow might be used here, when `dt` is dropped and runs the `Drop` code for type `Dt`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -25,10 +25,10 @@ LL |         pt = Pt("pt", &c_long, &c_shortest);
    |                                ^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     -
-   |     |
-   |     `c_shortest` dropped here while still borrowed
-   |     borrow might be used here, when `pt` is dropped and runs the `Drop` code for type `Pt`
+   |      -
+   |      |
+   |      `c_shortest` dropped here while still borrowed
+   |      borrow might be used here, when `pt` is dropped and runs the `Drop` code for type `Pt`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/dropck/dropck-eyepatch-reorder.stderr
+++ b/tests/ui/dropck/dropck-eyepatch-reorder.stderr
@@ -8,10 +8,10 @@ LL |         dt = Dt("dt", &c_shortest);
    |                       ^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     -
-   |     |
-   |     `c_shortest` dropped here while still borrowed
-   |     borrow might be used here, when `dt` is dropped and runs the `Drop` code for type `Dt`
+   |      -
+   |      |
+   |      `c_shortest` dropped here while still borrowed
+   |      borrow might be used here, when `dt` is dropped and runs the `Drop` code for type `Dt`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -25,10 +25,10 @@ LL |         pt = Pt("pt", &c_long, &c_shortest);
    |                                ^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     -
-   |     |
-   |     `c_shortest` dropped here while still borrowed
-   |     borrow might be used here, when `pt` is dropped and runs the `Drop` code for type `Pt`
+   |      -
+   |      |
+   |      `c_shortest` dropped here while still borrowed
+   |      borrow might be used here, when `pt` is dropped and runs the `Drop` code for type `Pt`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/dropck/dropck-eyepatch.stderr
+++ b/tests/ui/dropck/dropck-eyepatch.stderr
@@ -8,10 +8,10 @@ LL |         dt = Dt("dt", &c_shortest);
    |                       ^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     -
-   |     |
-   |     `c_shortest` dropped here while still borrowed
-   |     borrow might be used here, when `dt` is dropped and runs the `Drop` code for type `Dt`
+   |      -
+   |      |
+   |      `c_shortest` dropped here while still borrowed
+   |      borrow might be used here, when `dt` is dropped and runs the `Drop` code for type `Dt`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -25,10 +25,10 @@ LL |         pt = Pt("pt", &c_long, &c_shortest);
    |                                ^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     -
-   |     |
-   |     `c_shortest` dropped here while still borrowed
-   |     borrow might be used here, when `pt` is dropped and runs the `Drop` code for type `Pt`
+   |      -
+   |      |
+   |      `c_shortest` dropped here while still borrowed
+   |      borrow might be used here, when `pt` is dropped and runs the `Drop` code for type `Pt`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/dropck/dropck-union.stderr
+++ b/tests/ui/dropck/dropck-union.stderr
@@ -6,10 +6,10 @@ LL |     let v : Wrap<C> = Wrap::new(C(Cell::new(None)));
 LL |     v.0.set(Some(&v));
    |                  ^^ borrowed value does not live long enough
 LL | }
-   | -
-   | |
-   | `v` dropped here while still borrowed
-   | borrow might be used here, when `v` is dropped and runs the `Drop` code for type `Wrap`
+   |  -
+   |  |
+   |  `v` dropped here while still borrowed
+   |  borrow might be used here, when `v` is dropped and runs the `Drop` code for type `Wrap`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/dropck/dropck_trait_cycle_checked.stderr
+++ b/tests/ui/dropck/dropck_trait_cycle_checked.stderr
@@ -7,7 +7,7 @@ LL |     o1.set0(&o2);
    |             ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `o2` dropped here while still borrowed
+   |  - `o2` dropped here while still borrowed
    |
    = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<(dyn Obj<'_> + 'static)>`
 
@@ -21,7 +21,7 @@ LL |     o1.set1(&o3);
    |             ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `o3` dropped here while still borrowed
+   |  - `o3` dropped here while still borrowed
    |
    = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<(dyn Obj<'_> + 'static)>`
 
@@ -63,7 +63,7 @@ LL |     o3.set0(&o1);
    |             ^^^ borrowed value does not live long enough
 LL |     o3.set1(&o2);
 LL | }
-   | - `o1` dropped here while still borrowed
+   |  - `o1` dropped here while still borrowed
    |
    = note: due to object lifetime defaults, `Box<dyn Obj<'_>>` actually means `Box<(dyn Obj<'_> + 'static)>`
 

--- a/tests/ui/dst/dst-bad-coerce3.stderr
+++ b/tests/ui/dst/dst-bad-coerce3.stderr
@@ -12,7 +12,7 @@ LL |     let f3: &'a Fat<[isize]> = f2;
    |             ---------------- type annotation requires that `f1` is borrowed for `'a`
 ...
 LL | }
-   | - `f1` dropped here while still borrowed
+   |  - `f1` dropped here while still borrowed
 
 error[E0597]: `f1` does not live long enough
   --> $DIR/dst-bad-coerce3.rs:19:25
@@ -27,7 +27,7 @@ LL |     let f2: &Fat<Foo> = &f1;
 LL |     let f3: &'a Fat<dyn Bar> = f2;
    |             ---------------- type annotation requires that `f1` is borrowed for `'a`
 LL | }
-   | - `f1` dropped here while still borrowed
+   |  - `f1` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0597.stderr
+++ b/tests/ui/error-codes/E0597.stderr
@@ -7,10 +7,10 @@ LL |     x.x = Some(&y);
    |                ^^ borrowed value does not live long enough
 LL |
 LL | }
-   | -
-   | |
-   | `y` dropped here while still borrowed
-   | borrow might be used here, when `x` is dropped and runs the `Drop` code for type `Foo`
+   |  -
+   |  |
+   |  `y` dropped here while still borrowed
+   |  borrow might be used here, when `x` is dropped and runs the `Drop` code for type `Foo`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/feature-gates/feature-gate-shorter_tail_lifetimes.stderr
+++ b/tests/ui/feature-gates/feature-gate-shorter_tail_lifetimes.stderr
@@ -9,10 +9,10 @@ LL |     c.borrow().len()
    |     borrowed value does not live long enough
    |     a temporary with access to the borrow is created here ...
 LL | }
-   | -
-   | |
-   | `c` dropped here while still borrowed
-   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, &str>`
+   |  -
+   |  |
+   |  `c` dropped here while still borrowed
+   |  ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, &str>`
    |
    = note: the temporary is part of an expression at the end of a block;
            consider forcing this temporary to be dropped sooner, before the block's local variables are dropped

--- a/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
+++ b/tests/ui/fn/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.stderr
@@ -61,7 +61,7 @@ LL |    object = &object2;
    |    assignment requires that `object2` is borrowed for `'1`
 ...
 LL | }
-   | - `object2` dropped here while still borrowed
+   |  - `object2` dropped here while still borrowed
 
 error: value assigned to `object` is never read
   --> $DIR/mut-arg-of-borrowed-type-meant-to-be-arg-of-mut-borrow.rs:22:5

--- a/tests/ui/fn/suggest-return-closure.stderr
+++ b/tests/ui/fn/suggest-return-closure.stderr
@@ -54,9 +54,10 @@ LL |         x.push(c);
    |         ^ borrowed value does not live long enough
 ...
 LL | }
-   | -- borrow later used here
-   | |
-   | `x` dropped here while still borrowed
+   |  -
+   |  |
+   |  `x` dropped here while still borrowed
+   |  borrow later used here
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
+++ b/tests/ui/generic-associated-types/bugs/hrtb-implied-1.stderr
@@ -7,7 +7,7 @@ LL |     let windows = WindowsMut { slice };
 LL |     print_items::<WindowsMut<'_>>(windows);
    |     -------------------------------------- argument requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
    |
 note: due to current limitations in the borrow checker, this implies a `'static` lifetime
   --> $DIR/hrtb-implied-1.rs:26:26

--- a/tests/ui/impl-trait/feature-self-return-type.stderr
+++ b/tests/ui/impl-trait/feature-self-return-type.stderr
@@ -9,7 +9,7 @@ LL |             Foo::new(&bar).into()
    |                      ^^^^ borrowed value does not live long enough
 LL |
 LL |         };
-   |         - `bar` dropped here while still borrowed
+   |          - `bar` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/feature-self-return-type.rs:62:17
@@ -22,7 +22,7 @@ LL |             foo(&y)
    |                 ^^ borrowed value does not live long enough
 LL |
 LL |         };
-   |         - `y` dropped here while still borrowed
+   |          - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/feature-self-return-type.rs:94:17
@@ -35,7 +35,7 @@ LL |             foo(&y)
    |                 ^^ borrowed value does not live long enough
 LL |
 LL |         };
-   |         - `y` dropped here while still borrowed
+   |          - `y` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/impl-trait/in-bindings/lifetime-failure.stderr
+++ b/tests/ui/impl-trait/in-bindings/lifetime-failure.stderr
@@ -9,7 +9,7 @@ LL |     let _: W<impl Static> = W(&local);
    |            type annotation requires that `local` is borrowed for `'static`
 LL |
 LL | }
-   | - `local` dropped here while still borrowed
+   |  - `local` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/in-bindings/nesting-lifetime-failure.stderr
+++ b/tests/ui/impl-trait/in-bindings/nesting-lifetime-failure.stderr
@@ -9,7 +9,7 @@ LL |     let _: impl IntoIterator<Item = impl Static> = [&local];
    |            type annotation requires that `local` is borrowed for `'static`
 LL |
 LL | }
-   | - `local` dropped here while still borrowed
+   |  - `local` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/precise-capturing/migration-note.stderr
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.stderr
@@ -11,7 +11,7 @@ LL |     display_len(&x)
    |     argument requires that `x` is borrowed for `'static`
 ...
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
   --> $DIR/migration-note.rs:19:5
@@ -48,7 +48,7 @@ LL |     needs_static(a);
    |     --------------- argument requires that `x` is borrowed for `'static`
 LL |
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
   --> $DIR/migration-note.rs:29:13
@@ -73,7 +73,7 @@ LL |     mv(x);
    |        ^ move out of `x` occurs here
 ...
 LL | }
-   | - borrow might be used here, when `a` is dropped and runs the destructor for type `impl std::fmt::Display`
+   |  - borrow might be used here, when `a` is dropped and runs the destructor for type `impl std::fmt::Display`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
   --> $DIR/migration-note.rs:43:13
@@ -124,7 +124,7 @@ LL |     needs_static(a);
    |     --------------- argument requires that `x` is borrowed for `'static`
 LL |
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
   --> $DIR/migration-note.rs:76:13
@@ -149,7 +149,7 @@ LL |     mv(x);
    |        ^ move out of `x` occurs here
 ...
 LL | }
-   | - borrow might be used here, when `a` is dropped and runs the destructor for type `impl std::fmt::Display`
+   |  - borrow might be used here, when `a` is dropped and runs the destructor for type `impl std::fmt::Display`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
   --> $DIR/migration-note.rs:90:13
@@ -241,10 +241,10 @@ LL |         x = display_len(&z.f);
    |                         ^^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - `z.f` dropped here while still borrowed
+   |      - `z.f` dropped here while still borrowed
 LL |
 LL | }
-   | - borrow might be used here, when `x` is dropped and runs the destructor for type `impl std::fmt::Display`
+   |  - borrow might be used here, when `x` is dropped and runs the destructor for type `impl std::fmt::Display`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
@@ -261,9 +261,9 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/migration-note.rs:170:40
    |
 LL |     let x = { let x = display_len(&mut vec![0]); x };
-   |                                        ^^^^^^^ - - borrow later used here
-   |                                        |       |
-   |                                        |       temporary value is freed at the end of this statement
+   |                                        ^^^^^^^  -- borrow later used here
+   |                                        |        |
+   |                                        |        temporary value is freed at the end of this statement
    |                                        creates a temporary value which is freed while still in use
    |
    = note: consider using a `let` binding to create a longer lived value
@@ -291,7 +291,7 @@ LL |     drop(x);
    |          ^ move out of `x` occurs here
 ...
 LL | }
-   | - borrow might be used here, when `y` is dropped and runs the destructor for type `impl Sized`
+   |  - borrow might be used here, when `y` is dropped and runs the destructor for type `impl Sized`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
   --> $DIR/migration-note.rs:195:13

--- a/tests/ui/implied-bounds/assoc-ty-wf-used-to-get-assoc-ty.stderr
+++ b/tests/ui/implied-bounds/assoc-ty-wf-used-to-get-assoc-ty.stderr
@@ -10,7 +10,7 @@ LL |     let _: &'static u8 = test(&x, &&3);
    |                          argument requires that `x` is borrowed for `'static`
 ...
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy-1.stderr
+++ b/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy-1.stderr
@@ -7,7 +7,7 @@ LL |         subs_to_soup((x.as_str(), &mut d));
    |                       ^ borrowed value does not live long enough
 LL |
 LL |     }
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 LL |     println!("{}", d);
    |                    - borrow later used here
 

--- a/tests/ui/inline-const/const-expr-lifetime-err.stderr
+++ b/tests/ui/inline-const/const-expr-lifetime-err.stderr
@@ -11,7 +11,7 @@ LL |     equate(InvariantRef::new(&y), const { InvariantRef::<'a>::NEW });
    |                              borrowed value does not live long enough
 LL |
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inline-const/promotion.stderr
+++ b/tests/ui/inline-const/promotion.stderr
@@ -7,7 +7,7 @@ LL |             let _x: &'static i32 = &div_by_zero();
    |                     type annotation requires that borrow lasts for `'static`
 LL |
 LL |         }
-   |         - temporary value is freed at the end of this statement
+   |          - temporary value is freed at the end of this statement
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inline-const/using-late-bound-from-closure.stderr
+++ b/tests/ui/inline-const/using-late-bound-from-closure.stderr
@@ -12,7 +12,7 @@ LL |             let _: &'a () = &awd;
    |                    type annotation requires that `awd` is borrowed for `'a`
 LL |
 LL |         };
-   |         - `awd` dropped here while still borrowed
+   |          - `awd` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-18783.stderr
+++ b/tests/ui/issues/issue-18783.stderr
@@ -11,7 +11,7 @@ LL |     c.push(Box::new(|| y = 0));
    |                     second mutable borrow occurs here
 LL |
 LL | }
-   | - first borrow might be used here, when `c` is dropped and runs the destructor for type `RefCell<Vec<Box<dyn FnMut()>>>`
+   |  - first borrow might be used here, when `c` is dropped and runs the destructor for type `RefCell<Vec<Box<dyn FnMut()>>>`
 
 error[E0499]: cannot borrow `y` as mutable more than once at a time
   --> $DIR/issue-18783.rs:16:29
@@ -26,7 +26,7 @@ LL |     Push::push(&c, Box::new(|| y = 0));
    |                             second mutable borrow occurs here
 LL |
 LL | }
-   | - first borrow might be used here, when `c` is dropped and runs the destructor for type `RefCell<Vec<Box<dyn FnMut()>>>`
+   |  - first borrow might be used here, when `c` is dropped and runs the destructor for type `RefCell<Vec<Box<dyn FnMut()>>>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-29861.stderr
+++ b/tests/ui/issues/issue-29861.stderr
@@ -8,9 +8,10 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-29861.rs:16:43
    |
 LL | fn foo() -> <String as MakeRef2>::Ref2 { &String::from("foo") }
-   |                                           ^^^^^^^^^^^^^^^^^^^ -- borrow later used here
-   |                                           |                   |
-   |                                           |                   temporary value is freed at the end of this statement
+   |                                           ^^^^^^^^^^^^^^^^^^^  -
+   |                                           |                    |
+   |                                           |                    temporary value is freed at the end of this statement
+   |                                           |                    borrow later used here
    |                                           creates a temporary value which is freed while still in use
    |
    = note: consider using a `let` binding to create a longer lived value

--- a/tests/ui/issues/issue-46471-1.stderr
+++ b/tests/ui/issues/issue-46471-1.stderr
@@ -6,7 +6,7 @@ LL |         let mut z = 0;
 LL |         &mut z
    |         ^^^^^^ borrowed value does not live long enough
 LL |     };
-   |     - `z` dropped here while still borrowed
+   |      - `z` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-47184.stderr
+++ b/tests/ui/issues/issue-47184.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-47184.rs:2:44
    |
 LL |     let _vec: Vec<&'static String> = vec![&String::new()];
-   |               --------------------         ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |               --------------------         ^^^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |               |                            |
    |               |                            creates a temporary value which is freed while still in use
    |               type annotation requires that borrow lasts for `'static`

--- a/tests/ui/issues/issue-52049.stderr
+++ b/tests/ui/issues/issue-52049.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-52049.rs:6:10
    |
 LL |     foo(&unpromotable(5u32));
-   |     -----^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+   |     -----^^^^^^^^^^^^^^^^^^- - temporary value is freed at the end of this statement
    |     |    |
    |     |    creates a temporary value which is freed while still in use
    |     argument requires that borrow lasts for `'static`

--- a/tests/ui/issues/issue-52126-assign-op-invariance.stderr
+++ b/tests/ui/issues/issue-52126-assign-op-invariance.stderr
@@ -10,7 +10,7 @@ LL |         acc += cnt2;
    |         --- borrow later used here
 ...
 LL |     }
-   |     - `line` dropped here while still borrowed
+   |      - `line` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/tests/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/borrowck-let-suggestion.rs:2:17
    |
 LL |     let mut x = vec![1].iter();
-   |                 ^^^^^^^       - temporary value is freed at the end of this statement
+   |                 ^^^^^^^        - temporary value is freed at the end of this statement
    |                 |
    |                 creates a temporary value which is freed while still in use
 LL |

--- a/tests/ui/lifetimes/refcell-in-tail-expr.edition2021.stderr
+++ b/tests/ui/lifetimes/refcell-in-tail-expr.edition2021.stderr
@@ -11,10 +11,10 @@ LL |     if let Ok(mut byte) = cell.try_borrow_mut() {
    |                           a temporary with access to the borrow is created here ...
 ...
 LL | }
-   | -
-   | |
-   | `cell` dropped here while still borrowed
-   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Result<RefMut<'_, u8>, BorrowMutError>`
+   |  -
+   |  |
+   |  `cell` dropped here while still borrowed
+   |  ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Result<RefMut<'_, u8>, BorrowMutError>`
    |
 help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
    |

--- a/tests/ui/lifetimes/shorter-tail-expr-lifetime.edition2021.stderr
+++ b/tests/ui/lifetimes/shorter-tail-expr-lifetime.edition2021.stderr
@@ -9,10 +9,10 @@ LL |     c.borrow().len()
    |     borrowed value does not live long enough
    |     a temporary with access to the borrow is created here ...
 LL | }
-   | -
-   | |
-   | `c` dropped here while still borrowed
-   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, &str>`
+   |  -
+   |  |
+   |  `c` dropped here while still borrowed
+   |  ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, &str>`
    |
    = note: the temporary is part of an expression at the end of a block;
            consider forcing this temporary to be dropped sooner, before the block's local variables are dropped

--- a/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
+++ b/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
@@ -2,9 +2,9 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/tail-expr-in-nested-expr.rs:4:15
    |
 LL |     let _ = { String::new().as_str() }.len();
-   |               ^^^^^^^^^^^^^        -   --- borrow later used by call
-   |               |                    |
-   |               |                    temporary value is freed at the end of this statement
+   |               ^^^^^^^^^^^^^         -  --- borrow later used by call
+   |               |                     |
+   |               |                     temporary value is freed at the end of this statement
    |               creates a temporary value which is freed while still in use
    |
    = note: consider using a `let` binding to create a longer lived value

--- a/tests/ui/lint/lint-unconditional-drop-recursion.stderr
+++ b/tests/ui/lint/lint-unconditional-drop-recursion.stderr
@@ -4,7 +4,7 @@ error: function cannot return without recursing
 LL |     fn drop(&mut self) {
    |     ^^^^^^^^^^^^^^^^^^ cannot return without recursing
 LL |         let _ = RecursiveDrop;
-   |                              - recursive call site
+   |                               - recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
 note: the lint level is defined here

--- a/tests/ui/macros/format-args-temporaries-in-write.stderr
+++ b/tests/ui/macros/format-args-temporaries-in-write.stderr
@@ -10,9 +10,9 @@ LL |         write!(Out, "{}", mutex.lock()) /* no semicolon */
    |                           a temporary with access to the borrow is created here ...
 LL |
 LL |     };
-   |     -- ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `MutexGuard`
-   |     |
-   |     `mutex` dropped here while still borrowed
+   |      -- ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `MutexGuard`
+   |      |
+   |      `mutex` dropped here while still borrowed
    |
 
 error[E0597]: `mutex` does not live long enough
@@ -27,9 +27,9 @@ LL |         writeln!(Out, "{}", mutex.lock()) /* no semicolon */
    |                             a temporary with access to the borrow is created here ...
 LL |
 LL |     };
-   |     -- ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `MutexGuard`
-   |     |
-   |     `mutex` dropped here while still borrowed
+   |      -- ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `MutexGuard`
+   |      |
+   |      `mutex` dropped here while still borrowed
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/match/issue-74050-end-span.stderr
+++ b/tests/ui/match/issue-74050-end-span.stderr
@@ -9,7 +9,7 @@ LL |             match arg.to_str() {
    |                   ^^^ borrowed value does not live long enough
 ...
 LL |         }
-   |         - `arg` dropped here while still borrowed
+   |          - `arg` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/mir/drop-elaboration-after-borrowck-error.stderr
+++ b/tests/ui/mir/drop-elaboration-after-borrowck-error.stderr
@@ -14,7 +14,7 @@ LL |     let a: [String; 1];
    |         ^ the destructor for this type cannot be evaluated in statics
 ...
 LL | };
-   | - value is dropped here
+   |  - value is dropped here
 
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
   --> $DIR/drop-elaboration-after-borrowck-error.rs:17:9
@@ -32,7 +32,7 @@ LL |         let _this = self;
    |             ^^^^^ the destructor for this type cannot be evaluated in constant functions
 ...
 LL |     }
-   |     - value is dropped here
+   |      - value is dropped here
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/nll/borrowed-local-error.stderr
+++ b/tests/ui/nll/borrowed-local-error.stderr
@@ -9,7 +9,7 @@ LL |         &v
    |         ^^ borrowed value does not live long enough
 LL |
 LL |     });
-   |     - `v` dropped here while still borrowed
+   |      - `v` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/borrowed-temporary-error.stderr
+++ b/tests/ui/nll/borrowed-temporary-error.stderr
@@ -5,7 +5,7 @@ LL |         &(v,)
    |          ^^^^ creates a temporary value which is freed while still in use
 LL |
 LL |     });
-   |       - temporary value is freed at the end of this statement
+   |        - temporary value is freed at the end of this statement
 LL |     println!("{:?}", x);
    |                      - borrow later used here
    |

--- a/tests/ui/nll/capture-ref-in-struct.stderr
+++ b/tests/ui/nll/capture-ref-in-struct.stderr
@@ -8,7 +8,7 @@ LL |             y: &y,
    |                ^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - `y` dropped here while still borrowed
+   |      - `y` dropped here while still borrowed
 LL |
 LL |     deref(p);
    |           - borrow later used here

--- a/tests/ui/nll/check-normalized-sig-for-wf.current.stderr
+++ b/tests/ui/nll/check-normalized-sig-for-wf.current.stderr
@@ -11,7 +11,7 @@ LL |     f(&s).0
    |     argument requires that `s` is borrowed for `'static`
 LL |
 LL | }
-   | - `s` dropped here while still borrowed
+   |  - `s` dropped here while still borrowed
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/check-normalized-sig-for-wf.rs:19:5

--- a/tests/ui/nll/check-normalized-sig-for-wf.next.stderr
+++ b/tests/ui/nll/check-normalized-sig-for-wf.next.stderr
@@ -11,7 +11,7 @@ LL |     f(&s).0
    |     argument requires that `s` is borrowed for `'static`
 LL |
 LL | }
-   | - `s` dropped here while still borrowed
+   |  - `s` dropped here while still borrowed
 
 error[E0521]: borrowed data escapes outside of function
   --> $DIR/check-normalized-sig-for-wf.rs:19:5

--- a/tests/ui/nll/closure-borrow-spans.stderr
+++ b/tests/ui/nll/closure-borrow-spans.stderr
@@ -32,7 +32,7 @@ LL |         f = || x;
    |             |
    |             value captured here
 LL |     }
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 LL |     f.use_ref();
    |     - borrow later used here
 
@@ -94,7 +94,7 @@ LL |         f = || x = 0;
    |             |
    |             value captured here
 LL |     }
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 LL |     f.use_ref();
    |     - borrow later used here
 
@@ -156,7 +156,7 @@ LL |         f = || *x = 0;
    |             |
    |             value captured here
 LL |     }
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 LL |     f.use_ref();
    |     - borrow later used here
 

--- a/tests/ui/nll/closure-requirements/escape-argument.stderr
+++ b/tests/ui/nll/closure-requirements/escape-argument.stderr
@@ -28,7 +28,7 @@ LL |         closure(&mut p, &y);
    |                         ^^ borrowed value does not live long enough
 LL |
 LL |     }
-   |     - `y` dropped here while still borrowed
+   |      - `y` dropped here while still borrowed
 LL |
 LL |     deref(p);
    |           - borrow later used here

--- a/tests/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/tests/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -46,7 +46,7 @@ LL |             let mut closure1 = || p = &y;
    |                                        ^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - `y` dropped here while still borrowed
+   |      - `y` dropped here while still borrowed
 LL |
 LL |     deref(p);
    |           - borrow later used here

--- a/tests/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/tests/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -31,7 +31,7 @@ LL |         let mut closure = || p = &y;
    |                           value captured here
 ...
 LL |     }
-   |     - `y` dropped here while still borrowed
+   |      - `y` dropped here while still borrowed
 LL |
 LL |     deref(p);
    |           - borrow later used here

--- a/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-comparing-against-free.stderr
@@ -66,7 +66,7 @@ LL |         cell_x.set(cell_a.get()); // forces 'a: 'x, implies 'a = 'static ->
    |         ------------------------ argument requires that `a` is borrowed for `'static`
 LL |     })
 LL | }
-   | - `a` dropped here while still borrowed
+   |  - `a` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
+++ b/tests/ui/nll/closure-requirements/propagate-multiple-requirements.stderr
@@ -12,7 +12,7 @@ LL |         z = &local_arr;
    |              ^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `local_arr` dropped here while still borrowed
+   |  - `local_arr` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/do-not-ignore-lifetime-bounds-in-copy-proj.stderr
+++ b/tests/ui/nll/do-not-ignore-lifetime-bounds-in-copy-proj.stderr
@@ -9,7 +9,7 @@ LL |     drop(a.0);
    |          --- copying this value requires that `s` is borrowed for `'static`
 LL |     drop(a.0);
 LL | }
-   | - `s` dropped here while still borrowed
+   |  - `s` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/do-not-ignore-lifetime-bounds-in-copy.stderr
+++ b/tests/ui/nll/do-not-ignore-lifetime-bounds-in-copy.stderr
@@ -9,7 +9,7 @@ LL |     drop(a);
    |          - copying this value requires that `s` is borrowed for `'static`
 LL |     drop(a);
 LL | }
-   | - `s` dropped here while still borrowed
+   |  - `s` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/dont-print-desugared.stderr
+++ b/tests/ui/nll/dont-print-desugared.stderr
@@ -14,10 +14,10 @@ LL |         let y = ();
 LL |         *d = D(&y);
    |                ^^ borrowed value does not live long enough
 LL |     }
-   |     -
-   |     |
-   |     `y` dropped here while still borrowed
-   |     ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |      -
+   |      |
+   |      `y` dropped here while still borrowed
+   |      ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/drop-no-may-dangle.stderr
+++ b/tests/ui/nll/drop-no-may-dangle.stderr
@@ -8,7 +8,7 @@ LL |         v[0] += 1;
    |         ^^^^^^^^^ `v[_]` is assigned to here but it was already borrowed
 ...
 LL | }
-   | - borrow might be used here, when `p` is dropped and runs the `Drop` code for type `WrapMayNotDangle`
+   |  - borrow might be used here, when `p` is dropped and runs the `Drop` code for type `WrapMayNotDangle`
 
 error[E0506]: cannot assign to `v[_]` because it is borrowed
   --> $DIR/drop-no-may-dangle.rs:21:5
@@ -19,7 +19,7 @@ LL |     let p: WrapMayNotDangle<&usize> = WrapMayNotDangle { value: &v[0] };
 LL |     v[0] += 1;
    |     ^^^^^^^^^ `v[_]` is assigned to here but it was already borrowed
 LL | }
-   | - borrow might be used here, when `p` is dropped and runs the `Drop` code for type `WrapMayNotDangle`
+   |  - borrow might be used here, when `p` is dropped and runs the `Drop` code for type `WrapMayNotDangle`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/enum-drop-access.stderr
+++ b/tests/ui/nll/enum-drop-access.stderr
@@ -10,7 +10,7 @@ LL |             Some(r)
    |             ------- returning this value requires that `*opt.0` is borrowed for `'1`
 ...
 LL | }
-   | - here, drop of `opt` needs exclusive access to `*opt.0`, because the type `DropOption<&mut i32>` implements the `Drop` trait
+   |  - here, drop of `opt` needs exclusive access to `*opt.0`, because the type `DropOption<&mut i32>` implements the `Drop` trait
 
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/enum-drop-access.rs:22:36
@@ -24,7 +24,7 @@ LL |             Some(r)
    |             ------- returning this value requires that `*opt.0.0` is borrowed for `'1`
 ...
 LL | }
-   | - here, drop of `opt` needs exclusive access to `*opt.0.0`, because the type `DropOption<&mut i32>` implements the `Drop` trait
+   |  - here, drop of `opt` needs exclusive access to `*opt.0.0`, because the type `DropOption<&mut i32>` implements the `Drop` trait
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/ice-106874.stderr
+++ b/tests/ui/nll/ice-106874.stderr
@@ -73,16 +73,16 @@ LL |     A(B(C::new(D::new(move |st| f(st)))))
    = note: ...but it actually implements `FnOnce<(&'2 mut V,)>`, for some specific lifetime `'2`
 
 error: higher-ranked subtype error
-  --> $DIR/ice-106874.rs:8:41
+  --> $DIR/ice-106874.rs:8:42
    |
 LL |     A(B(C::new(D::new(move |st| f(st)))))
-   |                                         ^
+   |                                          ^
 
 error: higher-ranked subtype error
-  --> $DIR/ice-106874.rs:8:41
+  --> $DIR/ice-106874.rs:8:42
    |
 LL |     A(B(C::new(D::new(move |st| f(st)))))
-   |                                         ^
+   |                                          ^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/nll/issue-31567.stderr
+++ b/tests/ui/nll/issue-31567.stderr
@@ -9,7 +9,7 @@ LL |     let s_inner: &'a S = &*v.0;
    |                  type annotation requires that `*v.0` is borrowed for `'a`
 LL |     &s_inner.0
 LL | }
-   | - here, drop of `v` needs exclusive access to `*v.0`, because the type `VecWrapper<'_>` implements the `Drop` trait
+   |  - here, drop of `v` needs exclusive access to `*v.0`, because the type `VecWrapper<'_>` implements the `Drop` trait
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/issue-45696-scribble-on-boxed-borrow.stderr
+++ b/tests/ui/nll/issue-45696-scribble-on-boxed-borrow.stderr
@@ -6,7 +6,7 @@ LL | fn scribbled<'a>(s: Scribble<'a>) -> &'a mut u32 {
 LL |     &mut *s.0
    |     ^^^^^^^^^ returning this value requires that `*s.0` is borrowed for `'a`
 LL | }
-   | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
+   |  - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
 
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:39:5
@@ -16,7 +16,7 @@ LL | fn boxed_scribbled<'a>(s: Box<Scribble<'a>>) -> &'a mut u32 {
 LL |     &mut *(*s).0
    |     ^^^^^^^^^^^^ returning this value requires that `*s.0` is borrowed for `'a`
 LL | }
-   | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
+   |  - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
 
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-45696-scribble-on-boxed-borrow.rs:44:5
@@ -26,7 +26,7 @@ LL | fn boxed_boxed_scribbled<'a>(s: Box<Box<Scribble<'a>>>) -> &'a mut u32 {
 LL |     &mut *(**s).0
    |     ^^^^^^^^^^^^^ returning this value requires that `*s.0` is borrowed for `'a`
 LL | }
-   | - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
+   |  - here, drop of `s` needs exclusive access to `*s.0`, because the type `Scribble<'_>` implements the `Drop` trait
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/issue-52059-report-when-borrow-and-drop-conflict.stderr
+++ b/tests/ui/nll/issue-52059-report-when-borrow-and-drop-conflict.stderr
@@ -6,7 +6,7 @@ LL | fn finish_1(s: S) -> &mut String {
 LL |     s.url
    |     ^^^^^ returning this value requires that `*s.url` is borrowed for `'1`
 LL | }
-   | - here, drop of `s` needs exclusive access to `*s.url`, because the type `S<'_>` implements the `Drop` trait
+   |  - here, drop of `s` needs exclusive access to `*s.url`, because the type `S<'_>` implements the `Drop` trait
 
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-52059-report-when-borrow-and-drop-conflict.rs:16:13
@@ -16,7 +16,7 @@ LL | fn finish_2(s: S) -> &mut String {
 LL |     let p = &mut *s.url; p
    |             ^^^^^^^^^^^  - returning this value requires that `*s.url` is borrowed for `'1`
 LL | }
-   | - here, drop of `s` needs exclusive access to `*s.url`, because the type `S<'_>` implements the `Drop` trait
+   |  - here, drop of `s` needs exclusive access to `*s.url`, because the type `S<'_>` implements the `Drop` trait
 
 error[E0713]: borrow may still be in use when destructor runs
   --> $DIR/issue-52059-report-when-borrow-and-drop-conflict.rs:21:21
@@ -26,7 +26,7 @@ LL | fn finish_3(s: S) -> &mut String {
 LL |     let p: &mut _ = s.url; p
    |                     ^^^^^  - returning this value requires that `*s.url` is borrowed for `'1`
 LL | }
-   | - here, drop of `s` needs exclusive access to `*s.url`, because the type `S<'_>` implements the `Drop` trait
+   |  - here, drop of `s` needs exclusive access to `*s.url`, because the type `S<'_>` implements the `Drop` trait
 
 error[E0509]: cannot move out of type `S<'_>`, which implements the `Drop` trait
   --> $DIR/issue-52059-report-when-borrow-and-drop-conflict.rs:26:13

--- a/tests/ui/nll/issue-52534-2.stderr
+++ b/tests/ui/nll/issue-52534-2.stderr
@@ -7,7 +7,7 @@ LL |         y = &x
    |             ^^ borrowed value does not live long enough
 LL |
 LL |     }
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 LL |
 LL |     println!("{}", y);
    |                    - borrow later used here

--- a/tests/ui/nll/issue-52534.stderr
+++ b/tests/ui/nll/issue-52534.stderr
@@ -7,7 +7,7 @@ LL |     foo(|a| &x)
    |          has type `&'0 u32`
 LL |
 LL | }
-   | - ...but `x` will be dropped here, when the function `bar` returns
+   |  - ...but `x` will be dropped here, when the function `bar` returns
    |
    = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#dangling-references>
@@ -21,7 +21,7 @@ LL |     baz(|first, second| &y)
    |          has type `&'0 u32`
 LL |
 LL | }
-   | - ...but `y` will be dropped here, when the function `foobar` returns
+   |  - ...but `y` will be dropped here, when the function `foobar` returns
    |
    = note: functions cannot return a borrow to data owned within the function's scope, functions can only return borrows to data passed as arguments
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#dangling-references>

--- a/tests/ui/nll/issue-52663-trait-object.stderr
+++ b/tests/ui/nll/issue-52663-trait-object.stderr
@@ -8,7 +8,7 @@ LL |         let tmp1 = &tmp0;
 LL |         Box::new(tmp1) as Box<dyn Foo + '_>
    |         ----------------------------------- borrow later captured here by trait object
 LL |     };
-   |     - `tmp0` dropped here while still borrowed
+   |      - `tmp0` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/issue-53773.stderr
+++ b/tests/ui/nll/issue-53773.stderr
@@ -7,7 +7,7 @@ LL |         members.push(child.raw);
    |         borrow later used here
 LL |
 LL |     }
-   |     - here, drop of `child` needs exclusive access to `*child.raw`, because the type `C<'_>` implements the `Drop` trait
+   |      - here, drop of `child` needs exclusive access to `*child.raw`, because the type `C<'_>` implements the `Drop` trait
    |
    = note: consider using a `let` binding to create a longer lived value
 

--- a/tests/ui/nll/issue-54382-use-span-of-tail-of-block.stderr
+++ b/tests/ui/nll/issue-54382-use-span-of-tail-of-block.stderr
@@ -11,10 +11,10 @@ LL |             D("other").next(&_thing1)
    |             a temporary with access to the borrow is created here ...
 ...
 LL |     }
-   |     - `_thing1` dropped here while still borrowed
+   |      - `_thing1` dropped here while still borrowed
 LL |
 LL |     ;
-   |     - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |      - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
    |
 help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
    |

--- a/tests/ui/nll/issue-54556-niconii.edition2021.stderr
+++ b/tests/ui/nll/issue-54556-niconii.edition2021.stderr
@@ -11,10 +11,10 @@ LL |     if let Ok(_) = counter.lock() { }
    |                    a temporary with access to the borrow is created here ...
 ...
 LL | }
-   | -
-   | |
-   | `counter` dropped here while still borrowed
-   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Result<MutexGuard<'_>, ()>`
+   |  -
+   |  |
+   |  `counter` dropped here while still borrowed
+   |  ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Result<MutexGuard<'_>, ()>`
    |
 help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
    |

--- a/tests/ui/nll/issue-54556-stephaneyfx.stderr
+++ b/tests/ui/nll/issue-54556-stephaneyfx.stderr
@@ -9,10 +9,10 @@ LL |     rows.map(|row| row).next()
    |     ------------------- a temporary with access to the borrow is created here ...
 ...
 LL | }
-   | -
-   | |
-   | `stmt` dropped here while still borrowed
-   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Map<Rows<'_>, {closure@$DIR/issue-54556-stephaneyfx.rs:28:14: 28:19}>`
+   |  -
+   |  |
+   |  `stmt` dropped here while still borrowed
+   |  ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Map<Rows<'_>, {closure@$DIR/issue-54556-stephaneyfx.rs:28:14: 28:19}>`
    |
    = note: the temporary is part of an expression at the end of a block;
            consider forcing this temporary to be dropped sooner, before the block's local variables are dropped

--- a/tests/ui/nll/issue-54556-temps-in-tail-diagnostic.stderr
+++ b/tests/ui/nll/issue-54556-temps-in-tail-diagnostic.stderr
@@ -10,10 +10,10 @@ LL |         D(&_thing1).end()
    |         | borrowed value does not live long enough
    |         a temporary with access to the borrow is created here ...
 LL |     }
-   |     - `_thing1` dropped here while still borrowed
+   |      - `_thing1` dropped here while still borrowed
 LL |
 LL |     ;
-   |     - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |      - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
    |
 help: consider adding semicolon after the expression so its temporaries are dropped sooner, before the local variables declared by the block are dropped
    |

--- a/tests/ui/nll/issue-54556-used-vs-unused-tails.stderr
+++ b/tests/ui/nll/issue-54556-used-vs-unused-tails.stderr
@@ -2,9 +2,9 @@ error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:10:55
    |
 LL |     {              let mut _t1 = D(Box::new("t1")); D(&_t1).end()    } ; // suggest `;`
-   |                        -------                      --^^^^-          - - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
-   |                        |                            | |              |
-   |                        |                            | |              `_t1` dropped here while still borrowed
+   |                        -------                      --^^^^-           - - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |                        |                            | |               |
+   |                        |                            | |               `_t1` dropped here while still borrowed
    |                        |                            | borrowed value does not live long enough
    |                        |                            a temporary with access to the borrow is created here ...
    |                        binding `_t1` declared here
@@ -18,9 +18,9 @@ error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:13:55
    |
 LL |     {            { let mut _t1 = D(Box::new("t1")); D(&_t1).end() }  } ; // suggest `;`
-   |                        -------                      --^^^^-       -    - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
-   |                        |                            | |           |
-   |                        |                            | |           `_t1` dropped here while still borrowed
+   |                        -------                      --^^^^-        -    - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |                        |                            | |            |
+   |                        |                            | |            `_t1` dropped here while still borrowed
    |                        |                            | borrowed value does not live long enough
    |                        |                            a temporary with access to the borrow is created here ...
    |                        binding `_t1` declared here
@@ -34,9 +34,9 @@ error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:16:55
    |
 LL |     {            { let mut _t1 = D(Box::new("t1")); D(&_t1).end() }; }   // suggest `;`
-   |                        -------                      --^^^^-       -- ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
-   |                        |                            | |           |
-   |                        |                            | |           `_t1` dropped here while still borrowed
+   |                        -------                      --^^^^-        -- ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |                        |                            | |            |
+   |                        |                            | |            `_t1` dropped here while still borrowed
    |                        |                            | borrowed value does not live long enough
    |                        |                            a temporary with access to the borrow is created here ...
    |                        binding `_t1` declared here
@@ -50,9 +50,9 @@ error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:19:55
    |
 LL |     let _ =      { let mut _t1 = D(Box::new("t1")); D(&_t1).end()    } ; // suggest `;`
-   |                        -------                      --^^^^-          - - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
-   |                        |                            | |              |
-   |                        |                            | |              `_t1` dropped here while still borrowed
+   |                        -------                      --^^^^-           - - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |                        |                            | |               |
+   |                        |                            | |               `_t1` dropped here while still borrowed
    |                        |                            | borrowed value does not live long enough
    |                        |                            a temporary with access to the borrow is created here ...
    |                        binding `_t1` declared here
@@ -66,9 +66,9 @@ error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:22:55
    |
 LL |     let _u =     { let mut _t1 = D(Box::new("t1")); D(&_t1).unit()   } ; // suggest `;`
-   |                        -------                      --^^^^-          - - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
-   |                        |                            | |              |
-   |                        |                            | |              `_t1` dropped here while still borrowed
+   |                        -------                      --^^^^-           - - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |                        |                            | |               |
+   |                        |                            | |               `_t1` dropped here while still borrowed
    |                        |                            | borrowed value does not live long enough
    |                        |                            a temporary with access to the borrow is created here ...
    |                        binding `_t1` declared here
@@ -82,9 +82,9 @@ error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:25:55
    |
 LL |     let _x =     { let mut _t1 = D(Box::new("t1")); D(&_t1).end()    } ; // `let x = ...; x`
-   |                        -------                      --^^^^-          - - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
-   |                        |                            | |              |
-   |                        |                            | |              `_t1` dropped here while still borrowed
+   |                        -------                      --^^^^-           - - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |                        |                            | |               |
+   |                        |                            | |               `_t1` dropped here while still borrowed
    |                        |                            | borrowed value does not live long enough
    |                        |                            a temporary with access to the borrow is created here ...
    |                        binding `_t1` declared here
@@ -100,9 +100,9 @@ error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:30:55
    |
 LL |     _y =         { let mut _t1 = D(Box::new("t1")); D(&_t1).end() } ; // `let x = ...; x`
-   |                        -------                      --^^^^-       - - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
-   |                        |                            | |           |
-   |                        |                            | |           `_t1` dropped here while still borrowed
+   |                        -------                      --^^^^-        - - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |                        |                            | |            |
+   |                        |                            | |            `_t1` dropped here while still borrowed
    |                        |                            | borrowed value does not live long enough
    |                        |                            a temporary with access to the borrow is created here ...
    |                        binding `_t1` declared here
@@ -118,10 +118,10 @@ error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:37:55
    |
 LL | fn f_local_ref() { let mut _t1 = D(Box::new("t1")); D(&_t1).unit()   }  // suggest `;`
-   |                        -------                      --^^^^-          -
-   |                        |                            | |              |
-   |                        |                            | |              `_t1` dropped here while still borrowed
-   |                        |                            | |              ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |                        -------                      --^^^^-           -
+   |                        |                            | |               |
+   |                        |                            | |               `_t1` dropped here while still borrowed
+   |                        |                            | |               ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
    |                        |                            | borrowed value does not live long enough
    |                        |                            a temporary with access to the borrow is created here ...
    |                        binding `_t1` declared here
@@ -135,10 +135,10 @@ error[E0597]: `_t1` does not live long enough
   --> $DIR/issue-54556-used-vs-unused-tails.rs:40:55
    |
 LL | fn f() -> String { let mut _t1 = D(Box::new("t1")); D(&_t1).end()   }   // `let x = ...; x`
-   |                        -------                      --^^^^-         -
-   |                        |                            | |             |
-   |                        |                            | |             `_t1` dropped here while still borrowed
-   |                        |                            | |             ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
+   |                        -------                      --^^^^-          -
+   |                        |                            | |              |
+   |                        |                            | |              `_t1` dropped here while still borrowed
+   |                        |                            | |              ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
    |                        |                            | borrowed value does not live long enough
    |                        |                            a temporary with access to the borrow is created here ...
    |                        binding `_t1` declared here

--- a/tests/ui/nll/issue-54556-wrap-it-up.stderr
+++ b/tests/ui/nll/issue-54556-wrap-it-up.stderr
@@ -7,7 +7,7 @@ LL |     let wrap = Wrap { p: &mut x };
 LL |     x = 1;
    |     ^^^^^ `x` is assigned to here but it was already borrowed
 LL | }
-   | - borrow might be used here, when `foo` is dropped and runs the destructor for type `Foo<'_>`
+   |  - borrow might be used here, when `foo` is dropped and runs the destructor for type `Foo<'_>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/issue-55511.stderr
+++ b/tests/ui/nll/issue-55511.stderr
@@ -10,7 +10,7 @@ LL |         <() as Foo<'static>>::C => { }
    |         ----------------------- type annotation requires that `a` is borrowed for `'static`
 ...
 LL | }
-   | - `a` dropped here while still borrowed
+   |  - `a` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/issue-57265-return-type-wf-check.stderr
+++ b/tests/ui/nll/issue-57265-return-type-wf-check.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/issue-57265-return-type-wf-check.rs:20:23
    |
 LL |     let (_, z) = foo(&"hello".to_string());
-   |                  -----^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+   |                  -----^^^^^^^^^^^^^^^^^^^- - temporary value is freed at the end of this statement
    |                  |    |
    |                  |    creates a temporary value which is freed while still in use
    |                  argument requires that borrow lasts for `'static`

--- a/tests/ui/nll/issue-68550.stderr
+++ b/tests/ui/nll/issue-68550.stderr
@@ -11,7 +11,7 @@ LL |     let _: &'a A = &x;
    |            |
    |            type annotation requires that `x` is borrowed for `'a`
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/issue-69114-static-mut-ty.stderr
+++ b/tests/ui/nll/issue-69114-static-mut-ty.stderr
@@ -11,7 +11,7 @@ LL |         BAR = &n;
    |         assignment requires that `n` is borrowed for `'static`
 ...
 LL | }
-   | - `n` dropped here while still borrowed
+   |  - `n` dropped here while still borrowed
 
 error[E0597]: `n` does not live long enough
   --> $DIR/issue-69114-static-mut-ty.rs:30:22
@@ -26,7 +26,7 @@ LL |         BAR_ELIDED = &n;
    |         assignment requires that `n` is borrowed for `'static`
 ...
 LL | }
-   | - `n` dropped here while still borrowed
+   |  - `n` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/issue-69114-static-ty.stderr
+++ b/tests/ui/nll/issue-69114-static-ty.stderr
@@ -10,7 +10,7 @@ LL |     FOO(&n);
    |     argument requires that `n` is borrowed for `'static`
 LL |
 LL | }
-   | - `n` dropped here while still borrowed
+   |  - `n` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/local-outlives-static-via-hrtb.stderr
+++ b/tests/ui/nll/local-outlives-static-via-hrtb.stderr
@@ -10,7 +10,7 @@ LL |     assert_static_via_hrtb(&local);
    |     argument requires that `local` is borrowed for `'static`
 LL |     assert_static_via_hrtb_with_assoc_type(&&local);
 LL | }
-   | - `local` dropped here while still borrowed
+   |  - `local` dropped here while still borrowed
    |
 note: due to current limitations in the borrow checker, this implies a `'static` lifetime
   --> $DIR/local-outlives-static-via-hrtb.rs:15:53

--- a/tests/ui/nll/maybe-initialized-drop-implicit-fragment-drop.stderr
+++ b/tests/ui/nll/maybe-initialized-drop-implicit-fragment-drop.stderr
@@ -8,7 +8,7 @@ LL |     x = 1;
    |     ^^^^^ `x` is assigned to here but it was already borrowed
 LL |     // FIXME ^ Should not error in the future with implicit dtors, only manually implemented ones
 LL | }
-   | - borrow might be used here, when `foo` is dropped and runs the destructor for type `Foo<'_>`
+   |  - borrow might be used here, when `foo` is dropped and runs the destructor for type `Foo<'_>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/maybe-initialized-drop-with-fragment.stderr
+++ b/tests/ui/nll/maybe-initialized-drop-with-fragment.stderr
@@ -7,7 +7,7 @@ LL |     let wrap = Wrap { p: &mut x };
 LL |     x = 1;
    |     ^^^^^ `x` is assigned to here but it was already borrowed
 LL | }
-   | - borrow might be used here, when `foo` is dropped and runs the destructor for type `Foo<'_>`
+   |  - borrow might be used here, when `foo` is dropped and runs the destructor for type `Foo<'_>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/maybe-initialized-drop-with-uninitialized-fragments.stderr
+++ b/tests/ui/nll/maybe-initialized-drop-with-uninitialized-fragments.stderr
@@ -8,7 +8,7 @@ LL |     x = 1;
    |     ^^^^^ `x` is assigned to here but it was already borrowed
 LL |     // FIXME ^ This currently errors and it should not.
 LL | }
-   | - borrow might be used here, when `foo` is dropped and runs the destructor for type `Foo<'_>`
+   |  - borrow might be used here, when `foo` is dropped and runs the destructor for type `Foo<'_>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/maybe-initialized-drop.stderr
+++ b/tests/ui/nll/maybe-initialized-drop.stderr
@@ -6,7 +6,7 @@ LL |     let wrap = Wrap { p: &mut x };
 LL |     x = 1;
    |     ^^^^^ `x` is assigned to here but it was already borrowed
 LL | }
-   | - borrow might be used here, when `wrap` is dropped and runs the `Drop` code for type `Wrap`
+   |  - borrow might be used here, when `wrap` is dropped and runs the `Drop` code for type `Wrap`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/missing-universe-cause-issue-114907.stderr
+++ b/tests/ui/nll/missing-universe-cause-issue-114907.stderr
@@ -38,16 +38,16 @@ LL |     accept(callback);
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: higher-ranked subtype error
-  --> $DIR/missing-universe-cause-issue-114907.rs:33:21
+  --> $DIR/missing-universe-cause-issue-114907.rs:33:22
    |
 LL |     accept(callback);
-   |                     ^
+   |                      ^
 
 error: higher-ranked subtype error
-  --> $DIR/missing-universe-cause-issue-114907.rs:33:21
+  --> $DIR/missing-universe-cause-issue-114907.rs:33:22
    |
 LL |     accept(callback);
-   |                     ^
+   |                      ^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.nll.stderr
@@ -11,7 +11,7 @@ LL |     let b = |_| &a;
    |             value captured here
 ...
 LL | }
-   | - `a` dropped here while still borrowed
+   |  - `a` dropped here while still borrowed
    |
 note: due to current limitations in the borrow checker, this implies a `'static` lifetime
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22

--- a/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
+++ b/tests/ui/nll/polonius/location-insensitive-scopes-issue-117146.polonius.stderr
@@ -11,7 +11,7 @@ LL |     let b = |_| &a;
    |             value captured here
 ...
 LL | }
-   | - `a` dropped here while still borrowed
+   |  - `a` dropped here while still borrowed
    |
 note: due to current limitations in the borrow checker, this implies a `'static` lifetime
   --> $DIR/location-insensitive-scopes-issue-117146.rs:20:22

--- a/tests/ui/nll/promoted-bounds.stderr
+++ b/tests/ui/nll/promoted-bounds.stderr
@@ -9,7 +9,7 @@ LL |         let b = &l;
    |                 ^^ borrowed value does not live long enough
 ...
 LL |     };
-   |     - `l` dropped here while still borrowed
+   |      - `l` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/relate_tys/var-appears-twice.stderr
+++ b/tests/ui/nll/relate_tys/var-appears-twice.stderr
@@ -11,7 +11,7 @@ LL |     let x: DoubleCell<_> = make_cell(&b);
    |                            assignment requires that `b` is borrowed for `'static`
 ...
 LL | }
-   | - `b` dropped here while still borrowed
+   |  - `b` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/user-annotations/adt-brace-enums.stderr
+++ b/tests/ui/nll/user-annotations/adt-brace-enums.stderr
@@ -9,7 +9,7 @@ LL |     SomeEnum::SomeVariant::<&'static u32> { t: &c };
    |                                                borrowed value does not live long enough
    |                                                this usage requires that `c` is borrowed for `'static`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-enums.rs:30:43
@@ -24,7 +24,7 @@ LL |     SomeEnum::SomeVariant::<&'a u32> { t: &c };
    |                                           borrowed value does not live long enough
    |                                           this usage requires that `c` is borrowed for `'a`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-enums.rs:40:47
@@ -40,7 +40,7 @@ LL |         SomeEnum::SomeVariant::<&'a u32> { t: &c };
    |                                               borrowed value does not live long enough
    |                                               this usage requires that `c` is borrowed for `'a`
 LL |     };
-   |     - `c` dropped here while still borrowed
+   |      - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/adt-brace-structs.stderr
+++ b/tests/ui/nll/user-annotations/adt-brace-structs.stderr
@@ -9,7 +9,7 @@ LL |     SomeStruct::<&'static u32> { t: &c };
    |                                     borrowed value does not live long enough
    |                                     this usage requires that `c` is borrowed for `'static`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-structs.rs:28:32
@@ -24,7 +24,7 @@ LL |     SomeStruct::<&'a u32> { t: &c };
    |                                borrowed value does not live long enough
    |                                this usage requires that `c` is borrowed for `'a`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-brace-structs.rs:38:36
@@ -40,7 +40,7 @@ LL |         SomeStruct::<&'a u32> { t: &c };
    |                                    borrowed value does not live long enough
    |                                    this usage requires that `c` is borrowed for `'a`
 LL |     };
-   |     - `c` dropped here while still borrowed
+   |      - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/adt-nullary-enums.stderr
+++ b/tests/ui/nll/user-annotations/adt-nullary-enums.stderr
@@ -10,7 +10,7 @@ LL | |         SomeEnum::SomeOtherVariant::<Cell<&'static u32>>,
 LL | |     );
    | |_____- argument requires that `c` is borrowed for `'static`
 LL |   }
-   |   - `c` dropped here while still borrowed
+   |    - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:41:41
@@ -26,7 +26,7 @@ LL | |         SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
 LL | |     );
    | |_____- argument requires that `c` is borrowed for `'a`
 LL |   }
-   |   - `c` dropped here while still borrowed
+   |    - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-nullary-enums.rs:54:45
@@ -43,7 +43,7 @@ LL | |             SomeEnum::SomeOtherVariant::<Cell<&'a u32>>,
 LL | |         );
    | |_________- argument requires that `c` is borrowed for `'a`
 LL |       };
-   |       - `c` dropped here while still borrowed
+   |        - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/adt-tuple-enums.stderr
+++ b/tests/ui/nll/user-annotations/adt-tuple-enums.stderr
@@ -9,7 +9,7 @@ LL |     SomeEnum::SomeVariant::<&'static u32>(&c);
    |                                           borrowed value does not live long enough
    |                                           this usage requires that `c` is borrowed for `'static`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-enums.rs:33:38
@@ -24,7 +24,7 @@ LL |     SomeEnum::SomeVariant::<&'a u32>(&c);
    |                                      borrowed value does not live long enough
    |                                      this usage requires that `c` is borrowed for `'a`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-enums.rs:43:42
@@ -40,7 +40,7 @@ LL |         SomeEnum::SomeVariant::<&'a u32>(&c);
    |                                          borrowed value does not live long enough
    |                                          this usage requires that `c` is borrowed for `'a`
 LL |     };
-   |     - `c` dropped here while still borrowed
+   |      - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
+++ b/tests/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
@@ -8,7 +8,7 @@ LL |     let f = SomeStruct::<&'static u32>;
 LL |     f(&c);
    |       ^^ borrowed value does not live long enough
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct-calls.rs:33:7
@@ -22,7 +22,7 @@ LL |     let f = SomeStruct::<&'a u32>;
 LL |     f(&c);
    |       ^^ borrowed value does not live long enough
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct-calls.rs:45:11
@@ -37,7 +37,7 @@ LL |         let f = SomeStruct::<&'a u32>;
 LL |         f(&c);
    |           ^^ borrowed value does not live long enough
 LL |     };
-   |     - `c` dropped here while still borrowed
+   |      - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct-calls.rs:53:11
@@ -53,7 +53,7 @@ LL |         f(&c);
    |         | borrowed value does not live long enough
    |         argument requires that `c` is borrowed for `'1`
 LL |     };
-   |     - `c` dropped here while still borrowed
+   |      - `c` dropped here while still borrowed
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/nll/user-annotations/adt-tuple-struct.stderr
+++ b/tests/ui/nll/user-annotations/adt-tuple-struct.stderr
@@ -9,7 +9,7 @@ LL |     SomeStruct::<&'static u32>(&c);
    |                                borrowed value does not live long enough
    |                                this usage requires that `c` is borrowed for `'static`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct.rs:28:27
@@ -24,7 +24,7 @@ LL |     SomeStruct::<&'a u32>(&c);
    |                           borrowed value does not live long enough
    |                           this usage requires that `c` is borrowed for `'a`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/adt-tuple-struct.rs:38:31
@@ -40,7 +40,7 @@ LL |         SomeStruct::<&'a u32>(&c);
    |                               borrowed value does not live long enough
    |                               this usage requires that `c` is borrowed for `'a`
 LL |     };
-   |     - `c` dropped here while still borrowed
+   |      - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/cast_static_lifetime.stderr
+++ b/tests/ui/nll/user-annotations/cast_static_lifetime.stderr
@@ -8,7 +8,7 @@ LL |     let y: &u32 = (&x) as &'static u32;
    |                   |
    |                   borrowed value does not live long enough
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/user-annotations/constant-in-expr-inherent-2.stderr
+++ b/tests/ui/nll/user-annotations/constant-in-expr-inherent-2.stderr
@@ -10,7 +10,7 @@ LL |     FUN(&x);
    |     argument requires that `x` is borrowed for `'static`
 ...
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/constant-in-expr-inherent-2.rs:24:23

--- a/tests/ui/nll/user-annotations/fns.stderr
+++ b/tests/ui/nll/user-annotations/fns.stderr
@@ -9,7 +9,7 @@ LL |     some_fn::<&'static u32>(&c);
    |     |                       borrowed value does not live long enough
    |     argument requires that `c` is borrowed for `'static`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/fns.rs:28:24
@@ -24,7 +24,7 @@ LL |     some_fn::<&'a u32>(&c);
    |     |                  borrowed value does not live long enough
    |     argument requires that `c` is borrowed for `'a`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/fns.rs:38:28
@@ -40,7 +40,7 @@ LL |         some_fn::<&'a u32>(&c);
    |         |                  borrowed value does not live long enough
    |         argument requires that `c` is borrowed for `'a`
 LL |     };
-   |     - `c` dropped here while still borrowed
+   |      - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/method-call.stderr
+++ b/tests/ui/nll/user-annotations/method-call.stderr
@@ -9,7 +9,7 @@ LL |     a.method::<&'static u32>(b,  &c);
    |     |                            borrowed value does not live long enough
    |     argument requires that `c` is borrowed for `'static`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-call.rs:43:29
@@ -25,7 +25,7 @@ LL |     a.method::<&'a u32>(b,  &c);
    |     |                       borrowed value does not live long enough
    |     argument requires that `c` is borrowed for `'a`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-call.rs:57:33
@@ -41,7 +41,7 @@ LL |         a.method::<&'a u32>(b,  &c);
    |         |                       borrowed value does not live long enough
    |         argument requires that `c` is borrowed for `'a`
 LL |     };
-   |     - `c` dropped here while still borrowed
+   |      - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/method-ufcs-1.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-1.stderr
@@ -9,7 +9,7 @@ LL |     let x = <&'static u32 as Bazoom<_>>::method;
 LL |     x(&a, b, c);
    |       ^^ borrowed value does not live long enough
 LL | }
-   | - `a` dropped here while still borrowed
+   |  - `a` dropped here while still borrowed
 
 error[E0597]: `a` does not live long enough
   --> $DIR/method-ufcs-1.rs:37:36
@@ -25,7 +25,7 @@ LL |     <&'a u32 as Bazoom<_>>::method(&a, b, c);
    |     |                              borrowed value does not live long enough
    |     argument requires that `a` is borrowed for `'a`
 LL | }
-   | - `a` dropped here while still borrowed
+   |  - `a` dropped here while still borrowed
 
 error[E0597]: `a` does not live long enough
   --> $DIR/method-ufcs-1.rs:51:41
@@ -45,7 +45,7 @@ LL |         <&'a u32 as Bazoom<_>>::method(&a, b, c);
    |         argument requires that `a` is borrowed for `'a`
 LL |     };
 LL | }
-   | - `a` dropped here while still borrowed
+   |  - `a` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/method-ufcs-2.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-2.stderr
@@ -9,7 +9,7 @@ LL |     let x = <&'static u32 as Bazoom<_>>::method;
 LL |     x(&a, b, c);
    |       ^^ borrowed value does not live long enough
 LL | }
-   | - `a` dropped here while still borrowed
+   |  - `a` dropped here while still borrowed
 
 error[E0597]: `b` does not live long enough
   --> $DIR/method-ufcs-2.rs:37:39
@@ -26,7 +26,7 @@ LL |     <_ as Bazoom<&'a u32>>::method(a, &b, c);
    |     |                                 borrowed value does not live long enough
    |     argument requires that `b` is borrowed for `'a`
 LL | }
-   | - `b` dropped here while still borrowed
+   |  - `b` dropped here while still borrowed
 
 error[E0597]: `b` does not live long enough
   --> $DIR/method-ufcs-2.rs:51:44
@@ -46,7 +46,7 @@ LL |         <_ as Bazoom<&'a u32>>::method(a, &b, c);
    |         argument requires that `b` is borrowed for `'a`
 LL |     };
 LL | }
-   | - `b` dropped here while still borrowed
+   |  - `b` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/method-ufcs-3.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-3.stderr
@@ -9,7 +9,7 @@ LL |     <_ as Bazoom<_>>::method::<&'static u32>(&a, b, &c);
    |     |                                               borrowed value does not live long enough
    |     argument requires that `c` is borrowed for `'static`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-ufcs-3.rs:43:48
@@ -25,7 +25,7 @@ LL |     <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
    |     |                                          borrowed value does not live long enough
    |     argument requires that `c` is borrowed for `'a`
 LL | }
-   | - `c` dropped here while still borrowed
+   |  - `c` dropped here while still borrowed
 
 error[E0597]: `c` does not live long enough
   --> $DIR/method-ufcs-3.rs:57:52
@@ -41,7 +41,7 @@ LL |         <_ as Bazoom<_>>::method::<&'a u32>(&a, b, &c);
    |         |                                          borrowed value does not live long enough
    |         argument requires that `c` is borrowed for `'a`
 LL |     };
-   |     - `c` dropped here while still borrowed
+   |      - `c` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/nll/user-annotations/method-ufcs-inherent-1.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-inherent-1.stderr
@@ -12,7 +12,7 @@ LL |     let x = A::<'a>::new(&v, 22);
    |             argument requires that `v` is borrowed for `'a`
 LL |
 LL | }
-   | - `v` dropped here while still borrowed
+   |  - `v` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/user-annotations/method-ufcs-inherent-2.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-inherent-2.stderr
@@ -12,7 +12,7 @@ LL |     let x = A::<'a>::new::<&'a u32>(&v, &v);
    |             argument requires that `v` is borrowed for `'a`
 ...
 LL | }
-   | - `v` dropped here while still borrowed
+   |  - `v` dropped here while still borrowed
 
 error[E0597]: `v` does not live long enough
   --> $DIR/method-ufcs-inherent-2.rs:14:41

--- a/tests/ui/nll/user-annotations/method-ufcs-inherent-3.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-inherent-3.stderr
@@ -12,7 +12,7 @@ LL |     let x = <A<'a>>::new(&v, 22);
    |             argument requires that `v` is borrowed for `'a`
 LL |
 LL | }
-   | - `v` dropped here while still borrowed
+   |  - `v` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/user-annotations/method-ufcs-inherent-4.stderr
+++ b/tests/ui/nll/user-annotations/method-ufcs-inherent-4.stderr
@@ -12,7 +12,7 @@ LL |     let x = <A<'a>>::new::<&'a u32>(&v, &v);
    |             argument requires that `v` is borrowed for `'a`
 ...
 LL | }
-   | - `v` dropped here while still borrowed
+   |  - `v` dropped here while still borrowed
 
 error[E0597]: `v` does not live long enough
   --> $DIR/method-ufcs-inherent-4.rs:15:41

--- a/tests/ui/nll/user-annotations/normalization-infer.stderr
+++ b/tests/ui/nll/user-annotations/normalization-infer.stderr
@@ -105,13 +105,13 @@ LL |     let _: Alias<_, _> = (&temp(), 0u8);
    |            type annotation requires that borrow lasts for `'static`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/normalization-infer.rs:33:27
    |
 LL |     Some::<Alias<_, _>>((&temp(), 0u8));
-   |                         --^^^^^^------ - temporary value is freed at the end of this statement
+   |                         --^^^^^^------  - temporary value is freed at the end of this statement
    |                         | |
    |                         | creates a temporary value which is freed while still in use
    |                         this usage requires that borrow lasts for `'static`

--- a/tests/ui/nll/user-annotations/normalization.stderr
+++ b/tests/ui/nll/user-annotations/normalization.stderr
@@ -9,7 +9,7 @@ LL |     let _: <() as Foo>::Out = &a;
    |            type annotation requires that `a` is borrowed for `'static`
 ...
 LL | }
-   | - `a` dropped here while still borrowed
+   |  - `a` dropped here while still borrowed
 
 error[E0597]: `a` does not live long enough
   --> $DIR/normalization.rs:13:40
@@ -22,7 +22,7 @@ LL |     let _: <&'static () as Foo>::Out = &a;
    |            type annotation requires that `a` is borrowed for `'static`
 ...
 LL | }
-   | - `a` dropped here while still borrowed
+   |  - `a` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
+++ b/tests/ui/nll/user-annotations/pattern_substs_on_brace_enum_variant.stderr
@@ -9,7 +9,7 @@ LL |
 LL |     let Foo::Bar::<'static> { field: _z } = foo;
    |         --------------------------------- type annotation requires that `y` is borrowed for `'static`
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_brace_enum_variant.rs:14:33
@@ -23,7 +23,7 @@ LL |         Foo::Bar::<'static> { field: _z } => {
    |         --------------------------------- type annotation requires that `y` is borrowed for `'static`
 ...
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/user-annotations/pattern_substs_on_brace_struct.stderr
+++ b/tests/ui/nll/user-annotations/pattern_substs_on_brace_struct.stderr
@@ -9,7 +9,7 @@ LL |
 LL |     let Foo::<'static> { field: _z } = foo;
    |         ---------------------------- type annotation requires that `y` is borrowed for `'static`
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_brace_struct.rs:12:28
@@ -23,7 +23,7 @@ LL |         Foo::<'static> { field: _z } => {
    |         ---------------------------- type annotation requires that `y` is borrowed for `'static`
 ...
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
+++ b/tests/ui/nll/user-annotations/pattern_substs_on_tuple_enum_variant.stderr
@@ -9,7 +9,7 @@ LL |
 LL |     let Foo::Bar::<'static>(_z) = foo;
    |         ----------------------- type annotation requires that `y` is borrowed for `'static`
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_tuple_enum_variant.rs:14:24
@@ -23,7 +23,7 @@ LL |         Foo::Bar::<'static>(_z) => {
    |         ----------------------- type annotation requires that `y` is borrowed for `'static`
 ...
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/user-annotations/pattern_substs_on_tuple_struct.stderr
+++ b/tests/ui/nll/user-annotations/pattern_substs_on_tuple_struct.stderr
@@ -9,7 +9,7 @@ LL |
 LL |     let Foo::<'static>(_z) = foo;
    |         ------------------ type annotation requires that `y` is borrowed for `'static`
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/pattern_substs_on_tuple_struct.rs:12:19
@@ -23,7 +23,7 @@ LL |         Foo::<'static>(_z) => {
    |         ------------------ type annotation requires that `y` is borrowed for `'static`
 ...
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/nll/user-annotations/patterns.stderr
+++ b/tests/ui/nll/user-annotations/patterns.stderr
@@ -8,7 +8,7 @@ LL |     let y: &'static u32;
 LL |     y = &x;
    |         ^^ borrowed value does not live long enough
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:14:9
@@ -20,7 +20,7 @@ LL |     let (y, z): (&'static u32, &'static u32);
 LL |     y = &x;
    |         ^^ borrowed value does not live long enough
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:20:13
@@ -33,7 +33,7 @@ LL |     let ref z: &'static u32 = y;
    |                ------------ type annotation requires that `x` is borrowed for `'static`
 LL |     **z
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:39:9
@@ -45,7 +45,7 @@ LL |     let Single { value: y }: Single<&'static u32>;
 LL |     y = &x;
    |         ^^ borrowed value does not live long enough
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:51:10
@@ -57,7 +57,7 @@ LL |     let Single2 { value: mut _y }: Single2<StaticU32>;
 LL |     _y = &x;
    |          ^^ borrowed value does not live long enough
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:56:27
@@ -69,7 +69,7 @@ LL |     let y: &'static u32 = &x;
    |            |
    |            type annotation requires that `x` is borrowed for `'static`
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:61:27
@@ -82,13 +82,13 @@ LL |     let _: &'static u32 = &x;
    |            type annotation requires that `x` is borrowed for `'static`
 ...
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/patterns.rs:63:41
    |
 LL |     let _: Vec<&'static String> = vec![&String::new()];
-   |            --------------------         ^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |            --------------------         ^^^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |            |                            |
    |            |                            creates a temporary value which is freed while still in use
    |            type annotation requires that borrow lasts for `'static`
@@ -97,7 +97,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/patterns.rs:66:52
    |
 LL |     let (_, a): (Vec<&'static String>, _) = (vec![&String::new()], 44);
-   |                 -------------------------          ^^^^^^^^^^^^^      - temporary value is freed at the end of this statement
+   |                 -------------------------          ^^^^^^^^^^^^^       - temporary value is freed at the end of this statement
    |                 |                                  |
    |                 |                                  creates a temporary value which is freed while still in use
    |                 type annotation requires that borrow lasts for `'static`
@@ -106,7 +106,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/patterns.rs:69:53
    |
 LL |     let (_a, b): (Vec<&'static String>, _) = (vec![&String::new()], 44);
-   |                  -------------------------          ^^^^^^^^^^^^^      - temporary value is freed at the end of this statement
+   |                  -------------------------          ^^^^^^^^^^^^^       - temporary value is freed at the end of this statement
    |                  |                                  |
    |                  |                                  creates a temporary value which is freed while still in use
    |                  type annotation requires that borrow lasts for `'static`
@@ -121,7 +121,7 @@ LL |     let (_, _): (&'static u32, u32) = (&x, 44);
    |                 |
    |                 type annotation requires that `x` is borrowed for `'static`
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:80:40
@@ -133,7 +133,7 @@ LL |     let (y, _): (&'static u32, u32) = (&x, 44);
    |                 |
    |                 type annotation requires that `x` is borrowed for `'static`
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:85:69
@@ -145,7 +145,7 @@ LL |     let Single { value: y }: Single<&'static u32> = Single { value: &x };
    |                              |
    |                              type annotation requires that `x` is borrowed for `'static`
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:90:69
@@ -157,7 +157,7 @@ LL |     let Single { value: _ }: Single<&'static u32> = Single { value: &x };
    |                              |
    |                              type annotation requires that `x` is borrowed for `'static`
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/patterns.rs:98:17
@@ -170,7 +170,7 @@ LL |         value1: &x,
    |                 ^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error: lifetime may not live long enough
   --> $DIR/patterns.rs:111:5

--- a/tests/ui/nll/user-annotations/promoted-annotation.stderr
+++ b/tests/ui/nll/user-annotations/promoted-annotation.stderr
@@ -11,7 +11,7 @@ LL |     f(&x);
    |       ^^ borrowed value does not live long enough
 LL |
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/nll/user-annotations/type_ascription_static_lifetime.stderr
+++ b/tests/ui/nll/user-annotations/type_ascription_static_lifetime.stderr
@@ -8,7 +8,7 @@ LL |     let y: &u32 = type_ascribe!(&x, &'static u32);
    |                                 |
    |                                 borrowed value does not live long enough
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
+++ b/tests/ui/parser/variadic-ffi-semantic-restrictions.stderr
@@ -205,7 +205,7 @@ error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
   --> $DIR/variadic-ffi-semantic-restrictions.rs:32:43
    |
 LL | const unsafe extern "C" fn f4_1(x: isize, ...) {}
-   |                                           ^^^   - value is dropped here
+   |                                           ^^^    - value is dropped here
    |                                           |
    |                                           the destructor for this type cannot be evaluated in constant functions
 
@@ -213,7 +213,7 @@ error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
   --> $DIR/variadic-ffi-semantic-restrictions.rs:36:36
    |
 LL | const extern "C" fn f4_2(x: isize, ...) {}
-   |                                    ^^^   - value is dropped here
+   |                                    ^^^    - value is dropped here
    |                                    |
    |                                    the destructor for this type cannot be evaluated in constant functions
 
@@ -221,7 +221,7 @@ error[E0493]: destructor of `VaListImpl<'_>` cannot be evaluated at compile-time
   --> $DIR/variadic-ffi-semantic-restrictions.rs:64:29
    |
 LL |     const fn i_f5(x: isize, ...) {}
-   |                             ^^^   - value is dropped here
+   |                             ^^^    - value is dropped here
    |                             |
    |                             the destructor for this type cannot be evaluated in constant functions
 

--- a/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.stderr
+++ b/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/lifetime_errors_on_promotion_misusage.rs:11:35
    |
 LL |     let phantom_pinned = identity(pin!(PhantomPinned));
-   |                                   ^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
+   |                                   ^^^^^^^^^^^^^^^^^^^  - temporary value is freed at the end of this statement
    |                                   |
    |                                   creates a temporary value which is freed while still in use
 LL |
@@ -25,7 +25,7 @@ LL |         let phantom_pinned = pin!(PhantomPinned);
    |                              ^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
 ...
 LL |     };
-   |     - temporary value is freed at the end of this statement
+   |      - temporary value is freed at the end of this statement
    |
    = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/regions/do-not-suggest-adding-bound-to-opaque-type.stderr
+++ b/tests/ui/regions/do-not-suggest-adding-bound-to-opaque-type.stderr
@@ -9,7 +9,7 @@ LL |     S(&x)
    |     | borrowed value does not live long enough
    |     opaque type requires that `x` is borrowed for `'static`
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-free-region-ordering-caller1.stderr
+++ b/tests/ui/regions/regions-free-region-ordering-caller1.stderr
@@ -10,7 +10,7 @@ LL |     let z: &'a & usize = &(&y);
    |            type annotation requires that borrow lasts for `'a`
 ...
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error[E0597]: `y` does not live long enough
   --> $DIR/regions-free-region-ordering-caller1.rs:9:27
@@ -26,7 +26,7 @@ LL |     let z: &'a & usize = &(&y);
    |            type annotation requires that `y` is borrowed for `'a`
 ...
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/regions/regions-infer-proc-static-upvar.stderr
+++ b/tests/ui/regions/regions-infer-proc-static-upvar.stderr
@@ -10,7 +10,7 @@ LL | |         let _a = *y;
 LL | |     });
    | |______- argument requires that `x` is borrowed for `'static`
 LL |   }
-   |   - `x` dropped here while still borrowed
+   |    - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-nested-fns-2.stderr
+++ b/tests/ui/regions/regions-nested-fns-2.stderr
@@ -13,7 +13,7 @@ LL |             if false { &y } else { z }
    |                        returning this value requires that `y` is borrowed for `'static`
 ...
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-nested-fns.stderr
+++ b/tests/ui/regions/regions-nested-fns.stderr
@@ -22,7 +22,7 @@ LL |         if false { return ay; }
    |                           -- returning this value requires that `y` is borrowed for `'static`
 ...
 LL | }
-   | - `y` dropped here while still borrowed
+   |  - `y` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/regions-nested-fns.rs:10:15

--- a/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
+++ b/tests/ui/regions/regions-pattern-typing-issue-19552.stderr
@@ -9,7 +9,7 @@ LL |         [ word ] => { assert_static(word); }
    |                       ------------------- argument requires that `line` is borrowed for `'static`
 LL |     }
 LL | }
-   | - `line` dropped here while still borrowed
+   |  - `line` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-steal-closure.stderr
+++ b/tests/ui/regions/regions-steal-closure.stderr
@@ -10,7 +10,7 @@ LL |         box_it(Box::new(|| i += 1))
    |                         |
    |                         value captured here
 LL |     };
-   |     - `i` dropped here while still borrowed
+   |      - `i` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-var-type-out-of-scope.stderr
+++ b/tests/ui/regions/regions-var-type-out-of-scope.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/regions-var-type-out-of-scope.rs:9:14
    |
 LL |         x = &id(3);
-   |              ^^^^^- temporary value is freed at the end of this statement
+   |              ^^^^^ - temporary value is freed at the end of this statement
    |              |
    |              creates a temporary value which is freed while still in use
 LL |         assert_eq!(*x, 3);

--- a/tests/ui/rfcs/rfc-2528-type-changing-struct-update/lifetime-update.stderr
+++ b/tests/ui/rfcs/rfc-2528-type-changing-struct-update/lifetime-update.stderr
@@ -11,7 +11,7 @@ LL |     let m2: Machine<'static, State1> = Machine {
    |             ------------------------ type annotation requires that `s` is borrowed for `'static`
 ...
 LL | }
-   | - `s` dropped here while still borrowed
+   |  - `s` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/self/arbitrary-self-from-method-substs-ice.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs-ice.stderr
@@ -14,7 +14,7 @@ LL |     const fn get<R: Deref<Target = Self>>(self: R) -> u32 {
    |                                           ^^^^ the destructor for this type cannot be evaluated in constant functions
 ...
 LL |     }
-   |     - value is dropped here
+   |      - value is dropped here
 
 error[E0801]: invalid generic `self` parameter type: `R`
   --> $DIR/arbitrary-self-from-method-substs-ice.rs:10:49

--- a/tests/ui/self/issue-61882-2.stderr
+++ b/tests/ui/self/issue-61882-2.stderr
@@ -10,7 +10,7 @@ LL |         Self(&x);
    |              this usage requires that `x` is borrowed for `'static`
 LL |
 LL |     }
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/E0493.stderr
+++ b/tests/ui/span/E0493.stderr
@@ -2,7 +2,7 @@ error[E0493]: destructor of `(Foo, Foo)` cannot be evaluated at compile-time
   --> $DIR/E0493.rs:17:17
    |
 LL | const F : Foo = (Foo { a : 0 }, Foo { a : 1 }).1;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - value is dropped here
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  - value is dropped here
    |                 |
    |                 the destructor for this type cannot be evaluated in constants
 

--- a/tests/ui/span/borrowck-let-suggestion-suffixes.stderr
+++ b/tests/ui/span/borrowck-let-suggestion-suffixes.stderr
@@ -8,7 +8,7 @@ LL |         v2.push(&young[0]);      // statement 4
    |                 ^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - `young[_]` dropped here while still borrowed
+   |      - `young[_]` dropped here while still borrowed
 ...
 LL |     (v1, v2, v3, /* v4 is above. */ v5).use_ref();
    |          -- borrow later used here
@@ -17,7 +17,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/borrowck-let-suggestion-suffixes.rs:20:14
    |
 LL |     v3.push(&id('x'));           // statement 6
-   |              ^^^^^^^ - temporary value is freed at the end of this statement
+   |              ^^^^^^^  - temporary value is freed at the end of this statement
    |              |
    |              creates a temporary value which is freed while still in use
 ...
@@ -34,7 +34,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/borrowck-let-suggestion-suffixes.rs:30:18
    |
 LL |         v4.push(&id('y'));
-   |                  ^^^^^^^ - temporary value is freed at the end of this statement
+   |                  ^^^^^^^  - temporary value is freed at the end of this statement
    |                  |
    |                  creates a temporary value which is freed while still in use
 ...
@@ -47,7 +47,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/borrowck-let-suggestion-suffixes.rs:41:14
    |
 LL |     v5.push(&id('z'));
-   |              ^^^^^^^ - temporary value is freed at the end of this statement
+   |              ^^^^^^^  - temporary value is freed at the end of this statement
    |              |
    |              creates a temporary value which is freed while still in use
 ...

--- a/tests/ui/span/borrowck-ref-into-rvalue.stderr
+++ b/tests/ui/span/borrowck-ref-into-rvalue.stderr
@@ -5,7 +5,7 @@ LL |     match Some("Hello".to_string()) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
 ...
 LL |     }
-   |     - temporary value is freed at the end of this statement
+   |      - temporary value is freed at the end of this statement
 LL |     println!("{}", *msg);
    |                    ---- borrow later used here
    |

--- a/tests/ui/span/destructor-restrictions.stderr
+++ b/tests/ui/span/destructor-restrictions.stderr
@@ -9,9 +9,9 @@ LL |         *a.borrow() + 1
    |          borrowed value does not live long enough
    |          a temporary with access to the borrow is created here ...
 LL |     };
-   |     -- ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, i32>`
-   |     |
-   |     `*a` dropped here while still borrowed
+   |      -- ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, i32>`
+   |      |
+   |      `*a` dropped here while still borrowed
    |
    = note: the temporary is part of an expression at the end of a block;
            consider forcing this temporary to be dropped sooner, before the block's local variables are dropped

--- a/tests/ui/span/dropck-object-cycle.stderr
+++ b/tests/ui/span/dropck-object-cycle.stderr
@@ -7,10 +7,10 @@ LL |     assert_eq!(object_invoke1(&*m), (4,5));
    |                               ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `*m` dropped here while still borrowed
-   | borrow might be used here, when `m` is dropped and runs the destructor for type `Box<dyn Trait<'_>>`
+   |  -
+   |  |
+   |  `*m` dropped here while still borrowed
+   |  borrow might be used here, when `m` is dropped and runs the destructor for type `Box<dyn Trait<'_>>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/dropck_arr_cycle_checked.stderr
+++ b/tests/ui/span/dropck_arr_cycle_checked.stderr
@@ -8,10 +8,10 @@ LL |     b1.a[0].v.set(Some(&b2));
    |                        ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `b2` dropped here while still borrowed
-   | borrow might be used here, when `b1` is dropped and runs the destructor for type `B<'_>`
+   |  -
+   |  |
+   |  `b2` dropped here while still borrowed
+   |  borrow might be used here, when `b1` is dropped and runs the destructor for type `B<'_>`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -25,10 +25,10 @@ LL |     b1.a[1].v.set(Some(&b3));
    |                        ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `b3` dropped here while still borrowed
-   | borrow might be used here, when `b1` is dropped and runs the destructor for type `B<'_>`
+   |  -
+   |  |
+   |  `b3` dropped here while still borrowed
+   |  borrow might be used here, when `b1` is dropped and runs the destructor for type `B<'_>`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -42,10 +42,10 @@ LL |     b3.a[0].v.set(Some(&b1));
    |                        ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `b1` dropped here while still borrowed
-   | borrow might be used here, when `b1` is dropped and runs the destructor for type `B<'_>`
+   |  -
+   |  |
+   |  `b1` dropped here while still borrowed
+   |  borrow might be used here, when `b1` is dropped and runs the destructor for type `B<'_>`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/span/dropck_direct_cycle_with_drop.stderr
+++ b/tests/ui/span/dropck_direct_cycle_with_drop.stderr
@@ -7,10 +7,10 @@ LL |     d1.p.set(Some(&d2));
    |                   ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `d2` dropped here while still borrowed
-   | borrow might be used here, when `d1` is dropped and runs the `Drop` code for type `D`
+   |  -
+   |  |
+   |  `d2` dropped here while still borrowed
+   |  borrow might be used here, when `d1` is dropped and runs the `Drop` code for type `D`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -24,10 +24,10 @@ LL |     d2.p.set(Some(&d1));
    |                   ^^^ borrowed value does not live long enough
 LL |
 LL | }
-   | -
-   | |
-   | `d1` dropped here while still borrowed
-   | borrow might be used here, when `d1` is dropped and runs the `Drop` code for type `D`
+   |  -
+   |  |
+   |  `d1` dropped here while still borrowed
+   |  borrow might be used here, when `d1` is dropped and runs the `Drop` code for type `D`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/span/dropck_misc_variants.stderr
+++ b/tests/ui/span/dropck_misc_variants.stderr
@@ -7,10 +7,10 @@ LL |     bomb = vec![""];
 LL |     _w = Wrap::<&[&str]>(NoisyDrop(&bomb));
    |                                    ^^^^^ borrowed value does not live long enough
 LL | }
-   | -
-   | |
-   | `bomb` dropped here while still borrowed
-   | borrow might be used here, when `_w` is dropped and runs the destructor for type `Wrap<&[&str]>`
+   |  -
+   |  |
+   |  `bomb` dropped here while still borrowed
+   |  borrow might be used here, when `_w` is dropped and runs the destructor for type `Wrap<&[&str]>`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -24,10 +24,10 @@ LL |         let u = NoisyDrop(&v);
    |                           ^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `v` dropped here while still borrowed
-   | borrow might be used here, when `_w` is dropped and runs the destructor for closure
+   |  -
+   |  |
+   |  `v` dropped here while still borrowed
+   |  borrow might be used here, when `_w` is dropped and runs the destructor for closure
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/span/dropck_vec_cycle_checked.stderr
+++ b/tests/ui/span/dropck_vec_cycle_checked.stderr
@@ -8,10 +8,10 @@ LL |     c1.v[0].v.set(Some(&c2));
    |                        ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `c2` dropped here while still borrowed
-   | borrow might be used here, when `c1` is dropped and runs the destructor for type `C<'_>`
+   |  -
+   |  |
+   |  `c2` dropped here while still borrowed
+   |  borrow might be used here, when `c1` is dropped and runs the destructor for type `C<'_>`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -25,10 +25,10 @@ LL |     c1.v[1].v.set(Some(&c3));
    |                        ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `c3` dropped here while still borrowed
-   | borrow might be used here, when `c1` is dropped and runs the destructor for type `C<'_>`
+   |  -
+   |  |
+   |  `c3` dropped here while still borrowed
+   |  borrow might be used here, when `c1` is dropped and runs the destructor for type `C<'_>`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -42,10 +42,10 @@ LL |     c3.v[0].v.set(Some(&c1));
    |                        ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `c1` dropped here while still borrowed
-   | borrow might be used here, when `c1` is dropped and runs the destructor for type `C<'_>`
+   |  -
+   |  |
+   |  `c1` dropped here while still borrowed
+   |  borrow might be used here, when `c1` is dropped and runs the destructor for type `C<'_>`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/span/issue-15480.stderr
+++ b/tests/ui/span/issue-15480.stderr
@@ -4,7 +4,7 @@ error[E0716]: temporary value dropped while borrowed
 LL |         &id(3)
    |          ^^^^^ creates a temporary value which is freed while still in use
 LL |     ];
-   |      - temporary value is freed at the end of this statement
+   |       - temporary value is freed at the end of this statement
 ...
 LL |     for &&x in &v {
    |                -- borrow later used here

--- a/tests/ui/span/issue-23338-locals-die-before-temps-of-body.stderr
+++ b/tests/ui/span/issue-23338-locals-die-before-temps-of-body.stderr
@@ -9,10 +9,10 @@ LL |     y.borrow().clone()
    |     borrowed value does not live long enough
    |     a temporary with access to the borrow is created here ...
 LL | }
-   | -
-   | |
-   | `y` dropped here while still borrowed
-   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, String>`
+   |  -
+   |  |
+   |  `y` dropped here while still borrowed
+   |  ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, String>`
    |
    = note: the temporary is part of an expression at the end of a block;
            consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
@@ -32,9 +32,9 @@ LL |         y.borrow().clone()
    |         borrowed value does not live long enough
    |         a temporary with access to the borrow is created here ...
 LL |     };
-   |     -- ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, String>`
-   |     |
-   |     `y` dropped here while still borrowed
+   |      -- ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `Ref<'_, String>`
+   |      |
+   |      `y` dropped here while still borrowed
    |
    = note: the temporary is part of an expression at the end of a block;
            consider forcing this temporary to be dropped sooner, before the block's local variables are dropped

--- a/tests/ui/span/issue-24805-dropck-child-has-items-via-parent.stderr
+++ b/tests/ui/span/issue-24805-dropck-child-has-items-via-parent.stderr
@@ -8,10 +8,10 @@ LL |     _d = D_Child(&d1);
    |                  ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `d1` dropped here while still borrowed
-   | borrow might be used here, when `_d` is dropped and runs the `Drop` code for type `D_Child`
+   |  -
+   |  |
+   |  `d1` dropped here while still borrowed
+   |  borrow might be used here, when `_d` is dropped and runs the `Drop` code for type `D_Child`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/span/issue-24805-dropck-trait-has-items.stderr
+++ b/tests/ui/span/issue-24805-dropck-trait-has-items.stderr
@@ -7,10 +7,10 @@ LL |     d1 = D_HasSelfMethod(1);
 LL |     _d = D_HasSelfMethod(&d1);
    |                          ^^^ borrowed value does not live long enough
 LL | }
-   | -
-   | |
-   | `d1` dropped here while still borrowed
-   | borrow might be used here, when `_d` is dropped and runs the `Drop` code for type `D_HasSelfMethod`
+   |  -
+   |  |
+   |  `d1` dropped here while still borrowed
+   |  borrow might be used here, when `_d` is dropped and runs the `Drop` code for type `D_HasSelfMethod`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -23,10 +23,10 @@ LL |     d1 = D_HasMethodWithSelfArg(1);
 LL |     _d = D_HasMethodWithSelfArg(&d1);
    |                                 ^^^ borrowed value does not live long enough
 LL | }
-   | -
-   | |
-   | `d1` dropped here while still borrowed
-   | borrow might be used here, when `_d` is dropped and runs the `Drop` code for type `D_HasMethodWithSelfArg`
+   |  -
+   |  |
+   |  `d1` dropped here while still borrowed
+   |  borrow might be used here, when `_d` is dropped and runs the `Drop` code for type `D_HasMethodWithSelfArg`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -39,10 +39,10 @@ LL |     d1 = D_HasType(1);
 LL |     _d = D_HasType(&d1);
    |                    ^^^ borrowed value does not live long enough
 LL | }
-   | -
-   | |
-   | `d1` dropped here while still borrowed
-   | borrow might be used here, when `_d` is dropped and runs the `Drop` code for type `D_HasType`
+   |  -
+   |  |
+   |  `d1` dropped here while still borrowed
+   |  borrow might be used here, when `_d` is dropped and runs the `Drop` code for type `D_HasType`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/span/issue-24895-copy-clone-dropck.stderr
+++ b/tests/ui/span/issue-24895-copy-clone-dropck.stderr
@@ -7,10 +7,10 @@ LL |     d1 = D(34, "d1");
 LL |     d2 = D(S(&d1, "inner"), "d2");
    |              ^^^ borrowed value does not live long enough
 LL | }
-   | -
-   | |
-   | `d1` dropped here while still borrowed
-   | borrow might be used here, when `d2` is dropped and runs the `Drop` code for type `D`
+   |  -
+   |  |
+   |  `d1` dropped here while still borrowed
+   |  borrow might be used here, when `d2` is dropped and runs the `Drop` code for type `D`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/span/issue-25199.stderr
+++ b/tests/ui/span/issue-25199.stderr
@@ -7,10 +7,10 @@ LL |     let test = Test{test: &container};
    |                           ^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `container` dropped here while still borrowed
-   | borrow might be used here, when `container` is dropped and runs the destructor for type `Container<'_>`
+   |  -
+   |  |
+   |  `container` dropped here while still borrowed
+   |  borrow might be used here, when `container` is dropped and runs the destructor for type `Container<'_>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/issue-26656.stderr
+++ b/tests/ui/span/issue-26656.stderr
@@ -7,10 +7,10 @@ LL |     let (mut zook, ticking);
 LL |     zook.button = B::BigRedButton(&ticking);
    |                                   ^^^^^^^^ borrowed value does not live long enough
 LL | }
-   | -
-   | |
-   | `ticking` dropped here while still borrowed
-   | borrow might be used here, when `zook` is dropped and runs the `Drop` code for type `Zook`
+   |  -
+   |  |
+   |  `ticking` dropped here while still borrowed
+   |  borrow might be used here, when `zook` is dropped and runs the `Drop` code for type `Zook`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/span/issue-29106.stderr
+++ b/tests/ui/span/issue-29106.stderr
@@ -7,10 +7,10 @@ LL |         x = "alive".to_string();
 LL |         y = Arc::new(Foo(&x));
    |                          ^^ borrowed value does not live long enough
 LL |     }
-   |     -
-   |     |
-   |     `x` dropped here while still borrowed
-   |     borrow might be used here, when `y` is dropped and runs the `Drop` code for type `Arc`
+   |      -
+   |      |
+   |      `x` dropped here while still borrowed
+   |      borrow might be used here, when `y` is dropped and runs the `Drop` code for type `Arc`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -23,10 +23,10 @@ LL |         x = "alive".to_string();
 LL |         y = Rc::new(Foo(&x));
    |                         ^^ borrowed value does not live long enough
 LL |     }
-   |     -
-   |     |
-   |     `x` dropped here while still borrowed
-   |     borrow might be used here, when `y` is dropped and runs the `Drop` code for type `Rc`
+   |      -
+   |      |
+   |      `x` dropped here while still borrowed
+   |      borrow might be used here, when `y` is dropped and runs the `Drop` code for type `Rc`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/span/issue-36537.stderr
+++ b/tests/ui/span/issue-36537.stderr
@@ -7,7 +7,7 @@ LL |         p = &a;
    |             ^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 LL |     p.use_ref();
    |     - borrow later used here
 

--- a/tests/ui/span/issue-40157.stderr
+++ b/tests/ui/span/issue-40157.stderr
@@ -2,7 +2,7 @@ error[E0597]: `foo` does not live long enough
   --> $DIR/issue-40157.rs:2:53
    |
 LL |     {println!("{:?}", match { let foo = vec![1, 2]; foo.get(1) } { x => x });}
-   |                                   ---               ^^^        - `foo` dropped here while still borrowed
+   |                                   ---               ^^^         - `foo` dropped here while still borrowed
    |                                   |                 |
    |                                   |                 borrowed value does not live long enough
    |                                   binding `foo` declared here

--- a/tests/ui/span/issue28498-reject-ex1.stderr
+++ b/tests/ui/span/issue28498-reject-ex1.stderr
@@ -5,10 +5,10 @@ LL |     foo.data[0].1.set(Some(&foo.data[1]));
    |                             ^^^^^^^^
 ...
 LL | }
-   | -
-   | |
-   | here, drop of `foo` needs exclusive access to `foo.data`, because the type `Foo<Concrete<'_>>` implements the `Drop` trait
-   | borrow might be used here, when `foo` is dropped and runs the `Drop` code for type `Foo`
+   |  -
+   |  |
+   |  here, drop of `foo` needs exclusive access to `foo.data`, because the type `Foo<Concrete<'_>>` implements the `Drop` trait
+   |  borrow might be used here, when `foo` is dropped and runs the `Drop` code for type `Foo`
    |
    = note: consider using a `let` binding to create a longer lived value
 

--- a/tests/ui/span/issue28498-reject-lifetime-param.stderr
+++ b/tests/ui/span/issue28498-reject-lifetime-param.stderr
@@ -8,10 +8,10 @@ LL |     foo1 = Foo(1, &first_dropped);
    |                   ^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `first_dropped` dropped here while still borrowed
-   | borrow might be used here, when `foo1` is dropped and runs the `Drop` code for type `Foo`
+   |  -
+   |  |
+   |  `first_dropped` dropped here while still borrowed
+   |  borrow might be used here, when `foo1` is dropped and runs the `Drop` code for type `Foo`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/span/issue28498-reject-passed-to-fn.stderr
+++ b/tests/ui/span/issue28498-reject-passed-to-fn.stderr
@@ -8,10 +8,10 @@ LL |     foo1 = Foo(1, &first_dropped, Box::new(callback));
    |                   ^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `first_dropped` dropped here while still borrowed
-   | borrow might be used here, when `foo1` is dropped and runs the `Drop` code for type `Foo`
+   |  -
+   |  |
+   |  `first_dropped` dropped here while still borrowed
+   |  borrow might be used here, when `foo1` is dropped and runs the `Drop` code for type `Foo`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/span/issue28498-reject-trait-bound.stderr
+++ b/tests/ui/span/issue28498-reject-trait-bound.stderr
@@ -8,10 +8,10 @@ LL |     foo1 = Foo(1, &first_dropped);
    |                   ^^^^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `first_dropped` dropped here while still borrowed
-   | borrow might be used here, when `foo1` is dropped and runs the `Drop` code for type `Foo`
+   |  -
+   |  |
+   |  `first_dropped` dropped here while still borrowed
+   |  borrow might be used here, when `foo1` is dropped and runs the `Drop` code for type `Foo`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/span/mut-ptr-cant-outlive-ref.stderr
+++ b/tests/ui/span/mut-ptr-cant-outlive-ref.stderr
@@ -6,7 +6,7 @@ LL |         let b = m.borrow();
 LL |         p = &*b;
    |               ^ borrowed value does not live long enough
 LL |     }
-   |     - `b` dropped here while still borrowed
+   |      - `b` dropped here while still borrowed
 LL |
 LL |     p.use_ref();
    |     - borrow later used here

--- a/tests/ui/span/range-2.stderr
+++ b/tests/ui/span/range-2.stderr
@@ -9,7 +9,7 @@ LL |         let b = 42;
 LL |         &a..&b
    |         ^^ borrowed value does not live long enough
 LL |     };
-   |     - `a` dropped here while still borrowed
+   |      - `a` dropped here while still borrowed
 
 error[E0597]: `b` does not live long enough
   --> $DIR/range-2.rs:7:13
@@ -22,7 +22,7 @@ LL |         let b = 42;
 LL |         &a..&b
    |             ^^ borrowed value does not live long enough
 LL |     };
-   |     - `b` dropped here while still borrowed
+   |      - `b` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/span/regionck-unboxed-closure-lifetimes.stderr
+++ b/tests/ui/span/regionck-unboxed-closure-lifetimes.stderr
@@ -7,7 +7,7 @@ LL |         let c_ref = &c;
    |                     ^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - `c` dropped here while still borrowed
+   |      - `c` dropped here while still borrowed
 LL |     f.use_mut();
    |     - borrow later used here
 

--- a/tests/ui/span/regions-close-over-borrowed-ref-in-obj.stderr
+++ b/tests/ui/span/regions-close-over-borrowed-ref-in-obj.stderr
@@ -5,9 +5,9 @@ LL |         let ss: &isize = &id(1);
    |                           ^^^^^ creates a temporary value which is freed while still in use
 ...
 LL |     }
-   |     - temporary value is freed at the end of this statement
+   |      - temporary value is freed at the end of this statement
 LL | }
-   | - borrow might be used here, when `blah` is dropped and runs the destructor for type `Box<dyn Foo>`
+   |  - borrow might be used here, when `blah` is dropped and runs the destructor for type `Box<dyn Foo>`
    |
    = note: consider using a `let` binding to create a longer lived value
 

--- a/tests/ui/span/regions-close-over-type-parameter-2.stderr
+++ b/tests/ui/span/regions-close-over-type-parameter-2.stderr
@@ -8,7 +8,7 @@ LL |         let tmp1 = &tmp0;
 LL |         repeater3(tmp1)
    |         --------------- borrow later captured here by trait object
 LL |     };
-   |     - `tmp0` dropped here while still borrowed
+   |      - `tmp0` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/regions-escape-loop-via-variable.stderr
+++ b/tests/ui/span/regions-escape-loop-via-variable.stderr
@@ -8,7 +8,7 @@ LL |         let x = 1 + *p;
 LL |         p = &x;
    |             ^^ borrowed value does not live long enough
 LL |     }
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/span/regions-escape-loop-via-vec.stderr
+++ b/tests/ui/span/regions-escape-loop-via-vec.stderr
@@ -31,7 +31,7 @@ LL |         _y.push(&mut z);
    |         borrow later used here
 ...
 LL |     }
-   |     - `z` dropped here while still borrowed
+   |      - `z` dropped here while still borrowed
 
 error[E0503]: cannot use `x` because it was mutably borrowed
   --> $DIR/regions-escape-loop-via-vec.rs:9:9

--- a/tests/ui/span/regions-infer-borrow-scope-within-loop.stderr
+++ b/tests/ui/span/regions-infer-borrow-scope-within-loop.stderr
@@ -8,7 +8,7 @@ LL |         y = borrow(&*x);
    |                    ^^^ borrowed value does not live long enough
 ...
 LL |     }
-   |     - `*x` dropped here while still borrowed
+   |      - `*x` dropped here while still borrowed
 LL |     assert!(*y != 0);
    |             -- borrow later used here
 

--- a/tests/ui/span/send-is-not-static-ensures-scoping.stderr
+++ b/tests/ui/span/send-is-not-static-ensures-scoping.stderr
@@ -9,7 +9,7 @@ LL |         let y = &x;
    |                 ^^ borrowed value does not live long enough
 ...
 LL |     };
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 
 error[E0597]: `y` does not live long enough
   --> $DIR/send-is-not-static-ensures-scoping.rs:20:22
@@ -26,7 +26,7 @@ LL |             let _z = y;
    |                      ^ borrowed value does not live long enough
 ...
 LL |     };
-   |     - `y` dropped here while still borrowed
+   |      - `y` dropped here while still borrowed
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/span/send-is-not-static-std-sync-2.stderr
+++ b/tests/ui/span/send-is-not-static-std-sync-2.stderr
@@ -8,7 +8,7 @@ LL |         let x = 1;
 LL |         Mutex::new(&x)
    |                    ^^ borrowed value does not live long enough
 LL |     };
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/send-is-not-static-std-sync-2.rs:21:21
@@ -20,7 +20,7 @@ LL |         let x = 1;
 LL |         RwLock::new(&x)
    |                     ^^ borrowed value does not live long enough
 LL |     };
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 
 error[E0597]: `x` does not live long enough
   --> $DIR/send-is-not-static-std-sync-2.rs:31:25
@@ -32,7 +32,7 @@ LL |         let _ = tx.send(&x);
    |                         ^^ borrowed value does not live long enough
 LL |         (tx, rx)
 LL |     };
-   |     - `x` dropped here while still borrowed
+   |      - `x` dropped here while still borrowed
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/span/send-is-not-static-std-sync.stderr
+++ b/tests/ui/span/send-is-not-static-std-sync.stderr
@@ -26,7 +26,7 @@ LL |         let z = 2;
 LL |         *lock.lock().unwrap() = &z;
    |                                 ^^ borrowed value does not live long enough
 LL |     }
-   |     - `z` dropped here while still borrowed
+   |      - `z` dropped here while still borrowed
 LL |
 LL |     lock.use_ref(); // (Mutex is #[may_dangle] so its dtor does not use `z` => needs explicit use)
    |     ---- borrow later used here
@@ -59,7 +59,7 @@ LL |         let z = 2;
 LL |         *lock.write().unwrap() = &z;
    |                                  ^^ borrowed value does not live long enough
 LL |     }
-   |     - `z` dropped here while still borrowed
+   |      - `z` dropped here while still borrowed
 LL |
 LL |     lock.use_ref(); // (RwLock is #[may_dangle] so its dtor does not use `z` => needs explicit use)
    |     ---- borrow later used here
@@ -92,7 +92,7 @@ LL |         let z = 2;
 LL |         tx.send(&z).unwrap();
    |                 ^^ borrowed value does not live long enough
 LL |     }
-   |     - `z` dropped here while still borrowed
+   |      - `z` dropped here while still borrowed
 LL |
 LL |     tx.use_ref(); // (channel drop glue does not use `z` => needs explicit use)
    |     -- borrow later used here

--- a/tests/ui/span/slice-borrow.stderr
+++ b/tests/ui/span/slice-borrow.stderr
@@ -5,7 +5,7 @@ LL |         let x: &[isize] = &vec![1, 2, 3, 4, 5];
    |                            ^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
 ...
 LL |     }
-   |     - temporary value is freed at the end of this statement
+   |      - temporary value is freed at the end of this statement
 LL |     y.use_ref();
    |     - borrow later used here
    |

--- a/tests/ui/span/vec-must-not-hide-type-from-dropck.stderr
+++ b/tests/ui/span/vec-must-not-hide-type-from-dropck.stderr
@@ -8,10 +8,10 @@ LL |     c1.v[0].v.set(Some(&c2));
    |                        ^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `c2` dropped here while still borrowed
-   | borrow might be used here, when `c1` is dropped and runs the destructor for type `C<'_>`
+   |  -
+   |  |
+   |  `c2` dropped here while still borrowed
+   |  borrow might be used here, when `c1` is dropped and runs the destructor for type `C<'_>`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -25,10 +25,10 @@ LL |     c2.v[0].v.set(Some(&c1));
    |                        ^^^ borrowed value does not live long enough
 LL |
 LL | }
-   | -
-   | |
-   | `c1` dropped here while still borrowed
-   | borrow might be used here, when `c1` is dropped and runs the destructor for type `C<'_>`
+   |  -
+   |  |
+   |  `c1` dropped here while still borrowed
+   |  borrow might be used here, when `c1` is dropped and runs the destructor for type `C<'_>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/span/vec_refs_data_with_early_death.stderr
+++ b/tests/ui/span/vec_refs_data_with_early_death.stderr
@@ -8,10 +8,10 @@ LL |     v.push(&x);
    |            ^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `x` dropped here while still borrowed
-   | borrow might be used here, when `v` is dropped and runs the `Drop` code for type `Bag`
+   |  -
+   |  |
+   |  `x` dropped here while still borrowed
+   |  borrow might be used here, when `v` is dropped and runs the `Drop` code for type `Bag`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 
@@ -25,10 +25,10 @@ LL |     v.push(&y);
    |            ^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `y` dropped here while still borrowed
-   | borrow might be used here, when `v` is dropped and runs the `Drop` code for type `Bag`
+   |  -
+   |  |
+   |  `y` dropped here while still borrowed
+   |  borrow might be used here, when `v` is dropped and runs the `Drop` code for type `Bag`
    |
    = note: values in a scope are dropped in the opposite order they are defined
 

--- a/tests/ui/span/wf-method-late-bound-regions.stderr
+++ b/tests/ui/span/wf-method-late-bound-regions.stderr
@@ -8,7 +8,7 @@ LL |         let pointer = Box::new(42);
 LL |         f2.xmute(&pointer)
    |                  ^^^^^^^^ borrowed value does not live long enough
 LL |     };
-   |     - `pointer` dropped here while still borrowed
+   |      - `pointer` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/issue-18118.stderr
+++ b/tests/ui/static/issue-18118.stderr
@@ -9,7 +9,7 @@ LL |         &p
    |         borrowed value does not live long enough
    |         using this value as a constant requires that `p` is borrowed for `'static`
 LL |     };
-   |     - `p` dropped here while still borrowed
+   |      - `p` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/static-drop-scope.stderr
+++ b/tests/ui/static/static-drop-scope.stderr
@@ -2,7 +2,7 @@ error[E0493]: destructor of `WithDtor` cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:7:60
    |
 LL | static PROMOTION_FAIL_S: Option<&'static WithDtor> = Some(&WithDtor);
-   |                                                            ^^^^^^^^- value is dropped here
+   |                                                            ^^^^^^^^ - value is dropped here
    |                                                            |
    |                                                            the destructor for this type cannot be evaluated in statics
 
@@ -10,7 +10,7 @@ error[E0493]: destructor of `WithDtor` cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:10:59
    |
 LL | const PROMOTION_FAIL_C: Option<&'static WithDtor> = Some(&WithDtor);
-   |                                                           ^^^^^^^^- value is dropped here
+   |                                                           ^^^^^^^^ - value is dropped here
    |                                                           |
    |                                                           the destructor for this type cannot be evaluated in constants
 
@@ -18,7 +18,7 @@ error[E0493]: destructor of `(WithDtor, i32)` cannot be evaluated at compile-tim
   --> $DIR/static-drop-scope.rs:13:28
    |
 LL | static EARLY_DROP_S: i32 = (WithDtor, 0).1;
-   |                            ^^^^^^^^^^^^^ - value is dropped here
+   |                            ^^^^^^^^^^^^^  - value is dropped here
    |                            |
    |                            the destructor for this type cannot be evaluated in statics
 
@@ -26,7 +26,7 @@ error[E0493]: destructor of `(WithDtor, i32)` cannot be evaluated at compile-tim
   --> $DIR/static-drop-scope.rs:16:27
    |
 LL | const EARLY_DROP_C: i32 = (WithDtor, 0).1;
-   |                           ^^^^^^^^^^^^^ - value is dropped here
+   |                           ^^^^^^^^^^^^^  - value is dropped here
    |                           |
    |                           the destructor for this type cannot be evaluated in constants
 
@@ -34,7 +34,7 @@ error[E0493]: destructor of `(Option<WithDtor>, i32)` cannot be evaluated at com
   --> $DIR/static-drop-scope.rs:27:34
    |
 LL | const EARLY_DROP_C_OPTION: i32 = (Some(WithDtor), 0).1;
-   |                                  ^^^^^^^^^^^^^^^^^^^ - value is dropped here
+   |                                  ^^^^^^^^^^^^^^^^^^^  - value is dropped here
    |                                  |
    |                                  the destructor for this type cannot be evaluated in constants
 
@@ -42,7 +42,7 @@ error[E0493]: destructor of `(Option<WithDtor>, i32)` cannot be evaluated at com
   --> $DIR/static-drop-scope.rs:32:43
    |
 LL | const EARLY_DROP_C_OPTION_CONSTANT: i32 = (HELPER, 0).1;
-   |                                           ^^^^^^^^^^^ - value is dropped here
+   |                                           ^^^^^^^^^^^  - value is dropped here
    |                                           |
    |                                           the destructor for this type cannot be evaluated in constants
 
@@ -50,7 +50,7 @@ error[E0493]: destructor of `T` cannot be evaluated at compile-time
   --> $DIR/static-drop-scope.rs:19:24
    |
 LL | const fn const_drop<T>(_: T) {}
-   |                        ^      - value is dropped here
+   |                        ^       - value is dropped here
    |                        |
    |                        the destructor for this type cannot be evaluated in constant functions
 
@@ -61,7 +61,7 @@ LL |     (x, ()).1
    |     ^^^^^^^ the destructor for this type cannot be evaluated in constant functions
 LL |
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/static/static-lifetime-bound.stderr
+++ b/tests/ui/static/static-lifetime-bound.stderr
@@ -9,7 +9,7 @@ LL |     f(&x);
    |     | borrowed value does not live long enough
    |     argument requires that `x` is borrowed for `'static`
 LL | }
-   | - `x` dropped here while still borrowed
+   |  - `x` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/static/static-reference-to-fn-2.stderr
+++ b/tests/ui/static/static-reference-to-fn-2.stderr
@@ -4,7 +4,7 @@ error[E0716]: temporary value dropped while borrowed
 LL | fn state1(self_: &mut StateMachineIter) -> Option<&'static str> {
    |           ----- has type `&mut StateMachineIter<'1>`
 LL |     self_.statefn = &id(state2 as StateMachineFunc);
-   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
    |     |                |
    |     |                creates a temporary value which is freed while still in use
    |     assignment requires that borrow lasts for `'1`
@@ -15,7 +15,7 @@ error[E0716]: temporary value dropped while borrowed
 LL | fn state2(self_: &mut StateMachineIter) -> Option<(&'static str)> {
    |           ----- has type `&mut StateMachineIter<'1>`
 LL |     self_.statefn = &id(state3 as StateMachineFunc);
-   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
    |     |                |
    |     |                creates a temporary value which is freed while still in use
    |     assignment requires that borrow lasts for `'1`
@@ -26,7 +26,7 @@ error[E0716]: temporary value dropped while borrowed
 LL | fn state3(self_: &mut StateMachineIter) -> Option<(&'static str)> {
    |           ----- has type `&mut StateMachineIter<'1>`
 LL |     self_.statefn = &id(finished as StateMachineFunc);
-   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- temporary value is freed at the end of this statement
+   |     -----------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
    |     |                |
    |     |                creates a temporary value which is freed while still in use
    |     assignment requires that borrow lasts for `'1`

--- a/tests/ui/static/static-region-bound.stderr
+++ b/tests/ui/static/static-region-bound.stderr
@@ -6,7 +6,7 @@ LL |     let x = &id(3);
 LL |     f(x);
    |     ---- argument requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/statics/check-values-constraints.stderr
+++ b/tests/ui/statics/check-values-constraints.stderr
@@ -9,7 +9,7 @@ LL | |         field2: SafeEnum::Variant1,
 LL | |     }
    | |_____^ the destructor for this type cannot be evaluated in statics
 LL |   };
-   |   - value is dropped here
+   |    - value is dropped here
 
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-values-constraints.rs:81:33

--- a/tests/ui/statics/issue-44373.stderr
+++ b/tests/ui/statics/issue-44373.stderr
@@ -6,7 +6,7 @@ LL |     let _val: &'static [&'static u32] = &[&FOO];
    |               |
    |               type annotation requires that borrow lasts for `'static`
 LL | }
-   | - temporary value is freed at the end of this statement
+   |  - temporary value is freed at the end of this statement
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-3.stderr
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-3.stderr
@@ -10,7 +10,7 @@ LL |         z = f::<dyn X<Y = &str>>(&s);
    |             argument requires that `s` is borrowed for `'static`
 LL |
 LL |     }
-   |     - `s` dropped here while still borrowed
+   |      - `s` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/coercion-generic-regions.stderr
+++ b/tests/ui/traits/coercion-generic-regions.stderr
@@ -8,7 +8,7 @@ LL |     let person: &str = &person;
 LL |     let s: Box<dyn Trait<&'static str>> = Box::new(Struct { person: person });
    |                                                                     ------ this usage requires that `person` is borrowed for `'static`
 LL | }
-   | - `person` dropped here while still borrowed
+   |  - `person` dropped here while still borrowed
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/minicore-drop-fail.stderr
+++ b/tests/ui/traits/const-traits/minicore-drop-fail.stderr
@@ -2,7 +2,7 @@ error[E0493]: destructor of `NotDropImpl` cannot be evaluated at compile-time
   --> $DIR/minicore-drop-fail.rs:27:13
    |
 LL |     let _ = NotDropImpl;
-   |             ^^^^^^^^^^^- value is dropped here
+   |             ^^^^^^^^^^^ - value is dropped here
    |             |
    |             the destructor for this type cannot be evaluated in constant functions
 
@@ -10,7 +10,7 @@ error[E0493]: destructor of `Contains<NotDropImpl>` cannot be evaluated at compi
   --> $DIR/minicore-drop-fail.rs:29:13
    |
 LL |     let _ = Contains(NotDropImpl);
-   |             ^^^^^^^^^^^^^^^^^^^^^- value is dropped here
+   |             ^^^^^^^^^^^^^^^^^^^^^ - value is dropped here
    |             |
    |             the destructor for this type cannot be evaluated in constant functions
 
@@ -18,7 +18,7 @@ error[E0493]: destructor of `Conditional<()>` cannot be evaluated at compile-tim
   --> $DIR/minicore-drop-fail.rs:31:13
    |
 LL |     let _ = Conditional(());
-   |             ^^^^^^^^^^^^^^^- value is dropped here
+   |             ^^^^^^^^^^^^^^^ - value is dropped here
    |             |
    |             the destructor for this type cannot be evaluated in constant functions
 
@@ -29,7 +29,7 @@ LL | const fn drop_arbitrary<T>(_: T) {
    |                            ^ the destructor for this type cannot be evaluated in constant functions
 LL |
 LL | }
-   | - value is dropped here
+   |  - value is dropped here
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/traits/const-traits/minicore-drop-without-feature-gate.no.stderr
+++ b/tests/ui/traits/const-traits/minicore-drop-without-feature-gate.no.stderr
@@ -2,7 +2,7 @@ error[E0493]: destructor of `ConstDrop` cannot be evaluated at compile-time
   --> $DIR/minicore-drop-without-feature-gate.rs:24:13
    |
 LL |     let _ = ConstDrop;
-   |             ^^^^^^^^^- value is dropped here
+   |             ^^^^^^^^^ - value is dropped here
    |             |
    |             the destructor for this type cannot be evaluated in constant functions
    |

--- a/tests/ui/traits/trait-object-lifetime-default-note.stderr
+++ b/tests/ui/traits/trait-object-lifetime-default-note.stderr
@@ -10,7 +10,7 @@ LL |     require_box(Box::new(r));
    |                 ----------- coercion requires that `local` is borrowed for `'static`
 ...
 LL | }
-   | - `local` dropped here while still borrowed
+   |  - `local` dropped here while still borrowed
    |
    = note: due to object lifetime defaults, `Box<dyn A>` actually means `Box<(dyn A + 'static)>`
 

--- a/tests/ui/try-block/try-block-bad-lifetime.stderr
+++ b/tests/ui/try-block/try-block-bad-lifetime.stderr
@@ -9,7 +9,7 @@ LL |             let my_str: & str = & my_string;
    |                                 ^^^^^^^^^^^ borrowed value does not live long enough
 ...
 LL |         };
-   |         - `my_string` dropped here while still borrowed
+   |          - `my_string` dropped here while still borrowed
 
 error[E0506]: cannot assign to `i` because it is borrowed
   --> $DIR/try-block-bad-lifetime.rs:29:13

--- a/tests/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-1.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-1.stderr
@@ -10,10 +10,10 @@ LL |         let g = factorial.as_ref().unwrap();
    |                 ^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | -
-   | |
-   | `factorial` dropped here while still borrowed
-   | borrow might be used here, when `factorial` is dropped and runs the destructor for type `Option<Box<dyn Fn(u32) -> u32>>`
+   |  -
+   |  |
+   |  `factorial` dropped here while still borrowed
+   |  borrow might be used here, when `factorial` is dropped and runs the destructor for type `Option<Box<dyn Fn(u32) -> u32>>`
 
 error[E0506]: cannot assign to `factorial` because it is borrowed
   --> $DIR/unboxed-closures-failed-recursive-fn-1.rs:20:5
@@ -43,7 +43,7 @@ LL |         let g = factorial.as_ref().unwrap();
    |                 ^^^^^^^^^ borrowed value does not live long enough
 ...
 LL | }
-   | - `factorial` dropped here while still borrowed
+   |  - `factorial` dropped here while still borrowed
 
 error[E0506]: cannot assign to `factorial` because it is borrowed
   --> $DIR/unboxed-closures-failed-recursive-fn-1.rs:33:5

--- a/tests/ui/wf/wf-in-where-clause-static.current.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.current.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/wf-in-where-clause-static.rs:18:18
    |
 LL |     let s = foo(&String::from("blah blah blah"));
-   |             -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+   |             -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- - temporary value is freed at the end of this statement
    |             |    |
    |             |    creates a temporary value which is freed while still in use
    |             argument requires that borrow lasts for `'static`

--- a/tests/ui/wf/wf-in-where-clause-static.next.stderr
+++ b/tests/ui/wf/wf-in-where-clause-static.next.stderr
@@ -2,7 +2,7 @@ error[E0716]: temporary value dropped while borrowed
   --> $DIR/wf-in-where-clause-static.rs:18:18
    |
 LL |     let s = foo(&String::from("blah blah blah"));
-   |             -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-- temporary value is freed at the end of this statement
+   |             -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- - temporary value is freed at the end of this statement
    |             |    |
    |             |    creates a temporary value which is freed while still in use
    |             argument requires that borrow lasts for `'static`


### PR DESCRIPTION
This probably won't do any good, but I saw the `mir_build` query being recomputed in incremental a lot b/c it accesses untracked span data via the `SourceMap::end_point` method.

There may be a smarter way to compute this w/o needing to do span computations which negatively affect incremental.

r? @ghost