### PR TITLE
Report higher-ranked trait error when higher-ranked projection goal fails in new solver

### DIFF
--- a/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-project.current.stderr
+++ b/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-project.current.stderr
@@ -13,7 +13,7 @@ LL | fn projection_bound<T: for<'a> Trait<'a, Assoc = usize>>() {}
    |                                          ^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/candidate-from-env-universe-err-project.rs:53:30
+  --> $DIR/candidate-from-env-universe-err-project.rs:52:30
    |
 LL |     let _higher_ranked_norm: for<'a> fn(<T as Trait<'a>>::Assoc) = |_| ();
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
@@ -22,7 +22,7 @@ LL |     let _higher_ranked_norm: for<'a> fn(<T as Trait<'a>>::Assoc) = |_| ();
               found associated type `<T as Trait<'a>>::Assoc`
 
 error[E0308]: mismatched types
-  --> $DIR/candidate-from-env-universe-err-project.rs:53:30
+  --> $DIR/candidate-from-env-universe-err-project.rs:52:30
    |
 LL |     let _higher_ranked_norm: for<'a> fn(<T as Trait<'a>>::Assoc) = |_| ();
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other

--- a/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-project.next.stderr
+++ b/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-project.next.stderr
@@ -22,38 +22,20 @@ note: required by a bound in `projection_bound`
 LL | fn projection_bound<T: for<'a> Trait<'a, Assoc = usize>>() {}
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `projection_bound`
 
-error[E0271]: type mismatch resolving `<T as Trait<'a>>::Assoc == usize`
-  --> $DIR/candidate-from-env-universe-err-project.rs:38:24
-   |
-LL |     projection_bound::<T>();
-   |                        ^ type mismatch resolving `<T as Trait<'a>>::Assoc == usize`
-   |
-note: types differ
-  --> $DIR/candidate-from-env-universe-err-project.rs:14:18
-   |
-LL |     type Assoc = usize;
-   |                  ^^^^^
-note: required by a bound in `projection_bound`
-  --> $DIR/candidate-from-env-universe-err-project.rs:18:42
-   |
-LL | fn projection_bound<T: for<'a> Trait<'a, Assoc = usize>>() {}
-   |                                          ^^^^^^^^^^^^^ required by this bound in `projection_bound`
-
 error: higher-ranked subtype error
-  --> $DIR/candidate-from-env-universe-err-project.rs:53:30
+  --> $DIR/candidate-from-env-universe-err-project.rs:52:30
    |
 LL |     let _higher_ranked_norm: for<'a> fn(<T as Trait<'a>>::Assoc) = |_| ();
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: higher-ranked subtype error
-  --> $DIR/candidate-from-env-universe-err-project.rs:53:30
+  --> $DIR/candidate-from-env-universe-err-project.rs:52:30
    |
 LL |     let _higher_ranked_norm: for<'a> fn(<T as Trait<'a>>::Assoc) = |_| ();
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0271, E0277.
-For more information about an error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-project.rs
+++ b/tests/ui/higher-ranked/leak-check/candidate-from-env-universe-err-project.rs
@@ -36,9 +36,8 @@ fn function2<T: Trait<'static, Assoc = usize>>() {
     // does not use the leak check when trying the where-bound, causing us
     // to prefer it over the impl, resulting in a placeholder error.
     projection_bound::<T>();
-    //[next]~^ ERROR type mismatch resolving `<T as Trait<'a>>::Assoc == usize`
-    //[next]~| ERROR the trait bound `for<'a> T: Trait<'a>` is not satisfied
-    //[current]~^^^ ERROR mismatched types
+    //[next]~^ ERROR the trait bound `for<'a> T: Trait<'a>` is not satisfied
+    //[current]~^^ ERROR mismatched types
 }
 
 fn function3<T: Trait<'static, Assoc = usize>>() {

