### PR TITLE
Improve `AssocItem::descr`.

### DIFF
--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -98,10 +98,10 @@ impl AssocItem {
 
     pub fn descr(&self) -> &'static str {
         match self.kind {
-            ty::AssocKind::Const => "const",
+            ty::AssocKind::Const => "associated const",
             ty::AssocKind::Fn if self.fn_has_self_parameter => "method",
             ty::AssocKind::Fn => "associated function",
-            ty::AssocKind::Type => "type",
+            ty::AssocKind::Type => "associated type",
         }
     }
 
@@ -155,6 +155,8 @@ impl AssocKind {
 impl std::fmt::Display for AssocKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            // FIXME: fails to distinguish between "associated function" and
+            // "method" because `has_self` isn't known here.
             AssocKind::Fn => write!(f, "method"),
             AssocKind::Const => write!(f, "associated const"),
             AssocKind::Type => write!(f, "associated type"),

--- a/tests/ui/consts/static-default-lifetime/elided-lifetime.rs
+++ b/tests/ui/consts/static-default-lifetime/elided-lifetime.rs
@@ -16,7 +16,7 @@ impl Bar for Foo<'_> {
     const STATIC: &str = "";
     //~^ ERROR `&` without an explicit lifetime name cannot be used here
     //~| WARN this was previously accepted by the compiler but is being phased out
-    //~| ERROR lifetime parameters or bounds on const `STATIC` do not match the trait declaration
+    //~| ERROR lifetime parameters or bounds on associated const `STATIC` do not match the trait declaration
 }
 
 fn main() {}

--- a/tests/ui/consts/static-default-lifetime/elided-lifetime.stderr
+++ b/tests/ui/consts/static-default-lifetime/elided-lifetime.stderr
@@ -39,14 +39,14 @@ help: use the `'static` lifetime
 LL |     const STATIC: &'static str = "";
    |                    +++++++
 
-error[E0195]: lifetime parameters or bounds on const `STATIC` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated const `STATIC` do not match the trait declaration
   --> $DIR/elided-lifetime.rs:16:17
    |
 LL |     const STATIC: &str;
-   |                 - lifetimes in impl do not match this const in trait
+   |                 - lifetimes in impl do not match this associated const in trait
 ...
 LL |     const STATIC: &str = "";
-   |                 ^ lifetimes do not match const in trait
+   |                 ^ lifetimes do not match associated const in trait
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/consts/static-default-lifetime/static-trait-impl.rs
+++ b/tests/ui/consts/static-default-lifetime/static-trait-impl.rs
@@ -9,7 +9,7 @@ impl Bar<'_> for A {
     const STATIC: &str = "";
     //~^ ERROR `&` without an explicit lifetime name cannot be used here
     //~| WARN this was previously accepted by the compiler but is being phased out
-    //~| ERROR lifetime parameters or bounds on const `STATIC` do not match the trait declaration
+    //~| ERROR lifetime parameters or bounds on associated const `STATIC` do not match the trait declaration
 }
 
 struct B;

--- a/tests/ui/consts/static-default-lifetime/static-trait-impl.stderr
+++ b/tests/ui/consts/static-default-lifetime/static-trait-impl.stderr
@@ -21,14 +21,14 @@ help: use the `'static` lifetime
 LL |     const STATIC: &'static str = "";
    |                    +++++++
 
-error[E0195]: lifetime parameters or bounds on const `STATIC` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated const `STATIC` do not match the trait declaration
   --> $DIR/static-trait-impl.rs:9:17
    |
 LL |     const STATIC: &'a str;
-   |                 - lifetimes in impl do not match this const in trait
+   |                 - lifetimes in impl do not match this associated const in trait
 ...
 LL |     const STATIC: &str = "";
