### PR TITLE
Explicitly export core and std macros

### DIFF
--- a/compiler/rustc_builtin_macros/src/standard_library_imports.rs
+++ b/compiler/rustc_builtin_macros/src/standard_library_imports.rs
@@ -43,7 +43,7 @@ pub fn inject(
 
     let item = cx.item(
         span,
-        thin_vec![cx.attr_word(sym::macro_use, span)],
+        ast::AttrVec::new(),
         ast::ItemKind::ExternCrate(None, Ident::new(name, ident_span)),
     );
 

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -19,6 +19,7 @@ declare_lint_pass! {
         AMBIGUOUS_ASSOCIATED_ITEMS,
         AMBIGUOUS_GLOB_IMPORTS,
         AMBIGUOUS_GLOB_REEXPORTS,
+        AMBIGUOUS_PANIC_IMPORTS,
         ARITHMETIC_OVERFLOW,
         ASM_SUB_REGISTER,
         BAD_ASM_STYLE,
@@ -4469,6 +4470,42 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: fcw!(FutureReleaseError #114095),
         report_in_deps: true,
+    };
+}
+
+declare_lint! {
+    /// The `ambiguous_panic_imports` lint detects ambiguous core and std panic imports, but
+    /// previously didn't do that due to `#[macro_use]` prelude macro import.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(ambiguous_panic_imports)]
+    /// #![no_std]
+    ///
+    /// extern crate std;
+    /// use std::prelude::v1::*;
+    ///
+    /// fn xx() {
+    ///     panic!(); // resolves to core::panic
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Future versions of Rust will no longer accept the ambiguous resolution.
+    ///
+    /// This is a [future-incompatible] lint to transition this to a hard error in the future.
+    ///
+    /// [future-incompatible]: ../index.md#future-incompatible-lints
+    pub AMBIGUOUS_PANIC_IMPORTS,
+    Warn,
+    "detects ambiguous core and std panic imports",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: fcw!(FutureReleaseError #147319),
+        report_in_deps: false,
     };
 }
 

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -8,6 +8,7 @@ use rustc_hir::def::{DefKind, MacroKinds, Namespace, NonMacroAttrKind, PartialRe
 use rustc_middle::{bug, span_bug};
 use rustc_session::lint::builtin::PROC_MACRO_DERIVE_RESOLUTION_FALLBACK;
 use rustc_session::parse::feature_err;
+use rustc_span::edition::Edition;
 use rustc_span::hygiene::{ExpnId, ExpnKind, LocalExpnId, MacroKind, SyntaxContext};
 use rustc_span::{Ident, Macros20NormalizedIdent, Span, kw, sym};
 use smallvec::SmallVec;
@@ -20,9 +21,10 @@ use crate::late::{
 };
 use crate::macros::{MacroRulesScope, sub_namespace_match};
 use crate::{
-    AmbiguityError, AmbiguityKind, BindingKey, CmResolver, Decl, DeclKind, Determinacy, Finalize,
-    ImportKind, LateDecl, Module, ModuleKind, ModuleOrUniformRoot, ParentScope, PathResult,
-    PrivacyError, Res, ResolutionError, Resolver, Scope, ScopeSet, Segment, Stage, Used, errors,
+    AmbiguityError, AmbiguityKind, AmbiguityWarning, BindingKey, CmResolver, Decl, DeclKind,
+    Determinacy, Finalize, ImportKind, LateDecl, Module, ModuleKind, ModuleOrUniformRoot,
+    ParentScope, PathResult, PrivacyError, Res, ResolutionError, Resolver, Scope, ScopeSet,
+    Segment, Stage, Used, errors,
 };
 
 #[derive(Copy, Clone)]
@@ -841,6 +843,19 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             if issue_145575_hack || issue_149681_hack {
                 self.issue_145575_hack_applied = true;
             } else {
+                // Turn ambiguity errors for core vs std panic into warnings.
+                // FIXME: Remove with lang team approval.
+                let is_issue_147319_hack = orig_ident.span.edition() <= Edition::Edition2024
+                    && matches!(orig_ident.name, sym::panic)
+                    && matches!(scope, Scope::StdLibPrelude)
+                    && matches!(innermost_scope, Scope::ModuleGlobs(_, _))
+                    && ((self.is_specific_builtin_macro(res, sym::std_panic)
+                        && self.is_specific_builtin_macro(innermost_res, sym::core_panic))
+                        || (self.is_specific_builtin_macro(res, sym::core_panic)
+                            && self.is_specific_builtin_macro(innermost_res, sym::std_panic)));
+
+                let warning = is_issue_147319_hack.then_some(AmbiguityWarning::PanicImport);
+
                 self.ambiguity_errors.push(AmbiguityError {
                     kind,
                     ident: orig_ident,
@@ -848,7 +863,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     b2: decl,
                     scope1: innermost_scope,
                     scope2: scope,
-                    warning: false,
+                    warning,
                 });
                 return true;
             }

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -959,8 +959,9 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
             ImportKind::Single { decls, .. } => decls[TypeNS].get().decl(),
             _ => None,
         };
-        let ambiguity_errors_len =
-            |errors: &Vec<AmbiguityError<'_>>| errors.iter().filter(|error| !error.warning).count();
+        let ambiguity_errors_len = |errors: &Vec<AmbiguityError<'_>>| {
+            errors.iter().filter(|error| error.warning.is_none()).count()
+        };
         let prev_ambiguity_errors_len = ambiguity_errors_len(&self.ambiguity_errors);
         let finalize = Finalize::with_root_span(import.root_id, import.span, import.root_span);
 
@@ -1176,7 +1177,7 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                         });
                         let res = binding.res();
                         let has_ambiguity_error =
