### PR TITLE
Introduce a `//@ needs-crate-type` compiletest directive

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -191,8 +191,13 @@ settings:
   specified atomic widths, e.g. the test with `//@ needs-target-has-atomic: 8,
   16, ptr` will only run if it supports the comma-separated list of atomic
   widths.
-- `needs-dynamic-linking` - ignores if target does not support dynamic linking
+- `needs-dynamic-linking` — ignores if target does not support dynamic linking
   (which is orthogonal to it being unable to create `dylib` and `cdylib` crate types)
+- `needs-crate-type` — ignores if target platform does not support one or more
+  of the comma-delimited list of specified crate types. For example,
+  `//@ needs-crate-type: cdylib, proc-macro` will cause the test to be ignored
+  on `wasm32-unknown-unknown` target because the target does not support the
+  `proc-macro` crate type.
 
 The following directives will check LLVM support:
 

--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -133,6 +133,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "min-llvm-version",
     "min-system-llvm-version",
     "needs-asm-support",
+    "needs-crate-type",
     "needs-deterministic-layouts",
     "needs-dlltool",
     "needs-dynamic-linking",

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -431,6 +431,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
 
         target_cfgs: OnceLock::new(),
         builtin_cfg_names: OnceLock::new(),
+        supported_crate_types: OnceLock::new(),
 
         nocapture: matches.opt_present("no-capture"),
 

--- a/tests/ui/invalid-compile-flags/crate-type-flag.rs
+++ b/tests/ui/invalid-compile-flags/crate-type-flag.rs
@@ -3,8 +3,6 @@
 //!
 //! This test does not try to check if the output artifacts are valid.
 
-// FIXME(#132309): add a proper `supports-crate-type` directive.
-
 // Single valid crate types should pass
 //@ revisions: lib rlib staticlib dylib cdylib bin proc_dash_macro
 
@@ -17,19 +15,18 @@
 //@[staticlib] compile-flags: --crate-type=staticlib
 //@[staticlib] check-pass
 
-//@[dylib] ignore-musl (dylib is supported, but musl libc is statically linked by default)
-//@[dylib] ignore-wasm (dylib is not supported)
+//@[dylib] needs-crate-type: dylib
 //@[dylib] compile-flags: --crate-type=dylib
 //@[dylib] check-pass
 
-//@[cdylib] ignore-musl (cdylib is supported, but musl libc is statically linked by default)
+//@[cdylib] needs-crate-type: cdylib
 //@[cdylib] compile-flags: --crate-type=cdylib
 //@[cdylib] check-pass
 
 //@[bin] compile-flags: --crate-type=bin
 //@[bin] check-pass
 
-//@[proc_dash_macro] ignore-wasm (proc-macro is not supported)
+//@[proc_dash_macro] needs-crate-type: proc-macro
 //@[proc_dash_macro] needs-unwind (panic=abort causes warning to be emitted)
 //@[proc_dash_macro] compile-flags: --crate-type=proc-macro
 //@[proc_dash_macro] check-pass

--- a/tests/ui/linkage-attr/issue-12133-3.rs
+++ b/tests/ui/linkage-attr/issue-12133-3.rs
@@ -2,8 +2,7 @@
 //@ aux-build:issue-12133-rlib.rs
 //@ aux-build:issue-12133-dylib.rs
 //@ aux-build:issue-12133-dylib2.rs
-//@ ignore-wasm32 no dylib support
-//@ ignore-musl
+//@ needs-crate-type: dylib
 //@ needs-dynamic-linking
 
 

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.cdylib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.cdylib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:36:18
+  --> $DIR/lint-non-snake-case-crate.rs:35:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:38:9
+  --> $DIR/lint-non-snake-case-crate.rs:37:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.dylib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.dylib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:36:18
+  --> $DIR/lint-non-snake-case-crate.rs:35:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:38:9
+  --> $DIR/lint-non-snake-case-crate.rs:37:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.lib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.lib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:36:18
+  --> $DIR/lint-non-snake-case-crate.rs:35:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:38:9
+  --> $DIR/lint-non-snake-case-crate.rs:37:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.proc_macro_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.proc_macro_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:36:18
+  --> $DIR/lint-non-snake-case-crate.rs:35:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:38:9
+  --> $DIR/lint-non-snake-case-crate.rs:37:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rlib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rlib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:36:18
+  --> $DIR/lint-non-snake-case-crate.rs:35:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:38:9
+  --> $DIR/lint-non-snake-case-crate.rs:37:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rs
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rs
@@ -10,28 +10,27 @@
 
 // But should fire on non-binary crates.
 
