### PR TITLE
libtest: Pass the test's panic payload as Option instead of Result

### DIFF
--- a/library/test/src/test_result.rs
+++ b/library/test/src/test_result.rs
@@ -39,15 +39,18 @@ pub enum TestResult {
 
 /// Creates a `TestResult` depending on the raw result of test execution
 /// and associated data.
-pub(crate) fn calc_result<'a>(
+pub(crate) fn calc_result(
     desc: &TestDesc,
-    task_result: Result<(), &'a (dyn Any + 'static + Send)>,
+    panic_payload: Option<&(dyn Any + Send)>,
     time_opts: Option<&time::TestTimeOptions>,
     exec_time: Option<&time::TestExecTime>,
 ) -> TestResult {
-    let result = match (&desc.should_panic, task_result) {
-        (&ShouldPanic::No, Ok(())) | (&ShouldPanic::Yes, Err(_)) => TestResult::TrOk,
-        (&ShouldPanic::YesWithMessage(msg), Err(err)) => {
+    let result = match (desc.should_panic, panic_payload) {
+        // The test did or didn't panic, as expected.
+        (ShouldPanic::No, None) | (ShouldPanic::Yes, Some(_)) => TestResult::TrOk,
+
+        // Check the actual panic message against the expected message.
+        (ShouldPanic::YesWithMessage(msg), Some(err)) => {
             let maybe_panic_str = err
                 .downcast_ref::<String>()
                 .map(|e| &**e)
@@ -71,10 +74,14 @@ pub(crate) fn calc_result<'a>(
                 ))
             }
         }
-        (&ShouldPanic::Yes, Ok(())) | (&ShouldPanic::YesWithMessage(_), Ok(())) => {
+
+        // The test should have panicked, but didn't panic.
+        (ShouldPanic::Yes, None) | (ShouldPanic::YesWithMessage(_), None) => {
             TestResult::TrFailedMsg("test did not panic as expected".to_string())
         }
-        _ => TestResult::TrFailed,
+
+        // The test should not have panicked, but did panic.
+        (ShouldPanic::No, Some(_)) => TestResult::TrFailed,
     };
 
     // If test is already failed (or allowed to fail), do not change the result.


### PR DESCRIPTION
Passing a `Result<(), &dyn Any>` to `calc_result` requires awkward code at both call sites to build a fake result, for no real benefit. It's much easier to just pass the payload as `Option<&dyn Any>`.

No functional change.