-                            this.ambiguity_errors.iter().any(|error| !error.warning);
+                            this.ambiguity_errors.iter().any(|error| error.warning.is_none());
                         if res == Res::Err || has_ambiguity_error {
                             this.dcx()
                                 .span_delayed_bug(import.span, "some error happened for an import");

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -835,10 +835,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                                  res: Res| {
             if let Some(initial_res) = initial_res {
                 if res != initial_res {
-                    // Make sure compilation does not succeed if preferred macro resolution
-                    // has changed after the macro had been expanded. In theory all such
-                    // situations should be reported as errors, so this is a bug.
-                    this.dcx().span_delayed_bug(span, "inconsistent resolution for a macro");
+                    if this.ambiguity_errors.is_empty() {
+                        // Make sure compilation does not succeed if preferred macro resolution
+                        // has changed after the macro had been expanded. In theory all such
+                        // situations should be reported as errors, so this is a bug.
+                        this.dcx().span_delayed_bug(span, "inconsistent resolution for a macro");
+                    }
                 }
             } else if this.tcx.dcx().has_errors().is_none() && this.privacy_errors.is_empty() {
                 // It's possible that the macro was unresolved (indeterminate) and silently

--- a/library/alloctests/lib.rs
+++ b/library/alloctests/lib.rs
@@ -65,6 +65,7 @@
 #![feature(negative_impls)]
 #![feature(never_type)]
 #![feature(optimize_attribute)]
+#![feature(prelude_import)]
 #![feature(rustc_allow_const_fn_unstable)]
 #![feature(rustc_attrs)]
 #![feature(staged_api)]
@@ -74,11 +75,17 @@
 
 // Allow testing this library
 extern crate alloc as realalloc;
-#[macro_use]
+
+// This is needed to provide macros to the directly imported alloc modules below.
 extern crate std;
+#[prelude_import]
+#[allow(unused_imports)]
+use std::prelude::rust_2024::*;
+
 #[cfg(test)]
 extern crate test;
 mod testing;
+
 use realalloc::*;
 
 // We are directly including collections, raw_vec, and wtf8 here as they use non-public
@@ -102,8 +109,7 @@ pub(crate) mod test_helpers {
         let mut hasher = std::hash::RandomState::new().build_hasher();
         std::panic::Location::caller().hash(&mut hasher);
         let hc64 = hasher.finish();
-        let seed_vec =
-            hc64.to_le_bytes().into_iter().chain(0u8..8).collect::<crate::vec::Vec<u8>>();
+        let seed_vec = hc64.to_le_bytes().into_iter().chain(0u8..8).collect::<std::vec::Vec<u8>>();
         let seed: [u8; 16] = seed_vec.as_slice().try_into().unwrap();
         rand::SeedableRng::from_seed(seed)
     }

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -59,11 +59,30 @@ pub use crate::hash::macros::Hash;
 
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(no_inline)]
+#[expect(deprecated)]
 pub use crate::{
-    assert, cfg, column, compile_error, concat, env, file, format_args,
-    format_args_nl, include, include_bytes, include_str, line, log_syntax, module_path, option_env,
-    stringify, trace_macros,
+    assert, assert_eq, assert_ne, cfg, column, compile_error, concat, debug_assert, debug_assert_eq,
+    debug_assert_ne, file, format_args, include, include_bytes, include_str, line, matches,
+    module_path, option_env, stringify, todo, r#try, unimplemented, unreachable, write, writeln,
 };
+
+// These macros need special handling, so that we don't export them *and* the modules of the same
+// name. We only want the macros in the prelude so we shadow the original modules with private
+// modules with the same names.
+mod ambiguous_macros_only {
+    mod env {}
+    #[expect(hidden_glob_reexports)]
+    mod panic {}
+    #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+    pub use crate::*;
+}
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use self::ambiguous_macros_only::{env, panic};
+
+#[unstable(feature = "cfg_select", issue = "115585")]
+#[doc(no_inline)]
+pub use crate::cfg_select;
 
 #[unstable(
     feature = "concat_bytes",
@@ -72,6 +91,30 @@ pub use crate::{
 )]
 #[doc(no_inline)]
 pub use crate::concat_bytes;
+
+#[unstable(feature = "const_format_args", issue = "none")]
+#[doc(no_inline)]
+pub use crate::const_format_args;
+
+#[unstable(
+    feature = "log_syntax",
+    issue = "29598",
+    reason = "`log_syntax!` is not stable enough for use and is subject to change"
+)]
+#[doc(no_inline)]
+pub use crate::log_syntax;
+
+#[unstable(feature = "pattern_type_macro", issue = "123646")]
+#[doc(no_inline)]
+pub use crate::pattern_type;
+
+#[unstable(
+    feature = "trace_macros",
+    issue = "29598",
+    reason = "`trace_macros` is not stable enough for use and is subject to change"
+)]
+#[doc(no_inline)]
+pub use crate::trace_macros;
 
 // Do not `doc(no_inline)` so that they become doc items on their own
 // (no public module for them to be re-exported from).

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -54,9 +54,9 @@
 //! * <code>[std::convert]::{[AsRef], [AsMut], [Into], [From]}</code>, generic
 //!   conversions, used by savvy API authors to create overloaded methods.
 //! * <code>[std::default]::[Default]</code>, types that have default values.
-//! * <code>[std::iter]::{[Iterator], [Extend], [IntoIterator], [DoubleEndedIterator], [ExactSizeIterator]}</code>,
-//!   iterators of various
-//!   kinds.
+//! * <code>[std::iter]::{[Iterator], [Extend], [IntoIterator], [DoubleEndedIterator],
+//!   [ExactSizeIterator]}</code>, iterators of various kinds.
+//! * Most of the standard macros.
 //! * <code>[std::option]::[Option]::{[self][Option], [Some], [None]}</code>, a
 //!   type which expresses the presence or absence of a value. This type is so
 //!   commonly used, its variants are also exported.
@@ -145,6 +145,11 @@ pub mod rust_2021 {
     #[stable(feature = "prelude_2021", since = "1.55.0")]
     #[doc(no_inline)]
     pub use core::prelude::rust_2021::*;
+
+    // There are two different panic macros, one in `core` and one in `std`. They are slightly
+    // different. For `std` we explicitly want the one defined in `std`.
+    #[stable(feature = "prelude_2021", since = "1.55.0")]
+    pub use super::v1::panic;
 }
 
 /// The 2024 version of the prelude of The Rust Standard Library.
@@ -159,6 +164,11 @@ pub mod rust_2024 {
     #[stable(feature = "prelude_2024", since = "1.85.0")]
     #[doc(no_inline)]
     pub use core::prelude::rust_2024::*;
+
+    // There are two different panic macros, one in `core` and one in `std`. They are slightly
+    // different. For `std` we explicitly want the one defined in `std`.
+    #[stable(feature = "prelude_2024", since = "1.85.0")]
+    pub use super::v1::panic;
 }
 
 /// The Future version of the prelude of The Rust Standard Library.
@@ -174,4 +184,9 @@ pub mod rust_future {
     #[unstable(feature = "prelude_next", issue = "none")]
     #[doc(no_inline)]
     pub use core::prelude::rust_future::*;
+
+    // There are two different panic macros, one in `core` and one in `std`. They are slightly
+    // different. For `std` we explicitly want the one defined in `std`.
+    #[unstable(feature = "prelude_next", issue = "none")]
+    pub use super::v1::panic;
 }

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -43,14 +43,45 @@ pub use crate::option::Option::{self, None, Some};
 #[doc(no_inline)]
 pub use crate::result::Result::{self, Err, Ok};
 
-// Re-exported built-in macros
+// Re-exported built-in macros and traits
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(no_inline)]
+#[expect(deprecated)]
 pub use core::prelude::v1::{
-    assert, cfg, column, compile_error, concat, env, file, format_args,
-    format_args_nl, include, include_bytes, include_str, line, log_syntax, module_path, option_env,
-    stringify, trace_macros, Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd,
+    assert, assert_eq, assert_ne, cfg, column, compile_error, concat, debug_assert, debug_assert_eq,
+    debug_assert_ne, env, file, format_args, include, include_bytes, include_str, line, matches,
+    module_path, option_env, stringify, todo, r#try, unimplemented, unreachable, write,
+    writeln, Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd,
 };
+
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use crate::{
+    dbg, eprint, eprintln, format, is_x86_feature_detected, print, println, thread_local
+};
+
+// These macros need special handling, so that we don't export them *and* the modules of the same
+// name. We only want the macros in the prelude so we shadow the original modules with private
+// modules with the same names.
+mod ambiguous_macros_only {
+    #[expect(hidden_glob_reexports)]
+    mod vec {}
+    #[expect(hidden_glob_reexports)]
+    mod panic {}
+    // Building std without the expect exported_private_dependencies will create warnings, but then
+    // clippy claims its a useless_attribute. So silence both.
+    #[expect(clippy::useless_attribute)]
+    #[expect(exported_private_dependencies)]
+    #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+    pub use crate::*;
+}
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use self::ambiguous_macros_only::{vec, panic};
+
+#[unstable(feature = "cfg_select", issue = "115585")]
+#[doc(no_inline)]
+pub use core::prelude::v1::cfg_select;
 
 #[unstable(
     feature = "concat_bytes",
@@ -59,6 +90,26 @@ pub use core::prelude::v1::{
 )]
 #[doc(no_inline)]
 pub use core::prelude::v1::concat_bytes;
+
+#[unstable(feature = "const_format_args", issue = "none")]
+#[doc(no_inline)]
+pub use core::prelude::v1::const_format_args;
+
+#[unstable(
+    feature = "log_syntax",
+    issue = "29598",
+    reason = "`log_syntax!` is not stable enough for use and is subject to change"
+)]
+#[doc(no_inline)]
+pub use core::prelude::v1::log_syntax;
+
+#[unstable(
+    feature = "trace_macros",
+    issue = "29598",
+    reason = "`trace_macros` is not stable enough for use and is subject to change"
+)]
+#[doc(no_inline)]
+pub use core::prelude::v1::trace_macros;
 
 // Do not `doc(no_inline)` so that they become doc items on their own
 // (no public module for them to be re-exported from).

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -167,7 +167,7 @@ use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut};
 use crate::num::NonZero;
 use crate::path::Path;
 use crate::sys::{AsInner, AsInnerMut, FromInner, IntoInner, process as imp};
-use crate::{fmt, fs, str};
+use crate::{fmt, format_args_nl, fs, str};
 
 /// Representation of a running or exited child process.
 ///

