### PR TITLE
Rustfmt now support use closures

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -55,8 +55,4 @@ ignore = [
     # Code automatically generated and included.
     "compiler/rustc_codegen_gcc/src/intrinsic/archs.rs",
     "compiler/rustc_codegen_gcc/example",
-
-    # Rustfmt doesn't support use closures yet
-    "tests/mir-opt/ergonomic-clones/closure.rs",
-    "tests/codegen-llvm/ergonomic-clones/closure.rs",
 ]

--- a/tests/codegen-llvm/ergonomic-clones/closure.rs
+++ b/tests/codegen-llvm/ergonomic-clones/closure.rs
@@ -1,7 +1,6 @@
 //@ compile-flags: -C no-prepopulate-passes -Copt-level=0 -Zmir-opt-level=0
 
 #![crate_type = "lib"]
-
 #![feature(ergonomic_clones)]
 #![allow(incomplete_features)]
 


### PR DESCRIPTION
This should be merged when https://github.com/rust-lang/rustfmt/pull/6532 is used by CI's rustfmt.