-   |                 ^ lifetimes do not match const in trait
+   |                 ^ lifetimes do not match associated const in trait
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generic-associated-types/const_params_have_right_type.stderr
+++ b/tests/ui/generic-associated-types/const_params_have_right_type.stderr
@@ -1,4 +1,4 @@
-error[E0053]: type `Foo` has an incompatible generic parameter for trait `Trait`
+error[E0053]: associated type `Foo` has an incompatible generic parameter for trait `Trait`
   --> $DIR/const_params_have_right_type.rs:6:14
    |
 LL | trait Trait {

--- a/tests/ui/generic-associated-types/issue-102114.current.stderr
+++ b/tests/ui/generic-associated-types/issue-102114.current.stderr
@@ -1,4 +1,4 @@
-error[E0049]: type `B` has 1 type parameter but its trait declaration has 0 type parameters
+error[E0049]: associated type `B` has 1 type parameter but its trait declaration has 0 type parameters
   --> $DIR/issue-102114.rs:15:12
    |
 LL |     type B<'b>;

--- a/tests/ui/generic-associated-types/issue-102114.next.stderr
+++ b/tests/ui/generic-associated-types/issue-102114.next.stderr
@@ -1,4 +1,4 @@
-error[E0049]: type `B` has 1 type parameter but its trait declaration has 0 type parameters
+error[E0049]: associated type `B` has 1 type parameter but its trait declaration has 0 type parameters
   --> $DIR/issue-102114.rs:15:12
    |
 LL |     type B<'b>;

--- a/tests/ui/generic-associated-types/parameter_number_and_kind_impl.rs
+++ b/tests/ui/generic-associated-types/parameter_number_and_kind_impl.rs
@@ -12,11 +12,11 @@ struct Fooy;
 
 impl Foo for Fooy {
     type A = u32;
-    //~^ ERROR lifetime parameters or bounds on type `A` do not match the trait declaration
+    //~^ ERROR lifetime parameters or bounds on associated type `A` do not match the trait declaration
     type B<'a, T> = Vec<T>;
     //~^ ERROR type `B` has 1 type parameter but its trait declaration has 0 type parameters
     type C<'a> = u32;
-    //~^ ERROR lifetime parameters or bounds on type `C` do not match the trait declaration
+    //~^ ERROR lifetime parameters or bounds on associated type `C` do not match the trait declaration
 }
 
 struct Fooer;
@@ -25,7 +25,7 @@ impl Foo for Fooer {
     type A<T> = u32;
     //~^ ERROR type `A` has 1 type parameter but its trait declaration has 0 type parameters
     type B<'a> = u32;
-    //~^ ERROR lifetime parameters or bounds on type `B` do not match the trait declaration
+    //~^ ERROR lifetime parameters or bounds on associated type `B` do not match the trait declaration
     type C<T> = T;
     //~^ ERROR type `C` has 1 type parameter but its trait declaration has 0 type parameters
 }

--- a/tests/ui/generic-associated-types/parameter_number_and_kind_impl.stderr
+++ b/tests/ui/generic-associated-types/parameter_number_and_kind_impl.stderr
@@ -1,13 +1,13 @@
-error[E0195]: lifetime parameters or bounds on type `A` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated type `A` do not match the trait declaration
   --> $DIR/parameter_number_and_kind_impl.rs:14:11
    |
 LL |     type A<'a>;
-   |           ---- lifetimes in impl do not match this type in trait
+   |           ---- lifetimes in impl do not match this associated type in trait
 ...
 LL |     type A = u32;
-   |           ^ lifetimes do not match type in trait
+   |           ^ lifetimes do not match associated type in trait
 
-error[E0049]: type `B` has 1 type parameter but its trait declaration has 0 type parameters
+error[E0049]: associated type `B` has 1 type parameter but its trait declaration has 0 type parameters
   --> $DIR/parameter_number_and_kind_impl.rs:16:12
    |
 LL |     type B<'a, 'b>;
@@ -20,16 +20,16 @@ LL |     type B<'a, T> = Vec<T>;
    |            |
    |            found 1 type parameter
 
-error[E0195]: lifetime parameters or bounds on type `C` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated type `C` do not match the trait declaration
   --> $DIR/parameter_number_and_kind_impl.rs:18:11
    |
 LL |     type C;
-   |           - lifetimes in impl do not match this type in trait
+   |           - lifetimes in impl do not match this associated type in trait
 ...
 LL |     type C<'a> = u32;
-   |           ^^^^ lifetimes do not match type in trait
+   |           ^^^^ lifetimes do not match associated type in trait
 
-error[E0049]: type `A` has 1 type parameter but its trait declaration has 0 type parameters
+error[E0049]: associated type `A` has 1 type parameter but its trait declaration has 0 type parameters
   --> $DIR/parameter_number_and_kind_impl.rs:25:12
    |
 LL |     type A<'a>;
@@ -38,16 +38,16 @@ LL |     type A<'a>;
 LL |     type A<T> = u32;
    |            ^ found 1 type parameter
 
-error[E0195]: lifetime parameters or bounds on type `B` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated type `B` do not match the trait declaration
   --> $DIR/parameter_number_and_kind_impl.rs:27:11
    |
 LL |     type B<'a, 'b>;
-   |           -------- lifetimes in impl do not match this type in trait
+   |           -------- lifetimes in impl do not match this associated type in trait
 ...
 LL |     type B<'a> = u32;
-   |           ^^^^ lifetimes do not match type in trait
+   |           ^^^^ lifetimes do not match associated type in trait
 
-error[E0049]: type `C` has 1 type parameter but its trait declaration has 0 type parameters
+error[E0049]: associated type `C` has 1 type parameter but its trait declaration has 0 type parameters
   --> $DIR/parameter_number_and_kind_impl.rs:29:12
    |
 LL |     type C;

--- a/tests/ui/generic-const-items/assoc-const-missing-type.rs
+++ b/tests/ui/generic-const-items/assoc-const-missing-type.rs
@@ -14,7 +14,7 @@ impl Trait for () {
     //~| ERROR mismatched types
     const Q = "";
     //~^ ERROR missing type for `const` item
-    //~| ERROR lifetime parameters or bounds on const `Q` do not match the trait declaration
+    //~| ERROR lifetime parameters or bounds on associated const `Q` do not match the trait declaration
 }
 
 fn main() {}

--- a/tests/ui/generic-const-items/assoc-const-missing-type.stderr
+++ b/tests/ui/generic-const-items/assoc-const-missing-type.stderr
@@ -15,14 +15,14 @@ error: missing type for `const` item
 LL |     const K<T> = ();
    |               ^ help: provide a type for the associated constant: `()`
 
-error[E0195]: lifetime parameters or bounds on const `Q` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated const `Q` do not match the trait declaration
   --> $DIR/assoc-const-missing-type.rs:15:12
    |
 LL |     const Q<'a>: &'a str;
-   |            ---- lifetimes in impl do not match this const in trait
+   |            ---- lifetimes in impl do not match this associated const in trait
 ...
 LL |     const Q = "";
-   |            ^ lifetimes do not match const in trait
+   |            ^ lifetimes do not match associated const in trait
 
 error: missing type for `const` item
   --> $DIR/assoc-const-missing-type.rs:15:12

--- a/tests/ui/generic-const-items/compare-impl-item.rs
+++ b/tests/ui/generic-const-items/compare-impl-item.rs
@@ -22,7 +22,7 @@ impl<P> Trait<P> for () {
     const D<const N: u16>: u16 = N;
     //~^ ERROR const `D` has an incompatible generic parameter for trait `Trait`
     const E: &'static () = &();
-    //~^ ERROR lifetime parameters or bounds on const `E` do not match the trait declaration
+    //~^ ERROR lifetime parameters or bounds on associated const `E` do not match the trait declaration
 
     const F: usize = 1024
     where

--- a/tests/ui/generic-const-items/compare-impl-item.stderr
+++ b/tests/ui/generic-const-items/compare-impl-item.stderr
@@ -1,4 +1,4 @@
-error[E0049]: const `A` has 1 type parameter but its trait declaration has 0 type parameters
+error[E0049]: associated const `A` has 1 type parameter but its trait declaration has 0 type parameters
   --> $DIR/compare-impl-item.rs:16:13
    |
 LL |     const A: ();
@@ -7,7 +7,7 @@ LL |     const A: ();
 LL |     const A<T>: () = ();
    |             ^ found 1 type parameter
 
-error[E0049]: const `B` has 1 const parameter but its trait declaration has 2 const parameters
+error[E0049]: associated const `B` has 1 const parameter but its trait declaration has 2 const parameters
   --> $DIR/compare-impl-item.rs:18:13
    |
 LL |     const B<const K: u64, const Q: u64>: u64;
@@ -18,7 +18,7 @@ LL |     const B<const K: u64, const Q: u64>: u64;
 LL |     const B<const K: u64>: u64 = 0;
    |             ^^^^^^^^^^^^ found 1 const parameter
 
-error[E0049]: const `C` has 0 type parameters but its trait declaration has 1 type parameter
+error[E0049]: associated const `C` has 0 type parameters but its trait declaration has 1 type parameter
   --> $DIR/compare-impl-item.rs:20:13
    |
 LL |     const C<T>: T;
@@ -27,7 +27,7 @@ LL |     const C<T>: T;
 LL |     const C<'a>: &'a str = "";
    |             ^^ found 0 type parameters
 
-error[E0053]: const `D` has an incompatible generic parameter for trait `Trait`
+error[E0053]: associated const `D` has an incompatible generic parameter for trait `Trait`
   --> $DIR/compare-impl-item.rs:22:13
    |
 LL | trait Trait<P> {
@@ -42,14 +42,14 @@ LL | impl<P> Trait<P> for () {
 LL |     const D<const N: u16>: u16 = N;
    |             ^^^^^^^^^^^^ found const parameter of type `u16`
 
-error[E0195]: lifetime parameters or bounds on const `E` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated const `E` do not match the trait declaration
   --> $DIR/compare-impl-item.rs:24:12
    |
 LL |     const E<'a>: &'a ();
-   |            ---- lifetimes in impl do not match this const in trait
+   |            ---- lifetimes in impl do not match this associated const in trait
 ...
 LL |     const E: &'static () = &();
-   |            ^ lifetimes do not match const in trait
+   |            ^ lifetimes do not match associated const in trait
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/compare-impl-item.rs:29:12

--- a/tests/ui/impl-trait/ice-unexpected-param-type-whensubstituting-in-region-112823.current.stderr
+++ b/tests/ui/impl-trait/ice-unexpected-param-type-whensubstituting-in-region-112823.current.stderr
@@ -4,7 +4,7 @@ error[E0407]: method `line_stream` is not a member of trait `X`
 LL |     fn line_stream<'a, Repr>(&'a self) -> Self::LineStreamFut<'a, Repr> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `X`
 
-error[E0049]: type `LineStream` has 0 type parameters but its trait declaration has 1 type parameter
+error[E0049]: associated type `LineStream` has 0 type parameters but its trait declaration has 1 type parameter
   --> $DIR/ice-unexpected-param-type-whensubstituting-in-region-112823.rs:25:21
    |
 LL |     type LineStream<'a, Repr>

--- a/tests/ui/impl-trait/ice-unexpected-param-type-whensubstituting-in-region-112823.next.stderr
+++ b/tests/ui/impl-trait/ice-unexpected-param-type-whensubstituting-in-region-112823.next.stderr
@@ -4,7 +4,7 @@ error[E0407]: method `line_stream` is not a member of trait `X`
 LL |     fn line_stream<'a, Repr>(&'a self) -> Self::LineStreamFut<'a, Repr> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `X`
 
-error[E0049]: type `LineStream` has 0 type parameters but its trait declaration has 1 type parameter
+error[E0049]: associated type `LineStream` has 0 type parameters but its trait declaration has 1 type parameter
   --> $DIR/ice-unexpected-param-type-whensubstituting-in-region-112823.rs:25:21
    |
 LL |     type LineStream<'a, Repr>

--- a/tests/ui/impl-trait/in-trait/span-bug-issue-121457.rs
+++ b/tests/ui/impl-trait/in-trait/span-bug-issue-121457.rs
@@ -8,7 +8,7 @@ pub trait Iterable {
 
 impl<'a, I: 'a + Iterable> Iterable for &'a I {
     type Item = u32;
-    //~^ ERROR lifetime parameters or bounds on type `Item` do not match the trait declaration
+    //~^ ERROR lifetime parameters or bounds on associated type `Item` do not match the trait declaration
 
     fn iter(&self) -> impl for<'missing> Iterator<Item = Self::Item<'missing>> {}
     //~^ ERROR binding for associated type `Item` references lifetime `'missing`

--- a/tests/ui/impl-trait/in-trait/span-bug-issue-121457.stderr
+++ b/tests/ui/impl-trait/in-trait/span-bug-issue-121457.stderr
@@ -12,17 +12,17 @@ LL |     fn iter(&self) -> impl for<'missing> Iterator<Item = Self::Item<'missin
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0195]: lifetime parameters or bounds on type `Item` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated type `Item` do not match the trait declaration
   --> $DIR/span-bug-issue-121457.rs:10:14
    |
 LL |     type Item<'a>
-   |              ---- lifetimes in impl do not match this type in trait
+   |              ---- lifetimes in impl do not match this associated type in trait
 LL |     where
 LL |         Self: 'a;
    |               -- this bound might be missing in the impl
 ...
 LL |     type Item = u32;
-   |              ^ lifetimes do not match type in trait
+   |              ^ lifetimes do not match associated type in trait
 
 error[E0277]: `()` is not an iterator
   --> $DIR/span-bug-issue-121457.rs:13:23

--- a/tests/ui/lifetimes/no_lending_iterators.rs
+++ b/tests/ui/lifetimes/no_lending_iterators.rs
@@ -25,7 +25,7 @@ impl Bar for usize {
 
 impl Bar for isize {
     type Item<'a> = &'a isize;
-    //~^ ERROR 27:14: 27:18: lifetime parameters or bounds on type `Item` do not match the trait declaration [E0195]
+    //~^ ERROR 27:14: 27:18: lifetime parameters or bounds on associated type `Item` do not match the trait declaration [E0195]
 
     fn poke(&mut self, item: Self::Item) {
         self += *item;

--- a/tests/ui/lifetimes/no_lending_iterators.stderr
+++ b/tests/ui/lifetimes/no_lending_iterators.stderr
@@ -16,14 +16,14 @@ error: in the trait associated type is declared without lifetime parameters, so 
 LL |     type Item = &usize;
    |                 ^ this lifetime must come from the implemented type
 
-error[E0195]: lifetime parameters or bounds on type `Item` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated type `Item` do not match the trait declaration
   --> $DIR/no_lending_iterators.rs:27:14
    |
 LL |     type Item;
-   |              - lifetimes in impl do not match this type in trait
+   |              - lifetimes in impl do not match this associated type in trait
 ...
 LL |     type Item<'a> = &'a isize;
-   |              ^^^^ lifetimes do not match type in trait
+   |              ^^^^ lifetimes do not match associated type in trait
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/type-alias-impl-trait/impl-trait-in-type-alias-with-bad-substs.stderr
+++ b/tests/ui/type-alias-impl-trait/impl-trait-in-type-alias-with-bad-substs.stderr
@@ -1,4 +1,4 @@
-error[E0049]: type `Baz` has 1 type parameter but its trait declaration has 0 type parameters
+error[E0049]: associated type `Baz` has 1 type parameter but its trait declaration has 0 type parameters
   --> $DIR/impl-trait-in-type-alias-with-bad-substs.rs:19:14
    |
 LL |     type Baz<'a>;


### PR DESCRIPTION
The commit adds "associated" to the description of associated types and associated consts, to match the description of associated functions. This increases error message precision and consistency with `AssocKind::fmt`.

The commit also notes an imperfection in `AssocKind::fmt`; fixing this imperfection is possible but beyond the scope of this PR.

r? @estebank 