--- a/tests/pretty/asm.pp
+++ b/tests/pretty/asm.pp
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/autodiff/autodiff_forward.pp
+++ b/tests/pretty/autodiff/autodiff_forward.pp
@@ -3,7 +3,6 @@
 //@ only-nightly
 
 #![feature(autodiff)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/autodiff/autodiff_reverse.pp
+++ b/tests/pretty/autodiff/autodiff_reverse.pp
@@ -3,7 +3,6 @@
 //@ only-nightly
 
 #![feature(autodiff)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/autodiff/inherent_impl.pp
+++ b/tests/pretty/autodiff/inherent_impl.pp
@@ -3,7 +3,6 @@
 //@ only-nightly
 
 #![feature(autodiff)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/cast-lt.pp
+++ b/tests/pretty/cast-lt.pp
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/delegation-impl-reuse.pp
+++ b/tests/pretty/delegation-impl-reuse.pp
@@ -6,7 +6,6 @@
 
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/delegation-inherit-attributes.pp
+++ b/tests/pretty/delegation-inherit-attributes.pp
@@ -6,7 +6,6 @@
 
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use std::prelude::rust_2021::*;

--- a/tests/pretty/delegation-inline-attribute.pp
+++ b/tests/pretty/delegation-inline-attribute.pp
@@ -4,7 +4,6 @@
 
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/dollar-crate.pp
+++ b/tests/pretty/dollar-crate.pp
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/expanded-and-path-remap-80832.pp
+++ b/tests/pretty/expanded-and-path-remap-80832.pp
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/format-args-str-escape.pp
+++ b/tests/pretty/format-args-str-escape.pp
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/hir-delegation.pp
+++ b/tests/pretty/hir-delegation.pp
@@ -4,7 +4,6 @@
 
 #![allow(incomplete_features)]
 #![feature(fn_delegation)]
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/hir-fn-params.pp
+++ b/tests/pretty/hir-fn-params.pp
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/hir-fn-variadic.pp
+++ b/tests/pretty/hir-fn-variadic.pp
@@ -3,7 +3,6 @@
 //@ pp-exact:hir-fn-variadic.pp
 
 #![feature(c_variadic)]
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/hir-if-else.pp
+++ b/tests/pretty/hir-if-else.pp
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/hir-lifetimes.pp
+++ b/tests/pretty/hir-lifetimes.pp
@@ -5,7 +5,6 @@
 // This tests the pretty-printing of lifetimes in lots of ways.
 
 #![allow(unused)]
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/hir-pretty-attr.pp
+++ b/tests/pretty/hir-pretty-attr.pp
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/hir-pretty-loop.pp
+++ b/tests/pretty/hir-pretty-loop.pp
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/hir-struct-expr.pp
+++ b/tests/pretty/hir-struct-expr.pp
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/if-else.pp
+++ b/tests/pretty/if-else.pp
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/issue-12590-c.pp
+++ b/tests/pretty/issue-12590-c.pp
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/issue-4264.pp
+++ b/tests/pretty/issue-4264.pp
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/issue-85089.pp
+++ b/tests/pretty/issue-85089.pp
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/never-pattern.pp
+++ b/tests/pretty/never-pattern.pp
@@ -7,7 +7,6 @@
 #![allow(incomplete_features)]
 #![feature(never_patterns)]
 #![feature(never_type)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/pin-ergonomics-hir.pp
+++ b/tests/pretty/pin-ergonomics-hir.pp
@@ -4,7 +4,6 @@
 
 #![feature(pin_ergonomics)]
 #![allow(dead_code, incomplete_features)]
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/postfix-match/precedence.pp
+++ b/tests/pretty/postfix-match/precedence.pp
@@ -1,7 +1,6 @@
 #![feature(prelude_import)]
 #![no_std]
 #![feature(postfix_match)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/shebang-at-top.pp
+++ b/tests/pretty/shebang-at-top.pp
@@ -1,7 +1,6 @@
 #!/usr/bin/env rust
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/pretty/tests-are-sorted.pp
+++ b/tests/pretty/tests-are-sorted.pp
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/rustdoc-js-std/println-typo.js
+++ b/tests/rustdoc-js-std/println-typo.js
@@ -6,7 +6,10 @@ const EXPECTED = {
     'query': 'prinltn',
     'others': [
         { 'path': 'std', 'name': 'println' },
+        { 'path': 'std::prelude::v1', 'name': 'println' },
         { 'path': 'std', 'name': 'print' },
+        { 'path': 'std::prelude::v1', 'name': 'print' },
         { 'path': 'std', 'name': 'eprintln' },
+        { 'path': 'std::prelude::v1', 'name': 'eprintln' },
     ],
 };

--- a/tests/ui/asm/unpretty-expanded.stdout
+++ b/tests/ui/asm/unpretty-expanded.stdout
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stdout
+++ b/tests/ui/associated-type-bounds/return-type-notation/unpretty-parenthesized.stdout
@@ -1,5 +1,4 @@
 #![feature(prelude_import)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use std::prelude::rust_2021::*;

--- a/tests/ui/codemap_tests/unicode.expanded.stdout
+++ b/tests/ui/codemap_tests/unicode.expanded.stdout
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/const-generics/defaults/pretty-printing-ast.stdout
+++ b/tests/ui/const-generics/defaults/pretty-printing-ast.stdout
@@ -6,7 +6,6 @@
 //@ edition: 2015
 
 #![crate_type = "lib"]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/deriving/built-in-proc-macro-scope.stdout
+++ b/tests/ui/deriving/built-in-proc-macro-scope.stdout
@@ -6,7 +6,6 @@
 //@ edition:2015
 
 #![feature(derive_coerce_pointee)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/deriving/deriving-all-codegen.stdout
+++ b/tests/ui/deriving/deriving-all-codegen.stdout
@@ -18,7 +18,6 @@
 #![allow(dead_code)]
 #![allow(deprecated)]
 #![feature(derive_from)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use std::prelude::rust_2021::*;

--- a/tests/ui/deriving/deriving-coerce-pointee-expanded.stdout
+++ b/tests/ui/deriving/deriving-coerce-pointee-expanded.stdout
@@ -4,7 +4,6 @@
 //@ compile-flags: -Zunpretty=expanded
 //@ edition: 2015
 #![feature(derive_coerce_pointee)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/deriving/proc-macro-attribute-mixing.stdout
+++ b/tests/ui/deriving/proc-macro-attribute-mixing.stdout
@@ -12,7 +12,6 @@
 //@ edition: 2015
 
 #![feature(derive_coerce_pointee)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/feature-gates/feature-gate-format_args_nl.rs
+++ b/tests/ui/feature-gates/feature-gate-format_args_nl.rs
@@ -1,3 +1,5 @@
+use std::format_args_nl; //~ ERROR `format_args_nl` is only for internal language use
+
 fn main() {
     format_args_nl!(""); //~ ERROR `format_args_nl` is only for internal language use
 }

--- a/tests/ui/feature-gates/feature-gate-format_args_nl.stderr
+++ b/tests/ui/feature-gates/feature-gate-format_args_nl.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature `format_args_nl`: `format_args_nl` is only for internal language use and is subject to change
-  --> $DIR/feature-gate-format_args_nl.rs:2:5
+  --> $DIR/feature-gate-format_args_nl.rs:4:5
    |
 LL |     format_args_nl!("");
    |     ^^^^^^^^^^^^^^
