### PR TITLE
compiletest: Add directive `dont-require-annotations`

### DIFF
--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -22,6 +22,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "dont-check-compiler-stderr",
     "dont-check-compiler-stdout",
     "dont-check-failure-status",
+    "dont-require-annotations",
     "edition",
     "error-pattern",
     "exact-llvm-major-version",

--- a/src/tools/compiletest/src/errors.rs
+++ b/src/tools/compiletest/src/errors.rs
@@ -8,7 +8,7 @@ use std::sync::OnceLock;
 use regex::Regex;
 use tracing::*;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ErrorKind {
     Help,
     Error,
@@ -38,6 +38,15 @@ impl ErrorKind {
             "SUGGESTION" => ErrorKind::Suggestion,
             "WARN" | "WARNING" | "warn" | "warning" => ErrorKind::Warning,
             _ => return None,
+        })
+    }
+
+    pub fn expect_from_user_str(s: &str) -> ErrorKind {
+        ErrorKind::from_user_str(s).unwrap_or_else(|| {
+            panic!(
+                "unexpected diagnostic kind `{s}`, expected \
+                 `ERROR`, `WARN`, `NOTE`, `HELP` or `SUGGESTION`"
+            )
         })
     }
 }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -710,10 +710,6 @@ impl<'test> TestCx<'test> {
             self.testpaths.file.display().to_string()
         };
 
-        // If the testcase being checked contains at least one expected "help"
-        // message, then we'll ensure that all "help" messages are expected.
-        // Otherwise, all "help" messages reported by the compiler will be ignored.
-        // This logic also applies to "note" messages.
         let expect_help = expected_errors.iter().any(|ee| ee.kind == Some(ErrorKind::Help));
         let expect_note = expected_errors.iter().any(|ee| ee.kind == Some(ErrorKind::Note));
 
@@ -801,9 +797,7 @@ impl<'test> TestCx<'test> {
     }
 
     /// Returns `true` if we should report an error about `actual_error`,
