### PR TITLE
Allow for reparsing failure when reparsing a pasted metavar.

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -793,7 +793,12 @@ impl<'a> Parser<'a> {
                 self.bump();
                 Some(res)
             } else {
-                panic!("no close delim when reparsing {mv_kind:?}");
+                // This can occur when invalid syntax is passed to a decl macro. E.g. see #139248,
+                // where the reparse attempt of an invalid expr consumed the trailing invisible
+                // delimiter.
+                self.dcx()
+                    .span_delayed_bug(self.token.span, "no close delim with reparsing {mv_kind:?}");
+                None
             }
         } else {
             None

--- a/tests/ui/macros/failed-to-reparse-issue-139445.rs
+++ b/tests/ui/macros/failed-to-reparse-issue-139445.rs
@@ -1,0 +1,6 @@
+fn main() {
+    assert_eq!(3, 'a,)
+    //~^ ERROR expected `while`, `for`, `loop` or `{` after a label
+    //~| ERROR expected `while`, `for`, `loop` or `{` after a label
+    //~| ERROR expected expression, found ``
+}

--- a/tests/ui/macros/failed-to-reparse-issue-139445.stderr
+++ b/tests/ui/macros/failed-to-reparse-issue-139445.stderr
@@ -1,0 +1,24 @@
+error: expected `while`, `for`, `loop` or `{` after a label
+  --> $DIR/failed-to-reparse-issue-139445.rs:2:21
+   |
+LL |     assert_eq!(3, 'a,)
+   |                     ^ expected `while`, `for`, `loop` or `{` after a label
+
+error: expected `while`, `for`, `loop` or `{` after a label
+  --> $DIR/failed-to-reparse-issue-139445.rs:2:5
+   |
+LL |     assert_eq!(3, 'a,)
+   |     ^^^^^^^^^^^^^^^^^^ expected `while`, `for`, `loop` or `{` after a label
+   |
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected expression, found ``
+  --> $DIR/failed-to-reparse-issue-139445.rs:2:5
+   |
+LL |     assert_eq!(3, 'a,)
+   |     ^^^^^^^^^^^^^^^^^^ expected expression
+   |
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/macros/no-close-delim-issue-139248.rs
+++ b/tests/ui/macros/no-close-delim-issue-139248.rs
@@ -1,0 +1,14 @@
+// This code caused a "no close delim when reparsing Expr" ICE in #139248.
+
+macro_rules! m {
+    (static a : () = $e:expr) => {
+        static a : () = $e;
+        //~^ ERROR macro expansion ends with an incomplete expression: expected expression
+    }
+}
+
+m! { static a : () = (if b) }
+//~^ ERROR expected `{`, found `)`
+//~| ERROR expected `{`, found `)`
+
+fn main() {}

--- a/tests/ui/macros/no-close-delim-issue-139248.stderr
+++ b/tests/ui/macros/no-close-delim-issue-139248.stderr
@@ -1,0 +1,33 @@
+error: expected `{`, found `)`
+  --> $DIR/no-close-delim-issue-139248.rs:10:27
+   |
+LL | m! { static a : () = (if b) }
+   |                           ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/no-close-delim-issue-139248.rs:10:26
+   |
+LL | m! { static a : () = (if b) }
+   |                          ^
+
+error: expected `{`, found `)`
+  --> $DIR/no-close-delim-issue-139248.rs:10:27
+   |
+LL | m! { static a : () = (if b) }
+   |                           ^ expected `{`
+   |
+note: the `if` expression is missing a block after this condition
+  --> $DIR/no-close-delim-issue-139248.rs:10:26
+   |
+LL | m! { static a : () = (if b) }
+   |                          ^
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: macro expansion ends with an incomplete expression: expected expression
+  --> $DIR/no-close-delim-issue-139248.rs:5:28
+   |
+LL |         static a : () = $e;
+   |                            ^ expected expression
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Fix some metavar reparsing issues.
    
Fixes #139248 and #139445.
    
r? @petrochenkov 
