### PR TITLE
Fix typo in documentation

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -109,7 +109,7 @@
 //! parameters (corresponding to `format_spec` in [the syntax](#syntax)). These
 //! parameters affect the string representation of what's being formatted.
 //!
-//! The colon `:` in format syntax divides indentifier of the input data and
+//! The colon `:` in format syntax divides identifier of the input data and
 //! the formatting options, the colon itself does not change anything, only
 //! introduces the options.
 //!


### PR DESCRIPTION
Correct the misspelling of "indentifier" to "identifier" in `library/alloc/src/fmt.rs`.