### PR TITLE
Update `compiler-builtins` to 0.1.153

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.152"
+version = "0.1.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2153cf213eb259361567720ce55f6446f17acd0ccca87fb6dc05360578228a58"
+checksum = "926ef6a360c15a911023352fd6969c51605d70495406f735beb1ca0257448e59"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 
 [dependencies]
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.152", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "=0.1.153", features = ['rustc-dep-of-std'] }
 
 [features]
 compiler-builtins-mem = ['compiler_builtins/mem']

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.152" }
+compiler_builtins = { version = "=0.1.153" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',


### PR DESCRIPTION
Includes the following changes:

* Avoid OOB access in `memcpy` and `memmove` [1]
* Enable intrinsics on AVR [2]
* `libm` updates to avoid using `core::arch` vector intrinsics [3]
* Re-enable `f16` on aarch64 without Neon [4]

[1]: https://github.com/rust-lang/compiler-builtins/pull/799
[2]: https://github.com/rust-lang/compiler-builtins/pull/791
[3]: https://github.com/rust-lang/compiler-builtins/pull/814
[4]: https://github.com/rust-lang/compiler-builtins/pull/809

<!-- homu-ignore:start -->
r? @ghost
<!-- homu-ignore:end -->
