### PR TITLE
`impl Default for RepeatN`

### DIFF
--- a/library/core/src/iter/sources/repeat_n.rs
+++ b/library/core/src/iter/sources/repeat_n.rs
@@ -102,6 +102,15 @@ impl<A: fmt::Debug> fmt::Debug for RepeatN<A> {
     }
 }
 
+/// Creates an empty iterator, like [`repeat_n(value, 0)`][`repeat_n`]
+/// but without needing any such value at hand.
+#[stable(feature = "iter_repeat_n_default", since = "CURRENT_RUSTC_VERSION")]
+impl<A> Default for RepeatN<A> {
+    fn default() -> Self {
+        RepeatN { inner: None }
+    }
+}
+
 #[stable(feature = "iter_repeat_n", since = "1.82.0")]
 impl<A: Clone> Iterator for RepeatN<A> {
     type Item = A;

--- a/library/coretests/tests/iter/sources.rs
+++ b/library/coretests/tests/iter/sources.rs
@@ -192,3 +192,19 @@ fn test_repeat_n_soundness() {
     let _z = y;
     assert_eq!(0, *x);
 }
+
+#[test]
+fn test_repeat_n_default() {
+    #[derive(Clone)]
+    pub struct PanicOnDrop;
+
+    impl Drop for PanicOnDrop {
+        fn drop(&mut self) {
+            unreachable!()
+        }
+    }
+
+    // The default is an empty iterator, so there's never any item to drop.
+    let iter = RepeatN::<PanicOnDrop>::default();
+    assert_eq!(iter.count(), 0);
+}


### PR DESCRIPTION
This creates an empty iterator, like `repeat_n(value, 0)` but without
needing any such value at hand. There's precedent in many other
iterators that the `Default` is empty, like `slice::Iter`.

I found myself wanting this for rayon's `RepeatN` as it lowers to a
sequential iterator [here][1]. Since rayon is also optimizing to avoid
extra clones, it may end up with parallel splits that have count 0 and
no item value. Calling `std::iter::repeat_n(x, 0)` just drops that
value, but there's no way to construct the same result without a value
yet. This would be straightforward with an empty `Default`.

[1]: https://github.com/rayon-rs/rayon/blob/ae07384e3e0b238cea89f0c14891f351c65a5cee/src/iter/repeat.rs#L201-L202

r? libs-api (insta-stable)
