### PR TITLE
Bump `FileEncoder` buffer size to 64 kB

### DIFF
--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -19,7 +19,7 @@ pub type FileEncodeResult = Result<usize, (PathBuf, io::Error)>;
 pub const MAGIC_END_BYTES: &[u8] = b"rust-end-file";
 
 /// The size of the buffer in `FileEncoder`.
-const BUF_SIZE: usize = 8192;
+const BUF_SIZE: usize = 64 * 1024;
 
 /// `FileEncoder` encodes data to file via fixed-size buffer.
 ///


### PR DESCRIPTION
This helps avoid file system overhead on Windows. The improvement are probably reduced a bit on other platforms. Making the buffer size even larger does further improve performance, but that increase memory use further.

<table><tr><td rowspan="2">Benchmark</td><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th><td colspan="1"><b>Before</b></th><td colspan="2"><b>After</b></th></tr><tr><td align="right">Time</td><td align="right">Time</td><td align="right">%</th><td align="right">Physical Memory</td><td align="right">Physical Memory</td><td align="right">%</th><td align="right">Committed Memory</td><td align="right">Committed Memory</td><td align="right">%</th></tr><tr><td>🟣 <b>clap</b>:check:unchanged</td><td align="right">0.3336s</td><td align="right">0.3242s</td><td align="right">💚  -2.82%</td><td align="right">96.97 MiB</td><td align="right">97.12 MiB</td><td align="right"> 0.16%</td><td align="right">167.87 MiB</td><td align="right">167.97 MiB</td><td align="right"> 0.06%</td></tr><tr><td>🟣 <b>hyper</b>:check:unchanged</td><td align="right">0.1331s</td><td align="right">0.1307s</td><td align="right">💚  -1.79%</td><td align="right">61.92 MiB</td><td align="right">62.05 MiB</td><td align="right"> 0.20%</td><td align="right">124.66 MiB</td><td align="right">124.74 MiB</td><td align="right"> 0.06%</td></tr><tr><td>🟣 <b>regex</b>:check:unchanged</td><td align="right">0.2485s</td><td align="right">0.2399s</td><td align="right">💚  -3.45%</td><td align="right">78.32 MiB</td><td align="right">78.55 MiB</td><td align="right"> 0.29%</td><td align="right">145.22 MiB</td><td align="right">145.45 MiB</td><td align="right"> 0.15%</td></tr><tr><td>🟣 <b>syn</b>:check:unchanged</td><td align="right">0.5321s</td><td align="right">0.5175s</td><td align="right">💚  -2.76%</td><td align="right">118.58 MiB</td><td align="right">118.77 MiB</td><td align="right"> 0.16%</td><td align="right">192.99 MiB</td><td align="right">193.17 MiB</td><td align="right"> 0.09%</td></tr><tr><td>Total</td><td align="right">1.2474s</td><td align="right">1.2123s</td><td align="right">💚  -2.81%</td><td align="right">355.78 MiB</td><td align="right">356.49 MiB</td><td align="right"> 0.20%</td><td align="right">630.74 MiB</td><td align="right">631.32 MiB</td><td align="right"> 0.09%</td></tr><tr><td>Summary</td><td align="right">1.0000s</td><td align="right">0.9729s</td><td align="right">💚  -2.71%</td><td align="right">1 byte</td><td align="right">1.00 bytes</td><td align="right"> 0.20%</td><td align="right">1 byte</td><td align="right">1.00 bytes</td><td align="right"> 0.09%</td></tr></table>