### PR TITLE
Don't allow flattened format_args in const.

### DIFF
--- a/library/core/src/fmt/rt.rs
+++ b/library/core/src/fmt/rt.rs
@@ -174,8 +174,15 @@ impl Argument<'_> {
     /// let f = format_args!("{}", "a");
     /// println!("{f}");
     /// ```
+    ///
+    /// This function should _not_ be const, to make sure we don't accept
+    /// format_args!() and panic!() with arguments in const, even when not evaluated:
+    ///
+    /// ```compile_fail,E0015
+    /// const _: () = if false { panic!("a {}", "a") };
+    /// ```
     #[inline]
-    pub const fn none() -> [Self; 0] {
+    pub fn none() -> [Self; 0] {
         []
     }
 }

--- a/tests/ui/consts/const-eval/format.rs
+++ b/tests/ui/consts/const-eval/format.rs
@@ -9,4 +9,9 @@ const fn print() {
     //~| ERROR cannot call non-const function `_print` in constant functions
 }
 
+const fn format_args() {
+    format_args!("{}", 0);
+    //~^ ERROR cannot call non-const formatting macro in constant functions
+}
+
 fn main() {}

--- a/tests/ui/consts/const-eval/format.stderr
+++ b/tests/ui/consts/const-eval/format.stderr
@@ -24,6 +24,14 @@ LL |     println!("{:?}", 0);
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error[E0015]: cannot call non-const formatting macro in constant functions
+  --> $DIR/format.rs:13:5
+   |
+LL |     format_args!("{}", 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0015`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/139136

Fixes https://github.com/rust-lang/rust/issues/139621

We allow `format_args!("a")` in const, but don't allow any format_args with arguments in const, such as `format_args!("{}", arg)`.

However, we accidentally allow `format_args!("hello {}", "world")` in const, as it gets flattened to `format_args!("hello world")`.

This also applies to panic in const.

This wasn't supposed to happen. I added protection against this in the format args flattening code, ~~but I accidentally marked a function as const that shouldn't have been const~~ but this was removed in https://github.com/rust-lang/rust/pull/135139.

This is a breaking change. The crater found no breakage, however.

This breaks things like:

```rust
const _: () = if false { panic!("a {}", "a") };
```

and

```rust
const F: std::fmt::Arguments<'static> = format_args!("a {}", "a");
```