--- a/tests/ui/mismatched_types/closure-mismatch.current.stderr
+++ b/tests/ui/mismatched_types/closure-mismatch.current.stderr
@@ -1,5 +1,5 @@
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/closure-mismatch.rs:8:5
+  --> $DIR/closure-mismatch.rs:12:5
    |
 LL |     baz(|_| ());
    |     ^^^^^^^^^^^ implementation of `FnOnce` is not general enough
@@ -8,7 +8,7 @@ LL |     baz(|_| ());
    = note: ...but it actually implements `FnOnce<(&'2 (),)>`, for some specific lifetime `'2`
 
 error: implementation of `Fn` is not general enough
-  --> $DIR/closure-mismatch.rs:8:5
+  --> $DIR/closure-mismatch.rs:12:5
    |
 LL |     baz(|_| ());
    |     ^^^^^^^^^^^ implementation of `Fn` is not general enough
@@ -17,7 +17,7 @@ LL |     baz(|_| ());
    = note: ...but it actually implements `Fn<(&'2 (),)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/closure-mismatch.rs:11:5
+  --> $DIR/closure-mismatch.rs:16:5
    |
 LL |     baz(|x| ());
    |     ^^^^^^^^^^^ implementation of `FnOnce` is not general enough
@@ -26,7 +26,7 @@ LL |     baz(|x| ());
    = note: ...but it actually implements `FnOnce<(&'2 (),)>`, for some specific lifetime `'2`
 
 error: implementation of `Fn` is not general enough
-  --> $DIR/closure-mismatch.rs:11:5
+  --> $DIR/closure-mismatch.rs:16:5
    |
 LL |     baz(|x| ());
    |     ^^^^^^^^^^^ implementation of `Fn` is not general enough

--- a/tests/ui/mismatched_types/closure-mismatch.next.stderr
+++ b/tests/ui/mismatched_types/closure-mismatch.next.stderr
@@ -1,0 +1,67 @@
+error[E0277]: the trait bound `{closure@$DIR/closure-mismatch.rs:12:9: 12:12}: Foo` is not satisfied
+  --> $DIR/closure-mismatch.rs:12:9
+   |
+LL |     baz(|_| ());
+   |     --- ^^^^^^ unsatisfied trait bound
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `for<'a> FnOnce(&'a ())` is not implemented for closure `{closure@$DIR/closure-mismatch.rs:12:9: 12:12}`
+   = note: expected a closure with signature `for<'a> fn(&'a ())`
+              found a closure with signature `fn(&())`
+note: this is a known limitation of the trait solver that will be lifted in the future
+  --> $DIR/closure-mismatch.rs:12:9
+   |
+LL |     baz(|_| ());
+   |     ----^^^----
+   |     |   |
+   |     |   the trait solver is unable to infer the generic types that should be inferred from this argument
+   |     add turbofish arguments to this call to specify the types manually, even if it's redundant
+note: required for `{closure@$DIR/closure-mismatch.rs:12:9: 12:12}` to implement `Foo`
+  --> $DIR/closure-mismatch.rs:7:18
+   |
+LL | impl<T: Fn(&())> Foo for T {}
+   |         -------  ^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+note: required by a bound in `baz`
+  --> $DIR/closure-mismatch.rs:9:11
+   |
+LL | fn baz<T: Foo>(_: T) {}
+   |           ^^^ required by this bound in `baz`
+
+error[E0277]: the trait bound `{closure@$DIR/closure-mismatch.rs:16:9: 16:12}: Foo` is not satisfied
+  --> $DIR/closure-mismatch.rs:16:9
+   |
+LL |     baz(|x| ());
+   |     --- ^^^^^^ unsatisfied trait bound
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `for<'a> FnOnce(&'a ())` is not implemented for closure `{closure@$DIR/closure-mismatch.rs:16:9: 16:12}`
+   = note: expected a closure with signature `for<'a> fn(&'a ())`
+              found a closure with signature `fn(&())`
+note: this is a known limitation of the trait solver that will be lifted in the future
+  --> $DIR/closure-mismatch.rs:16:9
+   |
+LL |     baz(|x| ());
+   |     ----^^^----
+   |     |   |
+   |     |   the trait solver is unable to infer the generic types that should be inferred from this argument
+   |     add turbofish arguments to this call to specify the types manually, even if it's redundant
+note: required for `{closure@$DIR/closure-mismatch.rs:16:9: 16:12}` to implement `Foo`
+  --> $DIR/closure-mismatch.rs:7:18
+   |
+LL | impl<T: Fn(&())> Foo for T {}
+   |         -------  ^^^     ^
+   |         |
+   |         unsatisfied trait bound introduced here
+note: required by a bound in `baz`
+  --> $DIR/closure-mismatch.rs:9:11
+   |
+LL | fn baz<T: Foo>(_: T) {}
+   |           ^^^ required by this bound in `baz`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/mismatched_types/closure-mismatch.rs
+++ b/tests/ui/mismatched_types/closure-mismatch.rs
@@ -1,3 +1,7 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+
 trait Foo {}
 
 impl<T: Fn(&())> Foo for T {}
@@ -6,9 +10,11 @@ fn baz<T: Foo>(_: T) {}
 
 fn main() {
     baz(|_| ());
-    //~^ ERROR implementation of `FnOnce` is not general enough
-    //~| ERROR implementation of `Fn` is not general enough
+    //[current]~^ ERROR implementation of `FnOnce` is not general enough
+    //[current]~| ERROR implementation of `Fn` is not general enough
+    //[next]~^^^ ERROR Foo` is not satisfied
     baz(|x| ());
