### PR TITLE
rustdoc: Enable Markdown extensions when looking for doctests

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -721,7 +721,7 @@ pub(crate) fn find_codes<T: doctest::DocTestVisitor>(
     extra_info: Option<&ExtraInfo<'_>>,
     include_non_rust: bool,
 ) {
-    let mut parser = Parser::new(doc).into_offset_iter();
+    let mut parser = Parser::new_ext(doc, main_body_opts()).into_offset_iter();
     let mut prev_offset = 0;
     let mut nb_lines = 0;
     let mut register_header = None;

--- a/tests/rustdoc-ui/multi-par-footnote.rs
+++ b/tests/rustdoc-ui/multi-par-footnote.rs
@@ -1,0 +1,18 @@
+//@ check-pass
+//@ compile-flags:--test
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+// Regression test for #139064.
+
+/// Example
+///
+/// Footnote with multiple paragraphs[^multiple]
+///
+/// [^multiple]:
+///     One
+///
+///     Two
+///
+///     Three
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}

--- a/tests/rustdoc-ui/multi-par-footnote.stdout
+++ b/tests/rustdoc-ui/multi-par-footnote.stdout
@@ -1,0 +1,5 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
Fixes #139064.

We should enable these to avoid misinterpreting uses of the extended
syntax as code blocks. This happens in practice with multi-paragraph
footnotes, as discovered in #139064.
