### PR TITLE
Tracking issue template: fine-grained information on style update status

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -41,7 +41,10 @@ for larger features an implementation could be broken up into multiple PRs.
 - [ ] Implement the RFC (cc @rust-lang/XXX -- can anyone write up mentoring
       instructions?)
 - [ ] Adjust documentation ([see instructions on rustc-dev-guide][doc-guide])
-- [ ] Formatting for new syntax has been added to the [Style Guide] ([nightly-style-procedure])
+- [ ] Style updates for any new syntax ([nightly-style-procedure])
+  - [ ] Style team decision on new formatting
+  - [ ] Formatting for new syntax has been added to the [Style Guide]
+  - [ ] (non-blocking) Formatting has been implemented in `rustfmt`
 - [ ] Stabilization PR ([see instructions on rustc-dev-guide][stabilization-guide])
 
 [stabilization-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#stabilization-pr


### PR DESCRIPTION
Inspired by some of the communication issues around the stabilization of
`let`-chains, give more fine-grained information about the status of
updating style for any new syntax.

This does not change the process or blockers in any way; it only
*documents* the current state in the tracking issue. For instance, in
the case of `let`-chains, we would have checked the boxes for "Style
team decision" and "(non-blocking) Formatting has been implemented", and
not checked the box for the style guide. That would have then provided
better supporting information for any decisions.
