### PR TITLE
tests/codegen: ignore x86-64-v3 in `issue-101082` for now

### DIFF
--- a/tests/codegen/issues/issue-101082.rs
+++ b/tests/codegen/issues/issue-101082.rs
@@ -1,8 +1,18 @@
 //@ compile-flags: -Copt-level=3
-//@ revisions: host x86-64-v3
+//@ revisions: host x86-64 x86-64-v3
 //@ min-llvm-version: 20
 
-// This particular CPU regressed in #131563
+//@[host] ignore-x86_64
+
+// Set the base cpu explicitly, in case the default has been changed.
+//@[x86-64] only-x86_64
+//@[x86-64] compile-flags: -Ctarget-cpu=x86-64
+
+// FIXME(cuviper) x86-64-v3 in particular regressed in #131563, and the
+// workaround at the time still sometimes fails, so ignore it for now.
+// - https://github.com/llvm/llvm-project/issues/134513
+// - https://github.com/llvm/llvm-project/issues/134735
+//@[x86-64-v3] ignore-test
 //@[x86-64-v3] only-x86_64
 //@[x86-64-v3] compile-flags: -Ctarget-cpu=x86-64-v3
 


### PR DESCRIPTION
LLVM is struggling to optimize this test when AVX is enabled, but
there's not much Rust can be expected to do about it. Let's ignore that
part until we learn more on the LLVM side, hopefully fixed and updated.

Ref: llvm/llvm-project#134513 llvm/llvm-project#134735
Unblocks: #138380 
cc @scottmcm 
r? nikic