### PR TITLE
compiletest maintenance: sort deps and drop dep on `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,6 @@ name = "compiletest"
 version = "0.0.0"
 dependencies = [
  "anstyle-svg",
- "anyhow",
  "build_helper",
  "colored",
  "diff",

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -7,25 +7,27 @@ edition = "2021"
 doctest = false
 
 [dependencies]
+# tidy-alphabetical-start
 anstyle-svg = "0.1.3"
+anyhow = "1"
+build_helper = { path = "../../build_helper" }
 colored = "2"
 diff = "0.1.10"
-unified-diff = "0.2.1"
 getopts = "0.2"
+glob = "0.3.0"
+home = "0.5.5"
 indexmap = "2.0.0"
 miropt-test-tools = { path = "../miropt-test-tools" }
-build_helper = { path = "../../build_helper" }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.3", default-features = false, features = ["ansi", "env-filter", "fmt", "parking_lot", "smallvec"] }
 regex = "1.0"
+rustfix = "0.8.1"
 semver = { version = "1.0.23", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rustfix = "0.8.1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.3", default-features = false, features = ["ansi", "env-filter", "fmt", "parking_lot", "smallvec"] }
+unified-diff = "0.2.1"
 walkdir = "2"
-glob = "0.3.0"
-anyhow = "1"
-home = "0.5.5"
+# tidy-alphabetical-end
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -9,7 +9,6 @@ doctest = false
 [dependencies]
 # tidy-alphabetical-start
 anstyle-svg = "0.1.3"
-anyhow = "1"
 build_helper = { path = "../../build_helper" }
 colored = "2"
 diff = "0.1.10"

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -10,7 +10,6 @@ use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::sync::Arc;
 use std::{env, iter, str};
 
-use anyhow::Context;
 use colored::Colorize;
 use regex::{Captures, Regex};
 use tracing::*;
@@ -143,11 +142,11 @@ pub fn run(config: Arc<Config>, testpaths: &TestPaths, revision: Option<&str>) {
     }
 
     let cx = TestCx { config: &config, props: &props, testpaths, revision };
-    create_dir_all(&cx.output_base_dir())
-        .with_context(|| {
-            format!("failed to create output base directory {}", cx.output_base_dir().display())
-        })
-        .unwrap();
+
+    if let Err(e) = create_dir_all(&cx.output_base_dir()) {
+        panic!("failed to create output base directory {}: {e}", cx.output_base_dir().display());
+    }
+
     if props.incremental {
         cx.init_incremental_test();
     }


### PR DESCRIPTION
Two changes:

1. Sort compiletest deps alphabetically because it was annoying me (harder to quickly glance what deps compiletest is using).
2. Drop dependency on `anyhow`. There's only one usage of `anyhow`, which is for `with_context` on sth that would immediately panic anyway.