### PR TITLE
Stop calling `source_span` query in significant drop order code

### DIFF
--- a/compiler/rustc_middle/src/ty/significant_drop_order.rs
+++ b/compiler/rustc_middle/src/ty/significant_drop_order.rs
@@ -143,25 +143,11 @@ pub fn ty_dtor_span<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Option<Span> {
         | ty::UnsafeBinder(_) => None,
 
         ty::Adt(adt_def, _) => {
-            let did = adt_def.did();
-            let try_local_did_span = |did: DefId| {
-                if let Some(local) = did.as_local() {
-                    tcx.source_span(local)
-                } else {
-                    tcx.def_span(did)
-                }
-            };
-            let dtor = if let Some(dtor) = tcx.adt_destructor(did) {
-                dtor.did
-            } else if let Some(dtor) = tcx.adt_async_destructor(did) {
-                return Some(tcx.source_span(dtor.impl_did));
+            if let Some(dtor) = tcx.adt_destructor(adt_def.did()) {
+                Some(tcx.def_span(tcx.parent(dtor.did)))
             } else {
-                return Some(try_local_did_span(did));
-            };
-            let def_key = tcx.def_key(dtor);
-            let Some(parent_index) = def_key.parent else { return Some(try_local_did_span(dtor)) };
-            let parent_did = DefId { index: parent_index, krate: dtor.krate };
-            Some(try_local_did_span(parent_did))
+                Some(tcx.def_span(adt_def.did()))
+            }
         }
         ty::Coroutine(did, _)
         | ty::CoroutineWitness(did, _)

--- a/tests/ui/drop/drop-order-comparisons.e2021.stderr
+++ b/tests/ui/drop/drop-order-comparisons.e2021.stderr
@@ -31,39 +31,23 @@ LL | |     }, e.mark(3), e.ok(4));
 note: `#3` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `_v` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 note: the lint level is defined here
   --> $DIR/drop-order-comparisons.rs:28:25
@@ -95,21 +79,13 @@ LL | |     }, e.mark(1), e.ok(4));
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: relative drop order changing in Rust 2024
@@ -135,21 +111,13 @@ LL | |     }, e.mark(1), e.ok(4));
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: relative drop order changing in Rust 2024
@@ -175,21 +143,13 @@ LL | |     }, e.mark(2), e.ok(3));
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: relative drop order changing in Rust 2024
@@ -215,21 +175,13 @@ LL | |     }, e.mark(2), e.ok(3));
 note: `#2` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 warning: `if let` assigns a shorter lifetime since Edition 2024
