### PR TITLE
Use LTO to optimize Rust tools (cargo, miri, rustfmt, clippy, Rust Analyzer)

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -148,7 +148,9 @@ impl Step for ToolBuild {
             &self.extra_features,
         );
 
-        if path.ends_with("/rustdoc") &&
+        // Rustc tools (miri, clippy, cargo, rustfmt, rust-analyzer)
+        // could use the additional optimizations.
+        if self.mode == Mode::ToolRustc &&
             // rustdoc is performance sensitive, so apply LTO to it.
             is_lto_stage(&self.compiler)
         {


### PR DESCRIPTION
Trying if LTO/PGO can help RA's performance, and by how much. As @Noratrieb suggested, we could actually LTO optimize all the important tools.

CC @Veykril I realized that we don't even do LTO for Rust Analyzer, that could be a very low hanging fruit to improve its performance :sweat_smile:

try-job: dist-x86_64-linux