-// FIXME(#132309): dylib crate type is not supported on wasm; we need a proper
-// supports-crate-type directive. Also, needs-dynamic-linking should rule out
-// musl since it supports neither dylibs nor cdylibs.
-//@[dylib_] ignore-wasm
-//@[dylib_] ignore-musl
-//@[cdylib_] ignore-musl
-
-//@[dylib_] needs-dynamic-linking
+//@[cdylib_] compile-flags: --crate-type=cdylib
 //@[cdylib_] needs-dynamic-linking
+//@[cdylib_] needs-crate-type: cdylib
+
+//@[dylib_] compile-flags: --crate-type=dylib
+//@[dylib_] needs-dynamic-linking
+//@[dylib_] needs-crate-type: dylib
+
+//@[lib_] compile-flags: --crate-type=lib
+
 //@[proc_macro_] force-host
 //@[proc_macro_] no-prefer-dynamic
-
-//@[cdylib_] compile-flags: --crate-type=cdylib
-//@[dylib_] compile-flags: --crate-type=dylib
-//@[lib_] compile-flags: --crate-type=lib
 //@[proc_macro_] compile-flags: --crate-type=proc-macro
-//@[rlib_] compile-flags: --crate-type=rlib
-//@[staticlib_] compile-flags: --crate-type=staticlib
-
-// The compiler may emit a warning that causes stderr output
-// that contains a warning this test does not wish to check.
+// The compiler may emit a warning that causes stderr output that contains a warning this test does
+// not wish to check.
 //@[proc_macro_] needs-unwind
+//@[proc_macro_] needs-crate-type: proc-macro
+
+//@[rlib_] compile-flags: --crate-type=rlib
+
+//@[staticlib_] compile-flags: --crate-type=staticlib
 
 #![crate_name = "NonSnakeCase"]
 //[cdylib_,dylib_,lib_,proc_macro_,rlib_,staticlib_]~^ ERROR crate `NonSnakeCase` should have a snake case name

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.staticlib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.staticlib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:36:18
+  --> $DIR/lint-non-snake-case-crate.rs:35:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:38:9
+  --> $DIR/lint-non-snake-case-crate.rs:37:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/panic-runtime/abort-link-to-unwind-dylib.rs
+++ b/tests/ui/panic-runtime/abort-link-to-unwind-dylib.rs
@@ -1,9 +1,7 @@
 //@ build-fail
 //@ compile-flags:-C panic=abort -C prefer-dynamic
 //@ needs-unwind
-//@ ignore-musl - no dylibs here
-//@ ignore-emscripten
-//@ ignore-sgx no dynamic lib support
+//@ needs-crate-type: dylib
 
 // This is a test where the local crate, compiled with `panic=abort`, links to
 // the standard library **dynamically** which is already linked against


### PR DESCRIPTION
The `//@ needs-crate-type: $crate_types...` directive takes a comma-separated list of crate types that the target platform must support in order for the test to be run. This allows the test writer to semantically convey that the ignore condition is based on target crate type needs, instead of using a general purpose `//@ ignore-$target` directive (often without comment).

Fixes #132309.

### Example

```rs
//@ needs-crate-type: dylib (ignored on e.g. wasm32-unknown-unknown)
//@ compile-flags: --crate-type=dylib

fn foo() {}
```

### Review advice

- Best reviewed commit-by-commit.
- The impl is not very clean, I briefly attempted to clean up the directive handling but found that more invasive changes are needed, so I'd like to not block on the cleanup for now.

try-job: test-various
try-job: armhf-gnu