### PR TITLE
Fix infinte loop when reading from Stdin

### DIFF
--- a/library/std/src/sys/stdio/uefi.rs
+++ b/library/std/src/sys/stdio/uefi.rs
@@ -142,8 +142,12 @@ impl io::Write for Stderr {
 // UTF-16 character should occupy 4 bytes at most in UTF-8
 pub const STDIN_BUF_SIZE: usize = 4;
 
-pub fn is_ebadf(_err: &io::Error) -> bool {
-    false
+pub fn is_ebadf(err: &io::Error) -> bool {
+    if let Some(x) = err.raw_os_error() {
+        r_efi::efi::Status::NOT_READY.as_usize() == x
+    } else {
+        false
+    }
 }
 
 pub fn panic_output() -> Option<impl io::Write> {


### PR DESCRIPTION
In the old implementation, it would infinitely retry on status `NOT_READY`. This is not desirable since `NOT_READY` can be used as the way to perform NULL reads. For more context how that is useful, checkout: https://github.com/rust-lang/rust/pull/139517

cc @nicholasbishop