### PR TITLE
Simplify `ObligationCauseCode::IfExpression`

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -583,7 +583,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ascribed_ty
             }
             ExprKind::If(cond, then_expr, opt_else_expr) => {
-                self.check_expr_if(cond, then_expr, opt_else_expr, expr.span, expected)
+                self.check_expr_if(expr.hir_id, cond, then_expr, opt_else_expr, expr.span, expected)
             }
             ExprKind::DropTemps(e) => self.check_expr_with_expectation(e, expected),
             ExprKind::Array(args) => self.check_expr_array(args, expected, expr),
@@ -1343,6 +1343,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     // or 'if-else' expression.
     fn check_expr_if(
         &self,
+        expr_id: HirId,
         cond_expr: &'tcx hir::Expr<'tcx>,
         then_expr: &'tcx hir::Expr<'tcx>,
         opt_else_expr: Option<&'tcx hir::Expr<'tcx>>,
@@ -1382,15 +1383,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             let tail_defines_return_position_impl_trait =
                 self.return_position_impl_trait_from_match_expectation(orig_expected);
-            let if_cause = self.if_cause(
-                sp,
-                cond_expr.span,
-                then_expr,
-                else_expr,
-                then_ty,
-                else_ty,
-                tail_defines_return_position_impl_trait,
-            );
+            let if_cause =
+                self.if_cause(expr_id, else_expr, tail_defines_return_position_impl_trait);
 
             coerce.coerce(self, &if_cause, else_expr, else_ty);
 

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -332,7 +332,11 @@ pub enum ObligationCauseCode<'tcx> {
     },
 
     /// Computing common supertype in an if expression
-    IfExpression(Box<IfExpressionCause<'tcx>>),
+    IfExpression {
+        expr_id: HirId,
+        // Is the expectation of this match expression an RPIT?
+        tail_defines_return_position_impl_trait: Option<LocalDefId>,
+    },
 
     /// Computing common supertype of an if expression with no else counter-part
     IfExpressionWithNoElse,
@@ -548,18 +552,6 @@ pub struct PatternOriginExpr {
     /// Does the peeled expression need to be wrapped in parentheses for
     /// a prefix suggestion (i.e., dereference) to be valid.
     pub peeled_prefix_suggestion_parentheses: bool,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[derive(TypeFoldable, TypeVisitable, HashStable, TyEncodable, TyDecodable)]
-pub struct IfExpressionCause<'tcx> {
-    pub then_id: HirId,
-    pub else_id: HirId,
-    pub then_ty: Ty<'tcx>,
-    pub else_ty: Ty<'tcx>,
-    pub outer_span: Option<Span>,
-    // Is the expectation of this match expression an RPIT?
-    pub tail_defines_return_position_impl_trait: Option<LocalDefId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, HashStable, TyEncodable, TyDecodable)]

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -82,9 +82,7 @@ use crate::infer;
 use crate::infer::relate::{self, RelateResult, TypeRelation};
 use crate::infer::{InferCtxt, InferCtxtExt as _, TypeTrace, ValuePairs};
 use crate::solve::deeply_normalize_for_diagnostics;
-use crate::traits::{
-    IfExpressionCause, MatchExpressionArmCause, ObligationCause, ObligationCauseCode,
-};
+use crate::traits::{MatchExpressionArmCause, ObligationCause, ObligationCauseCode};
 
 mod note_and_explain;
 mod suggest;
@@ -613,18 +611,28 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     }
                 }
             },
