### PR TITLE
Instantiate higher-ranked transmute goal w/ placeholders before emitting sub-obligations

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -317,7 +317,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     obligation.cause.clone(),
                     obligation.recursion_depth + 1,
                     obligation.param_env,
-                    obligation.predicate.rebind(trait_ref),
+                    trait_ref,
                 )
             };
 
@@ -343,7 +343,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     obligation.cause.clone(),
                     obligation.recursion_depth + 1,
                     obligation.param_env,
-                    obligation.predicate.rebind(outlives),
+                    outlives,
                 )
             };
 
@@ -404,7 +404,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
         }
 
-        let predicate = obligation.predicate.skip_binder();
+        let predicate = self.infcx.enter_forall_and_leak_universe(obligation.predicate);
 
         let mut assume = predicate.trait_ref.args.const_at(2);
         // FIXME(mgca): We should shallowly normalize this.

--- a/tests/ui/transmutability/transmute-higher-ranked.rs
+++ b/tests/ui/transmutability/transmute-higher-ranked.rs
@@ -1,0 +1,18 @@
+// Ensure we don't ICE when transmuting higher-ranked types via a
+// higher-ranked transmute goal.
+
+//@ check-pass
+
+#![feature(transmutability)]
+
+use std::mem::TransmuteFrom;
+
+pub fn transmute()
+where
+    for<'a> &'a &'a i32: TransmuteFrom<&'a &'a u32>,
+{
+}
+
+fn main() {
+    transmute();
+}


### PR DESCRIPTION
This avoids an ICE where we weren't keeping track of bound variables correctly in the `Freeze` obligations we emit for transmute goals. We could use `rebind` instead on that goal, but I think it's better just to instantiate the binder.

Fixes #139538

r? @lcnr or reassign