### PR TITLE
Proactively update coroutine drop shim's phase to account for later passes applied during shim query

### DIFF
--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -1169,6 +1169,13 @@ fn create_coroutine_drop_shim<'tcx>(
     dump_mir(tcx, false, "coroutine_drop", &0, &body, |_, _| Ok(()));
     body.source.instance = drop_instance;
 
+    // Creating a coroutine drop shim happens on `Analysis(PostCleanup) -> Runtime(Initial)`
+    // but the pass manager doesn't update the phase of the coroutine drop shim. Update the
+    // phase of the drop shim so that later on when we run the pass manager on the shim, in
+    // the `mir_shims` query, we don't ICE on the intra-pass validation before we've updated
+    // the phase of the body from analysis.
+    body.phase = MirPhase::Runtime(RuntimePhase::Initial);
+
     body
 }
 

--- a/tests/ui/async-await/post-cleanup-phase-validation.rs
+++ b/tests/ui/async-await/post-cleanup-phase-validation.rs
@@ -1,0 +1,19 @@
+//@ compile-flags: -Zvalidate-mir
+//@ edition: 2024
+//@ build-pass
+
+// Regression test that we don't ICE when encountering a transmute in a coroutine's
+// drop shim body, which is conceptually in the Runtime phase but wasn't having the
+// phase updated b/c the pass manager neither optimizes nor updates the phase for
+// drop shim bodies.
+
+struct HasDrop;
+impl Drop for HasDrop {
+    fn drop(&mut self) {}
+}
+
+fn main() {
+    async {
+        vec![async { HasDrop }.await];
+    };
+}


### PR DESCRIPTION
See comments in the pass and on test. Also see https://github.com/rust-lang/rust/pull/137264#issuecomment-2669706718.

Fixes https://github.com/rust-lang/rust/issues/137243
Fixes https://github.com/rust-lang/rust/issues/139698

r? scottmcm