### PR TITLE
UI tests: add missing diagnostic kinds where possible

### DIFF
--- a/tests/rustdoc-ui/invalid-syntax.rs
+++ b/tests/rustdoc-ui/invalid-syntax.rs
@@ -47,7 +47,7 @@ pub fn baz() {}
 ///
 /// Indented block end
 pub fn quux() {}
-//~^^^^^ could not parse code block as Rust code
+//~^^^^^ WARN could not parse code block as Rust code
 
 /// Unclosed fence
 ///

--- a/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.rs
+++ b/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.rs
@@ -5,10 +5,10 @@ use std::ops::Index;
 pub fn next<'a, T>(s: &'a mut dyn SVec<Item = T, Output = T>) {
     //~^ expected 1 lifetime argument
     //~| expected 1 generic argument
-    //~| the trait `SVec` is not dyn compatible
+    //~| ERROR the trait `SVec` is not dyn compatible
     //~| `SVec` is not dyn compatible
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
     let _ = s;
 }
 
@@ -16,52 +16,52 @@ pub trait SVec: Index<
     <Self as SVec>::Item,
     //~^ expected 1 lifetime argument
     //~| expected 1 generic argument
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
     Output = <Index<<Self as SVec>::Item,
     //~^ expected 1 lifetime argument
     //~| expected 1 generic argument
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
     Output = <Self as SVec>::Item> as SVec>::Item,
     //~^ expected 1 lifetime argument
     //~| expected 1 generic argument
     //~| expected 1 lifetime argument
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
     //~| expected 1 generic argument
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
-    //~| missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
 > {
     type Item<'a, T>;
 
     fn len(&self) -> <Self as SVec>::Item;
     //~^ expected 1 lifetime argument
-    //~| missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
     //~| expected 1 generic argument
-    //~| missing generics for associated type `SVec::Item`
+    //~| ERROR missing generics for associated type `SVec::Item`
 }

--- a/tests/rustdoc-ui/issues/ice-typeof-102986.rs
+++ b/tests/rustdoc-ui/issues/ice-typeof-102986.rs
@@ -1,5 +1,5 @@
 // https://github.com/rust-lang/rust/issues/102986
 struct Struct {
     y: (typeof("hey"),),
-    //~^ `typeof` is a reserved keyword but unimplemented
+    //~^ ERROR `typeof` is a reserved keyword but unimplemented
 }

--- a/tests/ui-fulldeps/hash-stable-is-unstable.rs
+++ b/tests/ui-fulldeps/hash-stable-is-unstable.rs
@@ -1,24 +1,24 @@
 //@ compile-flags: -Zdeduplicate-diagnostics=yes
 extern crate rustc_data_structures;
-//~^ use of unstable library feature `rustc_private`
+//~^ ERROR use of unstable library feature `rustc_private`
 //~| NOTE: issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
 //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 extern crate rustc_macros;
-//~^ use of unstable library feature `rustc_private`
+//~^ ERROR use of unstable library feature `rustc_private`
 //~| NOTE: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
 //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 extern crate rustc_query_system;
-//~^ use of unstable library feature `rustc_private`
+//~^ ERROR use of unstable library feature `rustc_private`
 //~| NOTE: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
 //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 use rustc_macros::HashStable;
-//~^ use of unstable library feature `rustc_private`
+//~^ ERROR use of unstable library feature `rustc_private`
 //~| NOTE: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
 //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 #[derive(HashStable)]
-//~^ use of unstable library feature `rustc_private`
+//~^ ERROR use of unstable library feature `rustc_private`
 //~| NOTE: in this expansion of #[derive(HashStable)]
 //~| NOTE: in this expansion of #[derive(HashStable)]
 //~| NOTE: in this expansion of #[derive(HashStable)]

--- a/tests/ui-fulldeps/try-from-u32/errors.rs
+++ b/tests/ui-fulldeps/try-from-u32/errors.rs
@@ -8,17 +8,17 @@ extern crate rustc_macros;
 use rustc_macros::TryFromU32;
 
 #[derive(TryFromU32)]
-struct MyStruct {} //~ type is not an enum
+struct MyStruct {} //~ ERROR type is not an enum
 
 #[derive(TryFromU32)]
 enum NonTrivial {
     A,
     B(),
     C {},
-    D(bool),                //~ enum variant cannot have fields
-    E(bool, bool),          //~ enum variant cannot have fields
-    F { x: bool },          //~ enum variant cannot have fields
-    G { x: bool, y: bool }, //~ enum variant cannot have fields
+    D(bool),                //~ ERROR enum variant cannot have fields
+    E(bool, bool),          //~ ERROR enum variant cannot have fields
+    F { x: bool },          //~ ERROR enum variant cannot have fields
+    G { x: bool, y: bool }, //~ ERROR enum variant cannot have fields
 }
 
 fn main() {}

--- a/tests/ui/abi/simd-abi-checks-avx.rs
+++ b/tests/ui/abi/simd-abi-checks-avx.rs
@@ -14,19 +14,19 @@ use std::arch::x86_64::*;
 struct Wrapper(__m256);
 
 unsafe extern "C" fn w(_: Wrapper) {
-    //~^ requires the `avx` target feature, which is not enabled
+    //~^ WARN requires the `avx` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
     todo!()
 }
 
 unsafe extern "C" fn f(_: __m256) {
-    //~^ requires the `avx` target feature, which is not enabled
+    //~^ WARN requires the `avx` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
     todo!()
 }
 
 unsafe extern "C" fn g() -> __m256 {
-    //~^ requires the `avx` target feature, which is not enabled
+    //~^ WARN requires the `avx` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
     todo!()
 }

--- a/tests/ui/abi/simd-abi-checks-empty-list.rs
+++ b/tests/ui/abi/simd-abi-checks-empty-list.rs
@@ -14,5 +14,5 @@ use minicore::*;
 pub struct SimdVec([i32; 4]);
 
 pub extern "C" fn pass_by_vec(_: SimdVec) {}
-//~^ this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
+//~^ WARN this function definition uses SIMD vector type `SimdVec` which is not currently supported with the chosen ABI
 //~| WARNING this was previously accepted by the compiler

--- a/tests/ui/abi/simd-abi-checks-sse.rs
+++ b/tests/ui/abi/simd-abi-checks-sse.rs
@@ -18,6 +18,6 @@ pub struct SseVector([i64; 2]);
 
 #[no_mangle]
 pub unsafe extern "C" fn f(_: SseVector) {
-    //~^ this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
+    //~^ WARN this function definition uses SIMD vector type `SseVector` which (with the chosen ABI) requires the `sse` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
 }

--- a/tests/ui/abi/vectorcall-abi-checks.rs
+++ b/tests/ui/abi/vectorcall-abi-checks.rs
@@ -11,11 +11,11 @@ use minicore::*;
 
 #[no_mangle]
 pub extern "vectorcall" fn f() {
-    //~^ ABI "vectorcall" which requires the `sse2` target feature
+    //~^ ERROR ABI "vectorcall" which requires the `sse2` target feature
 }
 
 #[no_mangle]
 pub fn call_site() {
     f();
-    //~^ ABI "vectorcall" which requires the `sse2` target feature
+    //~^ ERROR ABI "vectorcall" which requires the `sse2` target feature
 }