@@ -245,12 +197,8 @@ LL |     _ = (if let Ok(_) = e.ok(4).as_ref() {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:127:5
    |
@@ -279,12 +227,8 @@ LL |     _ = (if let Ok(_) = e.err(4).as_ref() {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:145:44
    |
@@ -312,12 +256,8 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:247:43
    |
@@ -345,12 +285,8 @@ LL |         if let true = e.err(9).is_ok() {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:352:41
    |
@@ -378,12 +314,8 @@ LL |         if let Ok(_v) = e.err(8) {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:355:35
    |
@@ -411,12 +343,8 @@ LL |         if let Ok(_) = e.err(7) {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:358:34
    |
@@ -444,12 +372,8 @@ LL |         if let Ok(_) = e.err(6).as_ref() {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:361:43
    |
@@ -477,12 +401,8 @@ LL |         if let Ok(_v) = e.err(5) {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:365:35
    |
@@ -510,12 +430,8 @@ LL |         if let Ok(_) = e.err(4) {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:368:34
    |
@@ -543,12 +459,8 @@ LL |         if let Ok(_) = e.err(4).as_ref() {} else {
 note: value invokes this custom destructor
   --> $DIR/drop-order-comparisons.rs:571:1
    |
-LL | / impl<'b> Drop for LogDrop<'b> {
-LL | |     fn drop(&mut self) {
-LL | |         self.0.mark(self.1);
-LL | |     }
-LL | | }
-   | |_^
+LL | impl<'b> Drop for LogDrop<'b> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/drop-order-comparisons.rs:404:43
    |

--- a/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
@@ -11,12 +11,8 @@ LL |     if let Some(_value) = Droppy.get() {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope-gated.rs:14:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope-gated.rs:30:5
    |

--- a/tests/ui/drop/lint-if-let-rescope-with-macro.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-with-macro.stderr
@@ -18,12 +18,8 @@ LL | |     };
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope-with-macro.rs:22:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope-with-macro.rs:12:38
    |

--- a/tests/ui/drop/lint-if-let-rescope.stderr
+++ b/tests/ui/drop/lint-if-let-rescope.stderr
@@ -11,12 +11,8 @@ LL |     if let Some(_value) = droppy().get() {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:32:5
    |
@@ -55,21 +51,13 @@ LL |     } else if let Some(_value) = droppy().get() {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:42:5
    |
@@ -105,12 +93,8 @@ LL |     } else if let Some(_value) = droppy().get() {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:54:5
    |
@@ -140,12 +124,8 @@ LL |     if let Some(1) = { if let Some(_value) = Droppy.get() { Some(1) } else 
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:58:69
    |
@@ -170,12 +150,8 @@ LL |     if (if let Some(_value) = droppy().get() { true } else { false }) {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:72:53
    |
@@ -200,12 +176,8 @@ LL |     } else if (((if let Some(_value) = droppy().get() { true } else { false
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:78:62
    |
@@ -230,12 +202,8 @@ LL |     while (if let Some(_value) = droppy().get() { false } else { true }) {
 note: value invokes this custom destructor
   --> $DIR/lint-if-let-rescope.rs:11:1
    |
-LL | / impl Drop for Droppy {
-LL | |     fn drop(&mut self) {
-LL | |         println!("dropped");
-LL | |     }
-LL | | }
-   | |_^
+LL | impl Drop for Droppy {
+   | ^^^^^^^^^^^^^^^^^^^^
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:90:57
    |

--- a/tests/ui/drop/lint-tail-expr-drop-order.stderr
+++ b/tests/ui/drop/lint-tail-expr-drop-order.stderr
@@ -21,17 +21,13 @@ LL | }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 note: the lint level is defined here
   --> $DIR/lint-tail-expr-drop-order.rs:6:9
@@ -62,17 +58,13 @@ LL |     }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -98,17 +90,13 @@ LL | }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -134,10 +122,8 @@ LL | }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -185,17 +171,13 @@ LL | }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -221,23 +203,13 @@ LL | }
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:193:5
    |
-LL | /     impl Drop for LoudDropper3 {
-LL | |
-LL | |         fn drop(&mut self) {
-LL | |             println!("loud drop");
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl Drop for LoudDropper3 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:205:5
    |
-LL | /     impl Drop for LoudDropper2 {
-LL | |
-LL | |         fn drop(&mut self) {
-LL | |             println!("loud drop");
-LL | |         }
-LL | |     }
-   | |_____^
+LL |     impl Drop for LoudDropper2 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -263,17 +235,13 @@ LL |     ));
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `_x` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
-LL | / impl Drop for LoudDropper {
-...  |
-LL | | }
-   | |_^
+LL | impl Drop for LoudDropper {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: aborting due to 8 previous errors

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
@@ -27,24 +27,18 @@ LL |     }
 note: `#2` invokes this custom destructor
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
-LL | / impl std::ops::Drop for Drop {
-LL | |     fn drop(&mut self) {}
-LL | | }
-   | |_^
+LL | impl std::ops::Drop for Drop {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `#1` invokes this custom destructor
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
-LL | / impl std::ops::Drop for Drop {
-LL | |     fn drop(&mut self) {}
-LL | | }
-   | |_^
+LL | impl std::ops::Drop for Drop {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: `e` invokes this custom destructor
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
-LL | / impl std::ops::Drop for Drop {
-LL | |     fn drop(&mut self) {}
-LL | | }
-   | |_^
+LL | impl std::ops::Drop for Drop {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 note: the lint level is defined here
   --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:6:9


### PR DESCRIPTION
`source_span` is only meant for incremental tracking. I don't really think we need to highlight the whole drop impl span anyways; it can be quite large.

r? oli-obk