### PR TITLE
emit a better error message for using the macro incorrectly

### DIFF
--- a/compiler/rustc_builtin_macros/src/autodiff.rs
+++ b/compiler/rustc_builtin_macros/src/autodiff.rs
@@ -234,7 +234,7 @@ mod llvm_enzyme {
         let meta_item_vec: ThinVec<MetaItemInner> = match meta_item.kind {
             ast::MetaItemKind::List(ref vec) => vec.clone(),
             _ => {
-                dcx.emit_err(errors::AutoDiffInvalidApplication { span: item.span() });
+                dcx.emit_err(errors::AutoDiffMissingConfig { span: item.span() });
                 return vec![item];
             }
         };

--- a/tests/ui/autodiff/autodiff_illegal.rs
+++ b/tests/ui/autodiff/autodiff_illegal.rs
@@ -63,7 +63,7 @@ fn dummy() {
 // Malformed, where args?
 #[autodiff]
 pub fn f7(x: f64) {
-    //~^ ERROR autodiff must be applied to function
+    //~^ ERROR autodiff requires at least a name and mode
     unimplemented!()
 }
 
@@ -77,7 +77,7 @@ pub fn f8(x: f64) {
 // Invalid attribute syntax
 #[autodiff = ""]
 pub fn f9(x: f64) {
-    //~^ ERROR autodiff must be applied to function
+    //~^ ERROR autodiff requires at least a name and mode
     unimplemented!()
 }
 

--- a/tests/ui/autodiff/autodiff_illegal.stderr
+++ b/tests/ui/autodiff/autodiff_illegal.stderr
@@ -62,7 +62,7 @@ error: autodiff must be applied to function
 LL |     let add_one_v2 = |x: u32| -> u32 { x + 1 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: autodiff must be applied to function
+error: autodiff requires at least a name and mode
   --> $DIR/autodiff_illegal.rs:65:1
    |
 LL | / pub fn f7(x: f64) {
@@ -80,7 +80,7 @@ LL | |     unimplemented!()
 LL | | }
    | |_^
 
-error: autodiff must be applied to function
+error: autodiff requires at least a name and mode
   --> $DIR/autodiff_illegal.rs:79:1
    |
 LL | / pub fn f9(x: f64) {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

fixing: https://github.com/EnzymeAD/rust/issues/185
I feel like it's not a perfect message either, so I'm open to suggestions.
But at the end of the day users will need to read the docs anyway, and emitting 
multi-line errors each time this gets triggered can probably become annoying?

r? @jieyouxu since you've reviewed my frontend work back in the days.

Tracking:

- https://github.com/rust-lang/rust/issues/124509