### PR TITLE
Remove `Symbol` from `Named` variant of `BoundRegionKind`/`LateParamRegionKind`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -4195,7 +4195,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         let return_ty = sig.output();
         match return_ty.skip_binder().kind() {
             ty::Ref(return_region, _, _)
-                if return_region.has_name(self.infcx.tcx) && !is_closure =>
+                if return_region.is_named(self.infcx.tcx) && !is_closure =>
             {
                 // This is case 1 from above, return type is a named reference so we need to
                 // search for relevant arguments.

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -4194,7 +4194,9 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         //    anything.
         let return_ty = sig.output();
         match return_ty.skip_binder().kind() {
-            ty::Ref(return_region, _, _) if return_region.has_name() && !is_closure => {
+            ty::Ref(return_region, _, _)
+                if return_region.has_name(self.infcx.tcx) && !is_closure =>
+            {
                 // This is case 1 from above, return type is a named reference so we need to
                 // search for relevant arguments.
                 let mut arguments = Vec::new();

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -853,7 +853,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             };
 
             let lifetime =
-                if f.has_name(self.infcx.tcx) { fr_name.name } else { kw::UnderscoreLifetime };
+                if f.is_named(self.infcx.tcx) { fr_name.name } else { kw::UnderscoreLifetime };
 
             let arg = match param.param.pat.simple_ident() {
                 Some(simple_ident) => format!("argument `{simple_ident}`"),

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -852,7 +852,8 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 return;
             };
 
-            let lifetime = if f.has_name() { fr_name.name } else { kw::UnderscoreLifetime };
+            let lifetime =
+                if f.has_name(self.infcx.tcx) { fr_name.name } else { kw::UnderscoreLifetime };
 
             let arg = match param.param.pat.simple_ident() {
                 Some(simple_ident) => format!("argument `{simple_ident}`"),

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -289,7 +289,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
 
         debug!("give_region_a_name: error_region = {:?}", error_region);
         match error_region.kind() {
-            ty::ReEarlyParam(ebr) => ebr.has_name().then(|| {
+            ty::ReEarlyParam(ebr) => ebr.is_named().then(|| {
                 let def_id = tcx.generics_of(self.mir_def_id()).region_param(ebr, tcx).def_id;
                 let span = tcx.hir_span_if_local(def_id).unwrap_or(DUMMY_SP);
                 RegionName { name: ebr.name, source: RegionNameSource::NamedEarlyParamRegion(span) }
@@ -895,7 +895,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
         let ty::ReEarlyParam(region) = self.to_error_region(fr)?.kind() else {
             return None;
         };
-        if region.has_name() {
+        if region.is_named() {
             return None;
         };
 
@@ -930,7 +930,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
         let ty::ReEarlyParam(region) = self.to_error_region(fr)?.kind() else {
             return None;
         };
-        if region.has_name() {
+        if region.is_named() {
             return None;
         };
 

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -300,16 +300,11 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
             }
 
             ty::ReLateParam(late_param) => match late_param.kind {
-                ty::LateParamRegionKind::Named(region_def_id, name) => {
+                ty::LateParamRegionKind::Named(region_def_id) => {
                     // Get the span to point to, even if we don't use the name.
                     let span = tcx.hir_span_if_local(region_def_id).unwrap_or(DUMMY_SP);
-                    debug!(
-                        "bound region named: {:?}, is_named: {:?}",
-                        name,
-                        late_param.kind.is_named()
-                    );
 
-                    if late_param.kind.is_named() {
+                    if let Some(name) = late_param.kind.get_name(tcx) {
                         // A named region that is actually named.
                         Some(RegionName {
                             name,
@@ -369,6 +364,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
                 }
 
                 ty::LateParamRegionKind::Anon(_) => None,
+                ty::LateParamRegionKind::NamedAnon(_, _) => bug!("only used for pretty printing"),
             },
 
             ty::ReBound(..)

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -232,13 +232,13 @@ pub(super) fn dump_nll_mir<'tcx>(
     // Also dump the region constraint graph as a graphviz file.
     let _: io::Result<()> = try {
         let mut file = create_dump_file(tcx, "regioncx.all.dot", false, "nll", &0, body)?;
-        regioncx.dump_graphviz_raw_constraints(&mut file)?;
+        regioncx.dump_graphviz_raw_constraints(tcx, &mut file)?;
     };
 
     // Also dump the region constraint SCC graph as a graphviz file.
     let _: io::Result<()> = try {
         let mut file = create_dump_file(tcx, "regioncx.scc.dot", false, "nll", &0, body)?;
-        regioncx.dump_graphviz_scc_constraints(&mut file)?;
+        regioncx.dump_graphviz_scc_constraints(tcx, &mut file)?;
     };
 }
 

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -786,8 +786,11 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                     let region_ctxt_fn = || {
                         let reg_info = match br.kind {
                             ty::BoundRegionKind::Anon => sym::anon,
-                            ty::BoundRegionKind::Named(_, name) => name,
+                            ty::BoundRegionKind::Named(def_id) => tcx.item_name(def_id),
                             ty::BoundRegionKind::ClosureEnv => sym::env,
+                            ty::BoundRegionKind::NamedAnon(_) => {
+                                bug!("only used for pretty printing")
+                            }
                         };
 
                         RegionCtxt::LateBound(reg_info)

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -497,7 +497,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
                 |r| {
                     debug!(?r);
                     let region_vid = {
-                        let name = r.get_name_or_anon();
+                        let name = r.get_name_or_anon(self.infcx.tcx);
                         self.infcx.next_nll_region_var(FR, || RegionCtxt::LateBound(name))
                     };
 
@@ -523,7 +523,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
                 let kind = ty::LateParamRegionKind::from_bound(ty::BoundVar::from_usize(idx), kind);
                 let r = ty::Region::new_late_param(self.infcx.tcx, self.mir_def.to_def_id(), kind);
                 let region_vid = {
-                    let name = r.get_name_or_anon();
+                    let name = r.get_name_or_anon(self.infcx.tcx);
                     self.infcx.next_nll_region_var(FR, || RegionCtxt::LateBound(name))
                 };
 
@@ -861,7 +861,7 @@ impl<'tcx> BorrowckInferCtxt<'tcx> {
         T: TypeFoldable<TyCtxt<'tcx>>,
     {
         fold_regions(self.infcx.tcx, value, |region, _depth| {
-            let name = region.get_name_or_anon();
+            let name = region.get_name_or_anon(self.infcx.tcx);
             debug!(?region, ?name);
 
             self.next_nll_region_var(origin, || RegionCtxt::Free(name))

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -2468,7 +2468,7 @@ fn param_env_with_gat_bounds<'tcx>(
         let normalize_impl_ty_args = ty::GenericArgs::identity_for_item(tcx, container_id)
             .extend_to(tcx, impl_ty.def_id, |param, _| match param.kind {
                 GenericParamDefKind::Type { .. } => {
-                    let kind = ty::BoundTyKind::Param(param.def_id, param.name);
+                    let kind = ty::BoundTyKind::Param(param.def_id);
                     let bound_var = ty::BoundVariableKind::Ty(kind);
                     bound_vars.push(bound_var);
                     Ty::new_bound(

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1239,7 +1239,7 @@ fn check_region_late_boundedness<'tcx>(
                 .unwrap_region_constraints()
                 .opportunistic_resolve_var(tcx, vid)
             && let ty::ReLateParam(ty::LateParamRegion {
-                kind: ty::LateParamRegionKind::Named(trait_param_def_id, _),
+                kind: ty::LateParamRegionKind::Named(trait_param_def_id),
                 ..
             }) = r.kind()
             && let ty::ReEarlyParam(ebr) = id_arg.expect_region().kind()
@@ -1264,7 +1264,7 @@ fn check_region_late_boundedness<'tcx>(
                 .unwrap_region_constraints()
                 .opportunistic_resolve_var(tcx, vid)
             && let ty::ReLateParam(ty::LateParamRegion {
-                kind: ty::LateParamRegionKind::Named(impl_param_def_id, _),
+                kind: ty::LateParamRegionKind::Named(impl_param_def_id),
                 ..
             }) = r.kind()
             && let ty::ReEarlyParam(ebr) = id_arg.expect_region().kind()
@@ -2479,7 +2479,7 @@ fn param_env_with_gat_bounds<'tcx>(
                     .into()
                 }
                 GenericParamDefKind::Lifetime => {
-                    let kind = ty::BoundRegionKind::Named(param.def_id, param.name);
+                    let kind = ty::BoundRegionKind::Named(param.def_id);
                     let bound_var = ty::BoundVariableKind::Region(kind);
                     bound_vars.push(bound_var);
                     ty::Region::new_bound(

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -2338,7 +2338,7 @@ fn lint_redundant_lifetimes<'tcx>(
             lifetimes.push(ty::Region::new_late_param(tcx, owner_id.to_def_id(), kind));
         }
     }
-    lifetimes.retain(|candidate| candidate.has_name(tcx));
+    lifetimes.retain(|candidate| candidate.is_named(tcx));
 
     // Keep track of lifetimes which have already been replaced with other lifetimes.
     // This makes sure that if `'a = 'b = 'c`, we don't say `'c` should be replaced by

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -2338,7 +2338,7 @@ fn lint_redundant_lifetimes<'tcx>(
             lifetimes.push(ty::Region::new_late_param(tcx, owner_id.to_def_id(), kind));
         }
     }
-    lifetimes.retain(|candidate| candidate.has_name());
+    lifetimes.retain(|candidate| candidate.has_name(tcx));
 
     // Keep track of lifetimes which have already been replaced with other lifetimes.
     // This makes sure that if `'a = 'b = 'c`, we don't say `'c` should be replaced by

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -654,7 +654,7 @@ fn infringing_fields_error<'tcx>(
                                 .or_default()
                                 .push(origin.span());
                             if let ty::RegionKind::ReEarlyParam(ebr) = b.kind()
-                                && ebr.has_name()
+                                && ebr.is_named()
                             {
                                 bounds.push((b.to_string(), a.to_string(), None));
                             }

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -578,9 +578,7 @@ fn get_new_lifetime_name<'tcx>(
     let existing_lifetimes = tcx
         .collect_referenced_late_bound_regions(poly_trait_ref)
         .into_iter()
-        .filter_map(|lt| {
-            if let Some(name) = lt.get_name(tcx) { Some(name.as_str().to_string()) } else { None }
-        })
+        .filter_map(|lt| lt.get_name(tcx).map(|name| name.as_str().to_string()))
         .chain(generics.params.iter().filter_map(|param| {
             if let hir::GenericParamKind::Lifetime { .. } = &param.kind {
                 Some(param.name.ident().as_str().to_string())

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -579,11 +579,7 @@ fn get_new_lifetime_name<'tcx>(
         .collect_referenced_late_bound_regions(poly_trait_ref)
         .into_iter()
         .filter_map(|lt| {
-            if let ty::BoundRegionKind::Named(_, name) = lt {
-                Some(name.as_str().to_string())
-            } else {
-                None
-            }
+            if let Some(name) = lt.get_name(tcx) { Some(name.as_str().to_string()) } else { None }
         })
         .chain(generics.params.iter().filter_map(|param| {
             if let hir::GenericParamKind::Lifetime { .. } = &param.kind {

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -287,7 +287,7 @@ fn late_arg_as_bound_arg<'tcx>(
     let name = tcx.item_name(def_id);
     match param.kind {
         GenericParamKind::Lifetime { .. } => {
-            ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id, name))
+            ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id))
         }
         GenericParamKind::Type { .. } => {
             ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(def_id, name))
@@ -302,7 +302,7 @@ fn late_arg_as_bound_arg<'tcx>(
 fn generic_param_def_as_bound_arg(param: &ty::GenericParamDef) -> ty::BoundVariableKind {
     match param.kind {
         ty::GenericParamDefKind::Lifetime => {
-            ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(param.def_id, param.name))
+            ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(param.def_id))
         }
         ty::GenericParamDefKind::Type { .. } => {
             ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(param.def_id, param.name))

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -1050,7 +1050,7 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for GenericParamAndBoundVarCollector<'_, 't
             }
             ty::Bound(db, bt) if *db >= self.depth => {
                 self.vars.insert(match bt.kind {
-                    ty::BoundTyKind::Param(def_id, _) => def_id,
+                    ty::BoundTyKind::Param(def_id) => def_id,
                     ty::BoundTyKind::Anon => {
                         let reported = self
                             .cx

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -12,7 +12,7 @@ use rustc_middle::ty::{
     self as ty, IsSuggestable, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt,
     TypeVisitor, Upcast,
 };
-use rustc_span::{ErrorGuaranteed, Ident, Span, kw};
+use rustc_span::{ErrorGuaranteed, Ident, Span, kw, sym};
 use rustc_trait_selection::traits;
 use smallvec::SmallVec;
 use tracing::{debug, instrument};

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2067,10 +2067,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let tcx = self.tcx();
         match tcx.named_bound_var(hir_id) {
             Some(rbv::ResolvedArg::LateBound(debruijn, index, def_id)) => {
-                let name = tcx.item_name(def_id.to_def_id());
                 let br = ty::BoundTy {
                     var: ty::BoundVar::from_u32(index),
-                    kind: ty::BoundTyKind::Param(def_id.to_def_id(), name),
+                    kind: ty::BoundTyKind::Param(def_id.to_def_id()),
                 };
                 Ty::new_bound(tcx, debruijn, br)
             }

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -392,16 +392,14 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     #[instrument(level = "debug", skip(self), ret)]
     pub fn lower_resolved_lifetime(&self, resolved: rbv::ResolvedArg) -> ty::Region<'tcx> {
         let tcx = self.tcx();
-        let lifetime_name = |def_id| tcx.hir_name(tcx.local_def_id_to_hir_id(def_id));
 
         match resolved {
             rbv::ResolvedArg::StaticLifetime => tcx.lifetimes.re_static,
 
             rbv::ResolvedArg::LateBound(debruijn, index, def_id) => {
-                let name = lifetime_name(def_id);
                 let br = ty::BoundRegion {
                     var: ty::BoundVar::from_u32(index),
-                    kind: ty::BoundRegionKind::Named(def_id.to_def_id(), name),
+                    kind: ty::BoundRegionKind::Named(def_id.to_def_id()),
                 };
                 ty::Region::new_bound(tcx, debruijn, br)
             }
@@ -415,11 +413,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             }
 
             rbv::ResolvedArg::Free(scope, id) => {
-                let name = lifetime_name(id);
                 ty::Region::new_late_param(
                     tcx,
                     scope.to_def_id(),
-                    ty::LateParamRegionKind::Named(id.to_def_id(), name),
+                    ty::LateParamRegionKind::Named(id.to_def_id()),
                 )
 
                 // (*) -- not late-bound, won't change
@@ -2749,18 +2746,15 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         generate_err: impl Fn(&str) -> Diag<'cx>,
     ) {
         for br in referenced_regions.difference(&constrained_regions) {
-            let br_name = match *br {
-                ty::BoundRegionKind::Named(_, kw::UnderscoreLifetime)
-                | ty::BoundRegionKind::Anon
-                | ty::BoundRegionKind::ClosureEnv => "an anonymous lifetime".to_string(),
-                ty::BoundRegionKind::Named(_, name) => format!("lifetime `{name}`"),
+            let br_name = if let Some(name) = br.get_name(self.tcx()) {
+                format!("lifetime `{name}`")
+            } else {
+                "an anonymous lifetime".to_string()
             };
 
             let mut err = generate_err(&br_name);
 
-            if let ty::BoundRegionKind::Named(_, kw::UnderscoreLifetime)
-            | ty::BoundRegionKind::Anon = *br
-            {
+            if !br.is_named(self.tcx()) {
                 // The only way for an anonymous lifetime to wind up
                 // in the return type but **also** be unconstrained is
                 // if it only appears in "associated types" in the

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -655,7 +655,7 @@ impl<'tcx> fmt::Display for GenericKind<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             GenericKind::Param(ref p) => write!(f, "{p}"),
-            GenericKind::Placeholder(ref p) => write!(f, "{p:?}"),
+            GenericKind::Placeholder(ref p) => write!(f, "{p}"),
             GenericKind::Alias(ref p) => write!(f, "{p}"),
         }
     }

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -215,7 +215,7 @@ where
             let arg: ty::BoundVariableKind = arg;
             match arg {
                 ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id))
-                | ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(def_id, _)) => {
+                | ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(def_id)) => {
                     added.push(def_id);
                     let unique = self.in_scope_parameters.insert(def_id, ParamKind::Late);
                     assert_eq!(unique, None);

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -136,7 +136,7 @@ enum ParamKind {
     // Early-bound var.
     Early(Symbol, u32),
     // Late-bound var on function, not within a binder. We can capture these.
-    Free(DefId, Symbol),
+    Free(DefId),
     // Late-bound var in a binder. We can't capture these yet.
     Late,
 }
@@ -156,12 +156,11 @@ fn check_fn(tcx: TyCtxt<'_>, parent_def_id: LocalDefId) {
     }
 
     for bound_var in sig.bound_vars() {
-        let ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id, name)) = bound_var
-        else {
+        let ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id)) = bound_var else {
             span_bug!(tcx.def_span(parent_def_id), "unexpected non-lifetime binder on fn sig");
         };
 
-        in_scope_parameters.insert(def_id, ParamKind::Free(def_id, name));
+        in_scope_parameters.insert(def_id, ParamKind::Free(def_id));
     }
 
     let sig = tcx.liberate_late_bound_regions(parent_def_id.to_def_id(), sig);
@@ -215,7 +214,7 @@ where
         for arg in t.bound_vars() {
             let arg: ty::BoundVariableKind = arg;
             match arg {
-                ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id, ..))
+                ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id))
                 | ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(def_id, _)) => {
                     added.push(def_id);
                     let unique = self.in_scope_parameters.insert(def_id, ParamKind::Late);
@@ -316,10 +315,10 @@ where
                             self.tcx,
                             ty::EarlyParamRegion { name, index },
                         ),
-                        ParamKind::Free(def_id, name) => ty::Region::new_late_param(
+                        ParamKind::Free(def_id) => ty::Region::new_late_param(
                             self.tcx,
                             self.parent_def_id.to_def_id(),
-                            ty::LateParamRegionKind::Named(def_id, name),
+                            ty::LateParamRegionKind::Named(def_id),
                         ),
                         // Totally ignore late bound args from binders.
                         ParamKind::Late => return true,
@@ -463,13 +462,10 @@ fn extract_def_id_from_arg<'tcx>(
     match arg.kind() {
         ty::GenericArgKind::Lifetime(re) => match re.kind() {
             ty::ReEarlyParam(ebr) => generics.region_param(ebr, tcx).def_id,
-            ty::ReBound(
-                _,
-                ty::BoundRegion { kind: ty::BoundRegionKind::Named(def_id, ..), .. },
-            )
+            ty::ReBound(_, ty::BoundRegion { kind: ty::BoundRegionKind::Named(def_id), .. })
             | ty::ReLateParam(ty::LateParamRegion {
                 scope: _,
-                kind: ty::LateParamRegionKind::Named(def_id, ..),
+                kind: ty::LateParamRegionKind::Named(def_id),
             }) => def_id,
             _ => unreachable!(),
         },
@@ -532,13 +528,10 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for FunctionalVariances<'tcx> {
     ) -> RelateResult<'tcx, ty::Region<'tcx>> {
         let def_id = match a.kind() {
             ty::ReEarlyParam(ebr) => self.generics.region_param(ebr, self.tcx).def_id,
-            ty::ReBound(
-                _,
-                ty::BoundRegion { kind: ty::BoundRegionKind::Named(def_id, ..), .. },
-            )
+            ty::ReBound(_, ty::BoundRegion { kind: ty::BoundRegionKind::Named(def_id), .. })
             | ty::ReLateParam(ty::LateParamRegion {
                 scope: _,
-                kind: ty::LateParamRegionKind::Named(def_id, ..),
+                kind: ty::LateParamRegionKind::Named(def_id),
             }) => def_id,
             _ => {
                 return Ok(a);

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -3279,10 +3279,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     return ty::Region::new_late_param(
                         self,
                         new_parent.to_def_id(),
-                        ty::LateParamRegionKind::Named(
-                            lbv.to_def_id(),
-                            self.item_name(lbv.to_def_id()),
-                        ),
+                        ty::LateParamRegionKind::Named(lbv.to_def_id()),
                     );
                 }
                 resolve_bound_vars::ResolvedArg::Error(guar) => {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -474,7 +474,7 @@ impl<'tcx> rustc_type_ir::Flags for Ty<'tcx> {
 impl EarlyParamRegion {
     /// Does this early bound region have a name? Early bound regions normally
     /// always have names except when using anonymous lifetimes (`'_`).
-    pub fn has_name(&self) -> bool {
+    pub fn is_named(&self) -> bool {
         self.name != kw::UnderscoreLifetime
     }
 }

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -822,13 +822,7 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             ty::Alias(ty::Projection | ty::Inherent | ty::Free, ref data) => {
                 p!(print(data))
             }
-            ty::Placeholder(placeholder) => match placeholder.bound.kind {
-                ty::BoundTyKind::Anon => p!(write("{placeholder:?}")),
-                ty::BoundTyKind::Param(def_id) => match self.should_print_verbose() {
-                    true => p!(write("{:?}", ty.kind())),
-                    false => p!(write("{}", self.tcx().item_name(def_id))),
-                },
-            },
+            ty::Placeholder(placeholder) => p!(print(placeholder)),
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) => {
                 // We use verbose printing in 'NO_QUERIES' mode, to
                 // avoid needing to call `predicates_of`. This should
@@ -3371,6 +3365,16 @@ define_print_and_forward_display! {
 
     ty::ParamTy {
         p!(write("{}", self.name))
+    }
+
+    ty::PlaceholderType {
+        match self.bound.kind {
+            ty::BoundTyKind::Anon => p!(write("{self:?}")),
+            ty::BoundTyKind::Param(def_id) => match cx.should_print_verbose() {
+                true => p!(write("{self:?}")),
+                false => p!(write("{}", cx.tcx().item_name(def_id))),
+            },
+        }
     }
 
     ty::ParamConst {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -795,9 +795,9 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
                 ty::BoundTyKind::Anon => {
                     rustc_type_ir::debug_bound_var(self, debruijn, bound_ty.var)?
                 }
-                ty::BoundTyKind::Param(_, s) => match self.should_print_verbose() {
+                ty::BoundTyKind::Param(def_id) => match self.should_print_verbose() {
                     true => p!(write("{:?}", ty.kind())),
-                    false => p!(write("{s}")),
+                    false => p!(write("{}", self.tcx().item_name(def_id))),
                 },
             },
             ty::Adt(def, args) => {
@@ -824,9 +824,9 @@ pub trait PrettyPrinter<'tcx>: Printer<'tcx> + fmt::Write {
             }
             ty::Placeholder(placeholder) => match placeholder.bound.kind {
                 ty::BoundTyKind::Anon => p!(write("{placeholder:?}")),
-                ty::BoundTyKind::Param(_, name) => match self.should_print_verbose() {
+                ty::BoundTyKind::Param(def_id) => match self.should_print_verbose() {
                     true => p!(write("{:?}", ty.kind())),
-                    false => p!(write("{name}")),
+                    false => p!(write("{}", self.tcx().item_name(def_id))),
                 },
             },
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) => {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2545,7 +2545,7 @@ impl<'tcx> PrettyPrinter<'tcx> for FmtPrinter<'_, 'tcx> {
         let identify_regions = self.tcx.sess.opts.unstable_opts.identify_regions;
 
         match region.kind() {
-            ty::ReEarlyParam(ref data) => data.has_name(),
+            ty::ReEarlyParam(ref data) => data.is_named(),
 
             ty::ReLateParam(ty::LateParamRegion { kind, .. }) => kind.is_named(self.tcx),
             ty::ReBound(_, ty::BoundRegion { kind: br, .. })

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -163,37 +163,33 @@ impl<'tcx> Region<'tcx> {
         *self.0.0
     }
 
-    pub fn get_name(self) -> Option<Symbol> {
-        if self.has_name() {
-            match self.kind() {
-                ty::ReEarlyParam(ebr) => Some(ebr.name),
-                ty::ReBound(_, br) => br.kind.get_name(),
-                ty::ReLateParam(fr) => fr.kind.get_name(),
-                ty::ReStatic => Some(kw::StaticLifetime),
-                ty::RePlaceholder(placeholder) => placeholder.bound.kind.get_name(),
-                _ => None,
-            }
-        } else {
-            None
+    pub fn get_name(self, tcx: TyCtxt<'tcx>) -> Option<Symbol> {
+        match self.kind() {
+            ty::ReEarlyParam(ebr) => Some(ebr.name),
+            ty::ReBound(_, br) => br.kind.get_name(tcx),
+            ty::ReLateParam(fr) => fr.kind.get_name(tcx),
+            ty::ReStatic => Some(kw::StaticLifetime),
+            ty::RePlaceholder(placeholder) => placeholder.bound.kind.get_name(tcx),
+            _ => None,
         }
     }
 
-    pub fn get_name_or_anon(self) -> Symbol {
-        match self.get_name() {
+    pub fn get_name_or_anon(self, tcx: TyCtxt<'tcx>) -> Symbol {
+        match self.get_name(tcx) {
             Some(name) => name,
             None => sym::anon,
         }
     }
 
     /// Is this region named by the user?
-    pub fn has_name(self) -> bool {
+    pub fn has_name(self, tcx: TyCtxt<'tcx>) -> bool {
         match self.kind() {
             ty::ReEarlyParam(ebr) => ebr.has_name(),
-            ty::ReBound(_, br) => br.kind.is_named(),
-            ty::ReLateParam(fr) => fr.kind.is_named(),
+            ty::ReBound(_, br) => br.kind.is_named(tcx),
+            ty::ReLateParam(fr) => fr.kind.is_named(tcx),
             ty::ReStatic => true,
             ty::ReVar(..) => false,
-            ty::RePlaceholder(placeholder) => placeholder.bound.kind.is_named(),
+            ty::RePlaceholder(placeholder) => placeholder.bound.kind.is_named(tcx),
             ty::ReErased => false,
             ty::ReError(_) => false,
         }
@@ -313,7 +309,7 @@ impl<'tcx> Region<'tcx> {
                 Some(tcx.generics_of(binding_item).region_param(ebr, tcx).def_id)
             }
             ty::ReLateParam(ty::LateParamRegion {
-                kind: ty::LateParamRegionKind::Named(def_id, _),
+                kind: ty::LateParamRegionKind::Named(def_id),
                 ..
             }) => Some(def_id),
             _ => None,
@@ -371,11 +367,13 @@ pub enum LateParamRegionKind {
     /// sake of diagnostics in `FnCtxt::sig_of_closure_with_expectation`.
     Anon(u32),
 
-    /// Named region parameters for functions (a in &'a T)
+    /// An anonymous region parameter with a `Symbol` name.
     ///
-    /// The `DefId` is needed to distinguish free regions in
-    /// the event of shadowing.
-    Named(DefId, Symbol),
+    /// Used to give late-bound regions names for things like pretty printing.
+    NamedAnon(u32, Symbol),
+
+    /// Late-bound regions that appear in the AST.
+    Named(DefId),
 
     /// Anonymous region for the implicit env pointer parameter
     /// to a closure
@@ -386,32 +384,30 @@ impl LateParamRegionKind {
     pub fn from_bound(var: BoundVar, br: BoundRegionKind) -> LateParamRegionKind {
         match br {
             BoundRegionKind::Anon => LateParamRegionKind::Anon(var.as_u32()),
-            BoundRegionKind::Named(def_id, name) => LateParamRegionKind::Named(def_id, name),
+            BoundRegionKind::Named(def_id) => LateParamRegionKind::Named(def_id),
             BoundRegionKind::ClosureEnv => LateParamRegionKind::ClosureEnv,
+            BoundRegionKind::NamedAnon(name) => LateParamRegionKind::NamedAnon(var.as_u32(), name),
         }
     }
 
-    pub fn is_named(&self) -> bool {
+    pub fn is_named(&self, tcx: TyCtxt<'_>) -> bool {
+        self.get_name(tcx).is_some()
+    }
+
+    pub fn get_name(&self, tcx: TyCtxt<'_>) -> Option<Symbol> {
         match *self {
-            LateParamRegionKind::Named(_, name) => name != kw::UnderscoreLifetime,
-            _ => false,
-        }
-    }
-
-    pub fn get_name(&self) -> Option<Symbol> {
-        if self.is_named() {
-            match *self {
-                LateParamRegionKind::Named(_, name) => return Some(name),
-                _ => unreachable!(),
+            LateParamRegionKind::Named(def_id) => {
+                let name = tcx.item_name(def_id);
+                if name != kw::UnderscoreLifetime { Some(name) } else { None }
             }
+            LateParamRegionKind::NamedAnon(_, name) => Some(name),
+            _ => None,
         }
-
-        None
     }
 
     pub fn get_id(&self) -> Option<DefId> {
         match *self {
-            LateParamRegionKind::Named(id, _) => Some(id),
+            LateParamRegionKind::Named(id) => Some(id),
             _ => None,
         }
     }
@@ -423,11 +419,13 @@ pub enum BoundRegionKind {
     /// An anonymous region parameter for a given fn (&T)
     Anon,
 
-    /// Named region parameters for functions (a in &'a T)
+    /// An anonymous region parameter with a `Symbol` name.
     ///
-    /// The `DefId` is needed to distinguish free regions in
-    /// the event of shadowing.
-    Named(DefId, Symbol),
+    /// Used to give late-bound regions names for things like pretty printing.
+    NamedAnon(Symbol),
+
+    /// Late-bound regions that appear in the AST.
+    Named(DefId),
 
     /// Anonymous region for the implicit env pointer parameter
     /// to a closure
@@ -456,35 +454,35 @@ impl core::fmt::Debug for BoundRegion {
         match self.kind {
             BoundRegionKind::Anon => write!(f, "{:?}", self.var),
             BoundRegionKind::ClosureEnv => write!(f, "{:?}.Env", self.var),
-            BoundRegionKind::Named(def, symbol) => {
-                write!(f, "{:?}.Named({:?}, {:?})", self.var, def, symbol)
+            BoundRegionKind::Named(def) => {
+                write!(f, "{:?}.Named({:?})", self.var, def)
+            }
+            BoundRegionKind::NamedAnon(symbol) => {
+                write!(f, "{:?}.NamedAnon({:?})", self.var, symbol)
             }
         }
     }
 }
 
 impl BoundRegionKind {
-    pub fn is_named(&self) -> bool {
-        match *self {
-            BoundRegionKind::Named(_, name) => name != kw::UnderscoreLifetime,
-            _ => false,
-        }
+    pub fn is_named(&self, tcx: TyCtxt<'_>) -> bool {
+        self.get_name(tcx).is_some()
     }
 
-    pub fn get_name(&self) -> Option<Symbol> {
-        if self.is_named() {
-            match *self {
-                BoundRegionKind::Named(_, name) => return Some(name),
-                _ => unreachable!(),
+    pub fn get_name(&self, tcx: TyCtxt<'_>) -> Option<Symbol> {
+        match *self {
+            BoundRegionKind::Named(def_id) => {
+                let name = tcx.item_name(def_id);
+                if name != kw::UnderscoreLifetime { Some(name) } else { None }
             }
+            BoundRegionKind::NamedAnon(name) => Some(name),
+            _ => None,
         }
-
-        None
     }
 
     pub fn get_id(&self) -> Option<DefId> {
         match *self {
-            BoundRegionKind::Named(id, _) => Some(id),
+            BoundRegionKind::Named(id) => Some(id),
             _ => None,
         }
     }

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -182,7 +182,7 @@ impl<'tcx> Region<'tcx> {
     }
 
     /// Is this region named by the user?
-    pub fn has_name(self, tcx: TyCtxt<'tcx>) -> bool {
+    pub fn is_named(self, tcx: TyCtxt<'tcx>) -> bool {
         match self.kind() {
             ty::ReEarlyParam(ebr) => ebr.is_named(),
             ty::ReBound(_, br) => br.kind.is_named(tcx),

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -165,7 +165,7 @@ impl<'tcx> Region<'tcx> {
 
     pub fn get_name(self, tcx: TyCtxt<'tcx>) -> Option<Symbol> {
         match self.kind() {
-            ty::ReEarlyParam(ebr) => Some(ebr.name),
+            ty::ReEarlyParam(ebr) => ebr.is_named().then_some(ebr.name),
             ty::ReBound(_, br) => br.kind.get_name(tcx),
             ty::ReLateParam(fr) => fr.kind.get_name(tcx),
             ty::ReStatic => Some(kw::StaticLifetime),
@@ -184,7 +184,7 @@ impl<'tcx> Region<'tcx> {
     /// Is this region named by the user?
     pub fn has_name(self, tcx: TyCtxt<'tcx>) -> bool {
         match self.kind() {
-            ty::ReEarlyParam(ebr) => ebr.has_name(),
+            ty::ReEarlyParam(ebr) => ebr.is_named(),
             ty::ReBound(_, br) => br.kind.is_named(tcx),
             ty::ReLateParam(fr) => fr.kind.is_named(tcx),
             ty::ReStatic => true,

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -183,7 +183,7 @@ impl fmt::Debug for ty::BoundTy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             ty::BoundTyKind::Anon => write!(f, "{:?}", self.var),
-            ty::BoundTyKind::Param(_, sym) => write!(f, "{sym:?}"),
+            ty::BoundTyKind::Param(def_id) => write!(f, "{def_id:?}"),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -272,7 +272,6 @@ TrivialTypeTraversalImpls! {
     crate::ty::BoundVar,
     crate::ty::InferConst,
     crate::ty::Placeholder<crate::ty::BoundRegion>,
-    crate::ty::Placeholder<crate::ty::BoundTy>,
     crate::ty::Placeholder<ty::BoundVar>,
     crate::ty::UserTypeAnnotationIndex,
     crate::ty::ValTree<'tcx>,
@@ -303,6 +302,7 @@ TrivialTypeTraversalAndLiftImpls! {
     // tidy-alphabetical-start
     crate::ty::ParamConst,
     crate::ty::ParamTy,
+    crate::ty::Placeholder<crate::ty::BoundTy>,
     crate::ty::instance::ReifyReason,
     rustc_hir::def_id::DefId,
     // tidy-alphabetical-end

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -69,12 +69,11 @@ impl fmt::Debug for ty::BoundRegionKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ty::BoundRegionKind::Anon => write!(f, "BrAnon"),
-            ty::BoundRegionKind::Named(did, name) => {
-                if did.is_crate_root() {
-                    write!(f, "BrNamed({name})")
-                } else {
-                    write!(f, "BrNamed({did:?}, {name})")
-                }
+            ty::BoundRegionKind::NamedAnon(name) => {
+                write!(f, "BrNamedAnon({name})")
+            }
+            ty::BoundRegionKind::Named(did) => {
+                write!(f, "BrNamed({did:?})")
             }
             ty::BoundRegionKind::ClosureEnv => write!(f, "BrEnv"),
         }
@@ -91,12 +90,11 @@ impl fmt::Debug for ty::LateParamRegionKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ty::LateParamRegionKind::Anon(idx) => write!(f, "LateAnon({idx})"),
-            ty::LateParamRegionKind::Named(did, name) => {
-                if did.is_crate_root() {
-                    write!(f, "LateNamed({name})")
-                } else {
-                    write!(f, "LateNamed({did:?}, {name})")
-                }
+            ty::LateParamRegionKind::NamedAnon(idx, name) => {
+                write!(f, "LateNamedAnon({idx:?}, {name})")
+            }
+            ty::LateParamRegionKind::Named(did) => {
+                write!(f, "LateNamed({did:?})")
             }
             ty::LateParamRegionKind::ClosureEnv => write!(f, "LateEnv"),
         }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -400,7 +400,7 @@ impl<'tcx> rustc_type_ir::inherent::BoundVarLike<TyCtxt<'tcx>> for BoundTy {
 #[derive(HashStable)]
 pub enum BoundTyKind {
     Anon,
-    Param(DefId, Symbol),
+    Param(DefId),
 }
 
 impl From<BoundVar> for BoundTy {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2032,7 +2032,7 @@ mod size_asserts {
 
     use super::*;
     // tidy-alphabetical-start
-    static_assert_size!(ty::RegionKind<'_>, 24);
+    static_assert_size!(ty::RegionKind<'_>, 20);
     static_assert_size!(ty::TyKind<'_>, 24);
     // tidy-alphabetical-end
 }

--- a/compiler/rustc_smir/src/stable_mir/unstable/convert/internal.rs
+++ b/compiler/rustc_smir/src/stable_mir/unstable/convert/internal.rs
@@ -453,10 +453,9 @@ impl RustcInternal for BoundVariableKind {
             }),
             BoundVariableKind::Region(kind) => rustc_ty::BoundVariableKind::Region(match kind {
                 BoundRegionKind::BrAnon => rustc_ty::BoundRegionKind::Anon,
-                BoundRegionKind::BrNamed(def, symbol) => rustc_ty::BoundRegionKind::Named(
-                    def.0.internal(tables, tcx),
-                    Symbol::intern(symbol),
-                ),
+                BoundRegionKind::BrNamed(def, _symbol) => {
+                    rustc_ty::BoundRegionKind::Named(def.0.internal(tables, tcx))
+                }
                 BoundRegionKind::BrEnv => rustc_ty::BoundRegionKind::ClosureEnv,
             }),
             BoundVariableKind::Const => rustc_ty::BoundVariableKind::Const,

--- a/compiler/rustc_smir/src/stable_mir/unstable/convert/internal.rs
+++ b/compiler/rustc_smir/src/stable_mir/unstable/convert/internal.rs
@@ -7,7 +7,6 @@
 
 use rustc_middle::ty::{self as rustc_ty, Const as InternalConst, Ty as InternalTy};
 use rustc_smir::Tables;
-use rustc_span::Symbol;
 use stable_mir::abi::Layout;
 use stable_mir::compiler_interface::BridgeTys;
 use stable_mir::mir::alloc::AllocId;
@@ -446,10 +445,9 @@ impl RustcInternal for BoundVariableKind {
         match self {
             BoundVariableKind::Ty(kind) => rustc_ty::BoundVariableKind::Ty(match kind {
                 BoundTyKind::Anon => rustc_ty::BoundTyKind::Anon,
-                BoundTyKind::Param(def, symbol) => rustc_ty::BoundTyKind::Param(
-                    def.0.internal(tables, tcx),
-                    Symbol::intern(symbol),
-                ),
+                BoundTyKind::Param(def, _symbol) => {
+                    rustc_ty::BoundTyKind::Param(def.0.internal(tables, tcx))
+                }
             }),
             BoundVariableKind::Region(kind) => rustc_ty::BoundVariableKind::Region(match kind {
                 BoundRegionKind::BrAnon => rustc_ty::BoundRegionKind::Anon,

--- a/compiler/rustc_smir/src/stable_mir/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/unstable/convert/stable/ty.rs
@@ -291,14 +291,14 @@ impl<'tcx> Stable<'tcx> for ty::BoundTyKind {
     fn stable<'cx>(
         &self,
         tables: &mut Tables<'cx, BridgeTys>,
-        _: &SmirCtxt<'cx, BridgeTys>,
+        cx: &SmirCtxt<'cx, BridgeTys>,
     ) -> Self::T {
         use stable_mir::ty::BoundTyKind;
 
         match self {
             ty::BoundTyKind::Anon => BoundTyKind::Anon,
-            ty::BoundTyKind::Param(def_id, symbol) => {
-                BoundTyKind::Param(tables.param_def(*def_id), symbol.to_string())
+            ty::BoundTyKind::Param(def_id) => {
+                BoundTyKind::Param(tables.param_def(*def_id), cx.tcx.item_name(*def_id).to_string())
             }
         }
     }

--- a/compiler/rustc_smir/src/stable_mir/unstable/convert/stable/ty.rs
+++ b/compiler/rustc_smir/src/stable_mir/unstable/convert/stable/ty.rs
@@ -1,7 +1,7 @@
 //! Conversion of internal Rust compiler `ty` items to stable ones.
 
 use rustc_middle::ty::Ty;
-use rustc_middle::{mir, ty};
+use rustc_middle::{bug, mir, ty};
 use rustc_smir::Tables;
 use rustc_smir::context::SmirCtxt;
 use stable_mir::alloc;
@@ -310,16 +310,18 @@ impl<'tcx> Stable<'tcx> for ty::BoundRegionKind {
     fn stable<'cx>(
         &self,
         tables: &mut Tables<'cx, BridgeTys>,
-        _: &SmirCtxt<'cx, BridgeTys>,
+        cx: &SmirCtxt<'cx, BridgeTys>,
     ) -> Self::T {
         use stable_mir::ty::BoundRegionKind;
 
         match self {
             ty::BoundRegionKind::Anon => BoundRegionKind::BrAnon,
-            ty::BoundRegionKind::Named(def_id, symbol) => {
-                BoundRegionKind::BrNamed(tables.br_named_def(*def_id), symbol.to_string())
-            }
+            ty::BoundRegionKind::Named(def_id) => BoundRegionKind::BrNamed(
+                tables.br_named_def(*def_id),
+                cx.tcx.item_name(*def_id).to_string(),
+            ),
             ty::BoundRegionKind::ClosureEnv => BoundRegionKind::BrEnv,
+            ty::BoundRegionKind::NamedAnon(_) => bug!("only used for pretty printing"),
         }
     }
 }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/named_anon_conflict.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/named_anon_conflict.rs
@@ -2,8 +2,6 @@
 //! where one region is named and the other is anonymous.
 
 use rustc_errors::Diag;
-use rustc_middle::ty;
-use rustc_span::kw;
 use tracing::debug;
 
 use crate::error_reporting::infer::nice_region_error::NiceRegionError;
@@ -27,12 +25,12 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         // only introduced anonymous regions in parameters) as well as a
         // version new_ty of its type where the anonymous region is replaced
         // with the named one.
-        let (named, anon, anon_param_info, region_info) = if sub.has_name()
+        let (named, anon, anon_param_info, region_info) = if sub.has_name(self.tcx())
             && let Some(region_info) = self.tcx().is_suitable_region(self.generic_param_scope, sup)
             && let Some(anon_param_info) = self.find_param_with_region(sup, sub)
         {
             (sub, sup, anon_param_info, region_info)
-        } else if sup.has_name()
+        } else if sup.has_name(self.tcx())
             && let Some(region_info) = self.tcx().is_suitable_region(self.generic_param_scope, sub)
             && let Some(anon_param_info) = self.find_param_with_region(sub, sup)
         {
@@ -58,14 +56,12 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let scope_def_id = region_info.scope;
         let is_impl_item = region_info.is_impl_item;
 
-        match anon_param_info.kind {
-            ty::LateParamRegionKind::Named(_, kw::UnderscoreLifetime)
-            | ty::LateParamRegionKind::Anon(_) => {}
-            _ => {
-                /* not an anonymous region */
-                debug!("try_report_named_anon_conflict: not an anonymous region");
-                return None;
-            }
+        if !anon_param_info.kind.is_named(self.tcx()) {
+            // Anon region
+        } else {
+            /* not an anonymous region */
+            debug!("try_report_named_anon_conflict: not an anonymous region");
+            return None;
         }
 
         if is_impl_item {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/named_anon_conflict.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/named_anon_conflict.rs
@@ -25,12 +25,12 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         // only introduced anonymous regions in parameters) as well as a
         // version new_ty of its type where the anonymous region is replaced
         // with the named one.
-        let (named, anon, anon_param_info, region_info) = if sub.has_name(self.tcx())
+        let (named, anon, anon_param_info, region_info) = if sub.is_named(self.tcx())
             && let Some(region_info) = self.tcx().is_suitable_region(self.generic_param_scope, sup)
             && let Some(anon_param_info) = self.find_param_with_region(sup, sub)
         {
             (sub, sup, anon_param_info, region_info)
-        } else if sup.has_name(self.tcx())
+        } else if sup.is_named(self.tcx())
             && let Some(region_info) = self.tcx().is_suitable_region(self.generic_param_scope, sub)
             && let Some(anon_param_info) = self.find_param_with_region(sub, sup)
         {
@@ -56,9 +56,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let scope_def_id = region_info.scope;
         let is_impl_item = region_info.is_impl_item;
 
-        if !anon_param_info.kind.is_named(self.tcx()) {
-            // Anon region
-        } else {
+        if anon_param_info.kind.is_named(self.tcx()) {
             /* not an anonymous region */
             debug!("try_report_named_anon_conflict: not an anonymous region");
             return None;

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
@@ -164,7 +164,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                 sub_region @ Region(Interned(RePlaceholder(_), _)),
                 sup_region,
             )) => self.try_report_trait_placeholder_mismatch(
-                (!sup_region.has_name(self.tcx())).then_some(*sup_region),
+                (!sup_region.is_named(self.tcx())).then_some(*sup_region),
                 cause,
                 Some(*sub_region),
                 None,
@@ -176,7 +176,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                 sub_region,
                 sup_region @ Region(Interned(RePlaceholder(_), _)),
             )) => self.try_report_trait_placeholder_mismatch(
-                (!sub_region.has_name(self.tcx())).then_some(*sub_region),
+                (!sub_region.is_named(self.tcx())).then_some(*sub_region),
                 cause,
                 None,
                 Some(*sup_region),

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
@@ -164,7 +164,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                 sub_region @ Region(Interned(RePlaceholder(_), _)),
                 sup_region,
             )) => self.try_report_trait_placeholder_mismatch(
-                (!sup_region.has_name()).then_some(*sup_region),
+                (!sup_region.has_name(self.tcx())).then_some(*sup_region),
                 cause,
                 Some(*sub_region),
                 None,
@@ -176,7 +176,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                 sub_region,
                 sup_region @ Region(Interned(RePlaceholder(_), _)),
             )) => self.try_report_trait_placeholder_mismatch(
-                (!sub_region.has_name()).then_some(*sub_region),
+                (!sub_region.has_name(self.tcx())).then_some(*sub_region),
                 cause,
                 None,
                 Some(*sup_region),

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_relation.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_relation.rs
@@ -1,5 +1,6 @@
 use rustc_data_structures::intern::Interned;
 use rustc_errors::Diag;
+use rustc_middle::bug;
 use rustc_middle::ty::{self, RePlaceholder, Region};
 
 use crate::error_reporting::infer::nice_region_error::NiceRegionError;
@@ -28,20 +29,22 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                 )),
             )) => {
                 let span = *span;
-                let (sub_span, sub_symbol) = match sub_name {
-                    ty::BoundRegionKind::Named(def_id, symbol) => {
-                        (Some(self.tcx().def_span(def_id)), Some(symbol))
+                let (sub_span, sub_symbol) = match *sub_name {
+                    ty::BoundRegionKind::Named(def_id) => {
+                        (Some(self.tcx().def_span(def_id)), Some(self.tcx().item_name(def_id)))
                     }
                     ty::BoundRegionKind::Anon | ty::BoundRegionKind::ClosureEnv => (None, None),
+                    ty::BoundRegionKind::NamedAnon(_) => bug!("only used for pretty printing"),
                 };
-                let (sup_span, sup_symbol) = match sup_name {
-                    ty::BoundRegionKind::Named(def_id, symbol) => {
-                        (Some(self.tcx().def_span(def_id)), Some(symbol))
+                let (sup_span, sup_symbol) = match *sup_name {
+                    ty::BoundRegionKind::Named(def_id) => {
+                        (Some(self.tcx().def_span(def_id)), Some(self.tcx().item_name(def_id)))
                     }
                     ty::BoundRegionKind::Anon | ty::BoundRegionKind::ClosureEnv => (None, None),
+                    ty::BoundRegionKind::NamedAnon(_) => bug!("only used for pretty printing"),
                 };
                 let diag = match (sub_span, sup_span, sub_symbol, sup_symbol) {
-                    (Some(sub_span), Some(sup_span), Some(&sub_symbol), Some(&sup_symbol)) => {
+                    (Some(sub_span), Some(sup_span), Some(sub_symbol), Some(sup_symbol)) => {
                         PlaceholderRelationLfNotSatisfied::HasBoth {
                             span,
                             sub_span,
@@ -51,7 +54,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                             note: (),
                         }
                     }
-                    (Some(sub_span), Some(sup_span), _, Some(&sup_symbol)) => {
+                    (Some(sub_span), Some(sup_span), _, Some(sup_symbol)) => {
                         PlaceholderRelationLfNotSatisfied::HasSup {
                             span,
                             sub_span,
@@ -60,7 +63,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
                             note: (),
                         }
                     }
-                    (Some(sub_span), Some(sup_span), Some(&sub_symbol), _) => {
+                    (Some(sub_span), Some(sup_span), Some(sub_symbol), _) => {
                         PlaceholderRelationLfNotSatisfied::HasSub {
                             span,
                             sub_span,

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
@@ -45,7 +45,8 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let return_sp = sub_origin.span();
         let param = self.find_param_with_region(*sup_r, *sub_r)?;
         let simple_ident = param.param.pat.simple_ident();
-        let lifetime_name = if sup_r.has_name() { sup_r.to_string() } else { "'_".to_owned() };
+        let lifetime_name =
+            if sup_r.has_name(self.tcx()) { sup_r.to_string() } else { "'_".to_owned() };
 
         let (mention_influencer, influencer_point) =
             if sup_origin.span().overlaps(param.param_ty_span) {
@@ -99,7 +100,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             // We don't need a note, it's already at the end, it can be shown as a `span_label`.
             require_span_as_label: (!require_as_note).then_some(require_span),
 
-            has_lifetime: sup_r.has_name(),
+            has_lifetime: sup_r.has_name(self.tcx()),
             lifetime: lifetime_name.clone(),
             has_param_name: simple_ident.is_some(),
             param_name: simple_ident.map(|x| x.to_string()).unwrap_or_default(),

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
@@ -46,7 +46,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let param = self.find_param_with_region(*sup_r, *sub_r)?;
         let simple_ident = param.param.pat.simple_ident();
         let lifetime_name =
-            if sup_r.has_name(self.tcx()) { sup_r.to_string() } else { "'_".to_owned() };
+            if sup_r.is_named(self.tcx()) { sup_r.to_string() } else { "'_".to_owned() };
 
         let (mention_influencer, influencer_point) =
             if sup_origin.span().overlaps(param.param_ty_span) {
@@ -100,7 +100,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             // We don't need a note, it's already at the end, it can be shown as a `span_label`.
             require_span_as_label: (!require_as_note).then_some(require_span),
 
-            has_lifetime: sup_r.has_name(self.tcx()),
+            has_lifetime: sup_r.is_named(self.tcx()),
             lifetime: lifetime_name.clone(),
             has_param_name: simple_ident.is_some(),
             param_name: simple_ident.map(|x| x.to_string()).unwrap_or_default(),

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/trait_impl_difference.rs
@@ -76,7 +76,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
 
         impl<'tcx> ty::TypeVisitor<TyCtxt<'tcx>> for HighlightBuilder<'tcx> {
             fn visit_region(&mut self, r: ty::Region<'tcx>) {
-                if !r.has_name(self.tcx) && self.counter <= 3 {
+                if !r.is_named(self.tcx) && self.counter <= 3 {
                     self.highlight.highlighting_region(r, self.counter);
                     self.counter += 1;
                 }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/trait_impl_difference.rs
@@ -60,14 +60,15 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         // Mark all unnamed regions in the type with a number.
         // This diagnostic is called in response to lifetime errors, so be informative.
         struct HighlightBuilder<'tcx> {
+            tcx: TyCtxt<'tcx>,
             highlight: RegionHighlightMode<'tcx>,
             counter: usize,
         }
 
         impl<'tcx> HighlightBuilder<'tcx> {
-            fn build(sig: ty::PolyFnSig<'tcx>) -> RegionHighlightMode<'tcx> {
+            fn build(tcx: TyCtxt<'tcx>, sig: ty::PolyFnSig<'tcx>) -> RegionHighlightMode<'tcx> {
                 let mut builder =
-                    HighlightBuilder { highlight: RegionHighlightMode::default(), counter: 1 };
+                    HighlightBuilder { tcx, highlight: RegionHighlightMode::default(), counter: 1 };
                 sig.visit_with(&mut builder);
                 builder.highlight
             }
@@ -75,15 +76,15 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
 
         impl<'tcx> ty::TypeVisitor<TyCtxt<'tcx>> for HighlightBuilder<'tcx> {
             fn visit_region(&mut self, r: ty::Region<'tcx>) {
-                if !r.has_name() && self.counter <= 3 {
+                if !r.has_name(self.tcx) && self.counter <= 3 {
                     self.highlight.highlighting_region(r, self.counter);
                     self.counter += 1;
                 }
             }
         }
 
-        let expected_highlight = HighlightBuilder::build(expected);
         let tcx = self.cx.tcx;
+        let expected_highlight = HighlightBuilder::build(tcx, expected);
         let expected = Highlighted {
             highlight: expected_highlight,
             ns: Namespace::TypeNS,
@@ -91,7 +92,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             value: expected,
         }
         .to_string();
-        let found_highlight = HighlightBuilder::build(found);
+        let found_highlight = HighlightBuilder::build(tcx, found);
         let found =
             Highlighted { highlight: found_highlight, ns: Namespace::TypeNS, tcx, value: found }
                 .to_string();

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/util.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/util.rs
@@ -46,7 +46,7 @@ pub fn find_param_with_region<'tcx>(
         ty::ReLateParam(late_param) => (late_param.scope, late_param.kind),
         ty::ReEarlyParam(ebr) => {
             let region_def = tcx.generics_of(generic_param_scope).region_param(ebr, tcx).def_id;
-            (tcx.parent(region_def), ty::LateParamRegionKind::Named(region_def, ebr.name))
+            (tcx.parent(region_def), ty::LateParamRegionKind::Named(region_def))
         }
         _ => return None, // not a free region
     };
@@ -144,7 +144,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         // We are only checking is any region meets the condition so order doesn't matter
         #[allow(rustc::potential_query_instability)]
         late_bound_regions.iter().any(|r| match *r {
-            ty::BoundRegionKind::Named(def_id, _) => def_id == region_def_id,
+            ty::BoundRegionKind::Named(def_id) => def_id == region_def_id,
             _ => false,
         })
     }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -1109,7 +1109,7 @@ fn msg_span_from_named_region<'tcx>(
         ty::ReEarlyParam(br) => {
             let param_def_id = tcx.generics_of(generic_param_scope).region_param(br, tcx).def_id;
             let span = tcx.def_span(param_def_id);
-            let text = if br.has_name() {
+            let text = if br.is_named() {
                 format!("the lifetime `{}` as defined here", br.name)
             } else {
                 "the anonymous lifetime as defined here".to_string()

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -713,14 +713,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
 
         let labeled_user_string = match bound_kind {
-            GenericKind::Param(ref p) => format!("the parameter type `{p}`"),
-            GenericKind::Placeholder(ref p) => format!("the placeholder type `{p:?}`"),
-            GenericKind::Alias(ref p) => match p.kind(self.tcx) {
+            GenericKind::Param(_) => format!("the parameter type `{bound_kind}`"),
+            GenericKind::Placeholder(_) => format!("the placeholder type `{bound_kind}`"),
+            GenericKind::Alias(p) => match p.kind(self.tcx) {
                 ty::Projection | ty::Inherent => {
-                    format!("the associated type `{p}`")
+                    format!("the associated type `{bound_kind}`")
                 }
-                ty::Free => format!("the type alias `{p}`"),
-                ty::Opaque => format!("the opaque type `{p}`"),
+                ty::Free => format!("the type alias `{bound_kind}`"),
+                ty::Opaque => format!("the opaque type `{bound_kind}`"),
             },
         };
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -729,7 +729,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             .dcx()
             .struct_span_err(span, format!("{labeled_user_string} may not live long enough"));
         err.code(match sub.kind() {
-            ty::ReEarlyParam(_) | ty::ReLateParam(_) if sub.has_name(self.tcx) => E0309,
+            ty::ReEarlyParam(_) | ty::ReLateParam(_) if sub.is_named(self.tcx) => E0309,
             ty::ReStatic => E0310,
             _ => E0311,
         });
@@ -877,7 +877,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
 
         let (lifetime_def_id, lifetime_scope) =
             match self.tcx.is_suitable_region(generic_param_scope, lifetime) {
-                Some(info) if !lifetime.has_name(self.tcx) => {
+                Some(info) if !lifetime.is_named(self.tcx) => {
                     (info.region_def_id.expect_local(), info.scope)
                 }
                 _ => return lifetime.get_name_or_anon(self.tcx).to_string(),

--- a/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
@@ -39,14 +39,15 @@ impl<'a> DescriptionCtx<'a> {
                 }
             }
             ty::ReLateParam(ref fr) => {
-                if !fr.kind.is_named()
+                if !fr.kind.is_named(tcx)
                     && let Some((ty, _)) = find_anon_type(tcx, generic_param_scope, region)
                 {
                     (Some(ty.span), "defined_here", String::new())
                 } else {
                     let scope = fr.scope.expect_local();
                     match fr.kind {
-                        ty::LateParamRegionKind::Named(_, name) => {
+                        ty::LateParamRegionKind::Named(def_id) => {
+                            let name = tcx.item_name(def_id);
                             let span = if let Some(param) = tcx
                                 .hir_get_generics(scope)
                                 .and_then(|generics| generics.get_named(name))

--- a/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
@@ -32,7 +32,7 @@ impl<'a> DescriptionCtx<'a> {
                 } else {
                     tcx.def_span(scope)
                 };
-                if br.has_name() {
+                if br.is_named() {
                     (Some(span), "as_defined", br.name.to_string())
                 } else {
                     (Some(span), "as_defined_anon", String::new())

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -293,7 +293,7 @@ pub(super) fn build_function(cx: &mut DocContext<'_>, def_id: DefId) -> Box<clea
     let sig = cx.tcx.fn_sig(def_id).instantiate_identity();
     // The generics need to be cleaned before the signature.
     let mut generics = clean_ty_generics(cx, def_id);
-    let bound_vars = clean_bound_vars(sig.bound_vars());
+    let bound_vars = clean_bound_vars(sig.bound_vars(), cx);
 
     // At the time of writing early & late-bound params are stored separately in rustc,
     // namely in `generics.params` and `bound_vars` respectively.

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -273,7 +273,7 @@ fn clean_poly_trait_ref_with_constraints<'tcx>(
     GenericBound::TraitBound(
         PolyTrait {
             trait_: clean_trait_ref_with_constraints(cx, poly_trait_ref, constraints),
-            generic_params: clean_bound_vars(poly_trait_ref.bound_vars()),
+            generic_params: clean_bound_vars(poly_trait_ref.bound_vars(), cx),
         },
         hir::TraitBoundModifiers::NONE,
     )
@@ -325,24 +325,11 @@ pub(crate) fn clean_middle_const<'tcx>(
     ConstantKind::TyConst { expr: constant.skip_binder().to_string().into() }
 }
 
-pub(crate) fn clean_middle_region(region: ty::Region<'_>) -> Option<Lifetime> {
-    match region.kind() {
-        ty::ReStatic => Some(Lifetime::statik()),
-        _ if !region.has_name() => None,
-        ty::ReBound(_, ty::BoundRegion { kind: ty::BoundRegionKind::Named(_, name), .. }) => {
-            Some(Lifetime(name))
-        }
-        ty::ReEarlyParam(ref data) => Some(Lifetime(data.name)),
-        ty::ReBound(..)
-        | ty::ReLateParam(..)
-        | ty::ReVar(..)
-        | ty::ReError(_)
-        | ty::RePlaceholder(..)
-        | ty::ReErased => {
-            debug!("cannot clean region {region:?}");
-            None
-        }
-    }
+pub(crate) fn clean_middle_region<'tcx>(
+    region: ty::Region<'tcx>,
+    cx: &mut DocContext<'tcx>,
+) -> Option<Lifetime> {
+    region.get_name(cx.tcx).map(Lifetime)
 }
 
 fn clean_where_predicate<'tcx>(
@@ -384,7 +371,7 @@ pub(crate) fn clean_predicate<'tcx>(
     let bound_predicate = predicate.kind();
     match bound_predicate.skip_binder() {
         ty::ClauseKind::Trait(pred) => clean_poly_trait_predicate(bound_predicate.rebind(pred), cx),
-        ty::ClauseKind::RegionOutlives(pred) => Some(clean_region_outlives_predicate(pred)),
+        ty::ClauseKind::RegionOutlives(pred) => Some(clean_region_outlives_predicate(pred, cx)),
         ty::ClauseKind::TypeOutlives(pred) => {
             Some(clean_type_outlives_predicate(bound_predicate.rebind(pred), cx))
         }
@@ -418,13 +405,16 @@ fn clean_poly_trait_predicate<'tcx>(
     })
 }
 
-fn clean_region_outlives_predicate(pred: ty::RegionOutlivesPredicate<'_>) -> WherePredicate {
+fn clean_region_outlives_predicate<'tcx>(
+    pred: ty::RegionOutlivesPredicate<'tcx>,
+    cx: &mut DocContext<'tcx>,
+) -> WherePredicate {
     let ty::OutlivesPredicate(a, b) = pred;
 
     WherePredicate::RegionPredicate {
-        lifetime: clean_middle_region(a).expect("failed to clean lifetime"),
+        lifetime: clean_middle_region(a, cx).expect("failed to clean lifetime"),
         bounds: vec![GenericBound::Outlives(
-            clean_middle_region(b).expect("failed to clean bounds"),
+            clean_middle_region(b, cx).expect("failed to clean bounds"),
         )],
     }
 }
@@ -438,7 +428,7 @@ fn clean_type_outlives_predicate<'tcx>(
     WherePredicate::BoundPredicate {
         ty: clean_middle_ty(pred.rebind(ty), cx, None, None),
         bounds: vec![GenericBound::Outlives(
-            clean_middle_region(lt).expect("failed to clean lifetimes"),
+            clean_middle_region(lt, cx).expect("failed to clean lifetimes"),
         )],
         bound_params: Vec::new(),
     }
@@ -1905,8 +1895,8 @@ fn clean_trait_object_lifetime_bound<'tcx>(
     match region.kind() {
         ty::ReStatic => Some(Lifetime::statik()),
         ty::ReEarlyParam(region) => Some(Lifetime(region.name)),
-        ty::ReBound(_, ty::BoundRegion { kind: ty::BoundRegionKind::Named(_, name), .. }) => {
-            Some(Lifetime(name))
+        ty::ReBound(_, ty::BoundRegion { kind: ty::BoundRegionKind::Named(def_id), .. }) => {
+            Some(Lifetime(tcx.item_name(def_id)))
         }
         ty::ReBound(..)
         | ty::ReLateParam(_)
@@ -1935,7 +1925,9 @@ fn can_elide_trait_object_lifetime_bound<'tcx>(
     match default {
         ObjectLifetimeDefault::Static => return region.kind() == ty::ReStatic,
         // FIXME(fmease): Don't compare lexically but respect de Bruijn indices etc. to handle shadowing correctly.
-        ObjectLifetimeDefault::Arg(default) => return region.get_name() == default.get_name(),
+        ObjectLifetimeDefault::Arg(default) => {
+            return region.get_name(tcx) == default.get_name(tcx);
+        }
         // > If there is more than one bound from the containing type then an explicit bound must be specified
         // Due to ambiguity there is no default trait-object lifetime and thus elision is impossible.
         // Don't elide the lifetime.
@@ -1957,7 +1949,7 @@ fn can_elide_trait_object_lifetime_bound<'tcx>(
         // > If the trait is defined with a single lifetime bound then that bound is used.
         // > If 'static is used for any lifetime bound then 'static is used.
         // FIXME(fmease): Don't compare lexically but respect de Bruijn indices etc. to handle shadowing correctly.
-        [object_region] => object_region.get_name() == region.get_name(),
+        [object_region] => object_region.get_name(tcx) == region.get_name(tcx),
         // There are several distinct trait regions and none are `'static`.
         // Due to ambiguity there is no default trait-object lifetime and thus elision is impossible.
         // Don't elide the lifetime.
@@ -2051,7 +2043,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
             RawPointer(mutbl, Box::new(clean_middle_ty(bound_ty.rebind(ty), cx, None, None)))
         }
         ty::Ref(r, ty, mutbl) => BorrowedRef {
-            lifetime: clean_middle_region(r),
+            lifetime: clean_middle_region(r, cx),
             mutability: mutbl,
             type_: Box::new(clean_middle_ty(
                 bound_ty.rebind(ty),
@@ -2064,7 +2056,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
             // FIXME: should we merge the outer and inner binders somehow?
             let sig = bound_ty.skip_binder().fn_sig(cx.tcx);
             let decl = clean_poly_fn_sig(cx, None, sig);
-            let generic_params = clean_bound_vars(sig.bound_vars());
+            let generic_params = clean_bound_vars(sig.bound_vars(), cx);
 
             BareFunction(Box::new(BareFunctionDecl {
                 safety: sig.safety(),
@@ -2074,7 +2066,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
             }))
         }
         ty::UnsafeBinder(inner) => {
-            let generic_params = clean_bound_vars(inner.bound_vars());
+            let generic_params = clean_bound_vars(inner.bound_vars(), cx);
             let ty = clean_middle_ty(inner.into(), cx, None, None);
             UnsafeBinder(Box::new(UnsafeBinderTy { generic_params, ty }))
         }
@@ -2148,10 +2140,13 @@ pub(crate) fn clean_middle_ty<'tcx>(
                 .iter()
                 .flat_map(|pred| pred.bound_vars())
                 .filter_map(|var| match var {
-                    ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id, name))
-                        if name != kw::UnderscoreLifetime =>
-                    {
-                        Some(GenericParamDef::lifetime(def_id, name))
+                    ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id)) => {
+                        let name = cx.tcx.item_name(def_id);
+                        if name != kw::UnderscoreLifetime {
+                            Some(GenericParamDef::lifetime(def_id, name))
+                        } else {
+                            None
+                        }
                     }
                     _ => None,
                 })
@@ -2282,7 +2277,7 @@ fn clean_middle_opaque_bounds<'tcx>(
             let trait_ref = match bound_predicate.skip_binder() {
                 ty::ClauseKind::Trait(tr) => bound_predicate.rebind(tr.trait_ref),
                 ty::ClauseKind::TypeOutlives(ty::OutlivesPredicate(_ty, reg)) => {
-                    return clean_middle_region(reg).map(GenericBound::Outlives);
+                    return clean_middle_region(reg, cx).map(GenericBound::Outlives);
                 }
                 _ => return None,
             };
@@ -3182,14 +3177,20 @@ fn clean_assoc_item_constraint<'tcx>(
     }
 }
 
-fn clean_bound_vars(bound_vars: &ty::List<ty::BoundVariableKind>) -> Vec<GenericParamDef> {
+fn clean_bound_vars<'tcx>(
+    bound_vars: &ty::List<ty::BoundVariableKind>,
+    cx: &mut DocContext<'tcx>,
+) -> Vec<GenericParamDef> {
     bound_vars
         .into_iter()
         .filter_map(|var| match var {
-            ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id, name))
-                if name != kw::UnderscoreLifetime =>
-            {
-                Some(GenericParamDef::lifetime(def_id, name))
+            ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id)) => {
+                let name = cx.tcx.item_name(def_id);
+                if name != kw::UnderscoreLifetime {
+                    Some(GenericParamDef::lifetime(def_id, name))
+                } else {
+                    None
+                }
             }
             ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(def_id, name)) => {
                 Some(GenericParamDef {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2221,7 +2221,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
         }
 
         ty::Bound(_, ref ty) => match ty.kind {
-            ty::BoundTyKind::Param(_, name) => Generic(name),
+            ty::BoundTyKind::Param(def_id) => Generic(cx.tcx.item_name(def_id)),
             ty::BoundTyKind::Anon => panic!("unexpected anonymous bound type variable"),
         },
 
@@ -3192,7 +3192,8 @@ fn clean_bound_vars<'tcx>(
                     None
                 }
             }
-            ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(def_id, name)) => {
+            ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(def_id)) => {
+                let name = cx.tcx.item_name(def_id);
                 Some(GenericParamDef {
                     name,
                     def_id,

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -125,9 +125,9 @@ pub(crate) fn clean_middle_generic_args<'tcx>(
         }
 
         match arg.skip_binder().kind() {
-            GenericArgKind::Lifetime(lt) => {
-                Some(GenericArg::Lifetime(clean_middle_region(lt).unwrap_or(Lifetime::elided())))
-            }
+            GenericArgKind::Lifetime(lt) => Some(GenericArg::Lifetime(
+                clean_middle_region(lt, cx).unwrap_or(Lifetime::elided()),
+            )),
             GenericArgKind::Type(ty) => Some(GenericArg::Type(clean_middle_ty(
                 arg.rebind(ty),
                 cx,

--- a/tests/ui/coherence/occurs-check/associated-type.next.stderr
+++ b/tests/ui/coherence/occurs-check/associated-type.next.stderr
@@ -1,5 +1,5 @@
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1), "'a")], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1), "'a")], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
+ WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1))], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
+ WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1))], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
 error[E0119]: conflicting implementations of trait `Overlap<for<'a> fn(&'a (), ())>` for type `for<'a> fn(&'a (), ())`
   --> $DIR/associated-type.rs:32:1
    |

--- a/tests/ui/coherence/occurs-check/associated-type.old.stderr
+++ b/tests/ui/coherence/occurs-check/associated-type.old.stderr
@@ -1,5 +1,5 @@
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1), "'a")], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1), "'a")], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
+ WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1))], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
+ WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [*const ?1t, '^0.Named(DefId(0:27 ~ associated_type[f554]::{impl#3}::'a#1))], def_id: DefId(0:5 ~ associated_type[f554]::ToUnit::Unit), .. }
 error[E0119]: conflicting implementations of trait `Overlap<for<'a> fn(&'a (), ())>` for type `for<'a> fn(&'a (), ())`
   --> $DIR/associated-type.rs:32:1
    |

--- a/tests/ui/higher-ranked/structually-relate-aliases.stderr
+++ b/tests/ui/higher-ranked/structually-relate-aliases.stderr
@@ -1,4 +1,4 @@
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [?1t, '^0.Named(DefId(0:15 ~ structually_relate_aliases[de75]::{impl#1}::'a), "'a")], def_id: DefId(0:5 ~ structually_relate_aliases[de75]::ToUnit::Unit), .. }
+ WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: [?1t, '^0.Named(DefId(0:15 ~ structually_relate_aliases[de75]::{impl#1}::'a))], def_id: DefId(0:5 ~ structually_relate_aliases[de75]::ToUnit::Unit), .. }
 error[E0277]: the trait bound `for<'a> T: ToUnit<'a>` is not satisfied
   --> $DIR/structually-relate-aliases.rs:13:36
    |

--- a/tests/ui/nll/ty-outlives/impl-trait-captures.stderr
+++ b/tests/ui/nll/ty-outlives/impl-trait-captures.stderr
@@ -4,14 +4,14 @@ error[E0700]: hidden type for `Opaque(DefId(0:11 ~ impl_trait_captures[aeb9]::fo
 LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> {
    |                  --     ------------ opaque type defined here
    |                  |
-   |                  hidden type `&ReLateParam(DefId(0:8 ~ impl_trait_captures[aeb9]::foo), LateNamed(DefId(0:13 ~ impl_trait_captures[aeb9]::foo::'_), '_)) T` captures the anonymous lifetime defined here
+   |                  hidden type `&ReLateParam(DefId(0:8 ~ impl_trait_captures[aeb9]::foo), LateNamed(DefId(0:13 ~ impl_trait_captures[aeb9]::foo::'_))) T` captures the anonymous lifetime defined here
 LL |     x
    |     ^
    |
-help: add a `use<...>` bound to explicitly capture `ReLateParam(DefId(0:8 ~ impl_trait_captures[aeb9]::foo), LateNamed(DefId(0:13 ~ impl_trait_captures[aeb9]::foo::'_), '_))`
+help: add a `use<...>` bound to explicitly capture `ReLateParam(DefId(0:8 ~ impl_trait_captures[aeb9]::foo), LateNamed(DefId(0:13 ~ impl_trait_captures[aeb9]::foo::'_)))`
    |
-LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> + use<'a, ReLateParam(DefId(0:8 ~ impl_trait_captures[aeb9]::foo), LateNamed(DefId(0:13 ~ impl_trait_captures[aeb9]::foo::'_), '_)), T> {
-   |                                      +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> + use<'a, ReLateParam(DefId(0:8 ~ impl_trait_captures[aeb9]::foo), LateNamed(DefId(0:13 ~ impl_trait_captures[aeb9]::foo::'_))), T> {
+   |                                      +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/next-solver/issue-118950-root-region.stderr
+++ b/tests/ui/traits/next-solver/issue-118950-root-region.stderr
@@ -25,7 +25,7 @@ help: this trait has no implementations, consider adding one
 LL | trait ToUnit<'a> {
    | ^^^^^^^^^^^^^^^^
 
- WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: ['^0.Named(DefId(0:15 ~ issue_118950_root_region[d54f]::{impl#1}::'a), "'a"), ?1t], def_id: DefId(0:8 ~ issue_118950_root_region[d54f]::Assoc), .. }
+ WARN rustc_infer::infer::relate::generalize may incompletely handle alias type: AliasTy { args: ['^0.Named(DefId(0:15 ~ issue_118950_root_region[d54f]::{impl#1}::'a)), ?1t], def_id: DefId(0:8 ~ issue_118950_root_region[d54f]::Assoc), .. }
 error[E0277]: the trait bound `for<'a> *const T: ToUnit<'a>` is not satisfied
   --> $DIR/issue-118950-root-region.rs:19:9
    |

--- a/tests/ui/traits/non_lifetime_binders/placeholders-dont-outlive-static.bad.stderr
+++ b/tests/ui/traits/non_lifetime_binders/placeholders-dont-outlive-static.bad.stderr
@@ -7,19 +7,19 @@ LL | #![feature(non_lifetime_binders)]
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0310]: the placeholder type `!1_"T"` may not live long enough
+error[E0310]: the placeholder type `T` may not live long enough
   --> $DIR/placeholders-dont-outlive-static.rs:13:5
    |
 LL |     foo();
    |     ^^^^^
    |     |
-   |     the placeholder type `!1_"T"` must be valid for the static lifetime...
+   |     the placeholder type `T` must be valid for the static lifetime...
    |     ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound
    |
-LL | fn bad() where !1_"T": 'static {
-   |          +++++++++++++++++++++
+LL | fn bad() where T: 'static {
+   |          ++++++++++++++++
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/traits/non_lifetime_binders/placeholders-dont-outlive-static.good.stderr
+++ b/tests/ui/traits/non_lifetime_binders/placeholders-dont-outlive-static.good.stderr
@@ -7,19 +7,19 @@ LL | #![feature(non_lifetime_binders)]
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0310]: the placeholder type `!1_"T"` may not live long enough
+error[E0310]: the placeholder type `T` may not live long enough
   --> $DIR/placeholders-dont-outlive-static.rs:19:5
    |
 LL |     foo();
    |     ^^^^^
    |     |
-   |     the placeholder type `!1_"T"` must be valid for the static lifetime...
+   |     the placeholder type `T` must be valid for the static lifetime...
    |     ...so that the type `T` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound
    |
-LL | fn good() where for<T> T: 'static, !1_"T": 'static {
-   |                                  +++++++++++++++++
+LL | fn good() where for<T> T: 'static, T: 'static {
+   |                                  ++++++++++++
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/traits/non_lifetime_binders/placeholders-dont-outlive-static.rs
+++ b/tests/ui/traits/non_lifetime_binders/placeholders-dont-outlive-static.rs
@@ -11,7 +11,7 @@ fn foo() where for<T> T: 'static {}
 #[cfg(bad)]
 fn bad() {
     foo();
-    //[bad]~^ ERROR the placeholder type `!1_"T"` may not live long enough
+    //[bad]~^ ERROR the placeholder type `T` may not live long enough
 }
 
 #[cfg(good)]

--- a/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.stderr
+++ b/tests/ui/traits/non_lifetime_binders/type-match-with-late-bound.stderr
@@ -7,11 +7,11 @@ LL | #![feature(non_lifetime_binders)]
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0309]: the placeholder type `!1_"F"` may not live long enough
+error[E0309]: the placeholder type `F` may not live long enough
   --> $DIR/type-match-with-late-bound.rs:8:1
    |
 LL |   async fn walk2<'a, T: 'a>(_: T)
-   |   ^              -- the placeholder type `!1_"F"` must be valid for the lifetime `'a` as defined here...
+   |   ^              -- the placeholder type `F` must be valid for the lifetime `'a` as defined here...
    |  _|
    | |
 LL | | where
@@ -25,36 +25,37 @@ LL |     for<F> F: 'a,
    |               ^^
 help: consider adding an explicit lifetime bound
    |
-LL |     for<F> F: 'a, !1_"F": 'a
-   |                   ++++++++++
+LL |     for<F> F: 'a, F: 'a
+   |                   +++++
 
-error[E0309]: the placeholder type `!1_"F"` may not live long enough
+error[E0309]: the placeholder type `F` may not live long enough
   --> $DIR/type-match-with-late-bound.rs:11:1
    |
 LL | async fn walk2<'a, T: 'a>(_: T)
-   |                -- the placeholder type `!1_"F"` must be valid for the lifetime `'a` as defined here...
+   |                -- the placeholder type `F` must be valid for the lifetime `'a` as defined here...
 ...
 LL | {}
    | ^^ ...so that the type `F` will meet its required lifetime bounds
    |
 help: consider adding an explicit lifetime bound
    |
-LL |     for<F> F: 'a, !1_"F": 'a
-   |                   ++++++++++
+LL |     for<F> F: 'a, F: 'a
+   |                   +++++
 
-error[E0309]: the placeholder type `!2_"F"` may not live long enough
+error[E0309]: the placeholder type `F` may not live long enough
   --> $DIR/type-match-with-late-bound.rs:11:1
    |
 LL | async fn walk2<'a, T: 'a>(_: T)
-   |                -- the placeholder type `!2_"F"` must be valid for the lifetime `'a` as defined here...
+   |                -- the placeholder type `F` must be valid for the lifetime `'a` as defined here...
 ...
 LL | {}
    | ^^ ...so that the type `F` will meet its required lifetime bounds
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider adding an explicit lifetime bound
    |
-LL |     for<F> F: 'a, !2_"F": 'a
-   |                   ++++++++++
+LL |     for<F> F: 'a, F: 'a
+   |                   +++++
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/tests/ui/where-clauses/higher-ranked-fn-type.verbose.stderr
+++ b/tests/ui/where-clauses/higher-ranked-fn-type.verbose.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `for<Region(BrNamed(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), 'b))> fn(&'^1_0.Named(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), "'b") ()): Foo` is not satisfied
+error[E0277]: the trait bound `for<Region(BrNamed(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b)))> fn(&'^1_0.Named(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b)) ()): Foo` is not satisfied
   --> $DIR/higher-ranked-fn-type.rs:20:5
    |
 LL |     called()
    |     ^^^^^^^^ unsatisfied trait bound
    |
-   = help: the trait `for<Region(BrNamed(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), 'b))> Foo` is not implemented for `fn(&'^1_0.Named(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), "'b") ())`
+   = help: the trait `for<Region(BrNamed(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b)))> Foo` is not implemented for `fn(&'^1_0.Named(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b)) ())`
 help: this trait has no implementations, consider adding one
   --> $DIR/higher-ranked-fn-type.rs:6:1
    |


### PR DESCRIPTION
The `Symbol` is redundant, since we already store a `DefId` in the region variant. Instead, load the name via `item_name` when needed (which is almost always on the diagnostic path).

This introduces a `BoundRegionKind::NamedAnon` which is used for giving anonymous bound regions names, but which should only be used during pretty printing and error reporting.