### PR TITLE
Update library tracking issue template to set S-tracking-unimplemented

### DIFF
--- a/.github/ISSUE_TEMPLATE/library_tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/library_tracking_issue.md
@@ -2,7 +2,7 @@
 name: Library Tracking Issue
 about: A tracking issue for an unstable library feature.
 title: Tracking Issue for XXX
-labels: C-tracking-issue, T-libs-api
+labels: C-tracking-issue, T-libs-api, S-tracking-unimplemented
 ---
 <!--
 Thank you for creating a tracking issue!
@@ -48,6 +48,8 @@ impl Magic {
 For larger features, more steps might be involved.
 If the feature is changed later, please add those PRs here as well.
 -->
+
+(Remember to update the `S-tracking-*` label when checking boxes.)
 
 - [ ] Implementation: #...
 - [ ] Final comment period (FCP)[^1]


### PR DESCRIPTION
This will help people notice the `S-tracking-*` labels, and if the
tracking issue *is* implemented, they can change the label.

Discussed in a @rust-lang/libs-api meeting.

r? @Amanieu