### PR TITLE
Update documentation of `as_ptr` function of Atomic$Int to clarify circumstances of usage

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -3401,12 +3401,8 @@ macro_rules! atomic_int {
             /// Doing non-atomic reads and writes on the resulting integer can be a data race.
             /// This method is mostly useful for FFI, where the function signature may use
             #[doc = concat!("`*mut ", stringify!($int_type), "` instead of `&", stringify!($atomic_type), "`.")]
-            ///
-            /// Returning an `*mut` pointer from a shared reference to this atomic is safe because the
-            /// atomic types work with interior mutability. All modifications of an atomic change the value
-            /// through a shared reference, and can do so safely as long as they use atomic operations. Any
-            /// use of the returned raw pointer requires an `unsafe` block and still has to uphold the same
-            /// restriction: operations on it must be atomic.
+            /// All modifications of an atomic change the value through a shared reference, and can do so safely
+            /// as long as they use atomic operations.
             ///
             /// # Examples
             ///
@@ -3420,7 +3416,7 @@ macro_rules! atomic_int {
             ///
             #[doc = concat!("let atomic = ", stringify!($atomic_type), "::new(1);")]
             ///
-            /// // SAFETY: Safe as long as `my_atomic_op` is atomic.
+            /// // SAFETY: `my_atomic_op` only uses atomic operations so it will not lead to a data race.
             /// unsafe {
             ///     my_atomic_op(atomic.as_ptr());
             /// }

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1113,7 +1113,9 @@ impl AtomicBool {
 
     /// Returns a mutable pointer to the underlying [`bool`].
     ///
-    /// Doing non-atomic reads and writes on the resulting boolean can be a data race.
+    /// Note that doing non-atomic reads or writes on the resulting integer can be
+    /// Undefined Behavior due to a data race; see the [memory model section] for further information.
+    ///
     /// This method is mostly useful for FFI, where the function signature may use
     /// `*mut bool` instead of `&AtomicBool`. All modifications of an atomic change the value
     /// through a shared reference, and can do so safely as long as they use atomic operations.
@@ -1136,6 +1138,7 @@ impl AtomicBool {
     /// }
     /// # }
     /// ```
+    /// [memory model section]: self#memory-model-for-atomic-accesses
     #[inline]
     #[stable(feature = "atomic_as_ptr", since = "1.70.0")]
     #[rustc_const_stable(feature = "atomic_as_ptr", since = "1.70.0")]
@@ -2303,7 +2306,9 @@ impl<T> AtomicPtr<T> {
 
     /// Returns a mutable pointer to the underlying pointer.
     ///
-    /// Doing non-atomic reads and writes on the resulting pointer can be a data race.
+    /// Note that doing non-atomic reads or writes on the resulting integer can be
+    /// Undefined Behavior due to a data race; see the [memory model section] for further information.
+    ///
     /// This method is mostly useful for FFI, where the function signature may use
     /// `*mut *mut T` instead of `&AtomicPtr<T>`. All modifications of an atomic change the value
     /// through a shared reference, and can do so safely as long as they use atomic operations.
@@ -2325,6 +2330,7 @@ impl<T> AtomicPtr<T> {
     ///     my_atomic_op(atomic.as_ptr());
     /// }
     /// ```
+    /// [memory model section]: self#memory-model-for-atomic-accesses
     #[inline]
     #[stable(feature = "atomic_as_ptr", since = "1.70.0")]
     #[rustc_const_stable(feature = "atomic_as_ptr", since = "1.70.0")]
@@ -3390,7 +3396,9 @@ macro_rules! atomic_int {
 
             /// Returns a mutable pointer to the underlying integer.
             ///
-            /// Doing non-atomic reads and writes on the resulting integer can be a data race.
+            /// Note that doing non-atomic reads or writes on the resulting integer can be
+            /// Undefined Behavior due to a data race; see the [memory model section] for further information.
+            ///
             /// This method is mostly useful for FFI, where the function signature may use
             #[doc = concat!("`*mut ", stringify!($int_type), "` instead of `&", stringify!($atomic_type), "`.")]
             /// All modifications of an atomic change the value through a shared reference, and can do so safely
@@ -3414,6 +3422,7 @@ macro_rules! atomic_int {
             /// }
             /// # }
             /// ```
+            /// [memory model section]: self#memory-model-for-atomic-accesses
             #[inline]
             #[stable(feature = "atomic_as_ptr", since = "1.70.0")]
             #[rustc_const_stable(feature = "atomic_as_ptr", since = "1.70.0")]

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1115,13 +1115,8 @@ impl AtomicBool {
     ///
     /// Doing non-atomic reads and writes on the resulting boolean can be a data race.
     /// This method is mostly useful for FFI, where the function signature may use
-    /// `*mut bool` instead of `&AtomicBool`.
-    ///
-    /// Returning an `*mut` pointer from a shared reference to this atomic is safe because the
-    /// atomic types work with interior mutability. All modifications of an atomic change the value
-    /// through a shared reference, and can do so safely as long as they use atomic operations. Any
-    /// use of the returned raw pointer requires an `unsafe` block and still has to uphold the same
-    /// restriction: operations on it must be atomic.
+    /// `*mut bool` instead of `&AtomicBool`. All modifications of an atomic change the value
+    /// through a shared reference, and can do so safely as long as they use atomic operations.
     ///
     /// # Examples
     ///
@@ -1134,6 +1129,8 @@ impl AtomicBool {
     /// }
     ///
     /// let mut atomic = AtomicBool::new(true);
+    ///
+    /// // SAFETY: `my_atomic_op` only uses atomic operations so it will not lead to a data race.
     /// unsafe {
     ///     my_atomic_op(atomic.as_ptr());
     /// }
@@ -2308,13 +2305,8 @@ impl<T> AtomicPtr<T> {
     ///
     /// Doing non-atomic reads and writes on the resulting pointer can be a data race.
     /// This method is mostly useful for FFI, where the function signature may use
-    /// `*mut *mut T` instead of `&AtomicPtr<T>`.
-    ///
-    /// Returning an `*mut` pointer from a shared reference to this atomic is safe because the
-    /// atomic types work with interior mutability. All modifications of an atomic change the value
-    /// through a shared reference, and can do so safely as long as they use atomic operations. Any
-    /// use of the returned raw pointer requires an `unsafe` block and still has to uphold the same
-    /// restriction: operations on it must be atomic.
+    /// `*mut *mut T` instead of `&AtomicPtr<T>`. All modifications of an atomic change the value
+    /// through a shared reference, and can do so safely as long as they use atomic operations.
     ///
     /// # Examples
     ///


### PR DESCRIPTION


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
## Context
The documentation of `as_ptr` mentions that "operations on it must be atomic". This may confuse developers, since non-atomic reads may be safely performed in certain circumstances (eg: when they do not lead to a data race).

The core message is that non-atomic accesses are UB if they cause a data race.

This update ensures such clarity on the circumstances of usage of the `as_ptr` function.

## Associated Issue
- https://github.com/rust-lang/rust/issues/138246

cc: @RalfJung @briansmith 

<!-- homu-ignore:end -->
