### PR TITLE
Add regression test for graceful error for wrong number of activities

### DIFF
--- a/tests/ui/autodiff/autodiff_illegal.rs
+++ b/tests/ui/autodiff/autodiff_illegal.rs
@@ -30,16 +30,24 @@ pub fn f4(x: f64) {
     unimplemented!()
 }
 
+
+#[autodiff(df5, Forward, Dual, Dual)]
+fn f5(x: f32, y: f32) -> f32 {
+    //~^^ ERROR     expected 3 activities, but found 2
+    x + y
+}
+
+
 // We can't use Dual in Reverse mode
-#[autodiff(df5, Reverse, Dual)]
-pub fn f5(x: f64) {
+#[autodiff(df6, Reverse, Dual)]
+pub fn f6(x: f64) {
     //~^^ ERROR     Dual can not be used in Reverse Mode
     unimplemented!()
 }
 
 // We can't use Duplicated in Forward mode
-#[autodiff(df6, Forward, Duplicated)]
-pub fn f6(x: f64) {
+#[autodiff(df7, Forward, Duplicated)]
+pub fn f7(x: f64) {
     //~^^ ERROR Duplicated can not be used in Forward Mode
     //~^^ ERROR Duplicated can not be used for this type
     unimplemented!()
@@ -62,21 +70,21 @@ fn dummy() {
 
 // Malformed, where args?
 #[autodiff]
-pub fn f7(x: f64) {
+pub fn f8(x: f64) {
     //~^ ERROR autodiff requires at least a name and mode
     unimplemented!()
 }
 
 // Malformed, where args?
 #[autodiff()]
-pub fn f8(x: f64) {
+pub fn f9(x: f64) {
     //~^ ERROR autodiff requires at least a name and mode
     unimplemented!()
 }
 
 // Invalid attribute syntax
 #[autodiff = ""]
-pub fn f9(x: f64) {
+pub fn f10(x: f64) {
     //~^ ERROR autodiff requires at least a name and mode
     unimplemented!()
 }
@@ -85,29 +93,29 @@ fn fn_exists() {}
 
 // We colide with an already existing function
 #[autodiff(fn_exists, Reverse, Active)]
-pub fn f10(x: f64) {
+pub fn f11(x: f64) {
     //~^^ ERROR the name `fn_exists` is defined multiple times [E0428]
     unimplemented!()
 }
 
 // Malformed, missing a mode
-#[autodiff(df11)]
-pub fn f11() {
+#[autodiff(df12)]
+pub fn f12() {
     //~^ ERROR autodiff requires at least a name and mode
     unimplemented!()
 }
 
 // Invalid Mode
-#[autodiff(df12, Debug)]
-pub fn f12() {
+#[autodiff(df13, Debug)]
+pub fn f13() {
     //~^^ ERROR unknown Mode: `Debug`. Use `Forward` or `Reverse`
     unimplemented!()
 }
 
 // Invalid, please pick one Mode
 // or use two autodiff macros.
-#[autodiff(df13, Forward, Reverse)]
-pub fn f13() {
+#[autodiff(df14, Forward, Reverse)]
+pub fn f14() {
     //~^^ ERROR did not recognize Activity: `Reverse`
     unimplemented!()
 }
@@ -117,8 +125,8 @@ struct Foo {}
 // We can't handle Active structs, because that would mean (in the general case), that we would
 // need to allocate and initialize arbitrary user types. We have Duplicated/Dual input args for
 // that. FIXME: Give a nicer error and suggest to the user to have a `&mut Foo` input instead.
-#[autodiff(df14, Reverse, Active, Active)]
-fn f14(x: f32) -> Foo {
+#[autodiff(df15, Reverse, Active, Active)]
+fn f15(x: f32) -> Foo {
     unimplemented!()
 }
 
@@ -127,15 +135,15 @@ type MyFloat = f32;
 // We would like to support type alias to f32/f64 in argument type in the future,
 // but that requires us to implement our checks at a later stage
 // like THIR which has type information available.
-#[autodiff(df15, Reverse, Active, Active)]
-fn f15(x: MyFloat) -> f32 {
+#[autodiff(df16, Reverse, Active, Active)]
+fn f16(x: MyFloat) -> f32 {
     //~^^ ERROR failed to resolve: use of undeclared type `MyFloat` [E0433]
     unimplemented!()
 }
 
 // We would like to support type alias to f32/f64 in return type in the future
-#[autodiff(df16, Reverse, Active, Active)]
-fn f16(x: f32) -> MyFloat {
+#[autodiff(df17, Reverse, Active, Active)]
+fn f17(x: f32) -> MyFloat {
     unimplemented!()
 }
 
@@ -145,41 +153,41 @@ struct F64Trans {
 }
 
 // We would like to support `#[repr(transparent)]` f32/f64 wrapper in return type in the future
-#[autodiff(df17, Reverse, Active, Active)]
-fn f17(x: f64) -> F64Trans {
+#[autodiff(df18, Reverse, Active, Active)]
+fn f18(x: f64) -> F64Trans {
     unimplemented!()
 }
 
 // We would like to support `#[repr(transparent)]` f32/f64 wrapper in argument type in the future
-#[autodiff(df18, Reverse, Active, Active)]
-fn f18(x: F64Trans) -> f64 {
+#[autodiff(df19, Reverse, Active, Active)]
+fn f19(x: F64Trans) -> f64 {
     //~^^ ERROR failed to resolve: use of undeclared type `F64Trans` [E0433]
     unimplemented!()
 }
 
 // Invalid return activity
-#[autodiff(df19, Forward, Dual, Active)]
-fn f19(x: f32) -> f32 {
+#[autodiff(df20, Forward, Dual, Active)]
+fn f20(x: f32) -> f32 {
     //~^^ ERROR invalid return activity Active in Forward Mode
     unimplemented!()
 }
 
-#[autodiff(df20, Reverse, Active, Dual)]
-fn f20(x: f32) -> f32 {
+#[autodiff(df21, Reverse, Active, Dual)]
+fn f21(x: f32) -> f32 {
     //~^^ ERROR invalid return activity Dual in Reverse Mode
     unimplemented!()
 }
 
 // Duplicated cannot be used as return activity
-#[autodiff(df21, Reverse, Active, Duplicated)]
-fn f21(x: f32) -> f32 {
+#[autodiff(df22, Reverse, Active, Duplicated)]
+fn f22(x: f32) -> f32 {
     //~^^ ERROR invalid return activity Duplicated in Reverse Mode
     unimplemented!()
 }
 
 struct DoesNotImplDefault;
-#[autodiff(df22, Forward, Dual)]
-pub fn f22() -> DoesNotImplDefault {
+#[autodiff(df23, Forward, Dual)]
+pub fn f23() -> DoesNotImplDefault {
     //~^^ ERROR the function or associated item `default` exists for tuple `(DoesNotImplDefault, DoesNotImplDefault)`, but its trait bounds were not satisfied
     unimplemented!()
 }

--- a/tests/ui/autodiff/autodiff_illegal.stderr
+++ b/tests/ui/autodiff/autodiff_illegal.stderr
@@ -1,5 +1,5 @@
 error[E0658]: attributes on expressions are experimental
-  --> $DIR/autodiff_illegal.rs:53:5
+  --> $DIR/autodiff_illegal.rs:61:5
    |
 LL |     #[autodiff(df7, Forward, Dual)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,53 +26,50 @@ error: expected 1 activities, but found 0
 LL | #[autodiff(df4, Reverse)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Dual can not be used in Reverse Mode
+error: expected 3 activities, but found 2
   --> $DIR/autodiff_illegal.rs:34:1
    |
-LL | #[autodiff(df5, Reverse, Dual)]
+LL | #[autodiff(df5, Forward, Dual, Dual)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Dual can not be used in Reverse Mode
+  --> $DIR/autodiff_illegal.rs:42:1
+   |
+LL | #[autodiff(df6, Reverse, Dual)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Duplicated can not be used in Forward Mode
-  --> $DIR/autodiff_illegal.rs:41:1
+  --> $DIR/autodiff_illegal.rs:49:1
    |
-LL | #[autodiff(df6, Forward, Duplicated)]
+LL | #[autodiff(df7, Forward, Duplicated)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Duplicated can not be used for this type
-  --> $DIR/autodiff_illegal.rs:42:14
+  --> $DIR/autodiff_illegal.rs:50:14
    |
-LL | pub fn f6(x: f64) {
+LL | pub fn f7(x: f64) {
    |              ^^^
 
 error: autodiff must be applied to function
-  --> $DIR/autodiff_illegal.rs:50:5
+  --> $DIR/autodiff_illegal.rs:58:5
    |
 LL |     let mut x = 5;
    |     ^^^^^^^^^^^^^^
 
 error: autodiff must be applied to function
-  --> $DIR/autodiff_illegal.rs:54:5
+  --> $DIR/autodiff_illegal.rs:62:5
    |
 LL |     x = x + 3;
    |     ^
 
 error: autodiff must be applied to function
-  --> $DIR/autodiff_illegal.rs:59:5
+  --> $DIR/autodiff_illegal.rs:67:5
    |
 LL |     let add_one_v2 = |x: u32| -> u32 { x + 1 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: autodiff requires at least a name and mode
-  --> $DIR/autodiff_illegal.rs:65:1
-   |
-LL | / pub fn f7(x: f64) {
-LL | |
-LL | |     unimplemented!()
-LL | | }
-   | |_^
-
-error: autodiff requires at least a name and mode
-  --> $DIR/autodiff_illegal.rs:72:1
+  --> $DIR/autodiff_illegal.rs:73:1
    |
 LL | / pub fn f8(x: f64) {
 LL | |
@@ -81,7 +78,7 @@ LL | | }
    | |_^
 
 error: autodiff requires at least a name and mode
-  --> $DIR/autodiff_illegal.rs:79:1
+  --> $DIR/autodiff_illegal.rs:80:1
    |
 LL | / pub fn f9(x: f64) {
 LL | |
@@ -89,8 +86,17 @@ LL | |     unimplemented!()
 LL | | }
    | |_^
 
-error[E0428]: the name `fn_exists` is defined multiple times
+error: autodiff requires at least a name and mode
   --> $DIR/autodiff_illegal.rs:87:1
+   |
+LL | / pub fn f10(x: f64) {
+LL | |
+LL | |     unimplemented!()
+LL | | }
+   | |_^
+
+error[E0428]: the name `fn_exists` is defined multiple times
+  --> $DIR/autodiff_illegal.rs:95:1
    |
 LL | fn fn_exists() {}
    | -------------- previous definition of the value `fn_exists` here
@@ -101,62 +107,62 @@ LL | #[autodiff(fn_exists, Reverse, Active)]
    = note: `fn_exists` must be defined only once in the value namespace of this module
 
 error: autodiff requires at least a name and mode
-  --> $DIR/autodiff_illegal.rs:95:1
+  --> $DIR/autodiff_illegal.rs:103:1
    |
-LL | / pub fn f11() {
+LL | / pub fn f12() {
 LL | |
 LL | |     unimplemented!()
 LL | | }
    | |_^
 
 error: unknown Mode: `Debug`. Use `Forward` or `Reverse`
-  --> $DIR/autodiff_illegal.rs:101:18
+  --> $DIR/autodiff_illegal.rs:109:18
    |
-LL | #[autodiff(df12, Debug)]
+LL | #[autodiff(df13, Debug)]
    |                  ^^^^^
 
 error: did not recognize Activity: `Reverse`
-  --> $DIR/autodiff_illegal.rs:109:27
+  --> $DIR/autodiff_illegal.rs:117:27
    |
-LL | #[autodiff(df13, Forward, Reverse)]
+LL | #[autodiff(df14, Forward, Reverse)]
    |                           ^^^^^^^
 
 error: invalid return activity Active in Forward Mode
-  --> $DIR/autodiff_illegal.rs:161:1
+  --> $DIR/autodiff_illegal.rs:169:1
    |
-LL | #[autodiff(df19, Forward, Dual, Active)]
+LL | #[autodiff(df20, Forward, Dual, Active)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid return activity Dual in Reverse Mode
-  --> $DIR/autodiff_illegal.rs:167:1
+  --> $DIR/autodiff_illegal.rs:175:1
    |
-LL | #[autodiff(df20, Reverse, Active, Dual)]
+LL | #[autodiff(df21, Reverse, Active, Dual)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: invalid return activity Duplicated in Reverse Mode
-  --> $DIR/autodiff_illegal.rs:174:1
+  --> $DIR/autodiff_illegal.rs:182:1
    |
-LL | #[autodiff(df21, Reverse, Active, Duplicated)]
+LL | #[autodiff(df22, Reverse, Active, Duplicated)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0433]: failed to resolve: use of undeclared type `MyFloat`
-  --> $DIR/autodiff_illegal.rs:130:1
+  --> $DIR/autodiff_illegal.rs:138:1
    |
-LL | #[autodiff(df15, Reverse, Active, Active)]
+LL | #[autodiff(df16, Reverse, Active, Active)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `MyFloat`
 
 error[E0433]: failed to resolve: use of undeclared type `F64Trans`
-  --> $DIR/autodiff_illegal.rs:154:1
+  --> $DIR/autodiff_illegal.rs:162:1
    |
-LL | #[autodiff(df18, Reverse, Active, Active)]
+LL | #[autodiff(df19, Reverse, Active, Active)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared type `F64Trans`
 
 error[E0599]: the function or associated item `default` exists for tuple `(DoesNotImplDefault, DoesNotImplDefault)`, but its trait bounds were not satisfied
-  --> $DIR/autodiff_illegal.rs:181:1
+  --> $DIR/autodiff_illegal.rs:189:1
    |
 LL | struct DoesNotImplDefault;
    | ------------------------- doesn't satisfy `DoesNotImplDefault: Default`
-LL | #[autodiff(df22, Forward, Dual)]
+LL | #[autodiff(df23, Forward, Dual)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item cannot be called on `(DoesNotImplDefault, DoesNotImplDefault)` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
@@ -168,7 +174,7 @@ LL + #[derive(Default)]
 LL | struct DoesNotImplDefault;
    |
 
-error: aborting due to 23 previous errors
+error: aborting due to 24 previous errors
 
 Some errors have detailed explanations: E0428, E0433, E0599, E0658.
 For more information about an error, try `rustc --explain E0428`.


### PR DESCRIPTION
Fix for: https://github.com/rust-lang/rust/issues/139590

- Added graceful error message instead of an ICE
- Blessed tests

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

Edit: one of @ZuseZ4 's commits fixed it. This PR just adds the test case to avoid regressions.