### PR TITLE
compiletest: Remove the `--logfile` flag

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -275,9 +275,6 @@ pub struct Config {
     /// Explicitly enable or disable running.
     pub run: Option<bool>,
 
-    /// Write out a parseable log of tests that were run
-    pub logfile: Option<PathBuf>,
-
     /// A command line to prefix program execution with,
     /// for running under valgrind for example.
     ///

--- a/src/tools/compiletest/src/executor.rs
+++ b/src/tools/compiletest/src/executor.rs
@@ -138,7 +138,7 @@ fn test_opts(config: &Config) -> test::TestOpts {
         filter_exact: config.filter_exact,
         run_ignored: if config.run_ignored { test::RunIgnored::Yes } else { test::RunIgnored::No },
         format: config.format.to_libtest(),
-        logfile: config.logfile.clone(),
+        logfile: None,
         run_tests: true,
         bench_benchmarks: true,
         nocapture: config.nocapture,

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -139,7 +139,6 @@ pub fn parse_config(args: Vec<String>) -> Config {
         .optflag("", "quiet", "print one character per test instead of one line")
         .optopt("", "color", "coloring: auto, always, never", "WHEN")
         .optflag("", "json", "emit json output instead of plaintext output")
-        .optopt("", "logfile", "file to log test execution to", "FILE")
         .optopt("", "target", "the target to build for", "TARGET")
         .optopt("", "host", "the host to build for", "HOST")
         .optopt("", "cdb", "path to CDB to use for CDB debuginfo tests", "PATH")
@@ -378,7 +377,6 @@ pub fn parse_config(args: Vec<String>) -> Config {
             "never" => Some(false),
             _ => panic!("unknown `--run` option `{}` given", mode),
         }),
-        logfile: matches.opt_str("logfile").map(|s| PathBuf::from(&s)),
         runner: matches.opt_str("runner"),
         host_rustcflags: matches.opt_strs("host-rustcflags"),
         target_rustcflags: matches.opt_strs("target-rustcflags"),


### PR DESCRIPTION
This flag is deprecated in libtest (#134283), and there's no evidence in-tree of this flag actually being passed to compiletest.

For detailed information about test results, bootstrap parses JSON output from compiletest instead (#108659).

As part of my experimental work on removing the libtest dependency from compiletest, it's useful to be able to disconnect libtest functionality that isn't needed.