@@ -7,6 +7,15 @@ LL |     format_args_nl!("");
    = help: add `#![feature(format_args_nl)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0658]: use of unstable library feature `format_args_nl`: `format_args_nl` is only for internal language use and is subject to change
+  --> $DIR/feature-gate-format_args_nl.rs:1:5
+   |
+LL | use std::format_args_nl;
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(format_args_nl)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/hygiene/format-args.rs
+++ b/tests/ui/hygiene/format-args.rs
@@ -3,6 +3,8 @@
 #![allow(non_upper_case_globals)]
 #![feature(format_args_nl)]
 
+use std::format_args_nl;
+
 static arg0: () = ();
 
 fn main() {

--- a/tests/ui/imports/ambiguous-panic-glob-vs-multiouter.rs
+++ b/tests/ui/imports/ambiguous-panic-glob-vs-multiouter.rs
@@ -1,0 +1,16 @@
+//@ edition: 2024
+#![crate_type = "lib"]
+mod m1 {
+    pub use core::prelude::v1::*;
+}
+
+mod m2 {
+    pub use std::prelude::v1::*;
+}
+
+use m2::*;
+fn foo() {
+    use m1::*;
+
+    panic!(); //~ ERROR: `panic` is ambiguous [E0659]
+}

--- a/tests/ui/imports/ambiguous-panic-glob-vs-multiouter.stderr
+++ b/tests/ui/imports/ambiguous-panic-glob-vs-multiouter.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-glob-vs-multiouter.rs:15:5
+   |
+LL |     panic!();
+   |     ^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-glob-vs-multiouter.rs:13:9
+   |
+LL |     use m1::*;
+   |         ^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+note: `panic` could also refer to the macro imported here
+  --> $DIR/ambiguous-panic-glob-vs-multiouter.rs:11:5
+   |
+LL | use m2::*;
+   |     ^^^^^
+   = help: use `crate::panic` to refer to this macro unambiguously
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/ambiguous-panic-globvsglob.rs
+++ b/tests/ui/imports/ambiguous-panic-globvsglob.rs
@@ -1,0 +1,23 @@
+//@ edition: 2024
+#![crate_type = "lib"]
+mod m1 {
+    pub use core::prelude::v1::*;
+}
+
+mod m2 {
+    pub use std::prelude::v1::*;
+}
+
+fn foo() {
+    use m1::*;
+    use m2::*;
+
+    // I had hoped that this would not produce the globvsglob error because it would never be
+    // resolving `panic` via one of the ambiguous glob imports above but it appears to do so, not
+    // sure why
+    panic!();
+    //~^ WARN: `panic` is ambiguous [ambiguous_panic_imports]
+    //~| WARN: this was previously accepted by the compiler
+    //~| ERROR: `panic` is ambiguous [ambiguous_glob_imports]
+    //~| WARN: this was previously accepted by the compiler
+}

--- a/tests/ui/imports/ambiguous-panic-globvsglob.stderr
+++ b/tests/ui/imports/ambiguous-panic-globvsglob.stderr
@@ -1,0 +1,68 @@
+error: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-globvsglob.rs:18:5
+   |
+LL |     panic!();
+   |     ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-globvsglob.rs:12:9
+   |
+LL |     use m1::*;
+   |         ^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+note: `panic` could also refer to the macro imported here
+  --> $DIR/ambiguous-panic-globvsglob.rs:13:9
+   |
+LL |     use m2::*;
+   |         ^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+
+warning: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-globvsglob.rs:18:5
+   |
+LL |     panic!();
+   |     ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-globvsglob.rs:12:9
+   |
+LL |     use m1::*;
+   |         ^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
+   = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+Future incompatibility report: Future breakage diagnostic:
+error: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-globvsglob.rs:18:5
+   |
+LL |     panic!();
+   |     ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #114095 <https://github.com/rust-lang/rust/issues/114095>
+   = note: ambiguous because of multiple glob imports of a name in the same module
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-globvsglob.rs:12:9
+   |
+LL |     use m1::*;
+   |         ^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+note: `panic` could also refer to the macro imported here
+  --> $DIR/ambiguous-panic-globvsglob.rs:13:9
+   |
+LL |     use m2::*;
+   |         ^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+   = note: `#[deny(ambiguous_glob_imports)]` (part of `#[deny(future_incompatible)]`) on by default
+

--- a/tests/ui/imports/ambiguous-panic-no-implicit-prelude.rs
+++ b/tests/ui/imports/ambiguous-panic-no-implicit-prelude.rs
@@ -1,0 +1,16 @@
+//@ edition: 2024
+#![crate_type = "lib"]
+#![no_implicit_prelude]
+
+mod m1 {
+    macro_rules! panic {
+        () => {};
+    }
+
+    pub(crate) use panic;
+}
+
+fn foo() {
+    use m1::*;
+    panic!(); //~ERROR: `panic` is ambiguous [E0659]
+}