-            ObligationCauseCode::IfExpression(box IfExpressionCause {
-                then_id,
-                else_id,
-                then_ty,
-                else_ty,
-                outer_span,
-                ..
-            }) => {
-                let then_span = self.find_block_span_from_hir_id(then_id);
-                let else_span = self.find_block_span_from_hir_id(else_id);
-                if let hir::Node::Expr(e) = self.tcx.hir_node(else_id)
-                    && let hir::ExprKind::If(_cond, _then, None) = e.kind
+            ObligationCauseCode::IfExpression { expr_id, .. } => {
+                let hir::Node::Expr(&hir::Expr {
+                    kind: hir::ExprKind::If(cond_expr, then_expr, Some(else_expr)),
+                    span: expr_span,
+                    ..
+                }) = self.tcx.hir_node(expr_id)
+                else {
+                    return;
+                };
+                let then_span = self.find_block_span_from_hir_id(then_expr.hir_id);
+                let then_ty = self
+                    .typeck_results
+                    .as_ref()
+                    .expect("if expression only expected inside FnCtxt")
+                    .expr_ty(then_expr);
+                let else_span = self.find_block_span_from_hir_id(else_expr.hir_id);
+                let else_ty = self
+                    .typeck_results
+                    .as_ref()
+                    .expect("if expression only expected inside FnCtxt")
+                    .expr_ty(else_expr);
+                if let hir::ExprKind::If(_cond, _then, None) = else_expr.kind
                     && else_ty.is_unit()
                 {
                     // Account for `let x = if a { 1 } else if b { 2 };`
@@ -632,9 +640,32 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     err.note("consider adding an `else` block that evaluates to the expected type");
                 }
                 err.span_label(then_span, "expected because of this");
+
+                let outer_span = if self.tcx.sess.source_map().is_multiline(expr_span) {
+                    if then_span.hi() == expr_span.hi() || else_span.hi() == expr_span.hi() {
+                        // Point at condition only if either block has the same end point as
+                        // the whole expression, since that'll cause awkward overlapping spans.
+                        Some(expr_span.shrink_to_lo().to(cond_expr.peel_drop_temps().span))
+                    } else {
+                        Some(expr_span)
+                    }
+                } else {
+                    None
+                };
                 if let Some(sp) = outer_span {
                     err.span_label(sp, "`if` and `else` have incompatible types");
                 }
+
+                let then_id = if let hir::ExprKind::Block(then_blk, _) = then_expr.kind {
+                    then_blk.hir_id
+                } else {
+                    then_expr.hir_id
+                };
+                let else_id = if let hir::ExprKind::Block(else_blk, _) = else_expr.kind {
+                    else_blk.hir_id
+                } else {
+                    else_expr.hir_id
+                };
                 if let Some(subdiag) = self.suggest_remove_semi_or_return_binding(
                     Some(then_id),
                     then_ty,

--- a/tests/ui/expr/if/if-else-chain-missing-else.stderr
+++ b/tests/ui/expr/if/if-else-chain-missing-else.stderr
@@ -1,18 +1,15 @@
 error[E0308]: `if` and `else` have incompatible types
   --> $DIR/if-else-chain-missing-else.rs:12:12
    |
-LL |        let x = if let Ok(x) = res {
-   |  ______________-
-LL | |          x
-   | |          - expected because of this
-LL | |      } else if let Err(e) = res {
-   | | ____________^
-LL | ||         return Err(e);
-LL | ||     };
-   | ||     ^
-   | ||_____|
-   |  |_____`if` and `else` have incompatible types
-   |        expected `i32`, found `()`
+LL |       let x = if let Ok(x) = res {
+   |               ------------------ `if` and `else` have incompatible types
+LL |           x
+   |           - expected because of this
+LL |       } else if let Err(e) = res {
+   |  ____________^
+LL | |         return Err(e);
+LL | |     };
+   | |_____^ expected `i32`, found `()`
    |
    = note: `if` expressions without `else` evaluate to `()`
    = note: consider adding an `else` block that evaluates to the expected type

--- a/tests/ui/expr/if/if-else-type-mismatch.stderr
+++ b/tests/ui/expr/if/if-else-type-mismatch.stderr
@@ -92,13 +92,16 @@ LL | |     };
 error[E0308]: `if` and `else` have incompatible types
   --> $DIR/if-else-type-mismatch.rs:37:9
    |
-LL |       let _ = if true {
-   |  _____________________-
-LL | |
-LL | |     } else {
-   | |_____- expected because of this
-LL |           11u32
-   |           ^^^^^ expected `()`, found `u32`
+LL |        let _ = if true {
+   |  ______________-       -
+   | | _____________________|
+LL | ||
+LL | ||     } else {
+   | ||_____- expected because of this
+LL | |          11u32
+   | |          ^^^^^ expected `()`, found `u32`
+LL | |      };
+   | |______- `if` and `else` have incompatible types
 
 error[E0308]: `if` and `else` have incompatible types
   --> $DIR/if-else-type-mismatch.rs:42:12

--- a/tests/ui/inference/deref-suggestion.stderr
+++ b/tests/ui/inference/deref-suggestion.stderr
@@ -164,21 +164,18 @@ LL |         *b
 error[E0308]: `if` and `else` have incompatible types
   --> $DIR/deref-suggestion.rs:69:12
    |
-LL |        let val = if true {
-   |  ________________-
-LL | |          *a
-   | |          -- expected because of this
-LL | |      } else if true {
-   | | ____________^
-LL | ||
-LL | ||         b
-LL | ||     } else {
-LL | ||         &0
-LL | ||     };
-   | ||     ^
-   | ||_____|
-   |  |_____`if` and `else` have incompatible types
-   |        expected `i32`, found `&{integer}`
+LL |       let val = if true {
+   |                 ------- `if` and `else` have incompatible types
+LL |           *a
+   |           -- expected because of this
+LL |       } else if true {
+   |  ____________^
+LL | |
+LL | |         b
+LL | |     } else {
+LL | |         &0
+LL | |     };
+   | |_____^ expected `i32`, found `&{integer}`
 
 error[E0308]: mismatched types
   --> $DIR/deref-suggestion.rs:81:15

--- a/tests/ui/suggestions/return-bindings.stderr
+++ b/tests/ui/suggestions/return-bindings.stderr
@@ -62,12 +62,16 @@ LL ~
 error[E0308]: `if` and `else` have incompatible types
   --> $DIR/return-bindings.rs:30:9
    |
-LL |       let s = if let Some(s) = opt_str {
-   |  ______________________________________-
-LL | |     } else {
-   | |_____- expected because of this
-LL |           String::new()
-   |           ^^^^^^^^^^^^^ expected `()`, found `String`
+LL |        let s = if let Some(s) = opt_str {
+   |  ______________-                        -
+   | | ______________________________________|
+LL | ||     } else {
+   | ||_____- expected because of this
+LL | |          String::new()
+   | |          ^^^^^^^^^^^^^ expected `()`, found `String`
+LL | |
+LL | |      };
+   | |______- `if` and `else` have incompatible types
    |
 help: consider returning the local binding `s`
    |

--- a/tests/ui/typeck/consider-borrowing-141810-1.stderr
+++ b/tests/ui/typeck/consider-borrowing-141810-1.stderr
@@ -1,20 +1,17 @@
 error[E0308]: `if` and `else` have incompatible types
   --> $DIR/consider-borrowing-141810-1.rs:4:12
    |
-LL |        let x = if true {
-   |  ______________-
-LL | |          &true
-   | |          ----- expected because of this
-LL | |      } else if false {
-   | | ____________^
-LL | ||         true
-LL | ||     } else {
-LL | ||         true
-LL | ||     };
-   | ||     ^
-   | ||_____|
-   |  |_____`if` and `else` have incompatible types
-   |        expected `&bool`, found `bool`
+LL |       let x = if true {
+   |               ------- `if` and `else` have incompatible types
+LL |           &true
+   |           ----- expected because of this
+LL |       } else if false {
+   |  ____________^
+LL | |         true
+LL | |     } else {
+LL | |         true
+LL | |     };
+   | |_____^ expected `&bool`, found `bool`
    |
 help: consider borrowing here
    |

--- a/tests/ui/typeck/consider-borrowing-141810-2.stderr
+++ b/tests/ui/typeck/consider-borrowing-141810-2.stderr
@@ -1,18 +1,15 @@
 error[E0308]: `if` and `else` have incompatible types
   --> $DIR/consider-borrowing-141810-2.rs:4:12
    |
-LL |        let x = if true {
-   |  ______________-
-LL | |          &()
-   | |          --- expected because of this
-LL | |      } else if false {
-   | | ____________^
-LL | ||     } else {
-LL | ||     };
-   | ||     ^
-   | ||_____|
-   |  |_____`if` and `else` have incompatible types
-   |        expected `&()`, found `()`
+LL |       let x = if true {
+   |               ------- `if` and `else` have incompatible types
+LL |           &()
+   |           --- expected because of this
+LL |       } else if false {
+   |  ____________^
+LL | |     } else {
+LL | |     };
+   | |_____^ expected `&()`, found `()`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/consider-borrowing-141810-3.stderr
+++ b/tests/ui/typeck/consider-borrowing-141810-3.stderr
@@ -1,18 +1,15 @@
 error[E0308]: `if` and `else` have incompatible types
   --> $DIR/consider-borrowing-141810-3.rs:4:12
    |
-LL |        let x = if true {
-   |  ______________-
-LL | |          &()
-   | |          --- expected because of this
-LL | |      } else if false {
-   | | ____________^
-LL | ||
-LL | ||     };
-   | ||     ^
-   | ||_____|
-   |  |_____`if` and `else` have incompatible types
-   |        expected `&()`, found `()`
+LL |       let x = if true {
+   |               ------- `if` and `else` have incompatible types
+LL |           &()
+   |           --- expected because of this
+LL |       } else if false {
+   |  ____________^
+LL | |
+LL | |     };
+   | |_____^ expected `&()`, found `()`
    |
    = note: `if` expressions without `else` evaluate to `()`
    = note: consider adding an `else` block that evaluates to the expected type


### PR DESCRIPTION
This originally started out as an experiment to do less incremental invalidation by deferring the span operations that happen on the good path in `check_expr_if`, but it ended up not helping much (or at least not showing up in our incremental tests).

As a side-effect though, I think the code is a lot cleaner and there are modest diagnostics improvements with overlapping spans, so I think it's still worth landing.