### PR TITLE
Make algebraic functions in `f16`, `f32`, `f64`, and `f128` into `const fn` items.

### DIFF
--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -12,9 +12,10 @@
 #![unstable(feature = "f128", issue = "116909")]
 
 use crate::convert::FloatToInt;
+use crate::intrinsics::{self, const_eval_select};
+use crate::mem;
 use crate::num::FpCategory;
 use crate::panic::const_assert;
-use crate::{intrinsics, mem};
 
 /// Basic mathematical constants.
 #[unstable(feature = "f128", issue = "116909")]
@@ -1368,9 +1369,19 @@ impl f128 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_add(self, rhs: f128) -> f128 {
-        intrinsics::fadd_algebraic(self, rhs)
+    pub const fn algebraic_add(self, rhs: f128) -> f128 {
+        const fn const_algebraic_add(lhs: f128, rhs: f128) -> f128 {
+            lhs + rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_add(lhs: f128, rhs: f128) -> f128 {
+            intrinsics::fadd_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_add, rt_algebraic_add)
     }
 
     /// Float subtraction that allows optimizations based on algebraic rules.
@@ -1378,9 +1389,19 @@ impl f128 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_sub(self, rhs: f128) -> f128 {
-        intrinsics::fsub_algebraic(self, rhs)
+    pub const fn algebraic_sub(self, rhs: f128) -> f128 {
+        const fn const_algebraic_sub(lhs: f128, rhs: f128) -> f128 {
+            lhs - rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_sub(lhs: f128, rhs: f128) -> f128 {
+            intrinsics::fsub_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_sub, rt_algebraic_sub)
     }
 
     /// Float multiplication that allows optimizations based on algebraic rules.
@@ -1388,9 +1409,19 @@ impl f128 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_mul(self, rhs: f128) -> f128 {
-        intrinsics::fmul_algebraic(self, rhs)
+    pub const fn algebraic_mul(self, rhs: f128) -> f128 {
+        const fn const_algebraic_mul(lhs: f128, rhs: f128) -> f128 {
+            lhs * rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_mul(lhs: f128, rhs: f128) -> f128 {
+            intrinsics::fmul_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_mul, rt_algebraic_mul)
     }
 
     /// Float division that allows optimizations based on algebraic rules.
@@ -1398,9 +1429,19 @@ impl f128 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_div(self, rhs: f128) -> f128 {
-        intrinsics::fdiv_algebraic(self, rhs)
+    pub const fn algebraic_div(self, rhs: f128) -> f128 {
+        const fn const_algebraic_div(lhs: f128, rhs: f128) -> f128 {
+            lhs / rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_div(lhs: f128, rhs: f128) -> f128 {
+            intrinsics::fdiv_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_div, rt_algebraic_div)
     }
 
     /// Float remainder that allows optimizations based on algebraic rules.
@@ -1408,8 +1449,18 @@ impl f128 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_rem(self, rhs: f128) -> f128 {
-        intrinsics::frem_algebraic(self, rhs)
+    pub const fn algebraic_rem(self, rhs: f128) -> f128 {
+        const fn const_algebraic_rem(lhs: f128, rhs: f128) -> f128 {
+            lhs % rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_rem(lhs: f128, rhs: f128) -> f128 {
+            intrinsics::frem_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_rem, rt_algebraic_rem)
     }
 }

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -12,9 +12,10 @@
 #![unstable(feature = "f16", issue = "116909")]
 
 use crate::convert::FloatToInt;
+use crate::intrinsics::{self, const_eval_select};
+use crate::mem;
 use crate::num::FpCategory;
 use crate::panic::const_assert;
-use crate::{intrinsics, mem};
 
 /// Basic mathematical constants.
 #[unstable(feature = "f16", issue = "116909")]
@@ -1344,9 +1345,19 @@ impl f16 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_add(self, rhs: f16) -> f16 {
-        intrinsics::fadd_algebraic(self, rhs)
+    pub const fn algebraic_add(self, rhs: f16) -> f16 {
+        const fn const_algebraic_add(lhs: f16, rhs: f16) -> f16 {
+            lhs + rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_add(lhs: f16, rhs: f16) -> f16 {
+            intrinsics::fadd_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_add, rt_algebraic_add)
     }
 
     /// Float subtraction that allows optimizations based on algebraic rules.
@@ -1354,9 +1365,19 @@ impl f16 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_sub(self, rhs: f16) -> f16 {
-        intrinsics::fsub_algebraic(self, rhs)
+    pub const fn algebraic_sub(self, rhs: f16) -> f16 {
+        const fn const_algebraic_sub(lhs: f16, rhs: f16) -> f16 {
+            lhs - rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_sub(lhs: f16, rhs: f16) -> f16 {
+            intrinsics::fsub_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_sub, rt_algebraic_sub)
     }
 
     /// Float multiplication that allows optimizations based on algebraic rules.
@@ -1364,9 +1385,19 @@ impl f16 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_mul(self, rhs: f16) -> f16 {
-        intrinsics::fmul_algebraic(self, rhs)
+    pub const fn algebraic_mul(self, rhs: f16) -> f16 {
+        const fn const_algebraic_mul(lhs: f16, rhs: f16) -> f16 {
+            lhs * rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_mul(lhs: f16, rhs: f16) -> f16 {
+            intrinsics::fmul_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_mul, rt_algebraic_mul)
     }
 
     /// Float division that allows optimizations based on algebraic rules.
@@ -1374,9 +1405,19 @@ impl f16 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_div(self, rhs: f16) -> f16 {
-        intrinsics::fdiv_algebraic(self, rhs)
+    pub const fn algebraic_div(self, rhs: f16) -> f16 {
+        const fn const_algebraic_div(lhs: f16, rhs: f16) -> f16 {
+            lhs / rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_div(lhs: f16, rhs: f16) -> f16 {
+            intrinsics::fdiv_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_div, rt_algebraic_div)
     }
 
     /// Float remainder that allows optimizations based on algebraic rules.
@@ -1384,8 +1425,18 @@ impl f16 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_rem(self, rhs: f16) -> f16 {
-        intrinsics::frem_algebraic(self, rhs)
+    pub const fn algebraic_rem(self, rhs: f16) -> f16 {
+        const fn const_algebraic_rem(lhs: f16, rhs: f16) -> f16 {
+            lhs % rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_rem(lhs: f16, rhs: f16) -> f16 {
+            intrinsics::frem_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_rem, rt_algebraic_rem)
     }
 }

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -12,9 +12,10 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::convert::FloatToInt;
+use crate::intrinsics::{self, const_eval_select};
 use crate::num::FpCategory;
 use crate::panic::const_assert;
-use crate::{cfg_match, intrinsics, mem};
+use crate::{cfg_match, mem};
 
 /// The radix or base of the internal representation of `f32`.
 /// Use [`f32::RADIX`] instead.
@@ -1510,9 +1511,19 @@ impl f32 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_add(self, rhs: f32) -> f32 {
-        intrinsics::fadd_algebraic(self, rhs)
+    pub const fn algebraic_add(self, rhs: f32) -> f32 {
+        const fn const_algebraic_add(lhs: f32, rhs: f32) -> f32 {
+            lhs + rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_add(lhs: f32, rhs: f32) -> f32 {
+            intrinsics::fadd_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_add, rt_algebraic_add)
     }
 
     /// Float subtraction that allows optimizations based on algebraic rules.
@@ -1520,9 +1531,19 @@ impl f32 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_sub(self, rhs: f32) -> f32 {
-        intrinsics::fsub_algebraic(self, rhs)
+    pub const fn algebraic_sub(self, rhs: f32) -> f32 {
+        const fn const_algebraic_sub(lhs: f32, rhs: f32) -> f32 {
+            lhs - rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_sub(lhs: f32, rhs: f32) -> f32 {
+            intrinsics::fsub_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_sub, rt_algebraic_sub)
     }
 
     /// Float multiplication that allows optimizations based on algebraic rules.
@@ -1530,9 +1551,19 @@ impl f32 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_mul(self, rhs: f32) -> f32 {
-        intrinsics::fmul_algebraic(self, rhs)
+    pub const fn algebraic_mul(self, rhs: f32) -> f32 {
+        const fn const_algebraic_mul(lhs: f32, rhs: f32) -> f32 {
+            lhs * rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_mul(lhs: f32, rhs: f32) -> f32 {
+            intrinsics::fmul_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_mul, rt_algebraic_mul)
     }
 
     /// Float division that allows optimizations based on algebraic rules.
@@ -1540,9 +1571,19 @@ impl f32 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_div(self, rhs: f32) -> f32 {
-        intrinsics::fdiv_algebraic(self, rhs)
+    pub const fn algebraic_div(self, rhs: f32) -> f32 {
+        const fn const_algebraic_div(lhs: f32, rhs: f32) -> f32 {
+            lhs / rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_div(lhs: f32, rhs: f32) -> f32 {
+            intrinsics::fdiv_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_div, rt_algebraic_div)
     }
 
     /// Float remainder that allows optimizations based on algebraic rules.
@@ -1550,8 +1591,18 @@ impl f32 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_rem(self, rhs: f32) -> f32 {
-        intrinsics::frem_algebraic(self, rhs)
+    pub const fn algebraic_rem(self, rhs: f32) -> f32 {
+        const fn const_algebraic_rem(lhs: f32, rhs: f32) -> f32 {
+            lhs % rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_rem(lhs: f32, rhs: f32) -> f32 {
+            intrinsics::frem_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_rem, rt_algebraic_rem)
     }
 }

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -12,9 +12,10 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::convert::FloatToInt;
+use crate::intrinsics::{self, const_eval_select};
+use crate::mem;
 use crate::num::FpCategory;
 use crate::panic::const_assert;
-use crate::{intrinsics, mem};
 
 /// The radix or base of the internal representation of `f64`.
 /// Use [`f64::RADIX`] instead.
@@ -1509,9 +1510,19 @@ impl f64 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_add(self, rhs: f64) -> f64 {
-        intrinsics::fadd_algebraic(self, rhs)
+    pub const fn algebraic_add(self, rhs: f64) -> f64 {
+        const fn const_algebraic_add(lhs: f64, rhs: f64) -> f64 {
+            lhs + rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_add(lhs: f64, rhs: f64) -> f64 {
+            intrinsics::fadd_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_add, rt_algebraic_add)
     }
 
     /// Float subtraction that allows optimizations based on algebraic rules.
@@ -1519,9 +1530,19 @@ impl f64 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_sub(self, rhs: f64) -> f64 {
-        intrinsics::fsub_algebraic(self, rhs)
+    pub const fn algebraic_sub(self, rhs: f64) -> f64 {
+        const fn const_algebraic_sub(lhs: f64, rhs: f64) -> f64 {
+            lhs - rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_sub(lhs: f64, rhs: f64) -> f64 {
+            intrinsics::fsub_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_sub, rt_algebraic_sub)
     }
 
     /// Float multiplication that allows optimizations based on algebraic rules.
@@ -1529,9 +1550,19 @@ impl f64 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_mul(self, rhs: f64) -> f64 {
-        intrinsics::fmul_algebraic(self, rhs)
+    pub const fn algebraic_mul(self, rhs: f64) -> f64 {
+        const fn const_algebraic_mul(lhs: f64, rhs: f64) -> f64 {
+            lhs * rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_mul(lhs: f64, rhs: f64) -> f64 {
+            intrinsics::fmul_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_mul, rt_algebraic_mul)
     }
 
     /// Float division that allows optimizations based on algebraic rules.
@@ -1539,9 +1570,19 @@ impl f64 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_div(self, rhs: f64) -> f64 {
-        intrinsics::fdiv_algebraic(self, rhs)
+    pub const fn algebraic_div(self, rhs: f64) -> f64 {
+        const fn const_algebraic_div(lhs: f64, rhs: f64) -> f64 {
+            lhs / rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_div(lhs: f64, rhs: f64) -> f64 {
+            intrinsics::fdiv_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_div, rt_algebraic_div)
     }
 
     /// Float remainder that allows optimizations based on algebraic rules.
@@ -1549,8 +1590,18 @@ impl f64 {
     /// See [algebraic operators](primitive@f32#algebraic-operators) for more info.
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "float_algebraic", issue = "136469")]
+    #[rustc_const_unstable(feature = "float_algebraic", issue = "136469")]
     #[inline]
-    pub fn algebraic_rem(self, rhs: f64) -> f64 {
-        intrinsics::frem_algebraic(self, rhs)
+    pub const fn algebraic_rem(self, rhs: f64) -> f64 {
+        const fn const_algebraic_rem(lhs: f64, rhs: f64) -> f64 {
+            lhs % rhs
+        }
+
+        #[inline(always)]
+        fn rt_algebraic_rem(lhs: f64, rhs: f64) -> f64 {
+            intrinsics::frem_algebraic(lhs, rhs)
+        }
+
+        const_eval_select((self, rhs), const_algebraic_rem, rt_algebraic_rem)
     }
 }


### PR DESCRIPTION
Tracking issue: #136469

This PR makes the unstable `algebraic_add`, `algebraic_sub`, `algebraic_mul`, `algebraic_div`, and `algebraic_rem` methods in `f16`, `f32`, `f64`, and `f128` into `const fn` items.

Please note that there hasn't yet been a definitive decision on the exact semantics of these functions being `const fn`. But that should not block any non-`const` stabilisations.

<sub>Also note that a cleaner solution would be to make the intrinsics in `core::intrinsics` into `const fn` as well. This PR is merely a temporary solution, as a I am not familiar with implementing compiler built-ins.</sub>