### PR TITLE
Remove unnecessary `mut` in test.

### DIFF
--- a/tests/ui/sanitizer/cfi/coroutine.rs
+++ b/tests/ui/sanitizer/cfi/coroutine.rs
@@ -26,7 +26,7 @@ use std::async_iter::AsyncIterator;
 
 #[test]
 fn general_coroutine() {
-    let mut coro = #[coroutine] |x: i32| {
+    let coro = #[coroutine] |x: i32| {
         yield x;
         "done"
     };


### PR DESCRIPTION
The value is moved in `pin!()`, so the binding doesn't need to be `mut` itself.

(Rustc doesn't warn about this due to the current hacky implementation of `pin!()`. That is fixed by https://github.com/rust-lang/rust/pull/139114.)