### PR TITLE
std: sys: process: uefi: Use NULL stdin by default

### DIFF
--- a/library/std/src/sys/process/uefi.rs
+++ b/library/std/src/sys/process/uefi.rs
@@ -23,6 +23,7 @@ pub struct Command {
     args: Vec<OsString>,
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
+    stdin: Option<Stdio>,
     env: CommandEnv,
 }
 
@@ -48,6 +49,7 @@ impl Command {
             args: Vec::new(),
             stdout: None,
             stderr: None,
+            stdin: None,
             env: Default::default(),
         }
     }
@@ -64,8 +66,8 @@ impl Command {
         panic!("unsupported")
     }
 
-    pub fn stdin(&mut self, _stdin: Stdio) {
-        panic!("unsupported")
+    pub fn stdin(&mut self, stdin: Stdio) {
+        self.stdin = Some(stdin);
     }
 
     pub fn stdout(&mut self, stdout: Stdio) {
@@ -166,7 +168,8 @@ impl Command {
         };
 
         // Setup Stdin
-        let stdin = Self::create_stdin(Stdio::Null)?;
+        let stdin = self.stdin.unwrap_or(Stdio::Null);
+        let stdin = Self::create_stdin(stdin)?;
         if let Some(con) = stdin {
             cmd.stdin_init(con)
         } else {

--- a/library/std/src/sys/process/uefi.rs
+++ b/library/std/src/sys/process/uefi.rs
@@ -1,4 +1,4 @@
-use r_efi::protocols::simple_text_output;
+use r_efi::protocols::{simple_text_input, simple_text_output};
 
 use crate::collections::BTreeMap;
 pub use crate::ffi::OsString as EnvKey;
@@ -122,6 +122,22 @@ impl Command {
         }
     }
 
+    fn create_stdin(
+        s: Stdio,
+    ) -> io::Result<Option<helpers::OwnedProtocol<uefi_command_internal::InputProtocol>>> {
+        match s {
+            Stdio::Null => unsafe {
+                helpers::OwnedProtocol::create(
+                    uefi_command_internal::InputProtocol::null(),
+                    simple_text_input::PROTOCOL_GUID,
+                )
+            }
+            .map(Some),
+            Stdio::Inherit => Ok(None),
+            Stdio::MakePipe => unsupported(),
+        }
+    }
+
     pub fn output(&mut self) -> io::Result<(ExitStatus, Vec<u8>, Vec<u8>)> {
         let mut cmd = uefi_command_internal::Image::load_image(&self.prog)?;
 
@@ -147,6 +163,14 @@ impl Command {
             cmd.stderr_init(con)
         } else {
             cmd.stderr_inherit()
+        };
+
+        // Setup Stdin
+        let stdin = Self::create_stdin(Stdio::Null)?;
+        if let Some(con) = stdin {
+            cmd.stdin_init(con)
+        } else {
+            cmd.stdin_inherit()
         };
 
         let env = env_changes(&self.env);
@@ -334,7 +358,7 @@ impl<'a> fmt::Debug for CommandArgs<'a> {
 
 #[allow(dead_code)]
 mod uefi_command_internal {
-    use r_efi::protocols::{loaded_image, simple_text_output};
+    use r_efi::protocols::{loaded_image, simple_text_input, simple_text_output};
 
     use crate::ffi::{OsStr, OsString};
     use crate::io::{self, const_error};
@@ -350,6 +374,7 @@ mod uefi_command_internal {
         handle: NonNull<crate::ffi::c_void>,
         stdout: Option<helpers::OwnedProtocol<PipeProtocol>>,
         stderr: Option<helpers::OwnedProtocol<PipeProtocol>>,
+        stdin: Option<helpers::OwnedProtocol<InputProtocol>>,
         st: OwnedTable<r_efi::efi::SystemTable>,
         args: Option<(*mut u16, usize)>,
     }
@@ -384,7 +409,14 @@ mod uefi_command_internal {
                     helpers::open_protocol(child_handle, loaded_image::PROTOCOL_GUID).unwrap();
                 let st = OwnedTable::from_table(unsafe { (*loaded_image.as_ptr()).system_table });
 
-                Ok(Self { handle: child_handle, stdout: None, stderr: None, st, args: None })
+                Ok(Self {
+                    handle: child_handle,
+                    stdout: None,
+                    stderr: None,
+                    stdin: None,
+                    st,
+                    args: None,
+                })
             }
         }
 
@@ -445,6 +477,17 @@ mod uefi_command_internal {
             }
         }
 
+        fn set_stdin(
+            &mut self,
+            handle: r_efi::efi::Handle,
+            protocol: *mut simple_text_input::Protocol,
+        ) {
+            unsafe {
+                (*self.st.as_mut_ptr()).console_in_handle = handle;
+                (*self.st.as_mut_ptr()).con_in = protocol;
+            }
+        }
+
         pub fn stdout_init(&mut self, protocol: helpers::OwnedProtocol<PipeProtocol>) {
             self.set_stdout(
                 protocol.handle().as_ptr(),
@@ -469,6 +512,19 @@ mod uefi_command_internal {
         pub fn stderr_inherit(&mut self) {
             let st: NonNull<r_efi::efi::SystemTable> = system_table().cast();
             unsafe { self.set_stderr((*st.as_ptr()).standard_error_handle, (*st.as_ptr()).std_err) }
+        }
+
+        pub(crate) fn stdin_init(&mut self, protocol: helpers::OwnedProtocol<InputProtocol>) {
+            self.set_stdin(
+                protocol.handle().as_ptr(),
+                protocol.as_ref() as *const InputProtocol as *mut simple_text_input::Protocol,
+            );
+            self.stdin = Some(protocol);
+        }
+
+        pub(crate) fn stdin_inherit(&mut self) {
+            let st: NonNull<r_efi::efi::SystemTable> = system_table().cast();
+            unsafe { self.set_stdin((*st.as_ptr()).console_in_handle, (*st.as_ptr()).con_in) }
         }
 
         pub fn stderr(&self) -> io::Result<Vec<u8>> {
@@ -718,6 +774,56 @@ mod uefi_command_internal {
         fn drop(&mut self) {
             unsafe {
                 let _ = Box::from_raw(self.mode);
+            }
+        }
+    }
+
+    #[repr(C)]
+    pub(crate) struct InputProtocol {
+        reset: simple_text_input::ProtocolReset,
+        read_key_stroke: simple_text_input::ProtocolReadKeyStroke,
+        wait_for_key: r_efi::efi::Event,
+    }
+
+    impl InputProtocol {
+        pub(crate) fn null() -> Self {
+            let evt = helpers::OwnedEvent::new(
+                r_efi::efi::EVT_NOTIFY_WAIT,
+                r_efi::efi::TPL_CALLBACK,
+                Some(Self::empty_notify),
+                None,
+            )
+            .unwrap();
+
+            Self {
+                reset: Self::null_reset,
+                read_key_stroke: Self::null_read_key,
+                wait_for_key: evt.into_raw(),
+            }
+        }
+
+        extern "efiapi" fn null_reset(
+            _: *mut simple_text_input::Protocol,
+            _: r_efi::efi::Boolean,
+        ) -> r_efi::efi::Status {
+            r_efi::efi::Status::SUCCESS
+        }
+
+        extern "efiapi" fn null_read_key(
+            _: *mut simple_text_input::Protocol,
+            _: *mut simple_text_input::InputKey,
+        ) -> r_efi::efi::Status {
+            r_efi::efi::Status::UNSUPPORTED
+        }
+
+        extern "efiapi" fn empty_notify(_: r_efi::efi::Event, _: *mut crate::ffi::c_void) {}
+    }
+
+    impl Drop for InputProtocol {
+        fn drop(&mut self) {
+            // Close wait_for_key
+            unsafe {
+                let _ = helpers::OwnedEvent::from_raw(self.wait_for_key);
             }
         }
     }

--- a/library/std/src/sys/stdio/uefi.rs
+++ b/library/std/src/sys/stdio/uefi.rs
@@ -142,8 +142,12 @@ impl io::Write for Stderr {
 // UTF-16 character should occupy 4 bytes at most in UTF-8
 pub const STDIN_BUF_SIZE: usize = 4;
 
-pub fn is_ebadf(_err: &io::Error) -> bool {
-    false
+pub fn is_ebadf(err: &io::Error) -> bool {
+    if let Some(x) = err.raw_os_error() {
+        r_efi::efi::Status::UNSUPPORTED.as_usize() == x
+    } else {
+        false
+    }
 }
 
 pub fn panic_output() -> Option<impl io::Write> {


### PR DESCRIPTION
According to the docs in `Command::output`:

> By default, stdout and stderr are captured (and used to provide the
resulting output). Stdin is not inherited from the parent and any attempt by the child process to read from the stdin stream will result in the stream immediately closing.

This was being violated by UEFI which was inheriting stdin by default.

While the docs don't explicitly state that the default should be NULL, the behaviour seems like reading from NULL.

UEFI however, has a bit of a problem. The `EFI_SIMPLE_TEXT_INPUT_PROTOCOL` only provides support for reading 1 key press. This means that you either get an error, or it is assumed that the keypress was read successfully. So there is no way to have a successful read of length 0. Currently, I am returning UNSUPPORTED error when trying to read from NULL stdin. On linux however, you will get a read of length 0 for Null stdin.

One possible way to get around this is to translate one of the UEFI errors to a read 0 (Maybe unsupported?). It is also possible to have a non-standard error code, but well, not sure if we go that route.

Alternatively, if meaning of Stdio::Null is platform dependent, it should be fine to keep the current behaviour of returning an error.

cc @nicholasbishop @dvdhrm 