### PR TITLE
Allow parenthesis around inferred array lengths

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2034,7 +2034,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     fn lower_array_length_to_const_arg(&mut self, c: &AnonConst) -> &'hir hir::ConstArg<'hir> {
-        match c.value.kind {
+        // We cannot just match on `ExprKind::Underscore` as `(_)` is represented as
+        // `ExprKind::Paren(ExprKind::Underscore)` and should also be lowered to `GenericArg::Infer`
+        match c.value.peel_parens().kind {
             ExprKind::Underscore => {
                 if !self.tcx.features().generic_arg_infer() {
                     feature_err(

--- a/tests/ui/const-generics/generic_arg_infer/parend_infer.nogate.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/parend_infer.nogate.stderr
@@ -1,0 +1,53 @@
+error[E0658]: const arguments cannot yet be inferred with `_`
+  --> $DIR/parend_infer.rs:24:16
+   |
+LL |     let c: Foo<_> = Foo::<1>;
+   |                ^
+   |
+   = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
+   = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: const arguments cannot yet be inferred with `_`
+  --> $DIR/parend_infer.rs:26:16
+   |
+LL |     let c: Foo<(_)> = Foo::<1>;
+   |                ^^^
+   |
+   = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
+   = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: const arguments cannot yet be inferred with `_`
+  --> $DIR/parend_infer.rs:28:16
+   |
+LL |     let c: Foo<(((_)))> = Foo::<1>;
+   |                ^^^^^^^
+   |
+   = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
+   = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: using `_` for array lengths is unstable
+  --> $DIR/parend_infer.rs:17:17
+   |
+LL |     let b: [u8; (_)] = [1; (((((_)))))];
+   |                 ^^^
+   |
+   = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
+   = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: using `_` for array lengths is unstable
+  --> $DIR/parend_infer.rs:17:28
+   |
+LL |     let b: [u8; (_)] = [1; (((((_)))))];
+   |                            ^^^^^^^^^^^
+   |
+   = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information
+   = help: add `#![feature(generic_arg_infer)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/const-generics/generic_arg_infer/parend_infer.rs
+++ b/tests/ui/const-generics/generic_arg_infer/parend_infer.rs
@@ -1,6 +1,8 @@
-//@ check-pass
+//@[gate] check-pass
 //@ revisions: gate nogate
 #![cfg_attr(gate, feature(generic_arg_infer))]
+
+struct Foo<const N: usize>;
 
 fn main() {
     // AST Types preserve parens for pretty printing reasons. This means
@@ -9,4 +11,20 @@ fn main() {
     // but `TyKind::Infer` wrapped in arbitrarily many `TyKind::Paren`.
     let a: Vec<(_)> = vec![1_u8];
     let a: Vec<(((((_)))))> = vec![1_u8];
+
+    // AST Exprs similarly preserve parens for pretty printing reasons.
+    #[rustfmt::skip]
+    let b: [u8; (_)] = [1; (((((_)))))];
+    //[nogate]~^ error: using `_` for array lengths is unstable
+    //[nogate]~| error: using `_` for array lengths is unstable
+    let b: [u8; 2] = b;
+
+    // This is the same case as AST types as the parser doesn't distinguish between const
+    // and type args when they share syntax
+    let c: Foo<_> = Foo::<1>;
+    //[nogate]~^ error: const arguments cannot yet be inferred with `_`
+    let c: Foo<(_)> = Foo::<1>;
+    //[nogate]~^ error: const arguments cannot yet be inferred with `_`
+    let c: Foo<(((_)))> = Foo::<1>;
+    //[nogate]~^ error: const arguments cannot yet be inferred with `_`
 }


### PR DESCRIPTION
In #135272 it was noticed that we weren't handling `Vec<(((((_)))))>` correctly under the new desugaring for `generic_arg_infer`, this had to be fixed in order to not regress stable code for types that should continue working. This has the side effect of *also* allowing the following to work:
```rust
#![feature(generic_arg_infer)]
struct Bar<const N: usize>;
fn main() {
    let a: Bar<((_))> = Bar::<10>;
}
```

However I did not make the same change for array lengths resulting in the following not compiling:
```rust
#![feature(generic_arg_infer)]
fn main() {
    let a: [u8; (((_)))] = [2; 2];
    let a: [u8; 2] = [2; (((((_)))))];
}
```

This is rather inconsistent as parenthesis around `_` *are* supported for const args to non-arrays, and type args. This PR fixes this allowing the above example to compile. No stable impact.

r? compiler-errors