### PR TITLE
opt-dist: explicitly pass `--set build.metrics=true` while running build

### DIFF
--- a/src/tools/opt-dist/src/exec.rs
+++ b/src/tools/opt-dist/src/exec.rs
@@ -111,6 +111,8 @@ impl Bootstrap {
             "--stage",
             "2",
             "library/std",
+            "--set",
+            "build.metrics=true",
         ])
         .env("RUST_BACKTRACE", "full");
         Self { cmd, metrics_path }


### PR DESCRIPTION
at first it's not obvious that build.metrics should be enabled to use opt-dist which will lead to confusion. probably it's better to add a good error message which instructs to set this option manually

edit: are there more places which need such change?

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
