### PR TITLE
Fix profiler_builtins build script to handle full path to profiler lib

### DIFF
--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -9,8 +9,14 @@ use std::path::PathBuf;
 
 fn main() {
     if let Ok(rt) = tracked_env_var("LLVM_PROFILER_RT_LIB") {
-        println!("cargo::rustc-link-lib=static:+verbatim={rt}");
-        return;
+        let rt = PathBuf::from(rt);
+        if let Some(lib) = rt.file_name() {
+            if let Some(dir) = rt.parent() {
+                println!("cargo::rustc-link-search=native={}", dir.display());
+            }
+            println!("cargo::rustc-link-lib=static:+verbatim={}", lib.to_str().unwrap());
+            return;
+        }
     }
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS was not set");


### PR DESCRIPTION
LLVM_PROFILER_RT_LIB may be set to an absolute path (e.g., in Fedora builds), but `-l` expects a library name, not a path. After #138273, this caused builds to fail with a "could not find native static library" error.

This patch updates the build script to split the path into directory and filename, using `cargo::rustc-link-search` for the directory and `cargo::rustc-link-lib=+verbatim` for the file. This allows profiler_builtins to correctly link the static library even when an absolute path is provided.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