--- a/tests/ui/imports/ambiguous-panic-no-implicit-prelude.stderr
+++ b/tests/ui/imports/ambiguous-panic-no-implicit-prelude.stderr
@@ -1,0 +1,19 @@
+error[E0659]: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-no-implicit-prelude.rs:15:5
+   |
+LL |     panic!();
+   |     ^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-no-implicit-prelude.rs:14:9
+   |
+LL |     use m1::*;
+   |         ^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/ambiguous-panic-non-prelude-core-glob.rs
+++ b/tests/ui/imports/ambiguous-panic-non-prelude-core-glob.rs
@@ -1,0 +1,11 @@
+//@ edition: 2024
+//@ check-pass
+#![crate_type = "lib"]
+
+use ::core::*;
+
+fn f() {
+    panic!();
+    //~^ WARN: `panic` is ambiguous [ambiguous_panic_imports]
+    //~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+}

--- a/tests/ui/imports/ambiguous-panic-non-prelude-core-glob.stderr
+++ b/tests/ui/imports/ambiguous-panic-non-prelude-core-glob.stderr
@@ -1,0 +1,22 @@
+warning: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-non-prelude-core-glob.rs:8:5
+   |
+LL |     panic!();
+   |     ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-non-prelude-core-glob.rs:5:5
+   |
+LL | use ::core::*;
+   |     ^^^^^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+   = help: or use `crate::panic` to refer to this macro unambiguously
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
+   = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/imports/ambiguous-panic-non-prelude-std-glob.rs
+++ b/tests/ui/imports/ambiguous-panic-non-prelude-std-glob.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+#![crate_type = "lib"]
+#![no_std]
+
+extern crate std;
+use ::std::*;
+
+fn f() {
+    panic!();
+    //~^ WARN: `panic` is ambiguous [ambiguous_panic_imports]
+    //~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+}

--- a/tests/ui/imports/ambiguous-panic-non-prelude-std-glob.stderr
+++ b/tests/ui/imports/ambiguous-panic-non-prelude-std-glob.stderr
@@ -1,0 +1,22 @@
+warning: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-non-prelude-std-glob.rs:9:5
+   |
+LL |     panic!();
+   |     ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-non-prelude-std-glob.rs:6:5
+   |
+LL | use ::std::*;
+   |     ^^^^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+   = help: or use `crate::panic` to refer to this macro unambiguously
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/core/src/prelude/mod.rs:LL:COL
+   = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/imports/ambiguous-panic-pick-core.rs
+++ b/tests/ui/imports/ambiguous-panic-pick-core.rs
@@ -1,0 +1,11 @@
+//@ edition: 2018
+//@ check-pass
+#![crate_type = "lib"]
+use ::core::prelude::v1::*;
+
+fn f() {
+    panic!(&std::string::String::new());
+    //~^ WARN: `panic` is ambiguous [ambiguous_panic_imports]
+    //~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //~| WARN: panic message is not a string literal [non_fmt_panics]
+}

--- a/tests/ui/imports/ambiguous-panic-pick-core.stderr
+++ b/tests/ui/imports/ambiguous-panic-pick-core.stderr
@@ -1,0 +1,37 @@
+warning: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-pick-core.rs:7:5
+   |
+LL |     panic!(&std::string::String::new());
+   |     ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-pick-core.rs:4:5
+   |
+LL | use ::core::prelude::v1::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+   = help: or use `crate::panic` to refer to this macro unambiguously
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
+   = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: panic message is not a string literal
+  --> $DIR/ambiguous-panic-pick-core.rs:7:12
+   |
+LL |     panic!(&std::string::String::new());
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: `#[warn(non_fmt_panics)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
+help: add a "{}" format string to `Display` the message
+   |
+LL |     panic!("{}", &std::string::String::new());
+   |            +++++
+
+warning: 2 warnings emitted
+

--- a/tests/ui/imports/ambiguous-panic-pick-std.rs
+++ b/tests/ui/imports/ambiguous-panic-pick-std.rs
@@ -1,0 +1,14 @@
+//@ edition: 2018
+//@ check-pass
+#![crate_type = "lib"]
+#![no_std]
+
+extern crate std;
+use ::std::prelude::v1::*;
+
+fn f() {
+    panic!(std::string::String::new());
+    //~^ WARN: `panic` is ambiguous [ambiguous_panic_imports]
+    //~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //~| WARN: panic message is not a string literal [non_fmt_panics]
+}

--- a/tests/ui/imports/ambiguous-panic-pick-std.stderr
+++ b/tests/ui/imports/ambiguous-panic-pick-std.stderr
@@ -1,0 +1,37 @@
+warning: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-pick-std.rs:10:5
+   |
+LL |     panic!(std::string::String::new());
+   |     ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-pick-std.rs:7:5
+   |
+LL | use ::std::prelude::v1::*;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+   = help: or use `crate::panic` to refer to this macro unambiguously
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/core/src/prelude/mod.rs:LL:COL
+   = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: panic message is not a string literal
+  --> $DIR/ambiguous-panic-pick-std.rs:10:12
+   |
+LL |     panic!(std::string::String::new());
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2021/panic-macro-consistency.html>
+   = note: `#[warn(non_fmt_panics)]` (part of `#[warn(rust_2021_compatibility)]`) on by default
+help: add a "{}" format string to `Display` the message
+   |
+LL |     panic!("{}", std::string::String::new());
+   |            +++++
+
+warning: 2 warnings emitted
+

--- a/tests/ui/imports/ambiguous-panic-re-emit.rs
+++ b/tests/ui/imports/ambiguous-panic-re-emit.rs
@@ -1,0 +1,23 @@
+#![crate_type = "lib"]
+#![no_std]
+
+macro_rules! re_emit {
+    ($($i:item)*) => ($($i)*)
+}
+
+// By re-emitting the prelude import via a macro, we run into the delayed bugs code path.
+re_emit! {
+    extern crate std;
+    use std::prelude::v1::*;
+}
+
+fn xx() {
+    panic!();
+    //~^ WARNING `panic` is ambiguous
+    //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+    // We can't deny the above lint, or else it *won't* run into the problematic issue of *not*
+    // having reported an error. So we crate a dummy error.
+    let _ = unknown_item;
+    //~^ ERROR: cannot find value `unknown_item`
+}

--- a/tests/ui/imports/ambiguous-panic-re-emit.stderr
+++ b/tests/ui/imports/ambiguous-panic-re-emit.stderr
@@ -1,0 +1,29 @@
+error[E0425]: cannot find value `unknown_item` in this scope
+  --> $DIR/ambiguous-panic-re-emit.rs:21:13
+   |
+LL |     let _ = unknown_item;
+   |             ^^^^^^^^^^^^ not found in this scope
+
+warning: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-re-emit.rs:15:5
+   |
+LL |     panic!();
+   |     ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-re-emit.rs:11:9
+   |
+LL |     use std::prelude::v1::*;
+   |         ^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+   = help: or use `crate::panic` to refer to this macro unambiguously
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/core/src/prelude/mod.rs:LL:COL
+   = note: `#[warn(ambiguous_panic_imports)]` (part of `#[warn(future_incompatible)]`) on by default
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/imports/ambiguous-panic-rename-builtin.rs
+++ b/tests/ui/imports/ambiguous-panic-rename-builtin.rs
@@ -1,0 +1,15 @@
+//@ edition: 2024
+#![crate_type = "lib"]
+#![no_std]
+
+extern crate std;
+mod m1 {
+    pub use std::prelude::v1::env as panic;
+}
+use m1::*;
+
+fn xx() {
+    panic!();
+    //~^ ERROR: `env!()` takes 1 or 2 arguments
+    //~| ERROR: `panic` is ambiguous [E0659]
+}

--- a/tests/ui/imports/ambiguous-panic-rename-builtin.stderr
+++ b/tests/ui/imports/ambiguous-panic-rename-builtin.stderr
@@ -1,0 +1,26 @@
+error: `env!()` takes 1 or 2 arguments
+  --> $DIR/ambiguous-panic-rename-builtin.rs:12:5
+   |
+LL |     panic!();
+   |     ^^^^^^^^
+
+error[E0659]: `panic` is ambiguous
+  --> $DIR/ambiguous-panic-rename-builtin.rs:12:5
+   |
+LL |     panic!();
+   |     ^^^^^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-rename-builtin.rs:9:5
+   |
+LL | use m1::*;
+   |     ^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+   = help: or use `crate::panic` to refer to this macro unambiguously
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/core/src/prelude/mod.rs:LL:COL
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/ambiguous-panic-rename-panics.rs
+++ b/tests/ui/imports/ambiguous-panic-rename-panics.rs
@@ -1,0 +1,17 @@
+//@ edition: 2024
+#![crate_type = "lib"]
+
+mod m1 {
+    pub use core::prelude::v1::panic as p;
+}
+
+mod m2 {
+    pub use std::prelude::v1::panic as p;
+}
+
+use m2::*;
+fn xx() {
+    use m1::*;
+
+    p!(); //~ ERROR: `p` is ambiguous [E0659]
+}

--- a/tests/ui/imports/ambiguous-panic-rename-panics.stderr
+++ b/tests/ui/imports/ambiguous-panic-rename-panics.stderr
@@ -1,0 +1,23 @@
+error[E0659]: `p` is ambiguous
+  --> $DIR/ambiguous-panic-rename-panics.rs:16:5
+   |
+LL |     p!();
+   |     ^ ambiguous name
+   |
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `p` could refer to the macro imported here
+  --> $DIR/ambiguous-panic-rename-panics.rs:14:9
+   |
+LL |     use m1::*;
+   |         ^^^^^
+   = help: consider adding an explicit import of `p` to disambiguate
+note: `p` could also refer to the macro imported here
+  --> $DIR/ambiguous-panic-rename-panics.rs:12:5
+   |
+LL | use m2::*;
+   |     ^^^^^
+   = help: use `crate::p` to refer to this macro unambiguously
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0659`.

--- a/tests/ui/imports/ambiguous-panic.rs
+++ b/tests/ui/imports/ambiguous-panic.rs
@@ -1,0 +1,12 @@
+#![deny(ambiguous_panic_imports)]
+#![crate_type = "lib"]
+#![no_std]
+
+extern crate std;
+use std::prelude::v1::*;
+
+fn xx() {
+    panic!();
+    //~^ ERROR `panic` is ambiguous
+    //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+}

--- a/tests/ui/imports/ambiguous-panic.stderr
+++ b/tests/ui/imports/ambiguous-panic.stderr
@@ -1,0 +1,26 @@
+error: `panic` is ambiguous
+  --> $DIR/ambiguous-panic.rs:9:5
+   |
+LL |     panic!();
+   |     ^^^^^ ambiguous name
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #147319 <https://github.com/rust-lang/rust/issues/147319>
+   = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
+note: `panic` could refer to the macro imported here
+  --> $DIR/ambiguous-panic.rs:6:5
+   |
+LL | use std::prelude::v1::*;
+   |     ^^^^^^^^^^^^^^^^^^^
+   = help: consider adding an explicit import of `panic` to disambiguate
+   = help: or use `crate::panic` to refer to this macro unambiguously
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/core/src/prelude/mod.rs:LL:COL
+note: the lint level is defined here
+  --> $DIR/ambiguous-panic.rs:1:9
+   |
+LL | #![deny(ambiguous_panic_imports)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/imports/glob-shadowing.stderr
+++ b/tests/ui/imports/glob-shadowing.stderr
@@ -5,14 +5,15 @@ LL |         let x = env!("PATH");
    |                 ^^^ ambiguous name
    |
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
-   = note: `env` could refer to a macro from prelude
-note: `env` could also refer to the macro imported here
+note: `env` could refer to the macro imported here
   --> $DIR/glob-shadowing.rs:9:9
    |
 LL |     use crate::m::*;
    |         ^^^^^^^^^^^
    = help: consider adding an explicit import of `env` to disambiguate
    = help: or use `self::env` to refer to this macro unambiguously
+note: `env` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
 
 error[E0659]: `env` is ambiguous
   --> $DIR/glob-shadowing.rs:19:21
@@ -21,13 +22,14 @@ LL |             let x = env!("PATH");
    |                     ^^^ ambiguous name
    |
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
-   = note: `env` could refer to a macro from prelude
-note: `env` could also refer to the macro imported here
+note: `env` could refer to the macro imported here
   --> $DIR/glob-shadowing.rs:17:13
    |
 LL |         use crate::m::*;
    |             ^^^^^^^^^^^
    = help: consider adding an explicit import of `env` to disambiguate
+note: `env` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
 
 error[E0659]: `fenv` is ambiguous
   --> $DIR/glob-shadowing.rs:29:21

--- a/tests/ui/imports/local-modularized-tricky-fail-1.stderr
+++ b/tests/ui/imports/local-modularized-tricky-fail-1.stderr
@@ -31,8 +31,7 @@ LL |     panic!();
    |     ^^^^^ ambiguous name
    |
    = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
-   = note: `panic` could refer to a macro from prelude
-note: `panic` could also refer to the macro defined here
+note: `panic` could refer to the macro defined here
   --> $DIR/local-modularized-tricky-fail-1.rs:12:5
    |
 LL | /     macro_rules! panic {
@@ -43,6 +42,8 @@ LL | |     }
 LL |       define_panic!();
    |       --------------- in this macro invocation
    = help: use `crate::panic` to refer to this macro unambiguously
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
    = note: this error originates in the macro `define_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `include` is ambiguous
@@ -52,8 +53,7 @@ LL | include!();
    | ^^^^^^^ ambiguous name
    |
    = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
-   = note: `include` could refer to a macro from prelude
-note: `include` could also refer to the macro defined here
+note: `include` could refer to the macro defined here
   --> $DIR/local-modularized-tricky-fail-1.rs:18:5
    |
 LL | /     macro_rules! include {
@@ -64,6 +64,8 @@ LL | |     }
 LL |       define_include!();
    |       ----------------- in this macro invocation
    = help: use `crate::include` to refer to this macro unambiguously
+note: `include` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
    = note: this error originates in the macro `define_include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/tests/ui/imports/shadow_builtin_macros.stderr
+++ b/tests/ui/imports/shadow_builtin_macros.stderr
@@ -5,14 +5,15 @@ LL |     fn f() { panic!(); }
    |              ^^^^^ ambiguous name
    |
    = note: ambiguous because of a conflict between a name from a glob import and an outer scope during import or macro resolution
-   = note: `panic` could refer to a macro from prelude
-note: `panic` could also refer to the macro imported here
+note: `panic` could refer to the macro imported here
   --> $DIR/shadow_builtin_macros.rs:14:9
    |
 LL |     use crate::foo::*;
    |         ^^^^^^^^^^^^^
    = help: consider adding an explicit import of `panic` to disambiguate
    = help: or use `self::panic` to refer to this macro unambiguously
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
 
 error[E0659]: `panic` is ambiguous
   --> $DIR/shadow_builtin_macros.rs:33:5
@@ -21,8 +22,7 @@ LL |     panic!();
    |     ^^^^^ ambiguous name
    |
    = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
-   = note: `panic` could refer to a macro from prelude
-note: `panic` could also refer to the macro defined here
+note: `panic` could refer to the macro defined here
   --> $DIR/shadow_builtin_macros.rs:30:9
    |
 LL |         macro_rules! panic { () => {} }
@@ -30,6 +30,8 @@ LL |         macro_rules! panic { () => {} }
 LL |     } }
 LL |     m!();
    |     ---- in this macro invocation
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
    = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `n` is ambiguous
@@ -59,13 +61,14 @@ LL |     fn f() { panic!(); }
    |              ^^^^^ ambiguous name
    |
    = note: ambiguous because of a conflict between a macro-expanded name and a less macro-expanded name from outer scope during import or macro resolution
-   = note: `panic` could refer to a macro from prelude
-note: `panic` could also refer to the macro imported here
+note: `panic` could refer to the macro imported here
   --> $DIR/shadow_builtin_macros.rs:19:26
    |
 LL |     ::two_macros::m!(use crate::foo::panic;);
    |                          ^^^^^^^^^^^^^^^^^
    = help: use `self::panic` to refer to this macro unambiguously
+note: `panic` could also refer to a macro from prelude
+  --> $SRC_DIR/std/src/prelude/mod.rs:LL:COL
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/lint/dead-code/with-core-crate.rs
+++ b/tests/ui/lint/dead-code/with-core-crate.rs
@@ -1,7 +1,6 @@
 #![deny(dead_code)]
 #![allow(unreachable_code)]
 
-#[macro_use]
 extern crate core;
 
 fn foo() { //~ ERROR function `foo` is never used

--- a/tests/ui/lint/dead-code/with-core-crate.stderr
+++ b/tests/ui/lint/dead-code/with-core-crate.stderr
@@ -1,5 +1,5 @@
 error: function `foo` is never used
-  --> $DIR/with-core-crate.rs:7:4
+  --> $DIR/with-core-crate.rs:6:4
    |
 LL | fn foo() {
    |    ^^^

--- a/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.stdout
+++ b/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.stdout
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/non-consuming-methods-have-optimized-codegen.stdout
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/non-consuming-methods-have-optimized-codegen.stdout
@@ -5,7 +5,6 @@
 //@ edition: 2015
 
 #![feature(core_intrinsics, generic_assert)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/match/issue-82392.stdout
+++ b/tests/ui/match/issue-82392.stdout
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/tests/ui/proc-macro/meta-macro-hygiene.stdout
@@ -16,7 +16,6 @@ Respanned: TokenStream [Ident { ident: "$crate", span: $DIR/auxiliary/make-macro
 // in the stdout
 
 #![no_std /* 0#0 */]
-#[macro_use /* 0#1 */]
 extern crate core /* 0#1 */;
 #[prelude_import /* 0#1 */]
 use core /* 0#1 */::prelude /* 0#1 */::rust_2018 /* 0#1 */::*;

--- a/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
+++ b/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
@@ -36,7 +36,6 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
 
 #![feature /* 0#0 */(decl_macro)]
 #![no_std /* 0#0 */]
-#[macro_use /* 0#1 */]
 extern crate core /* 0#2 */;
 #[prelude_import /* 0#1 */]
 use ::core /* 0#1 */::prelude /* 0#1 */::rust_2015 /* 0#1 */::*;

--- a/tests/ui/proc-macro/quote/debug.stdout
+++ b/tests/ui/proc-macro/quote/debug.stdout
@@ -12,7 +12,6 @@
 
 #![feature(proc_macro_quote)]
 #![crate_type = "proc-macro"]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-pretty-check.stdout
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-pretty-check.stdout
@@ -1,6 +1,5 @@
 #![feature(prelude_import)]
 #![no_std]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -15,7 +15,7 @@ ast-stats - Ptr                       64 (NN.N%)             1
 ast-stats - Ref                       64 (NN.N%)             1
 ast-stats - ImplicitSelf             128 (NN.N%)             2
 ast-stats - Path                     640 (NN.N%)            10
-ast-stats PathSegment              888 (NN.N%)            37            24
+ast-stats PathSegment              864 (NN.N%)            36            24
 ast-stats Expr                     648 (NN.N%)             9            72
 ast-stats - InlineAsm                 72 (NN.N%)             1
 ast-stats - Match                     72 (NN.N%)             1
@@ -41,9 +41,9 @@ ast-stats - Let                       32 (NN.N%)             1
 ast-stats - Semi                      32 (NN.N%)             1
 ast-stats - Expr                      96 (NN.N%)             3
 ast-stats Param                    160 (NN.N%)             4            40
-ast-stats Attribute                160 (NN.N%)             5            32
+ast-stats Attribute                128 (NN.N%)             4            32
 ast-stats - DocComment                32 (NN.N%)             1
-ast-stats - Normal                   128 (NN.N%)             4
+ast-stats - Normal                    96 (NN.N%)             3
 ast-stats InlineAsm                120 (NN.N%)             1           120
 ast-stats FnDecl                   120 (NN.N%)             5            24
 ast-stats Local                     96 (NN.N%)             1            96
@@ -57,7 +57,7 @@ ast-stats GenericArgs               40 (NN.N%)             1            40
 ast-stats - AngleBracketed            40 (NN.N%)             1
 ast-stats Crate                     40 (NN.N%)             1            40
 ast-stats ----------------------------------------------------------------
-ast-stats Total                  7_616                   129
+ast-stats Total                  7_560                   127
 ast-stats ================================================================
 hir-stats ================================================================
 hir-stats HIR STATS: input_stats
@@ -93,7 +93,7 @@ hir-stats GenericParam             400 (NN.N%)             5            80
 hir-stats Block                    288 (NN.N%)             6            48
 hir-stats GenericBound             256 (NN.N%)             4            64
 hir-stats - Trait                    256 (NN.N%)             4
-hir-stats Attribute                200 (NN.N%)             5            40
+hir-stats Attribute                160 (NN.N%)             4            40
 hir-stats Variant                  144 (NN.N%)             2            72
 hir-stats GenericArgs              144 (NN.N%)             3            48
 hir-stats FieldDef                 128 (NN.N%)             2            64
@@ -119,5 +119,5 @@ hir-stats TraitItemId                8 (NN.N%)             2             4
 hir-stats ImplItemId                 8 (NN.N%)             2             4
 hir-stats ForeignItemId              4 (NN.N%)             1             4
 hir-stats ----------------------------------------------------------------
-hir-stats Total                  8_616                   173
+hir-stats Total                  8_576                   172
 hir-stats ================================================================

--- a/tests/ui/type-alias-impl-trait/issue-60662.stdout
+++ b/tests/ui/type-alias-impl-trait/issue-60662.stdout
@@ -3,7 +3,6 @@
 //@ edition: 2015
 
 #![feature(type_alias_impl_trait)]
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/unpretty/bad-literal.stdout
+++ b/tests/ui/unpretty/bad-literal.stdout
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/unpretty/deprecated-attr.stdout
+++ b/tests/ui/unpretty/deprecated-attr.stdout
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/unpretty/diagnostic-attr.stdout
+++ b/tests/ui/unpretty/diagnostic-attr.stdout
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/unpretty/exhaustive-asm.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.expanded.stdout
@@ -1,5 +1,4 @@
 #![feature(prelude_import)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use std::prelude::rust_2024::*;

--- a/tests/ui/unpretty/exhaustive-asm.hir.stdout
+++ b/tests/ui/unpretty/exhaustive-asm.hir.stdout
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use std::prelude::rust_2024::*;

--- a/tests/ui/unpretty/exhaustive.expanded.stdout
+++ b/tests/ui/unpretty/exhaustive.expanded.stdout
@@ -31,7 +31,6 @@
 #![feature(try_blocks_heterogeneous)]
 #![feature(yeet_expr)]
 #![allow(incomplete_features)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use std::prelude::rust_2024::*;

--- a/tests/ui/unpretty/exhaustive.hir.stdout
+++ b/tests/ui/unpretty/exhaustive.hir.stdout
@@ -30,7 +30,6 @@
 #![feature(try_blocks_heterogeneous)]
 #![feature(yeet_expr)]
 #![allow(incomplete_features)]
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use std::prelude::rust_2024::*;

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/unpretty/interpolation-expanded.stdout
+++ b/tests/ui/unpretty/interpolation-expanded.stdout
@@ -10,7 +10,6 @@
 // synthesizing parentheses indiscriminately; only where necessary.
 
 #![feature(if_let_guard)]
-#[macro_use]
 extern crate std;
 #[prelude_import]
 use std::prelude::rust_2024::*;

--- a/tests/ui/unpretty/let-else-hir.stdout
+++ b/tests/ui/unpretty/let-else-hir.stdout
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/unpretty/self-hir.stdout
+++ b/tests/ui/unpretty/self-hir.stdout
@@ -1,4 +1,3 @@
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
+++ b/tests/ui/unpretty/struct-exprs-tuple-call-pretty-printing.stdout
@@ -4,7 +4,6 @@
 #![feature(min_generic_const_args, adt_const_params)]
 #![expect(incomplete_features)]
 #![allow(dead_code)]
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
+++ b/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
@@ -8,7 +8,6 @@
 //@ compile-flags: -Zunpretty=hir,typed
 //@ edition: 2015
 #![allow(dead_code)]
-#[attr = MacroUse {arguments: UseAll}]
 extern crate std;
 #[prelude_import]
 use ::std::prelude::rust_2015::*;


### PR DESCRIPTION
Currently all core and std macros are automatically added to the prelude via #[macro_use]. However a situation arose where we want to add a new macro `assert_matches` but don't want to pull it into the standard prelude for compatibility reasons. By explicitly exporting the macros found in the core and std crates we get to decide on a per macro basis and can later add them via the rust_20xx preludes.

Closes https://github.com/rust-lang/rust/issues/53977
Unlocks https://github.com/rust-lang/rust/pull/137487

Reference PR:

- https://github.com/rust-lang/reference/pull/2077

# Stabilization report lib

Everything N/A or already covered by lang report except, breaking changes: The unstable and never intended for public use `format_args_nl` macro is no longer publicly accessible as requested by @petrochenkov. Affects <10 crates including dependencies.

# Stabilization report lang

## Summary

Explicitly export core and std macros.

This change if merged would change the code injected into user crates to no longer include #[macro_use] on extern crate core and extern crate std. This change is motivated by a near term goal and a longer term goal. The near term goal is to allow a macro to be defined at the std or core crate root but not have it be part of the implicit prelude. Such macros can then be separately promoted to the prelude in a new edition. Specifically this is blocking the stabilization of assert_matches rust-lang/rust#137487. The longer term goal is to gradually deprecate #[macro_use]. By no longer requiring it for standard library usage, this serves as a step towards that goal. For more information see rust-lang/rust#53977.

PR link: https://github.com/rust-lang/rust/pull/139493

Tracking:

- https://github.com/rust-lang/rust/issues/147319

Reference PRs:

- https://github.com/rust-lang/rust/pull/139493

cc @rust-lang/lang @rust-lang/lang-advisors

### What is stabilized

Stabilization:
    
* `#[macro_use]` is no longer automatically included in the crate root module. This allows the explicit import of macros in the `core` and `std` prelude e.g. `pub use crate::dbg;`.

* `ambiguous_panic_imports` lint. Code that previously passed without warnings, but included the following or equivalent - only pertaining to core vs std panic - will now receive a warning:

  ```rust
  #![no_std]
  extern crate std;
  use std::prelude::v1::*;
  fn xx() {
      panic!(); // resolves to core::panic
      //~^ WARNING `panic` is ambiguous
      //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  }
  ```

  This lint is tied to a new exception to the name resolution logic in [compiler/rustc_resolve/src/ident.rs](https://github.com/rust-lang/rust/pull/139493/files#diff-c046507afdba3b0705638f53fffa156cbad72ed17aa01d96d7bd1cc10b8d9bce) similar to an exception added for https://github.com/rust-lang/rust/issues/145575. Specifically this only happens if the import of two builtin macros is ambiguous and they are named `sym::panic`. I.e. this can only happen for `core::panic` and `std::panic`. While there are some tiny differences in what syntax is allowed in `std::panic` vs `core::panic` in editions 2015 and 2018, [see](https://github.com/rust-lang/rust/pull/139493#issuecomment-2796481622). The behavior at runtime will always be the same if it compiles, implying minimal risk in what specific macro is resolved. At worst some closed source project not captured by crater will stop compiling because a different panic is resolved than previously and they were using obscure syntax like `panic!(&String::new())`.

## Design

N/A

### Reference

> What updates are needed to the Reference? Link to each PR. If the Reference is missing content needed for describing this feature, discuss that.

- https://github.com/rust-lang/reference/pull/2077

### RFC history

> What RFCs have been accepted for this feature?

N/A

### Answers to unresolved questions

N/A

### Post-RFC changes

> What other user-visible changes have occurred since the RFC was accepted? Describe both changes that the lang team accepted (and link to those decisions) as well as changes that are being presented to the team for the first time in this stabilization report.

N/A

### Key points

> What decisions have been most difficult and what behaviors to be stabilized have proved most contentious? Summarize the major arguments on all sides and link to earlier documents and discussions.

- Nothing was really contentious.

### Nightly extensions

> Are there extensions to this feature that remain unstable? How do we know that we are not accidentally committing to those?

N/A

### Doors closed

> What doors does this stabilization close for later changes to the language? E.g., does this stabilization make any other RFCs, lang experiments, or known in-flight proposals more difficult or impossible to do later?

No known doors are closed.

## Feedback

### Call for testing

> Has a "call for testing" been done? If so, what feedback was received?

No.

### Nightly use

> Do any known nightly users use this feature? Counting instances of `#![feature(FEATURE_NAME)]` on GitHub with grep might be informative.

N/A

## Implementation

### Major parts

> Summarize the major parts of the implementation and provide links into the code and to relevant PRs.
>
> See, e.g., this breakdown of the major parts of async closures:
>
> - <https://rustc-dev-guide.rust-lang.org/coroutine-closures.html>

The key change is [compiler/rustc_builtin_macros/src/standard_library_imports.rs](https://github.com/rust-lang/rust/pull/139493/files#diff-be08752823b8f862bb0c7044ef049b0f4724dbde39306b98dea2adb82ec452b0) removing the macro_use inject and the `v1.rs` preludes now explicitly `pub use`ing the macros https://github.com/rust-lang/rust/pull/139493/files#diff-a6f9f476d41575b19b399c6d236197355556958218fd035549db6d584dbdea1d + https://github.com/rust-lang/rust/pull/139493/files#diff-49849ff961ebc978f98448c8990cf7aae8e94cb03db44f016011aa8400170587.

### Coverage

> Summarize the test coverage of this feature.
>
> Consider what the "edges" of this feature are. We're particularly interested in seeing tests that assure us about exactly what nearby things we're not stabilizing. Tests should of course comprehensively demonstrate that the feature works. Think too about demonstrating the diagnostics seen when common mistakes are made and the feature is used incorrectly.
>
> Within each test, include a comment at the top describing the purpose of the test and what set of invariants it intends to demonstrate. This is a great help to our review.
>
> Describe any known or intentional gaps in test coverage.
>
> Contextualize and link to test folders and individual tests.

A variety of UI tests including edge cases have been added.

### Outstanding bugs

> What outstanding bugs involve this feature? List them. Should any block the stabilization? Discuss why or why not.

An old bug is made more noticeable by this change https://github.com/rust-lang/rust/issues/145577 but it was recommended to not block on it https://github.com/rust-lang/rust/pull/139493#issuecomment-3288311495.

### Outstanding FIXMEs

> What FIXMEs are still in the code for that feature and why is it OK to leave them there?

```
// Turn ambiguity errors for core vs std panic into warnings.
// FIXME: Remove with lang team approval.
```

https://github.com/rust-lang/rust/pull/139493/files#diff-c046507afdba3b0705638f53fffa156cbad72ed17aa01d96d7bd1cc10b8d9bce

### Tool changes

> What changes must be made to our other tools to support this feature. Has this work been done? Link to any relevant PRs and issues.

- ~~rustfmt~~
- ~~rust-analyzer~~
- ~~rustdoc (both JSON and HTML)~~
- ~~cargo~~
- ~~clippy~~
- ~~rustup~~
- ~~docs.rs~~

No known changes needed or expected.

### Breaking changes

> If this stabilization represents a known breaking change, link to the crater report, the analysis of the crater report, and to all PRs we've made to ecosystem projects affected by this breakage. Discuss any limitations of what we're able to know about or to fix.

Breaking changes:

* It's possible for user code to invoke an ambiguity by defining their own macros with standard library names and glob importing them, e.g. `use nom::*` importing `nom::dbg`. In practice this happens rarely based on crater data. The 3 public crates where this was an issue, have been fixed. The ambiguous panic import is more common and affects a non-trivial amount of the public - and likely private - crate ecosystem. To avoid a breaking change, a new future incompatible lint was added ambiguous_panic_imports see https://github.com/rust-lang/rust/issues/147319. This allows current code to continue compiling, albeit with a new warning. Future editions of Rust make this an error and future versions of Rust can choose to make this error. Technically this is a breaking change, but crater gives us the confidence that the impact will be at worst a new warning for 99+% of public and private crates.

  ```rust
  #![no_std]
  extern crate std;
  use std::prelude::v1::*;
  fn xx() {
      panic!(); // resolves to core::panic
      //~^ WARNING `panic` is ambiguous
      //~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  }
  ```

* Code using `#![no_implicit_prelude]` *and* Rust edition 2015 will no longer automatically have access to the prelude macros. The following works on nightly but would stop working with this change:

  ```rust
  #![no_implicit_prelude]
  // Uncomment to fix error.
  // use std::vec;
  fn main() {
      let _ = vec![3, 6];
  }
  ```

  Inversely with this change the `panic` and `unreachable` macro will always be in the prelude even if `#![no_implicit_prelude]` is specified.

  Error matrix when using `#![no_implicit_prelude]`, ✅ means compiler passes 🚫 means compiler error:
  
  Configuration | Rust 2015 | Rust 2018+
  --------------|-----------|-----------
  Nightly (panic\|unreachable) macro | ✅ | 🚫
  PR (panic\|unreachable) macro | ✅ | ✅
  Nightly (column\|concat\|file\|line\|module_path\|stringify) macro | ✅ | ✅
  PR (column\|concat\|file\|line\|module_path\|stringify) macro | ✅ | ✅
  Nightly remaining macros | ✅ | 🚫
  PR remaining macros | 🚫 | 🚫

  Addressing this issue is deemed expensive.

Crater found no instance of this pattern in use. Affected code can fix the issue by directly importing the macros. The new behavior matches the behavior of `#![no_implicit_prelude]` in Rust editions 2018 and beyond and it's intuitive meaning.

Crater report:

- https://crater-reports.s3.amazonaws.com/pr-139493-2/index.html (latest run, but partial run)
- https://crater-reports.s3.amazonaws.com/pr-139493-1/index.html (previous full run, one fix missing)

Crater analysis:

- Discussed in breaking changes.

PRs to affected crates:

- https://github.com/Michael-F-Bryan/gcode-rs/pull/57
- https://github.com/stbuehler/rust-ipcrypt/pull/1
- https://github.com/jcreekmore/dmidecode/pull/55

## Type system, opsem

### Compile-time checks

> What compilation-time checks are done that are needed to prevent undefined behavior?
>
> Link to tests demonstrating that these checks are being done.

N/A

### Type system rules

> What type system rules are enforced for this feature and what is the purpose of each?

N/A

### Sound by default?

> Does the feature's implementation need specific checks to prevent UB, or is it sound by default and need specific opt-in to perform the dangerous/unsafe operations? If it is not sound by default, what is the rationale?

N/A

### Breaks the AM?

> Can users use this feature to introduce undefined behavior, or use this feature to break the abstraction of Rust and expose the underlying assembly-level implementation? Describe this if so.

N/A

## Common interactions

### Temporaries

> Does this feature introduce new expressions that can produce temporaries? What are the scopes of those temporaries?

N/A

### Drop order

> Does this feature raise questions about the order in which we should drop values? Talk about the decisions made here and how they're consistent with our earlier decisions.

N/A

### Pre-expansion / post-expansion

> Does this feature raise questions about what should be accepted pre-expansion (e.g. in code covered by `#[cfg(false)]`) versus what should be accepted post-expansion? What decisions were made about this?

N/A

### Edition hygiene

> If this feature is gated on an edition, how do we decide, in the context of the edition hygiene of tokens, whether to accept or reject code. E.g., what token do we use to decide?

N/A

### SemVer implications

> Does this feature create any new ways in which library authors must take care to prevent breaking downstreams when making minor-version releases? Describe these. Are these new hazards "major" or "minor" according to [RFC 1105](https://rust-lang.github.io/rfcs/1105-api-evolution.html)?

No.

### Exposing other features

> Are there any other unstable features whose behavior may be exposed by this feature in any way? What features present the highest risk of that?

No.

## History

> List issues and PRs that are important for understanding how we got here.

- This change was asked for here https://github.com/rust-lang/rust/pull/137487#issuecomment-2770801974

## Acknowledgments

> Summarize contributors to the feature by name for recognition and so that those people are notified about the stabilization. Does anyone who worked on this *not* think it should be stabilized right now? We'd like to hear about that if so.

More or less solo developed by @Voultapher with some help from @petrochenkov.

## Open items

> List any known items that have not yet been completed and that should be before this is stabilized.

None.