### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -406,8 +406,8 @@ impl<'tcx> TypeOpInfo<'tcx> for crate::type_check::InstantiateOpaqueType<'tcx> {
             // started MIR borrowchecking with, so the region
             // constraints have already been taken. Use the data from
             // our `mbcx` instead.
-            |vid| mbcx.regioncx.var_infos[vid].origin,
-            |vid| mbcx.regioncx.var_infos[vid].universe,
+            |vid| RegionVariableOrigin::Nll(mbcx.regioncx.definitions[vid].origin),
+            |vid| mbcx.regioncx.definitions[vid].universe,
         )
     }
 }

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -8,9 +8,7 @@ use rustc_errors::{Applicability, Diag, EmissionGuarantee, MultiSpan, listify};
 use rustc_hir::def::{CtorKind, Namespace};
 use rustc_hir::{self as hir, CoroutineKind, LangItem};
 use rustc_index::IndexSlice;
-use rustc_infer::infer::{
-    BoundRegionConversionTime, NllRegionVariableOrigin, RegionVariableOrigin,
-};
+use rustc_infer::infer::{BoundRegionConversionTime, NllRegionVariableOrigin};
 use rustc_infer::traits::SelectionError;
 use rustc_middle::bug;
 use rustc_middle::mir::{
@@ -633,9 +631,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     ) {
         let predicate_span = path.iter().find_map(|constraint| {
             let outlived = constraint.sub;
-            if let Some(origin) = self.regioncx.var_infos.get(outlived)
-                && let RegionVariableOrigin::Nll(NllRegionVariableOrigin::Placeholder(_)) =
-                    origin.origin
+            if let Some(origin) = self.regioncx.definitions.get(outlived)
+                && let NllRegionVariableOrigin::Placeholder(_) = origin.origin
                 && let ConstraintCategory::Predicate(span) = constraint.category
             {
                 Some(span)

--- a/compiler/rustc_borrowck/src/polonius/dump.rs
+++ b/compiler/rustc_borrowck/src/polonius/dump.rs
@@ -334,7 +334,7 @@ fn emit_mermaid_nll_regions<'tcx>(
     writeln!(out, "flowchart TD")?;
 
     // Emit the region nodes.
-    for region in regioncx.var_infos.indices() {
+    for region in regioncx.definitions.indices() {
         write!(out, "{}[\"", region.as_usize())?;
         render_region(region, regioncx, out)?;
         writeln!(out, "\"]")?;
@@ -387,7 +387,7 @@ fn emit_mermaid_nll_sccs<'tcx>(
     // Gather and emit the SCC nodes.
     let mut nodes_per_scc: IndexVec<_, _> =
         regioncx.constraint_sccs().all_sccs().map(|_| Vec::new()).collect();
-    for region in regioncx.var_infos.indices() {
+    for region in regioncx.definitions.indices() {
         let scc = regioncx.constraint_sccs().scc(region);
         nodes_per_scc[scc].push(region);
     }

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -139,13 +139,11 @@ impl RegionTracker {
 }
 
 pub struct RegionInferenceContext<'tcx> {
-    pub var_infos: VarInfos,
-
     /// Contains the definition for every region variable. Region
     /// variables are identified by their index (`RegionVid`). The
     /// definition contains information about where the region came
     /// from as well as its final inferred value.
-    definitions: IndexVec<RegionVid, RegionDefinition<'tcx>>,
+    pub(crate) definitions: IndexVec<RegionVid, RegionDefinition<'tcx>>,
 
     /// The liveness constraints added to each region. For most
     /// regions, these start out empty and steadily grow, though for
@@ -449,7 +447,6 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             Rc::new(member_constraints.into_mapped(|r| constraint_sccs.scc(r)));
 
         let mut result = Self {
-            var_infos,
             definitions,
             liveness_constraints,
             constraints,

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -486,6 +486,9 @@ hir_analysis_self_in_impl_self =
     `Self` is not valid in the self type of an impl block
     .note = replace `Self` with a different type
 
+hir_analysis_self_in_type_alias = `Self` is not allowed in type aliases
+    .label = `Self` is only available in impls, traits, and concrete type definitions
+
 hir_analysis_self_ty_not_captured = `impl Trait` must mention the `Self` type of the trait in `use<...>`
     .label = `Self` type parameter is implicitly captured by this `impl Trait`
     .note = currently, all type parameters are required to be mentioned in the precise captures list

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1707,3 +1707,11 @@ pub(crate) enum SupertraitItemShadowee {
         traits: DiagSymbolList,
     },
 }
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_self_in_type_alias, code = E0411)]
+pub(crate) struct SelfInTypeAlias {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+}

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
@@ -16,6 +16,7 @@ use smallvec::{SmallVec, smallvec};
 use tracing::{debug, instrument};
 
 use super::HirTyLowerer;
+use crate::errors::SelfInTypeAlias;
 use crate::hir_ty_lowering::{
     GenericArgCountMismatch, GenericArgCountResult, PredicateFilter, RegionInferReason,
 };
@@ -113,6 +114,19 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         // ```
         let mut projection_bounds = FxIndexMap::default();
         for (proj, proj_span) in elaborated_projection_bounds {
+            let proj = proj.map_bound(|mut b| {
+                if let Some(term_ty) = &b.term.as_type() {
+                    let references_self = term_ty.walk().any(|arg| arg == dummy_self.into());
+                    if references_self {
+                        // With trait alias and type alias combined, type resolver
+                        // may not be able to catch all illegal `Self` usages (issue 139082)
+                        let guar = tcx.dcx().emit_err(SelfInTypeAlias { span });
+                        b.term = replace_dummy_self_with_error(tcx, b.term, guar);
+                    }
+                }
+                b
+            });
+
             let key = (
                 proj.skip_binder().projection_term.def_id,
                 tcx.anonymize_bound_vars(

--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -266,19 +266,16 @@ where
                 let tcx = self.tcx();
 
                 assert_eq!(self.elaborator.typing_env().typing_mode, ty::TypingMode::PostAnalysis);
-                // The type error for normalization may have been in dropck: see
-                // `compute_drop_data` in rustc_borrowck, in which case we wouldn't have
-                // deleted the MIR body and could have an error here as well.
                 let field_ty = match tcx
                     .try_normalize_erasing_regions(self.elaborator.typing_env(), f.ty(tcx, args))
                 {
                     Ok(t) => t,
                     Err(_) => Ty::new_error(
                         self.tcx(),
-                        self.elaborator
-                            .body()
-                            .tainted_by_errors
-                            .expect("Error in drop elaboration not found by dropck."),
+                        self.tcx().dcx().span_delayed_bug(
+                            self.elaborator.body().span,
+                            "Error normalizing in drop elaboration.",
+                        ),
                     ),
                 };
 

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -1090,26 +1090,36 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             {
                 // See `assemble_candidates_for_unsizing` for more info.
                 // We already checked the compatibility of auto traits within `assemble_candidates_for_unsizing`.
-                let iter = data_a
-                    .principal()
-                    .filter(|_| {
-                        // optionally drop the principal, if we're unsizing to no principal
-                        data_b.principal().is_some()
-                    })
-                    .map(|b| b.map_bound(ty::ExistentialPredicate::Trait))
-                    .into_iter()
-                    .chain(
+                let existential_predicates = if data_b.principal().is_some() {
+                    tcx.mk_poly_existential_predicates_from_iter(
                         data_a
-                            .projection_bounds()
-                            .map(|b| b.map_bound(ty::ExistentialPredicate::Projection)),
+                            .principal()
+                            .map(|b| b.map_bound(ty::ExistentialPredicate::Trait))
+                            .into_iter()
+                            .chain(
+                                data_a
+                                    .projection_bounds()
+                                    .map(|b| b.map_bound(ty::ExistentialPredicate::Projection)),
+                            )
+                            .chain(
+                                data_b
+                                    .auto_traits()
+                                    .map(ty::ExistentialPredicate::AutoTrait)
+                                    .map(ty::Binder::dummy),
+                            ),
                     )
-                    .chain(
+                } else {
+                    // If we're unsizing to a dyn type that has no principal, then drop
+                    // the principal and projections from the type. We use the auto traits
+                    // from the RHS type since as we noted that we've checked for auto
+                    // trait compatibility during unsizing.
+                    tcx.mk_poly_existential_predicates_from_iter(
                         data_b
                             .auto_traits()
                             .map(ty::ExistentialPredicate::AutoTrait)
                             .map(ty::Binder::dummy),
-                    );
-                let existential_predicates = tcx.mk_poly_existential_predicates_from_iter(iter);
+                    )
+                };
                 let source_trait = Ty::new_dynamic(tcx, existential_predicates, r_b, dyn_a);
 
                 // Require that the traits involved in this upcast are **equal**;

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -5,15 +5,11 @@
 //!
 //! # Const intrinsics
 //!
-//! Note: any changes to the constness of intrinsics should be discussed with the language team.
-//! This includes changes in the stability of the constness.
-//!
-//! //FIXME(#132735) "old" style intrinsics support has been removed
-//! In order to make an intrinsic usable at compile-time, it needs to be declared in the "new"
-//! style, i.e. as a `#[rustc_intrinsic]` function, not inside an `extern` block. Then copy the
-//! implementation from <https://github.com/rust-lang/miri/blob/master/src/intrinsics> to
+//! In order to make an intrinsic unstable usable at compile-time, copy the implementation from
+//! <https://github.com/rust-lang/miri/blob/master/src/intrinsics> to
 //! <https://github.com/rust-lang/rust/blob/master/compiler/rustc_const_eval/src/interpret/intrinsics.rs>
-//! and make the intrinsic declaration a `const fn`.
+//! and make the intrinsic declaration below a `const fn`. This should be done in coordination with
+//! wg-const-eval.
 //!
 //! If an intrinsic is supposed to be used from a `const fn` with a `rustc_const_stable` attribute,
 //! `#[rustc_intrinsic_const_stable_indirect]` needs to be added to the intrinsic. Such a change requires

--- a/src/doc/unstable-book/src/language-features/intrinsics.md
+++ b/src/doc/unstable-book/src/language-features/intrinsics.md
@@ -53,7 +53,8 @@ Various intrinsics have native MIR operations that they correspond to. Instead o
 backends to implement both the intrinsic and the MIR operation, the `lower_intrinsics` pass
 will convert the calls to the MIR operation. Backends do not need to know about these intrinsics
 at all. These intrinsics only make sense without a body, and can be declared as a `#[rustc_intrinsic]`.
-The body is never used, as calls to the intrinsic do not exist anymore after MIR analyses.
+The body is never used as the lowering pass implements support for all backends, so we never have to
+use the fallback logic.
 
 ## Intrinsics without fallback logic
 

--- a/tests/ui/drop/drop_elaboration_with_errors2.rs
+++ b/tests/ui/drop/drop_elaboration_with_errors2.rs
@@ -1,11 +1,14 @@
-//@ known-bug: #137287
+// Regression test for #137287
 
 mod defining_scope {
     use super::*;
     pub type Alias<T> = impl Sized;
+    //~^ ERROR unconstrained opaque type
+    //~| ERROR `impl Trait` in type aliases is unstable
 
     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
         x
+        //~^ ERROR mismatched types
     }
 }
 
@@ -21,6 +24,7 @@ impl<T> Trait<T> for T {
     type Assoc = Box<u32>;
 }
 impl<T> Trait<T> for defining_scope::Alias<T> {
+    //~^ ERROR conflicting implementations of trait `Trait<_>`
     type Assoc = usize;
 }
 

--- a/tests/ui/drop/drop_elaboration_with_errors2.stderr
+++ b/tests/ui/drop/drop_elaboration_with_errors2.stderr
@@ -1,0 +1,47 @@
+error[E0658]: `impl Trait` in type aliases is unstable
+  --> $DIR/drop_elaboration_with_errors2.rs:5:25
+   |
+LL |     pub type Alias<T> = impl Sized;
+   |                         ^^^^^^^^^^
+   |
+   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
+   = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0119]: conflicting implementations of trait `Trait<_>`
+  --> $DIR/drop_elaboration_with_errors2.rs:26:1
+   |
+LL | impl<T> Trait<T> for T {
+   | ---------------------- first implementation here
+...
+LL | impl<T> Trait<T> for defining_scope::Alias<T> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
+
+error: unconstrained opaque type
+  --> $DIR/drop_elaboration_with_errors2.rs:5:25
+   |
+LL |     pub type Alias<T> = impl Sized;
+   |                         ^^^^^^^^^^
+   |
+   = note: `Alias` must be used in combination with a concrete type within the same crate
+
+error[E0308]: mismatched types
+  --> $DIR/drop_elaboration_with_errors2.rs:10:9
+   |
+LL |     pub type Alias<T> = impl Sized;
+   |                         ---------- the found opaque type
+...
+LL |     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
+   |                 - expected this type parameter   --------------- expected `Container<T, T>` because of return type
+LL |         x
+   |         ^ expected `Container<T, T>`, found `Container<Alias<T>, T>`
+   |
+   = note: expected struct `Container<T, _>`
+              found struct `Container<Alias<T>, _>`
+   = help: type parameters must be constrained to match other types
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0119, E0308, E0658.
+For more information about an error, try `rustc --explain E0119`.

--- a/tests/ui/drop/drop_elaboration_with_errors3.rs
+++ b/tests/ui/drop/drop_elaboration_with_errors3.rs
@@ -1,4 +1,4 @@
-//@ known-bug: #135668
+// Regression test for #135668
 //@ compile-flags: --edition=2021
 use std::future::Future;
 
@@ -12,6 +12,7 @@ async fn create_task() -> impl Sized {
 
 async fn documentation() {
     include_str!("nonexistent");
+    //~^ ERROR couldn't read `$DIR/nonexistent`: No such file or directory
 }
 
 fn bind<F>(_filter: F) -> impl Sized
@@ -36,3 +37,5 @@ where
 {
     type Assoc = F;
 }
+
+fn main() {}

--- a/tests/ui/drop/drop_elaboration_with_errors3.stderr
+++ b/tests/ui/drop/drop_elaboration_with_errors3.stderr
@@ -1,0 +1,8 @@
+error: couldn't read `$DIR/nonexistent`: No such file or directory (os error 2)
+  --> $DIR/drop_elaboration_with_errors3.rs:14:5
+   |
+LL |     include_str!("nonexistent");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/dyn-compatibility/trait-alias-self-projection.rs
+++ b/tests/ui/dyn-compatibility/trait-alias-self-projection.rs
@@ -1,0 +1,12 @@
+#![feature(trait_alias)]
+trait B = Fn() -> Self;
+type D = &'static dyn B;
+//~^ ERROR E0411
+
+fn a() -> D {
+    unreachable!();
+}
+
+fn main() {
+    _ = a();
+}

--- a/tests/ui/dyn-compatibility/trait-alias-self-projection.stderr
+++ b/tests/ui/dyn-compatibility/trait-alias-self-projection.stderr
@@ -1,0 +1,9 @@
+error[E0411]: `Self` is not allowed in type aliases
+  --> $DIR/trait-alias-self-projection.rs:3:19
+   |
+LL | type D = &'static dyn B;
+   |                   ^^^^^ `Self` is only available in impls, traits, and concrete type definitions
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0411`.

--- a/tests/ui/traits/dyn-drop-principal-with-projections.rs
+++ b/tests/ui/traits/dyn-drop-principal-with-projections.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+
+trait Tr {
+    type Assoc;
+}
+
+impl Tr for () {
+    type Assoc = ();
+}
+
+fn main() {
+    let x = &() as &(dyn Tr<Assoc = ()> + Send) as &dyn Send;
+}

--- a/tests/ui/traits/non_lifetime_binders/diagnostic-hir-wf-check.rs
+++ b/tests/ui/traits/non_lifetime_binders/diagnostic-hir-wf-check.rs
@@ -1,0 +1,18 @@
+// Make sure not to construct predicates with escaping bound vars in `diagnostic_hir_wf_check`.
+// Regression test for <https://github.com/rust-lang/rust/issues/139330>.
+
+#![feature(non_lifetime_binders)]
+//~^ WARN the feature `non_lifetime_binders` is incomplete
+
+trait A<T: ?Sized> {}
+impl<T: ?Sized> A<T> for () {}
+
+trait B {}
+struct W<T: B>(T);
+
+fn b() -> (W<()>, impl for<C> A<C>) { (W(()), ()) }
+//~^ ERROR the trait bound `(): B` is not satisfied
+//~| ERROR the trait bound `(): B` is not satisfied
+//~| ERROR the trait bound `(): B` is not satisfied
+
+fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/diagnostic-hir-wf-check.stderr
+++ b/tests/ui/traits/non_lifetime_binders/diagnostic-hir-wf-check.stderr
@@ -1,0 +1,65 @@
+warning: the feature `non_lifetime_binders` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/diagnostic-hir-wf-check.rs:4:12
+   |
+LL | #![feature(non_lifetime_binders)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: the trait bound `(): B` is not satisfied
+  --> $DIR/diagnostic-hir-wf-check.rs:13:12
+   |
+LL | fn b() -> (W<()>, impl for<C> A<C>) { (W(()), ()) }
+   |            ^^^^^ the trait `B` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/diagnostic-hir-wf-check.rs:10:1
+   |
+LL | trait B {}
+   | ^^^^^^^
+note: required by a bound in `W`
+  --> $DIR/diagnostic-hir-wf-check.rs:11:13
+   |
+LL | struct W<T: B>(T);
+   |             ^ required by this bound in `W`
+
+error[E0277]: the trait bound `(): B` is not satisfied
+  --> $DIR/diagnostic-hir-wf-check.rs:13:42
+   |
+LL | fn b() -> (W<()>, impl for<C> A<C>) { (W(()), ()) }
+   |                                        - ^^ the trait `B` is not implemented for `()`
+   |                                        |
+   |                                        required by a bound introduced by this call
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/diagnostic-hir-wf-check.rs:10:1
+   |
+LL | trait B {}
+   | ^^^^^^^
+note: required by a bound in `W`
+  --> $DIR/diagnostic-hir-wf-check.rs:11:13
+   |
+LL | struct W<T: B>(T);
+   |             ^ required by this bound in `W`
+
+error[E0277]: the trait bound `(): B` is not satisfied
+  --> $DIR/diagnostic-hir-wf-check.rs:13:40
+   |
+LL | fn b() -> (W<()>, impl for<C> A<C>) { (W(()), ()) }
+   |                                        ^^^^^ the trait `B` is not implemented for `()`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/diagnostic-hir-wf-check.rs:10:1
+   |
+LL | trait B {}
+   | ^^^^^^^
+note: required by a bound in `W`
+  --> $DIR/diagnostic-hir-wf-check.rs:11:13
+   |
+LL | struct W<T: B>(T);
+   |             ^ required by this bound in `W`
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #139124 (compiler: report error when trait object type param reference self)
 - #139346 (Don't construct preds w escaping bound vars in `diagnostic_hir_wf_check`)
 - #139379 (Use delayed bug for normalization errors in drop elaboration)
 - #139421 (Fix trait upcasting to dyn type with no principal when there are projections)
 - #139468 (Don't call `Span::with_parent` on the good path in `has_stashed_diagnostic`)
 - #139476 (rm `RegionInferenceContext::var_infos`)
 - #139490 (Update some comment/docs related to "extern intrinsic" removal)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=139124,139346,139379,139421,139468,139476,139490)
<!-- homu-ignore:end -->