-    //~^ ERROR implementation of `FnOnce` is not general enough
-    //~| ERROR implementation of `Fn` is not general enough
+    //[current]~^ ERROR implementation of `FnOnce` is not general enough
+    //[current]~| ERROR implementation of `Fn` is not general enough
+    //[next]~^^^ ERROR Foo` is not satisfied
 }


### PR DESCRIPTION
~~See HACK comment inline. Not actually sure if it should be marked as a *HACK*, b/c~~ it's kinda a legitimate case we want to care about unless we're going to make the proof tree visitor *smarter* about the leak check than the actual trait solver itself.

Encountered this while battling with `NiceRegionError`s in the old solver b/c I wondered what this code ended up giving us in the *new* solver as a comparison:
```rust
trait Foo {}

impl<T: FnOnce(&())> Foo for T {}

fn baz<T: Foo>() {}

fn main() {
    baz::<fn(&'static ())>();
}
```

On master it's pretty bad:
```
error[E0271]: type mismatch resolving `<fn(&()) as FnOnce<(&(),)>>::Output == ()`
 --> <source>:8:11
  |
8 |     baz::<fn(&'static ())>();
  |           ^^^^^^^^^^^^^^^ types differ
  |
note: required for `fn(&'static ())` to implement `Foo`
 --> <source>:3:22
  |
3 | impl<T: FnOnce(&())> Foo for T {}
  |         -----------  ^^^     ^
  |         |
  |         unsatisfied trait bound introduced here
```

After this PR it's much better:
```
error[E0277]: the trait bound `fn(&'static ()): Foo` is not satisfied
 --> /home/mgx/test.rs:8:11
  |
8 |     baz::<fn(&'static ())>();
  |           ^^^^^^^^^^^^^^^ the trait `for<'a> FnOnce(&'a ())` is not implemented for `fn(&'static ())`
  |
  = note: expected a closure with arguments `(&'static (),)`
             found a closure with arguments `(&(),)`
note: required for `fn(&'static ())` to implement `Foo`
 --> /home/mgx/test.rs:3:22
  |
3 | impl<T: FnOnce(&())> Foo for T {}
  |         -----------  ^^^     ^
  |         |
  |         unsatisfied trait bound introduced here
note: required by a bound in `baz`
 --> /home/mgx/test.rs:5:11
  |
5 | fn baz<T: Foo>() {}
  |           ^^^ required by this bound in `baz`
```

r? lcnr