### PR TITLE
Handle a negated literal in `eat_token_lit`.

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2166,10 +2166,15 @@ impl<'a> Parser<'a> {
                 let expr = self
                     .eat_metavar_seq(mv_kind, |this| this.parse_expr())
                     .expect("metavar seq expr");
-                let ast::ExprKind::Lit(token_lit) = expr.kind else {
-                    panic!("didn't reparse an expr");
-                };
-                Some(token_lit)
+                if let ast::ExprKind::Lit(token_lit) = expr.kind {
+                    Some(token_lit)
+                } else if let ast::ExprKind::Unary(UnOp::Neg, inner) = &expr.kind
+                    && let ast::Expr { kind: ast::ExprKind::Lit(_), .. } = **inner
+                {
+                    None
+                } else {
+                    panic!("unexpected reparsed expr: {:?}", expr.kind);
+                }
             }
             _ => None,
         }

--- a/tests/ui/macros/reparse-expr-issue-139495.rs
+++ b/tests/ui/macros/reparse-expr-issue-139495.rs
@@ -1,0 +1,7 @@
+macro_rules! m {
+  ($abi : expr) => { extern $abi } //~ ERROR expected expression, found keyword `extern`
+}
+
+fn main() {
+    m!(-2)
+}

--- a/tests/ui/macros/reparse-expr-issue-139495.stderr
+++ b/tests/ui/macros/reparse-expr-issue-139495.stderr
@@ -1,0 +1,13 @@
+error: expected expression, found keyword `extern`
+  --> $DIR/reparse-expr-issue-139495.rs:2:22
+   |
+LL |   ($abi : expr) => { extern $abi }
+   |                      ^^^^^^ expected expression
+...
+LL |     m!(-2)
+   |     ------ in this macro invocation
+   |
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #139495.

r? @petrochenkov 