### PR TITLE
report call site of inlined scopes for large assignment lints

### DIFF
--- a/compiler/rustc_monomorphize/src/mono_checks/move_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/move_check.rs
@@ -162,13 +162,27 @@ impl<'tcx> MoveCheckVisitor<'tcx> {
             // but correct span? This would make the lint at least accept crate-level lint attributes.
             return;
         };
+
+        // If the source scope is inlined by the MIR inliner, report the lint on the call site.
+        let reported_span = self
+            .body
+            .source_scopes
+            .get(source_info.scope)
+            .and_then(|source_scope_data| source_scope_data.inlined)
+            .map(|(_, call_site)| call_site)
+            .unwrap_or(span);
+
         self.tcx.emit_node_span_lint(
             LARGE_ASSIGNMENTS,
             lint_root,
-            span,
-            LargeAssignmentsLint { span, size: too_large_size.bytes(), limit: limit as u64 },
+            reported_span,
+            LargeAssignmentsLint {
+                span: reported_span,
+                size: too_large_size.bytes(),
+                limit: limit as u64,
+            },
         );
-        self.move_size_spans.push(span);
+        self.move_size_spans.push(reported_span);
     }
 }
 

--- a/tests/ui/lint/large_assignments/inline_mir.rs
+++ b/tests/ui/lint/large_assignments/inline_mir.rs
@@ -1,0 +1,24 @@
+#![feature(large_assignments)]
+#![deny(large_assignments)]
+#![move_size_limit = "1000"]
+
+//! Tests that with `-Zinline-mir`, we do NOT get an error that points to the
+//! implementation of `UnsafeCell` since that is not actionable by the user:
+//!
+//! ```text
+//! error: moving 9999 bytes
+//!   --> /rustc/FAKE_PREFIX/library/core/src/cell.rs:2054:9
+//!    |
+//!    = note: value moved from here
+//! ```
+//!
+//! We want the diagnostics to point to the relevant user code.
+
+//@ build-fail
+//@ compile-flags: -Zmir-opt-level=1 -Zinline-mir
+
+pub fn main() {
+    let data = [10u8; 9999];
+    let cell = std::cell::UnsafeCell::new(data); //~ ERROR large_assignments
+    std::hint::black_box(cell);
+}

--- a/tests/ui/lint/large_assignments/inline_mir.stderr
+++ b/tests/ui/lint/large_assignments/inline_mir.stderr
@@ -1,0 +1,15 @@
+error: moving 9999 bytes
+  --> $DIR/inline_mir.rs:22:16
+   |
+LL |     let cell = std::cell::UnsafeCell::new(data);
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
+note: the lint level is defined here
+  --> $DIR/inline_mir.rs:2:9
+   |
+LL | #![deny(large_assignments)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Addressed issue: #121672
Tracking issue: #83518

r? @oli-obk

I tried to follow your comment about what to do [here](https://github.com/rust-lang/rust/issues/121672#issuecomment-1972783675). However, I'm totally unfamiliar with the code so far (this is my first contribution touching compiler code), so I apologize in advance if I did something stupid :sweat_smile: 

In particular, I'm not sure I use the _correct_ source scope to look for inline data, as there is a whole `IndexVec` of them. My changes definitely did something, as can be seen by the added ui test. However, the result is not as anticipated in the issue:
```
LL |     let cell = std::cell::UnsafeCell::new(data);
   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ value moved from here
```
instead of
```
LL |     let cell = std::cell::UnsafeCell::new(data);
   |                                           ^^^^ value moved from here
```
raising my suspicion that maybe I got the wrong source scope.