--- a/tests/ui/anon-params/anon-params-denied-2018.rs
+++ b/tests/ui/anon-params/anon-params-denied-2018.rs
@@ -3,7 +3,7 @@
 //@ edition:2018
 
 trait T {
-    fn foo(i32); //~ expected one of `:`, `@`, or `|`, found `)`
+    fn foo(i32); //~ ERROR expected one of `:`, `@`, or `|`, found `)`
 
     // Also checks with `&`
     fn foo_with_ref(&mut i32);

--- a/tests/ui/argument-suggestions/issue-100478.rs
+++ b/tests/ui/argument-suggestions/issue-100478.rs
@@ -45,7 +45,7 @@ fn main() {
     let p8 = Arc::default();
 
     foo(
-        //~^ 47:5: 47:8: this function takes 8 arguments but 7 arguments were supplied [E0061]
+        //~^ ERROR this function takes 8 arguments but 7 arguments were supplied [E0061]
         p1, //p2,
         p3, p4, p5, p6, p7, p8,
     );

--- a/tests/ui/argument-suggestions/issue-101097.rs
+++ b/tests/ui/argument-suggestions/issue-101097.rs
@@ -15,7 +15,7 @@ fn f(
 fn main() {
     f(C, A, A, A, B, B, C); //~ ERROR function takes 6 arguments but 7 arguments were supplied [E0061]
     f(C, C, A, A, B, B);  //~ ERROR arguments to this function are incorrect [E0308]
-    f(A, A, D, D, B, B);  //~ arguments to this function are incorrect [E0308]
-    f(C, C, B, B, A, A);  //~ arguments to this function are incorrect [E0308]
-    f(C, C, A, B, A, A);  //~ arguments to this function are incorrect [E0308]
+    f(A, A, D, D, B, B);  //~ ERROR arguments to this function are incorrect [E0308]
+    f(C, C, B, B, A, A);  //~ ERROR arguments to this function are incorrect [E0308]
+    f(C, C, A, B, A, A);  //~ ERROR arguments to this function are incorrect [E0308]
 }

--- a/tests/ui/array-slice-vec/array_const_index-0.rs
+++ b/tests/ui/array-slice-vec/array_const_index-0.rs
@@ -1,6 +1,6 @@
 const A: &'static [i32] = &[];
 const B: i32 = (&A)[1];
-//~^ index out of bounds: the length is 0 but the index is 1
+//~^ NOTE index out of bounds: the length is 0 but the index is 1
 //~| ERROR evaluation of constant value failed
 
 fn main() {

--- a/tests/ui/array-slice-vec/array_const_index-1.rs
+++ b/tests/ui/array-slice-vec/array_const_index-1.rs
@@ -1,6 +1,6 @@
 const A: [i32; 0] = [];
 const B: i32 = A[1];
-//~^ index out of bounds: the length is 0 but the index is 1
+//~^ NOTE index out of bounds: the length is 0 but the index is 1
 //~| ERROR evaluation of constant value failed
 
 fn main() {

--- a/tests/ui/asm/issue-85247.rs
+++ b/tests/ui/asm/issue-85247.rs
@@ -18,6 +18,6 @@ use minicore::*;
 fn main() {
     unsafe {
         asm!("", out("r9") _);
-        //[rwpi]~^ cannot use register `r9`
+        //[rwpi]~^ ERROR cannot use register `r9`
     }
 }

--- a/tests/ui/asm/issue-99071.rs
+++ b/tests/ui/asm/issue-99071.rs
@@ -13,6 +13,6 @@ use minicore::*;
 pub fn foo() {
     unsafe {
         asm!("", in("r8") 0);
-        //~^ cannot use register `r8`: high registers (r8+) can only be used as clobbers in Thumb-1 code
+        //~^ ERROR cannot use register `r8`: high registers (r8+) can only be used as clobbers in Thumb-1 code
     }
 }

--- a/tests/ui/asm/type-check-4.rs
+++ b/tests/ui/asm/type-check-4.rs
@@ -11,7 +11,7 @@ fn main() {
         let mut a = 0isize;
         let p = &a;
         asm!("{}", out(reg) a);
-        //~^ cannot assign to `a` because it is borrowed
+        //~^ ERROR cannot assign to `a` because it is borrowed
         println!("{}", p);
 
         // Can't read from mutable borrowed values.
@@ -19,7 +19,7 @@ fn main() {
         let mut a = 0isize;
         let p = &mut a;
         asm!("{}", in(reg) a);
-        //~^ cannot use `a` because it was mutably borrowed
+        //~^ ERROR cannot use `a` because it was mutably borrowed
         println!("{}", p);
     }
 }

--- a/tests/ui/asm/x86_64/issue-82869.rs
+++ b/tests/ui/asm/x86_64/issue-82869.rs
@@ -12,9 +12,9 @@ pub unsafe fn aarch64(a: f64, b: f64) -> f64 {
         || {};
         b
     });
-    //~^^^^ invalid register class
-    //~^^^^^ invalid register class
-    //~^^^^^^ invalid register
+    //~^^^^ ERROR invalid register class
+    //~^^^^^ ERROR invalid register class
+    //~^^^^^^ ERROR invalid register
     c
 }
 

--- a/tests/ui/associated-consts/defaults-cyclic-fail.rs
+++ b/tests/ui/associated-consts/defaults-cyclic-fail.rs
@@ -3,7 +3,7 @@
 // Cyclic assoc. const defaults don't error unless *used*
 trait Tr {
     const A: u8 = Self::B;
-    //~^ cycle detected
+    //~^ ERROR cycle detected
 
     const B: u8 = Self::A;
 }

--- a/tests/ui/associated-inherent-types/generic-associated-types-bad.rs
+++ b/tests/ui/associated-inherent-types/generic-associated-types-bad.rs
@@ -13,8 +13,8 @@ impl Ty {
 }
 
 #[cfg(item)]
-const _: Ty::Pr<String> = String::new(); //[item]~ the trait bound `String: Copy` is not satisfied
-//[item]~^ the trait bound `String: Copy` is not satisfied
+const _: Ty::Pr<String> = String::new(); //[item]~ ERROR the trait bound `String: Copy` is not satisfied
+//[item]~^ ERROR the trait bound `String: Copy` is not satisfied
 
 fn main() {
     #[cfg(local)]

--- a/tests/ui/associated-type-bounds/return-type-notation/path-missing.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-missing.rs
@@ -17,7 +17,7 @@ where
 fn type_dependent<T: A>()
 where
     T::method(..): Send,
-    //~^ associated function `method` not found for `T`
+    //~^ ERROR associated function `method` not found for `T`
 {
 }
 

--- a/tests/ui/associated-types/hr-associated-type-bound-2.rs
+++ b/tests/ui/associated-types/hr-associated-type-bound-2.rs
@@ -8,7 +8,7 @@ where
     }
 }
 
-impl X<'_> for u32 //~ overflow evaluating the requirement `for<'b> u32: X<'b>`
+impl X<'_> for u32 //~ ERROR overflow evaluating the requirement `for<'b> u32: X<'b>`
 where
     for<'b> <Self as X<'b>>::U: Clone,
 {

--- a/tests/ui/associated-types/hr-associated-type-bound-param-2.rs
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-2.rs
@@ -1,16 +1,16 @@
 trait Z<'a, T: ?Sized>
 where
     T: Z<'a, u16>,
-    //~^ the trait bound `str: Clone` is not satisfied
-    //~| the trait bound `str: Clone` is not satisfied
+    //~^ ERROR the trait bound `str: Clone` is not satisfied
+    //~| ERROR the trait bound `str: Clone` is not satisfied
     for<'b> <T as Z<'b, u16>>::W: Clone,
 {
     type W: ?Sized;
     fn h(&self, x: &T::W) {
         <T::W>::clone(x);
-        //~^ the trait bound `str: Clone` is not satisfied
-        //~| the trait bound `str: Clone` is not satisfied
-        //~| the trait bound `str: Clone` is not satisfied
+        //~^ ERROR the trait bound `str: Clone` is not satisfied
+        //~| ERROR the trait bound `str: Clone` is not satisfied
+        //~| ERROR the trait bound `str: Clone` is not satisfied
     }
 }
 

--- a/tests/ui/associated-types/hr-associated-type-projection-1.rs
+++ b/tests/ui/associated-types/hr-associated-type-projection-1.rs
@@ -12,10 +12,10 @@ where
 
 impl<T: Copy + std::ops::Deref> UnsafeCopy<'_, T> for T {
     type Item = T;
-    //~^ type mismatch resolving `<T as Deref>::Target == T`
+    //~^ ERROR type mismatch resolving `<T as Deref>::Target == T`
 }
 
 pub fn main() {
     <&'static str>::bug(&"");
-    //~^ type mismatch resolving `<&str as Deref>::Target == &str`
+    //~^ ERROR type mismatch resolving `<&str as Deref>::Target == &str`
 }

--- a/tests/ui/associated-types/issue-85103-layout-debug.rs
+++ b/tests/ui/associated-types/issue-85103-layout-debug.rs
@@ -4,6 +4,6 @@ use std::borrow::Cow;
 
 #[rustc_layout(debug)]
 type Edges<'a, E> = Cow<'a, [E]>;
-//~^ the trait bound `[E]: ToOwned` is not satisfied
+//~^ ERROR the trait bound `[E]: ToOwned` is not satisfied
 
 fn main() {}

--- a/tests/ui/associated-types/remove-invalid-type-bound-suggest-issue-127555.rs
+++ b/tests/ui/associated-types/remove-invalid-type-bound-suggest-issue-127555.rs
@@ -13,7 +13,7 @@ impl Foo for Baz {
     async fn bar<F>(&mut self, _func: F) -> ()
     where
         F: FnMut() + Send,
-        //~^ impl has stricter requirements than trait
+        //~^ ERROR impl has stricter requirements than trait
     {
         ()
     }

--- a/tests/ui/async-await/drop-track-field-assign-nonsend.rs
+++ b/tests/ui/async-await/drop-track-field-assign-nonsend.rs
@@ -40,5 +40,5 @@ fn main() {
     let agent = Agent { info_result: InfoResult { node: None } };
     // FIXME: It would be nice for this to work. See #94067.
     assert_send(agent.handle());
-    //~^ cannot be sent between threads safely
+    //~^ ERROR cannot be sent between threads safely
 }

--- a/tests/ui/async-await/field-assign-nonsend.rs
+++ b/tests/ui/async-await/field-assign-nonsend.rs
@@ -40,5 +40,5 @@ fn main() {
     let agent = Agent { info_result: InfoResult { node: None } };
     // FIXME: It would be nice for this to work. See #94067.
     assert_send(agent.handle());
-    //~^ cannot be sent between threads safely
+    //~^ ERROR cannot be sent between threads safely
 }

--- a/tests/ui/async-await/suggest-missing-await.rs
+++ b/tests/ui/async-await/suggest-missing-await.rs
@@ -43,7 +43,7 @@ async fn suggest_await_on_previous_match_arms() {
         0 => dummy(), //~ HELP consider `await`ing on the `Future`
         1 => dummy(),
         2 => dummy().await,
-        //~^ `match` arms have incompatible types [E0308]
+        //~^ ERROR `match` arms have incompatible types [E0308]
     };
 }
 

--- a/tests/ui/attributes/issue-90873.rs
+++ b/tests/ui/attributes/issue-90873.rs
@@ -1,7 +1,7 @@
 #![u=||{static d=||1;}]
-//~^ attribute value must be a literal
-//~| cannot find attribute `u` in this scope
-//~| missing type for `static` item
+//~^ ERROR attribute value must be a literal
+//~| ERROR cannot find attribute `u` in this scope
+//~| ERROR missing type for `static` item
 
 #![a={impl std::ops::Neg for i8 {}}]
 //~^ ERROR attribute value must be a literal

--- a/tests/ui/attributes/used_with_multi_args.rs
+++ b/tests/ui/attributes/used_with_multi_args.rs
@@ -1,6 +1,6 @@
 #![feature(used_with_arg)]
 
-#[used(compiler, linker)] //~ expected `used`, `used(compiler)` or `used(linker)`
+#[used(compiler, linker)] //~ ERROR expected `used`, `used(compiler)` or `used(linker)`
 static mut USED_COMPILER_LINKER: [usize; 1] = [0];
 
 fn main() {}

--- a/tests/ui/augmented-assignments.rs
+++ b/tests/ui/augmented-assignments.rs
@@ -16,13 +16,13 @@ fn main() {
     +=
     x;
     //~^ ERROR cannot move out of `x` because it is borrowed
-    //~| move out of `x` occurs here
+    //~| NOTE move out of `x` occurs here
 
     let y = Int(2);
     //~^ HELP consider changing this to be mutable
     //~| SUGGESTION mut
     y   //~ ERROR cannot borrow `y` as mutable, as it is not declared as mutable
-        //~| cannot borrow as mutable
+        //~| NOTE cannot borrow as mutable
     +=
     Int(1);
 }

--- a/tests/ui/auto-traits/auto-trait-validation.fixed
+++ b/tests/ui/auto-traits/auto-trait-validation.fixed
@@ -4,11 +4,11 @@
 //@ run-rustfix
 
 auto trait Generic {}
-//~^ auto traits cannot have generic parameters [E0567]
+//~^ ERROR auto traits cannot have generic parameters [E0567]
 auto trait Bound {}
-//~^ auto traits cannot have super traits or lifetime bounds [E0568]
+//~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
 auto trait LifetimeBound {}
-//~^ auto traits cannot have super traits or lifetime bounds [E0568]
+//~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
 auto trait MyTrait {  }
-//~^ auto traits cannot have associated items [E0380]
+//~^ ERROR auto traits cannot have associated items [E0380]
 fn main() {}

--- a/tests/ui/auto-traits/auto-trait-validation.rs
+++ b/tests/ui/auto-traits/auto-trait-validation.rs
@@ -4,11 +4,11 @@
 //@ run-rustfix
 
 auto trait Generic<T> {}
-//~^ auto traits cannot have generic parameters [E0567]
+//~^ ERROR auto traits cannot have generic parameters [E0567]
 auto trait Bound : Copy {}
-//~^ auto traits cannot have super traits or lifetime bounds [E0568]
+//~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
 auto trait LifetimeBound : 'static {}
-//~^ auto traits cannot have super traits or lifetime bounds [E0568]
+//~^ ERROR auto traits cannot have super traits or lifetime bounds [E0568]
 auto trait MyTrait { fn foo() {} }
-//~^ auto traits cannot have associated items [E0380]
+//~^ ERROR auto traits cannot have associated items [E0380]
 fn main() {}

--- a/tests/ui/borrowck/borrowck-fn-in-const-c.rs
+++ b/tests/ui/borrowck/borrowck-fn-in-const-c.rs
@@ -14,7 +14,7 @@ impl Drop for DropString {
 const LOCAL_REF: fn() -> &'static str = {
     fn broken() -> &'static str {
         let local = DropString { inner: format!("Some local string") };
-        return &local.inner; //~ borrow may still be in use when destructor runs
+        return &local.inner; //~ ERROR borrow may still be in use when destructor runs
     }
     broken
 };

--- a/tests/ui/borrowck/borrowck-vec-pattern-nesting.rs
+++ b/tests/ui/borrowck/borrowck-vec-pattern-nesting.rs
@@ -19,7 +19,7 @@ fn b() {
     let vec: &mut [Box<isize>] = &mut vec;
     match vec {
         &mut [ref _b @ ..] => {
-        //~^ `vec[_]` is borrowed here
+        //~^ NOTE `vec[_]` is borrowed here
             vec[0] = Box::new(4); //~ ERROR cannot assign
             //~^ NOTE `vec[_]` is assigned to here
             _b.use_ref();

--- a/tests/ui/borrowck/issue-36082.fixed
+++ b/tests/ui/borrowck/issue-36082.fixed
@@ -13,5 +13,5 @@ fn main() {
     //~| NOTE creates a temporary value which is freed while still in use
     //~| HELP consider using a `let` binding to create a longer lived value
     println!("{}", val);
-    //~^ borrow later used here
+    //~^ NOTE borrow later used here
 }

--- a/tests/ui/borrowck/issue-36082.rs
+++ b/tests/ui/borrowck/issue-36082.rs
@@ -12,5 +12,5 @@ fn main() {
     //~| NOTE creates a temporary value which is freed while still in use
     //~| HELP consider using a `let` binding to create a longer lived value
     println!("{}", val);
-    //~^ borrow later used here
+    //~^ NOTE borrow later used here
 }

--- a/tests/ui/borrowck/two-phase-multi-mut.rs
+++ b/tests/ui/borrowck/two-phase-multi-mut.rs
@@ -9,6 +9,6 @@ impl Foo {
 fn main() {
     let mut foo = Foo { };
     foo.method(&mut foo);
-    //~^     cannot borrow `foo` as mutable more than once at a time
-    //~^^    cannot borrow `foo` as mutable more than once at a time
+    //~^ ERROR cannot borrow `foo` as mutable more than once at a time
+    //~^^ ERROR cannot borrow `foo` as mutable more than once at a time
 }

--- a/tests/ui/closures/2229_closure_analysis/by_value.rs
+++ b/tests/ui/closures/2229_closure_analysis/by_value.rs
@@ -20,8 +20,8 @@ fn big_box() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         let p = t.0.0;
         //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
         //~| NOTE: Min Capture t[(0, 0)] -> ByValue

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-1.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-1.rs
@@ -17,8 +17,8 @@ fn main() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         println!("{:?}", p);
         //~^ NOTE: Capturing p[] -> Immutable
         //~| NOTE: Min Capture p[] -> Immutable

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-2.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-2.rs
@@ -16,8 +16,8 @@ fn main() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         let _x = p.x;
         //~^ NOTE: Capturing p[(0, 0)] -> ByValue
         //~| NOTE: p[] captured as ByValue here

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-3.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-3.rs
@@ -21,8 +21,8 @@ fn main() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         let _x = a.b.c;
         //~^ NOTE: Capturing a[(0, 0),(0, 0)] -> ByValue
         //~| NOTE: a[(0, 0)] captured as ByValue here

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-4.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-4.rs
@@ -21,8 +21,8 @@ fn main() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         let _x = a.b;
         //~^ NOTE: Capturing a[(0, 0)] -> ByValue
         //~| NOTE: Min Capture a[(0, 0)] -> ByValue

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.rs
@@ -15,8 +15,8 @@ fn main() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         println!("{}", p.x);
         //~^ NOTE: Capturing p[(0, 0)] -> Immutable
         //~| NOTE: Min Capture p[(0, 0)] -> Immutable

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.rs
@@ -10,8 +10,8 @@ fn main() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         println!("{}", t.0);
         //~^ NOTE: Capturing t[(0, 0)] -> Immutable
         //~| NOTE: Min Capture t[(0, 0)] -> Immutable

--- a/tests/ui/closures/2229_closure_analysis/capture-enums.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-enums.rs
@@ -18,8 +18,8 @@ fn multi_variant_enum() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         if let Info::Point(_, _, str) = point {
             //~^ NOTE: Capturing point[] -> Immutable
             //~| NOTE: Capturing point[(2, 0)] -> ByValue
@@ -50,8 +50,8 @@ fn single_variant_enum() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         let SingleVariant::Point(_, _, str) = point;
         //~^ NOTE: Capturing point[(2, 0)] -> ByValue
         //~| NOTE: Min Capture point[(2, 0)] -> ByValue

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/union.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/union.rs
@@ -11,15 +11,15 @@ union A {
 fn main() {
     let mut a = A { y: 1 };
     let mut c = || {
-    //~^ `a.y` is borrowed here
+    //~^ NOTE `a.y` is borrowed here
         let _ = unsafe { &a.y };
         let _ = &mut a;
-        //~^ borrow occurs due to use in closure
+        //~^ NOTE borrow occurs due to use in closure
         let _ = unsafe { &mut a.y };
     };
     a.y = 1;
-    //~^ cannot assign to `a.y` because it is borrowed [E0506]
-    //~| `a.y` is assigned to here
+    //~^ ERROR cannot assign to `a.y` because it is borrowed [E0506]
+    //~| NOTE `a.y` is assigned to here
     c();
-    //~^ borrow later used here
+    //~^ NOTE borrow later used here
 }

--- a/tests/ui/closures/2229_closure_analysis/match/patterns-capture-analysis.rs
+++ b/tests/ui/closures/2229_closure_analysis/match/patterns-capture-analysis.rs
@@ -10,8 +10,8 @@ fn test_1_should_capture() {
     let variant = Some(2229);
     let c =  #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         match variant {
         //~^ NOTE: Capturing variant[] -> Immutable
         //~| NOTE: Min Capture variant[] -> Immutable
@@ -28,7 +28,7 @@ fn test_2_should_not_capture() {
     let variant = Some(2229);
     let c =  #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
+    //~^ ERROR First Pass analysis includes:
         match variant {
             _ => {}
         }
@@ -47,7 +47,7 @@ fn test_3_should_not_capture_single_variant() {
     let variant = SingleVariant::Points(1);
     let c =  #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
+    //~^ ERROR First Pass analysis includes:
         match variant {
             SingleVariant::Points(_) => {}
         }
@@ -61,8 +61,8 @@ fn test_6_should_capture_single_variant() {
     let variant = SingleVariant::Points(1);
     let c =  #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         match variant {
             //~^ NOTE: Capturing variant[] -> Immutable
             //~| NOTE: Capturing variant[(0, 0)] -> Immutable
@@ -81,7 +81,7 @@ fn test_4_should_not_capture_array() {
     let array: [i32; 3] = [0; 3];
     let c =  #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
+    //~^ ERROR First Pass analysis includes:
         match array {
             [_,_,_] => {}
         }
@@ -93,7 +93,7 @@ fn test_4_should_not_capture_array() {
     let array: &[i32; 3] = &[0; 3];
     let c = #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
+    //~^ ERROR First Pass analysis includes:
         match array {
             [_, _, _] => {}
         }
@@ -106,7 +106,7 @@ fn test_4_should_not_capture_array() {
     let f = &Foo(&[10; 3]);
     let c = #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
+    //~^ ERROR First Pass analysis includes:
         match f {
             Foo([_, _, _]) => ()
         }
@@ -128,8 +128,8 @@ fn test_5_should_capture_multi_variant() {
     let variant = MVariant::A;
     let c =  #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         match variant {
         //~^ NOTE: Capturing variant[] -> Immutable
         //~| NOTE: Min Capture variant[] -> Immutable
@@ -146,8 +146,8 @@ fn test_7_should_capture_slice_len() {
     let slice: &[i32] = &[1, 2, 3];
     let c =  #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         match slice {
             //~^ NOTE: Capturing slice[] -> Immutable
             //~| NOTE: Min Capture slice[] -> Immutable
@@ -158,8 +158,8 @@ fn test_7_should_capture_slice_len() {
     c();
     let c =  #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         match slice {
             //~^ NOTE: Capturing slice[] -> Immutable
             //~| NOTE: Min Capture slice[] -> Immutable
@@ -170,8 +170,8 @@ fn test_7_should_capture_slice_len() {
     c();
     let c =  #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
-    //~| Min Capture analysis includes:
+    //~^ ERROR First Pass analysis includes:
+    //~| ERROR Min Capture analysis includes:
         match slice {
             //~^ NOTE: Capturing slice[] -> Immutable
             //~| NOTE: Min Capture slice[] -> Immutable
@@ -187,7 +187,7 @@ fn test_8_capture_slice_wild() {
     let slice: &[i32] = &[1, 2, 3];
     let c =  #[rustc_capture_analysis]
     || {
-    //~^ First Pass analysis includes:
+    //~^ ERROR First Pass analysis includes:
         match slice {
             [..] => {},
             _ => {}

--- a/tests/ui/closures/2229_closure_analysis/move_closure.rs
+++ b/tests/ui/closures/2229_closure_analysis/move_closure.rs
@@ -181,9 +181,9 @@ fn box_mut_1() {
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-    //~| First Pass analysis includes:
+    //~| ERROR First Pass analysis includes:
     //~| NOTE: Capturing box_p_foo[Deref,Deref,(0, 0)] -> Mutable
-    //~| Min Capture analysis includes:
+    //~| ERROR Min Capture analysis includes:
     //~| NOTE: Min Capture box_p_foo[] -> ByValue
 }
 
@@ -199,9 +199,9 @@ fn box_mut_2() {
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-    //~| First Pass analysis includes:
+    //~| ERROR First Pass analysis includes:
     //~| NOTE: Capturing p_foo[Deref,Deref,(0, 0)] -> Mutable
-    //~| Min Capture analysis includes:
+    //~| ERROR Min Capture analysis includes:
     //~| NOTE: Min Capture p_foo[] -> ByValue
 }
 
@@ -213,9 +213,9 @@ fn returned_closure_owns_copy_type_data() -> impl Fn() -> i32 {
     //~^ ERROR: attributes on expressions are experimental
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-    //~| First Pass analysis includes:
+    //~| ERROR First Pass analysis includes:
     //~| NOTE: Capturing x[] -> Immutable
-    //~| Min Capture analysis includes:
+    //~| ERROR Min Capture analysis includes:
     //~| NOTE: Min Capture x[] -> ByValue
 
     c

--- a/tests/ui/closures/binder/implicit-return.rs
+++ b/tests/ui/closures/binder/implicit-return.rs
@@ -2,5 +2,5 @@
 
 fn main() {
     let _f = for<'a> |_: &'a ()| {};
-    //~^ implicit types in closure signatures are forbidden when `for<...>` is present
+    //~^ ERROR implicit types in closure signatures are forbidden when `for<...>` is present
 }

--- a/tests/ui/closures/deduce-signature/obligation-with-leaking-placeholders.rs
+++ b/tests/ui/closures/deduce-signature/obligation-with-leaking-placeholders.rs
@@ -16,7 +16,7 @@ impl<'a, T> Foo<'a> for Wrap<T> where T: Fn(&'a i32) {}
 
 fn main() {
     needs_foo(|x| {
-        //[current]~^ implementation of `Foo` is not general enough
+        //[current]~^ ERROR implementation of `Foo` is not general enough
         //[next]~^^ ERROR type annotations needed
         x.to_string();
     });

--- a/tests/ui/closures/wrong-closure-arg-suggestion-125325.rs
+++ b/tests/ui/closures/wrong-closure-arg-suggestion-125325.rs
@@ -21,9 +21,9 @@ fn func(_f: impl Fn()) -> usize {
 fn test_func(s: &S) -> usize {
     let mut x = ();
     s.assoc_func(|| x = ());
-    //~^ cannot assign to `x`, as it is a captured variable in a `Fn` closure
+    //~^ ERROR cannot assign to `x`, as it is a captured variable in a `Fn` closure
     func(|| x = ())
-    //~^ cannot assign to `x`, as it is a captured variable in a `Fn` closure
+    //~^ ERROR cannot assign to `x`, as it is a captured variable in a `Fn` closure
 }
 
 fn main() {}

--- a/tests/ui/coercion/coerce-reborrow-multi-arg-fail.rs
+++ b/tests/ui/coercion/coerce-reborrow-multi-arg-fail.rs
@@ -2,5 +2,5 @@ fn test<T>(_a: T, _b: T) {}
 
 fn main() {
     test(&mut 7, &7);
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }

--- a/tests/ui/coercion/mut-mut-wont-coerce.rs
+++ b/tests/ui/coercion/mut-mut-wont-coerce.rs
@@ -33,7 +33,7 @@ fn make_foo(_: *mut *mut Foo) {
 
 fn main() {
     let mut result: SmartPtr<Foo> = SmartPtr(std::ptr::null_mut());
-    make_foo(&mut &mut *result); //~ mismatched types
+    make_foo(&mut &mut *result); //~ ERROR mismatched types
                                  //~^ expected `*mut *mut Foo`, found `&mut &mut Foo`
     make_foo(out(&mut result)); // works, but makes one wonder why above coercion cannot happen
 }

--- a/tests/ui/const-generics/adt_const_params/nested_bad_const_param_ty.rs
+++ b/tests/ui/const-generics/adt_const_params/nested_bad_const_param_ty.rs
@@ -4,18 +4,18 @@
 use std::marker::ConstParamTy;
 
 #[derive(ConstParamTy)]
-//~^ the trait `ConstParamTy_` cannot be implemented for this ty
-//~| the trait `ConstParamTy_` cannot be implemented for this ty
+//~^ ERROR the trait `ConstParamTy_` cannot be implemented for this ty
+//~| ERROR the trait `ConstParamTy_` cannot be implemented for this ty
 struct Foo([*const u8; 1]);
 
 #[derive(ConstParamTy)]
-//~^ the trait `ConstParamTy_` cannot be implemented for this ty
-//~| the trait `ConstParamTy_` cannot be implemented for this ty
+//~^ ERROR the trait `ConstParamTy_` cannot be implemented for this ty
+//~| ERROR the trait `ConstParamTy_` cannot be implemented for this ty
 struct Foo2([*mut u8; 1]);
 
 #[derive(ConstParamTy)]
-//~^ the trait `ConstParamTy_` cannot be implemented for this ty
-//~| the trait `ConstParamTy_` cannot be implemented for this ty
+//~^ ERROR the trait `ConstParamTy_` cannot be implemented for this ty
+//~| ERROR the trait `ConstParamTy_` cannot be implemented for this ty
 struct Foo3([fn(); 1]);
 
 fn main() {}

--- a/tests/ui/const-generics/early/invalid-const-arguments.rs
+++ b/tests/ui/const-generics/early/invalid-const-arguments.rs
@@ -4,7 +4,7 @@ struct A<const N: u8>;
 trait Foo {}
 impl Foo for A<N> {}
 //~^ ERROR cannot find type
-//~| unresolved item provided when a constant
+//~| ERROR unresolved item provided when a constant
 
 struct B<const N: u8>;
 impl<N> Foo for B<N> {}
@@ -13,4 +13,4 @@ impl<N> Foo for B<N> {}
 struct C<const C: u8, const N: u8>;
 impl<const N: u8> Foo for C<N, T> {}
 //~^ ERROR cannot find type
-//~| unresolved item provided when a constant
+//~| ERROR unresolved item provided when a constant

--- a/tests/ui/const-generics/issues/issue-68366.rs
+++ b/tests/ui/const-generics/issues/issue-68366.rs
@@ -11,7 +11,7 @@ struct Collatz<const N: Option<usize>>;
 
 impl <const N: usize> Collatz<{Some(N)}> {}
 //~^ ERROR the const parameter
-//[min]~^^ generic parameters may not be used in const operations
+//[min]~^^ ERROR generic parameters may not be used in const operations
 //[full]~^^^ ERROR overly complex
 
 struct Foo;

--- a/tests/ui/const-generics/issues/issue-74950.rs
+++ b/tests/ui/const-generics/issues/issue-74950.rs
@@ -17,9 +17,9 @@ struct Inner;
 // - impl StructuralPartialEq
 #[derive(PartialEq, Eq)]
 struct Outer<const I: Inner>;
-//[min]~^ `Inner` is forbidden
-//[min]~| `Inner` is forbidden
-//[min]~| `Inner` is forbidden
-//[min]~| `Inner` is forbidden
+//[min]~^ ERROR `Inner` is forbidden
+//[min]~| ERROR `Inner` is forbidden
+//[min]~| ERROR `Inner` is forbidden
+//[min]~| ERROR `Inner` is forbidden
 
 fn main() {}

--- a/tests/ui/const-generics/issues/issue-90318.rs
+++ b/tests/ui/const-generics/issues/issue-90318.rs
@@ -12,7 +12,7 @@ impl True for If<true> {}
 fn consume<T: 'static>(_val: T)
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-    //~^ overly complex generic constant
+    //~^ ERROR overly complex generic constant
     //~| ERROR: cannot call
 {
 }
@@ -20,7 +20,7 @@ where
 fn test<T: 'static>()
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-    //~^ overly complex generic constant
+    //~^ ERROR overly complex generic constant
     //~| ERROR: cannot call
 {
 }

--- a/tests/ui/consts/async-block.rs
+++ b/tests/ui/consts/async-block.rs
@@ -10,9 +10,9 @@ use std::future::Future;
 
 // From <https://github.com/rust-lang/rust/issues/77361>
 const _: i32 = { core::mem::ManuallyDrop::new(async { 0 }); 4 };
-//[without_feature]~^ `async` block
+//[without_feature]~^ ERROR `async` block
 
 static _FUT: &(dyn Future<Output = ()> + Sync) = &async {};
-//[without_feature]~^ `async` block
+//[without_feature]~^ ERROR `async` block
 
 fn main() {}

--- a/tests/ui/consts/const-array-oob-arith.rs
+++ b/tests/ui/consts/const-array-oob-arith.rs
@@ -4,10 +4,10 @@ const VAL: i32 = ARR[IDX];
 const BONG: [i32; (ARR[0] - 41) as usize] = [5];
 const BLUB: [i32; (ARR[0] - 40) as usize] = [5];
 //~^ ERROR: mismatched types
-//~| expected an array
+//~| NOTE expected an array
 const BOO: [i32; (ARR[0] - 41) as usize] = [5, 99];
 //~^ ERROR: mismatched types
-//~| expected an array
+//~| NOTE expected an array
 
 fn main() {
     let _ = VAL;

--- a/tests/ui/consts/const-deref-ptr.rs
+++ b/tests/ui/consts/const-deref-ptr.rs
@@ -3,6 +3,6 @@
 fn main() {
     static C: u64 = unsafe {*(0xdeadbeef as *const u64)};
     //~^ ERROR could not evaluate static initializer
-    //~| dangling pointer
+    //~| NOTE dangling pointer
     println!("{}", C);
 }

--- a/tests/ui/consts/const-err-enum-discriminant.rs
+++ b/tests/ui/consts/const-err-enum-discriminant.rs
@@ -7,7 +7,7 @@ union Foo {
 enum Bar {
     Boo = [unsafe { Foo { b: () }.a }; 4][3],
     //~^ ERROR evaluation of constant value failed
-    //~| uninitialized
+    //~| NOTE uninitialized
 }
 
 fn main() {

--- a/tests/ui/consts/const-eval/assign-to-static-within-other-static.rs
+++ b/tests/ui/consts/const-eval/assign-to-static-within-other-static.rs
@@ -6,7 +6,7 @@ use std::cell::UnsafeCell;
 static mut FOO: u32 = 42;
 static BOO: () = unsafe {
     FOO = 5;
-    //~^ could not evaluate static initializer [E0080]
+    //~^ ERROR could not evaluate static initializer [E0080]
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/const-eval-span.rs
+++ b/tests/ui/consts/const-eval/const-eval-span.rs
@@ -8,7 +8,7 @@ const CONSTANT: S = S(0);
 enum E {
     V = CONSTANT,
     //~^ ERROR mismatched types
-    //~| expected `isize`, found `S`
+    //~| NOTE expected `isize`, found `S`
 }
 
 fn main() {}

--- a/tests/ui/consts/const-eval/const_raw_ptr_ops2.rs
+++ b/tests/ui/consts/const-eval/const_raw_ptr_ops2.rs
@@ -5,6 +5,6 @@ const Z: i32 = unsafe { *(&1 as *const i32) };
 
 // bad, will thus error in miri
 const Z2: i32 = unsafe { *(42 as *const i32) }; //~ ERROR evaluation of constant value failed
-//~| is a dangling pointer
+//~| NOTE is a dangling pointer
 const Z3: i32 = unsafe { *(44 as *const i32) }; //~ ERROR evaluation of constant value failed
-//~| is a dangling pointer
+//~| NOTE is a dangling pointer

--- a/tests/ui/consts/const-eval/issue-91827-extern-types-field-offset.rs
+++ b/tests/ui/consts/const-eval/issue-91827-extern-types-field-offset.rs
@@ -37,7 +37,7 @@ const OFFSET: () = unsafe {
     // fails.
     let field = &x.a;
     //~^ ERROR: evaluation of constant value failed
-    //~| does not have a known offset
+    //~| NOTE does not have a known offset
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/partial_ptr_overwrite.rs
+++ b/tests/ui/consts/const-eval/partial_ptr_overwrite.rs
@@ -5,7 +5,7 @@ const PARTIAL_OVERWRITE: () = {
     unsafe {
         let ptr: *mut _ = &mut p;
         *(ptr as *mut u8) = 123; //~ ERROR constant
-        //~| unable to overwrite parts of a pointer
+        //~| NOTE unable to overwrite parts of a pointer
     }
     let x = *p;
 };

--- a/tests/ui/consts/const-eval/ub-enum-overwrite.rs
+++ b/tests/ui/consts/const-eval/ub-enum-overwrite.rs
@@ -10,7 +10,7 @@ const _: u8 = {
     e = E::B;
     unsafe { *p }
     //~^ ERROR evaluation of constant value failed
-    //~| uninitialized
+    //~| NOTE uninitialized
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-write-through-immutable.rs
+++ b/tests/ui/consts/const-eval/ub-write-through-immutable.rs
@@ -8,14 +8,14 @@ const WRITE_AFTER_CAST: () = unsafe {
     let mut x = 0;
     let ptr = &x as *const i32 as *mut i32;
     *ptr = 0; //~ERROR: evaluation of constant value failed
-    //~| immutable
+    //~| NOTE immutable
 };
 
 const WRITE_AFTER_TRANSMUTE: () = unsafe {
     let mut x = 0;
     let ptr: *mut i32 = mem::transmute(&x);
     *ptr = 0; //~ERROR: evaluation of constant value failed
-    //~| immutable
+    //~| NOTE immutable
 };
 
 // it's okay when there is interior mutability;

--- a/tests/ui/consts/const-eval/union-ice.rs
+++ b/tests/ui/consts/const-eval/union-ice.rs
@@ -13,13 +13,13 @@ const UNION: DummyUnion = DummyUnion { field1: 1065353216 };
 
 const FIELD3: Field3 = unsafe { UNION.field3 };
 //~^ ERROR evaluation of constant value failed
-//~| uninitialized
+//~| NOTE uninitialized
 
 const FIELD_PATH: Struct = Struct {
     a: 42,
     b: unsafe { UNION.field3 },
     //~^ ERROR evaluation of constant value failed
-    //~| uninitialized
+    //~| NOTE uninitialized
 };
 
 struct Struct {
@@ -32,7 +32,7 @@ const FIELD_PATH2: Struct2 = Struct2 {
         21,
         unsafe { UNION.field3 },
         //~^ ERROR evaluation of constant value failed
-        //~| uninitialized
+        //~| NOTE uninitialized
         23,
         24,
     ],

--- a/tests/ui/consts/const-eval/union_promotion.rs
+++ b/tests/ui/consts/const-eval/union_promotion.rs
@@ -5,7 +5,7 @@ union Foo {
 }
 
 fn main() {
-    let x: &'static bool = &unsafe { //~ temporary value dropped while borrowed
+    let x: &'static bool = &unsafe { //~ ERROR temporary value dropped while borrowed
         Foo { a: &1 }.b == Foo { a: &2 }.b
     };
 }

--- a/tests/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.rs
+++ b/tests/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.rs
@@ -8,11 +8,11 @@ const unsafe extern "C-unwind" fn bar() -> usize {
 
 fn main() {
     let a: [u8; foo()];
-    //~^ call to unsafe function `foo` is unsafe and requires unsafe function or block
+    //~^ ERROR call to unsafe function `foo` is unsafe and requires unsafe function or block
     foo();
     //~^ ERROR call to unsafe function `foo` is unsafe and requires unsafe function or block
     let b: [u8; bar()];
-    //~^ call to unsafe function `bar` is unsafe and requires unsafe function or block
+    //~^ ERROR call to unsafe function `bar` is unsafe and requires unsafe function or block
     bar();
     //~^ ERROR call to unsafe function `bar` is unsafe and requires unsafe function or block
 }

--- a/tests/ui/consts/const-integer-bool-ops.rs
+++ b/tests/ui/consts/const-integer-bool-ops.rs
@@ -1,67 +1,67 @@
 const X: usize = 42 && 39;
 //~^ ERROR mismatched types
-//~| expected `bool`, found integer
+//~| NOTE expected `bool`, found integer
 //~| ERROR mismatched types
-//~| expected `bool`, found integer
+//~| NOTE expected `bool`, found integer
 //~| ERROR mismatched types
-//~| expected `usize`, found `bool`
+//~| NOTE expected `usize`, found `bool`
 const ARR: [i32; X] = [99; 34];
 
 const X1: usize = 42 || 39;
 //~^ ERROR mismatched types
-//~| expected `bool`, found integer
+//~| NOTE expected `bool`, found integer
 //~| ERROR mismatched types
-//~| expected `bool`, found integer
+//~| NOTE expected `bool`, found integer
 //~| ERROR mismatched types
-//~| expected `usize`, found `bool`
+//~| NOTE expected `usize`, found `bool`
 const ARR1: [i32; X1] = [99; 47];
 
 const X2: usize = -42 || -39;
 //~^ ERROR mismatched types
-//~| expected `bool`, found integer
+//~| NOTE expected `bool`, found integer
 //~| ERROR mismatched types
-//~| expected `bool`, found integer
+//~| NOTE expected `bool`, found integer
 //~| ERROR mismatched types
-//~| expected `usize`, found `bool`
+//~| NOTE expected `usize`, found `bool`
 const ARR2: [i32; X2] = [99; 18446744073709551607];
 
 const X3: usize = -42 && -39;
 //~^ ERROR mismatched types
-//~| expected `bool`, found integer
+//~| NOTE expected `bool`, found integer
 //~| ERROR mismatched types
-//~| expected `bool`, found integer
+//~| NOTE expected `bool`, found integer
 //~| ERROR mismatched types
-//~| expected `usize`, found `bool`
+//~| NOTE expected `usize`, found `bool`
 const ARR3: [i32; X3] = [99; 6];
 
 const Y: usize = 42.0 == 42.0;
 //~^ ERROR mismatched types
-//~| expected `usize`, found `bool`
+//~| NOTE expected `usize`, found `bool`
 const ARRR: [i32; Y] = [99; 1];
 
 const Y1: usize = 42.0 >= 42.0;
 //~^ ERROR mismatched types
-//~| expected `usize`, found `bool`
+//~| NOTE expected `usize`, found `bool`
 const ARRR1: [i32; Y1] = [99; 1];
 
 const Y2: usize = 42.0 <= 42.0;
 //~^ ERROR mismatched types
-//~| expected `usize`, found `bool`
+//~| NOTE expected `usize`, found `bool`
 const ARRR2: [i32; Y2] = [99; 1];
 
 const Y3: usize = 42.0 > 42.0;
 //~^ ERROR mismatched types
-//~| expected `usize`, found `bool`
+//~| NOTE expected `usize`, found `bool`
 const ARRR3: [i32; Y3] = [99; 0];
 
 const Y4: usize = 42.0 < 42.0;
 //~^ ERROR mismatched types
-//~| expected `usize`, found `bool`
+//~| NOTE expected `usize`, found `bool`
 const ARRR4: [i32; Y4] = [99; 0];
 
 const Y5: usize = 42.0 != 42.0;
 //~^ ERROR mismatched types
-//~| expected `usize`, found `bool`
+//~| NOTE expected `usize`, found `bool`
 const ARRR5: [i32; Y5] = [99; 0];
 
 fn main() {

--- a/tests/ui/consts/const-len-underflow-subspans.rs
+++ b/tests/ui/consts/const-len-underflow-subspans.rs
@@ -7,5 +7,5 @@ const TWO: usize = 2;
 fn main() {
     let a: [i8; ONE - TWO] = unimplemented!();
     //~^ ERROR evaluation of constant value failed
-    //~| attempt to compute `1_usize - 2_usize`, which would overflow
+    //~| NOTE attempt to compute `1_usize - 2_usize`, which would overflow
 }

--- a/tests/ui/consts/const-slice-oob.rs
+++ b/tests/ui/consts/const-slice-oob.rs
@@ -1,6 +1,6 @@
 const FOO: &'static[u32] = &[1, 2, 3];
 const BAR: u32 = FOO[5];
-//~^ index out of bounds: the length is 3 but the index is 5
+//~^ NOTE index out of bounds: the length is 3 but the index is 5
 //~| ERROR evaluation of constant value failed
 
 fn main() {

--- a/tests/ui/consts/copy-intrinsic.rs
+++ b/tests/ui/consts/copy-intrinsic.rs
@@ -32,7 +32,7 @@ const COPY_OOB_1: () = unsafe {
     copy_nonoverlapping(0x100 as *const i32, dangle, 0);
     // Non-zero-sized copy is not.
     copy_nonoverlapping(0x100 as *const i32, dangle, 1); //~ ERROR evaluation of constant value failed [E0080]
-    //~| got 0x100[noalloc] which is a dangling pointer
+    //~| NOTE got 0x100[noalloc] which is a dangling pointer
 };
 const COPY_OOB_2: () = unsafe {
     let x = 0i32;
@@ -41,20 +41,20 @@ const COPY_OOB_2: () = unsafe {
     copy_nonoverlapping(dangle, 0x100 as *mut i32, 0);
     // Non-zero-sized copy is not.
     copy_nonoverlapping(dangle, 0x100 as *mut i32, 1); //~ ERROR evaluation of constant value failed [E0080]
-    //~| +0x28 which is at or beyond the end of the allocation
+    //~| NOTE +0x28 which is at or beyond the end of the allocation
 };
 
 const COPY_SIZE_OVERFLOW: () = unsafe {
     let x = 0;
     let mut y = 0;
     copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR evaluation of constant value failed [E0080]
-    //~| overflow computing total size of `copy`
+    //~| NOTE overflow computing total size of `copy`
 };
 const COPY_NONOVERLAPPING_SIZE_OVERFLOW: () = unsafe {
     let x = 0;
     let mut y = 0;
-    copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ evaluation of constant value failed [E0080]
-    //~| overflow computing total size of `copy_nonoverlapping`
+    copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR evaluation of constant value failed [E0080]
+    //~| NOTE overflow computing total size of `copy_nonoverlapping`
 };
 
 fn main() {

--- a/tests/ui/consts/drop_zst.rs
+++ b/tests/ui/consts/drop_zst.rs
@@ -11,7 +11,7 @@ impl Drop for S {
 }
 
 const fn foo() {
-    let s = S; //~ destructor
+    let s = S; //~ ERROR destructor
 }
 
 fn main() {}

--- a/tests/ui/consts/eval-enum.rs
+++ b/tests/ui/consts/eval-enum.rs
@@ -1,9 +1,9 @@
 enum Test {
     DivZero = 1/0,
-    //~^ attempt to divide `1_isize` by zero
+    //~^ NOTE attempt to divide `1_isize` by zero
     //~| ERROR evaluation of constant value failed
     RemZero = 1%0,
-    //~^ attempt to calculate the remainder of `1_isize` with a divisor of zero
+    //~^ NOTE attempt to calculate the remainder of `1_isize` with a divisor of zero
     //~| ERROR evaluation of constant value failed
 }
 

--- a/tests/ui/consts/extra-const-ub/detect-extra-ub.rs
+++ b/tests/ui/consts/extra-const-ub/detect-extra-ub.rs
@@ -28,32 +28,32 @@ enum UninhDiscriminant {
 const INVALID_BOOL: () = unsafe {
     let _x: bool = transmute(3u8);
     //[with_flag]~^ ERROR: evaluation of constant value failed
-    //[with_flag]~| invalid value
+    //[with_flag]~| NOTE invalid value
 };
 
 const INVALID_PTR_IN_INT: () = unsafe {
     let _x: usize = transmute(&3u8);
     //[with_flag]~^ ERROR: evaluation of constant value failed
-    //[with_flag]~| invalid value
+    //[with_flag]~| NOTE invalid value
 };
 
 const INVALID_PTR_IN_ENUM: () = unsafe {
     let _x: PtrSizedEnum = transmute(&3u8);
     //[with_flag]~^ ERROR: evaluation of constant value failed
-    //[with_flag]~| invalid value
+    //[with_flag]~| NOTE invalid value
 };
 
 const INVALID_SLICE_TO_USIZE_TRANSMUTE: () = unsafe {
     let x: &[u8] = &[0; 32];
     let _x: (usize, usize) = transmute(x);
     //[with_flag]~^ ERROR: evaluation of constant value failed
-    //[with_flag]~| invalid value
+    //[with_flag]~| NOTE invalid value
 };
 
 const UNALIGNED_PTR: () = unsafe {
     let _x: &u32 = transmute(&[0u8; 4]);
     //[with_flag]~^ ERROR: evaluation of constant value failed
-    //[with_flag]~| invalid value
+    //[with_flag]~| NOTE invalid value
 };
 
 const UNINHABITED_VARIANT: () = unsafe {
@@ -61,7 +61,7 @@ const UNINHABITED_VARIANT: () = unsafe {
     // Not using transmute, we want to hit the ImmTy code path.
     let v = *addr_of!(data).cast::<UninhDiscriminant>();
     //[with_flag]~^ ERROR: evaluation of constant value failed
-    //[with_flag]~| invalid value
+    //[with_flag]~| NOTE invalid value
 };
 
 const PARTIAL_POINTER: () = unsafe {
@@ -81,7 +81,7 @@ const PARTIAL_POINTER: () = unsafe {
     let mem = Align { p: mem, align: 0 };
     let _val = *(&mem as *const Align as *const [*const u8; 2]);
     //[with_flag]~^ ERROR: evaluation of constant value failed
-    //[with_flag]~| invalid value
+    //[with_flag]~| NOTE invalid value
 };
 
 // Regression tests for an ICE (related to <https://github.com/rust-lang/rust/issues/113988>).
@@ -96,7 +96,7 @@ const OVERSIZED_REF: () = { unsafe {
     let slice: *const [u8] = transmute((1usize, usize::MAX));
     let _val = &*slice;
     //[with_flag]~^ ERROR: evaluation of constant value failed
-    //[with_flag]~| slice is bigger than largest supported object
+    //[with_flag]~| NOTE slice is bigger than largest supported object
 } };
 
 fn main() {}

--- a/tests/ui/consts/issue-19244-2.rs
+++ b/tests/ui/consts/issue-19244-2.rs
@@ -3,5 +3,5 @@ const STRUCT: MyStruct = MyStruct { field: 42 };
 
 fn main() {
     let a: [isize; STRUCT.nonexistent_field];
-    //~^ no field `nonexistent_field` on type `MyStruct`
+    //~^ ERROR no field `nonexistent_field` on type `MyStruct`
 }

--- a/tests/ui/consts/min_const_fn/min_const_fn.rs
+++ b/tests/ui/consts/min_const_fn/min_const_fn.rs
@@ -34,13 +34,13 @@ const fn foo35(a: bool, b: bool) -> bool { a ^ b }
 struct Foo<T: ?Sized>(T);
 impl<T> Foo<T> {
     const fn new(t: T) -> Self { Foo(t) }
-    const fn into_inner(self) -> T { self.0 } //~ destructor of
+    const fn into_inner(self) -> T { self.0 } //~ ERROR destructor of
     const fn get(&self) -> &T { &self.0 }
     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
 }
 impl<'a, T> Foo<T> {
     const fn new_lt(t: T) -> Self { Foo(t) }
-    const fn into_inner_lt(self) -> T { self.0 } //~ destructor of
+    const fn into_inner_lt(self) -> T { self.0 } //~ ERROR destructor of
     const fn get_lt(&self) -> &T { &self.0 }
     const fn get_mut_lt(&mut self) -> &mut T { &mut self.0 }
 }

--- a/tests/ui/consts/miri_unleashed/ptr_arith.rs
+++ b/tests/ui/consts/miri_unleashed/ptr_arith.rs
@@ -6,7 +6,7 @@
 static PTR_INT_CAST: () = {
     let x = &0 as *const _ as usize;
     //~^ ERROR could not evaluate static initializer
-    //~| exposing pointers
+    //~| NOTE exposing pointers
     let _v = x == x;
 };
 
@@ -14,7 +14,7 @@ static PTR_INT_TRANSMUTE: () = unsafe {
     let x: usize = std::mem::transmute(&0);
     let _v = x + 0;
     //~^ ERROR could not evaluate static initializer
-    //~| unable to turn pointer into integer
+    //~| NOTE unable to turn pointer into integer
 };
 
 // I'd love to test pointer comparison, but that is not possible since

--- a/tests/ui/consts/no-ice-from-static-in-const-issue-52060.rs
+++ b/tests/ui/consts/no-ice-from-static-in-const-issue-52060.rs
@@ -4,6 +4,6 @@
 static mut A: &'static [u32] = &[1];
 static B: [u32; 1] = [0; unsafe { A.len() }];
 //~^ ERROR: evaluation of constant value failed
-//~| mutable global memory
+//~| NOTE mutable global memory
 
 fn main() {}

--- a/tests/ui/consts/promoted_running_out_of_memory_issue-130687.rs
+++ b/tests/ui/consts/promoted_running_out_of_memory_issue-130687.rs
@@ -12,6 +12,6 @@
 pub struct Data([u8; (1 << 47) - 1]);
 const _: &'static Data = &Data([0; (1 << 47) - 1]);
 //~^ERROR: evaluation of constant value failed
-//~| tried to allocate more memory than available to compiler
+//~| NOTE tried to allocate more memory than available to compiler
 
 fn main() {}

--- a/tests/ui/consts/promoted_size_overflow.rs
+++ b/tests/ui/consts/promoted_size_overflow.rs
@@ -2,6 +2,6 @@
 pub struct Data([u8; usize::MAX >> 2]);
 const _: &'static [Data] = &[];
 //~^ERROR: evaluation of constant value failed
-//~| too big for the target architecture
+//~| NOTE too big for the target architecture
 
 fn main() {}

--- a/tests/ui/consts/recursive-zst-static.rs
+++ b/tests/ui/consts/recursive-zst-static.rs
@@ -10,7 +10,7 @@
 static FOO: () = FOO;
 //~^ ERROR could not evaluate static initializer
 
-static A: () = B; //~ cycle detected when evaluating initializer of static `A`
+static A: () = B; //~ ERROR cycle detected when evaluating initializer of static `A`
 static B: () = A;
 
 fn main() {

--- a/tests/ui/consts/slice-index-overflow-issue-130284.rs
+++ b/tests/ui/consts/slice-index-overflow-issue-130284.rs
@@ -6,7 +6,7 @@ const C: () = {
         // This used to ICE, but it should just report UB.
         let _ice = (*fat)[usize::MAX - 1];
         //~^ERROR: constant value failed
-        //~| overflow
+        //~| NOTE overflow
     }
 };
 

--- a/tests/ui/coroutine/auto-trait-regions.rs
+++ b/tests/ui/coroutine/auto-trait-regions.rs
@@ -43,8 +43,8 @@ fn main() {
     // Disallow impls which relates lifetimes in the coroutine interior
     let gen = #[coroutine] move || {
         let a = A(&mut true, &mut true, No);
-        //~^ temporary value dropped while borrowed
-        //~| temporary value dropped while borrowed
+        //~^ ERROR temporary value dropped while borrowed
+        //~| ERROR temporary value dropped while borrowed
         yield;
         assert_foo(a);
     };

--- a/tests/ui/coroutine/coroutine-with-nll.rs
+++ b/tests/ui/coroutine/coroutine-with-nll.rs
@@ -6,7 +6,7 @@ fn main() {
         // The reference in `_a` is a Legal with NLL since it ends before the yield
         let _a = &mut true;
         let b = &mut true;
-        //~^ borrow may still be in use when coroutine yields
+        //~^ ERROR borrow may still be in use when coroutine yields
         yield ();
         println!("{}", b);
     };

--- a/tests/ui/coroutine/retain-resume-ref.rs
+++ b/tests/ui/coroutine/retain-resume-ref.rs
@@ -22,5 +22,5 @@ fn main() {
     let mut gen = Pin::new(&mut gen);
     gen.as_mut().resume(&mut thing);
     gen.as_mut().resume(&mut thing);
-    //~^ cannot borrow `thing` as mutable more than once at a time
+    //~^ ERROR cannot borrow `thing` as mutable more than once at a time
 }

--- a/tests/ui/deref-patterns/gate.rs
+++ b/tests/ui/deref-patterns/gate.rs
@@ -2,6 +2,6 @@
 fn main() {
     match String::new() {
         "" | _ => {}
-        //~^ mismatched types
+        //~^ ERROR mismatched types
     }
 }

--- a/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.rs
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.rs
@@ -55,6 +55,6 @@ impl<T> Foo for T where T: Expression {}
 fn main() {
     SelectInt.check("bar");
     //[current]~^ ERROR the trait bound `&str: AsExpression<Integer>` is not satisfied
-    //[next]~^^ the trait bound `&str: AsExpression<<SelectInt as Expression>::SqlType>` is not satisfied
-    //[next]~| type mismatch
+    //[next]~^^ ERROR the trait bound `&str: AsExpression<<SelectInt as Expression>::SqlType>` is not satisfied
+    //[next]~| ERROR type mismatch
 }

--- a/tests/ui/diagnostic_namespace/on_unimplemented/custom-on-unimplemented-diagnostic.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/custom-on-unimplemented-diagnostic.rs
@@ -15,7 +15,7 @@ struct B;
 
 fn main() {
     B.request();
-    //~^ my message [E0599]
+    //~^ ERROR my message [E0599]
     //~| my label
     //~| my note
 }

--- a/tests/ui/diagnostic_namespace/on_unimplemented/ignore_unsupported_options_and_continue_to_use_fallback.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/ignore_unsupported_options_and_continue_to_use_fallback.rs
@@ -8,8 +8,8 @@
     note = "custom note"
 )]
 #[diagnostic::on_unimplemented(message = "fallback!!")]
-//~^ `message` is ignored due to previous definition of `message`
-//~| `message` is ignored due to previous definition of `message`
+//~^ WARN `message` is ignored due to previous definition of `message`
+//~| WARN `message` is ignored due to previous definition of `message`
 #[diagnostic::on_unimplemented(label = "fallback label")]
 #[diagnostic::on_unimplemented(note = "fallback note")]
 trait Foo {}

--- a/tests/ui/did_you_mean/issue-38147-1.rs
+++ b/tests/ui/did_you_mean/issue-38147-1.rs
@@ -14,7 +14,7 @@ struct Foo<'a> {
 
 impl<'a> Foo<'a> {
     fn f(&self) {
-        self.s.push('x'); //~ cannot borrow `*self.s` as mutable, as it is behind a `&` reference
+        self.s.push('x'); //~ ERROR cannot borrow `*self.s` as mutable, as it is behind a `&` reference
     }
 }
 

--- a/tests/ui/did_you_mean/issue-40006.rs
+++ b/tests/ui/did_you_mean/issue-40006.rs
@@ -35,5 +35,5 @@ impl S {
 }
 
 fn main() {
-    S.hello_method(); //~ no method named `hello_method` found
+    S.hello_method(); //~ ERROR no method named `hello_method` found
 }

--- a/tests/ui/did_you_mean/issue-42764.rs
+++ b/tests/ui/did_you_mean/issue-42764.rs
@@ -26,5 +26,5 @@ struct Context { wrapper: Wrapper }
 fn overton() {
     let _c = Context { wrapper: Payload{} };
     //~^ ERROR mismatched types
-    //~| try wrapping the expression in `Wrapper`
+    //~| HELP try wrapping the expression in `Wrapper`
 }

--- a/tests/ui/drop/lint-tail-expr-drop-order-borrowck.rs
+++ b/tests/ui/drop/lint-tail-expr-drop-order-borrowck.rs
@@ -10,7 +10,7 @@ fn should_lint_with_potential_borrowck_err() {
     //~^ ERROR: relative drop order changing
     //~| WARN: this changes meaning in Rust 2024
     //~| NOTE: this temporary value will be dropped at the end of the block
-    //~| borrow later used by call
+    //~| NOTE: borrow later used by call
     //~| NOTE: for more information, see
 }
 
@@ -20,7 +20,7 @@ fn should_lint_with_unsafe_block() {
     //~^ ERROR: relative drop order changing
     //~| WARN: this changes meaning in Rust 2024
     //~| NOTE: this temporary value will be dropped at the end of the block
-    //~| borrow later used by call
+    //~| NOTE: borrow later used by call
     //~| NOTE: for more information, see
 }
 
@@ -32,7 +32,7 @@ fn should_lint_with_big_block() {
         //~^ ERROR: relative drop order changing
         //~| WARN: this changes meaning in Rust 2024
         //~| NOTE: this temporary value will be dropped at the end of the block
-        //~| borrow later used here
+        //~| NOTE: borrow later used here
         //~| NOTE: for more information, see
     })
 }
@@ -44,7 +44,7 @@ fn another_temp_that_is_copy_in_arg() {
     //~^ ERROR: relative drop order changing
     //~| WARN: this changes meaning in Rust 2024
     //~| NOTE: this temporary value will be dropped at the end of the block
-    //~| borrow later used by call
+    //~| NOTE: borrow later used by call
     //~| NOTE: for more information, see
 }
 

--- a/tests/ui/duplicate/dupe-symbols-1.rs
+++ b/tests/ui/duplicate/dupe-symbols-1.rs
@@ -10,5 +10,5 @@ pub fn a() {
 
 #[export_name="fail"]
 pub fn b() {
-//~^ symbol `fail` is already defined
+//~^ ERROR symbol `fail` is already defined
 }

--- a/tests/ui/duplicate/dupe-symbols-2.rs
+++ b/tests/ui/duplicate/dupe-symbols-2.rs
@@ -13,6 +13,6 @@ pub mod a {
 pub mod b {
     #[no_mangle]
     pub extern "C" fn fail() {
-    //~^ symbol `fail` is already defined
+    //~^ ERROR symbol `fail` is already defined
     }
 }

--- a/tests/ui/duplicate/dupe-symbols-3.rs
+++ b/tests/ui/duplicate/dupe-symbols-3.rs
@@ -10,5 +10,5 @@ pub fn a() {
 
 #[no_mangle]
 pub fn fail() {
-//~^ symbol `fail` is already defined
+//~^ ERROR symbol `fail` is already defined
 }

--- a/tests/ui/duplicate/dupe-symbols-5.rs
+++ b/tests/ui/duplicate/dupe-symbols-5.rs
@@ -9,5 +9,5 @@ static HELLO: u8 = 0;
 
 #[export_name="fail"]
 pub fn b() {
-//~^ symbol `fail` is already defined
+//~^ ERROR symbol `fail` is already defined
 }

--- a/tests/ui/duplicate/dupe-symbols-6.rs
+++ b/tests/ui/duplicate/dupe-symbols-6.rs
@@ -8,4 +8,4 @@ static HELLO: u8 = 0;
 
 #[export_name="fail"]
 static HELLO_TWICE: u16 = 0;
-//~^ symbol `fail` is already defined
+//~^ ERROR symbol `fail` is already defined

--- a/tests/ui/dyn-compatibility/taint-const-eval.rs
+++ b/tests/ui/dyn-compatibility/taint-const-eval.rs
@@ -5,8 +5,8 @@ trait Qux {
 }
 
 static FOO: &(dyn Qux + Sync) = "desc";
-//~^ the trait `Qux` is not dyn compatible
-//~| the trait `Qux` is not dyn compatible
-//~| the trait `Qux` is not dyn compatible
+//~^ ERROR the trait `Qux` is not dyn compatible
+//~| ERROR the trait `Qux` is not dyn compatible
+//~| ERROR the trait `Qux` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/dyn-star/async-block-dyn-star.rs
+++ b/tests/ui/dyn-star/async-block-dyn-star.rs
@@ -4,6 +4,6 @@
 //~^ WARN the feature `dyn_star` is incomplete
 
 static S: dyn* Send + Sync = async { 42 };
-//~^ needs to have the same ABI as a pointer
+//~^ ERROR needs to have the same ABI as a pointer
 
 pub fn main() {}

--- a/tests/ui/dyn-star/feature-gate-dyn_star.rs
+++ b/tests/ui/dyn-star/feature-gate-dyn_star.rs
@@ -3,7 +3,7 @@
 /// dyn* is not necessarily the final surface syntax (if we have one at all),
 /// but for now we will support it to aid in writing tests independently.
 pub fn dyn_star_parameter(_: &dyn* Send) {
-    //~^ `dyn*` trait objects are experimental
+    //~^ ERROR `dyn*` trait objects are experimental
 }
 
 fn main() {}

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.fixed
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.fixed
@@ -16,8 +16,8 @@ fn main() {
 }
 
 fn m() {
-    //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ WARN this function depends on never type fallback being `()`
+    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x: () = match true {
         true => Default::default(),
         //[e2024]~^ error: the trait bound `!: Default` is not satisfied
@@ -28,8 +28,8 @@ fn m() {
 }
 
 fn q() -> Option<()> {
-    //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ WARN this function depends on never type fallback being `()`
+    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     fn deserialize<T: Default>() -> Option<T> {
         Some(T::default())
     }
@@ -45,8 +45,8 @@ fn help<'a: 'a, T: Into<()>, U>(_: U) -> Result<T, ()> {
     Err(())
 }
 fn meow() -> Result<(), ()> {
-    //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ WARN this function depends on never type fallback being `()`
+    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     help::<(), _>(1)?;
     //[e2024]~^ error: the trait bound `(): From<!>` is not satisfied
     Ok(())
@@ -57,8 +57,8 @@ pub fn takes_apit<T>(_y: impl Fn() -> T) -> Result<T, ()> {
 }
 
 pub fn fallback_return() -> Result<(), ()> {
-    //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ WARN this function depends on never type fallback being `()`
+    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     takes_apit::<()>(|| Default::default())?;
     //[e2024]~^ error: the trait bound `!: Default` is not satisfied
     Ok(())
@@ -71,8 +71,8 @@ fn mk<T>() -> Result<T, ()> {
 fn takes_apit2(_x: impl Default) {}
 
 fn fully_apit() -> Result<(), ()> {
-    //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ WARN this function depends on never type fallback being `()`
+    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     takes_apit2(mk::<()>()?);
     //[e2024]~^ error: the trait bound `!: Default` is not satisfied
     Ok(())

--- a/tests/ui/editions/never-type-fallback-breaking.rs
+++ b/tests/ui/editions/never-type-fallback-breaking.rs
@@ -16,8 +16,8 @@ fn main() {
 }
 
 fn m() {
-    //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ WARN this function depends on never type fallback being `()`
+    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x = match true {
         true => Default::default(),
         //[e2024]~^ error: the trait bound `!: Default` is not satisfied
@@ -28,8 +28,8 @@ fn m() {
 }
 
 fn q() -> Option<()> {
-    //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ WARN this function depends on never type fallback being `()`
+    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     fn deserialize<T: Default>() -> Option<T> {
         Some(T::default())
     }
@@ -45,8 +45,8 @@ fn help<'a: 'a, T: Into<()>, U>(_: U) -> Result<T, ()> {
     Err(())
 }
 fn meow() -> Result<(), ()> {
-    //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ WARN this function depends on never type fallback being `()`
+    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     help(1)?;
     //[e2024]~^ error: the trait bound `(): From<!>` is not satisfied
     Ok(())
@@ -57,8 +57,8 @@ pub fn takes_apit<T>(_y: impl Fn() -> T) -> Result<T, ()> {
 }
 
 pub fn fallback_return() -> Result<(), ()> {
-    //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ WARN this function depends on never type fallback being `()`
+    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     takes_apit(|| Default::default())?;
     //[e2024]~^ error: the trait bound `!: Default` is not satisfied
     Ok(())
@@ -71,8 +71,8 @@ fn mk<T>() -> Result<T, ()> {
 fn takes_apit2(_x: impl Default) {}
 
 fn fully_apit() -> Result<(), ()> {
-    //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+    //[e2021]~^ WARN this function depends on never type fallback being `()`
+    //[e2021]~| WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     takes_apit2(mk()?);
     //[e2024]~^ error: the trait bound `!: Default` is not satisfied
     Ok(())

--- a/tests/ui/enum-discriminant/discriminant-ill-typed.rs
+++ b/tests/ui/enum-discriminant/discriminant-ill-typed.rs
@@ -14,7 +14,7 @@ fn f_i8() {
         Ok2,
         OhNo = 0_u8,
         //~^ ERROR mismatched types
-        //~| expected `i8`, found `u8`
+        //~| NOTE expected `i8`, found `u8`
     }
 
     let x = A::Ok;
@@ -27,7 +27,7 @@ fn f_u8() {
         Ok2,
         OhNo = 0_i8,
         //~^ ERROR mismatched types
-        //~| expected `u8`, found `i8`
+        //~| NOTE expected `u8`, found `i8`
     }
 
     let x = A::Ok;
@@ -40,7 +40,7 @@ fn f_i16() {
         Ok2,
         OhNo = 0_u16,
         //~^ ERROR mismatched types
-        //~| expected `i16`, found `u16`
+        //~| NOTE expected `i16`, found `u16`
     }
 
     let x = A::Ok;
@@ -53,7 +53,7 @@ fn f_u16() {
         Ok2,
         OhNo = 0_i16,
         //~^ ERROR mismatched types
-        //~| expected `u16`, found `i16`
+        //~| NOTE expected `u16`, found `i16`
     }
 
     let x = A::Ok;
@@ -66,7 +66,7 @@ fn f_i32() {
         Ok2,
         OhNo = 0_u32,
         //~^ ERROR mismatched types
-        //~| expected `i32`, found `u32`
+        //~| NOTE expected `i32`, found `u32`
     }
 
     let x = A::Ok;
@@ -79,7 +79,7 @@ fn f_u32() {
         Ok2,
         OhNo = 0_i32,
         //~^ ERROR mismatched types
-        //~| expected `u32`, found `i32`
+        //~| NOTE expected `u32`, found `i32`
     }
 
     let x = A::Ok;
@@ -92,7 +92,7 @@ fn f_i64() {
         Ok2,
         OhNo = 0_u64,
         //~^ ERROR mismatched types
-        //~| expected `i64`, found `u64`
+        //~| NOTE expected `i64`, found `u64`
     }
 
     let x = A::Ok;
@@ -105,7 +105,7 @@ fn f_u64() {
         Ok2,
         OhNo = 0_i64,
         //~^ ERROR mismatched types
-        //~| expected `u64`, found `i64`
+        //~| NOTE expected `u64`, found `i64`
     }
 
     let x = A::Ok;

--- a/tests/ui/error-codes/E0063.rs
+++ b/tests/ui/error-codes/E0063.rs
@@ -32,7 +32,7 @@ fn main() {
     let x = PluralFoo {x: 1};
     //~^ ERROR missing fields `y` and `z` in initializer of `PluralFoo`
     let y = TruncatedFoo{x:1};
-    //~^ missing fields `a`, `b`, `y` and 1 other field in initializer of `TruncatedFoo`
+    //~^ ERROR missing fields `a`, `b`, `y` and 1 other field in initializer of `TruncatedFoo`
     let z = TruncatedPluralFoo{x:1};
     //~^ ERROR missing fields `a`, `b`, `c` and 2 other fields in initializer of `TruncatedPluralFoo`
 }

--- a/tests/ui/error-codes/E0186.rs
+++ b/tests/ui/error-codes/E0186.rs
@@ -1,12 +1,12 @@
 trait Foo {
-    fn foo(&self); //~ `&self` used in trait
+    fn foo(&self); //~ NOTE `&self` used in trait
 }
 
 struct Bar;
 
 impl Foo for Bar {
     fn foo() {} //~ ERROR E0186
-    //~^ expected `&self` in impl
+    //~^ NOTE expected `&self` in impl
 }
 
 fn main() {

--- a/tests/ui/error-codes/E0261.rs
+++ b/tests/ui/error-codes/E0261.rs
@@ -1,9 +1,9 @@
 fn foo(x: &'a str) { } //~ ERROR E0261
-                       //~| undeclared lifetime
+                       //~| NOTE undeclared lifetime
 
 struct Foo {
     x: &'a str, //~ ERROR E0261
-                //~| undeclared lifetime
+                //~| NOTE undeclared lifetime
 }
 
 fn main() {}

--- a/tests/ui/error-codes/E0262.rs
+++ b/tests/ui/error-codes/E0262.rs
@@ -1,4 +1,4 @@
 fn foo<'static>(x: &'static str) { } //~ ERROR E0262
-                                     //~| 'static is a reserved lifetime name
+                                     //~| NOTE 'static is a reserved lifetime name
 
 fn main() {}

--- a/tests/ui/error-codes/E0516.rs
+++ b/tests/ui/error-codes/E0516.rs
@@ -1,4 +1,4 @@
 fn main() {
     let x: typeof(92) = 92; //~ ERROR E0516
-                            //~| reserved keyword
+                            //~| NOTE reserved keyword
 }

--- a/tests/ui/error-codes/E0597.rs
+++ b/tests/ui/error-codes/E0597.rs
@@ -6,7 +6,7 @@ fn main() {
     let mut x = Foo { x: None };
     let y = 0;
     x.x = Some(&y);
-    //~^ `y` does not live long enough [E0597]
+    //~^ ERROR `y` does not live long enough [E0597]
 }
 
 impl<'a> Drop for Foo<'a> { fn drop(&mut self) { } }

--- a/tests/ui/error-codes/E0606.rs
+++ b/tests/ui/error-codes/E0606.rs
@@ -1,4 +1,4 @@
 fn main() {
     let x = &(&0u8 as u8); //~ ERROR E0606
-    x as u8; //~ casting `&u8` as `u8` is invalid [E0606]
+    x as u8; //~ ERROR casting `&u8` as `u8` is invalid [E0606]
 }

--- a/tests/ui/extern/extern-main-issue-86110.rs
+++ b/tests/ui/extern/extern-main-issue-86110.rs
@@ -2,6 +2,6 @@
 extern "C" {
     fn missing();
     fn main();
-    //~^ the `main` function cannot be declared in an `extern` block
+    //~^ ERROR the `main` function cannot be declared in an `extern` block
     fn missing2();
 }

--- a/tests/ui/extern/issue-112363-extern-item-where-clauses-debug-ice.rs
+++ b/tests/ui/extern/issue-112363-extern-item-where-clauses-debug-ice.rs
@@ -1,10 +1,10 @@
 extern "C" {
     type Item = [T] where [T]: Sized;
-    //~^ incorrect `type` inside `extern` block
-    //~| `type`s inside `extern` blocks cannot have `where` clauses
-    //~| cannot find type `T` in this scope
-    //~| cannot find type `T` in this scope
-    //~| extern types are experimental
+    //~^ ERROR incorrect `type` inside `extern` block
+    //~| ERROR `type`s inside `extern` blocks cannot have `where` clauses
+    //~| ERROR cannot find type `T` in this scope
+    //~| ERROR cannot find type `T` in this scope
+    //~| ERROR extern types are experimental
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-c_variadic.rs
+++ b/tests/ui/feature-gates/feature-gate-c_variadic.rs
@@ -1,4 +1,4 @@
 #![crate_type="lib"]
 
 pub unsafe extern "C" fn test(_: i32, ap: ...) { }
-//~^ C-variadic functions are unstable
+//~^ ERROR C-variadic functions are unstable

--- a/tests/ui/feature-gates/feature-gate-cfg-emscripten-wasm-eh.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg-emscripten-wasm-eh.rs
@@ -1,4 +1,4 @@
 //@ compile-flags: --check-cfg=cfg(emscripten_wasm_eh)
 #[cfg(not(emscripten_wasm_eh))]
-//~^ `cfg(emscripten_wasm_eh)` is experimental
+//~^ ERROR `cfg(emscripten_wasm_eh)` is experimental
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-cfg-sanitizer_cfi.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg-sanitizer_cfi.rs
@@ -1,9 +1,9 @@
 #[cfg(sanitizer_cfi_generalize_pointers)]
-//~^ `cfg(sanitizer_cfi_generalize_pointers)` is experimental
+//~^ ERROR `cfg(sanitizer_cfi_generalize_pointers)` is experimental
 fn foo() {}
 
 #[cfg(sanitizer_cfi_normalize_integers)]
-//~^ `cfg(sanitizer_cfi_normalize_integers)` is experimental
+//~^ ERROR `cfg(sanitizer_cfi_normalize_integers)` is experimental
 fn bar() {}
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-cfg_sanitize.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg_sanitize.rs
@@ -1,3 +1,3 @@
 #[cfg(not(sanitize = "thread"))]
-//~^ `cfg(sanitize)` is experimental
+//~^ ERROR `cfg(sanitize)` is experimental
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-closure_track_caller.rs
+++ b/tests/ui/feature-gates/feature-gate-closure_track_caller.rs
@@ -3,7 +3,7 @@
 #![feature(coroutines)]
 
 fn main() {
-    let _closure = #[track_caller] || {}; //~ `#[track_caller]` on closures
-    let _coroutine = #[coroutine] #[track_caller] || { yield; }; //~ `#[track_caller]` on closures
-    let _future = #[track_caller] async {}; //~ `#[track_caller]` on closures
+    let _closure = #[track_caller] || {}; //~ ERROR `#[track_caller]` on closures
+    let _coroutine = #[coroutine] #[track_caller] || { yield; }; //~ ERROR `#[track_caller]` on closures
+    let _future = #[track_caller] async {}; //~ ERROR `#[track_caller]` on closures
 }

--- a/tests/ui/feature-gates/feature-gate-custom_mir.rs
+++ b/tests/ui/feature-gates/feature-gate-custom_mir.rs
@@ -1,13 +1,13 @@
 #![feature(core_intrinsics)]
 
 extern crate core;
-use core::intrinsics::mir::*; //~ custom_mir
+use core::intrinsics::mir::*; //~ ERROR custom_mir
 
 #[custom_mir(dialect = "built")] //~ ERROR the `#[custom_mir]` attribute is just used for the Rust test suite
 pub fn foo(_x: i32) -> i32 {
     mir! {
         {
-            Return() //~ custom_mir
+            Return() //~ ERROR custom_mir
         }
     }
 }

--- a/tests/ui/feature-gates/feature-gate-freeze-impls.rs
+++ b/tests/ui/feature-gates/feature-gate-freeze-impls.rs
@@ -5,11 +5,11 @@ use std::marker::Freeze;
 struct Foo;
 
 unsafe impl Freeze for Foo {}
-//~^ explicit impls for the `Freeze` trait are not permitted
+//~^ ERROR explicit impls for the `Freeze` trait are not permitted
 
 struct Bar;
 
 impl !Freeze for Bar {}
-//~^ explicit impls for the `Freeze` trait are not permitted
+//~^ ERROR explicit impls for the `Freeze` trait are not permitted
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-naked_functions.rs
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.rs
@@ -4,7 +4,7 @@ use std::arch::naked_asm;
 //~^ ERROR use of unstable library feature `naked_functions`
 
 #[naked]
-//~^ the `#[naked]` attribute is an experimental feature
+//~^ ERROR the `#[naked]` attribute is an experimental feature
 extern "C" fn naked() {
     naked_asm!("")
     //~^ ERROR use of unstable library feature `naked_functions`
@@ -12,7 +12,7 @@ extern "C" fn naked() {
 }
 
 #[naked]
-//~^ the `#[naked]` attribute is an experimental feature
+//~^ ERROR the `#[naked]` attribute is an experimental feature
 extern "C" fn naked_2() -> isize {
     naked_asm!("")
     //~^ ERROR use of unstable library feature `naked_functions`

--- a/tests/ui/feature-gates/feature-gate-new_range.rs
+++ b/tests/ui/feature-gates/feature-gate-new_range.rs
@@ -2,9 +2,9 @@
 
 fn main() {
     let a: core::range::RangeFrom<u8> = 1..;
-    //~^ mismatched types
+    //~^ ERROR mismatched types
     let b: core::range::Range<u8> = 2..3;
-    //~^ mismatched types
+    //~^ ERROR mismatched types
     let c: core::range::RangeInclusive<u8> = 4..=5;
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }

--- a/tests/ui/feature-gates/feature-gate-no_sanitize.rs
+++ b/tests/ui/feature-gates/feature-gate-no_sanitize.rs
@@ -1,4 +1,4 @@
 #[no_sanitize(address)]
-//~^ the `#[no_sanitize]` attribute is an experimental feature
+//~^ ERROR the `#[no_sanitize]` attribute is an experimental feature
 fn main() {
 }

--- a/tests/ui/feature-gates/feature-gate-rustc_const_unstable.rs
+++ b/tests/ui/feature-gates/feature-gate-rustc_const_unstable.rs
@@ -1,6 +1,6 @@
 // Test internal const fn feature gate.
 
-#[rustc_const_unstable(feature="fzzzzzt")] //~ stability attributes may not be used outside
+#[rustc_const_unstable(feature="fzzzzzt")] //~ ERROR stability attributes may not be used outside
 pub const fn bazinga() {}
 
 fn main() {

--- a/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
+++ b/tests/ui/feature-gates/issue-43106-gating-of-builtin-attrs.rs
@@ -174,16 +174,16 @@ mod macro_use {
     mod inner { #![macro_use] }
 
     #[macro_use] fn f() { }
-    //~^ `#[macro_use]` only has an effect
+    //~^ WARN `#[macro_use]` only has an effect
 
     #[macro_use] struct S;
-    //~^ `#[macro_use]` only has an effect
+    //~^ WARN `#[macro_use]` only has an effect
 
     #[macro_use] type T = S;
-    //~^ `#[macro_use]` only has an effect
+    //~^ WARN `#[macro_use]` only has an effect
 
     #[macro_use] impl S { }
-    //~^ `#[macro_use]` only has an effect
+    //~^ WARN `#[macro_use]` only has an effect
 }
 
 #[macro_export]

--- a/tests/ui/foreign/issue-74120-lowering-of-ffi-block-bodies.rs
+++ b/tests/ui/foreign/issue-74120-lowering-of-ffi-block-bodies.rs
@@ -5,7 +5,7 @@
 
 extern "C" {
     fn f() {
-    //~^ incorrect function inside `extern` block
+    //~^ ERROR incorrect function inside `extern` block
         fn g() {}
     }
 }

--- a/tests/ui/foreign/issue-91370-foreign-fn-block-impl.rs
+++ b/tests/ui/foreign/issue-91370-foreign-fn-block-impl.rs
@@ -3,7 +3,7 @@
 extern "C" {
     //~^ `extern` blocks define existing foreign functions
     fn f() {
-        //~^ incorrect function inside `extern` block
+        //~^ ERROR incorrect function inside `extern` block
         //~| cannot have a body
         impl Copy for u8 {}
     }

--- a/tests/ui/generic-associated-types/ambig-hr-projection-issue-93340.rs
+++ b/tests/ui/generic-associated-types/ambig-hr-projection-issue-93340.rs
@@ -13,7 +13,7 @@ fn cmp_eq<'a, 'b, A: Scalar, B: Scalar, O: Scalar>(a: A::RefType<'a>, b: B::RefT
 
 fn build_expression<A: Scalar, B: Scalar, O: Scalar>(
 ) -> impl Fn(A::RefType<'_>, B::RefType<'_>) -> O {
-    //[next]~^^ expected a `Fn(<A as Scalar>::RefType<'_>, <B as Scalar>::RefType<'_>)` closure
+    //[next]~^^ ERROR expected a `Fn(<A as Scalar>::RefType<'_>, <B as Scalar>::RefType<'_>)` closure
     cmp_eq
     //~^ ERROR type annotations needed
 }

--- a/tests/ui/generic-associated-types/bugs/hrtb-implied-3.rs
+++ b/tests/ui/generic-associated-types/bugs/hrtb-implied-3.rs
@@ -17,7 +17,7 @@ where
 
 fn fails(iter: &str) {
     trivial_bound(iter);
-    //~^ borrowed data escapes
+    //~^ ERROR borrowed data escapes
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/collectivity-regression.rs
+++ b/tests/ui/generic-associated-types/collectivity-regression.rs
@@ -11,7 +11,7 @@ where
     for<'a> T: Get<Value<'a> = ()>,
 {
     || {
-        //~^ `T` does not live long enough
+        //~^ ERROR `T` does not live long enough
         //
         // FIXME(#98437). This regressed at some point and
         // probably should work.

--- a/tests/ui/generic-associated-types/gat-in-trait-path.rs
+++ b/tests/ui/generic-associated-types/gat-in-trait-path.rs
@@ -20,11 +20,11 @@ impl<T> Foo for Fooer<T> {
 }
 
 fn f(_arg : Box<dyn for<'a> Foo<A<'a> = &'a ()>>) {}
-//~^ the trait `Foo` is not dyn compatible
+//~^ ERROR the trait `Foo` is not dyn compatible
 
 fn main() {
   let foo = Fooer(5);
   f(Box::new(foo));
-  //~^ the trait `Foo` is not dyn compatible
-  //~| the trait `Foo` is not dyn compatible
+  //~^ ERROR the trait `Foo` is not dyn compatible
+  //~| ERROR the trait `Foo` is not dyn compatible
 }

--- a/tests/ui/generic-associated-types/issue-74816.rs
+++ b/tests/ui/generic-associated-types/issue-74816.rs
@@ -11,7 +11,7 @@ trait Trait1 {
 trait Trait2 {
     type Associated: Trait1 = Self;
     //~^ ERROR: the trait bound `Self: Trait1` is not satisfied
-    //~| the size for values of type `Self` cannot be known
+    //~| ERROR the size for values of type `Self` cannot be known
 }
 
 impl Trait2 for () {}

--- a/tests/ui/generic-associated-types/issue-78113-lifetime-mismatch-dyn-trait-box.rs
+++ b/tests/ui/generic-associated-types/issue-78113-lifetime-mismatch-dyn-trait-box.rs
@@ -12,7 +12,7 @@ pub trait B {
 
 impl B for () {
     // `'a` doesn't match implicit `'static`: suggest `'_`
-    type T<'a> = Box<dyn A + 'a>; //~ incompatible lifetime on type
+    type T<'a> = Box<dyn A + 'a>; //~ ERROR incompatible lifetime on type
 }
 
 trait C {}
@@ -22,7 +22,7 @@ pub trait D {
 }
 impl D for () {
     // `'a` doesn't match explicit `'static`: we *should* suggest removing `'static`
-    type T<'a> = Box<dyn A + 'a>; //~ incompatible lifetime on type
+    type T<'a> = Box<dyn A + 'a>; //~ ERROR incompatible lifetime on type
 }
 
 trait E {}
@@ -32,7 +32,7 @@ pub trait F {
 }
 impl F for () {
     // `'a` doesn't match explicit `'static`: suggest `'_`
-    type T<'a> = (Box<dyn A + 'a>, Box<dyn A + 'a>); //~ incompatible lifetime on type
+    type T<'a> = (Box<dyn A + 'a>, Box<dyn A + 'a>); //~ ERROR incompatible lifetime on type
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/issue-86787.rs
+++ b/tests/ui/generic-associated-types/issue-86787.rs
@@ -8,7 +8,7 @@ enum Either<L, R> {
 pub trait HasChildrenOf {
     type T;
     type TRef<'a>;
-    //~^ missing required
+    //~^ ERROR missing required
 
     fn ref_children<'a>(&'a self) -> Vec<Self::TRef<'a>>;
     fn take_children(self) -> Vec<Self::T>;

--- a/tests/ui/generic-associated-types/issue-88360.fixed
+++ b/tests/ui/generic-associated-types/issue-88360.fixed
@@ -14,7 +14,7 @@ where
 {
     fn copy(&self) -> Self::Gat<'_> where T: Copy {
         self.test()
-        //~^ mismatched types
+        //~^ ERROR mismatched types
     }
 }
 

--- a/tests/ui/generic-associated-types/issue-88360.rs
+++ b/tests/ui/generic-associated-types/issue-88360.rs
@@ -14,7 +14,7 @@ where
 {
     fn copy(&self) -> Self::Gat<'_> where T: Copy {
         *self.test()
-        //~^ mismatched types
+        //~^ ERROR mismatched types
     }
 }
 

--- a/tests/ui/generic-associated-types/missing-where-clause-on-trait.rs
+++ b/tests/ui/generic-associated-types/missing-where-clause-on-trait.rs
@@ -5,7 +5,7 @@ trait Foo {
 }
 impl Foo for () {
     type Assoc<'a, 'b> = () where 'a: 'b;
-    //~^ impl has stricter requirements than trait
+    //~^ ERROR impl has stricter requirements than trait
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/self-outlives-lint.rs
+++ b/tests/ui/generic-associated-types/self-outlives-lint.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 // We have a `&'a self`, so we need a `Self: 'a`
 trait Iterable {
     type Item<'x>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn iter<'a>(&'a self) -> Self::Item<'a>;
 }
 
@@ -21,7 +21,7 @@ impl<T> Iterable for T {
 // We have a `&'a T`, so we need a `T: 'x`
 trait Deserializer<T> {
     type Out<'x>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn deserialize<'a>(&self, input: &'a T) -> Self::Out<'a>;
 }
 
@@ -35,14 +35,14 @@ impl<T> Deserializer<T> for () {
 // We have a `&'b T` and a `'b: 'a`, so it is implied that `T: 'a`. Therefore, we need a `T: 'x`
 trait Deserializer2<T> {
     type Out<'x>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn deserialize2<'a, 'b: 'a>(&self, input1: &'b T) -> Self::Out<'a>;
 }
 
 // We have a `&'a T` and a `&'b U`, so we need a `T: 'x` and a `U: 'y`
 trait Deserializer3<T, U> {
     type Out<'x, 'y>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn deserialize2<'a, 'b>(&self, input: &'a T, input2: &'b U) -> Self::Out<'a, 'b>;
 }
 
@@ -57,7 +57,7 @@ struct Wrap<T>(T);
 // We pass `Wrap<T>` and we see `&'z Wrap<T>`, so we require `D: 'x`
 trait Des {
     type Out<'x, D>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn des<'z, T>(&self, data: &'z Wrap<T>) -> Self::Out<'z, Wrap<T>>;
 }
 /*
@@ -73,7 +73,7 @@ impl Des for () {
 // implied bound that `T: 'z`, so we require `D: 'x`
 trait Des2 {
     type Out<'x, D>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn des<'z, T>(&self, data: &'z Wrap<T>) -> Self::Out<'z, T>;
 }
 /*
@@ -88,7 +88,7 @@ impl Des2 for () {
 // We see `&'z T`, so we require `D: 'x`
 trait Des3 {
     type Out<'x, D>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn des<'z, T>(&self, data: &'z T) -> Self::Out<'z, T>;
 }
 /*
@@ -110,7 +110,7 @@ trait NoGat<'a> {
 // FIXME: we require two bounds (`where Self: 'a, Self: 'b`) when we should only require one
 trait TraitLifetime<'a> {
     type Bar<'b>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn method(&'a self) -> Self::Bar<'a>;
 }
 
@@ -118,14 +118,14 @@ trait TraitLifetime<'a> {
 // FIXME: we require two bounds (`where Self: 'a, Self: 'b`) when we should only require one
 trait TraitLifetimeWhere<'a> where Self: 'a {
     type Bar<'b>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn method(&'a self) -> Self::Bar<'a>;
 }
 
 // Explicit bound instead of implicit; we want to still error
 trait ExplicitBound {
     type Bar<'b>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn method<'b>(&self, token: &'b ()) -> Self::Bar<'b> where Self: 'b;
 }
 
@@ -138,15 +138,15 @@ trait NotInReturn {
 // We obviously error for `Iterator`, but we should also error for `Item`
 trait IterableTwo {
     type Item<'a>;
-    //~^ missing required
+    //~^ ERROR missing required
     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn iter<'a>(&'a self) -> Self::Iterator<'a>;
 }
 
 trait IterableTwoWhere {
     type Item<'a>;
-    //~^ missing required
+    //~^ ERROR missing required
     type Iterator<'a>: Iterator<Item = Self::Item<'a>> where Self: 'a;
     fn iter<'a>(&'a self) -> Self::Iterator<'a>;
 }
@@ -155,7 +155,7 @@ trait IterableTwoWhere {
 // because of `&'x &'y`, so we require that `'b: 'a`.
 trait RegionOutlives {
     type Bar<'a, 'b>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn foo<'x, 'y>(&self, input: &'x &'y ()) -> Self::Bar<'x, 'y>;
 }
 
@@ -171,7 +171,7 @@ impl Foo for () {
 // Similar to the above, except with explicit bounds
 trait ExplicitRegionOutlives<'ctx> {
     type Fut<'out>;
-    //~^ missing required
+    //~^ ERROR missing required
 
     fn test<'out>(ctx: &'ctx i32) -> Self::Fut<'out>
     where
@@ -211,7 +211,7 @@ trait StaticReturnAndTakes<'a> {
 // We require bounds when the GAT appears in the inputs
 trait Input {
     type Item<'a>;
-    //~^ missing required
+    //~^ ERROR missing required
     fn takes_item<'a>(&'a self, item: Self::Item<'a>);
 }
 

--- a/tests/ui/generic-associated-types/trait-objects.rs
+++ b/tests/ui/generic-associated-types/trait-objects.rs
@@ -6,10 +6,10 @@ trait StreamingIterator {
 }
 
 fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize {
-    //~^ the trait `StreamingIterator` is not dyn compatible
+    //~^ ERROR the trait `StreamingIterator` is not dyn compatible
     x.size_hint().0
-    //~^ the trait `StreamingIterator` is not dyn compatible
-    //~| the trait `StreamingIterator` is not dyn compatible
+    //~^ ERROR the trait `StreamingIterator` is not dyn compatible
+    //~| ERROR the trait `StreamingIterator` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/type-param-defaults.rs
+++ b/tests/ui/generic-associated-types/type-param-defaults.rs
@@ -4,17 +4,17 @@
 
 trait Trait {
     type Assoc<T = u32>;
-    //~^ defaults for type parameters are only allowed
+    //~^ ERROR defaults for type parameters are only allowed
 }
 
 impl Trait for () {
     type Assoc<T = u32> = u64;
-    //~^ defaults for type parameters are only allowed
+    //~^ ERROR defaults for type parameters are only allowed
 }
 
 impl Trait for u32 {
     type Assoc<T = u32> = T;
-    //~^ defaults for type parameters are only allowed
+    //~^ ERROR defaults for type parameters are only allowed
 }
 
 trait Other {}

--- a/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.rs
+++ b/tests/ui/half-open-range-patterns/feature-gate-half-open-range-patterns-in-slices.rs
@@ -1,6 +1,6 @@
 fn main() {
     let xs = [13, 1, 5, 2, 3, 1, 21, 8];
     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
-    //~^ `X..` patterns in slices are experimental
+    //~^ ERROR `X..` patterns in slices are experimental
     //~| ERROR: refutable pattern
 }

--- a/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem0.rs
+++ b/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem0.rs
@@ -8,7 +8,7 @@ fn main() {
 
     // What if we wanted to pull this apart without individually binding a, b, and c?
     let [first_three @ ..3, rest @ 2..] = xs;
-    //~^ pattern requires 2 elements but array has 8
+    //~^ ERROR pattern requires 2 elements but array has 8
     // This is somewhat unintuitive and makes slice patterns exceedingly verbose.
     // We want to stabilize half-open RangeFrom (`X..`) patterns
     // but without banning us from using them for a more efficient slice pattern syntax.

--- a/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.rs
+++ b/tests/ui/half-open-range-patterns/slice_pattern_syntax_problem1.rs
@@ -2,6 +2,6 @@
 fn main() {
     let xs = [13, 1, 5, 2, 3, 1, 21, 8];
     let [a @ 3.., b @ ..3, c @ 4..6, ..] = xs;
-    //~^ `X..` patterns in slices are experimental
+    //~^ ERROR `X..` patterns in slices are experimental
     //~| ERROR: refutable pattern
 }

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-3.rs
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-62529-3.rs
@@ -23,7 +23,7 @@ impl WithDefault for () {
         //f(());
         // Going through another generic function works fine.
         call(f, ());
-        //~^ expected a
+        //~^ ERROR expected a
     }
 }
 

--- a/tests/ui/illegal-sized-bound/regular.rs
+++ b/tests/ui/illegal-sized-bound/regular.rs
@@ -4,7 +4,7 @@ pub trait MutTrait {
     fn function(&mut self)
     where
         Self: Sized;
-    //~^ this has a `Sized` requirement
+    //~^ NOTE this has a `Sized` requirement
 }
 
 impl MutTrait for MutType {
@@ -17,7 +17,7 @@ pub trait Trait {
     fn function(&self)
     where
         Self: Sized;
-    //~^ this has a `Sized` requirement
+    //~^ NOTE this has a `Sized` requirement
 }
 
 impl Trait for Type {

--- a/tests/ui/impl-trait/call_method_ambiguous.rs
+++ b/tests/ui/impl-trait/call_method_ambiguous.rs
@@ -24,7 +24,7 @@ where
 fn foo(n: usize, m: &mut ()) -> impl Get + use<'_> {
     if n > 0 {
         let mut iter = foo(n - 1, m);
-        //[next]~^ type annotations needed
+        //[next]~^ ERROR type annotations needed
         assert_eq!(iter.get(), 1);
     }
     m

--- a/tests/ui/impl-trait/call_method_on_inherent_impl.rs
+++ b/tests/ui/impl-trait/call_method_on_inherent_impl.rs
@@ -16,7 +16,7 @@ where
 fn my_foo() -> impl std::fmt::Debug {
     if false {
         let x = my_foo();
-        //[next]~^ type annotations needed
+        //[next]~^ ERROR type annotations needed
         x.my_debug();
     }
     ()

--- a/tests/ui/impl-trait/call_method_on_inherent_impl_ref.rs
+++ b/tests/ui/impl-trait/call_method_on_inherent_impl_ref.rs
@@ -15,9 +15,9 @@ where
 fn my_foo() -> impl std::fmt::Debug {
     if false {
         let x = my_foo();
-        //[next]~^ type annotations needed
+        //[next]~^ ERROR type annotations needed
         x.my_debug();
-        //[current]~^ no method named `my_debug` found
+        //[current]~^ ERROR no method named `my_debug` found
     }
     ()
 }
@@ -25,7 +25,7 @@ fn my_foo() -> impl std::fmt::Debug {
 fn my_bar() -> impl std::fmt::Debug {
     if false {
         let x = &my_bar();
-        //[next]~^ type annotations needed
+        //[next]~^ ERROR type annotations needed
         x.my_debug();
     }
     ()

--- a/tests/ui/impl-trait/ice-unexpected-param-type-whensubstituting-in-region-112823.rs
+++ b/tests/ui/impl-trait/ice-unexpected-param-type-whensubstituting-in-region-112823.rs
@@ -27,7 +27,7 @@ impl X for Y {
     //~| ERROR: unconstrained opaque type
     type LineStreamFut<'a, Repr> = impl Future<Output = Self::LineStream<'a, Repr>>;
     fn line_stream<'a, Repr>(&'a self) -> Self::LineStreamFut<'a, Repr> {}
-    //~^ method `line_stream` is not a member of trait `X`
+    //~^ ERROR method `line_stream` is not a member of trait `X`
     //[current]~^^ ERROR `()` is not a future
     //[next]~^^^ ERROR type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> == ()`
     //[next]~| ERROR type mismatch resolving `<Y as X>::LineStreamFut<'a, Repr> normalizes-to _`

--- a/tests/ui/impl-trait/implicit-capture-late.rs
+++ b/tests/ui/impl-trait/implicit-capture-late.rs
@@ -6,7 +6,7 @@
 
 use std::ops::Deref;
 
-fn foo(x: Vec<i32>) -> Box<dyn for<'a> Deref<Target = impl ?Sized>> { //~ ['a: o]
+fn foo(x: Vec<i32>) -> Box<dyn for<'a> Deref<Target = impl ?Sized>> { //~ ERROR ['a: o]
     //~^ ERROR cannot capture higher-ranked lifetime
     Box::new(x)
 }

--- a/tests/ui/impl-trait/in-trait/default-body-type-err.rs
+++ b/tests/ui/impl-trait/in-trait/default-body-type-err.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 pub trait Foo {
     fn lol(&self) -> impl Deref<Target = String> {
-        //~^ type mismatch resolving `<&i32 as Deref>::Target == String`
+        //~^ ERROR type mismatch resolving `<&i32 as Deref>::Target == String`
         &1i32
     }
 }

--- a/tests/ui/impl-trait/in-trait/rpitit-hidden-types-self-implied-wf-via-param.rs
+++ b/tests/ui/impl-trait/in-trait/rpitit-hidden-types-self-implied-wf-via-param.rs
@@ -6,7 +6,7 @@ impl Extend for () {
     fn extend<'a: 'a>(s: &'a str) -> (Option<&'static &'a ()>, &'static str)
     where
         'a: 'static,
-        //~^ impl has stricter requirements than trait
+        //~^ ERROR impl has stricter requirements than trait
     {
         (None, s)
     }

--- a/tests/ui/impl-trait/in-trait/variance.rs
+++ b/tests/ui/impl-trait/in-trait/variance.rs
@@ -4,22 +4,22 @@
 
 trait Foo<'i> {
     fn implicit_capture_early<'a: 'a>() -> impl Sized {}
-    //~^ [Self: o, 'i: o, 'a: *, 'i: o, 'a: o]
+    //~^ ERROR [Self: o, 'i: o, 'a: *, 'i: o, 'a: o]
 
     fn explicit_capture_early<'a: 'a>() -> impl Sized + use<'i, 'a, Self> {}
-    //~^ [Self: o, 'i: o, 'a: *, 'i: o, 'a: o]
+    //~^ ERROR [Self: o, 'i: o, 'a: *, 'i: o, 'a: o]
 
     fn not_captured_early<'a: 'a>() -> impl Sized + use<'i, Self> {}
-    //~^ [Self: o, 'i: o, 'a: *, 'i: o]
+    //~^ ERROR [Self: o, 'i: o, 'a: *, 'i: o]
 
     fn implicit_capture_late<'a>(_: &'a ()) -> impl Sized {}
-    //~^ [Self: o, 'i: o, 'i: o, 'a: o]
+    //~^ ERROR [Self: o, 'i: o, 'i: o, 'a: o]
 
     fn explicit_capture_late<'a>(_: &'a ()) -> impl Sized + use<'i, 'a, Self> {}
-    //~^ [Self: o, 'i: o, 'i: o, 'a: o]
+    //~^ ERROR [Self: o, 'i: o, 'i: o, 'a: o]
 
     fn not_captured_late<'a>(_: &'a ()) -> impl Sized + use<'i, Self> {}
-    //~^ [Self: o, 'i: o, 'i: o]
+    //~^ ERROR [Self: o, 'i: o, 'i: o]
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-54600.rs
+++ b/tests/ui/impl-trait/issues/issue-54600.rs
@@ -2,6 +2,6 @@ use std::fmt::Debug;
 
 fn main() {
     let x: Option<impl Debug> = Some(44_u32);
-    //~^ `impl Trait` is not allowed in the type of variable bindings
+    //~^ ERROR `impl Trait` is not allowed in the type of variable bindings
     println!("{:?}", x);
 }

--- a/tests/ui/impl-trait/issues/issue-54840.rs
+++ b/tests/ui/impl-trait/issues/issue-54840.rs
@@ -3,5 +3,5 @@ use std::ops::Add;
 fn main() {
     let i: i32 = 0;
     let j: &impl Add = &i;
-    //~^ `impl Trait` is not allowed in the type of variable bindings
+    //~^ ERROR `impl Trait` is not allowed in the type of variable bindings
 }

--- a/tests/ui/impl-trait/issues/issue-58504.rs
+++ b/tests/ui/impl-trait/issues/issue-58504.rs
@@ -8,5 +8,5 @@ fn mk_gen() -> impl Coroutine<Return=!, Yield=()> {
 
 fn main() {
     let gens: [impl Coroutine<Return=!, Yield=()>;2] = [ mk_gen(), mk_gen() ];
-    //~^ `impl Trait` is not allowed in the type of variable bindings
+    //~^ ERROR `impl Trait` is not allowed in the type of variable bindings
 }

--- a/tests/ui/impl-trait/issues/issue-58956.rs
+++ b/tests/ui/impl-trait/issues/issue-58956.rs
@@ -5,9 +5,9 @@ impl Lam for B {}
 pub struct Wrap<T>(T);
 
 const _A: impl Lam = {
-    //~^ `impl Trait` is not allowed in const types
+    //~^ ERROR `impl Trait` is not allowed in const types
     let x: Wrap<impl Lam> = Wrap(B);
-    //~^ `impl Trait` is not allowed in the type of variable bindings
+    //~^ ERROR `impl Trait` is not allowed in the type of variable bindings
     x.0
 };
 

--- a/tests/ui/impl-trait/issues/issue-70971.rs
+++ b/tests/ui/impl-trait/issues/issue-70971.rs
@@ -1,4 +1,4 @@
 fn main() {
     let x : (impl Copy,) = (true,);
-    //~^ `impl Trait` is not allowed in the type of variable bindings
+    //~^ ERROR `impl Trait` is not allowed in the type of variable bindings
 }

--- a/tests/ui/impl-trait/issues/issue-79099.rs
+++ b/tests/ui/impl-trait/issues/issue-79099.rs
@@ -1,8 +1,8 @@
 struct Bug {
     V1: [(); {
         let f: impl core::future::Future<Output = u8> = async { 1 };
-        //~^ `impl Trait` is not allowed in the type of variable bindings
-        //~| expected identifier
+        //~^ ERROR `impl Trait` is not allowed in the type of variable bindings
+        //~| ERROR expected identifier
         1
     }],
 }

--- a/tests/ui/impl-trait/issues/issue-84919.rs
+++ b/tests/ui/impl-trait/issues/issue-84919.rs
@@ -3,7 +3,7 @@ impl Trait for () {}
 
 fn foo<'a: 'a>() {
     let _x: impl Trait = ();
-    //~^ `impl Trait` is not allowed in the type of variable bindings
+    //~^ ERROR `impl Trait` is not allowed in the type of variable bindings
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/issues/issue-86642.rs
+++ b/tests/ui/impl-trait/issues/issue-86642.rs
@@ -1,5 +1,5 @@
 static x: impl Fn(&str) -> Result<&str, ()> = move |source| {
-    //~^ `impl Trait` is not allowed in static types
+    //~^ ERROR `impl Trait` is not allowed in static types
     let res = (move |source| Ok(source))(source);
     let res = res.or((move |source| Ok(source))(source));
     res

--- a/tests/ui/impl-trait/issues/issue-87295.rs
+++ b/tests/ui/impl-trait/issues/issue-87295.rs
@@ -14,5 +14,5 @@ impl<F> Struct<F> {
 
 fn main() {
     let _do_not_waste: Struct<impl Trait<Output = i32>> = Struct::new(());
-    //~^ `impl Trait` is not allowed in the type of variable bindings
+    //~^ ERROR `impl Trait` is not allowed in the type of variable bindings
 }

--- a/tests/ui/impl-trait/issues/issue-99348-impl-compatibility.rs
+++ b/tests/ui/impl-trait/issues/issue-99348-impl-compatibility.rs
@@ -6,7 +6,7 @@ type Tait = impl Sized;
 
 impl Foo for Concrete {
     type Item = Concrete;
-    //~^ type mismatch resolving
+    //~^ ERROR type mismatch resolving
 }
 
 impl Bar for Concrete {

--- a/tests/ui/impl-trait/method-resolution4.rs
+++ b/tests/ui/impl-trait/method-resolution4.rs
@@ -11,7 +11,7 @@
 fn foo(b: bool) -> impl Iterator<Item = ()> {
     if b {
         foo(false).next().unwrap();
-        //[next]~^ type annotations needed
+        //[next]~^ ERROR type annotations needed
     }
     std::iter::empty()
 }

--- a/tests/ui/impl-trait/nested_impl_trait.rs
+++ b/tests/ui/impl-trait/nested_impl_trait.rs
@@ -9,7 +9,7 @@ fn bad_in_ret_position(x: impl Into<u32>) -> impl Into<impl Debug> { x }
 
 fn bad_in_fn_syntax(x: fn() -> impl Into<impl Debug>) {}
 //~^ ERROR nested `impl Trait` is not allowed
-//~| `impl Trait` is not allowed in `fn` pointer
+//~| ERROR `impl Trait` is not allowed in `fn` pointer
 
 fn bad_in_arg_position(_: impl Into<impl Debug>) { }
 //~^ ERROR nested `impl Trait` is not allowed

--- a/tests/ui/impl-trait/variance.rs
+++ b/tests/ui/impl-trait/variance.rs
@@ -9,15 +9,15 @@ trait Captures<'a> {}
 impl<T> Captures<'_> for T {}
 
 fn not_captured_early<'a: 'a>() -> impl Sized {}
-//[old]~^ ['a: *]
-//[e2024]~^^ ['a: *, 'a: o]
+//[old]~^ ERROR ['a: *]
+//[e2024]~^^ ERROR ['a: *, 'a: o]
 
-fn captured_early<'a: 'a>() -> impl Sized + Captures<'a> {} //~ ['a: *, 'a: o]
+fn captured_early<'a: 'a>() -> impl Sized + Captures<'a> {} //~ ERROR ['a: *, 'a: o]
 
 fn not_captured_late<'a>(_: &'a ()) -> impl Sized {}
-//[old]~^ []
-//[e2024]~^^ ['a: o]
+//[old]~^ ERROR []
+//[e2024]~^^ ERROR ['a: o]
 
-fn captured_late<'a>(_: &'a ()) -> impl Sized + Captures<'a> {} //~ ['a: o]
+fn captured_late<'a>(_: &'a ()) -> impl Sized + Captures<'a> {} //~ ERROR ['a: o]
 
 fn main() {}

--- a/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy-1.rs
+++ b/tests/ui/implied-bounds/implied-bounds-on-trait-hierarchy-1.rs
@@ -32,7 +32,7 @@ fn main() {
     {
         let x = "Hello World".to_string();
         subs_to_soup((x.as_str(), &mut d));
-        //~^ does not live long enough
+        //~^ ERROR does not live long enough
     }
     println!("{}", d);
 }

--- a/tests/ui/implied-bounds/sod_service_chain.rs
+++ b/tests/ui/implied-bounds/sod_service_chain.rs
@@ -27,17 +27,17 @@ pub struct ServiceChainBuilder<P: Service, S: Service<Input = P::Output>> {
 }
 impl<P: Service, S: Service<Input = P::Output>> ServiceChainBuilder<P, S> {
     pub fn next<NS: Service<Input = S::Output>>(
-        //~^ the associated type
+        //~^ ERROR the associated type
+        //~| ERROR the associated type
+        //~| ERROR the associated type
         //~| the associated type
         //~| the associated type
         //~| the associated type
-        //~| the associated type
-        //~| the associated type
-        //~| may not live long enough
+        //~| ERROR may not live long enough
         self,
     ) -> ServiceChainBuilder<ServiceChain<P, S>, NS> {
-        //~^ the associated type
-        //~| the associated type
+        //~^ ERROR the associated type
+        //~| ERROR the associated type
         //~| the associated type
         //~| the associated type
         panic!();

--- a/tests/ui/imports/import-from-missing.rs
+++ b/tests/ui/imports/import-from-missing.rs
@@ -1,5 +1,5 @@
 use spam::{ham, eggs}; //~ ERROR unresolved import `spam::eggs` [E0432]
-                       //~^ no `eggs` in `spam`
+                       //~^ NOTE no `eggs` in `spam`
 
 mod spam {
     pub fn ham() { }

--- a/tests/ui/imports/import2.rs
+++ b/tests/ui/imports/import2.rs
@@ -1,5 +1,5 @@
 use baz::zed::bar; //~ ERROR unresolved import `baz::zed` [E0432]
-                   //~^ could not find `zed` in `baz`
+                   //~^ NOTE could not find `zed` in `baz`
 
 mod baz {}
 mod zed {

--- a/tests/ui/imports/issue-13404.rs
+++ b/tests/ui/imports/issue-13404.rs
@@ -1,6 +1,6 @@
 use a::f;
 use b::f; //~ ERROR: unresolved import `b::f` [E0432]
-          //~^ no `f` in `b`
+          //~^ NOTE no `f` in `b`
 
 mod a { pub fn f() {} }
 mod b { }

--- a/tests/ui/imports/issue-2937.rs
+++ b/tests/ui/imports/issue-2937.rs
@@ -1,5 +1,5 @@
 use m::f as x; //~ ERROR unresolved import `m::f` [E0432]
-               //~^ no `f` in `m`
+               //~^ NOTE no `f` in `m`
 
 mod m {}
 

--- a/tests/ui/imports/issue-32833.rs
+++ b/tests/ui/imports/issue-32833.rs
@@ -1,5 +1,5 @@
 use bar::Foo; //~ ERROR unresolved import `bar::Foo` [E0432]
-              //~^ no `Foo` in `bar`
+              //~^ NOTE no `Foo` in `bar`
 mod bar {
     use Foo;
 }

--- a/tests/ui/imports/issue-8208.rs
+++ b/tests/ui/imports/issue-8208.rs
@@ -1,14 +1,14 @@
 use self::*; //~ ERROR: unresolved import `self::*` [E0432]
-             //~^ cannot glob-import a module into itself
+             //~^ NOTE cannot glob-import a module into itself
 
 mod foo {
     use foo::*; //~ ERROR: unresolved import `foo::*` [E0432]
-                //~^ cannot glob-import a module into itself
+                //~^ NOTE cannot glob-import a module into itself
 
     mod bar {
         use super::bar::*;
         //~^ ERROR: unresolved import `super::bar::*` [E0432]
-        //~| cannot glob-import a module into itself
+        //~| NOTE cannot glob-import a module into itself
     }
 
 }

--- a/tests/ui/inline-const/in-pat-recovery.rs
+++ b/tests/ui/inline-const/in-pat-recovery.rs
@@ -4,7 +4,7 @@
 fn main() {
     match 1 {
         const { 1 + 7 } => {}
-        //~^ `inline_const_pat` has been removed
+        //~^ ERROR `inline_const_pat` has been removed
         2 => {}
         _ => {}
     }

--- a/tests/ui/inline-const/using-late-bound-from-closure.rs
+++ b/tests/ui/inline-const/using-late-bound-from-closure.rs
@@ -7,7 +7,7 @@ fn foo() {
         const {
             let awd = ();
             let _: &'a () = &awd;
-            //~^ `awd` does not live long enough
+            //~^ ERROR `awd` does not live long enough
         };
         b
     };

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.rs
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.rs
@@ -3,13 +3,13 @@
 const RAW_EQ_PADDING: bool = unsafe {
     std::intrinsics::raw_eq(&(1_u8, 2_u16), &(1_u8, 2_u16))
 //~^ ERROR evaluation of constant value failed
-//~| requires initialized memory
+//~| NOTE requires initialized memory
 };
 
 const RAW_EQ_PTR: bool = unsafe {
     std::intrinsics::raw_eq(&(&0), &(&1))
 //~^ ERROR evaluation of constant value failed
-//~| unable to turn pointer into integer
+//~| NOTE unable to turn pointer into integer
 };
 
 const RAW_EQ_NOT_ALIGNED: bool = unsafe {
@@ -17,7 +17,7 @@ const RAW_EQ_NOT_ALIGNED: bool = unsafe {
     let aref = &*arr.as_ptr().cast::<i32>();
     std::intrinsics::raw_eq(aref, aref)
 //~^ ERROR evaluation of constant value failed
-//~| alignment
+//~| NOTE alignment
 };
 
 pub fn main() {

--- a/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.rs
+++ b/tests/ui/invalid/invalid-rustc_legacy_const_generics-issue-123077.rs
@@ -6,26 +6,26 @@ const fn foo<const U: i32>() -> i32 {
 
 fn main() {
     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, || ());
-    //~^ invalid argument to a legacy const generic
+    //~^ ERROR invalid argument to a legacy const generic
 
     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, 5 + || ());
-    //~^ invalid argument to a legacy const generic
+    //~^ ERROR invalid argument to a legacy const generic
 
     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, foo::<{ 1 + 2 }>());
-    //~^ invalid argument to a legacy const generic
+    //~^ ERROR invalid argument to a legacy const generic
 
     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, foo::<3>());
-    //~^ invalid argument to a legacy const generic
+    //~^ ERROR invalid argument to a legacy const generic
 
     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, &const {});
-    //~^ invalid argument to a legacy const generic
+    //~^ ERROR invalid argument to a legacy const generic
 
     std::arch::x86_64::_mm_blend_ps(loop {}, loop {}, {
         struct F();
-        //~^ invalid argument to a legacy const generic
+        //~^ ERROR invalid argument to a legacy const generic
         1
     });
 
     std::arch::x86_64::_mm_inserti_si64(loop {}, loop {}, || (), 1 + || ());
-    //~^ invalid argument to a legacy const generic
+    //~^ ERROR invalid argument to a legacy const generic
 }

--- a/tests/ui/invalid_dispatch_from_dyn_impls.rs
+++ b/tests/ui/invalid_dispatch_from_dyn_impls.rs
@@ -20,7 +20,7 @@ struct MultiplePointers<T: ?Sized>{
 }
 
 impl<T: ?Sized, U: ?Sized> DispatchFromDyn<MultiplePointers<U>> for MultiplePointers<T>
-//~^ implementing `DispatchFromDyn` does not allow multiple fields to be coerced
+//~^ ERROR implementing `DispatchFromDyn` does not allow multiple fields to be coerced
 where
     T: Unsize<U>,
 {}

--- a/tests/ui/issues/issue-11004.rs
+++ b/tests/ui/issues/issue-11004.rs
@@ -4,8 +4,8 @@ struct A { x: i32, y: f64 }
 
 #[cfg(not(FALSE))]
 unsafe fn access(n:*mut A) -> (i32, f64) {
-    let x : i32 = n.x; //~ no field `x` on type `*mut A`
-    let y : f64 = n.y; //~ no field `y` on type `*mut A`
+    let x : i32 = n.x; //~ ERROR no field `x` on type `*mut A`
+    let y : f64 = n.y; //~ ERROR no field `y` on type `*mut A`
     (x, y)
 }
 

--- a/tests/ui/issues/issue-14721.rs
+++ b/tests/ui/issues/issue-14721.rs
@@ -1,4 +1,4 @@
 fn main() {
     let foo = "str";
-    println!("{}", foo.desc); //~ no field `desc` on type `&str`
+    println!("{}", foo.desc); //~ ERROR no field `desc` on type `&str`
 }

--- a/tests/ui/issues/issue-17740.rs
+++ b/tests/ui/issues/issue-17740.rs
@@ -4,11 +4,11 @@ struct Foo<'a> {
 
 impl <'a> Foo<'a>{
     fn bar(self: &mut Foo) {
-    //~^ mismatched `self` parameter type
+    //~^ ERROR mismatched `self` parameter type
     //~| expected struct `Foo<'a>`
     //~| found struct `Foo<'_>`
     //~| lifetime mismatch
-    //~| mismatched `self` parameter type
+    //~| ERROR mismatched `self` parameter type
     //~| expected struct `Foo<'a>`
     //~| found struct `Foo<'_>`
     //~| lifetime mismatch

--- a/tests/ui/issues/issue-23253.rs
+++ b/tests/ui/issues/issue-23253.rs
@@ -2,5 +2,5 @@ enum Foo { Bar }
 
 fn main() {
     Foo::Bar.a;
-    //~^ no field `a` on type `Foo`
+    //~^ ERROR no field `a` on type `Foo`
 }

--- a/tests/ui/issues/issue-24363.rs
+++ b/tests/ui/issues/issue-24363.rs
@@ -1,5 +1,5 @@
 fn main() {
-    1.create_a_type_error[ //~ `{integer}` is a primitive type and therefore doesn't have fields
+    1.create_a_type_error[ //~ ERROR `{integer}` is a primitive type and therefore doesn't have fields
         ()+() //~ ERROR cannot add
               //   ^ ensure that we typeck the inner expression ^
     ];

--- a/tests/ui/issues/issue-24365.rs
+++ b/tests/ui/issues/issue-24365.rs
@@ -7,13 +7,13 @@ pub enum Foo {
 }
 
 fn test(a: Foo) {
-    println!("{}", a.b); //~ no field `b` on type `Foo`
+    println!("{}", a.b); //~ ERROR no field `b` on type `Foo`
 }
 
 fn main() {
     let x = Attribute::Code {
         attr_name_idx: 42,
     };
-    let z = (&x).attr_name_idx; //~ no field `attr_name_idx` on type `&Attribute`
-    let y = x.attr_name_idx; //~ no field `attr_name_idx` on type `Attribute`
+    let z = (&x).attr_name_idx; //~ ERROR no field `attr_name_idx` on type `&Attribute`
+    let y = x.attr_name_idx; //~ ERROR no field `attr_name_idx` on type `Attribute`
 }

--- a/tests/ui/issues/issue-27008.rs
+++ b/tests/ui/issues/issue-27008.rs
@@ -3,5 +3,5 @@ struct S;
 fn main() {
     let b = [0; S];
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `S`
+    //~| NOTE expected `usize`, found `S`
 }

--- a/tests/ui/issues/issue-2848.rs
+++ b/tests/ui/issues/issue-2848.rs
@@ -11,8 +11,8 @@ mod bar {
 fn main() {
     use bar::foo::{alpha, charlie};
     match alpha {
-      alpha | beta => {} //~  ERROR variable `beta` is not bound in all patterns
-      //~^ ERROR: `beta` is named the same as one of the variants
+      alpha | beta => {} //~ ERROR variable `beta` is not bound in all patterns
+      //~^ ERROR `beta` is named the same as one of the variants
       charlie => {}
     }
 }

--- a/tests/ui/issues/issue-31011.rs
+++ b/tests/ui/issues/issue-31011.rs
@@ -1,7 +1,7 @@
 macro_rules! log {
     ( $ctx:expr, $( $args:expr),* ) => {
         if $ctx.trace {
-        //~^ no field `trace` on type `&T`
+        //~^ ERROR no field `trace` on type `&T`
             println!( $( $args, )* );
         }
     }

--- a/tests/ui/issues/issue-51102.rs
+++ b/tests/ui/issues/issue-51102.rs
@@ -11,7 +11,7 @@ fn main() {
         match simple {
             SimpleStruct {
                 state: 0,
-                //~^ struct `SimpleStruct` does not have a field named `state` [E0026]
+                //~^ ERROR struct `SimpleStruct` does not have a field named `state` [E0026]
                 ..
             } => (),
         }

--- a/tests/ui/issues/issue-69130.rs
+++ b/tests/ui/issues/issue-69130.rs
@@ -3,5 +3,5 @@
 enum F {
 M (§& u8)}
 //~^ ERROR unknown start of token
-//~| missing lifetime specifier
+//~| ERROR missing lifetime specifier
 fn main() {}

--- a/tests/ui/issues/issue-87199.rs
+++ b/tests/ui/issues/issue-87199.rs
@@ -17,5 +17,5 @@ fn ret() -> impl Iterator<Item = ()> + ?Send { std::iter::empty() }
 fn main() {
     ref_arg::<i32>(&5);
     ref_arg::<[i32]>(&[5]);
-    //~^ the size for values of type `[i32]` cannot be known
+    //~^ ERROR the size for values of type `[i32]` cannot be known
 }

--- a/tests/ui/issues/issue-8761.rs
+++ b/tests/ui/issues/issue-8761.rs
@@ -1,10 +1,10 @@
 enum Foo {
     A = 1i64,
     //~^ ERROR mismatched types
-    //~| expected `isize`, found `i64`
+    //~| NOTE expected `isize`, found `i64`
     B = 2u8
     //~^ ERROR mismatched types
-    //~| expected `isize`, found `u8`
+    //~| NOTE expected `isize`, found `u8`
 }
 
 fn main() {}

--- a/tests/ui/iterators/float_iterator_hint.rs
+++ b/tests/ui/iterators/float_iterator_hint.rs
@@ -3,7 +3,7 @@
 fn main() {
     for i in 0.2 {
         //~^ ERROR `{float}` is not an iterator
-        //~| `{float}` is not an iterator
+        //~| NOTE `{float}` is not an iterator
         //~| NOTE in this expansion of desugaring of `for` loop
         //~| NOTE in this expansion of desugaring of `for` loop
         //~| NOTE in this expansion of desugaring of `for` loop

--- a/tests/ui/layout/post-mono-layout-cycle.rs
+++ b/tests/ui/layout/post-mono-layout-cycle.rs
@@ -1,5 +1,5 @@
 //@ build-fail
-//~^ cycle detected when computing layout of `Wrapper<()>`
+//~^ ERROR cycle detected when computing layout of `Wrapper<()>`
 
 trait Trait {
     type Assoc;

--- a/tests/ui/lifetimes/conflicting-bounds.rs
+++ b/tests/ui/lifetimes/conflicting-bounds.rs
@@ -1,4 +1,4 @@
-//~ type annotations needed: cannot satisfy `Self: Gen<'source>`
+//~ ERROR type annotations needed: cannot satisfy `Self: Gen<'source>`
 
 pub trait Gen<'source> {
     type Output;

--- a/tests/ui/lifetimes/issue-83753-invalid-associated-type-supertrait-hrtb.rs
+++ b/tests/ui/lifetimes/issue-83753-invalid-associated-type-supertrait-hrtb.rs
@@ -3,6 +3,6 @@
 struct Foo {}
 impl Foo {
     fn bar(foo: Foo<Target = usize>) {}
-    //~^ associated item constraints are not allowed here
+    //~^ ERROR associated item constraints are not allowed here
 }
 fn main() {}

--- a/tests/ui/lifetimes/issue-83907-invalid-fn-like-path.rs
+++ b/tests/ui/lifetimes/issue-83907-invalid-fn-like-path.rs
@@ -1,7 +1,7 @@
 //@ check-fail
 
 static STATIC_VAR_FIVE: &One();
-//~^ cannot find type
-//~| free static item without body
+//~^ ERROR cannot find type
+//~| ERROR free static item without body
 
 fn main() {}

--- a/tests/ui/limits/huge-static.rs
+++ b/tests/ui/limits/huge-static.rs
@@ -18,9 +18,9 @@ impl TooBigArray {
 
 static MY_TOO_BIG_ARRAY_1: TooBigArray = TooBigArray::new();
 //~^ ERROR could not evaluate static initializer
-//~| too big
+//~| NOTE too big
 static MY_TOO_BIG_ARRAY_2: [u8; HUGE_SIZE] = [0x00; HUGE_SIZE];
 //~^ ERROR could not evaluate static initializer
-//~| too big
+//~| NOTE too big
 
 fn main() { }

--- a/tests/ui/lint/lint-attr-everywhere-early.rs
+++ b/tests/ui/lint/lint-attr-everywhere-early.rs
@@ -40,7 +40,7 @@ struct Associated;
 impl Associated {
     #![deny(unsafe_code)]
 
-    fn inherent_denied_from_inner() { unsafe {} } //~ usage of an `unsafe` block
+    fn inherent_denied_from_inner() { unsafe {} } //~ ERROR usage of an `unsafe` block
 
     #[deny(while_true)]
     fn inherent_fn() { while true {} } //~ ERROR denote infinite loops with

--- a/tests/ui/lint/lints-in-foreign-macros.rs
+++ b/tests/ui/lint/lints-in-foreign-macros.rs
@@ -1,7 +1,7 @@
 //@ aux-build:lints-in-foreign-macros.rs
 //@ check-pass
 
-#![warn(unused_imports)] //~ missing documentation for the crate [missing_docs]
+#![warn(unused_imports)] //~ WARN missing documentation for the crate [missing_docs]
 #![warn(missing_docs)]
 
 #[macro_use]

--- a/tests/ui/lint/rfc-2457-non-ascii-idents/lint-uncommon-codepoints.rs
+++ b/tests/ui/lint/rfc-2457-non-ascii-idents/lint-uncommon-codepoints.rs
@@ -1,6 +1,6 @@
 #![deny(uncommon_codepoints)]
 
-const µ: f64 = 0.000001; //~ identifier contains a non normalized (NFKC) character: 'µ'
+const µ: f64 = 0.000001; //~ ERROR identifier contains a non normalized (NFKC) character: 'µ'
 //~| WARNING should have an upper case name
 
 fn dĳkstra() {}

--- a/tests/ui/lint/unused-borrows.rs
+++ b/tests/ui/lint/unused-borrows.rs
@@ -4,24 +4,24 @@ fn foo(_: i32) -> bool { todo!() }
 
 fn bar() -> &'static i32 {
     &42;
-    //~^ unused
+    //~^ ERROR unused
 
     &mut foo(42);
-    //~^ unused
+    //~^ ERROR unused
 
     &&42;
-    //~^ unused
+    //~^ ERROR unused
 
     &&mut 42;
-    //~^ unused
+    //~^ ERROR unused
 
     &mut &42;
-    //~^ unused
+    //~^ ERROR unused
 
     let _result = foo(4)
         && foo(2); // Misplaced semi-colon (perhaps due to reordering of lines)
     && foo(42);
-    //~^ unused
+    //~^ ERROR unused
 
     let _ = &42; // ok
 

--- a/tests/ui/lint/unused/must_use-unit.rs
+++ b/tests/ui/lint/unused/must_use-unit.rs
@@ -10,7 +10,7 @@ fn bar() -> ! {
 }
 
 fn main() {
-    foo(); //~ unused return value of `foo`
+    foo(); //~ ERROR unused return value of `foo`
 
-    bar(); //~ unused return value of `bar`
+    bar(); //~ ERROR unused return value of `bar`
 }

--- a/tests/ui/lint/unused/useless-comment.rs
+++ b/tests/ui/lint/unused/useless-comment.rs
@@ -13,7 +13,7 @@ fn foo() {
     /// a //~ ERROR unused doc comment
     let x = 12;
 
-    /// multi-line //~ unused doc comment
+    /// multi-line //~ ERROR unused doc comment
     /// doc comment
     /// that is unused
     match x {

--- a/tests/ui/macros/issue-42954.fixed
+++ b/tests/ui/macros/issue-42954.fixed
@@ -4,7 +4,7 @@
 
 macro_rules! is_plainly_printable {
     ($i: ident) => {
-        ($i as u32) < 0 //~ `<` is interpreted as a start of generic arguments
+        ($i as u32) < 0 //~ ERROR `<` is interpreted as a start of generic arguments
     };
 }
 

--- a/tests/ui/macros/issue-42954.rs
+++ b/tests/ui/macros/issue-42954.rs
@@ -4,7 +4,7 @@
 
 macro_rules! is_plainly_printable {
     ($i: ident) => {
-        $i as u32 < 0 //~ `<` is interpreted as a start of generic arguments
+        $i as u32 < 0 //~ ERROR `<` is interpreted as a start of generic arguments
     };
 }
 

--- a/tests/ui/macros/issue-88228.rs
+++ b/tests/ui/macros/issue-88228.rs
@@ -13,7 +13,7 @@ struct A;
 
 #[derive(println)]
 //~^ ERROR cannot find derive macro `println`
-//~|`println` is in scope, but it is a function-like macro
+//~| NOTE `println` is in scope, but it is a function-like macro
 struct B;
 
 fn main() {

--- a/tests/ui/match/intended-binding-pattern-is-const.rs
+++ b/tests/ui/match/intended-binding-pattern-is-const.rs
@@ -1,8 +1,8 @@
 fn main() {
     match 1 { //~ ERROR non-exhaustive patterns
-        //~^ patterns `i32::MIN..=3_i32` and `5_i32..=i32::MAX` not covered
-        //~| the matched value is of type `i32`
-        x => {} //~ this pattern doesn't introduce a new catch-all binding
+        //~^ NOTE patterns `i32::MIN..=3_i32` and `5_i32..=i32::MAX` not covered
+        //~| NOTE the matched value is of type `i32`
+        x => {} //~ NOTE this pattern doesn't introduce a new catch-all binding
         //~^ HELP ensure that all possible cases are being handled
         //~| HELP if you meant to introduce a binding, use a different name
     }

--- a/tests/ui/match/postfix-match/pf-match-exhaustiveness.rs
+++ b/tests/ui/match/postfix-match/pf-match-exhaustiveness.rs
@@ -1,7 +1,7 @@
 #![feature(postfix_match)]
 
 fn main() {
-    Some(1).match { //~ non-exhaustive patterns
+    Some(1).match { //~ ERROR non-exhaustive patterns
         None => {},
     }
 }

--- a/tests/ui/methods/bad-wf-when-selecting-method.rs
+++ b/tests/ui/methods/bad-wf-when-selecting-method.rs
@@ -12,7 +12,7 @@ fn test<T>(t: T) {
     Wrapper(t).needs_sized();
     //~^ ERROR the trait bound `T: Wf` is not satisfied
     //~| ERROR the trait bound `T: Wf` is not satisfied
-    //~| the method `needs_sized` exists for struct `Wrapper<T, _>`, but its trait bounds were not satisfied
+    //~| ERROR the method `needs_sized` exists for struct `Wrapper<T, _>`, but its trait bounds were not satisfied
 }
 
 fn main() {}

--- a/tests/ui/methods/disambiguate-associated-function-first-arg.rs
+++ b/tests/ui/methods/disambiguate-associated-function-first-arg.rs
@@ -45,5 +45,5 @@ impl<T> TraitB for T {
 
 fn test() {
     S.f();
-   //~^ multiple applicable items in scope
+   //~^ ERROR multiple applicable items in scope
 }

--- a/tests/ui/methods/issues/issue-90315.rs
+++ b/tests/ui/methods/issues/issue-90315.rs
@@ -3,7 +3,7 @@ fn main() {
     let arr = &[0, 1, 2, 3];
     for _i in 0..arr.len().rev() {
         //~^ ERROR can't call method
-        //~| surround the range in parentheses
+        //~| HELP surround the range in parentheses
         // The above error used to say “the method `rev` exists for type `usize`”.
         // This regression test ensures it doesn't say that any more.
     }

--- a/tests/ui/mir/enable_passes_validation.rs
+++ b/tests/ui/mir/enable_passes_validation.rs
@@ -19,7 +19,7 @@ fn main() {}
 //[unprefixed]~? ERROR incorrect value `CheckAlignment` for unstable option `mir-enable-passes`
 //[mixed]~? WARN MIR pass `ThisPassDoesNotExist` is unknown and will be ignored
 //[mixed]~? WARN MIR pass `ThisPassDoesNotExist` is unknown and will be ignored
-//[all_unknown]~? MIR pass `ThisPass` is unknown and will be ignored
-//[all_unknown]~? MIR pass `DoesNotExist` is unknown and will be ignored
-//[all_unknown]~? MIR pass `ThisPass` is unknown and will be ignored
-//[all_unknown]~? MIR pass `DoesNotExist` is unknown and will be ignored
+//[all_unknown]~? WARN MIR pass `ThisPass` is unknown and will be ignored
+//[all_unknown]~? WARN MIR pass `DoesNotExist` is unknown and will be ignored
+//[all_unknown]~? WARN MIR pass `ThisPass` is unknown and will be ignored
+//[all_unknown]~? WARN MIR pass `DoesNotExist` is unknown and will be ignored

--- a/tests/ui/mismatched_types/suggest-adding-or-removing-ref-for-binding-pattern.fixed
+++ b/tests/ui/mismatched_types/suggest-adding-or-removing-ref-for-binding-pattern.fixed
@@ -16,6 +16,6 @@ fn main() {
     match Blah::A(1, 1, 2) {
         Blah::A(_, x, y) | Blah::B(x, y) => {}
         //~^ ERROR mismatched types
-        //~| variable `y` is bound inconsistently across alternatives separated by `|`
+        //~| ERROR variable `y` is bound inconsistently across alternatives separated by `|`
     }
 }

--- a/tests/ui/mismatched_types/suggest-adding-or-removing-ref-for-binding-pattern.rs
+++ b/tests/ui/mismatched_types/suggest-adding-or-removing-ref-for-binding-pattern.rs
@@ -16,6 +16,6 @@ fn main() {
     match Blah::A(1, 1, 2) {
         Blah::A(_, x, y) | Blah::B(x, ref y) => {}
         //~^ ERROR mismatched types
-        //~| variable `y` is bound inconsistently across alternatives separated by `|`
+        //~| ERROR variable `y` is bound inconsistently across alternatives separated by `|`
     }
 }

--- a/tests/ui/moves/moves-based-on-type-tuple.rs
+++ b/tests/ui/moves/moves-based-on-type-tuple.rs
@@ -2,7 +2,7 @@ fn dup(x: Box<isize>) -> Box<(Box<isize>,Box<isize>)> {
 
 
     Box::new((x, x))
-    //~^ use of moved value: `x` [E0382]
+    //~^ ERROR use of moved value: `x` [E0382]
 }
 
 fn main() {

--- a/tests/ui/moves/use_of_moved_value_clone_suggestions.rs
+++ b/tests/ui/moves/use_of_moved_value_clone_suggestions.rs
@@ -1,6 +1,6 @@
 // `Rc` is not ever `Copy`, we should not suggest adding `T: Copy` constraint
 fn duplicate_rc<T>(t: std::rc::Rc<T>) -> (std::rc::Rc<T>, std::rc::Rc<T>) {
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn main() {}

--- a/tests/ui/moves/use_of_moved_value_copy_suggestions.fixed
+++ b/tests/ui/moves/use_of_moved_value_copy_suggestions.fixed
@@ -4,27 +4,27 @@
 fn duplicate_t<T: Copy>(t: T) -> (T, T) {
     //~^ HELP consider restricting type parameter `T`
     //~| HELP if `T` implemented `Clone`, you could clone the value
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_opt<T: Copy>(t: Option<T>) -> (Option<T>, Option<T>) {
     //~^ HELP consider restricting type parameter `T`
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_tup1<T: Copy>(t: (T,)) -> ((T,), (T,)) {
     //~^ HELP consider restricting type parameter `T`
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_tup2<A: Copy, B: Copy>(t: (A, B)) -> ((A, B), (A, B)) {
     //~^ HELP consider restricting type parameters
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_custom<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) {
     //~^ HELP consider restricting type parameter `T`
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 struct S<T>(T);
@@ -42,7 +42,7 @@ trait B {}
 // Test where bounds are added with different bound placements
 fn duplicate_custom_1<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) where {
     //~^ HELP consider restricting type parameter `T`
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_custom_2<T>(t: S<T>) -> (S<T>, S<T>)
@@ -50,7 +50,7 @@ where
     T: A + Copy + Trait,
     //~^ HELP consider further restricting
 {
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_custom_3<T>(t: S<T>) -> (S<T>, S<T>)
@@ -59,7 +59,7 @@ where
     //~^ HELP consider further restricting
     T: B,
 {
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_custom_4<T: A + Copy + Trait>(t: S<T>) -> (S<T>, S<T>)
@@ -67,14 +67,14 @@ fn duplicate_custom_4<T: A + Copy + Trait>(t: S<T>) -> (S<T>, S<T>)
 where
     T: B,
 {
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 #[rustfmt::skip]
 fn existing_colon<T: Copy>(t: T) {
     //~^ HELP consider restricting type parameter `T`
     //~| HELP if `T` implemented `Clone`, you could clone the value
-    [t, t]; //~ use of moved value: `t`
+    [t, t]; //~ ERROR use of moved value: `t`
 }
 
 fn existing_colon_in_where<T>(t: T) //~ HELP if `T` implemented `Clone`, you could clone the value
@@ -82,7 +82,7 @@ where
     T:, T: Copy
     //~^ HELP consider further restricting type parameter `T`
 {
-    [t, t]; //~ use of moved value: `t`
+    [t, t]; //~ ERROR use of moved value: `t`
 }
 
 fn main() {}

--- a/tests/ui/moves/use_of_moved_value_copy_suggestions.rs
+++ b/tests/ui/moves/use_of_moved_value_copy_suggestions.rs
@@ -4,27 +4,27 @@
 fn duplicate_t<T>(t: T) -> (T, T) {
     //~^ HELP consider restricting type parameter `T`
     //~| HELP if `T` implemented `Clone`, you could clone the value
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_opt<T>(t: Option<T>) -> (Option<T>, Option<T>) {
     //~^ HELP consider restricting type parameter `T`
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_tup1<T>(t: (T,)) -> ((T,), (T,)) {
     //~^ HELP consider restricting type parameter `T`
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_tup2<A, B>(t: (A, B)) -> ((A, B), (A, B)) {
     //~^ HELP consider restricting type parameters
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_custom<T>(t: S<T>) -> (S<T>, S<T>) {
     //~^ HELP consider restricting type parameter `T`
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 struct S<T>(T);
@@ -42,7 +42,7 @@ trait B {}
 // Test where bounds are added with different bound placements
 fn duplicate_custom_1<T>(t: S<T>) -> (S<T>, S<T>) where {
     //~^ HELP consider restricting type parameter `T`
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_custom_2<T>(t: S<T>) -> (S<T>, S<T>)
@@ -50,7 +50,7 @@ where
     T: A,
     //~^ HELP consider further restricting
 {
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_custom_3<T>(t: S<T>) -> (S<T>, S<T>)
@@ -59,7 +59,7 @@ where
     //~^ HELP consider further restricting
     T: B,
 {
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 fn duplicate_custom_4<T: A>(t: S<T>) -> (S<T>, S<T>)
@@ -67,14 +67,14 @@ fn duplicate_custom_4<T: A>(t: S<T>) -> (S<T>, S<T>)
 where
     T: B,
 {
-    (t, t) //~ use of moved value: `t`
+    (t, t) //~ ERROR use of moved value: `t`
 }
 
 #[rustfmt::skip]
 fn existing_colon<T:>(t: T) {
     //~^ HELP consider restricting type parameter `T`
     //~| HELP if `T` implemented `Clone`, you could clone the value
-    [t, t]; //~ use of moved value: `t`
+    [t, t]; //~ ERROR use of moved value: `t`
 }
 
 fn existing_colon_in_where<T>(t: T) //~ HELP if `T` implemented `Clone`, you could clone the value
@@ -82,7 +82,7 @@ where
     T:,
     //~^ HELP consider further restricting type parameter `T`
 {
-    [t, t]; //~ use of moved value: `t`
+    [t, t]; //~ ERROR use of moved value: `t`
 }
 
 fn main() {}

--- a/tests/ui/never_type/fallback-closure-wrap.rs
+++ b/tests/ui/never_type/fallback-closure-wrap.rs
@@ -17,7 +17,7 @@ use std::marker::PhantomData;
 fn main() {
     let error = Closure::wrap(Box::new(move || {
         panic!("Can't connect to server.");
-        //[fallback]~^ to return `()`, but it returns `!`
+        //[fallback]~^ ERROR to return `()`, but it returns `!`
     }) as Box<dyn FnMut()>);
 }
 

--- a/tests/ui/nll/borrowed-match-issue-45045.rs
+++ b/tests/ui/nll/borrowed-match-issue-45045.rs
@@ -10,7 +10,7 @@ fn main() {
     let f = &mut e;
     let g = f;
     match e {
-        //~^ cannot use `e` because it was mutably borrowed [E0503]
+        //~^ ERROR cannot use `e` because it was mutably borrowed [E0503]
         Xyz::A => println!("a"),
         Xyz::B => println!("b"),
     };

--- a/tests/ui/nll/issue-48697.rs
+++ b/tests/ui/nll/issue-48697.rs
@@ -4,7 +4,7 @@ fn foo(x: &i32) -> &i32 {
     let z = 4;
     let f = &|y| y;
     let k = f(&z);
-    f(x) //~ cannot return value referencing local variable
+    f(x) //~ ERROR cannot return value referencing local variable
 }
 
 fn main() {}

--- a/tests/ui/nll/issue-54779-anon-static-lifetime.rs
+++ b/tests/ui/nll/issue-54779-anon-static-lifetime.rs
@@ -29,7 +29,7 @@ impl DebugWith<dyn DebugContext> for Foo {
         fmt: &mut std::fmt::Formatter<'_>,
     ) -> std::fmt::Result {
         let Foo { bar } = self;
-        bar.debug_with(cx); //~ borrowed data escapes outside of method
+        bar.debug_with(cx); //~ ERROR borrowed data escapes outside of method
         Ok(())
     }
 }

--- a/tests/ui/nll/member-constraints/nested-impl-trait-fail.rs
+++ b/tests/ui/nll/member-constraints/nested-impl-trait-fail.rs
@@ -15,8 +15,8 @@ where
     's: 'b,
 {
     [a]
-    //~^ E0700
-    //~| E0700
+    //~^ ERROR E0700
+    //~| ERROR E0700
 }
 
 // Same as the above but with late-bound regions.
@@ -26,8 +26,8 @@ fn fail_late_bound<'s, 'a, 'b>(
     _: &'b &'s u8,
 ) -> impl IntoIterator<Item = impl Cap<'a> + Cap<'b>> {
     [a]
-    //~^ E0700
-    //~| E0700
+    //~^ ERROR E0700
+    //~| ERROR E0700
 }
 
 fn main() {}

--- a/tests/ui/nonscalar-cast.fixed
+++ b/tests/ui/nonscalar-cast.fixed
@@ -12,5 +12,5 @@ impl From<Foo> for isize {
 }
 
 fn main() {
-    println!("{}", isize::from(Foo { x: 1 })); //~ non-primitive cast: `Foo` as `isize` [E0605]
+    println!("{}", isize::from(Foo { x: 1 })); //~ ERROR non-primitive cast: `Foo` as `isize` [E0605]
 }

--- a/tests/ui/nonscalar-cast.rs
+++ b/tests/ui/nonscalar-cast.rs
@@ -12,5 +12,5 @@ impl From<Foo> for isize {
 }
 
 fn main() {
-    println!("{}", Foo { x: 1 } as isize); //~ non-primitive cast: `Foo` as `isize` [E0605]
+    println!("{}", Foo { x: 1 } as isize); //~ ERROR non-primitive cast: `Foo` as `isize` [E0605]
 }

--- a/tests/ui/offset-of/offset-of-self.rs
+++ b/tests/ui/offset-of/offset-of-self.rs
@@ -15,8 +15,8 @@ impl S {
         offset_of!(Self, v)
     }
     fn v_offs_wrong_syntax() {
-        offset_of!(Self, Self::v); //~ offset_of expects dot-separated field and variant names
-        offset_of!(S, Self); //~ no field `Self` on type `S`
+        offset_of!(Self, Self::v); //~ ERROR offset_of expects dot-separated field and variant names
+        offset_of!(S, Self); //~ ERROR no field `Self` on type `S`
     }
     fn offs_in_c() -> usize {
         offset_of!(C<Self>, w)
@@ -48,6 +48,6 @@ fn main() {
     offset_of!(self::S, v);
     offset_of!(Self, v); //~ ERROR cannot find type `Self` in this scope
 
-    offset_of!(S, self); //~ no field `self` on type `S`
-    offset_of!(S, v.self); //~ no field `self` on type `u8`
+    offset_of!(S, self); //~ ERROR no field `self` on type `S`
+    offset_of!(S, v.self); //~ ERROR no field `self` on type `u8`
 }

--- a/tests/ui/offset-of/offset-of-tuple.rs
+++ b/tests/ui/offset-of/offset-of-tuple.rs
@@ -11,7 +11,7 @@ fn main() {
     offset_of!((u8, u8), +1); //~ ERROR no rules expected
     offset_of!((u8, u8), -1); //~ ERROR offset_of expects dot-separated field and variant names
     offset_of!((u8, u8), 1.); //~ ERROR offset_of expects dot-separated field and variant names
-    offset_of!((u8, u8), 1 .); //~ unexpected token: `)`
+    offset_of!((u8, u8), 1 .); //~ ERROR unexpected token: `)`
     builtin # offset_of((u8, u8), 1e2); //~ ERROR no field `1e2`
     builtin # offset_of((u8, u8), _0); //~ ERROR no field `_0`
     builtin # offset_of((u8, u8), 01); //~ ERROR no field `01`

--- a/tests/ui/on-unimplemented/bad-annotation.rs
+++ b/tests/ui/on-unimplemented/bad-annotation.rs
@@ -25,39 +25,39 @@ trait BadAnnotation2<A,B>
 {}
 
 #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{}>`"]
-//~^ only named generic parameters are allowed
+//~^ ERROR only named generic parameters are allowed
 trait BadAnnotation3<A,B>
 {}
 
 #[rustc_on_unimplemented(lorem="")]
-//~^ this attribute must have a valid
+//~^ ERROR this attribute must have a valid
 trait BadAnnotation4 {}
 
 #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
-//~^ this attribute must have a valid
+//~^ ERROR this attribute must have a valid
 trait BadAnnotation5 {}
 
 #[rustc_on_unimplemented(message="x", message="y")]
-//~^ this attribute must have a valid
+//~^ ERROR this attribute must have a valid
 trait BadAnnotation6 {}
 
 #[rustc_on_unimplemented(message="x", on(desugared, message="y"))]
-//~^ this attribute must have a valid
+//~^ ERROR this attribute must have a valid
 trait BadAnnotation7 {}
 
 #[rustc_on_unimplemented(on(), message="y")]
-//~^ empty `on`-clause
+//~^ ERROR empty `on`-clause
 trait BadAnnotation8 {}
 
 #[rustc_on_unimplemented(on="x", message="y")]
-//~^ this attribute must have a valid
+//~^ ERROR this attribute must have a valid
 trait BadAnnotation9 {}
 
 #[rustc_on_unimplemented(on(x="y"), message="y")]
 trait BadAnnotation10 {}
 
 #[rustc_on_unimplemented(on(desugared, on(desugared, message="x")), message="y")]
-//~^ this attribute must have a valid
+//~^ ERROR this attribute must have a valid
 trait BadAnnotation11 {}
 
 pub fn main() {

--- a/tests/ui/or-patterns/inner-or-pat.rs
+++ b/tests/ui/or-patterns/inner-or-pat.rs
@@ -49,7 +49,7 @@ fn hey() {
     match x {
         x @ ("foo" | "bar") |
         (x @ "red" | (x @ "blue" |  "red")) => {
-        //[or4]~^ variable `x` is not bound in all patterns
+        //[or4]~^ ERROR variable `x` is not bound in all patterns
         }
         _ => (),
     }

--- a/tests/ui/or-patterns/while-parsing-this-or-pattern.rs
+++ b/tests/ui/or-patterns/while-parsing-this-or-pattern.rs
@@ -3,7 +3,7 @@
 fn main() {
     match Some(42) {
         Some(42) | .=. => {} //~ ERROR expected pattern, found `.`
-        //~^ while parsing this or-pattern starting here
+        //~^ NOTE while parsing this or-pattern starting here
         //~| NOTE expected pattern
     }
 }

--- a/tests/ui/panic-handler/panic-handler-bad-signature-1.rs
+++ b/tests/ui/panic-handler/panic-handler-bad-signature-1.rs
@@ -7,4 +7,4 @@ use core::panic::PanicInfo;
 
 #[panic_handler]
 fn panic(info: PanicInfo) -> () {}
-//~^ `#[panic_handler]` function has wrong type [E0308]
+//~^ ERROR `#[panic_handler]` function has wrong type [E0308]

--- a/tests/ui/panic-handler/panic-handler-bad-signature-2.rs
+++ b/tests/ui/panic-handler/panic-handler-bad-signature-2.rs
@@ -7,7 +7,7 @@ use core::panic::PanicInfo;
 
 #[panic_handler]
 fn panic(info: &'static PanicInfo) -> !
-//~^ #[panic_handler]` function has wrong type [E0308]
+//~^ ERROR #[panic_handler]` function has wrong type [E0308]
 {
     loop {}
 }

--- a/tests/ui/panic-handler/panic-handler-bad-signature-3.rs
+++ b/tests/ui/panic-handler/panic-handler-bad-signature-3.rs
@@ -6,6 +6,6 @@
 use core::panic::PanicInfo;
 
 #[panic_handler]
-fn panic() -> ! { //~ #[panic_handler]` function has wrong type [E0308]
+fn panic() -> ! { //~ ERROR #[panic_handler]` function has wrong type [E0308]
     loop {}
 }

--- a/tests/ui/panic-handler/panic-handler-bad-signature-5.rs
+++ b/tests/ui/panic-handler/panic-handler-bad-signature-5.rs
@@ -7,7 +7,7 @@ use core::panic::PanicInfo;
 
 #[panic_handler]
 fn panic(info: &PanicInfo<'static>) -> !
-//~^ #[panic_handler]` function has wrong type [E0308]
+//~^ ERROR #[panic_handler]` function has wrong type [E0308]
 {
     loop {}
 }

--- a/tests/ui/parser/diff-markers/unclosed-delims-in-macro.rs
+++ b/tests/ui/parser/diff-markers/unclosed-delims-in-macro.rs
@@ -8,4 +8,4 @@ macro_rules! foo {
     () { //
 >>>>>>> 7a4f13c blah blah blah
     }
-} //~ this file contains an unclosed delimiter
+} //~ ERROR this file contains an unclosed delimiter

--- a/tests/ui/parser/diff-markers/unclosed-delims-in-macro.stderr
+++ b/tests/ui/parser/diff-markers/unclosed-delims-in-macro.stderr
@@ -1,5 +1,5 @@
 error: this file contains an unclosed delimiter
-  --> $DIR/unclosed-delims-in-macro.rs:11:48
+  --> $DIR/unclosed-delims-in-macro.rs:11:54
    |
 LL | macro_rules! foo {
    |                  - unclosed delimiter
@@ -8,7 +8,7 @@ LL |     () {
    |        - this delimiter might not be properly closed...
 ...
 LL | }
-   | -                                             ^
+   | -                                                   ^
    | |
    | ...as it matches this but it has different indentation
 

--- a/tests/ui/parser/diff-markers/unclosed-delims.rs
+++ b/tests/ui/parser/diff-markers/unclosed-delims.rs
@@ -9,4 +9,4 @@ mod tests {
     fn test2() {
 >>>>>>> 7a4f13c blah blah blah
     }
-} //~ this file contains an unclosed delimiter
+} //~ ERROR this file contains an unclosed delimiter

--- a/tests/ui/parser/diff-markers/unclosed-delims.stderr
+++ b/tests/ui/parser/diff-markers/unclosed-delims.stderr
@@ -1,5 +1,5 @@
 error: this file contains an unclosed delimiter
-  --> $DIR/unclosed-delims.rs:12:48
+  --> $DIR/unclosed-delims.rs:12:54
    |
 LL | mod tests {
    |           - unclosed delimiter
@@ -8,7 +8,7 @@ LL |     fn test1() {
    |                - this delimiter might not be properly closed...
 ...
 LL | }
-   | -                                             ^
+   | -                                                   ^
    | |
    | ...as it matches this but it has different indentation
 

--- a/tests/ui/parser/do-catch-suggests-try.rs
+++ b/tests/ui/parser/do-catch-suggests-try.rs
@@ -3,7 +3,7 @@
 fn main() {
     let _: Option<()> = do catch {};
     //~^ ERROR found removed `do catch` syntax
-    //~| replace with the new syntax
+    //~| HELP replace with the new syntax
     //~| following RFC #2388, the new non-placeholder syntax is `try`
 
     let _recovery_witness: () = 1; //~ ERROR mismatched types

--- a/tests/ui/parser/float-field.rs
+++ b/tests/ui/parser/float-field.rs
@@ -39,11 +39,11 @@ fn main() {
 
     { s.0x1.1; } //~ ERROR hexadecimal float literal is not supported
                  //~| ERROR unexpected token: `0x1.1`
-                 //~| expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1`
+                 //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1`
 
     { s.0x1.1e1; } //~ ERROR hexadecimal float literal is not supported
                    //~| ERROR unexpected token: `0x1.1e1`
-                   //~| expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1e1`
+                   //~| ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `0x1.1e1`
 
     { s.0x1e+; } //~ ERROR expected expression, found `;`
 

--- a/tests/ui/parser/intersection-patterns-1.fixed
+++ b/tests/ui/parser/intersection-patterns-1.fixed
@@ -16,8 +16,8 @@ fn main() {
     match s {
         y @ Some(x) => {}
         //~^ ERROR pattern on wrong side of `@`
-        //~| pattern on the left, should be on the right
-        //~| binding on the right, should be on the left
+        //~| NOTE pattern on the left, should be on the right
+        //~| NOTE binding on the right, should be on the left
         //~| HELP switch the order
         //~| SUGGESTION y @ Some(x)
         _ => {}
@@ -26,8 +26,8 @@ fn main() {
     match 2 {
         e @ 1..=5 => {}
         //~^ ERROR pattern on wrong side of `@`
-        //~| pattern on the left, should be on the right
-        //~| binding on the right, should be on the left
+        //~| NOTE pattern on the left, should be on the right
+        //~| NOTE binding on the right, should be on the left
         //~| HELP switch the order
         //~| SUGGESTION e @ 1..=5
         _ => {}

--- a/tests/ui/parser/intersection-patterns-1.rs
+++ b/tests/ui/parser/intersection-patterns-1.rs
@@ -16,8 +16,8 @@ fn main() {
     match s {
         Some(x) @ y => {}
         //~^ ERROR pattern on wrong side of `@`
-        //~| pattern on the left, should be on the right
-        //~| binding on the right, should be on the left
+        //~| NOTE pattern on the left, should be on the right
+        //~| NOTE binding on the right, should be on the left
         //~| HELP switch the order
         //~| SUGGESTION y @ Some(x)
         _ => {}
@@ -26,8 +26,8 @@ fn main() {
     match 2 {
         1 ..= 5 @ e => {}
         //~^ ERROR pattern on wrong side of `@`
-        //~| pattern on the left, should be on the right
-        //~| binding on the right, should be on the left
+        //~| NOTE pattern on the left, should be on the right
+        //~| NOTE binding on the right, should be on the left
         //~| HELP switch the order
         //~| SUGGESTION e @ 1..=5
         _ => {}

--- a/tests/ui/parser/intersection-patterns-2.rs
+++ b/tests/ui/parser/intersection-patterns-2.rs
@@ -12,8 +12,8 @@ fn main() {
     match s {
         Some(x) @ Some(y) => {}
         //~^ ERROR left-hand side of `@` must be a binding
-        //~| interpreted as a pattern, not a binding
-        //~| also a pattern
+        //~| NOTE interpreted as a pattern, not a binding
+        //~| NOTE also a pattern
         //~| NOTE bindings are `x`, `mut x`, `ref x`, and `ref mut x`
         _ => {}
     }

--- a/tests/ui/parser/issues/issue-101477-enum.fixed
+++ b/tests/ui/parser/issues/issue-101477-enum.fixed
@@ -4,7 +4,7 @@
 enum Demo {
     A = 1,
     B = 2 //~ ERROR unexpected `==`
-    //~^ expected item, found `==`
+    //~^ ERROR expected item, found `==`
 }
 
 fn main() {}

--- a/tests/ui/parser/issues/issue-101477-enum.rs
+++ b/tests/ui/parser/issues/issue-101477-enum.rs
@@ -4,7 +4,7 @@
 enum Demo {
     A = 1,
     B == 2 //~ ERROR unexpected `==`
-    //~^ expected item, found `==`
+    //~^ ERROR expected item, found `==`
 }
 
 fn main() {}

--- a/tests/ui/parser/issues/issue-102806.rs
+++ b/tests/ui/parser/issues/issue-102806.rs
@@ -15,7 +15,7 @@ fn pz(v: V3) {
     //~^ ERROR expected `..`
 
     let _ = V3 { z: 0.0, ... };
-    //~^ expected identifier
+    //~^ ERROR expected identifier
     //~| ERROR missing fields `x` and `y` in initializer of `V3`
 
     let V3 { z: val, ... } = v;

--- a/tests/ui/parser/issues/issue-89574.rs
+++ b/tests/ui/parser/issues/issue-89574.rs
@@ -1,5 +1,5 @@
 fn main() {
     const EMPTY_ARRAY = [];
-    //~^ missing type for `const` item
+    //~^ ERROR missing type for `const` item
     //~| ERROR type annotations needed
 }

--- a/tests/ui/parser/issues/issue-93867.rs
+++ b/tests/ui/parser/issues/issue-93867.rs
@@ -5,6 +5,6 @@ pub struct Entry<'a, K, V> {
 
 pub fn entry<'a, K, V>() -> Entry<'a K, V> {
 //                                  ^ missing comma
-//~^^ expected one of `,` or `>`, found `K`
+//~^^ ERROR expected one of `,` or `>`, found `K`
     unimplemented!()
 }

--- a/tests/ui/parser/macro/macro-expand-to-field.rs
+++ b/tests/ui/parser/macro/macro-expand-to-field.rs
@@ -49,7 +49,7 @@ enum EnumVariantField {
         field!(oopsies:()),
         //~^ NOTE macros cannot expand to struct fields
         //~| ERROR unexpected token: `!`
-        //~| unexpected token after this
+        //~| NOTE unexpected token after this
         field!(oopsies2:()),
     },
 }

--- a/tests/ui/parser/raw/issue-70677-panic-on-unterminated-raw-str-at-eof.rs
+++ b/tests/ui/parser/raw/issue-70677-panic-on-unterminated-raw-str-at-eof.rs
@@ -2,4 +2,4 @@
 // the last byte in the file (including not having a trailing newline)
 // Prior to the fix you get the error: 'expected item, found `r" ...`'
 // because the string being unterminated wasn't properly detected.
-r" //~ unterminated raw string
+r" //~ ERROR unterminated raw string

--- a/tests/ui/parser/raw/raw-byte-string-eof.rs
+++ b/tests/ui/parser/raw/raw-byte-string-eof.rs
@@ -1,3 +1,3 @@
 pub fn main() {
-    br##"a"#;  //~ unterminated raw string
+    br##"a"#;  //~ ERROR unterminated raw string
 }

--- a/tests/ui/parser/recover/recover-fn-trait-from-fn-kw.rs
+++ b/tests/ui/parser/recover/recover-fn-trait-from-fn-kw.rs
@@ -6,7 +6,7 @@ fn foo2<T: fn(i32)>(_: T) {}
 
 fn main() {
     foo(|| ());
-    //~^ mismatched types
+    //~^ ERROR mismatched types
     foo2(|_: ()| {});
-    //~^ type mismatch in closure arguments
+    //~^ ERROR type mismatch in closure arguments
 }

--- a/tests/ui/parser/require-parens-for-chained-comparison.rs
+++ b/tests/ui/parser/require-parens-for-chained-comparison.rs
@@ -27,7 +27,7 @@ fn main() {
     //~| ERROR invalid label name
 
     f<'_>();
-    //~^ comparison operators cannot be chained
+    //~^ ERROR comparison operators cannot be chained
     //~| HELP use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
     //~| ERROR expected
     //~| HELP add `'` to close the char literal

--- a/tests/ui/parser/shebang/issue-71471-ignore-tidy.rs
+++ b/tests/ui/parser/shebang/issue-71471-ignore-tidy.rs
@@ -1,4 +1,4 @@
 
-#!B //~ expected `[`, found `B`
+#!B //~ ERROR expected `[`, found `B`
 
 //@ reference: input.shebang

--- a/tests/ui/parser/shebang/shebang-must-start-file.rs
+++ b/tests/ui/parser/shebang/shebang-must-start-file.rs
@@ -1,5 +1,5 @@
 // something on the first line for tidy
-#!/bin/bash  //~ expected `[`, found `/`
+#!/bin/bash  //~ ERROR expected `[`, found `/`
 
 //@ reference: input.shebang
 

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.fixed
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.fixed
@@ -5,6 +5,6 @@ fn main() {
     fn x(a: &char) {
         let &(mut b) = a;
         b.make_ascii_uppercase();
-//~^ cannot borrow `b` as mutable, as it is not declared as mutable
+        //~^ ERROR cannot borrow `b` as mutable, as it is not declared as mutable
     }
 }

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.rs
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.rs
@@ -5,6 +5,6 @@ fn main() {
     fn x(a: &char) {
         let &b = a;
         b.make_ascii_uppercase();
-//~^ cannot borrow `b` as mutable, as it is not declared as mutable
+        //~^ ERROR cannot borrow `b` as mutable, as it is not declared as mutable
     }
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.rs
@@ -13,14 +13,14 @@
 /// to fail in HIR typeck on stable. As such, they need to be separate from the other tests.
 fn errors_caught_in_hir_typeck_on_stable() {
     let [&x] = &[&mut 0];
-    //[stable2021]~^ mismatched types
+    //[stable2021]~^ ERROR mismatched types
     //[stable2021]~| types differ in mutability
     //[classic2024]~^^^ ERROR: cannot move out of type
     #[cfg(any(classic2021, structural2021))] let _: u32 = x;
     #[cfg(structural2024)] let _: &u32 = x;
 
     let [&x] = &mut [&mut 0];
-    //[stable2021]~^ mismatched types
+    //[stable2021]~^ ERROR mismatched types
     //[stable2021]~| types differ in mutability
     //[classic2024]~^^^ ERROR: cannot move out of type
     #[cfg(any(classic2021, structural2021))] let _: u32 = x;
@@ -34,7 +34,7 @@ pub fn main() {
     }
 
     let &ref mut x = &0;
-    //~^ cannot borrow data in a `&` reference as mutable [E0596]
+    //~^ ERROR cannot borrow data in a `&` reference as mutable [E0596]
 
     // For 2021 edition, this is also a regression test for #136223
     // since the maximum mutability is downgraded during the pattern check process.

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mut-ref-mut.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mut-ref-mut.rs
@@ -28,6 +28,6 @@ pub fn main() {
     let [&mut mut x] = &[&mut 0];
     //[classic2024]~^ ERROR: mismatched types
     //[classic2024]~| cannot match inherited `&` with `&mut` pattern
-    //[structural2024]~^^^ binding cannot be both mutable and by-reference
+    //[structural2024]~^^^ ERROR binding cannot be both mutable and by-reference
     #[cfg(any(stable2021, classic2021, structural2021))] { x = 0 }
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.rs
@@ -30,63 +30,63 @@ pub fn main() {
         #[cfg(any(classic2024, structural2024))] let _: &u32 = x;
     }
     if let Some(Some(&&x)) = &Some(Some(&0)) {
-        //[stable2021,classic2021,structural2021]~^ mismatched types
+        //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
         //[stable2021,classic2021,structural2021]~| expected integer, found `&_`
         #[cfg(any(classic2024, structural2024))] let _: u32 = x;
     }
 
     // Tests for eating a lone inherited reference
     if let Some(Some(&x)) = &Some(&Some(0)) {
-        //[stable2021]~^ mismatched types
+        //[stable2021]~^ ERROR mismatched types
         //[stable2021]~| expected integer, found `&_`
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
     if let Some(&Some(x)) = &Some(Some(0)) {
-        //[stable2021]~^ mismatched types
+        //[stable2021]~^ ERROR mismatched types
         //[stable2021]~| expected `Option<{integer}>`, found `&_`
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
     if let Some(Some(&mut x)) = &mut Some(&mut Some(0)) {
-        //[stable2021]~^ mismatched types
+        //[stable2021]~^ ERROR mismatched types
         //[stable2021]~| expected integer, found `&mut _`
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
 
     // Tests for `&` patterns matching real `&mut` reference types
     if let Some(&Some(&x)) = Some(&Some(&mut 0)) {
-        //[stable2021]~^ mismatched types
+        //[stable2021]~^ ERROR mismatched types
         //[stable2021]~| types differ in mutability
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
 
     // Tests for eating only one layer and also eating a lone inherited reference
     if let Some(&Some(&x)) = &Some(&Some(0)) {
-        //[stable2021,classic2021,structural2021]~^ mismatched types
+        //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
         //[stable2021,classic2021,structural2021]~| expected integer, found `&_`
         #[cfg(any(classic2024, structural2024))] let _: u32 = x;
     }
 
     // Tests for `&` matching a lone inherited possibly-`&mut` reference
     if let Some(&Some(Some(&x))) = &Some(Some(&mut Some(0))) {
-        //[stable2021]~^ mismatched types
+        //[stable2021]~^ ERROR mismatched types
         //[stable2021]~| expected `Option<&mut Option<{integer}>>`, found `&_`
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
     if let Some(&Some(x)) = &mut Some(Some(0)) {
-        //[stable2021]~^ mismatched types
+        //[stable2021]~^ ERROR mismatched types
         //[stable2021]~| expected `Option<{integer}>`, found `&_`
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
 
     // Tests eating one layer, eating a lone inherited ref, and `&` eating `&mut` (realness varies)
     if let Some(&Some(&x)) = &Some(&mut Some(0)) {
-        //[stable2021,classic2021,structural2021]~^ mismatched types
+        //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
         //[stable2021]~| types differ in mutability
         //[classic2021,structural2021]~| expected integer, found `&_`
         #[cfg(any(classic2024, structural2024))] let _: u32 = x;
     }
     if let Some(&Some(&x)) = &mut Some(&Some(0)) {
-        //[stable2021,classic2021,structural2021]~^ mismatched types
+        //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
         //[stable2021,classic2021,structural2021]~| expected integer, found `&_`
         #[cfg(any(classic2024, structural2024))] let _: u32 = x;
     }
@@ -94,46 +94,46 @@ pub fn main() {
     // Tests for eat-inner and eat-both rulesets matching on the outer reference if matching on the
     // inner reference causes a mutability mismatch. i.e. tests for "fallback-to-outer" deref rules.
     let [&mut x] = &mut [&0];
-    //[stable2021]~^ mismatched types
+    //[stable2021]~^ ERROR mismatched types
     //[stable2021]~| types differ in mutability
     #[cfg(any(classic2021, structural2021))] let _: u32 = x;
     #[cfg(any(classic2024, structural2024))] let _: &u32 = x;
 
     let [&mut ref x] = &mut [&0];
-    //[stable2021]~^ mismatched types
+    //[stable2021]~^ ERROR mismatched types
     //[stable2021]~| types differ in mutability
     #[cfg(any(classic2021, structural2021))] let _: &u32 = x;
     #[cfg(any(classic2024, structural2024))] let _: &&u32 = x;
 
     fn borrowck_error_on_structural2021() {
         let [&mut ref mut x] = &mut [&0];
-        //[stable2021]~^ mismatched types
+        //[stable2021]~^ ERROR mismatched types
         //[stable2021]~| types differ in mutability
-        //[classic2021,structural2021]~^^^ cannot borrow data in a `&` reference as mutable
+        //[classic2021,structural2021]~^^^ ERROR cannot borrow data in a `&` reference as mutable
         #[cfg(any(classic2024, structural2024))] let _: &mut &u32 = x;
     }
     borrowck_error_on_structural2021();
 
     let [&mut mut x] = &mut [&0];
-    //[stable2021]~^ mismatched types
+    //[stable2021]~^ ERROR mismatched types
     //[stable2021]~| types differ in mutability
     #[cfg(any(classic2021, structural2021))] let _: u32 = x;
     #[cfg(any(classic2024, structural2024))] let _: &u32 = x;
 
     let [&mut &x] = &mut [&0];
-    //[stable2021,classic2021,structural2021]~^ mismatched types
+    //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
     //[stable2021]~| types differ in mutability
     //[classic2021,structural2021]~| expected integer, found `&_`
     #[cfg(any(classic2024, structural2024))] let _: u32 = x;
 
     let [&mut &ref x] = &mut [&0];
-    //[stable2021,classic2021,structural2021]~^ mismatched types
+    //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
     //[stable2021]~| types differ in mutability
     //[classic2021,structural2021]~| expected integer, found `&_`
     #[cfg(any(classic2024, structural2024))] let _: &u32 = x;
 
     let [&mut &(mut x)] = &mut [&0];
-    //[stable2021,classic2021,structural2021]~^ mismatched types
+    //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
     //[stable2021]~| types differ in mutability
     //[classic2021,structural2021]~| expected integer, found `&_`
     #[cfg(any(classic2024, structural2024))] let _: u32 = x;

--- a/tests/ui/pattern/usefulness/doc-hidden-fields.rs
+++ b/tests/ui/pattern/usefulness/doc-hidden-fields.rs
@@ -13,14 +13,14 @@ struct InCrate {
 
 fn main() {
     let HiddenStruct { one, two } = HiddenStruct::default();
-    //~^ pattern requires `..` due to inaccessible fields
+    //~^ ERROR pattern requires `..` due to inaccessible fields
 
     let HiddenStruct { one } = HiddenStruct::default();
-    //~^ pattern does not mention field `two` and inaccessible fields
+    //~^ ERROR pattern does not mention field `two` and inaccessible fields
 
     let HiddenStruct { one, hide } = HiddenStruct::default();
-    //~^ pattern does not mention field `two`
+    //~^ ERROR pattern does not mention field `two`
 
     let InCrate { a, b } = InCrate { a: 0, b: false, im_hidden: 0 };
-    //~^ pattern does not mention field `im_hidden`
+    //~^ ERROR pattern does not mention field `im_hidden`
 }

--- a/tests/ui/pattern/usefulness/doc-hidden-non-exhaustive.rs
+++ b/tests/ui/pattern/usefulness/doc-hidden-non-exhaustive.rs
@@ -16,28 +16,28 @@ fn main() {
         HiddenEnum::A => {}
         HiddenEnum::B => {}
     }
-    //~^^^^ non-exhaustive patterns: `_` not covered
+    //~^^^^ ERROR non-exhaustive patterns: `_` not covered
 
     match HiddenEnum::A {
         HiddenEnum::A => {}
         HiddenEnum::C => {}
     }
-    //~^^^^ non-exhaustive patterns: `HiddenEnum::B` not covered
+    //~^^^^ ERROR non-exhaustive patterns: `HiddenEnum::B` not covered
 
     match HiddenEnum::A {
         HiddenEnum::A => {}
     }
-    //~^^^ non-exhaustive patterns: `HiddenEnum::B` and `_` not covered
+    //~^^^ ERROR non-exhaustive patterns: `HiddenEnum::B` and `_` not covered
 
     match None {
         None => {}
         Some(HiddenEnum::A) => {}
     }
-    //~^^^^ non-exhaustive patterns: `Some(HiddenEnum::B)` and `Some(_)` not covered
+    //~^^^^ ERROR non-exhaustive patterns: `Some(HiddenEnum::B)` and `Some(_)` not covered
 
     match InCrate::A {
         InCrate::A => {}
         InCrate::B => {}
     }
-    //~^^^^ non-exhaustive patterns: `InCrate::C` not covered
+    //~^^^^ ERROR non-exhaustive patterns: `InCrate::C` not covered
 }

--- a/tests/ui/pattern/usefulness/non-exhaustive-defined-here.rs
+++ b/tests/ui/pattern/usefulness/non-exhaustive-defined-here.rs
@@ -24,12 +24,12 @@ enum E {
     //~| NOTE  not covered
     //~| NOTE  not covered
     C
-    //~^ not covered
-    //~| not covered
-    //~| not covered
-    //~| not covered
-    //~| not covered
-    //~| not covered
+    //~^ NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
+    //~| NOTE not covered
 }
 
 fn by_val(e: E) {
@@ -42,7 +42,7 @@ fn by_val(e: E) {
 
     let E::A = e;
     //~^ ERROR refutable pattern in local binding
-    //~| patterns `E::B` and `E::C` not covered
+    //~| NOTE patterns `E::B` and `E::C` not covered
     //~| NOTE `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with
     //~| NOTE for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
     //~| NOTE the matched value is of type `E`
@@ -51,14 +51,14 @@ fn by_val(e: E) {
 fn by_ref_once(e: &E) {
     match e {
     //~^ ERROR non-exhaustive patterns
-    //~| patterns `&E::B` and `&E::C` not covered
+    //~| NOTE patterns `&E::B` and `&E::C` not covered
     //~| NOTE the matched value is of type `&E`
         E::A => {}
     }
 
     let E::A = e;
     //~^ ERROR refutable pattern in local binding
-    //~| patterns `&E::B` and `&E::C` not covered
+    //~| NOTE patterns `&E::B` and `&E::C` not covered
     //~| NOTE `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with
     //~| NOTE for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
     //~| NOTE the matched value is of type `&E`
@@ -67,14 +67,14 @@ fn by_ref_once(e: &E) {
 fn by_ref_thrice(e: & &mut &E) {
     match e {
     //~^ ERROR non-exhaustive patterns
-    //~| patterns `&&mut &E::B` and `&&mut &E::C` not covered
+    //~| NOTE patterns `&&mut &E::B` and `&&mut &E::C` not covered
     //~| NOTE the matched value is of type `&&mut &E`
         E::A => {}
     }
 
     let E::A = e;
     //~^ ERROR refutable pattern in local binding
-    //~| patterns `&&mut &E::B` and `&&mut &E::C` not covered
+    //~| NOTE patterns `&&mut &E::B` and `&&mut &E::C` not covered
     //~| NOTE `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with
     //~| NOTE for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
     //~| NOTE the matched value is of type `&&mut &E`
@@ -93,7 +93,7 @@ enum Opt {
 fn ref_pat(e: Opt) {
     match e {
         //~^ ERROR non-exhaustive patterns
-        //~| pattern `Opt::None` not covered
+        //~| NOTE pattern `Opt::None` not covered
         //~| NOTE the matched value is of type `Opt`
         Opt::Some(ref _x) => {}
     }

--- a/tests/ui/pattern/usefulness/stable-gated-fields.rs
+++ b/tests/ui/pattern/usefulness/stable-gated-fields.rs
@@ -6,10 +6,10 @@ use unstable::UnstableStruct;
 
 fn main() {
     let UnstableStruct { stable } = UnstableStruct::default();
-    //~^ pattern does not mention field `stable2` and inaccessible fields
+    //~^ ERROR pattern does not mention field `stable2` and inaccessible fields
 
     let UnstableStruct { stable, stable2 } = UnstableStruct::default();
-    //~^ pattern requires `..` due to inaccessible fields
+    //~^ ERROR pattern requires `..` due to inaccessible fields
 
     // OK: stable field is matched
     let UnstableStruct { stable, stable2, .. } = UnstableStruct::default();

--- a/tests/ui/pattern/usefulness/stable-gated-patterns.rs
+++ b/tests/ui/pattern/usefulness/stable-gated-patterns.rs
@@ -8,11 +8,11 @@ fn main() {
     match UnstableEnum::Stable {
         UnstableEnum::Stable => {}
     }
-    //~^^^ non-exhaustive patterns: `UnstableEnum::Stable2` and `_` not covered
+    //~^^^ ERROR non-exhaustive patterns: `UnstableEnum::Stable2` and `_` not covered
 
     match UnstableEnum::Stable {
         UnstableEnum::Stable => {}
         UnstableEnum::Stable2 => {}
     }
-    //~^^^^ non-exhaustive patterns: `_` not covered
+    //~^^^^ ERROR non-exhaustive patterns: `_` not covered
 }

--- a/tests/ui/pattern/usefulness/unstable-gated-fields.rs
+++ b/tests/ui/pattern/usefulness/unstable-gated-fields.rs
@@ -8,10 +8,10 @@ use unstable::UnstableStruct;
 
 fn main() {
     let UnstableStruct { stable, stable2, } = UnstableStruct::default();
-    //~^ pattern does not mention field `unstable`
+    //~^ ERROR pattern does not mention field `unstable`
 
     let UnstableStruct { stable, unstable, } = UnstableStruct::default();
-    //~^ pattern does not mention field `stable2`
+    //~^ ERROR pattern does not mention field `stable2`
 
     // OK: stable field is matched
     let UnstableStruct { stable, stable2, unstable } = UnstableStruct::default();

--- a/tests/ui/pattern/usefulness/unstable-gated-patterns.rs
+++ b/tests/ui/pattern/usefulness/unstable-gated-patterns.rs
@@ -11,7 +11,7 @@ fn main() {
         UnstableEnum::Stable => {}
         UnstableEnum::Stable2 => {}
     }
-    //~^^^^ non-exhaustive patterns: `UnstableEnum::Unstable` not covered
+    //~^^^^ ERROR non-exhaustive patterns: `UnstableEnum::Unstable` not covered
 
     // Ok: all variants are explicitly matched
     match UnstableEnum::Stable {

--- a/tests/ui/privacy/privacy3.rs
+++ b/tests/ui/privacy/privacy3.rs
@@ -22,7 +22,7 @@ fn test1() {
     //~^ ERROR requires `sized` lang_item
     use bar::gpriv;
     //~^ ERROR unresolved import `bar::gpriv` [E0432]
-    //~| no `gpriv` in `bar`
+    //~| NOTE no `gpriv` in `bar`
 
     // This should pass because the compiler will insert a fake name binding
     // for `gpriv`

--- a/tests/ui/proc-macro/issue-50493.rs
+++ b/tests/ui/proc-macro/issue-50493.rs
@@ -5,7 +5,7 @@ extern crate issue_50493;
 
 #[derive(Derive)]
 struct Restricted {
-    pub(in restricted) field: usize, //~ visibilities can only be restricted to ancestor modules
+    pub(in restricted) field: usize, //~ ERROR visibilities can only be restricted to ancestor modules
 }
 
 mod restricted {}

--- a/tests/ui/proc-macro/pub-at-crate-root.rs
+++ b/tests/ui/proc-macro/pub-at-crate-root.rs
@@ -5,7 +5,7 @@
 
 extern crate proc_macro;
 
-pub mod a { //~ `proc-macro` crate types currently cannot export any items
+pub mod a { //~ ERROR `proc-macro` crate types currently cannot export any items
     use proc_macro::TokenStream;
 
     #[proc_macro_derive(B)]

--- a/tests/ui/pub/pub-restricted.rs
+++ b/tests/ui/pub/pub-restricted.rs
@@ -1,8 +1,8 @@
 mod a {}
 
-pub (a) fn afn() {} //~ incorrect visibility restriction
-pub (b) fn bfn() {} //~ incorrect visibility restriction
-pub (crate::a) fn cfn() {} //~ incorrect visibility restriction
+pub (a) fn afn() {} //~ ERROR incorrect visibility restriction
+pub (b) fn bfn() {} //~ ERROR incorrect visibility restriction
+pub (crate::a) fn cfn() {} //~ ERROR incorrect visibility restriction
 
 pub fn privfn() {}
 mod x {
@@ -19,7 +19,7 @@ mod y {
         pub (super) s: usize,
         valid_private: usize,
         pub (in y) valid_in_x: usize,
-        pub (a) invalid: usize, //~ incorrect visibility restriction
+        pub (a) invalid: usize, //~ ERROR incorrect visibility restriction
         pub (in x) non_parent_invalid: usize, //~ ERROR visibilities can only be restricted
     }
 }
@@ -28,4 +28,4 @@ fn main() {}
 
 // test multichar names
 mod xyz {}
-pub (xyz) fn xyz() {} //~ incorrect visibility restriction
+pub (xyz) fn xyz() {} //~ ERROR incorrect visibility restriction

--- a/tests/ui/repr/attr-usage-repr.rs
+++ b/tests/ui/repr/attr-usage-repr.rs
@@ -45,7 +45,7 @@ enum EInt {
     B,
 }
 
-#[repr()] //~ attribute should be applied to a struct, enum, function, associated function, or union [E0517]
+#[repr()] //~ ERROR attribute should be applied to a struct, enum, function, associated function, or union [E0517]
 type SirThisIsAType = i32;
 
 #[repr()]

--- a/tests/ui/resolve/crate-called-as-function.rs
+++ b/tests/ui/resolve/crate-called-as-function.rs
@@ -1,3 +1,3 @@
 fn main() {
-    ::foo() //~ cannot find external crate `foo` in the crate root
+    ::foo() //~ ERROR cannot find external crate `foo` in the crate root
 }

--- a/tests/ui/resolve/issue-118295.rs
+++ b/tests/ui/resolve/issue-118295.rs
@@ -1,11 +1,11 @@
 macro_rules! {}
 //~^ ERROR cannot find macro `macro_rules` in this scope
 //~| NOTE maybe you have forgotten to define a name for this `macro_rules!`
-//~| put a macro name here
+//~| NOTE put a macro name here
 
 macro_rules!{}
 //~^ ERROR cannot find macro `macro_rules` in this scope
 //~| NOTE maybe you have forgotten to define a name for this `macro_rules!`
-//~| put a macro name here
+//~| NOTE put a macro name here
 
 fn main() {}

--- a/tests/ui/resolve/tool-import.rs
+++ b/tests/ui/resolve/tool-import.rs
@@ -1,7 +1,7 @@
 //@ edition: 2018
 
 use clippy::time::Instant;
-//~^ `clippy` is a tool module
+//~^ ERROR `clippy` is a tool module
 
 fn main() {
     Instant::now();

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.rs
@@ -63,14 +63,14 @@ fn main() {
     }
 
     match non_enum {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         NonExhaustiveEnum::Unit => {}
         NonExhaustiveEnum::Tuple(_) => {}
         _ => {}
     }
 
     match non_enum {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         NonExhaustiveEnum::Unit | NonExhaustiveEnum::Struct { .. } => {}
         _ => {}
     }
@@ -91,7 +91,7 @@ fn main() {
         _ => {}
     }
     match (non_enum, true) {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         (NonExhaustiveEnum::Unit, true) => {}
         (NonExhaustiveEnum::Tuple(_), false) => {}
         _ => {}
@@ -104,14 +104,14 @@ fn main() {
         _ => {}
     }
     match (true, non_enum) {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         (true, NonExhaustiveEnum::Unit) => {}
         (false, NonExhaustiveEnum::Tuple(_)) => {}
         _ => {}
     }
 
     match Some(non_enum) {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         Some(NonExhaustiveEnum::Unit) => {}
         Some(NonExhaustiveEnum::Tuple(_)) => {}
         _ => {}
@@ -127,7 +127,7 @@ fn main() {
     }
 
     match NestedNonExhaustive::B {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         NestedNonExhaustive::A(NonExhaustiveEnum::Unit) => {}
         NestedNonExhaustive::A(_) => {}
         NestedNonExhaustive::B => {}
@@ -138,17 +138,17 @@ fn main() {
         VariantNonExhaustive::Baz(_, _) => {}
         VariantNonExhaustive::Bar { x, .. } => {}
     }
-    //~^^ some fields are not explicitly listed
+    //~^^ ERROR some fields are not explicitly listed
 
     let FunctionalRecord { first_field, second_field, .. } = FunctionalRecord::default();
-    //~^ some fields are not explicitly listed
+    //~^ ERROR some fields are not explicitly listed
 
     // Ok: this is local
     let Foo { a, b, .. } = Foo::default();
 
     let NestedStruct { bar: NormalStruct { first_field, .. }, .. } = NestedStruct::default();
-    //~^ some fields are not explicitly listed
-    //~^^ some fields are not explicitly listed
+    //~^ ERROR some fields are not explicitly listed
+    //~^^ ERROR some fields are not explicitly listed
 
     // Ok: this tests https://github.com/rust-lang/rust/issues/89382
     let MixedVisFields { a, b, .. } = MixedVisFields::default();
@@ -182,7 +182,7 @@ fn main() {
     if let NonExhaustiveEnum::Tuple(_) = non_enum {}
 
     match UnstableEnum::Stable {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         UnstableEnum::Stable => {}
         UnstableEnum::Stable2 => {}
         _ => {}
@@ -204,19 +204,19 @@ fn main() {
     }
 
     match OnlyUnstableEnum::Unstable {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         OnlyUnstableEnum::Unstable => {}
         _ => {}
     }
 
     let OnlyUnstableStruct { unstable, .. } = OnlyUnstableStruct::new();
-    //~^ some fields are not explicitly listed
+    //~^ ERROR some fields are not explicitly listed
 
     // OK: both unstable fields are matched with feature on
     let OnlyUnstableStruct { unstable, unstable2, .. } = OnlyUnstableStruct::new();
 
     let UnstableStruct { stable, stable2, .. } = UnstableStruct::default();
-    //~^ some fields are not explicitly listed
+    //~^ ERROR some fields are not explicitly listed
 
     // OK: both unstable and stable fields are matched with feature on
     let UnstableStruct { stable, stable2, unstable, .. } = UnstableStruct::default();
@@ -226,11 +226,11 @@ fn main() {
 
     // Ok: missing patterns will be blocked by the pattern being refutable
     let local_refutable @ NonExhaustiveEnum::Unit = NonExhaustiveEnum::Unit;
-    //~^ refutable pattern in local binding
+    //~^ ERROR refutable pattern in local binding
 
     // Check that matching on a reference results in a correct diagnostic
     match &non_enum {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         //~| pattern `&NonExhaustiveEnum::Struct { .. }` not covered
         NonExhaustiveEnum::Unit => {}
         NonExhaustiveEnum::Tuple(_) => {}
@@ -238,21 +238,21 @@ fn main() {
     }
 
     match (true, &non_enum) {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         //~| patterns `(_, &NonExhaustiveEnum::Tuple(_))` and `(_, &NonExhaustiveEnum::Struct { .. })` not covered
         (true, NonExhaustiveEnum::Unit) => {}
         _ => {}
     }
 
     match (&non_enum, true) {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         //~| patterns `(&NonExhaustiveEnum::Tuple(_), _)` and `(&NonExhaustiveEnum::Struct { .. }, _)` not covered
         (NonExhaustiveEnum::Unit, true) => {}
         _ => {}
     }
 
     match Some(&non_enum) {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         //~| pattern `Some(&NonExhaustiveEnum::Struct { .. })` not covered
         Some(NonExhaustiveEnum::Unit | NonExhaustiveEnum::Tuple(_)) => {}
         _ => {}

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/stable-omitted-patterns.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/stable-omitted-patterns.rs
@@ -19,7 +19,7 @@ fn main() {
 
     #[deny(non_exhaustive_omitted_patterns)]
     match UnstableEnum::Stable {
-        //~^ some variants are not matched explicitly
+        //~^ ERROR some variants are not matched explicitly
         UnstableEnum::Stable => {}
         _ => {}
     }
@@ -37,7 +37,7 @@ fn main() {
 
     #[warn(non_exhaustive_omitted_patterns)]
     let UnstableStruct { stable, .. } = UnstableStruct::default();
-    //~^ some fields are not explicitly listed
+    //~^ WARN some fields are not explicitly listed
 
     // OK: stable field is matched
     #[warn(non_exhaustive_omitted_patterns)]

--- a/tests/ui/rfcs/rfc-2093-infer-outlives/regions-enum-not-wf.rs
+++ b/tests/ui/rfcs/rfc-2093-infer-outlives/regions-enum-not-wf.rs
@@ -33,7 +33,7 @@ enum RefIndirect<'a, T> {
 
 enum RefDouble<'a, 'b, T> {
     RefDoubleVariant1(&'a RequireOutlives<'b, T>),
-    //~^ the parameter type `T` may not live long enough [E0309]
+    //~^ ERROR the parameter type `T` may not live long enough [E0309]
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2457-non-ascii-idents/extern_block_nonascii_forbidden.rs
+++ b/tests/ui/rfcs/rfc-2457-non-ascii-idents/extern_block_nonascii_forbidden.rs
@@ -1,9 +1,9 @@
 #![feature(extern_types)]
 
 extern "C" {
-    type 一; //~ items in `extern` blocks cannot use non-ascii identifiers
-    fn 二(); //~ items in `extern` blocks cannot use non-ascii identifiers
-    static 三: usize; //~ items in `extern` blocks cannot use non-ascii identifiers
+    type 一; //~ ERROR items in `extern` blocks cannot use non-ascii identifiers
+    fn 二(); //~ ERROR items in `extern` blocks cannot use non-ascii identifiers
+    static 三: usize; //~ ERROR items in `extern` blocks cannot use non-ascii identifiers
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2457-non-ascii-idents/mod_file_nonascii_forbidden.rs
+++ b/tests/ui/rfcs/rfc-2457-non-ascii-idents/mod_file_nonascii_forbidden.rs
@@ -1,4 +1,4 @@
-mod řųśť; //~ trying to load file for
-//~^ file not found for
+mod řųśť; //~ ERROR trying to load file for
+//~^ ERROR file not found for
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2457-non-ascii-idents/no_mangle_nonascii_forbidden.rs
+++ b/tests/ui/rfcs/rfc-2457-non-ascii-idents/no_mangle_nonascii_forbidden.rs
@@ -1,11 +1,11 @@
 #[no_mangle]
-pub fn řųśť() {}  //~ `#[no_mangle]` requires ASCII identifier
+pub fn řųśť() {}  //~ ERROR `#[no_mangle]` requires ASCII identifier
 
 pub struct Foo;
 
 impl Foo {
     #[no_mangle]
-    pub fn řųśť() {}  //~ `#[no_mangle]` requires ASCII identifier
+    pub fn řųśť() {}  //~ ERROR `#[no_mangle]` requires ASCII identifier
 }
 
 trait Bar {
@@ -14,7 +14,7 @@ trait Bar {
 
 impl Bar for Foo {
     #[no_mangle]
-    fn řųśť() {}  //~ `#[no_mangle]` requires ASCII identifier
+    fn řųśť() {}  //~ ERROR `#[no_mangle]` requires ASCII identifier
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.rs
+++ b/tests/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.rs
@@ -6,7 +6,7 @@ struct P<T> {
 
 impl<T> P<T> {
     fn y(&self, y: f64) -> Self { P{y, .. self.clone() } }
-                                       //~^ mismatched types [E0308]
+    //~^ ERROR mismatched types [E0308]
 }
 
 fn main() {}

--- a/tests/ui/rust-2018/edition-lint-nested-paths.fixed
+++ b/tests/ui/rust-2018/edition-lint-nested-paths.fixed
@@ -4,9 +4,9 @@
 
 use crate::foo::{a, b};
 //~^ ERROR absolute paths must start with
-//~| this is accepted in the current edition
+//~| WARN this is accepted in the current edition
 //~| ERROR absolute paths must start with
-//~| this is accepted in the current edition
+//~| WARN this is accepted in the current edition
 
 mod foo {
     pub(crate) fn a() {}
@@ -21,9 +21,9 @@ fn main() {
     {
         use crate::foo::{self as x, c};
         //~^ ERROR absolute paths must start with
-        //~| this is accepted in the current edition
+        //~| WARN this is accepted in the current edition
         //~| ERROR absolute paths must start with
-        //~| this is accepted in the current edition
+        //~| WARN this is accepted in the current edition
         x::a();
         c();
     }

--- a/tests/ui/rust-2018/edition-lint-nested-paths.rs
+++ b/tests/ui/rust-2018/edition-lint-nested-paths.rs
@@ -4,9 +4,9 @@
 
 use foo::{a, b};
 //~^ ERROR absolute paths must start with
-//~| this is accepted in the current edition
+//~| WARN this is accepted in the current edition
 //~| ERROR absolute paths must start with
-//~| this is accepted in the current edition
+//~| WARN this is accepted in the current edition
 
 mod foo {
     pub(crate) fn a() {}
@@ -21,9 +21,9 @@ fn main() {
     {
         use foo::{self as x, c};
         //~^ ERROR absolute paths must start with
-        //~| this is accepted in the current edition
+        //~| WARN this is accepted in the current edition
         //~| ERROR absolute paths must start with
-        //~| this is accepted in the current edition
+        //~| WARN this is accepted in the current edition
         x::a();
         c();
     }

--- a/tests/ui/rust-2021/future-prelude-collision-generic-trait.fixed
+++ b/tests/ui/rust-2021/future-prelude-collision-generic-trait.fixed
@@ -23,7 +23,7 @@ where
     fn try_into(&self) -> Result<&U, i32> {
         <U as PyTryFrom<'_, _>>::try_from(self)
         //~^ WARNING trait-associated function `try_from` will become ambiguous in Rust 2021
-        //~| this is accepted in the current edition (Rust 2018)
+        //~| WARN this is accepted in the current edition (Rust 2018)
     }
 }
 

--- a/tests/ui/rust-2021/future-prelude-collision-generic-trait.rs
+++ b/tests/ui/rust-2021/future-prelude-collision-generic-trait.rs
@@ -23,7 +23,7 @@ where
     fn try_into(&self) -> Result<&U, i32> {
         U::try_from(self)
         //~^ WARNING trait-associated function `try_from` will become ambiguous in Rust 2021
-        //~| this is accepted in the current edition (Rust 2018)
+        //~| WARN this is accepted in the current edition (Rust 2018)
     }
 }
 

--- a/tests/ui/rust-2021/future-prelude-collision-generic.fixed
+++ b/tests/ui/rust-2021/future-prelude-collision-generic.fixed
@@ -27,11 +27,11 @@ impl std::iter::FromIterator<i32> for Generic<'static, i32> {
 fn main() {
     <Generic<'_, _> as MyFromIter>::from_iter(1);
     //~^ WARNING trait-associated function `from_iter` will become ambiguous in Rust 2021
-    //~| this is accepted in the current edition (Rust 2018)
+    //~| WARN this is accepted in the current edition (Rust 2018)
     <Generic::<'static, i32> as MyFromIter>::from_iter(1);
     //~^ WARNING trait-associated function `from_iter` will become ambiguous in Rust 2021
-    //~| this is accepted in the current edition (Rust 2018)
+    //~| WARN this is accepted in the current edition (Rust 2018)
     <Generic::<'_, _> as MyFromIter>::from_iter(1);
     //~^ WARNING trait-associated function `from_iter` will become ambiguous in Rust 2021
-    //~| this is accepted in the current edition (Rust 2018)
+    //~| WARN this is accepted in the current edition (Rust 2018)
 }

--- a/tests/ui/rust-2021/future-prelude-collision-generic.rs
+++ b/tests/ui/rust-2021/future-prelude-collision-generic.rs
@@ -27,11 +27,11 @@ impl std::iter::FromIterator<i32> for Generic<'static, i32> {
 fn main() {
     Generic::from_iter(1);
     //~^ WARNING trait-associated function `from_iter` will become ambiguous in Rust 2021
-    //~| this is accepted in the current edition (Rust 2018)
+    //~| WARN this is accepted in the current edition (Rust 2018)
     Generic::<'static, i32>::from_iter(1);
     //~^ WARNING trait-associated function `from_iter` will become ambiguous in Rust 2021
-    //~| this is accepted in the current edition (Rust 2018)
+    //~| WARN this is accepted in the current edition (Rust 2018)
     Generic::<'_, _>::from_iter(1);
     //~^ WARNING trait-associated function `from_iter` will become ambiguous in Rust 2021
-    //~| this is accepted in the current edition (Rust 2018)
+    //~| WARN this is accepted in the current edition (Rust 2018)
 }

--- a/tests/ui/rust-2024/reserved-guarded-strings.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings.rs
@@ -46,13 +46,13 @@ fn main() {
     //~^ ERROR prefix `blah` is unknown
     //~| ERROR invalid string literal
 
-    demo2!(## "foo"); //~ reserved multi-hash token is forbidden
-    demo3!("foo"###); //~ reserved multi-hash token is forbidden
-    demo3!(### "foo"); //~ reserved multi-hash token is forbidden
-    demo3!(## "foo"#); //~ reserved multi-hash token is forbidden
+    demo2!(## "foo"); //~ ERROR reserved multi-hash token is forbidden
+    demo3!("foo"###); //~ ERROR reserved multi-hash token is forbidden
+    demo3!(### "foo"); //~ ERROR reserved multi-hash token is forbidden
+    demo3!(## "foo"#); //~ ERROR reserved multi-hash token is forbidden
     demo5!(### "foo"###);
-    //~^ reserved multi-hash token is forbidden
-    //~| reserved multi-hash token is forbidden
+    //~^ ERROR reserved multi-hash token is forbidden
+    //~| ERROR reserved multi-hash token is forbidden
 
     demo1!(#""); //~ ERROR invalid string literal
     demo1!(#""#); //~ ERROR invalid string literal

--- a/tests/ui/self/arbitrary_self_type_infinite_recursion.rs
+++ b/tests/ui/self/arbitrary_self_type_infinite_recursion.rs
@@ -10,15 +10,15 @@ struct Content;
 
 impl Content {
   fn method(self: MySmartPtr<Self>) { // note self type
-     //~^ reached the recursion limit
-     //~| reached the recursion limit
-     //~| invalid `self` parameter type
+     //~^ ERROR reached the recursion limit
+     //~| ERROR reached the recursion limit
+     //~| ERROR invalid `self` parameter type
   }
 }
 
 fn main() {
   let p = MySmartPtr(Content);
   p.method();
-  //~^ reached the recursion limit
-  //~| no method named `method`
+  //~^ ERROR reached the recursion limit
+  //~| ERROR no method named `method`
 }

--- a/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.rs
@@ -6,16 +6,16 @@ struct Foo;
 
 impl Foo {
     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 
     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 
 type Alias<T> = Pin<T>;
 impl Foo {
     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/tests/ui/simd/empty-simd-vector-in-operand.rs
+++ b/tests/ui/simd/empty-simd-vector-in-operand.rs
@@ -10,6 +10,6 @@ struct A();
 fn main() {
     unsafe {
         std::arch::asm!("{}", in(xmm_reg) A());
-        //~^ use of empty SIMD vector `A`
+        //~^ ERROR use of empty SIMD vector `A`
     }
 }

--- a/tests/ui/simd/monomorphize-shuffle-index.rs
+++ b/tests/ui/simd/monomorphize-shuffle-index.rs
@@ -34,7 +34,7 @@ trait Shuffle<const N: usize> {
         return simd_shuffle(a, b, Self::I);
         #[cfg(generic)]
         return simd_shuffle_const_generic::<_, _, { &Self::I.0 }>(a, b);
-        //[generic]~^ overly complex generic constant
+        //[generic]~^ ERROR overly complex generic constant
         #[cfg(generic_with_fn)]
         return simd_shuffle_const_generic::<_, _, { Self::J }>(a, b);
     }

--- a/tests/ui/stability-attribute/generics-default-stability.rs
+++ b/tests/ui/stability-attribute/generics-default-stability.rs
@@ -69,30 +69,30 @@ fn main() {
 
     let _ = STRUCT4;
     let _: Struct4<isize> = Struct4 { field: 1 };
-    //~^ use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
-    //~^^ use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
-    //~^^^ use of deprecated field `unstable_generic_param::Struct4::field`: test [deprecated]
+    //~^ WARN use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
+    //~^^ WARN use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
+    //~^^^ WARN use of deprecated field `unstable_generic_param::Struct4::field`: test [deprecated]
     let _ = STRUCT4;
-    let _: Struct4 = STRUCT4; //~ use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
-    let _: Struct4<usize> = STRUCT4; //~ use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
+    let _: Struct4 = STRUCT4; //~ WARN use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
+    let _: Struct4<usize> = STRUCT4; //~ WARN use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
     let _: Struct4<isize> = Struct4 { field: 0 };
-    //~^ use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
-    //~^^ use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
-    //~^^^ use of deprecated field `unstable_generic_param::Struct4::field`: test [deprecated]
+    //~^ WARN use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
+    //~^^ WARN use of deprecated struct `unstable_generic_param::Struct4`: test [deprecated]
+    //~^^^ WARN use of deprecated field `unstable_generic_param::Struct4::field`: test [deprecated]
 
     let _ = STRUCT5;
     let _: Struct5<isize> = Struct5 { field: 1 }; //~ ERROR use of unstable library feature `unstable_default`
-    //~^ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
-    //~^^ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
-    //~^^^ use of deprecated field `unstable_generic_param::Struct5::field`: test [deprecated]
+    //~^ WARN use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
+    //~^^ WARN use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
+    //~^^^ WARN use of deprecated field `unstable_generic_param::Struct5::field`: test [deprecated]
     let _ = STRUCT5;
-    let _: Struct5 = STRUCT5; //~ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
+    let _: Struct5 = STRUCT5; //~ WARN use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
     let _: Struct5<usize> = STRUCT5; //~ ERROR use of unstable library feature `unstable_default`
-    //~^ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
+    //~^ WARN use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
     let _: Struct5<isize> = Struct5 { field: 0 }; //~ ERROR use of unstable library feature `unstable_default`
-    //~^ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
-    //~^^ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
-    //~^^^ use of deprecated field `unstable_generic_param::Struct5::field`: test [deprecated]
+    //~^ WARN use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
+    //~^^ WARN use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
+    //~^^^ WARN use of deprecated field `unstable_generic_param::Struct5::field`: test [deprecated]
 
     let _: Struct6<isize> = Struct6 { field: 1 }; // ok
     let _: Struct6<isize> = Struct6 { field: 0 }; // ok
@@ -145,26 +145,26 @@ fn main() {
 
     let _ = ALIAS4;
     let _: Alias4<isize> = Alias4::Some(1);
-    //~^ use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
-    //~^^ use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
+    //~^ WARN use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
+    //~^^ WARN use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
     let _ = ALIAS4;
-    let _: Alias4 = ALIAS4; //~ use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
-    let _: Alias4<usize> = ALIAS4; //~ use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
+    let _: Alias4 = ALIAS4; //~ WARN use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
+    let _: Alias4<usize> = ALIAS4; //~ WARN use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
     let _: Alias4<isize> = Alias4::Some(0);
-    //~^ use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
-    //~^^ use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
+    //~^ WARN use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
+    //~^^ WARN use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
 
     let _ = ALIAS5;
     let _: Alias5<isize> = Alias5::Some(1); //~ ERROR use of unstable library feature `unstable_default`
-    //~^ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
-    //~^^ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
+    //~^ WARN use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
+    //~^^ WARN use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
     let _ = ALIAS5;
-    let _: Alias5 = ALIAS5; //~ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
+    let _: Alias5 = ALIAS5; //~ WARN use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
     let _: Alias5<usize> = ALIAS5; //~ ERROR use of unstable library feature `unstable_default`
-    //~^ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
+    //~^ WARN use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
     let _: Alias5<isize> = Alias5::Some(0); //~ ERROR use of unstable library feature `unstable_default`
-    //~^ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
-    //~^^ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
+    //~^ WARN use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
+    //~^^ WARN use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
 
     let _: Alias6<isize> = Alias6::Some(1); // ok
     let _: Alias6<isize> = Alias6::Some(0); // ok
@@ -217,26 +217,26 @@ fn main() {
 
     let _ = ENUM4;
     let _: Enum4<isize> = Enum4::Some(1);
-    //~^ use of deprecated tuple variant `unstable_generic_param::Enum4::Some`: test [deprecated]
-    //~^^ use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
+    //~^ WARN use of deprecated tuple variant `unstable_generic_param::Enum4::Some`: test [deprecated]
+    //~^^ WARN use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
     let _ = ENUM4;
-    let _: Enum4 = ENUM4; //~ use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
-    let _: Enum4<usize> = ENUM4; //~ use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
+    let _: Enum4 = ENUM4; //~ WARN use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
+    let _: Enum4<usize> = ENUM4; //~ WARN use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
     let _: Enum4<isize> = Enum4::Some(0);
-    //~^ use of deprecated tuple variant `unstable_generic_param::Enum4::Some`: test [deprecated]
-    //~^^ use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
+    //~^ WARN use of deprecated tuple variant `unstable_generic_param::Enum4::Some`: test [deprecated]
+    //~^^ WARN use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
 
     let _ = ENUM5;
     let _: Enum5<isize> = Enum5::Some(1); //~ ERROR use of unstable library feature `unstable_default`
-    //~^ use of deprecated tuple variant `unstable_generic_param::Enum5::Some`: test [deprecated]
-    //~^^ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
+    //~^ WARN use of deprecated tuple variant `unstable_generic_param::Enum5::Some`: test [deprecated]
+    //~^^ WARN use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
     let _ = ENUM5;
-    let _: Enum5 = ENUM5; //~ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
+    let _: Enum5 = ENUM5; //~ WARN use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
     let _: Enum5<usize> = ENUM5; //~ ERROR use of unstable library feature `unstable_default`
-    //~^ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
+    //~^ WARN use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
     let _: Enum5<isize> = Enum5::Some(0); //~ ERROR use of unstable library feature `unstable_default`
-    //~^ use of deprecated tuple variant `unstable_generic_param::Enum5::Some`: test [deprecated]
-    //~^^ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
+    //~^ WARN use of deprecated tuple variant `unstable_generic_param::Enum5::Some`: test [deprecated]
+    //~^^ WARN use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
 
     let _: Enum6<isize> = Enum6::Some(1); // ok
     let _: Enum6<isize> = Enum6::Some(0); // ok

--- a/tests/ui/static/bad-const-type.rs
+++ b/tests/ui/static/bad-const-type.rs
@@ -1,4 +1,4 @@
 static i: String = 10;
 //~^ ERROR mismatched types
-//~| expected `String`, found integer
+//~| NOTE expected `String`, found integer
 fn main() { println!("{}", i); }

--- a/tests/ui/structs/struct-missing-comma.fixed
+++ b/tests/ui/structs/struct-missing-comma.fixed
@@ -2,7 +2,7 @@
 //@ run-rustfix
 
 pub struct S {
-    pub foo: u32, //~ expected `,`, or `}`, found keyword `pub`
+    pub foo: u32, //~ ERROR expected `,`, or `}`, found keyword `pub`
     //     ~^ HELP try adding a comma: ','
     pub bar: u32
 }

--- a/tests/ui/structs/struct-missing-comma.rs
+++ b/tests/ui/structs/struct-missing-comma.rs
@@ -2,7 +2,7 @@
 //@ run-rustfix
 
 pub struct S {
-    pub foo: u32 //~ expected `,`, or `}`, found keyword `pub`
+    pub foo: u32 //~ ERROR expected `,`, or `}`, found keyword `pub`
     //     ~^ HELP try adding a comma: ','
     pub bar: u32
 }

--- a/tests/ui/structs/suggest-replacing-field-when-specifying-same-type.rs
+++ b/tests/ui/structs/suggest-replacing-field-when-specifying-same-type.rs
@@ -22,7 +22,7 @@ fn main() {
         //~| ERROR pattern does not mention field `b` [E0027]
         Foo::Baz { bb: "" } => (),
         //~^ ERROR variant `Foo::Baz` does not have a field named `bb` [E0026]
-        //~| pattern does not mention field `a` [E0027]
+        //~| ERROR pattern does not mention field `a` [E0027]
         _ => (),
     }
 }

--- a/tests/ui/suggestions/derive-trait-for-method-call.rs
+++ b/tests/ui/suggestions/derive-trait-for-method-call.rs
@@ -26,19 +26,19 @@ impl<X: Clone + Default + , Y: Clone + Default> Foo<X, Y> {
 fn test1() {
     let x = Foo(Enum::First, CloneEnum::First);
     let y = x.test();
-    //~^the method `test` exists for struct `Foo<Enum, CloneEnum>`, but its trait bounds were not satisfied [E0599]
+    //~^ ERROR the method `test` exists for struct `Foo<Enum, CloneEnum>`, but its trait bounds were not satisfied [E0599]
 }
 
 fn test2() {
     let x = Foo(Struct{}, CloneStruct{});
     let y = x.test();
-    //~^the method `test` exists for struct `Foo<Struct, CloneStruct>`, but its trait bounds were not satisfied [E0599]
+    //~^ ERROR the method `test` exists for struct `Foo<Struct, CloneStruct>`, but its trait bounds were not satisfied [E0599]
 }
 
 fn test3() {
     let x = Foo(Vec::<Enum>::new(), Instant::now());
     let y = x.test();
-    //~^the method `test` exists for struct `Foo<Vec<Enum>, Instant>`, but its trait bounds were not satisfied [E0599]
+    //~^ ERROR the method `test` exists for struct `Foo<Vec<Enum>, Instant>`, but its trait bounds were not satisfied [E0599]
 }
 
 fn main() {}

--- a/tests/ui/suggestions/field-has-method.rs
+++ b/tests/ui/suggestions/field-has-method.rs
@@ -17,7 +17,7 @@ struct InferOk<T> {
 
 fn foo(i: InferOk<Ty>) {
     let k = i.kind();
-    //~^ no method named `kind` found for struct `InferOk` in the current scope
+    //~^ ERROR no method named `kind` found for struct `InferOk` in the current scope
 }
 
 fn main() {}

--- a/tests/ui/suggestions/issue-101465.rs
+++ b/tests/ui/suggestions/issue-101465.rs
@@ -18,7 +18,7 @@ fn foo() -> impl Tr {
     match true {
         true => B,
         false => C,
-        //~^ `match` arms have incompatible types
+        //~^ ERROR `match` arms have incompatible types
     }
 }
 

--- a/tests/ui/suggestions/issue-81839.rs
+++ b/tests/ui/suggestions/issue-81839.rs
@@ -8,7 +8,7 @@ async fn test(ans: &str, num: i32, cx: &issue_81839::Test) -> u32 {
         1 => {
             cx.answer_str("hi");
         }
-        _ => cx.answer_str("hi"), //~ `match` arms have incompatible types
+        _ => cx.answer_str("hi"), //~ ERROR `match` arms have incompatible types
     }
 
     1

--- a/tests/ui/suggestions/partialeq_suggest_swap.rs
+++ b/tests/ui/suggestions/partialeq_suggest_swap.rs
@@ -7,5 +7,5 @@ impl PartialEq<i32> for T {
 }
 
 fn main() {
-    4i32 == T(4); //~ mismatched types [E0308]
+    4i32 == T(4); //~ ERROR mismatched types [E0308]
 }

--- a/tests/ui/suggestions/partialeq_suggest_swap_on_e0277.rs
+++ b/tests/ui/suggestions/partialeq_suggest_swap_on_e0277.rs
@@ -7,5 +7,5 @@ impl PartialEq<String> for T {
 }
 
 fn main() {
-    String::from("Girls Band Cry") == T(String::from("Girls Band Cry")); //~ can't compare `String` with `T` [E0277]
+    String::from("Girls Band Cry") == T(String::from("Girls Band Cry")); //~ ERROR can't compare `String` with `T` [E0277]
 }

--- a/tests/ui/suggestions/suggest-adding-reference-to-trait-assoc-item.fixed
+++ b/tests/ui/suggestions/suggest-adding-reference-to-trait-assoc-item.fixed
@@ -10,6 +10,6 @@ fn bar(bar: &usize) {
 }
 
 fn main() {
-    foo(&mut Default::default()); //~ the trait bound `&mut usize: Default` is not satisfied
-    bar(&Default::default()); //~ the trait bound `&usize: Default` is not satisfied
+    foo(&mut Default::default()); //~ ERROR the trait bound `&mut usize: Default` is not satisfied
+    bar(&Default::default()); //~ ERROR the trait bound `&usize: Default` is not satisfied
 }

--- a/tests/ui/suggestions/suggest-adding-reference-to-trait-assoc-item.rs
+++ b/tests/ui/suggestions/suggest-adding-reference-to-trait-assoc-item.rs
@@ -10,6 +10,6 @@ fn bar(bar: &usize) {
 }
 
 fn main() {
-    foo(Default::default()); //~ the trait bound `&mut usize: Default` is not satisfied
-    bar(Default::default()); //~ the trait bound `&usize: Default` is not satisfied
+    foo(Default::default()); //~ ERROR the trait bound `&mut usize: Default` is not satisfied
+    bar(Default::default()); //~ ERROR the trait bound `&usize: Default` is not satisfied
 }

--- a/tests/ui/suggestions/suggest-let-for-assignment.fixed
+++ b/tests/ui/suggestions/suggest-let-for-assignment.fixed
@@ -7,10 +7,10 @@ fn main() {
     let x = "x"; //~ ERROR cannot find value `x` in this scope
     println!("x: {}", x); //~ ERROR cannot find value `x` in this scope
 
-    let some_variable = 6; //~ cannot find value `let_some_variable` in this scope
+    let some_variable = 6; //~ ERROR cannot find value `let_some_variable` in this scope
     println!("some_variable: {}", some_variable); //~ ERROR cannot find value `some_variable` in this scope
 
-    let other_variable = 6; //~ cannot find value `letother_variable` in this scope
+    let other_variable = 6; //~ ERROR cannot find value `letother_variable` in this scope
     println!("other_variable: {}", other_variable); //~ ERROR cannot find value `other_variable` in this scope
 
     if x == "x" {

--- a/tests/ui/suggestions/suggest-let-for-assignment.rs
+++ b/tests/ui/suggestions/suggest-let-for-assignment.rs
@@ -7,10 +7,10 @@ fn main() {
     x = "x"; //~ ERROR cannot find value `x` in this scope
     println!("x: {}", x); //~ ERROR cannot find value `x` in this scope
 
-    let_some_variable = 6; //~ cannot find value `let_some_variable` in this scope
+    let_some_variable = 6; //~ ERROR cannot find value `let_some_variable` in this scope
     println!("some_variable: {}", some_variable); //~ ERROR cannot find value `some_variable` in this scope
 
-    letother_variable = 6; //~ cannot find value `letother_variable` in this scope
+    letother_variable = 6; //~ ERROR cannot find value `letother_variable` in this scope
     println!("other_variable: {}", other_variable); //~ ERROR cannot find value `other_variable` in this scope
 
     if x == "x" {

--- a/tests/ui/suggestions/suggest-null-ptr.fixed
+++ b/tests/ui/suggestions/suggest-null-ptr.fixed
@@ -16,16 +16,16 @@ extern "C" {
 fn main() {
     unsafe {
         foo(std::ptr::null());
-        //~^ mismatched types [E0308]
-        //~| if you meant to create a null pointer, use `std::ptr::null()`
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP if you meant to create a null pointer, use `std::ptr::null()`
         foo_mut(std::ptr::null_mut());
-        //~^ mismatched types [E0308]
-        //~| if you meant to create a null pointer, use `std::ptr::null_mut()`
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP if you meant to create a null pointer, use `std::ptr::null_mut()`
         usize(std::ptr::null());
-        //~^ mismatched types [E0308]
-        //~| if you meant to create a null pointer, use `std::ptr::null()`
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP if you meant to create a null pointer, use `std::ptr::null()`
         usize_mut(std::ptr::null_mut());
-        //~^ mismatched types [E0308]
-        //~| if you meant to create a null pointer, use `std::ptr::null_mut()`
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP if you meant to create a null pointer, use `std::ptr::null_mut()`
     }
 }

--- a/tests/ui/suggestions/suggest-null-ptr.rs
+++ b/tests/ui/suggestions/suggest-null-ptr.rs
@@ -16,16 +16,16 @@ extern "C" {
 fn main() {
     unsafe {
         foo(0);
-        //~^ mismatched types [E0308]
-        //~| if you meant to create a null pointer, use `std::ptr::null()`
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP if you meant to create a null pointer, use `std::ptr::null()`
         foo_mut(0);
-        //~^ mismatched types [E0308]
-        //~| if you meant to create a null pointer, use `std::ptr::null_mut()`
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP if you meant to create a null pointer, use `std::ptr::null_mut()`
         usize(0);
-        //~^ mismatched types [E0308]
-        //~| if you meant to create a null pointer, use `std::ptr::null()`
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP if you meant to create a null pointer, use `std::ptr::null()`
         usize_mut(0);
-        //~^ mismatched types [E0308]
-        //~| if you meant to create a null pointer, use `std::ptr::null_mut()`
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP if you meant to create a null pointer, use `std::ptr::null_mut()`
     }
 }

--- a/tests/ui/suggestions/types/dont-suggest-path-names.rs
+++ b/tests/ui/suggestions/types/dont-suggest-path-names.rs
@@ -5,11 +5,11 @@
 
 struct Select<F, I>(F, I);
 fn select<F, I>(filter: F) -> Select<F, I> {}
-//~^ 7:31: 7:43: mismatched types [E0308]
+//~^ ERROR mismatched types [E0308]
 
 fn parser1() {
     let lit = select(|x| match x {
-        //~^ 11:23: 11:24: type annotations needed [E0282]
+        //~^ ERROR type annotations needed [E0282]
         _ => (),
     });
 }

--- a/tests/ui/traits/alias/issue-108132-unmet-trait-alias-bound-on-generic-impl.rs
+++ b/tests/ui/traits/alias/issue-108132-unmet-trait-alias-bound-on-generic-impl.rs
@@ -11,5 +11,5 @@ impl<I: IteratorAlias> Foo<I> {
 }
 
 fn main() {
-    Foo::<()>::f() //~ trait bounds were not satisfied
+    Foo::<()>::f() //~ ERROR trait bounds were not satisfied
 }

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.rs
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-2.rs
@@ -11,5 +11,5 @@ fn f<T: for<'r> X<'r> + ?Sized>() {
 
 fn main() {
     f::<dyn for<'x> X<'x, F = i32>>();
-    //~^ expected a `FnOnce(&i32)` closure, found `i32`
+    //~^ ERROR expected a `FnOnce(&i32)` closure, found `i32`
 }

--- a/tests/ui/traits/associated_type_bound/check-trait-object-bounds-5.rs
+++ b/tests/ui/traits/associated_type_bound/check-trait-object-bounds-5.rs
@@ -21,7 +21,7 @@ fn is_obj<T: ?Sized + Obj>(_: &T) {}
 
 fn f(x: &dyn Obj<U = i32, V = i64>) {
     is_obj(x)
-    //~^ type mismatch resolving `<i32 as Is>::T == i64`
+    //~^ ERROR type mismatch resolving `<i32 as Is>::T == i64`
 }
 
 fn main() {}

--- a/tests/ui/traits/const-traits/ice-119717-constant-lifetime.rs
+++ b/tests/ui/traits/const-traits/ice-119717-constant-lifetime.rs
@@ -5,9 +5,9 @@ use std::ops::FromResidual;
 
 impl<T> const FromResidual for T {
     //~^ ERROR const `impl` for trait `FromResidual` which is not marked with `#[const_trait]`
-    //~| type parameter `T` must be used as the type parameter for some local type
+    //~| ERROR type parameter `T` must be used as the type parameter for some local type
     fn from_residual(t: T) -> _ {
-        //~^ the placeholder `_` is not allowed
+        //~^ ERROR the placeholder `_` is not allowed
         t
     }
 }

--- a/tests/ui/traits/const-traits/staged-api.rs
+++ b/tests/ui/traits/const-traits/staged-api.rs
@@ -96,12 +96,12 @@ trait S {}
 
 // implied stable
 impl const U for u8 {}
-//~^ const stability on the impl does not match the const stability on the trait
+//~^ ERROR const stability on the impl does not match the const stability on the trait
 
 #[rustc_const_stable(since = "0.0.0", feature = "beef2")]
 impl const U for u16 {}
-//~^ const stability on the impl does not match the const stability on the trait
-//~| trait implementations cannot be const stable yet
+//~^ ERROR const stability on the impl does not match the const stability on the trait
+//~| ERROR trait implementations cannot be const stable yet
 
 #[rustc_const_unstable(feature = "beef", issue = "none")]
 impl const U for u32 {}
@@ -111,10 +111,10 @@ impl const S for u8 {}
 
 #[rustc_const_stable(since = "0.0.0", feature = "beef2")]
 impl const S for u16 {}
-//~^ trait implementations cannot be const stable yet
+//~^ ERROR trait implementations cannot be const stable yet
 
 #[rustc_const_unstable(feature = "beef", issue = "none")]
 impl const S for u32 {}
-//~^ const stability on the impl does not match the const stability on the trait
+//~^ ERROR const stability on the impl does not match the const stability on the trait
 
 fn main() {}

--- a/tests/ui/traits/copy-is-not-modulo-regions.rs
+++ b/tests/ui/traits/copy-is-not-modulo-regions.rs
@@ -11,7 +11,7 @@ struct Bar<'lt>(Foo<'lt>);
 
 #[cfg(not_static)]
 impl<'any> Copy for Bar<'any> {}
-//[not_static]~^ the trait `Copy` cannot be implemented for this type
+//[not_static]~^ ERROR the trait `Copy` cannot be implemented for this type
 
 #[cfg(yes_static)]
 impl<'any> Copy for Bar<'static> {}

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of.rs
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of.rs
@@ -39,6 +39,6 @@ impl Equal for T2 {
 }
 
 impl Equal for T3 {}
-//~^ not all trait items implemented, missing one of: `eq`, `neq`
+//~^ ERROR not all trait items implemented, missing one of: `eq`, `neq`
 
 fn main() {}

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_duplicates.rs
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_duplicates.rs
@@ -1,15 +1,15 @@
 #![feature(rustc_attrs)]
 
 #[rustc_must_implement_one_of(a, a)]
-//~^ functions names are duplicated
+//~^ ERROR functions names are duplicated
 trait Trait {
     fn a() {}
 }
 
 #[rustc_must_implement_one_of(b, a, a, c, b, c)]
-//~^ functions names are duplicated
-//~| functions names are duplicated
-//~| functions names are duplicated
+//~^ ERROR functions names are duplicated
+//~| ERROR functions names are duplicated
+//~| ERROR functions names are duplicated
 trait Trait1 {
     fn a() {}
     fn b() {}

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_gated.rs
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_gated.rs
@@ -1,5 +1,5 @@
 #[rustc_must_implement_one_of(eq, neq)]
-//~^ the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete definition of a trait, it's currently in experimental form and should be changed before being exposed outside of the std
+//~^ ERROR the `#[rustc_must_implement_one_of]` attribute is used to change minimal complete definition of a trait, it's currently in experimental form and should be changed before being exposed outside of the std
 trait Equal {
     fn eq(&self, other: &Self) -> bool {
         !self.neq(other)

--- a/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.rs
+++ b/tests/ui/traits/default-method/rustc_must_implement_one_of_misuse.rs
@@ -1,46 +1,46 @@
 #![feature(rustc_attrs)]
 
 #[rustc_must_implement_one_of(a, b)]
-//~^ function not found in this trait
-//~| function not found in this trait
+//~^ ERROR function not found in this trait
+//~| ERROR function not found in this trait
 trait Tr0 {}
 
 #[rustc_must_implement_one_of(a, b)]
-//~^ function not found in this trait
+//~^ ERROR function not found in this trait
 trait Tr1 {
     fn a() {}
 }
 
 #[rustc_must_implement_one_of(a)]
-//~^ the `#[rustc_must_implement_one_of]` attribute must be used with at least 2 args
+//~^ ERROR the `#[rustc_must_implement_one_of]` attribute must be used with at least 2 args
 trait Tr2 {
     fn a() {}
 }
 
 #[rustc_must_implement_one_of]
-//~^ malformed `rustc_must_implement_one_of` attribute input
+//~^ ERROR malformed `rustc_must_implement_one_of` attribute input
 trait Tr3 {}
 
 #[rustc_must_implement_one_of(A, B)]
 trait Tr4 {
-    const A: u8 = 1; //~ not a function
+    const A: u8 = 1; //~ ERROR not a function
 
-    type B; //~ not a function
+    type B; //~ ERROR not a function
 }
 
 #[rustc_must_implement_one_of(a, b)]
 trait Tr5 {
-    fn a(); //~ function doesn't have a default implementation
+    fn a(); //~ ERROR function doesn't have a default implementation
 
-    fn b(); //~ function doesn't have a default implementation
+    fn b(); //~ ERROR function doesn't have a default implementation
 }
 
 #[rustc_must_implement_one_of(abc, xyz)]
-//~^ attribute should be applied to a trait
+//~^ ERROR attribute should be applied to a trait
 fn function() {}
 
 #[rustc_must_implement_one_of(abc, xyz)]
-//~^ attribute should be applied to a trait
+//~^ ERROR attribute should be applied to a trait
 struct Struct {}
 
 fn main() {}

--- a/tests/ui/traits/default_auto_traits/maybe-bounds-in-traits.rs
+++ b/tests/ui/traits/default_auto_traits/maybe-bounds-in-traits.rs
@@ -97,7 +97,7 @@ mod methods {
         fn mut_leak_foo(&mut self) {}
         // there is no relax bound on corresponding Receiver impl
         fn mut_maybe_leak_foo(&mut self) where Self: ?Leak {}
-        //~^  `&mut Self` cannot be used as the type of `self` without the `arbitrary_self_types`
+        //~^ ERROR `&mut Self` cannot be used as the type of `self` without the `arbitrary_self_types`
     }
 
     impl Trait for NonLeakS {}

--- a/tests/ui/traits/issue-106072.rs
+++ b/tests/ui/traits/issue-106072.rs
@@ -1,6 +1,6 @@
 #[derive(Clone)]
-//~^ expected a type, found a trait
-//~| expected a type, found a trait
+//~^ ERROR expected a type, found a trait
+//~| ERROR expected a type, found a trait
 struct Foo;
-trait Foo {} //~ the name `Foo` is defined multiple times
+trait Foo {} //~ ERROR the name `Foo` is defined multiple times
 fn main() {}

--- a/tests/ui/traits/next-solver/builtin-fn-must-return-sized.rs
+++ b/tests/ui/traits/next-solver/builtin-fn-must-return-sized.rs
@@ -13,5 +13,5 @@ fn foo<F: Fn<T>, T: Tuple>(f: Option<F>, t: T) {
 
 fn main() {
     foo::<fn() -> str, _>(None, ());
-    //~^ the size for values of type `str` cannot be known at compilation time
+    //~^ ERROR the size for values of type `str` cannot be known at compilation time
 }

--- a/tests/ui/traits/next-solver/diagnostics/point-at-failing-nested.rs
+++ b/tests/ui/traits/next-solver/diagnostics/point-at-failing-nested.rs
@@ -20,5 +20,5 @@ impl Constrain for () {
 fn needs_foo<T: Foo>() {}
 fn main() {
     needs_foo::<()>();
-    //~^ the trait bound `(): Foo` is not satisfied
+    //~^ ERROR the trait bound `(): Foo` is not satisfied
 }

--- a/tests/ui/traits/next-solver/gat-wf.rs
+++ b/tests/ui/traits/next-solver/gat-wf.rs
@@ -10,7 +10,7 @@ trait Foo {
 }
 
 impl Foo for &() {
-    type T<'a> = (); //~ the type `&()` does not fulfill the required lifetime
+    type T<'a> = (); //~ ERROR the type `&()` does not fulfill the required lifetime
 }
 
 fn main() {}

--- a/tests/ui/traits/non_lifetime_binders/type-alias-impl-trait/non-lifetime-binder-in-constraint.rs
+++ b/tests/ui/traits/non_lifetime_binders/type-alias-impl-trait/non-lifetime-binder-in-constraint.rs
@@ -6,7 +6,7 @@ trait Trait<T: ?Sized> {}
 fn produce() -> impl for<T> Trait<(), Assoc = impl Trait<T>> {
     //~^ ERROR associated type `Assoc` not found for `Trait`
     //~| ERROR associated type `Assoc` not found for `Trait`
-    //~| the trait bound `{integer}: Trait<()>` is not satisfied
+    //~| ERROR the trait bound `{integer}: Trait<()>` is not satisfied
     //~| ERROR cannot capture late-bound type parameter in nested `impl Trait`
     16
 }

--- a/tests/ui/traits/object/vs-lifetime.rs
+++ b/tests/ui/traits/object/vs-lifetime.rs
@@ -7,7 +7,7 @@ fn main() {
     // `'static` is a lifetime argument, `'static +` is a type argument
     let _: S<'static, u8>;
     let _: S<'static, dyn 'static +>;
-    //~^ at least one trait is required for an object type
+    //~^ ERROR at least one trait is required for an object type
     let _: S<'static, 'static>;
     //~^ ERROR struct takes 1 lifetime argument but 2 lifetime arguments were supplied
     //~| ERROR struct takes 1 generic argument but 0 generic arguments were supplied

--- a/tests/ui/transmutability/issue-101739-1.rs
+++ b/tests/ui/transmutability/issue-101739-1.rs
@@ -6,7 +6,7 @@ mod assert {
     pub fn is_transmutable<Src, const ASSUME_ALIGNMENT: bool>()
     where
         Dst: TransmuteFrom<Src, ASSUME_ALIGNMENT>, //~ ERROR cannot find type `Dst` in this scope
-                                                           //~| the constant `ASSUME_ALIGNMENT` is not of type `Assume`
+                                                   //~| ERROR the constant `ASSUME_ALIGNMENT` is not of type `Assume`
     {
     }
 }

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst.rs
@@ -15,5 +15,5 @@ mod assert {
 
 fn should_gracefully_handle_unknown_dst() {
     struct Src;
-    assert::is_transmutable::<Src, Dst>(); //~ cannot find type
+    assert::is_transmutable::<Src, Dst>(); //~ ERROR cannot find type
 }

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst_field.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst_field.rs
@@ -15,12 +15,12 @@ mod assert {
 
 fn should_gracefully_handle_unknown_dst_field() {
     #[repr(C)] struct Src;
-    #[repr(C)] struct Dst(Missing); //~ cannot find type
+    #[repr(C)] struct Dst(Missing); //~ ERROR cannot find type
     assert::is_transmutable::<Src, Dst>(); //~ ERROR cannot be safely transmuted
 }
 
 fn should_gracefully_handle_unknown_dst_ref_field() {
     #[repr(C)] struct Src(&'static Src);
-    #[repr(C)] struct Dst(&'static Missing); //~ cannot find type
+    #[repr(C)] struct Dst(&'static Missing); //~ ERROR cannot find type
     assert::is_transmutable::<Src, Dst>(); //~ ERROR cannot be safely transmuted
 }

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_src.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_src.rs
@@ -15,5 +15,5 @@ mod assert {
 
 fn should_gracefully_handle_unknown_src() {
     #[repr(C)] struct Dst;
-    assert::is_transmutable::<Src, Dst>(); //~ cannot find type
+    assert::is_transmutable::<Src, Dst>(); //~ ERROR cannot find type
 }

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_src_field.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_src_field.rs
@@ -14,13 +14,13 @@ mod assert {
 }
 
 fn should_gracefully_handle_unknown_src_field() {
-    #[repr(C)] struct Src(Missing); //~ cannot find type
+    #[repr(C)] struct Src(Missing); //~ ERROR cannot find type
     #[repr(C)] struct Dst();
     assert::is_transmutable::<Src, Dst>(); //~ ERROR cannot be safely transmuted
 }
 
 fn should_gracefully_handle_unknown_src_ref_field() {
-    #[repr(C)] struct Src(&'static Missing); //~ cannot find type
+    #[repr(C)] struct Src(&'static Missing); //~ ERROR cannot find type
     #[repr(C)] struct Dst(&'static Dst);
     assert::is_transmutable::<Src, Dst>(); //~ ERROR cannot be safely transmuted
 }

--- a/tests/ui/type-alias-impl-trait/auto-trait-leakage2.rs
+++ b/tests/ui/type-alias-impl-trait/auto-trait-leakage2.rs
@@ -4,8 +4,8 @@
 use std::rc::Rc;
 
 type Foo = impl std::fmt::Debug; //~ NOTE appears within the type
-//~^ within this `Foo`
-//~| expansion of desugaring
+//~^ NOTE within this `Foo`
+//~| NOTE expansion of desugaring
 
 #[define_opaque(Foo)]
 pub fn foo() -> Foo {
@@ -13,8 +13,8 @@ pub fn foo() -> Foo {
 }
 
 fn is_send<T: Send>(_: T) {}
-//~^ required by this bound
-//~| required by a bound
+//~^ NOTE required by this bound
+//~| NOTE required by a bound
 
 fn main() {
     is_send(foo());

--- a/tests/ui/type-alias-impl-trait/constrain_in_projection.rs
+++ b/tests/ui/type-alias-impl-trait/constrain_in_projection.rs
@@ -23,8 +23,8 @@ impl Trait<()> for Foo {
 #[define_opaque(Bar)]
 fn bop() {
     let x = <Foo as Trait<Bar>>::Assoc::default();
-    //[current]~^ `Foo: Trait<Bar>` is not satisfied
-    //[current]~| `Foo: Trait<Bar>` is not satisfied
+    //[current]~^ ERROR `Foo: Trait<Bar>` is not satisfied
+    //[current]~| ERROR `Foo: Trait<Bar>` is not satisfied
 }
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/declared_but_not_defined_in_scope.rs
+++ b/tests/ui/type-alias-impl-trait/declared_but_not_defined_in_scope.rs
@@ -9,5 +9,5 @@ mod boo {
 
 fn bomp() -> boo::Boo {
     ""
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }

--- a/tests/ui/type-alias-impl-trait/generic_duplicate_param_use8.rs
+++ b/tests/ui/type-alias-impl-trait/generic_duplicate_param_use8.rs
@@ -13,6 +13,6 @@ fn two<T: Debug, U: Debug>(t: T, _: U) -> Two<T, U> {
 
 #[define_opaque(Two)]
 fn three<T: Debug, U: Debug>(_: T, u: U) -> Two<T, U> {
-    //~^ concrete type differs
+    //~^ ERROR concrete type differs
     (u, 4u32)
 }

--- a/tests/ui/type-alias-impl-trait/issue-104817.rs
+++ b/tests/ui/type-alias-impl-trait/issue-104817.rs
@@ -15,6 +15,6 @@ fn mk_opaque() -> OpaqueType {
 trait AnotherTrait {}
 impl<T: Send> AnotherTrait for T {}
 impl AnotherTrait for OpaqueType {}
-//[stock]~^ conflicting implementations of trait `AnotherTrait`
+//[stock]~^ ERROR conflicting implementations of trait `AnotherTrait`
 
 fn main() {}

--- a/tests/ui/type-alias-impl-trait/not_well_formed.rs
+++ b/tests/ui/type-alias-impl-trait/not_well_formed.rs
@@ -9,8 +9,8 @@ trait TraitWithAssoc {
 }
 
 type Foo<V> = impl Trait<V::Assoc>;
-//~^ associated type `Assoc` not found for `V`
-//~| associated type `Assoc` not found for `V`
+//~^ ERROR associated type `Assoc` not found for `V`
+//~| ERROR associated type `Assoc` not found for `V`
 
 trait Trait<U> {}
 

--- a/tests/ui/type-alias-impl-trait/structural-match-no-leak.rs
+++ b/tests/ui/type-alias-impl-trait/structural-match-no-leak.rs
@@ -14,7 +14,7 @@ const LEAK_FREE: Bar = leak_free();
 fn leak_free_test() {
     match LEAK_FREE {
         LEAK_FREE => (),
-        //~^ `Bar` cannot be used in patterns
+        //~^ ERROR `Bar` cannot be used in patterns
         _ => (),
     }
 }

--- a/tests/ui/type-alias-impl-trait/structural-match.rs
+++ b/tests/ui/type-alias-impl-trait/structural-match.rs
@@ -15,7 +15,7 @@ const VALUE: Foo = value();
 fn test() {
     match VALUE {
         VALUE => (),
-        //~^ `Foo` cannot be used in patterns
+        //~^ ERROR `Foo` cannot be used in patterns
         _ => (),
     }
 }

--- a/tests/ui/type-alias-impl-trait/variance.rs
+++ b/tests/ui/type-alias-impl-trait/variance.rs
@@ -5,17 +5,17 @@
 trait Captures<'a> {}
 impl<T> Captures<'_> for T {}
 
-type NotCapturedEarly<'a> = impl Sized; //~ ['a: *, 'a: o]
+type NotCapturedEarly<'a> = impl Sized; //~ ERROR ['a: *, 'a: o]
 //~^ ERROR: unconstrained opaque type
 
-type CapturedEarly<'a> = impl Sized + Captures<'a>; //~ ['a: *, 'a: o]
+type CapturedEarly<'a> = impl Sized + Captures<'a>; //~ ERROR ['a: *, 'a: o]
 //~^ ERROR: unconstrained opaque type
 
-type NotCapturedLate<'a> = dyn for<'b> Iterator<Item = impl Sized>; //~ ['a: *, 'a: o, 'b: o]
+type NotCapturedLate<'a> = dyn for<'b> Iterator<Item = impl Sized>; //~ ERROR ['a: *, 'a: o, 'b: o]
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
 //~| ERROR: unconstrained opaque type
 
-type Captured<'a> = dyn for<'b> Iterator<Item = impl Sized + Captures<'a>>; //~ ['a: *, 'a: o, 'b: o]
+type Captured<'a> = dyn for<'b> Iterator<Item = impl Sized + Captures<'a>>; //~ ERROR ['a: *, 'a: o, 'b: o]
 //~^ ERROR `impl Trait` cannot capture higher-ranked lifetime from `dyn` type
 //~| ERROR: unconstrained opaque type
 
@@ -31,24 +31,24 @@ trait Foo<'i> {
 }
 
 impl<'i> Foo<'i> for &'i () {
-    type ImplicitCapture<'a> = impl Sized; //~ ['i: *, 'a: *, 'i: o, 'a: o]
+    type ImplicitCapture<'a> = impl Sized; //~ ERROR ['i: *, 'a: *, 'i: o, 'a: o]
     //~^ ERROR: unconstrained opaque type
 
-    type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>; //~ ['i: *, 'a: *, 'i: o, 'a: o]
+    type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>; //~ ERROR ['i: *, 'a: *, 'i: o, 'a: o]
     //~^ ERROR: unconstrained opaque type
 
-    type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>; //~ ['i: *, 'a: *, 'i: o, 'a: o]
+    type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>; //~ ERROR ['i: *, 'a: *, 'i: o, 'a: o]
     //~^ ERROR: unconstrained opaque type
 }
 
 impl<'i> Foo<'i> for () {
-    type ImplicitCapture<'a> = impl Sized; //~ ['i: *, 'a: *, 'i: o, 'a: o]
+    type ImplicitCapture<'a> = impl Sized; //~ ERROR ['i: *, 'a: *, 'i: o, 'a: o]
     //~^ ERROR: unconstrained opaque type
 
-    type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>; //~ ['i: *, 'a: *, 'i: o, 'a: o]
+    type ExplicitCaptureFromHeader<'a> = impl Sized + Captures<'i>; //~ ERROR ['i: *, 'a: *, 'i: o, 'a: o]
     //~^ ERROR: unconstrained opaque type
 
-    type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>; //~ ['i: *, 'a: *, 'i: o, 'a: o]
+    type ExplicitCaptureFromGat<'a> = impl Sized + Captures<'a>; //~ ERROR ['i: *, 'a: *, 'i: o, 'a: o]
     //~^ ERROR: unconstrained opaque type
 }
 
@@ -59,15 +59,15 @@ impl<'a> Nesting<'a> for &'a () {
     type Output = &'a ();
 }
 type NestedDeeply<'a> =
-    impl Nesting< //~ ['a: *, 'a: o]
+    impl Nesting< //~ ERROR ['a: *, 'a: o]
         'a,
-        Output = impl Nesting< //~ ['a: *, 'a: o]
+        Output = impl Nesting< //~ ERROR ['a: *, 'a: o]
             'a,
-            Output = impl Nesting< //~ ['a: *, 'a: o]
+            Output = impl Nesting< //~ ERROR ['a: *, 'a: o]
                 'a,
-                Output = impl Nesting< //~ ['a: *, 'a: o]
+                Output = impl Nesting< //~ ERROR ['a: *, 'a: o]
                     'a,
-                    Output = impl Nesting<'a> //~ ['a: *, 'a: o]
+                    Output = impl Nesting<'a> //~ ERROR ['a: *, 'a: o]
                 >
             >,
         >,

--- a/tests/ui/type/issue-103271.rs
+++ b/tests/ui/type/issue-103271.rs
@@ -1,15 +1,15 @@
 fn main() {
     let iter_fun = <&[u32]>::iter;
     //~^ ERROR no function or associated item named `iter` found for reference `&[u32]` in the current scope [E0599]
-    //~| function or associated item not found in `&[u32]`
+    //~| NOTE function or associated item not found in `&[u32]`
     //~| HELP the function `iter` is implemented on `[u32]`
     for item in iter_fun(&[1,1]) {
         let x: &u32 = item;
         assert_eq!(x, &1);
     }
     let iter_fun2 = <(&[u32])>::iter;
-    //~^ no function or associated item named `iter` found for reference `&[u32]` in the current scope [E0599]
-    //~| function or associated item not found in `&[u32]`
+    //~^ ERROR no function or associated item named `iter` found for reference `&[u32]` in the current scope [E0599]
+    //~| NOTE function or associated item not found in `&[u32]`
     //~| HELP the function `iter` is implemented on `[u32]`
     for item2 in iter_fun2(&[1,1]) {
         let x: &u32 = item2;

--- a/tests/ui/type/pattern_types/feature-gate-pattern_types.rs
+++ b/tests/ui/type/pattern_types/feature-gate-pattern_types.rs
@@ -3,13 +3,13 @@
 use std::pat::pattern_type;
 
 type NonNullU32 = pattern_type!(u32 is 1..);
-//~^ use of unstable library feature `pattern_type_macro`
+//~^ ERROR use of unstable library feature `pattern_type_macro`
 type Percent = pattern_type!(u32 is 0..=100);
-//~^ use of unstable library feature `pattern_type_macro`
+//~^ ERROR use of unstable library feature `pattern_type_macro`
 type Negative = pattern_type!(i32 is ..=0);
-//~^ use of unstable library feature `pattern_type_macro`
+//~^ ERROR use of unstable library feature `pattern_type_macro`
 type Positive = pattern_type!(i32 is 0..);
-//~^ use of unstable library feature `pattern_type_macro`
+//~^ ERROR use of unstable library feature `pattern_type_macro`
 type Always = pattern_type!(Option<u32> is Some(_));
-//~^ use of unstable library feature `pattern_type_macro`
+//~^ ERROR use of unstable library feature `pattern_type_macro`
 //~| ERROR pattern not supported in pattern types

--- a/tests/ui/type/pattern_types/literals.rs
+++ b/tests/ui/type/pattern_types/literals.rs
@@ -7,7 +7,7 @@ use std::pat::pattern_type;
 
 fn out_of_range() -> pattern_type!(u32 is 1..) {
     0
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn at_range_start() -> pattern_type!(u32 is 1..) {
@@ -34,7 +34,7 @@ fn positive_lit_in_range_of_signed() -> pattern_type!(i8 is -5..5) {
 
 fn negative_lit_at_range_start() -> pattern_type!(i8 is -5..5) {
     -5
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn positive_lit_at_range_end() -> pattern_type!(i8 is -5..5) {
@@ -43,22 +43,22 @@ fn positive_lit_at_range_end() -> pattern_type!(i8 is -5..5) {
 
 fn lit_one_beyond_range_end() -> pattern_type!(i8 is -5..5) {
     5
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn wrong_lit_kind() -> pattern_type!(u32 is 1..) {
     '3'
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn char_lit_in_range() -> pattern_type!(char is 'a'..'z') {
     'b'
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn char_lit_out_of_range() -> pattern_type!(char is 'a'..'z') {
     'A'
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn lit_at_unsigned_range_inclusive_end() -> pattern_type!(u32 is 0..=1) {
@@ -71,12 +71,12 @@ fn single_element_range() -> pattern_type!(u32 is 0..=0) {
 
 fn lit_oob_single_element_range() -> pattern_type!(u32 is 0..=0) {
     1
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn lit_oob_single_element_range_exclusive() -> pattern_type!(u32 is 0..1) {
     1
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn single_element_range_exclusive() -> pattern_type!(u32 is 0..1) {
@@ -84,53 +84,53 @@ fn single_element_range_exclusive() -> pattern_type!(u32 is 0..1) {
 }
 
 fn empty_range_at_base_type_min() -> pattern_type!(u32 is 0..0) {
-    //~^ evaluation of constant value failed
+    //~^ ERROR evaluation of constant value failed
     0
 }
 
 fn empty_range_at_base_type_min2() -> pattern_type!(u32 is 0..0) {
-    //~^ evaluation of constant value failed
+    //~^ ERROR evaluation of constant value failed
     1
 }
 
 fn empty_range() -> pattern_type!(u32 is 1..1) {
     0
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn empty_range2() -> pattern_type!(u32 is 1..1) {
     1
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn wraparound_range_at_base_ty_end() -> pattern_type!(u32 is 1..0) {
-    //~^ evaluation of constant value failed
+    //~^ ERROR evaluation of constant value failed
     1
 }
 
 fn wraparound_range_at_base_ty_end2() -> pattern_type!(u32 is 1..0) {
-    //~^ evaluation of constant value failed
+    //~^ ERROR evaluation of constant value failed
     0
 }
 
 fn wraparound_range_at_base_ty_end3() -> pattern_type!(u32 is 1..0) {
-    //~^ evaluation of constant value failed
+    //~^ ERROR evaluation of constant value failed
     2
 }
 
 fn wraparound_range() -> pattern_type!(u32 is 2..1) {
     1
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn lit_in_wraparound_range() -> pattern_type!(u32 is 2..1) {
     0
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn lit_at_wraparound_range_start() -> pattern_type!(u32 is 2..1) {
     2
-    //~^ mismatched types
+    //~^ ERROR mismatched types
 }
 
 fn main() {}

--- a/tests/ui/typeck/attempted-access-non-fatal.rs
+++ b/tests/ui/typeck/attempted-access-non-fatal.rs
@@ -1,10 +1,10 @@
 // Check that bogus field access is non-fatal
 fn main() {
     let x = 0;
-    let _ = x.foo; //~ `{integer}` is a primitive type and therefore doesn't have fields [E0610]
-    let _ = x.bar; //~ `{integer}` is a primitive type and therefore doesn't have fields [E0610]
-    let _ = 0.f; //~ `{integer}` is a primitive type and therefore doesn't have fields [E0610]
-    let _ = 2.l; //~ `{integer}` is a primitive type and therefore doesn't have fields [E0610]
-    let _ = 12.F; //~ `{integer}` is a primitive type and therefore doesn't have fields [E0610]
-    let _ = 34.L; //~ `{integer}` is a primitive type and therefore doesn't have fields [E0610]
+    let _ = x.foo; //~ ERROR `{integer}` is a primitive type and therefore doesn't have fields [E0610]
+    let _ = x.bar; //~ ERROR `{integer}` is a primitive type and therefore doesn't have fields [E0610]
+    let _ = 0.f; //~ ERROR `{integer}` is a primitive type and therefore doesn't have fields [E0610]
+    let _ = 2.l; //~ ERROR `{integer}` is a primitive type and therefore doesn't have fields [E0610]
+    let _ = 12.F; //~ ERROR `{integer}` is a primitive type and therefore doesn't have fields [E0610]
+    let _ = 34.L; //~ ERROR `{integer}` is a primitive type and therefore doesn't have fields [E0610]
 }

--- a/tests/ui/typeck/autoderef-with-param-env-error.rs
+++ b/tests/ui/typeck/autoderef-with-param-env-error.rs
@@ -1,7 +1,7 @@
 fn foo()
 where
     T: Send,
-    //~^ cannot find type `T` in this scope
+    //~^ ERROR cannot find type `T` in this scope
 {
     let s = "abc".to_string();
 }

--- a/tests/ui/typeck/issue-46112.rs
+++ b/tests/ui/typeck/issue-46112.rs
@@ -6,4 +6,4 @@
 extern crate xcrate_issue_46112_rexport_core;
 fn test(r: Result<Option<()>, &'static str>) { }
 fn main() { test(Ok(())); }
-//~^ mismatched types
+//~^ ERROR mismatched types

--- a/tests/ui/typeck/issue-79040.rs
+++ b/tests/ui/typeck/issue-79040.rs
@@ -1,6 +1,6 @@
 fn main() {
     const FOO = "hello" + 1;
     //~^ ERROR cannot add `{integer}` to `&str`
-    //~| missing type for `const` item
+    //~| ERROR missing type for `const` item
     println!("{}", FOO);
 }

--- a/tests/ui/typeck/issue-83693.rs
+++ b/tests/ui/typeck/issue-83693.rs
@@ -8,7 +8,7 @@ impl F {
     fn call() {
         <Self as Fn(&TestResult)>::call
         //~^ ERROR: cannot find type `TestResult` in this scope [E0412]
-        //~| associated item constraints are not allowed here [E0229]
+        //~| ERROR associated item constraints are not allowed here [E0229]
     }
 }
 

--- a/tests/ui/typeck/no-type-for-node-ice.rs
+++ b/tests/ui/typeck/no-type-for-node-ice.rs
@@ -1,5 +1,5 @@
 // Related issues: #20401, #20506, #20614, #20752, #20829, #20846, #20885, #20886
 
 fn main() {
-    "".homura[""]; //~ no field `homura` on type `&'static str`
+    "".homura[""]; //~ ERROR no field `homura` on type `&'static str`
 }

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.rs
@@ -15,6 +15,6 @@ fn doit<T,F>(val: T, f: &F)
 pub fn main() {
     doit(0, &|x, y| {
         x.set(y);
-        //~^ lifetime may not live long enough
+        //~^ ERROR lifetime may not live long enough
     });
 }

--- a/tests/ui/uninhabited/uninhabited-irrefutable.rs
+++ b/tests/ui/uninhabited/uninhabited-irrefutable.rs
@@ -29,7 +29,7 @@ fn main() {
     let x: Foo = Foo::D(123, 456);
     let Foo::D(_y, _z) = x;
     //~^ ERROR refutable pattern in local binding
-    //~| `Foo::A(_)` not covered
+    //~| NOTE `Foo::A(_)` not covered
     //~| NOTE `let` bindings require an "irrefutable pattern"
     //~| NOTE for more information
     //~| NOTE pattern `Foo::A(_)` is currently uninhabited

--- a/tests/ui/unsafe-binders/lifetime-resolution.rs
+++ b/tests/ui/unsafe-binders/lifetime-resolution.rs
@@ -9,7 +9,7 @@ fn foo<'a>() {
 
     fn inner<'b>() {
         let outer: unsafe<> &'a &'b ();
-        //~^ can't use generic parameters from outer item
+        //~^ ERROR can't use generic parameters from outer item
     }
 }
 

--- a/tests/ui/unsafe/unsafe-unstable-const-fn.rs
+++ b/tests/ui/unsafe/unsafe-unstable-const-fn.rs
@@ -5,7 +5,7 @@
 #[rustc_const_unstable(feature = "const_foo", issue = "none")]
 const fn unstable(a: *const i32, b: i32) -> bool {
     *a == b
-    //~^ dereference of raw pointer is unsafe
+    //~^ ERROR dereference of raw pointer is unsafe
 }
 
 fn main() {}

--- a/tests/ui/unsized-locals/issue-30276-feature-flagged.rs
+++ b/tests/ui/unsized-locals/issue-30276-feature-flagged.rs
@@ -5,4 +5,5 @@ struct Test([i32]);
 
 fn main() {
     let _x: fn(_) -> Test = Test;
-} //~^the size for values of type `[i32]` cannot be known at compilation time
+    //~^ ERROR the size for values of type `[i32]` cannot be known at compilation time
+}

--- a/tests/ui/unsized-locals/issue-30276.rs
+++ b/tests/ui/unsized-locals/issue-30276.rs
@@ -2,4 +2,5 @@ struct Test([i32]);
 
 fn main() {
     let _x: fn(_) -> Test = Test;
-} //~^the size for values of type `[i32]` cannot be known at compilation time
+    //~^ ERROR the size for values of type `[i32]` cannot be known at compilation time
+}

--- a/tests/ui/use/use-keyword.rs
+++ b/tests/ui/use/use-keyword.rs
@@ -7,10 +7,10 @@ mod a {
         //~^ ERROR `self` imports are only allowed within a { } list
         use super as B;
         //~^ ERROR unresolved import `super` [E0432]
-        //~| no `super` in the root
+        //~| NOTE no `super` in the root
         use super::{self as C};
         //~^ ERROR unresolved import `super` [E0432]
-        //~| no `super` in the root
+        //~| NOTE no `super` in the root
     }
 }
 

--- a/tests/ui/use/use-mod/use-mod-2.rs
+++ b/tests/ui/use/use-mod/use-mod-2.rs
@@ -1,11 +1,11 @@
 mod foo {
     use self::{self};
     //~^ ERROR unresolved import `self` [E0432]
-    //~| no `self` in the root
+    //~| NOTE no `self` in the root
 
     use super::{self};
     //~^ ERROR unresolved import `super` [E0432]
-    //~| no `super` in the root
+    //~| NOTE no `super` in the root
 }
 
 fn main() {}

--- a/tests/ui/variance/variance-btree-invariant-types.rs
+++ b/tests/ui/variance/variance-btree-invariant-types.rs
@@ -2,78 +2,78 @@ use std::collections::btree_map::{IterMut, OccupiedEntry, RangeMut, VacantEntry}
 
 fn iter_cov_key<'a, 'new>(v: IterMut<'a, &'static (), ()>) -> IterMut<'a, &'new (), ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (), &'new ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &'static (), ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (), &'static ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn range_cov_key<'a, 'new>(v: RangeMut<'a, &'static (), ()>) -> RangeMut<'a, &'new (), ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn range_cov_val<'a, 'new>(v: RangeMut<'a, (), &'static ()>) -> RangeMut<'a, (), &'new ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn range_contra_key<'a, 'new>(v: RangeMut<'a, &'new (), ()>) -> RangeMut<'a, &'static (), ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn range_contra_val<'a, 'new>(v: RangeMut<'a, (), &'new ()>) -> RangeMut<'a, (), &'static ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
                          -> OccupiedEntry<'a, &'new (), ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
                          -> OccupiedEntry<'a, (), &'new ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn occ_contra_key<'a, 'new>(v: OccupiedEntry<'a, &'new (), ()>)
                             -> OccupiedEntry<'a, &'static (), ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn occ_contra_val<'a, 'new>(v: OccupiedEntry<'a, (), &'new ()>)
                             -> OccupiedEntry<'a, (), &'static ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 
 fn vac_cov_key<'a, 'new>(v: VacantEntry<'a, &'static (), ()>)
                          -> VacantEntry<'a, &'new (), ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn vac_cov_val<'a, 'new>(v: VacantEntry<'a, (), &'static ()>)
                          -> VacantEntry<'a, (), &'new ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn vac_contra_key<'a, 'new>(v: VacantEntry<'a, &'new (), ()>)
                             -> VacantEntry<'a, &'static (), ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 fn vac_contra_val<'a, 'new>(v: VacantEntry<'a, (), &'new ()>)
                             -> VacantEntry<'a, (), &'static ()> {
     v
-    //~^ lifetime may not live long enough
+    //~^ ERROR lifetime may not live long enough
 }
 
 

--- a/tests/ui/wf/issue-95665.rs
+++ b/tests/ui/wf/issue-95665.rs
@@ -12,7 +12,7 @@ pub struct Struct<T: Trait> {
 
 extern "C" {
     static VAR: Struct<u8>;
-                //~^ 14:17: 14:27: the trait bound `u8: Trait` is not satisfied [E0277]
+    //~^ ERROR the trait bound `u8: Trait` is not satisfied [E0277]
 }
 
 fn main() {}

--- a/tests/ui/wf/wf-normalization-sized.rs
+++ b/tests/ui/wf/wf-normalization-sized.rs
@@ -17,10 +17,10 @@ impl<T: ?Sized> WellUnformed for T {
 }
 
 const _: <[[[[[[u8]]]]]] as WellUnformed>::RequestNormalize = ();
-//[next]~^ the size for values of type `[[[[[u8]]]]]` cannot be known at compilation time
-//[next]~| the size for values of type `[[[[[u8]]]]]` cannot be known at compilation time
+//[next]~^ ERROR the size for values of type `[[[[[u8]]]]]` cannot be known at compilation time
+//[next]~| ERROR the size for values of type `[[[[[u8]]]]]` cannot be known at compilation time
 const _: <Vec<str> as WellUnformed>::RequestNormalize = ();
-//[next]~^ the size for values of type `str` cannot be known at compilation time
-//[next]~| the size for values of type `str` cannot be known at compilation time
+//[next]~^ ERROR the size for values of type `str` cannot be known at compilation time
+//[next]~| ERROR the size for values of type `str` cannot be known at compilation time
 
 fn main() {}


### PR DESCRIPTION
The subset of https://github.com/rust-lang/rust/pull/139427 that only adds diagnostic kinds to line annotations, without changing any other things in annotations or compiletest.
After this only non-viral `NOTE`s and `HELP`s should be missing.

r? @jieyouxu 