-    /// which did not match any of the expected error. We always require
-    /// errors/warnings to be explicitly listed, but only require
-    /// helps/notes if there are explicit helps/notes given.
+    /// which did not match any of the expected error.
     fn is_unexpected_compiler_message(
         &self,
         actual_error: &Error,
@@ -811,12 +805,16 @@ impl<'test> TestCx<'test> {
         expect_note: bool,
     ) -> bool {
         actual_error.require_annotation
-            && match actual_error.kind {
-                Some(ErrorKind::Help) => expect_help,
-                Some(ErrorKind::Note) => expect_note,
-                Some(ErrorKind::Error) | Some(ErrorKind::Warning) => true,
-                Some(ErrorKind::Suggestion) | None => false,
-            }
+            && actual_error.kind.map_or(false, |err_kind| {
+                // If the test being checked doesn't contain any "help" or "note" annotations, then
+                // we don't require annotating "help" or "note" (respecively) diagnostics at all.
+                let default_require_annotations = self.props.require_annotations[&err_kind];
+                match err_kind {
+                    ErrorKind::Help => expect_help && default_require_annotations,
+                    ErrorKind::Note => expect_note && default_require_annotations,
+                    _ => default_require_annotations,
+                }
+            })
     }
 
     fn should_emit_metadata(&self, pm: Option<PassMode>) -> Emit {

--- a/tests/ui/cfg/cfg_false_no_std-2.rs
+++ b/tests/ui/cfg/cfg_false_no_std-2.rs
@@ -1,7 +1,6 @@
 // Error, the linked empty library is `no_std` and doesn't provide a panic handler.
 
-//@ compile-flags: --error-format=human
-//@ error-pattern: `#[panic_handler]` function required, but not found
+//@ dont-require-annotations:ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build: cfg_false_lib_no_std_before.rs
 
@@ -11,6 +10,7 @@ extern crate cfg_false_lib_no_std_before as _;
 
 fn main() {}
 
-// FIXME: The second error is target-dependent.
-//FIXME~? ERROR `#[panic_handler]` function required, but not found
+//~? ERROR `#[panic_handler]` function required, but not found
+// FIXME: This error is target-dependent, could be served by some "optional error" annotation
+// instead of `dont-require-annotations`.
 //FIXME~? ERROR unwinding panics are not supported without std

--- a/tests/ui/panic-runtime/two-panic-runtimes.rs
+++ b/tests/ui/panic-runtime/two-panic-runtimes.rs
@@ -1,7 +1,6 @@
 // ignore-tidy-linelength
 //@ build-fail
-//@ compile-flags: --error-format=human
-//@ error-pattern: cannot link together two panic runtimes: panic_runtime_unwind and panic_runtime_unwind2
+//@ dont-require-annotations:ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build:panic-runtime-unwind.rs
 //@ aux-build:panic-runtime-unwind2.rs
@@ -16,7 +15,8 @@ extern crate panic_runtime_lang_items;
 
 fn main() {}
 
-// FIXME: The second and third errors are target-dependent.
-//FIXME~? ERROR cannot link together two panic runtimes: panic_runtime_unwind and panic_runtime_unwind2
+//~? ERROR cannot link together two panic runtimes: panic_runtime_unwind and panic_runtime_unwind2
+// FIXME: These errors are target-dependent, could be served by some "optional error" annotation
+// instead of `dont-require-annotations`.
 //FIXME~? ERROR the linked panic runtime `panic_runtime_unwind2` is not compiled with this crate's panic strategy `abort`
 //FIXME~? ERROR the crate `panic_runtime_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`

--- a/tests/ui/panic-runtime/want-abort-got-unwind.rs
+++ b/tests/ui/panic-runtime/want-abort-got-unwind.rs
@@ -1,7 +1,6 @@
 // ignore-tidy-linelength
 //@ build-fail
-//@ compile-flags: --error-format=human
-//@ error-pattern: the linked panic runtime `panic_runtime_unwind` is not compiled with this crate's panic strategy `abort`
+//@ dont-require-annotations:ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build:panic-runtime-unwind.rs
 //@ compile-flags:-C panic=abort
@@ -10,7 +9,8 @@ extern crate panic_runtime_unwind;
 
 fn main() {}
 
-// FIXME: The first and third errors are target-dependent.
+//~? ERROR the linked panic runtime `panic_runtime_unwind` is not compiled with this crate's panic strategy `abort`
+// FIXME: These errors are target-dependent, could be served by some "optional error" annotation
+// instead of `dont-require-annotations`.
 //FIXME~? ERROR cannot link together two panic runtimes: panic_unwind and panic_runtime_unwind
-//FIXME~? ERROR the linked panic runtime `panic_runtime_unwind` is not compiled with this crate's panic strategy `abort`
 //FIXME~? ERROR the crate `panic_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`

--- a/tests/ui/panic-runtime/want-abort-got-unwind2.rs
+++ b/tests/ui/panic-runtime/want-abort-got-unwind2.rs
@@ -1,7 +1,6 @@
 // ignore-tidy-linelength
 //@ build-fail
-//@ compile-flags: --error-format=human
-//@ error-pattern: the linked panic runtime `panic_runtime_unwind` is not compiled with this crate's panic strategy `abort`
+//@ dont-require-annotations:ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build:panic-runtime-unwind.rs
 //@ aux-build:wants-panic-runtime-unwind.rs
@@ -11,7 +10,8 @@ extern crate wants_panic_runtime_unwind;
 
 fn main() {}
 
-// FIXME: The first and third errors are target-dependent.
+//~? ERROR the linked panic runtime `panic_runtime_unwind` is not compiled with this crate's panic strategy `abort`
+// FIXME: These errors are target-dependent, could be served by some "optional error" annotation
+// instead of `dont-require-annotations`.
 //FIXME~? ERROR cannot link together two panic runtimes: panic_unwind and panic_runtime_unwind
-//FIXME~? ERROR the linked panic runtime `panic_runtime_unwind` is not compiled with this crate's panic strategy `abort`
 //FIXME~? ERROR the crate `panic_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`


### PR DESCRIPTION
for making matching on specific diagnostic kinds non-exhaustive.

E.g. `//@ dont-require-annotations:ERROR`, like in the examples in this PR.

cc https://github.com/rust-lang/rust/pull/139427#issuecomment-2782827583

Closes #132647 FYI @BoxyUwU since you've wanted this.

r? @jieyouxu 