### PR TITLE
compiletest: Make diagnostic kind mandatory on line annotations (take 2)

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/ui.md
+++ b/src/doc/rustc-dev-guide/src/tests/ui.md
@@ -372,9 +372,9 @@ E.g. use `//@ dont-require-annotations: NOTE` to annotate notes selectively.
 Avoid using this directive for `ERROR`s and `WARN`ings, unless there's a serious reason, like
 target-dependent compiler output.
 
-Missing diagnostic kinds (`//~ message`) are currently accepted, but are being phased away.
-They will match any compiler output kind, but will not force exhaustive annotations for that kind.
-Prefer explicit kind and `//@ dont-require-annotations` to achieve the same effect.
+Some diagnostics are never required to be line-annotated, regardless of their kind or directives,
+for example secondary lines of multiline diagnostics,
+or ubiquitous diagnostics like `aborting due to N previous errors`.
 
 UI tests use the `-A unused` flag by default to ignore all unused warnings, as
 unused warnings are usually not the focus of a test. However, simple code

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -593,7 +593,7 @@ impl TestProps {
                         config.parse_name_value_directive(ln, DONT_REQUIRE_ANNOTATIONS)
                     {
                         self.dont_require_annotations
-                            .insert(ErrorKind::expect_from_user_str(err_kind.trim()));
+                            .insert(ErrorKind::from_user_str(err_kind.trim()));
                     }
                 },
             );

--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -229,7 +229,7 @@ fn push_actual_errors(
     // Convert multi-line messages into multiple errors.
     // We expect to replace these with something more structured anyhow.
     let mut message_lines = diagnostic.message.lines();
-    let kind = Some(ErrorKind::from_compiler_str(&diagnostic.level));
+    let kind = ErrorKind::from_compiler_str(&diagnostic.level);
     let first_line = message_lines.next().unwrap_or(&diagnostic.message);
     if primary_spans.is_empty() {
         static RE: OnceLock<Regex> = OnceLock::new();
@@ -278,7 +278,7 @@ fn push_actual_errors(
             for (index, line) in suggested_replacement.lines().enumerate() {
                 errors.push(Error {
                     line_num: Some(span.line_start + index),
-                    kind: Some(ErrorKind::Suggestion),
+                    kind: ErrorKind::Suggestion,
                     msg: line.to_string(),
                     require_annotation: true,
                 });
@@ -297,7 +297,7 @@ fn push_actual_errors(
     for span in spans_in_this_file.iter().filter(|span| span.label.is_some()) {
         errors.push(Error {
             line_num: Some(span.line_start),
-            kind: Some(ErrorKind::Note),
+            kind: ErrorKind::Note,
             msg: span.label.clone().unwrap(),
             require_annotation: true,
         });
@@ -317,7 +317,7 @@ fn push_backtrace(
     if Path::new(&expansion.span.file_name) == Path::new(&file_name) {
         errors.push(Error {
             line_num: Some(expansion.span.line_start),
-            kind: Some(ErrorKind::Note),
+            kind: ErrorKind::Note,
             msg: format!("in this expansion of {}", expansion.macro_decl_name),
             require_annotation: true,
         });

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -6,8 +6,8 @@ use rustfix::{Filter, apply_suggestions, get_suggestions_from_json};
 use tracing::debug;
 
 use super::{
-    AllowUnused, Emit, ErrorKind, FailMode, LinkToAux, PassMode, TargetLocation, TestCx,
-    TestOutput, Truncated, UI_FIXED, WillExecute,
+    AllowUnused, Emit, FailMode, LinkToAux, PassMode, TargetLocation, TestCx, TestOutput,
+    Truncated, UI_FIXED, WillExecute,
 };
 use crate::{errors, json};
 
@@ -176,7 +176,7 @@ impl TestCx<'_> {
             let msg = format!(
                 "line {}: cannot combine `--error-format` with {} annotations; use `error-pattern` instead",
                 expected_errors[0].line_num_str(),
-                expected_errors[0].kind.unwrap_or(ErrorKind::Error),
+                expected_errors[0].kind,
             );
             self.fatal(&msg);
         }

--- a/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.rs
+++ b/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.rs
@@ -1,12 +1,14 @@
 //@ compile-flags: -Znormalize-docs
+//@ dont-require-annotations: NOTE
+
 // https://github.com/rust-lang/rust/issues/105742
 use std::ops::Index;
 
 pub fn next<'a, T>(s: &'a mut dyn SVec<Item = T, Output = T>) {
-    //~^ expected 1 lifetime argument
-    //~| expected 1 generic argument
+    //~^ NOTE expected 1 lifetime argument
+    //~| NOTE expected 1 generic argument
     //~| ERROR the trait `SVec` is not dyn compatible
-    //~| `SVec` is not dyn compatible
+    //~| NOTE `SVec` is not dyn compatible
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     let _ = s;
@@ -14,8 +16,8 @@ pub fn next<'a, T>(s: &'a mut dyn SVec<Item = T, Output = T>) {
 
 pub trait SVec: Index<
     <Self as SVec>::Item,
-    //~^ expected 1 lifetime argument
-    //~| expected 1 generic argument
+    //~^ NOTE expected 1 lifetime argument
+    //~| NOTE expected 1 generic argument
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
@@ -25,8 +27,8 @@ pub trait SVec: Index<
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     Output = <Index<<Self as SVec>::Item,
-    //~^ expected 1 lifetime argument
-    //~| expected 1 generic argument
+    //~^ NOTE expected 1 lifetime argument
+    //~| NOTE expected 1 generic argument
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
@@ -36,16 +38,16 @@ pub trait SVec: Index<
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     Output = <Self as SVec>::Item> as SVec>::Item,
-    //~^ expected 1 lifetime argument
-    //~| expected 1 generic argument
-    //~| expected 1 lifetime argument
+    //~^ NOTE expected 1 lifetime argument
+    //~| NOTE expected 1 generic argument
+    //~| NOTE expected 1 lifetime argument
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
-    //~| expected 1 generic argument
+    //~| NOTE expected 1 generic argument
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
     //~| ERROR missing generics for associated type `SVec::Item`
@@ -60,8 +62,8 @@ pub trait SVec: Index<
     type Item<'a, T>;
 
     fn len(&self) -> <Self as SVec>::Item;
-    //~^ expected 1 lifetime argument
+    //~^ NOTE expected 1 lifetime argument
     //~| ERROR missing generics for associated type `SVec::Item`
-    //~| expected 1 generic argument
+    //~| NOTE expected 1 generic argument
     //~| ERROR missing generics for associated type `SVec::Item`
 }

--- a/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.stderr
+++ b/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.stderr
@@ -1,11 +1,11 @@
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:16:21
+  --> $DIR/ice-generic-type-alias-105742.rs:18:21
    |
 LL |     <Self as SVec>::Item,
    |                     ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -15,13 +15,13 @@ LL |     <Self as SVec>::Item<'a>,
    |                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:16:21
+  --> $DIR/ice-generic-type-alias-105742.rs:18:21
    |
 LL |     <Self as SVec>::Item,
    |                     ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -31,13 +31,13 @@ LL |     <Self as SVec>::Item<T>,
    |                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:27:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:37
    |
 LL |     Output = <Index<<Self as SVec>::Item,
    |                                     ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -47,13 +47,13 @@ LL |     Output = <Index<<Self as SVec>::Item<'a>,
    |                                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:27:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:37
    |
 LL |     Output = <Index<<Self as SVec>::Item,
    |                                     ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -63,13 +63,13 @@ LL |     Output = <Index<<Self as SVec>::Item<T>,
    |                                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:30
+  --> $DIR/ice-generic-type-alias-105742.rs:40:30
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                              ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -79,13 +79,13 @@ LL |     Output = <Self as SVec>::Item<'a>> as SVec>::Item,
    |                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:30
+  --> $DIR/ice-generic-type-alias-105742.rs:40:30
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                              ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -95,13 +95,13 @@ LL |     Output = <Self as SVec>::Item<T>> as SVec>::Item,
    |                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:46
+  --> $DIR/ice-generic-type-alias-105742.rs:40:46
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                                              ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -111,13 +111,13 @@ LL |     Output = <Self as SVec>::Item> as SVec>::Item<'a>,
    |                                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:46
+  --> $DIR/ice-generic-type-alias-105742.rs:40:46
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                                              ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -127,13 +127,13 @@ LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,
    |                                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:5:40
+  --> $DIR/ice-generic-type-alias-105742.rs:7:40
    |
 LL | pub fn next<'a, T>(s: &'a mut dyn SVec<Item = T, Output = T>) {
    |                                        ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -143,13 +143,13 @@ LL | pub fn next<'a, T>(s: &'a mut dyn SVec<Item<'_> = T, Output = T>) {
    |                                            ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:5:40
+  --> $DIR/ice-generic-type-alias-105742.rs:7:40
    |
 LL | pub fn next<'a, T>(s: &'a mut dyn SVec<Item = T, Output = T>) {
    |                                        ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -159,13 +159,13 @@ LL | pub fn next<'a, T>(s: &'a mut dyn SVec<Item<T> = T, Output = T>) {
    |                                            +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:16:21
+  --> $DIR/ice-generic-type-alias-105742.rs:18:21
    |
 LL |     <Self as SVec>::Item,
    |                     ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -176,13 +176,13 @@ LL |     <Self as SVec>::Item<'a>,
    |                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:16:21
+  --> $DIR/ice-generic-type-alias-105742.rs:18:21
    |
 LL |     <Self as SVec>::Item,
    |                     ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -193,13 +193,13 @@ LL |     <Self as SVec>::Item<T>,
    |                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:27:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:37
    |
 LL |     Output = <Index<<Self as SVec>::Item,
    |                                     ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -210,13 +210,13 @@ LL |     Output = <Index<<Self as SVec>::Item<'a>,
    |                                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:27:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:37
    |
 LL |     Output = <Index<<Self as SVec>::Item,
    |                                     ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -227,13 +227,13 @@ LL |     Output = <Index<<Self as SVec>::Item<T>,
    |                                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:30
+  --> $DIR/ice-generic-type-alias-105742.rs:40:30
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                              ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -244,13 +244,13 @@ LL |     Output = <Self as SVec>::Item<'a>> as SVec>::Item,
    |                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:30
+  --> $DIR/ice-generic-type-alias-105742.rs:40:30
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                              ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -261,13 +261,13 @@ LL |     Output = <Self as SVec>::Item<T>> as SVec>::Item,
    |                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:46
+  --> $DIR/ice-generic-type-alias-105742.rs:40:46
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                                              ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -278,13 +278,13 @@ LL |     Output = <Self as SVec>::Item> as SVec>::Item<'a>,
    |                                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:46
+  --> $DIR/ice-generic-type-alias-105742.rs:40:46
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                                              ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -295,14 +295,14 @@ LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,
    |                                                  +++
 
 error[E0038]: the trait `SVec` is not dyn compatible
-  --> $DIR/ice-generic-type-alias-105742.rs:5:35
+  --> $DIR/ice-generic-type-alias-105742.rs:7:35
    |
 LL | pub fn next<'a, T>(s: &'a mut dyn SVec<Item = T, Output = T>) {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ `SVec` is not dyn compatible
    |
 note: for a trait to be dyn compatible it needs to allow building a vtable
       for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility>
-  --> $DIR/ice-generic-type-alias-105742.rs:15:17
+  --> $DIR/ice-generic-type-alias-105742.rs:17:17
    |
 LL |    pub trait SVec: Index<
    |  ____________----__^
@@ -324,13 +324,13 @@ LL + pub fn next<'a, T>(s: &'a mut impl SVec<Item = T, Output = T>) {
    |
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:16:21
+  --> $DIR/ice-generic-type-alias-105742.rs:18:21
    |
 LL |     <Self as SVec>::Item,
    |                     ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -341,13 +341,13 @@ LL |     <Self as SVec>::Item<'a>,
    |                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:16:21
+  --> $DIR/ice-generic-type-alias-105742.rs:18:21
    |
 LL |     <Self as SVec>::Item,
    |                     ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -358,13 +358,13 @@ LL |     <Self as SVec>::Item<T>,
    |                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:27:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:37
    |
 LL |     Output = <Index<<Self as SVec>::Item,
    |                                     ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -375,13 +375,13 @@ LL |     Output = <Index<<Self as SVec>::Item<'a>,
    |                                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:27:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:37
    |
 LL |     Output = <Index<<Self as SVec>::Item,
    |                                     ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -392,13 +392,13 @@ LL |     Output = <Index<<Self as SVec>::Item<T>,
    |                                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:30
+  --> $DIR/ice-generic-type-alias-105742.rs:40:30
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                              ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -409,13 +409,13 @@ LL |     Output = <Self as SVec>::Item<'a>> as SVec>::Item,
    |                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:30
+  --> $DIR/ice-generic-type-alias-105742.rs:40:30
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                              ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -426,13 +426,13 @@ LL |     Output = <Self as SVec>::Item<T>> as SVec>::Item,
    |                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:46
+  --> $DIR/ice-generic-type-alias-105742.rs:40:46
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                                              ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -443,13 +443,13 @@ LL |     Output = <Self as SVec>::Item> as SVec>::Item<'a>,
    |                                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:46
+  --> $DIR/ice-generic-type-alias-105742.rs:40:46
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                                              ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -460,13 +460,13 @@ LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,
    |                                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:16:21
+  --> $DIR/ice-generic-type-alias-105742.rs:18:21
    |
 LL |     <Self as SVec>::Item,
    |                     ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -477,13 +477,13 @@ LL |     <Self as SVec>::Item<'a>,
    |                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:16:21
+  --> $DIR/ice-generic-type-alias-105742.rs:18:21
    |
 LL |     <Self as SVec>::Item,
    |                     ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -494,13 +494,13 @@ LL |     <Self as SVec>::Item<T>,
    |                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:27:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:37
    |
 LL |     Output = <Index<<Self as SVec>::Item,
    |                                     ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -511,13 +511,13 @@ LL |     Output = <Index<<Self as SVec>::Item<'a>,
    |                                         ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:27:37
+  --> $DIR/ice-generic-type-alias-105742.rs:29:37
    |
 LL |     Output = <Index<<Self as SVec>::Item,
    |                                     ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -528,13 +528,13 @@ LL |     Output = <Index<<Self as SVec>::Item<T>,
    |                                         +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:30
+  --> $DIR/ice-generic-type-alias-105742.rs:40:30
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                              ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -545,13 +545,13 @@ LL |     Output = <Self as SVec>::Item<'a>> as SVec>::Item,
    |                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:30
+  --> $DIR/ice-generic-type-alias-105742.rs:40:30
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                              ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -562,13 +562,13 @@ LL |     Output = <Self as SVec>::Item<T>> as SVec>::Item,
    |                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:46
+  --> $DIR/ice-generic-type-alias-105742.rs:40:46
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                                              ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -579,13 +579,13 @@ LL |     Output = <Self as SVec>::Item> as SVec>::Item<'a>,
    |                                                  ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:38:46
+  --> $DIR/ice-generic-type-alias-105742.rs:40:46
    |
 LL |     Output = <Self as SVec>::Item> as SVec>::Item,
    |                                              ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -
@@ -596,13 +596,13 @@ LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,
    |                                                  +++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:62:38
+  --> $DIR/ice-generic-type-alias-105742.rs:64:38
    |
 LL |     fn len(&self) -> <Self as SVec>::Item;
    |                                      ^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^ --
@@ -612,13 +612,13 @@ LL |     fn len(&self) -> <Self as SVec>::Item<'_>;
    |                                          ++++
 
 error[E0107]: missing generics for associated type `SVec::Item`
-  --> $DIR/ice-generic-type-alias-105742.rs:62:38
+  --> $DIR/ice-generic-type-alias-105742.rs:64:38
    |
 LL |     fn len(&self) -> <Self as SVec>::Item;
    |                                      ^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/ice-generic-type-alias-105742.rs:60:10
+  --> $DIR/ice-generic-type-alias-105742.rs:62:10
    |
 LL |     type Item<'a, T>;
    |          ^^^^     -

--- a/tests/ui/array-slice-vec/array-not-vector.rs
+++ b/tests/ui/array-slice-vec/array-not-vector.rs
@@ -1,12 +1,14 @@
+//@ dont-require-annotations: NOTE
+
 fn main() {
     let _x: i32 = [1, 2, 3];
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `[{integer}; 3]`
+    //~| NOTE expected `i32`, found `[{integer}; 3]`
 
     let x: &[i32] = &[1, 2, 3];
     let _y: &i32 = x;
     //~^ ERROR mismatched types
-    //~| expected reference `&i32`
-    //~| found reference `&[i32]`
-    //~| expected `&i32`, found `&[i32]`
+    //~| NOTE expected reference `&i32`
+    //~| NOTE found reference `&[i32]`
+    //~| NOTE expected `&i32`, found `&[i32]`
 }

--- a/tests/ui/array-slice-vec/array-not-vector.stderr
+++ b/tests/ui/array-slice-vec/array-not-vector.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/array-not-vector.rs:2:19
+  --> $DIR/array-not-vector.rs:4:19
    |
 LL |     let _x: i32 = [1, 2, 3];
    |             ---   ^^^^^^^^^ expected `i32`, found `[{integer}; 3]`
@@ -7,7 +7,7 @@ LL |     let _x: i32 = [1, 2, 3];
    |             expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/array-not-vector.rs:7:20
+  --> $DIR/array-not-vector.rs:9:20
    |
 LL |     let _y: &i32 = x;
    |             ----   ^ expected `&i32`, found `&[i32]`

--- a/tests/ui/array-slice-vec/slice-mut.rs
+++ b/tests/ui/array-slice-vec/slice-mut.rs
@@ -6,7 +6,8 @@ fn main() {
 
     let y: &mut[_] = &x[2..4];
     //~^ ERROR mismatched types
-    //~| expected mutable reference `&mut [_]`
-    //~| found reference `&[isize]`
-    //~| types differ in mutability
+    //~| NOTE expected mutable reference `&mut [_]`
+    //~| NOTE found reference `&[isize]`
+    //~| NOTE types differ in mutability
+    //~| NOTE expected due to this
 }

--- a/tests/ui/associated-consts/defaults-not-assumed-fail.rs
+++ b/tests/ui/associated-consts/defaults-not-assumed-fail.rs
@@ -1,4 +1,5 @@
 //@ build-fail
+//@ dont-require-annotations: NOTE
 
 trait Tr {
     const A: u8 = 255;
@@ -31,7 +32,7 @@ impl Tr for u32 {
 fn main() {
     assert_eq!(<() as Tr>::A, 255);
     assert_eq!(<() as Tr>::B, 0);    // causes the error above
-    //~^ constant
+    //~^ NOTE constant
 
     assert_eq!(<u8 as Tr>::A, 254);
     assert_eq!(<u8 as Tr>::B, 255);

--- a/tests/ui/associated-consts/defaults-not-assumed-fail.stderr
+++ b/tests/ui/associated-consts/defaults-not-assumed-fail.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of `<() as Tr>::B` failed
-  --> $DIR/defaults-not-assumed-fail.rs:8:19
+  --> $DIR/defaults-not-assumed-fail.rs:9:19
    |
 LL |     const B: u8 = Self::A + 1;
    |                   ^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
 
 note: erroneous constant encountered
-  --> $DIR/defaults-not-assumed-fail.rs:33:16
+  --> $DIR/defaults-not-assumed-fail.rs:34:16
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |                ^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/defaults-not-assumed-fail.rs:33:16
+  --> $DIR/defaults-not-assumed-fail.rs:34:16
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |                ^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/defaults-not-assumed-fail.rs:33:5
+  --> $DIR/defaults-not-assumed-fail.rs:34:5
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
-  --> $DIR/defaults-not-assumed-fail.rs:33:5
+  --> $DIR/defaults-not-assumed-fail.rs:34:5
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/associated-types/associated-types-eq-3.rs
+++ b/tests/ui/associated-types/associated-types-eq-3.rs
@@ -1,6 +1,8 @@
 // Test equality constraints on associated types. Check we get type errors
 // where we should.
 
+//@ dont-require-annotations: NOTE
+
 pub trait Foo {
     type A;
     fn boo(&self) -> <Self as Foo>::A;
@@ -22,9 +24,9 @@ fn foo1<I: Foo<A=Bar>>(x: I) {
 fn foo2<I: Foo>(x: I) {
     let _: Bar = x.boo();
     //~^ ERROR mismatched types
-    //~| found associated type `<I as Foo>::A`
-    //~| expected `Bar`, found
-    //~| expected struct `Bar`
+    //~| NOTE found associated type `<I as Foo>::A`
+    //~| NOTE expected `Bar`, found
+    //~| NOTE expected struct `Bar`
 }
 
 

--- a/tests/ui/associated-types/associated-types-eq-3.stderr
+++ b/tests/ui/associated-types/associated-types-eq-3.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/associated-types-eq-3.rs:23:18
+  --> $DIR/associated-types-eq-3.rs:25:18
    |
 LL |     let _: Bar = x.boo();
    |            ---   ^^^^^^^ expected `Bar`, found associated type
@@ -14,7 +14,7 @@ LL | fn foo2<I: Foo<A = Bar>>(x: I) {
    |               +++++++++
 
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
-  --> $DIR/associated-types-eq-3.rs:38:10
+  --> $DIR/associated-types-eq-3.rs:40:10
    |
 LL |     foo1(a);
    |     ---- ^ type mismatch resolving `<isize as Foo>::A == Bar`
@@ -22,24 +22,24 @@ LL |     foo1(a);
    |     required by a bound introduced by this call
    |
 note: expected this to be `Bar`
-  --> $DIR/associated-types-eq-3.rs:12:14
+  --> $DIR/associated-types-eq-3.rs:14:14
    |
 LL |     type A = usize;
    |              ^^^^^
 note: required by a bound in `foo1`
-  --> $DIR/associated-types-eq-3.rs:18:16
+  --> $DIR/associated-types-eq-3.rs:20:16
    |
 LL | fn foo1<I: Foo<A=Bar>>(x: I) {
    |                ^^^^^ required by this bound in `foo1`
 
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
-  --> $DIR/associated-types-eq-3.rs:40:9
+  --> $DIR/associated-types-eq-3.rs:42:9
    |
 LL |     baz(&a);
    |         ^^ type mismatch resolving `<isize as Foo>::A == Bar`
    |
 note: expected this to be `Bar`
-  --> $DIR/associated-types-eq-3.rs:12:14
+  --> $DIR/associated-types-eq-3.rs:14:14
    |
 LL |     type A = usize;
    |              ^^^^^

--- a/tests/ui/associated-types/associated-types-path-2.rs
+++ b/tests/ui/associated-types/associated-types-path-2.rs
@@ -1,5 +1,7 @@
 // Test type checking of uses of associated types via sugary paths.
 
+//@ dont-require-annotations: NOTE
+
 pub trait Foo {
     type A;
 
@@ -18,7 +20,7 @@ pub fn f2<T: Foo>(a: T) -> T::A {
 pub fn f1_int_int() {
     f1(2i32, 4i32);
     //~^ ERROR mismatched types
-    //~| expected `u32`, found `i32`
+    //~| NOTE expected `u32`, found `i32`
 }
 
 pub fn f1_int_uint() {
@@ -40,7 +42,7 @@ pub fn f1_uint_int() {
 pub fn f2_int() {
     let _: i32 = f2(2i32);
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `u32`
+    //~| NOTE expected `i32`, found `u32`
 }
 
 pub fn main() { }

--- a/tests/ui/associated-types/associated-types-path-2.stderr
+++ b/tests/ui/associated-types/associated-types-path-2.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/associated-types-path-2.rs:19:14
+  --> $DIR/associated-types-path-2.rs:21:14
    |
 LL |     f1(2i32, 4i32);
    |     --       ^^^^ expected `u32`, found `i32`
@@ -7,7 +7,7 @@ LL |     f1(2i32, 4i32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/associated-types-path-2.rs:13:8
+  --> $DIR/associated-types-path-2.rs:15:8
    |
 LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
    |        ^^               -------
@@ -18,7 +18,7 @@ LL +     f1(2i32, 4u32);
    |
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:29:8
+  --> $DIR/associated-types-path-2.rs:31:8
    |
 LL |     f1(2u32, 4u32);
    |     -- ^^^^ the trait `Foo` is not implemented for `u32`
@@ -27,13 +27,13 @@ LL |     f1(2u32, 4u32);
    |
    = help: the trait `Foo` is implemented for `i32`
 note: required by a bound in `f1`
-  --> $DIR/associated-types-path-2.rs:13:14
+  --> $DIR/associated-types-path-2.rs:15:14
    |
 LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
    |              ^^^ required by this bound in `f1`
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:29:14
+  --> $DIR/associated-types-path-2.rs:31:14
    |
 LL |     f1(2u32, 4u32);
    |              ^^^^ the trait `Foo` is not implemented for `u32`
@@ -41,7 +41,7 @@ LL |     f1(2u32, 4u32);
    = help: the trait `Foo` is implemented for `i32`
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:35:8
+  --> $DIR/associated-types-path-2.rs:37:8
    |
 LL |     f1(2u32, 4i32);
    |     -- ^^^^ the trait `Foo` is not implemented for `u32`
@@ -50,13 +50,13 @@ LL |     f1(2u32, 4i32);
    |
    = help: the trait `Foo` is implemented for `i32`
 note: required by a bound in `f1`
-  --> $DIR/associated-types-path-2.rs:13:14
+  --> $DIR/associated-types-path-2.rs:15:14
    |
 LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
    |              ^^^ required by this bound in `f1`
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
-  --> $DIR/associated-types-path-2.rs:35:14
+  --> $DIR/associated-types-path-2.rs:37:14
    |
 LL |     f1(2u32, 4i32);
    |              ^^^^ the trait `Foo` is not implemented for `u32`
@@ -64,7 +64,7 @@ LL |     f1(2u32, 4i32);
    = help: the trait `Foo` is implemented for `i32`
 
 error[E0308]: mismatched types
-  --> $DIR/associated-types-path-2.rs:41:18
+  --> $DIR/associated-types-path-2.rs:43:18
    |
 LL |     let _: i32 = f2(2i32);
    |            ---   ^^^^^^^^ expected `i32`, found `u32`

--- a/tests/ui/associated-types/substs-ppaux.normal.stderr
+++ b/tests/ui/associated-types/substs-ppaux.normal.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/substs-ppaux.rs:23:17
+  --> $DIR/substs-ppaux.rs:22:17
    |
 LL | /     fn bar<'a, T>()
 LL | |     where
@@ -19,7 +19,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static, u8>>::bar::<'static, char>();
    |                                                                        ++
 
 error[E0308]: mismatched types
-  --> $DIR/substs-ppaux.rs:31:17
+  --> $DIR/substs-ppaux.rs:30:17
    |
 LL | /     fn bar<'a, T>()
 LL | |     where
@@ -39,7 +39,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static, u32>>::bar::<'static, char>();
    |                                                                         ++
 
 error[E0308]: mismatched types
-  --> $DIR/substs-ppaux.rs:39:17
+  --> $DIR/substs-ppaux.rs:38:17
    |
 LL |     fn baz() {}
    |     -------- associated function `baz` defined here
@@ -57,7 +57,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static, u8>>::baz();
    |                                                       ++
 
 error[E0308]: mismatched types
-  --> $DIR/substs-ppaux.rs:47:17
+  --> $DIR/substs-ppaux.rs:46:17
    |
 LL | / fn foo<'z>()
 LL | | where
@@ -77,13 +77,13 @@ LL |     let x: () = foo::<'static>();
    |                               ++
 
 error[E0277]: the trait bound `str: Foo<'_, '_, u8>` is not satisfied
-  --> $DIR/substs-ppaux.rs:55:6
+  --> $DIR/substs-ppaux.rs:54:6
    |
 LL |     <str as Foo<u8>>::bar;
    |      ^^^ the trait `Sized` is not implemented for `str`
    |
 note: required for `str` to implement `Foo<'_, '_, u8>`
-  --> $DIR/substs-ppaux.rs:15:20
+  --> $DIR/substs-ppaux.rs:14:20
    |
 LL | impl<'a, 'b, T, S> Foo<'a, 'b, S> for T {}
    |              -     ^^^^^^^^^^^^^^     ^

--- a/tests/ui/associated-types/substs-ppaux.rs
+++ b/tests/ui/associated-types/substs-ppaux.rs
@@ -1,7 +1,6 @@
-//
 //@ revisions: verbose normal
-//
 //@[verbose] compile-flags: -Z verbose-internals
+//@ dont-require-annotations: NOTE
 
 trait Foo<'b, 'c, S = u32> {
     fn bar<'a, T>()
@@ -22,35 +21,35 @@ where
 {
     let x: () = <i8 as Foo<'static, 'static, u8>>::bar::<'static, char>;
     //[verbose]~^ ERROR mismatched types
-    //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
+    //[verbose]~| NOTE expected unit type `()`
+    //[verbose]~| NOTE found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
     //[normal]~^^^^ ERROR mismatched types
-    //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
+    //[normal]~| NOTE expected unit type `()`
+    //[normal]~| NOTE found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
 
     let x: () = <i8 as Foo<'static, 'static, u32>>::bar::<'static, char>;
     //[verbose]~^ ERROR mismatched types
-    //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
+    //[verbose]~| NOTE expected unit type `()`
+    //[verbose]~| NOTE found fn item `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
     //[normal]~^^^^ ERROR mismatched types
-    //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
+    //[normal]~| NOTE expected unit type `()`
+    //[normal]~| NOTE found fn item `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
 
     let x: () = <i8 as Foo<'static, 'static, u8>>::baz;
     //[verbose]~^ ERROR mismatched types
-    //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
+    //[verbose]~| NOTE expected unit type `()`
+    //[verbose]~| NOTE found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
     //[normal]~^^^^ ERROR mismatched types
-    //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
+    //[normal]~| NOTE expected unit type `()`
+    //[normal]~| NOTE found fn item `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
 
     let x: () = foo::<'static>;
     //[verbose]~^ ERROR mismatched types
-    //[verbose]~| expected unit type `()`
-    //[verbose]~| found fn item `fn() {foo::<'static>}`
+    //[verbose]~| NOTE expected unit type `()`
+    //[verbose]~| NOTE found fn item `fn() {foo::<'static>}`
     //[normal]~^^^^ ERROR mismatched types
-    //[normal]~| expected unit type `()`
-    //[normal]~| found fn item `fn() {foo::<'static>}`
+    //[normal]~| NOTE expected unit type `()`
+    //[normal]~| NOTE found fn item `fn() {foo::<'static>}`
 
     <str as Foo<u8>>::bar;
     //[verbose]~^ ERROR the trait bound `str: Foo<'?0, '?1, u8>` is not satisfied

--- a/tests/ui/associated-types/substs-ppaux.verbose.stderr
+++ b/tests/ui/associated-types/substs-ppaux.verbose.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/substs-ppaux.rs:23:17
+  --> $DIR/substs-ppaux.rs:22:17
    |
 LL | /     fn bar<'a, T>()
 LL | |     where
@@ -19,7 +19,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static, u8>>::bar::<'static, char>();
    |                                                                        ++
 
 error[E0308]: mismatched types
-  --> $DIR/substs-ppaux.rs:31:17
+  --> $DIR/substs-ppaux.rs:30:17
    |
 LL | /     fn bar<'a, T>()
 LL | |     where
@@ -39,7 +39,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static, u32>>::bar::<'static, char>();
    |                                                                         ++
 
 error[E0308]: mismatched types
-  --> $DIR/substs-ppaux.rs:39:17
+  --> $DIR/substs-ppaux.rs:38:17
    |
 LL |     fn baz() {}
    |     -------- associated function `baz` defined here
@@ -57,7 +57,7 @@ LL |     let x: () = <i8 as Foo<'static, 'static, u8>>::baz();
    |                                                       ++
 
 error[E0308]: mismatched types
-  --> $DIR/substs-ppaux.rs:47:17
+  --> $DIR/substs-ppaux.rs:46:17
    |
 LL | / fn foo<'z>()
 LL | | where
@@ -77,13 +77,13 @@ LL |     let x: () = foo::<'static>();
    |                               ++
 
 error[E0277]: the trait bound `str: Foo<'?0, '?1, u8>` is not satisfied
-  --> $DIR/substs-ppaux.rs:55:6
+  --> $DIR/substs-ppaux.rs:54:6
    |
 LL |     <str as Foo<u8>>::bar;
    |      ^^^ the trait `Sized` is not implemented for `str`
    |
 note: required for `str` to implement `Foo<'?0, '?1, u8>`
-  --> $DIR/substs-ppaux.rs:15:20
+  --> $DIR/substs-ppaux.rs:14:20
    |
 LL | impl<'a, 'b, T, S> Foo<'a, 'b, S> for T {}
    |              -     ^^^^^^^^^^^^^^     ^

--- a/tests/ui/binop/shift-various-bad-types.rs
+++ b/tests/ui/binop/shift-various-bad-types.rs
@@ -1,5 +1,7 @@
 // Test that we can do shifts by any integral type.
 
+//@ dont-require-annotations: NOTE
+
 struct Panolpy {
     char: char,
     str: &'static str,
@@ -24,7 +26,7 @@ fn foo(p: &Panolpy) {
     // Type of the result follows the LHS, not the RHS:
     let _: i32 = 22_i64 >> 1_i32;
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `i64`
+    //~| NOTE expected `i32`, found `i64`
 }
 
 fn main() {

--- a/tests/ui/binop/shift-various-bad-types.stderr
+++ b/tests/ui/binop/shift-various-bad-types.stderr
@@ -1,5 +1,5 @@
 error[E0277]: no implementation for `{integer} >> char`
-  --> $DIR/shift-various-bad-types.rs:9:8
+  --> $DIR/shift-various-bad-types.rs:11:8
    |
 LL |     22 >> p.char;
    |        ^^ no implementation for `{integer} >> char`
@@ -17,7 +17,7 @@ LL |     22 >> p.char;
            and 568 others
 
 error[E0277]: no implementation for `{integer} >> &str`
-  --> $DIR/shift-various-bad-types.rs:12:8
+  --> $DIR/shift-various-bad-types.rs:14:8
    |
 LL |     22 >> p.str;
    |        ^^ no implementation for `{integer} >> &str`
@@ -35,7 +35,7 @@ LL |     22 >> p.str;
            and 568 others
 
 error[E0277]: no implementation for `{integer} >> &Panolpy`
-  --> $DIR/shift-various-bad-types.rs:15:8
+  --> $DIR/shift-various-bad-types.rs:17:8
    |
 LL |     22 >> p;
    |        ^^ no implementation for `{integer} >> &Panolpy`
@@ -53,7 +53,7 @@ LL |     22 >> p;
            and 568 others
 
 error[E0308]: mismatched types
-  --> $DIR/shift-various-bad-types.rs:25:18
+  --> $DIR/shift-various-bad-types.rs:27:18
    |
 LL |     let _: i32 = 22_i64 >> 1_i32;
    |            ---   ^^^^^^^^^^^^^^^ expected `i32`, found `i64`

--- a/tests/ui/blind/blind-item-item-shadow.rs
+++ b/tests/ui/blind/blind-item-item-shadow.rs
@@ -1,7 +1,9 @@
+//@ dont-require-annotations: NOTE
+
 mod foo { pub mod foo {  } }
 
 use foo::foo;
 //~^ ERROR the name `foo` is defined multiple times
-//~| `foo` reimported here
+//~| NOTE `foo` reimported here
 
 fn main() {}

--- a/tests/ui/blind/blind-item-item-shadow.stderr
+++ b/tests/ui/blind/blind-item-item-shadow.stderr
@@ -1,5 +1,5 @@
 error[E0255]: the name `foo` is defined multiple times
-  --> $DIR/blind-item-item-shadow.rs:3:5
+  --> $DIR/blind-item-item-shadow.rs:5:5
    |
 LL | mod foo { pub mod foo {  } }
    | ------- previous definition of the module `foo` here

--- a/tests/ui/block-result/block-must-not-have-result-while.rs
+++ b/tests/ui/block-result/block-must-not-have-result-while.rs
@@ -1,6 +1,8 @@
+//@ dont-require-annotations: NOTE
+
 fn main() {
     while true { //~ WARN denote infinite loops with
         true //~  ERROR mismatched types
-             //~| expected `()`, found `bool`
+             //~| NOTE expected `()`, found `bool`
     }
 }

--- a/tests/ui/block-result/block-must-not-have-result-while.stderr
+++ b/tests/ui/block-result/block-must-not-have-result-while.stderr
@@ -1,5 +1,5 @@
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/block-must-not-have-result-while.rs:2:5
+  --> $DIR/block-must-not-have-result-while.rs:4:5
    |
 LL |     while true {
    |     ^^^^^^^^^^ help: use `loop`
@@ -7,7 +7,7 @@ LL |     while true {
    = note: `#[warn(while_true)]` on by default
 
 error[E0308]: mismatched types
-  --> $DIR/block-must-not-have-result-while.rs:3:9
+  --> $DIR/block-must-not-have-result-while.rs:5:9
    |
 LL | /     while true {
 LL | |         true

--- a/tests/ui/block-result/issue-13624.rs
+++ b/tests/ui/block-result/issue-13624.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 mod a {
   pub enum Enum {
     EnumStructVariant { x: u8, y: u8, z: u8 }
@@ -6,7 +8,7 @@ mod a {
   pub fn get_enum_struct_variant() -> () {
     Enum::EnumStructVariant { x: 1, y: 2, z: 3 }
     //~^ ERROR mismatched types
-    //~| expected `()`, found `Enum`
+    //~| NOTE expected `()`, found `Enum`
   }
 }
 
@@ -19,7 +21,7 @@ mod b {
       match enum_struct_variant {
         a::Enum::EnumStructVariant { x, y, z } => {
         //~^ ERROR mismatched types
-        //~| expected `()`, found `Enum`
+        //~| NOTE expected `()`, found `Enum`
         }
       }
     }

--- a/tests/ui/block-result/issue-13624.stderr
+++ b/tests/ui/block-result/issue-13624.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-13624.rs:7:5
+  --> $DIR/issue-13624.rs:9:5
    |
 LL |   pub fn get_enum_struct_variant() -> () {
    |                                       -- expected `()` because of return type
@@ -7,7 +7,7 @@ LL |     Enum::EnumStructVariant { x: 1, y: 2, z: 3 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Enum`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-13624.rs:20:9
+  --> $DIR/issue-13624.rs:22:9
    |
 LL |       match enum_struct_variant {
    |             ------------------- this expression has type `()`

--- a/tests/ui/block-result/issue-5500.rs
+++ b/tests/ui/block-result/issue-5500.rs
@@ -1,7 +1,7 @@
-fn main() {
+fn main() { //~ NOTE expected `()` because of default return type
     &panic!()
     //~^ ERROR mismatched types
-    //~| expected unit type `()`
-    //~| found reference `&_`
-    //~| expected `()`, found `&_`
+    //~| NOTE expected unit type `()`
+    //~| NOTE found reference `&_`
+    //~| NOTE expected `()`, found `&_`
 }

--- a/tests/ui/borrowck/borrowck-report-with-custom-diagnostic.rs
+++ b/tests/ui/borrowck/borrowck-report-with-custom-diagnostic.rs
@@ -1,11 +1,13 @@
+//@ dont-require-annotations: NOTE
+
 #![allow(dead_code)]
 fn main() {
     // Original borrow ends at end of function
     let mut x = 1;
     let y = &mut x;
-    //~^ mutable borrow occurs here
+    //~^ NOTE mutable borrow occurs here
     let z = &x; //~ ERROR cannot borrow
-    //~^ immutable borrow occurs here
+    //~^ NOTE immutable borrow occurs here
     z.use_ref();
     y.use_mut();
 }
@@ -16,9 +18,9 @@ fn foo() {
             // Original borrow ends at end of match arm
             let mut x = 1;
             let y = &x;
-            //~^ immutable borrow occurs here
+            //~^ NOTE immutable borrow occurs here
             let z = &mut x; //~ ERROR cannot borrow
-            //~^ mutable borrow occurs here
+            //~^ NOTE mutable borrow occurs here
             z.use_mut();
             y.use_ref();
         }
@@ -31,9 +33,9 @@ fn bar() {
     || {
         let mut x = 1;
         let y = &mut x;
-        //~^ first mutable borrow occurs here
+        //~^ NOTE first mutable borrow occurs here
         let z = &mut x; //~ ERROR cannot borrow
-        //~^ second mutable borrow occurs here
+        //~^ NOTE second mutable borrow occurs here
         z.use_mut();
         y.use_mut();
     };

--- a/tests/ui/borrowck/borrowck-report-with-custom-diagnostic.stderr
+++ b/tests/ui/borrowck/borrowck-report-with-custom-diagnostic.stderr
@@ -1,5 +1,5 @@
 error[E0502]: cannot borrow `x` as immutable because it is also borrowed as mutable
-  --> $DIR/borrowck-report-with-custom-diagnostic.rs:7:13
+  --> $DIR/borrowck-report-with-custom-diagnostic.rs:9:13
    |
 LL |     let y = &mut x;
    |             ------ mutable borrow occurs here
@@ -11,7 +11,7 @@ LL |     y.use_mut();
    |     - mutable borrow later used here
 
 error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
-  --> $DIR/borrowck-report-with-custom-diagnostic.rs:20:21
+  --> $DIR/borrowck-report-with-custom-diagnostic.rs:22:21
    |
 LL |             let y = &x;
    |                     -- immutable borrow occurs here
@@ -23,7 +23,7 @@ LL |             y.use_ref();
    |             - immutable borrow later used here
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
-  --> $DIR/borrowck-report-with-custom-diagnostic.rs:35:17
+  --> $DIR/borrowck-report-with-custom-diagnostic.rs:37:17
    |
 LL |         let y = &mut x;
    |                 ------ first mutable borrow occurs here

--- a/tests/ui/borrowck/issue-81899.rs
+++ b/tests/ui/borrowck/issue-81899.rs
@@ -1,14 +1,16 @@
 // Regression test for #81899.
 // The `panic!()` below is important to trigger the fixed ICE.
 
+//@ dont-require-annotations: NOTE
+
 const _CONST: &[u8] = &f(&[], |_| {}); //~ ERROR evaluation of constant value failed
-//~^ constant
+//~^ NOTE constant
 
 const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ inside `f
+    panic!() //~ NOTE inside `f
 }
 
 fn main() {}

--- a/tests/ui/borrowck/issue-81899.stderr
+++ b/tests/ui/borrowck/issue-81899.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-81899.rs:4:24
+  --> $DIR/issue-81899.rs:6:24
    |
 LL | const _CONST: &[u8] = &f(&[], |_| {});
    |                        ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
-note: inside `f::<{closure@$DIR/issue-81899.rs:4:31: 4:34}>`
-  --> $DIR/issue-81899.rs:11:5
+note: inside `f::<{closure@$DIR/issue-81899.rs:6:31: 6:34}>`
+  --> $DIR/issue-81899.rs:13:5
    |
 LL |     panic!()
    |     ^^^^^^^^ the failure occurred here
 
 note: erroneous constant encountered
-  --> $DIR/issue-81899.rs:4:23
+  --> $DIR/issue-81899.rs:6:23
    |
 LL | const _CONST: &[u8] = &f(&[], |_| {});
    |                       ^^^^^^^^^^^^^^^

--- a/tests/ui/borrowck/issue-88434-minimal-example.rs
+++ b/tests/ui/borrowck/issue-88434-minimal-example.rs
@@ -1,13 +1,15 @@
 // Regression test related to issue 88434
 
+//@ dont-require-annotations: NOTE
+
 const _CONST: &() = &f(&|_| {}); //~ ERROR evaluation of constant value failed
-//~^ constant
+//~^ NOTE constant
 
 const fn f<F>(_: &F)
 where
     F: FnMut(&u8),
 {
-    panic!() //~ inside `f
+    panic!() //~ NOTE inside `f
 }
 
 fn main() { }

--- a/tests/ui/borrowck/issue-88434-minimal-example.stderr
+++ b/tests/ui/borrowck/issue-88434-minimal-example.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-88434-minimal-example.rs:3:22
+  --> $DIR/issue-88434-minimal-example.rs:5:22
    |
 LL | const _CONST: &() = &f(&|_| {});
    |                      ^^^^^^^^^^ evaluation panicked: explicit panic
    |
-note: inside `f::<{closure@$DIR/issue-88434-minimal-example.rs:3:25: 3:28}>`
-  --> $DIR/issue-88434-minimal-example.rs:10:5
+note: inside `f::<{closure@$DIR/issue-88434-minimal-example.rs:5:25: 5:28}>`
+  --> $DIR/issue-88434-minimal-example.rs:12:5
    |
 LL |     panic!()
    |     ^^^^^^^^ the failure occurred here
 
 note: erroneous constant encountered
-  --> $DIR/issue-88434-minimal-example.rs:3:21
+  --> $DIR/issue-88434-minimal-example.rs:5:21
    |
 LL | const _CONST: &() = &f(&|_| {});
    |                     ^^^^^^^^^^^

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.rs
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.rs
@@ -1,13 +1,15 @@
 // Regression test for issue 88434
 
+//@ dont-require-annotations: NOTE
+
 const _CONST: &[u8] = &f(&[], |_| {}); //~ ERROR evaluation of constant value failed
-//~^ constant
+//~^ NOTE constant
 
 const fn f<F>(_: &[u8], _: F) -> &[u8]
 where
     F: FnMut(&u8),
 {
-    panic!() //~ inside `f
+    panic!() //~ NOTE inside `f
 }
 
 fn main() { }

--- a/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
+++ b/tests/ui/borrowck/issue-88434-removal-index-should-be-less.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-88434-removal-index-should-be-less.rs:3:24
+  --> $DIR/issue-88434-removal-index-should-be-less.rs:5:24
    |
 LL | const _CONST: &[u8] = &f(&[], |_| {});
    |                        ^^^^^^^^^^^^^^ evaluation panicked: explicit panic
    |
-note: inside `f::<{closure@$DIR/issue-88434-removal-index-should-be-less.rs:3:31: 3:34}>`
-  --> $DIR/issue-88434-removal-index-should-be-less.rs:10:5
+note: inside `f::<{closure@$DIR/issue-88434-removal-index-should-be-less.rs:5:31: 5:34}>`
+  --> $DIR/issue-88434-removal-index-should-be-less.rs:12:5
    |
 LL |     panic!()
    |     ^^^^^^^^ the failure occurred here
 
 note: erroneous constant encountered
-  --> $DIR/issue-88434-removal-index-should-be-less.rs:3:23
+  --> $DIR/issue-88434-removal-index-should-be-less.rs:5:23
    |
 LL | const _CONST: &[u8] = &f(&[], |_| {});
    |                       ^^^^^^^^^^^^^^^

--- a/tests/ui/cast/ptr-to-trait-obj-different-regions-misc.rs
+++ b/tests/ui/cast/ptr-to-trait-obj-different-regions-misc.rs
@@ -1,4 +1,5 @@
 //@ check-fail
+//@ dont-require-annotations: NOTE
 
 trait Trait<'a> {}
 
@@ -18,7 +19,7 @@ fn change_lt_ba<'a, 'b: 'a>(x: *mut dyn Trait<'a>) -> *mut dyn Trait<'b> {
 fn change_lt_hr<'a>(x: *mut dyn Trait<'a>) -> *mut dyn for<'b> Trait<'b> {
     x as _ //~ error: lifetime may not live long enough
     //~^ error: mismatched types
-    //~| one type is more general than the other
+    //~| NOTE one type is more general than the other
 }
 
 trait Assocked {

--- a/tests/ui/cast/ptr-to-trait-obj-different-regions-misc.stderr
+++ b/tests/ui/cast/ptr-to-trait-obj-different-regions-misc.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:6:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:7:5
    |
 LL | fn change_lt<'a, 'b>(x: *mut dyn Trait<'a>) -> *mut dyn Trait<'b> {
    |              --  -- lifetime `'b` defined here
@@ -14,7 +14,7 @@ LL |     x as _
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:6:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:7:5
    |
 LL | fn change_lt<'a, 'b>(x: *mut dyn Trait<'a>) -> *mut dyn Trait<'b> {
    |              --  -- lifetime `'b` defined here
@@ -31,7 +31,7 @@ LL |     x as _
 help: `'b` and `'a` must be the same: replace one with the other
 
 error: lifetime may not live long enough
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:11:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:12:5
    |
 LL | fn change_lt_ab<'a: 'b, 'b>(x: *mut dyn Trait<'a>) -> *mut dyn Trait<'b> {
    |                 --      -- lifetime `'b` defined here
@@ -46,7 +46,7 @@ LL |     x as _
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:15:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:16:5
    |
 LL | fn change_lt_ba<'a, 'b: 'a>(x: *mut dyn Trait<'a>) -> *mut dyn Trait<'b> {
    |                 --  -- lifetime `'b` defined here
@@ -61,7 +61,7 @@ LL |     x as _
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:19:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:20:5
    |
 LL | fn change_lt_hr<'a>(x: *mut dyn Trait<'a>) -> *mut dyn for<'b> Trait<'b> {
    |                 -- lifetime `'a` defined here
@@ -74,7 +74,7 @@ LL | fn change_lt_hr<'a>(x: *mut dyn Trait<'a>) -> *mut dyn for<'b> Trait<'b> + 
    |                                                                          ++++
 
 error[E0308]: mismatched types
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:19:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:20:5
    |
 LL |     x as _
    |     ^^^^^^ one type is more general than the other
@@ -83,7 +83,7 @@ LL |     x as _
               found trait object `dyn Trait<'_>`
 
 error: lifetime may not live long enough
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:31:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:32:5
    |
 LL | fn change_assoc_0<'a, 'b>(
    |                   --  -- lifetime `'b` defined here
@@ -99,7 +99,7 @@ LL |     x as _
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:31:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:32:5
    |
 LL | fn change_assoc_0<'a, 'b>(
    |                   --  -- lifetime `'b` defined here
@@ -119,7 +119,7 @@ help: `'b` and `'a` must be the same: replace one with the other
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: lifetime may not live long enough
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:38:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:39:5
    |
 LL | fn change_assoc_1<'a, 'b>(
    |                   --  -- lifetime `'b` defined here
@@ -135,7 +135,7 @@ LL |     x as _
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:38:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:39:5
    |
 LL | fn change_assoc_1<'a, 'b>(
    |                   --  -- lifetime `'b` defined here
@@ -155,7 +155,7 @@ help: `'b` and `'a` must be the same: replace one with the other
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:45:5
+  --> $DIR/ptr-to-trait-obj-different-regions-misc.rs:46:5
    |
 LL | fn extend_to_static<'a>(ptr: *const dyn Trait<'a>) {
    |                     --  ---

--- a/tests/ui/coercion/coerce-mut.rs
+++ b/tests/ui/coercion/coerce-mut.rs
@@ -1,10 +1,12 @@
+//@ dont-require-annotations: NOTE
+
 fn f(x: &mut i32) {}
 
 fn main() {
     let x = 0;
     f(&x);
     //~^ ERROR mismatched types
-    //~| expected mutable reference `&mut i32`
-    //~| found reference `&{integer}`
-    //~| types differ in mutability
+    //~| NOTE expected mutable reference `&mut i32`
+    //~| NOTE found reference `&{integer}`
+    //~| NOTE types differ in mutability
 }

--- a/tests/ui/coercion/coerce-mut.stderr
+++ b/tests/ui/coercion/coerce-mut.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/coerce-mut.rs:5:7
+  --> $DIR/coerce-mut.rs:7:7
    |
 LL |     f(&x);
    |     - ^^ types differ in mutability
@@ -9,7 +9,7 @@ LL |     f(&x);
    = note: expected mutable reference `&mut i32`
                       found reference `&{integer}`
 note: function defined here
-  --> $DIR/coerce-mut.rs:1:4
+  --> $DIR/coerce-mut.rs:3:4
    |
 LL | fn f(x: &mut i32) {}
    |    ^ -----------

--- a/tests/ui/coercion/coercion-slice.rs
+++ b/tests/ui/coercion/coercion-slice.rs
@@ -3,5 +3,6 @@
 fn main() {
     let _: &[i32] = [0];
     //~^ ERROR mismatched types
-    //~| expected `&[i32]`, found `[{integer}; 1]`
+    //~| NOTE expected `&[i32]`, found `[{integer}; 1]`
+    //~| NOTE expected due to this
 }

--- a/tests/ui/coercion/mut-mut-wont-coerce.rs
+++ b/tests/ui/coercion/mut-mut-wont-coerce.rs
@@ -2,6 +2,9 @@
 // Making this compile was a feature request in rust-lang/rust#34117 but this is currently
 // "working as intended". Allowing "deep pointer coercion" seems footgun-prone, and would
 // require proceeding carefully.
+
+//@ dont-require-annotations: NOTE
+
 use std::ops::{Deref, DerefMut};
 
 struct Foo(i32);
@@ -34,7 +37,7 @@ fn make_foo(_: *mut *mut Foo) {
 fn main() {
     let mut result: SmartPtr<Foo> = SmartPtr(std::ptr::null_mut());
     make_foo(&mut &mut *result); //~ ERROR mismatched types
-                                 //~^ expected `*mut *mut Foo`, found `&mut &mut Foo`
+                                 //~^ NOTE expected `*mut *mut Foo`, found `&mut &mut Foo`
     make_foo(out(&mut result)); // works, but makes one wonder why above coercion cannot happen
 }
 

--- a/tests/ui/coercion/mut-mut-wont-coerce.stderr
+++ b/tests/ui/coercion/mut-mut-wont-coerce.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/mut-mut-wont-coerce.rs:36:14
+  --> $DIR/mut-mut-wont-coerce.rs:39:14
    |
 LL |     make_foo(&mut &mut *result);
    |     -------- ^^^^^^^^^^^^^^^^^ expected `*mut *mut Foo`, found `&mut &mut Foo`
@@ -9,7 +9,7 @@ LL |     make_foo(&mut &mut *result);
    = note:    expected raw pointer `*mut *mut Foo`
            found mutable reference `&mut &mut Foo`
 note: function defined here
-  --> $DIR/mut-mut-wont-coerce.rs:30:4
+  --> $DIR/mut-mut-wont-coerce.rs:33:4
    |
 LL | fn make_foo(_: *mut *mut Foo) {
    |    ^^^^^^^^ ----------------

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.rs
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_impl_no_structural_eq.rs
@@ -9,11 +9,11 @@ struct CantParam(ImplementsConstParamTy);
 
 impl std::marker::UnsizedConstParamTy for CantParam {}
 //~^ error: the type `CantParam` does not `#[derive(PartialEq)]`
-//~| the trait bound `CantParam: Eq` is not satisfied
+//~| ERROR the trait bound `CantParam: Eq` is not satisfied
 
 #[derive(std::marker::UnsizedConstParamTy)]
 //~^ error: the type `CantParamDerive` does not `#[derive(PartialEq)]`
-//~| the trait bound `CantParamDerive: Eq` is not satisfied
+//~| ERROR the trait bound `CantParamDerive: Eq` is not satisfied
 struct CantParamDerive(ImplementsConstParamTy);
 
 fn check<T: std::marker::UnsizedConstParamTy>() {}

--- a/tests/ui/const-generics/defaults/mismatch.rs
+++ b/tests/ui/const-generics/defaults/mismatch.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 pub struct Example<const N: usize = 13>;
 pub struct Example2<T = u32, const N: usize = 13>(T);
 pub struct Example3<const N: usize = 13, T = u32>(T);
@@ -6,17 +8,17 @@ pub struct Example4<const N: usize = 13, const M: usize = 4>;
 fn main() {
     let e: Example<13> = ();
     //~^ ERROR mismatched types
-    //~| expected struct `Example`
+    //~| NOTE expected struct `Example`
     let e: Example2<u32, 13> = ();
     //~^ ERROR mismatched types
-    //~| expected struct `Example2`
+    //~| NOTE expected struct `Example2`
     let e: Example3<13, u32> = ();
     //~^ ERROR mismatched types
-    //~| expected struct `Example3`
+    //~| NOTE expected struct `Example3`
     let e: Example3<7> = ();
     //~^ ERROR mismatched types
-    //~| expected struct `Example3<7>`
+    //~| NOTE expected struct `Example3<7>`
     let e: Example4<7> = ();
     //~^ ERROR mismatched types
-    //~| expected struct `Example4<7>`
+    //~| NOTE expected struct `Example4<7>`
 }

--- a/tests/ui/const-generics/defaults/mismatch.stderr
+++ b/tests/ui/const-generics/defaults/mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:7:26
+  --> $DIR/mismatch.rs:9:26
    |
 LL |     let e: Example<13> = ();
    |            -----------   ^^ expected `Example`, found `()`
@@ -10,7 +10,7 @@ LL |     let e: Example<13> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:10:32
+  --> $DIR/mismatch.rs:12:32
    |
 LL |     let e: Example2<u32, 13> = ();
    |            -----------------   ^^ expected `Example2`, found `()`
@@ -21,7 +21,7 @@ LL |     let e: Example2<u32, 13> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:13:32
+  --> $DIR/mismatch.rs:15:32
    |
 LL |     let e: Example3<13, u32> = ();
    |            -----------------   ^^ expected `Example3`, found `()`
@@ -32,7 +32,7 @@ LL |     let e: Example3<13, u32> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:16:26
+  --> $DIR/mismatch.rs:18:26
    |
 LL |     let e: Example3<7> = ();
    |            -----------   ^^ expected `Example3<7>`, found `()`
@@ -43,7 +43,7 @@ LL |     let e: Example3<7> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:19:26
+  --> $DIR/mismatch.rs:21:26
    |
 LL |     let e: Example4<7> = ();
    |            -----------   ^^ expected `Example4<7>`, found `()`

--- a/tests/ui/const-generics/issues/issue-100313.rs
+++ b/tests/ui/const-generics/issues/issue-100313.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 #![allow(incomplete_features)]
 #![feature(adt_const_params, unsized_const_params)]
 
@@ -6,7 +8,7 @@ struct T<const B: &'static bool>;
 impl<const B: &'static bool> T<B> {
     const fn set_false(&self) {
         unsafe {
-            *(B as *const bool as *mut bool) = false; //~ inside `T
+            *(B as *const bool as *mut bool) = false; //~ NOTE inside `T
         }
     }
 }

--- a/tests/ui/const-generics/issues/issue-100313.stderr
+++ b/tests/ui/const-generics/issues/issue-100313.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-100313.rs:16:5
+  --> $DIR/issue-100313.rs:18:5
    |
 LL |     x.set_false();
    |     ^^^^^^^^^^^^^ writing to ALLOC0 which is read-only
    |
 note: inside `T::<&true>::set_false`
-  --> $DIR/issue-100313.rs:9:13
+  --> $DIR/issue-100313.rs:11:13
    |
 LL |             *(B as *const bool as *mut bool) = false;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.32bit.stderr
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.32bit.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/invalid-patterns.rs:38:32
+  --> $DIR/invalid-patterns.rs:40:32
    |
 LL |   get_flag::<false, { unsafe { char_raw.character } }>();
    |                                ^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:41:14
+  --> $DIR/invalid-patterns.rs:43:14
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0x42, but expected a boolean
@@ -16,7 +16,7 @@ LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:43:14
+  --> $DIR/invalid-patterns.rs:45:14
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0x42, but expected a boolean
@@ -27,31 +27,31 @@ LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/invalid-patterns.rs:43:58
+  --> $DIR/invalid-patterns.rs:45:58
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
    |                                                          ^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0308]: mismatched types
-  --> $DIR/invalid-patterns.rs:29:21
+  --> $DIR/invalid-patterns.rs:31:21
    |
 LL |   get_flag::<false, 0xFF>();
    |                     ^^^^ expected `char`, found `u8`
 
 error[E0308]: mismatched types
-  --> $DIR/invalid-patterns.rs:31:14
+  --> $DIR/invalid-patterns.rs:33:14
    |
 LL |   get_flag::<7, 'c'>();
    |              ^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/invalid-patterns.rs:33:14
+  --> $DIR/invalid-patterns.rs:35:14
    |
 LL |   get_flag::<42, 0x5ad>();
    |              ^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/invalid-patterns.rs:33:18
+  --> $DIR/invalid-patterns.rs:35:18
    |
 LL |   get_flag::<42, 0x5ad>();
    |                  ^^^^^ expected `char`, found `u8`

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.64bit.stderr
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.64bit.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/invalid-patterns.rs:38:32
+  --> $DIR/invalid-patterns.rs:40:32
    |
 LL |   get_flag::<false, { unsafe { char_raw.character } }>();
    |                                ^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:41:14
+  --> $DIR/invalid-patterns.rs:43:14
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0x42, but expected a boolean
@@ -16,7 +16,7 @@ LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:43:14
+  --> $DIR/invalid-patterns.rs:45:14
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0x42, but expected a boolean
@@ -27,31 +27,31 @@ LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/invalid-patterns.rs:43:58
+  --> $DIR/invalid-patterns.rs:45:58
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
    |                                                          ^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0308]: mismatched types
-  --> $DIR/invalid-patterns.rs:29:21
+  --> $DIR/invalid-patterns.rs:31:21
    |
 LL |   get_flag::<false, 0xFF>();
    |                     ^^^^ expected `char`, found `u8`
 
 error[E0308]: mismatched types
-  --> $DIR/invalid-patterns.rs:31:14
+  --> $DIR/invalid-patterns.rs:33:14
    |
 LL |   get_flag::<7, 'c'>();
    |              ^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/invalid-patterns.rs:33:14
+  --> $DIR/invalid-patterns.rs:35:14
    |
 LL |   get_flag::<42, 0x5ad>();
    |              ^^ expected `bool`, found integer
 
 error[E0308]: mismatched types
-  --> $DIR/invalid-patterns.rs:33:18
+  --> $DIR/invalid-patterns.rs:35:18
    |
 LL |   get_flag::<42, 0x5ad>();
    |                  ^^^^^ expected `char`, found `u8`

--- a/tests/ui/const-generics/min_const_generics/invalid-patterns.rs
+++ b/tests/ui/const-generics/min_const_generics/invalid-patterns.rs
@@ -1,4 +1,6 @@
 //@ stderr-per-bitwidth
+//@ dont-require-annotations: NOTE
+
 use std::mem::transmute;
 
 fn get_flag<const FlagSet: bool, const ShortName: char>() -> Option<char> {
@@ -37,11 +39,11 @@ fn main() {
 
   get_flag::<false, { unsafe { char_raw.character } }>();
   //~^ ERROR evaluation of constant value failed
-  //~| uninitialized
+  //~| NOTE uninitialized
   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
   //~^ ERROR it is undefined behavior
   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
   //~^ ERROR evaluation of constant value failed
-  //~| uninitialized
+  //~| NOTE uninitialized
   //~| ERROR it is undefined behavior
 }

--- a/tests/ui/consts/const-array-oob.rs
+++ b/tests/ui/consts/const-array-oob.rs
@@ -1,10 +1,11 @@
 const FOO: [usize; 3] = [1, 2, 3];
 const BAR: usize = FOO[5];
 //~^ ERROR: evaluation of constant value failed
+//~| NOTE index out of bounds: the length is 3 but the index is 5
 
 const BLUB: [u32; FOO[4]] = [5, 6];
 //~^ ERROR evaluation of constant value failed [E0080]
-//~| index out of bounds: the length is 3 but the index is 4
+//~| NOTE index out of bounds: the length is 3 but the index is 4
 
 fn main() {
     let _ = BAR;

--- a/tests/ui/consts/const-array-oob.stderr
+++ b/tests/ui/consts/const-array-oob.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-array-oob.rs:5:19
+  --> $DIR/const-array-oob.rs:6:19
    |
 LL | const BLUB: [u32; FOO[4]] = [5, 6];
    |                   ^^^^^^ index out of bounds: the length is 3 but the index is 4

--- a/tests/ui/consts/const-err-late.rs
+++ b/tests/ui/consts/const-err-late.rs
@@ -1,5 +1,6 @@
 //@ build-fail
 //@ compile-flags: -C overflow-checks=on
+//@ dont-require-annotations: NOTE
 
 #![allow(arithmetic_overflow, unconditional_panic)]
 
@@ -16,5 +17,5 @@ impl<T> S<T> {
 }
 
 fn main() {
-    black_box((S::<i32>::FOO, S::<u32>::FOO)); //~ constant
+    black_box((S::<i32>::FOO, S::<u32>::FOO)); //~ NOTE constant
 }

--- a/tests/ui/consts/const-err-late.stderr
+++ b/tests/ui/consts/const-err-late.stderr
@@ -1,29 +1,29 @@
 error[E0080]: evaluation of `S::<i32>::FOO` failed
-  --> $DIR/const-err-late.rs:13:21
+  --> $DIR/const-err-late.rs:14:21
    |
 LL |     const FOO: u8 = [5u8][1];
    |                     ^^^^^^^^ index out of bounds: the length is 1 but the index is 1
 
 note: erroneous constant encountered
-  --> $DIR/const-err-late.rs:19:16
+  --> $DIR/const-err-late.rs:20:16
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    |                ^^^^^^^^^^^^^
 
 error[E0080]: evaluation of `S::<u32>::FOO` failed
-  --> $DIR/const-err-late.rs:13:21
+  --> $DIR/const-err-late.rs:14:21
    |
 LL |     const FOO: u8 = [5u8][1];
    |                     ^^^^^^^^ index out of bounds: the length is 1 but the index is 1
 
 note: erroneous constant encountered
-  --> $DIR/const-err-late.rs:19:31
+  --> $DIR/const-err-late.rs:20:31
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    |                               ^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/const-err-late.rs:19:16
+  --> $DIR/const-err-late.rs:20:16
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    |                ^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/const-err-late.rs:19:31
+  --> $DIR/const-err-late.rs:20:31
    |
 LL |     black_box((S::<i32>::FOO, S::<u32>::FOO));
    |                               ^^^^^^^^^^^^^

--- a/tests/ui/consts/const-err-multi.rs
+++ b/tests/ui/consts/const-err-multi.rs
@@ -1,11 +1,12 @@
 pub const A: i8 = -i8::MIN;
 //~^ ERROR constant
+//~| NOTE attempt to negate `i8::MIN`, which would overflow
 pub const B: i8 = A;
-//~^ constant
+//~^ NOTE constant
 pub const C: u8 = A as u8;
-//~^ constant
+//~^ NOTE constant
 pub const D: i8 = 50 - A;
-//~^ constant
+//~^ NOTE constant
 
 fn main() {
     let _ = (A, B, C, D);

--- a/tests/ui/consts/const-err-multi.stderr
+++ b/tests/ui/consts/const-err-multi.stderr
@@ -5,19 +5,19 @@ LL | pub const A: i8 = -i8::MIN;
    |                   ^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
 
 note: erroneous constant encountered
-  --> $DIR/const-err-multi.rs:3:19
+  --> $DIR/const-err-multi.rs:4:19
    |
 LL | pub const B: i8 = A;
    |                   ^
 
 note: erroneous constant encountered
-  --> $DIR/const-err-multi.rs:5:19
+  --> $DIR/const-err-multi.rs:6:19
    |
 LL | pub const C: u8 = A as u8;
    |                   ^
 
 note: erroneous constant encountered
-  --> $DIR/const-err-multi.rs:7:24
+  --> $DIR/const-err-multi.rs:8:24
    |
 LL | pub const D: i8 = 50 - A;
    |                        ^

--- a/tests/ui/consts/const-eval/const-eval-overflow-4b.rs
+++ b/tests/ui/consts/const-eval/const-eval-overflow-4b.rs
@@ -3,12 +3,14 @@
 //
 // This test is checking the count in an array type.
 
+//@ dont-require-annotations: NOTE
+
 #![allow(unused_imports)]
 
 const A_I8_T
     : [u32; (i8::MAX as i8 + 1u8) as usize]
     //~^ ERROR mismatched types
-    //~| expected `i8`, found `u8`
+    //~| NOTE expected `i8`, found `u8`
     //~| ERROR cannot add `u8` to `i8`
     = [0; (i8::MAX as usize) + 1];
 

--- a/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> $DIR/const-eval-overflow-4b.rs:9:30
+  --> $DIR/const-eval-overflow-4b.rs:11:30
    |
 LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
    |                              ^^^ expected `i8`, found `u8`
 
 error[E0277]: cannot add `u8` to `i8`
-  --> $DIR/const-eval-overflow-4b.rs:9:28
+  --> $DIR/const-eval-overflow-4b.rs:11:28
    |
 LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
    |                            ^ no implementation for `i8 + u8`
@@ -18,13 +18,13 @@ LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
              `i8` implements `Add`
 
 error[E0604]: only `u8` can be cast as `char`, not `i8`
-  --> $DIR/const-eval-overflow-4b.rs:22:13
+  --> $DIR/const-eval-overflow-4b.rs:24:13
    |
 LL |     : [u32; 5i8 as char as usize]
    |             ^^^^^^^^^^^ invalid cast
    |
 help: try casting from `u8` instead
-  --> $DIR/const-eval-overflow-4b.rs:22:13
+  --> $DIR/const-eval-overflow-4b.rs:24:13
    |
 LL |     : [u32; 5i8 as char as usize]
    |             ^^^^^^^^^^^

--- a/tests/ui/consts/const-eval/const-pointer-values-in-various-types.64bit.stderr
+++ b/tests/ui/consts/const-eval/const-pointer-values-in-various-types.64bit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:26:49
+  --> $DIR/const-pointer-values-in-various-types.rs:27:49
    |
 LL |     const I32_REF_USIZE_UNION: usize = unsafe { Nonsense { int_32_ref: &3 }.u };
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -8,7 +8,7 @@ LL |     const I32_REF_USIZE_UNION: usize = unsafe { Nonsense { int_32_ref: &3 }
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:29:43
+  --> $DIR/const-pointer-values-in-various-types.rs:30:43
    |
 LL |     const I32_REF_U8_UNION: u8 = unsafe { Nonsense { int_32_ref: &3 }.uint_8 };
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -17,7 +17,7 @@ LL |     const I32_REF_U8_UNION: u8 = unsafe { Nonsense { int_32_ref: &3 }.uint_
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:32:45
+  --> $DIR/const-pointer-values-in-various-types.rs:33:45
    |
 LL |     const I32_REF_U16_UNION: u16 = unsafe { Nonsense { int_32_ref: &3 }.uint_16 };
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -26,7 +26,7 @@ LL |     const I32_REF_U16_UNION: u16 = unsafe { Nonsense { int_32_ref: &3 }.uin
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:35:45
+  --> $DIR/const-pointer-values-in-various-types.rs:36:45
    |
 LL |     const I32_REF_U32_UNION: u32 = unsafe { Nonsense { int_32_ref: &3 }.uint_32 };
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -35,7 +35,7 @@ LL |     const I32_REF_U32_UNION: u32 = unsafe { Nonsense { int_32_ref: &3 }.uin
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:38:45
+  --> $DIR/const-pointer-values-in-various-types.rs:39:45
    |
 LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uint_64 };
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -44,13 +44,13 @@ LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uin
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:41:47
+  --> $DIR/const-pointer-values-in-various-types.rs:42:47
    |
 LL |     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.uint_128 };
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:45:43
+  --> $DIR/const-pointer-values-in-various-types.rs:46:43
    |
 LL |     const I32_REF_I8_UNION: i8 = unsafe { Nonsense { int_32_ref: &3 }.int_8 };
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -59,7 +59,7 @@ LL |     const I32_REF_I8_UNION: i8 = unsafe { Nonsense { int_32_ref: &3 }.int_8
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:48:45
+  --> $DIR/const-pointer-values-in-various-types.rs:49:45
    |
 LL |     const I32_REF_I16_UNION: i16 = unsafe { Nonsense { int_32_ref: &3 }.int_16 };
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -68,7 +68,7 @@ LL |     const I32_REF_I16_UNION: i16 = unsafe { Nonsense { int_32_ref: &3 }.int
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:51:45
+  --> $DIR/const-pointer-values-in-various-types.rs:52:45
    |
 LL |     const I32_REF_I32_UNION: i32 = unsafe { Nonsense { int_32_ref: &3 }.int_32 };
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -77,7 +77,7 @@ LL |     const I32_REF_I32_UNION: i32 = unsafe { Nonsense { int_32_ref: &3 }.int
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:54:45
+  --> $DIR/const-pointer-values-in-various-types.rs:55:45
    |
 LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int_64 };
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -86,13 +86,13 @@ LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:57:47
+  --> $DIR/const-pointer-values-in-various-types.rs:58:47
    |
 LL |     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.int_128 };
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:61:45
+  --> $DIR/const-pointer-values-in-various-types.rs:62:45
    |
 LL |     const I32_REF_F32_UNION: f32 = unsafe { Nonsense { int_32_ref: &3 }.float_32 };
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -101,7 +101,7 @@ LL |     const I32_REF_F32_UNION: f32 = unsafe { Nonsense { int_32_ref: &3 }.flo
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:64:45
+  --> $DIR/const-pointer-values-in-various-types.rs:65:45
    |
 LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.float_64 };
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -110,7 +110,7 @@ LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.flo
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:67:47
+  --> $DIR/const-pointer-values-in-various-types.rs:68:47
    |
 LL |     const I32_REF_BOOL_UNION: bool = unsafe { Nonsense { int_32_ref: &3 }.truthy_falsey };
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -119,7 +119,7 @@ LL |     const I32_REF_BOOL_UNION: bool = unsafe { Nonsense { int_32_ref: &3 }.t
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:70:47
+  --> $DIR/const-pointer-values-in-various-types.rs:71:47
    |
 LL |     const I32_REF_CHAR_UNION: char = unsafe { Nonsense { int_32_ref: &3 }.character };
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -128,7 +128,7 @@ LL |     const I32_REF_CHAR_UNION: char = unsafe { Nonsense { int_32_ref: &3 }.c
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:73:39
+  --> $DIR/const-pointer-values-in-various-types.rs:74:39
    |
 LL |     const STR_U8_UNION: u8 = unsafe { Nonsense { stringy: "3" }.uint_8 };
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -137,7 +137,7 @@ LL |     const STR_U8_UNION: u8 = unsafe { Nonsense { stringy: "3" }.uint_8 };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:76:41
+  --> $DIR/const-pointer-values-in-various-types.rs:77:41
    |
 LL |     const STR_U16_UNION: u16 = unsafe { Nonsense { stringy: "3" }.uint_16 };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -146,7 +146,7 @@ LL |     const STR_U16_UNION: u16 = unsafe { Nonsense { stringy: "3" }.uint_16 }
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:79:41
+  --> $DIR/const-pointer-values-in-various-types.rs:80:41
    |
 LL |     const STR_U32_UNION: u32 = unsafe { Nonsense { stringy: "3" }.uint_32 };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -155,7 +155,7 @@ LL |     const STR_U32_UNION: u32 = unsafe { Nonsense { stringy: "3" }.uint_32 }
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:82:41
+  --> $DIR/const-pointer-values-in-various-types.rs:83:41
    |
 LL |     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -164,7 +164,7 @@ LL |     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 }
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:85:43
+  --> $DIR/const-pointer-values-in-various-types.rs:86:43
    |
 LL |     const STR_U128_UNION: u128 = unsafe { Nonsense { stringy: "3" }.uint_128 };
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -173,7 +173,7 @@ LL |     const STR_U128_UNION: u128 = unsafe { Nonsense { stringy: "3" }.uint_12
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:88:39
+  --> $DIR/const-pointer-values-in-various-types.rs:89:39
    |
 LL |     const STR_I8_UNION: i8 = unsafe { Nonsense { stringy: "3" }.int_8 };
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -182,7 +182,7 @@ LL |     const STR_I8_UNION: i8 = unsafe { Nonsense { stringy: "3" }.int_8 };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:91:41
+  --> $DIR/const-pointer-values-in-various-types.rs:92:41
    |
 LL |     const STR_I16_UNION: i16 = unsafe { Nonsense { stringy: "3" }.int_16 };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -191,7 +191,7 @@ LL |     const STR_I16_UNION: i16 = unsafe { Nonsense { stringy: "3" }.int_16 };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:94:41
+  --> $DIR/const-pointer-values-in-various-types.rs:95:41
    |
 LL |     const STR_I32_UNION: i32 = unsafe { Nonsense { stringy: "3" }.int_32 };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -200,7 +200,7 @@ LL |     const STR_I32_UNION: i32 = unsafe { Nonsense { stringy: "3" }.int_32 };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:97:41
+  --> $DIR/const-pointer-values-in-various-types.rs:98:41
    |
 LL |     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -209,7 +209,7 @@ LL |     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:100:43
+  --> $DIR/const-pointer-values-in-various-types.rs:101:43
    |
 LL |     const STR_I128_UNION: i128 = unsafe { Nonsense { stringy: "3" }.int_128 };
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -218,7 +218,7 @@ LL |     const STR_I128_UNION: i128 = unsafe { Nonsense { stringy: "3" }.int_128
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:103:41
+  --> $DIR/const-pointer-values-in-various-types.rs:104:41
    |
 LL |     const STR_F32_UNION: f32 = unsafe { Nonsense { stringy: "3" }.float_32 };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -227,7 +227,7 @@ LL |     const STR_F32_UNION: f32 = unsafe { Nonsense { stringy: "3" }.float_32 
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:106:41
+  --> $DIR/const-pointer-values-in-various-types.rs:107:41
    |
 LL |     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -236,7 +236,7 @@ LL |     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:109:43
+  --> $DIR/const-pointer-values-in-various-types.rs:110:43
    |
 LL |     const STR_BOOL_UNION: bool = unsafe { Nonsense { stringy: "3" }.truthy_falsey };
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -245,7 +245,7 @@ LL |     const STR_BOOL_UNION: bool = unsafe { Nonsense { stringy: "3" }.truthy_
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-pointer-values-in-various-types.rs:112:43
+  --> $DIR/const-pointer-values-in-various-types.rs:113:43
    |
 LL |     const STR_CHAR_UNION: char = unsafe { Nonsense { stringy: "3" }.character };
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer

--- a/tests/ui/consts/const-eval/const-pointer-values-in-various-types.rs
+++ b/tests/ui/consts/const-eval/const-pointer-values-in-various-types.rs
@@ -1,5 +1,6 @@
 //@ only-x86_64
 //@ stderr-per-bitwidth
+//@ dont-require-annotations: NOTE
 
 #[repr(C)]
 union Nonsense {
@@ -40,7 +41,7 @@ fn main() {
 
     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.uint_128 };
     //~^ ERROR evaluation of constant value failed
-    //~| uninitialized
+    //~| NOTE uninitialized
 
     const I32_REF_I8_UNION: i8 = unsafe { Nonsense { int_32_ref: &3 }.int_8 };
     //~^ ERROR evaluation of constant value failed
@@ -56,7 +57,7 @@ fn main() {
 
     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.int_128 };
     //~^ ERROR evaluation of constant value failed
-    //~| uninitialized
+    //~| NOTE uninitialized
 
     const I32_REF_F32_UNION: f32 = unsafe { Nonsense { int_32_ref: &3 }.float_32 };
     //~^ ERROR evaluation of constant value failed

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
@@ -1,11 +1,13 @@
+//@ dont-require-annotations: NOTE
+
 #![feature(core_intrinsics)]
 #![feature(const_heap)]
 use std::intrinsics;
 
-const FOO: i32 = foo(); //~ error: evaluation of constant value failed
+const FOO: i32 = foo(); //~ ERROR evaluation of constant value failed
 const fn foo() -> i32 {
     unsafe {
-        let _ = intrinsics::const_allocate(4, 3) as *mut i32; //~ inside `foo`
+        let _ = intrinsics::const_allocate(4, 3) as *mut i32; //~ NOTE inside `foo`
     }
     1
 }

--- a/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
+++ b/tests/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/alloc_intrinsic_errors.rs:5:18
+  --> $DIR/alloc_intrinsic_errors.rs:7:18
    |
 LL | const FOO: i32 = foo();
    |                  ^^^^^ invalid align passed to `const_allocate`: 3 is not a power of 2
    |
 note: inside `foo`
-  --> $DIR/alloc_intrinsic_errors.rs:8:17
+  --> $DIR/alloc_intrinsic_errors.rs:10:17
    |
 LL |         let _ = intrinsics::const_allocate(4, 3) as *mut i32;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here

--- a/tests/ui/consts/const-eval/issue-44578.rs
+++ b/tests/ui/consts/const-eval/issue-44578.rs
@@ -1,4 +1,5 @@
 //@ build-fail
+//@ dont-require-annotations: NOTE
 
 trait Foo {
     const AMT: usize;
@@ -23,5 +24,5 @@ impl Foo for u16 {
 
 fn main() {
     println!("{}", <Bar<u16, u8> as Foo>::AMT);
-    //~^ constant
+    //~^ NOTE constant
 }

--- a/tests/ui/consts/const-eval/issue-44578.stderr
+++ b/tests/ui/consts/const-eval/issue-44578.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of `<Bar<u16, u8> as Foo>::AMT` failed
-  --> $DIR/issue-44578.rs:13:24
+  --> $DIR/issue-44578.rs:14:24
    |
 LL |     const AMT: usize = [A::AMT][(A::AMT > B::AMT) as usize];
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1
 
 note: erroneous constant encountered
-  --> $DIR/issue-44578.rs:25:20
+  --> $DIR/issue-44578.rs:26:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/issue-44578.rs:25:20
+  --> $DIR/issue-44578.rs:26:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/issue-44578.rs:25:20
+  --> $DIR/issue-44578.rs:26:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
-  --> $DIR/issue-44578.rs:25:20
+  --> $DIR/issue-44578.rs:26:20
    |
 LL |     println!("{}", <Bar<u16, u8> as Foo>::AMT);
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/const-eval/issue-50814-2.mir-opt.stderr
+++ b/tests/ui/consts/const-eval/issue-50814-2.mir-opt.stderr
@@ -1,31 +1,23 @@
 error[E0080]: evaluation of `<A<()> as Foo<()>>::BAR` failed
-  --> $DIR/issue-50814-2.rs:16:24
+  --> $DIR/issue-50814-2.rs:17:24
    |
 LL |     const BAR: usize = [5, 6, 7][T::BOO];
    |                        ^^^^^^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 42
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814-2.rs:20:6
+  --> $DIR/issue-50814-2.rs:21:6
    |
 LL |     &<A<T> as Foo<T>>::BAR
    |      ^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814-2.rs:20:5
+  --> $DIR/issue-50814-2.rs:21:5
    |
 LL |     &<A<T> as Foo<T>>::BAR
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814-2.rs:20:5
-   |
-LL |     &<A<T> as Foo<T>>::BAR
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-note: erroneous constant encountered
-  --> $DIR/issue-50814-2.rs:20:5
+  --> $DIR/issue-50814-2.rs:21:5
    |
 LL |     &<A<T> as Foo<T>>::BAR
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +25,7 @@ LL |     &<A<T> as Foo<T>>::BAR
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814-2.rs:20:5
+  --> $DIR/issue-50814-2.rs:21:5
    |
 LL |     &<A<T> as Foo<T>>::BAR
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +33,15 @@ LL |     &<A<T> as Foo<T>>::BAR
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814-2.rs:20:6
+  --> $DIR/issue-50814-2.rs:21:5
+   |
+LL |     &<A<T> as Foo<T>>::BAR
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/issue-50814-2.rs:21:6
    |
 LL |     &<A<T> as Foo<T>>::BAR
    |      ^^^^^^^^^^^^^^^^^^^^^
@@ -49,7 +49,7 @@ LL |     &<A<T> as Foo<T>>::BAR
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814-2.rs:20:6
+  --> $DIR/issue-50814-2.rs:21:6
    |
 LL |     &<A<T> as Foo<T>>::BAR
    |      ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/const-eval/issue-50814-2.normal.stderr
+++ b/tests/ui/consts/const-eval/issue-50814-2.normal.stderr
@@ -1,23 +1,23 @@
 error[E0080]: evaluation of `<A<()> as Foo<()>>::BAR` failed
-  --> $DIR/issue-50814-2.rs:16:24
+  --> $DIR/issue-50814-2.rs:17:24
    |
 LL |     const BAR: usize = [5, 6, 7][T::BOO];
    |                        ^^^^^^^^^^^^^^^^^ index out of bounds: the length is 3 but the index is 42
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814-2.rs:20:6
+  --> $DIR/issue-50814-2.rs:21:6
    |
 LL |     &<A<T> as Foo<T>>::BAR
    |      ^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814-2.rs:20:5
+  --> $DIR/issue-50814-2.rs:21:5
    |
 LL |     &<A<T> as Foo<T>>::BAR
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814-2.rs:20:6
+  --> $DIR/issue-50814-2.rs:21:6
    |
 LL |     &<A<T> as Foo<T>>::BAR
    |      ^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     &<A<T> as Foo<T>>::BAR
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: the above error was encountered while instantiating `fn foo::<()>`
-  --> $DIR/issue-50814-2.rs:32:22
+  --> $DIR/issue-50814-2.rs:33:22
    |
 LL |     println!("{:x}", foo::<()>() as *const usize as usize);
    |                      ^^^^^^^^^^^

--- a/tests/ui/consts/const-eval/issue-50814-2.rs
+++ b/tests/ui/consts/const-eval/issue-50814-2.rs
@@ -1,6 +1,7 @@
 //@ build-fail
 //@ revisions: normal mir-opt
 //@ [mir-opt]compile-flags: -Zmir-opt-level=4
+//@ dont-require-annotations: NOTE
 
 trait C {
     const BOO: usize;
@@ -17,7 +18,7 @@ impl<T: C> Foo<T> for A<T> {
 }
 
 fn foo<T: C>() -> &'static usize {
-    &<A<T> as Foo<T>>::BAR //~ constant
+    &<A<T> as Foo<T>>::BAR //~ NOTE constant
 }
 
 impl C for () {

--- a/tests/ui/consts/const-eval/issue-50814.rs
+++ b/tests/ui/consts/const-eval/issue-50814.rs
@@ -1,4 +1,5 @@
 //@ build-fail
+//@ dont-require-annotations: NOTE
 
 trait Unsigned {
     const MAX: u8;
@@ -19,7 +20,7 @@ impl<A: Unsigned, B: Unsigned> Unsigned for Sum<A, B> {
 
 fn foo<T>(_: T) -> &'static u8 {
     &Sum::<U8, U8>::MAX
-    //~^ constant
+    //~^ NOTE constant
 }
 
 fn main() {

--- a/tests/ui/consts/const-eval/issue-50814.stderr
+++ b/tests/ui/consts/const-eval/issue-50814.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of `<Sum<U8, U8> as Unsigned>::MAX` failed
-  --> $DIR/issue-50814.rs:15:21
+  --> $DIR/issue-50814.rs:16:21
    |
 LL |     const MAX: u8 = A::MAX + B::MAX;
    |                     ^^^^^^^^^^^^^^^ attempt to compute `u8::MAX + u8::MAX`, which would overflow
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814.rs:21:6
+  --> $DIR/issue-50814.rs:22:6
    |
 LL |     &Sum::<U8, U8>::MAX
    |      ^^^^^^^^^^^^^^^^^^
 
 error[E0080]: evaluation of `<Sum<U8, U8> as Unsigned>::MAX` failed
-  --> $DIR/issue-50814.rs:15:21
+  --> $DIR/issue-50814.rs:16:21
    |
 LL |     const MAX: u8 = A::MAX + B::MAX;
    |                     ^^^^^^^^^^^^^^^ attempt to compute `u8::MAX + u8::MAX`, which would overflow
@@ -19,7 +19,7 @@ LL |     const MAX: u8 = A::MAX + B::MAX;
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814.rs:21:6
+  --> $DIR/issue-50814.rs:22:6
    |
 LL |     &Sum::<U8, U8>::MAX
    |      ^^^^^^^^^^^^^^^^^^
@@ -27,13 +27,13 @@ LL |     &Sum::<U8, U8>::MAX
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814.rs:21:5
+  --> $DIR/issue-50814.rs:22:5
    |
 LL |     &Sum::<U8, U8>::MAX
    |     ^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/issue-50814.rs:21:6
+  --> $DIR/issue-50814.rs:22:6
    |
 LL |     &Sum::<U8, U8>::MAX
    |      ^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL |     &Sum::<U8, U8>::MAX
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 note: the above error was encountered while instantiating `fn foo::<i32>`
-  --> $DIR/issue-50814.rs:26:5
+  --> $DIR/issue-50814.rs:27:5
    |
 LL |     foo(0);
    |     ^^^^^^

--- a/tests/ui/consts/const-eval/panic-assoc-never-type.rs
+++ b/tests/ui/consts/const-eval/panic-assoc-never-type.rs
@@ -1,4 +1,5 @@
 //@ build-fail
+//@ dont-require-annotations: NOTE
 
 // Regression test for #66975
 #![feature(never_type)]
@@ -11,5 +12,5 @@ impl PrintName {
 }
 
 fn main() {
-    let _ = PrintName::VOID; //~ erroneous constant encountered
+    let _ = PrintName::VOID; //~ NOTE erroneous constant encountered
 }

--- a/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/tests/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/panic-assoc-never-type.rs:9:21
+  --> $DIR/panic-assoc-never-type.rs:10:21
    |
 LL |     const VOID: ! = panic!();
    |                     ^^^^^^^^ evaluation panicked: explicit panic
 
 note: erroneous constant encountered
-  --> $DIR/panic-assoc-never-type.rs:14:13
+  --> $DIR/panic-assoc-never-type.rs:15:13
    |
 LL |     let _ = PrintName::VOID;
    |             ^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/panic-assoc-never-type.rs:14:13
+  --> $DIR/panic-assoc-never-type.rs:15:13
    |
 LL |     let _ = PrintName::VOID;
    |             ^^^^^^^^^^^^^^^

--- a/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.32bit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:21:1
+  --> $DIR/raw-bytes.rs:23:1
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered 0x00000001, but expected a valid enum tag
@@ -10,7 +10,7 @@ LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:29:1
+  --> $DIR/raw-bytes.rs:31:1
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered 0x00000000, but expected a valid enum tag
@@ -21,7 +21,7 @@ LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:43:1
+  --> $DIR/raw-bytes.rs:45:1
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
@@ -32,7 +32,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:45:1
+  --> $DIR/raw-bytes.rs:47:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
@@ -43,7 +43,7 @@ LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:51:1
+  --> $DIR/raw-bytes.rs:53:1
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
@@ -54,7 +54,7 @@ LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::tran
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:56:1
+  --> $DIR/raw-bytes.rs:58:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
@@ -65,7 +65,7 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:59:1
+  --> $DIR/raw-bytes.rs:61:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
@@ -76,7 +76,7 @@ LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:61:1
+  --> $DIR/raw-bytes.rs:63:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
@@ -87,7 +87,7 @@ LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:67:1
+  --> $DIR/raw-bytes.rs:69:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 42, but expected something in the range 10..=30
@@ -98,7 +98,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:73:1
+  --> $DIR/raw-bytes.rs:75:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 20, but expected something less or equal to 10, or greater or equal to 30
@@ -109,7 +109,7 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:76:1
+  --> $DIR/raw-bytes.rs:78:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
@@ -120,7 +120,7 @@ LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:84:1
+  --> $DIR/raw-bytes.rs:86:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
@@ -131,7 +131,7 @@ LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:88:1
+  --> $DIR/raw-bytes.rs:90:1
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
@@ -142,7 +142,7 @@ LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:92:1
+  --> $DIR/raw-bytes.rs:94:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^ constructing invalid value: encountered a null reference
@@ -153,7 +153,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:95:1
+  --> $DIR/raw-bytes.rs:97:1
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a null box
@@ -164,7 +164,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:98:1
+  --> $DIR/raw-bytes.rs:100:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
@@ -175,7 +175,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:101:1
+  --> $DIR/raw-bytes.rs:103:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
@@ -186,7 +186,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:104:1
+  --> $DIR/raw-bytes.rs:106:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered null pointer, but expected a function pointer
@@ -197,7 +197,7 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:106:1
+  --> $DIR/raw-bytes.rs:108:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
@@ -208,7 +208,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:108:1
+  --> $DIR/raw-bytes.rs:110:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered ALLOC3<imm>, but expected a function pointer
@@ -219,7 +219,7 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:114:1
+  --> $DIR/raw-bytes.rs:116:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a reference pointing to uninhabited type Bar
@@ -230,7 +230,7 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:139:1
+  --> $DIR/raw-bytes.rs:141:1
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
@@ -241,7 +241,7 @@ LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:141:1
+  --> $DIR/raw-bytes.rs:143:1
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered invalid reference metadata: slice is bigger than largest supported object
@@ -252,7 +252,7 @@ LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:143:1
+  --> $DIR/raw-bytes.rs:145:1
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
@@ -263,7 +263,7 @@ LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize:
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:146:1
+  --> $DIR/raw-bytes.rs:148:1
    |
 LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>: encountered uninitialized memory, but expected a string
@@ -274,7 +274,7 @@ LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit:
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:148:1
+  --> $DIR/raw-bytes.rs:150:1
    |
 LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered uninitialized memory, but expected a string
@@ -285,7 +285,7 @@ LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUni
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:150:1
+  --> $DIR/raw-bytes.rs:152:1
    |
 LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered a pointer, but expected a string
@@ -298,7 +298,7 @@ LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:154:1
+  --> $DIR/raw-bytes.rs:156:1
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
@@ -309,7 +309,7 @@ LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:156:1
+  --> $DIR/raw-bytes.rs:158:1
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
@@ -320,7 +320,7 @@ LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, is
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:159:1
+  --> $DIR/raw-bytes.rs:161:1
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (going beyond the bounds of its allocation)
@@ -331,7 +331,7 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:162:1
+  --> $DIR/raw-bytes.rs:164:1
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
@@ -342,13 +342,13 @@ LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:162:40
+  --> $DIR/raw-bytes.rs:164:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:168:1
+  --> $DIR/raw-bytes.rs:170:1
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
@@ -359,13 +359,13 @@ LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:168:42
+  --> $DIR/raw-bytes.rs:170:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:172:1
+  --> $DIR/raw-bytes.rs:174:1
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
@@ -376,13 +376,13 @@ LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::tran
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:172:42
+  --> $DIR/raw-bytes.rs:174:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:177:1
+  --> $DIR/raw-bytes.rs:179:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered ALLOC17<imm>, but expected a vtable pointer
@@ -393,7 +393,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:181:1
+  --> $DIR/raw-bytes.rs:183:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered ALLOC19<imm>, but expected a vtable pointer
@@ -404,7 +404,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:185:1
+  --> $DIR/raw-bytes.rs:187:1
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0x4[noalloc], but expected a vtable pointer
@@ -415,7 +415,7 @@ LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:188:1
+  --> $DIR/raw-bytes.rs:190:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered ALLOC22<imm>, but expected a vtable pointer
@@ -426,7 +426,7 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::trans
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:192:1
+  --> $DIR/raw-bytes.rs:194:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
@@ -437,7 +437,7 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:196:1
+  --> $DIR/raw-bytes.rs:198:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered null pointer, but expected a vtable pointer
@@ -448,7 +448,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:199:1
+  --> $DIR/raw-bytes.rs:201:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered ALLOC27<imm>, but expected a vtable pointer
@@ -459,7 +459,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transm
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:204:1
+  --> $DIR/raw-bytes.rs:206:1
    |
 LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^^^^ constructing invalid value: encountered a reference pointing to uninhabited type [!; 1]
@@ -470,7 +470,7 @@ LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:205:1
+  --> $DIR/raw-bytes.rs:207:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
@@ -481,7 +481,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:206:1
+  --> $DIR/raw-bytes.rs:208:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
    | ^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
@@ -492,7 +492,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:210:1
+  --> $DIR/raw-bytes.rs:212:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
@@ -503,7 +503,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:213:1
+  --> $DIR/raw-bytes.rs:215:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem::size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
@@ -516,7 +516,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem:
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:216:1
+  --> $DIR/raw-bytes.rs:218:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
@@ -527,7 +527,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:220:1
+  --> $DIR/raw-bytes.rs:222:1
    |
 LL | pub static S7: &[u16] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[1]: encountered uninitialized memory, but expected an integer
@@ -538,7 +538,7 @@ LL | pub static S7: &[u16] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:227:1
+  --> $DIR/raw-bytes.rs:229:1
    |
 LL | pub static R4: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
@@ -549,7 +549,7 @@ LL | pub static R4: &[u8] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:232:1
+  --> $DIR/raw-bytes.rs:234:1
    |
 LL | pub static R5: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
@@ -562,7 +562,7 @@ LL | pub static R5: &[u8] = unsafe {
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:237:1
+  --> $DIR/raw-bytes.rs:239:1
    |
 LL | pub static R6: &[bool] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean

--- a/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
+++ b/tests/ui/consts/const-eval/raw-bytes.64bit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:21:1
+  --> $DIR/raw-bytes.rs:23:1
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered 0x0000000000000001, but expected a valid enum tag
@@ -10,7 +10,7 @@ LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:29:1
+  --> $DIR/raw-bytes.rs:31:1
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered 0x0000000000000000, but expected a valid enum tag
@@ -21,7 +21,7 @@ LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:43:1
+  --> $DIR/raw-bytes.rs:45:1
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
@@ -32,7 +32,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:45:1
+  --> $DIR/raw-bytes.rs:47:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
@@ -43,7 +43,7 @@ LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:51:1
+  --> $DIR/raw-bytes.rs:53:1
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
@@ -54,7 +54,7 @@ LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::tran
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:56:1
+  --> $DIR/raw-bytes.rs:58:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
@@ -65,7 +65,7 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:59:1
+  --> $DIR/raw-bytes.rs:61:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
@@ -76,7 +76,7 @@ LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:61:1
+  --> $DIR/raw-bytes.rs:63:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
@@ -87,7 +87,7 @@ LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:67:1
+  --> $DIR/raw-bytes.rs:69:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 42, but expected something in the range 10..=30
@@ -98,7 +98,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:73:1
+  --> $DIR/raw-bytes.rs:75:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 20, but expected something less or equal to 10, or greater or equal to 30
@@ -109,7 +109,7 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:76:1
+  --> $DIR/raw-bytes.rs:78:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
@@ -120,7 +120,7 @@ LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:84:1
+  --> $DIR/raw-bytes.rs:86:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
@@ -131,7 +131,7 @@ LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:88:1
+  --> $DIR/raw-bytes.rs:90:1
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
@@ -142,7 +142,7 @@ LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:92:1
+  --> $DIR/raw-bytes.rs:94:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^ constructing invalid value: encountered a null reference
@@ -153,7 +153,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:95:1
+  --> $DIR/raw-bytes.rs:97:1
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a null box
@@ -164,7 +164,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:98:1
+  --> $DIR/raw-bytes.rs:100:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
@@ -175,7 +175,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:101:1
+  --> $DIR/raw-bytes.rs:103:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
@@ -186,7 +186,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:104:1
+  --> $DIR/raw-bytes.rs:106:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered null pointer, but expected a function pointer
@@ -197,7 +197,7 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:106:1
+  --> $DIR/raw-bytes.rs:108:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
@@ -208,7 +208,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:108:1
+  --> $DIR/raw-bytes.rs:110:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered ALLOC3<imm>, but expected a function pointer
@@ -219,7 +219,7 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:114:1
+  --> $DIR/raw-bytes.rs:116:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a reference pointing to uninhabited type Bar
@@ -230,7 +230,7 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:139:1
+  --> $DIR/raw-bytes.rs:141:1
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
@@ -241,7 +241,7 @@ LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:141:1
+  --> $DIR/raw-bytes.rs:143:1
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered invalid reference metadata: slice is bigger than largest supported object
@@ -252,7 +252,7 @@ LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:143:1
+  --> $DIR/raw-bytes.rs:145:1
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
@@ -263,7 +263,7 @@ LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize:
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:146:1
+  --> $DIR/raw-bytes.rs:148:1
    |
 LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>: encountered uninitialized memory, but expected a string
@@ -274,7 +274,7 @@ LL | const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit:
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:148:1
+  --> $DIR/raw-bytes.rs:150:1
    |
 LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered uninitialized memory, but expected a string
@@ -285,7 +285,7 @@ LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUni
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:150:1
+  --> $DIR/raw-bytes.rs:152:1
    |
 LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered a pointer, but expected a string
@@ -298,7 +298,7 @@ LL | const MYSTR_NO_INIT_ISSUE83182: &MyStr = unsafe { mem::transmute::<&[_], _>
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:154:1
+  --> $DIR/raw-bytes.rs:156:1
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (going beyond the bounds of its allocation)
@@ -309,7 +309,7 @@ LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:156:1
+  --> $DIR/raw-bytes.rs:158:1
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered invalid reference metadata: slice is bigger than largest supported object
@@ -320,7 +320,7 @@ LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, is
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:159:1
+  --> $DIR/raw-bytes.rs:161:1
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (going beyond the bounds of its allocation)
@@ -331,7 +331,7 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:162:1
+  --> $DIR/raw-bytes.rs:164:1
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x03, but expected a boolean
@@ -342,13 +342,13 @@ LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:162:40
+  --> $DIR/raw-bytes.rs:164:40
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:168:1
+  --> $DIR/raw-bytes.rs:170:1
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.0: encountered 0x03, but expected a boolean
@@ -359,13 +359,13 @@ LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:168:42
+  --> $DIR/raw-bytes.rs:170:42
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:172:1
+  --> $DIR/raw-bytes.rs:174:1
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.1[0]: encountered 0x03, but expected a boolean
@@ -376,13 +376,13 @@ LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::tran
            }
 
 note: erroneous constant encountered
-  --> $DIR/raw-bytes.rs:172:42
+  --> $DIR/raw-bytes.rs:174:42
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:177:1
+  --> $DIR/raw-bytes.rs:179:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered ALLOC17<imm>, but expected a vtable pointer
@@ -393,7 +393,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:181:1
+  --> $DIR/raw-bytes.rs:183:1
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered ALLOC19<imm>, but expected a vtable pointer
@@ -404,7 +404,7 @@ LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:185:1
+  --> $DIR/raw-bytes.rs:187:1
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0x4[noalloc], but expected a vtable pointer
@@ -415,7 +415,7 @@ LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:188:1
+  --> $DIR/raw-bytes.rs:190:1
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered ALLOC22<imm>, but expected a vtable pointer
@@ -426,7 +426,7 @@ LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::trans
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:192:1
+  --> $DIR/raw-bytes.rs:194:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
@@ -437,7 +437,7 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:196:1
+  --> $DIR/raw-bytes.rs:198:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered null pointer, but expected a vtable pointer
@@ -448,7 +448,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:199:1
+  --> $DIR/raw-bytes.rs:201:1
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered ALLOC27<imm>, but expected a vtable pointer
@@ -459,7 +459,7 @@ LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transm
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:204:1
+  --> $DIR/raw-bytes.rs:206:1
    |
 LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^^^^ constructing invalid value: encountered a reference pointing to uninhabited type [!; 1]
@@ -470,7 +470,7 @@ LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:205:1
+  --> $DIR/raw-bytes.rs:207:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
@@ -481,7 +481,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:206:1
+  --> $DIR/raw-bytes.rs:208:1
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
    | ^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a value of the never type `!`
@@ -492,7 +492,7 @@ LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:210:1
+  --> $DIR/raw-bytes.rs:212:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
@@ -503,7 +503,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:213:1
+  --> $DIR/raw-bytes.rs:215:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem::size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
@@ -516,7 +516,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, mem:
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:216:1
+  --> $DIR/raw-bytes.rs:218:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean
@@ -527,7 +527,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:220:1
+  --> $DIR/raw-bytes.rs:222:1
    |
 LL | pub static S7: &[u16] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[1]: encountered uninitialized memory, but expected an integer
@@ -538,7 +538,7 @@ LL | pub static S7: &[u16] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:227:1
+  --> $DIR/raw-bytes.rs:229:1
    |
 LL | pub static R4: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered uninitialized memory, but expected an integer
@@ -549,7 +549,7 @@ LL | pub static R4: &[u8] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:232:1
+  --> $DIR/raw-bytes.rs:234:1
    |
 LL | pub static R5: &[u8] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered a pointer, but expected an integer
@@ -562,7 +562,7 @@ LL | pub static R5: &[u8] = unsafe {
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/raw-bytes.rs:237:1
+  --> $DIR/raw-bytes.rs:239:1
    |
 LL | pub static R6: &[bool] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>[0]: encountered 0x11, but expected a boolean

--- a/tests/ui/consts/const-eval/raw-bytes.rs
+++ b/tests/ui/consts/const-eval/raw-bytes.rs
@@ -2,6 +2,8 @@
 //@ ignore-endian-big
 // ignore-tidy-linelength
 //@ normalize-stderr: "╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼" -> "╾ALLOC_ID$1╼"
+//@ dont-require-annotations: NOTE
+
 #![allow(invalid_value, unnecessary_transmutes)]
 #![feature(never_type, rustc_attrs, ptr_metadata, slice_from_ptr_range, const_slice_from_ptr_range)]
 
@@ -83,11 +85,11 @@ const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
 
 const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
 //~^ ERROR it is undefined behavior to use this value
-//~| constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
+//~| NOTE constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
 
 const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
 //~^ ERROR it is undefined behavior to use this value
-//~| constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
+//~| NOTE constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
 
 const NULL: &u16 = unsafe { mem::transmute(0usize) };
 //~^ ERROR it is undefined behavior to use this value
@@ -161,44 +163,44 @@ const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize))
 // bad data *inside* the slice
 const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
 //~^ ERROR it is undefined behavior to use this value
-//~| constant
+//~| NOTE constant
 
 
 // bad: sized field is not okay
 const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
 //~^ ERROR it is undefined behavior to use this value
-//~| constant
+//~| NOTE constant
 // bad: unsized part is not okay
 const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
 //~^ ERROR it is undefined behavior to use this value
-//~| constant
+//~| NOTE constant
 
 // bad trait object
 const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
 //~^ ERROR it is undefined behavior to use this value
-//~| expected a vtable
+//~| NOTE expected a vtable
 // bad trait object
 const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
 //~^ ERROR it is undefined behavior to use this value
-//~| expected a vtable
+//~| NOTE expected a vtable
 // bad trait object
 const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
 //~^ ERROR it is undefined behavior to use this value
-//~| expected a vtable
+//~| NOTE expected a vtable
 const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
 //~^ ERROR it is undefined behavior to use this value
-//~| expected a vtable
+//~| NOTE expected a vtable
 // bad data *inside* the trait object
 const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
 //~^ ERROR it is undefined behavior to use this value
-//~| expected a boolean
+//~| NOTE expected a boolean
 
 const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
 //~^ ERROR it is undefined behavior to use this value
-//~| null pointer
+//~| NOTE null pointer
 const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
 //~^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 
 // Uninhabited types
 const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) }; //~ ERROR undefined behavior

--- a/tests/ui/consts/const-eval/ub-enum.rs
+++ b/tests/ui/consts/const-eval/ub-enum.rs
@@ -2,6 +2,8 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 //@ normalize-stderr: "0x0+" -> "0x0"
+//@ dont-require-annotations: NOTE
+
 #![feature(never_type)]
 #![allow(invalid_value, unnecessary_transmutes)]
 
@@ -58,7 +60,7 @@ union MaybeUninit<T: Copy> {
 }
 const BAD_ENUM2_UNDEF : Enum2 = unsafe { MaybeUninit { uninit: () }.init };
 //~^ ERROR evaluation of constant value failed
-//~| uninitialized
+//~| NOTE uninitialized
 
 // Pointer value in an enum with a niche that is not just 0.
 const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };

--- a/tests/ui/consts/const-eval/ub-enum.stderr
+++ b/tests/ui/consts/const-eval/ub-enum.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:27:1
+  --> $DIR/ub-enum.rs:29:1
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered 0x01, but expected a valid enum tag
@@ -10,7 +10,7 @@ LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-enum.rs:30:1
+  --> $DIR/ub-enum.rs:32:1
    |
 LL | const BAD_ENUM_PTR: Enum = unsafe { mem::transmute(&1) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -19,7 +19,7 @@ LL | const BAD_ENUM_PTR: Enum = unsafe { mem::transmute(&1) };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-enum.rs:33:1
+  --> $DIR/ub-enum.rs:35:1
    |
 LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -28,7 +28,7 @@ LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:45:1
+  --> $DIR/ub-enum.rs:47:1
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered 0x0, but expected a valid enum tag
@@ -39,7 +39,7 @@ LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-enum.rs:47:1
+  --> $DIR/ub-enum.rs:49:1
    |
 LL | const BAD_ENUM2_PTR: Enum2 = unsafe { mem::transmute(&0) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -48,7 +48,7 @@ LL | const BAD_ENUM2_PTR: Enum2 = unsafe { mem::transmute(&0) };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-enum.rs:50:1
+  --> $DIR/ub-enum.rs:52:1
    |
 LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -57,13 +57,13 @@ LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-enum.rs:59:42
+  --> $DIR/ub-enum.rs:61:42
    |
 LL | const BAD_ENUM2_UNDEF : Enum2 = unsafe { MaybeUninit { uninit: () }.init };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-enum.rs:64:1
+  --> $DIR/ub-enum.rs:66:1
    |
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -72,7 +72,7 @@ LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:81:1
+  --> $DIR/ub-enum.rs:83:1
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
@@ -83,7 +83,7 @@ LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:83:1
+  --> $DIR/ub-enum.rs:85:1
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
@@ -94,7 +94,7 @@ LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:91:1
+  --> $DIR/ub-enum.rs:93:1
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
@@ -105,19 +105,19 @@ LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::tran
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-enum.rs:96:77
+  --> $DIR/ub-enum.rs:98:77
    |
 LL | const BAD_UNINHABITED_WITH_DATA1: Result<(i32, Never), (i32, !)> = unsafe { mem::transmute(0u64) };
    |                                                                             ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-enum.rs:98:77
+  --> $DIR/ub-enum.rs:100:77
    |
 LL | const BAD_UNINHABITED_WITH_DATA2: Result<(i32, !), (i32, Never)> = unsafe { mem::transmute(0u64) };
    |                                                                             ^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-enum.rs:103:14
+  --> $DIR/ub-enum.rs:105:14
    |
 LL |     unsafe { std::mem::discriminant(&*(&() as *const () as *const Never)); };
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ read discriminant of an uninhabited enum variant

--- a/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
+++ b/tests/ui/consts/const-eval/ub-incorrect-vtable.rs
@@ -11,19 +11,19 @@
 // errors are emitted instead of ICEs.
 
 //@ stderr-per-bitwidth
-
+//@ dont-require-annotations: NOTE
 
 trait Trait {}
 
 const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
 //~^^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 
 const INVALID_VTABLE_SIZE: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
 //~^^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 
 #[repr(transparent)]
 struct W<T>(T);
@@ -33,18 +33,18 @@ fn drop_me(_: *mut usize) {}
 const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
 //~^^ ERROR it is undefined behavior to use this value
-//~| expected a vtable pointer
+//~| NOTE expected a vtable pointer
 
 const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };
 //~^^ ERROR it is undefined behavior to use this value
-//~| expected a vtable pointer
+//~| NOTE expected a vtable pointer
 
 // Even if the vtable has a fn ptr and a reasonable size+align, it still does not work.
 const INVALID_VTABLE_UB: W<&dyn Trait> =
     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1usize))) };
 //~^^ ERROR it is undefined behavior to use this value
-//~| expected a vtable pointer
+//~| NOTE expected a vtable pointer
 
 // Trying to access the data in a vtable does not work, either.
 
@@ -90,7 +90,7 @@ union Transmute<T: Copy, U: Copy> {
 const FOO: &dyn Bar = &Foo { foo: 128, bar: false };
 const G: Wide = unsafe { Transmute { t: FOO }.u };
 //~^ ERROR it is undefined behavior to use this value
-//~| encountered a dangling reference
+//~| NOTE encountered a dangling reference
 // (it is dangling because vtables do not contain memory that can be dereferenced)
 
 fn main() {}

--- a/tests/ui/consts/const-eval/ub-int-array.rs
+++ b/tests/ui/consts/const-eval/ub-int-array.rs
@@ -1,6 +1,8 @@
 //! Test the "array of int" fast path in validity checking, and in particular whether it
 //! points at the right array element.
 
+//@ dont-require-annotations: NOTE
+
 use std::mem;
 
 #[repr(C)]
@@ -17,7 +19,7 @@ impl<T: Copy> MaybeUninit<T> {
 
 const UNINIT_INT_0: [u32; 3] = unsafe {
     //~^ ERROR it is undefined behavior to use this value
-    //~| invalid value at [0]
+    //~| NOTE invalid value at [0]
     mem::transmute([
         MaybeUninit { uninit: () },
         // Constants chosen to achieve endianness-independent hex dump.
@@ -27,7 +29,7 @@ const UNINIT_INT_0: [u32; 3] = unsafe {
 };
 const UNINIT_INT_1: [u32; 3] = unsafe {
     //~^ ERROR it is undefined behavior to use this value
-    //~| invalid value at [1]
+    //~| NOTE invalid value at [1]
     mem::transmute([
         MaybeUninit::new(0u8),
         MaybeUninit::new(0u8),
@@ -45,7 +47,7 @@ const UNINIT_INT_1: [u32; 3] = unsafe {
 };
 const UNINIT_INT_2: [u32; 3] = unsafe {
     //~^ ERROR it is undefined behavior to use this value
-    //~| invalid value at [2]
+    //~| NOTE invalid value at [2]
     mem::transmute([
         MaybeUninit::new(0u8),
         MaybeUninit::new(0u8),

--- a/tests/ui/consts/const-eval/ub-int-array.stderr
+++ b/tests/ui/consts/const-eval/ub-int-array.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-int-array.rs:18:1
+  --> $DIR/ub-int-array.rs:20:1
    |
 LL | const UNINIT_INT_0: [u32; 3] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at [0]: encountered uninitialized memory, but expected an integer
@@ -10,7 +10,7 @@ LL | const UNINIT_INT_0: [u32; 3] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-int-array.rs:28:1
+  --> $DIR/ub-int-array.rs:30:1
    |
 LL | const UNINIT_INT_1: [u32; 3] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at [1]: encountered uninitialized memory, but expected an integer
@@ -21,7 +21,7 @@ LL | const UNINIT_INT_1: [u32; 3] = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-int-array.rs:46:1
+  --> $DIR/ub-int-array.rs:48:1
    |
 LL | const UNINIT_INT_2: [u32; 3] = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at [2]: encountered uninitialized memory, but expected an integer

--- a/tests/ui/consts/const-eval/ub-nonnull.rs
+++ b/tests/ui/consts/const-eval/ub-nonnull.rs
@@ -1,6 +1,8 @@
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ dont-require-annotations: NOTE
+
 #![allow(invalid_value)] // make sure we cannot allow away the errors tested here
 #![feature(rustc_attrs, ptr_metadata)]
 
@@ -33,7 +35,7 @@ union MaybeUninit<T: Copy> {
 }
 const UNINIT: NonZero<u8> = unsafe { MaybeUninit { uninit: () }.init };
 //~^ ERROR evaluation of constant value failed
-//~| uninitialized
+//~| NOTE uninitialized
 
 // Also test other uses of rustc_layout_scalar_valid_range_start
 

--- a/tests/ui/consts/const-eval/ub-nonnull.stderr
+++ b/tests/ui/consts/const-eval/ub-nonnull.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:14:1
+  --> $DIR/ub-nonnull.rs:16:1
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1
@@ -10,13 +10,13 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-nonnull.rs:20:29
+  --> $DIR/ub-nonnull.rs:22:29
    |
 LL |     let out_of_bounds_ptr = &ptr[255];
    |                             ^^^^^^^^^ out-of-bounds pointer arithmetic: expected a pointer to 255 bytes of memory, but got ALLOC1 which is only 1 byte from the end of the allocation
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:24:1
+  --> $DIR/ub-nonnull.rs:26:1
    |
 LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
@@ -27,7 +27,7 @@ LL | const NULL_U8: NonZero<u8> = unsafe { mem::transmute(0u8) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:26:1
+  --> $DIR/ub-nonnull.rs:28:1
    |
 LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered 0, but expected something greater or equal to 1
@@ -38,13 +38,13 @@ LL | const NULL_USIZE: NonZero<usize> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-nonnull.rs:34:38
+  --> $DIR/ub-nonnull.rs:36:38
    |
 LL | const UNINIT: NonZero<u8> = unsafe { MaybeUninit { uninit: () }.init };
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:43:1
+  --> $DIR/ub-nonnull.rs:45:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 42, but expected something in the range 10..=30
@@ -55,7 +55,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:49:1
+  --> $DIR/ub-nonnull.rs:51:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 20, but expected something less or equal to 10, or greater or equal to 30
@@ -66,7 +66,7 @@ LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:52:1
+  --> $DIR/ub-nonnull.rs:54:1
    |
 LL | const NULL_FAT_PTR: NonNull<dyn Send> = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0, but expected something greater or equal to 1

--- a/tests/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.rs
@@ -2,6 +2,8 @@
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ dont-require-annotations: NOTE
+
 #![allow(invalid_value)]
 
 use std::mem;
@@ -14,11 +16,11 @@ union MaybeUninit<T: Copy> {
 
 const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
 //~^ ERROR it is undefined behavior to use this value
-//~| constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
+//~| NOTE constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
 
 const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
 //~^ ERROR it is undefined behavior to use this value
-//~| constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
+//~| NOTE constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
 
 const NULL: &u16 = unsafe { mem::transmute(0usize) };
 //~^ ERROR it is undefined behavior to use this value
@@ -47,13 +49,13 @@ const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
 
 const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
 //~^ ERROR evaluation of constant value failed
-//~| uninitialized
+//~| NOTE uninitialized
 
 const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
 //~^ ERROR it is undefined behavior to use this value
 const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
 //~^ ERROR evaluation of constant value failed
-//~| uninitialized
+//~| NOTE uninitialized
 const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
 //~^ ERROR it is undefined behavior to use this value
 const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };

--- a/tests/ui/consts/const-eval/ub-ref-ptr.stderr
+++ b/tests/ui/consts/const-eval/ub-ref-ptr.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:15:1
+  --> $DIR/ub-ref-ptr.rs:17:1
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned reference (required 2 byte alignment but found 1)
@@ -10,7 +10,7 @@ LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:19:1
+  --> $DIR/ub-ref-ptr.rs:21:1
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered an unaligned box (required 2 byte alignment but found 1)
@@ -21,7 +21,7 @@ LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:23:1
+  --> $DIR/ub-ref-ptr.rs:25:1
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^ constructing invalid value: encountered a null reference
@@ -32,7 +32,7 @@ LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:26:1
+  --> $DIR/ub-ref-ptr.rs:28:1
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a null box
@@ -43,7 +43,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:33:1
+  --> $DIR/ub-ref-ptr.rs:35:1
    |
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -52,7 +52,7 @@ LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:36:39
+  --> $DIR/ub-ref-ptr.rs:38:39
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -61,13 +61,13 @@ LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 note: erroneous constant encountered
-  --> $DIR/ub-ref-ptr.rs:36:38
+  --> $DIR/ub-ref-ptr.rs:38:38
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:39:86
+  --> $DIR/ub-ref-ptr.rs:41:86
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
    |                                                                                      ^^^^^^^^^^^^^^^^^^^^ unable to turn pointer into integer
@@ -76,13 +76,13 @@ LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[us
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
 note: erroneous constant encountered
-  --> $DIR/ub-ref-ptr.rs:39:85
+  --> $DIR/ub-ref-ptr.rs:41:85
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
    |                                                                                     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:42:1
+  --> $DIR/ub-ref-ptr.rs:44:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling reference (0x539[noalloc] has no provenance)
@@ -93,7 +93,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:45:1
+  --> $DIR/ub-ref-ptr.rs:47:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (0x539[noalloc] has no provenance)
@@ -104,13 +104,13 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:48:41
+  --> $DIR/ub-ref-ptr.rs:50:41
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:52:1
+  --> $DIR/ub-ref-ptr.rs:54:1
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered null pointer, but expected a function pointer
@@ -121,13 +121,13 @@ LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:54:38
+  --> $DIR/ub-ref-ptr.rs:56:38
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:57:1
+  --> $DIR/ub-ref-ptr.rs:59:1
    |
 LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0xd[noalloc], but expected a function pointer
@@ -138,7 +138,7 @@ LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:59:1
+  --> $DIR/ub-ref-ptr.rs:61:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered ALLOC2<imm>, but expected a function pointer
@@ -149,7 +149,7 @@ LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-ref-ptr.rs:66:5
+  --> $DIR/ub-ref-ptr.rs:68:5
    |
 LL |     ptr.read();
    |     ^^^^^^^^^^ accessing memory based on pointer with alignment 1, but alignment 4 is required

--- a/tests/ui/consts/const-eval/ub-uninhabit.rs
+++ b/tests/ui/consts/const-eval/ub-uninhabit.rs
@@ -1,6 +1,8 @@
 // Strip out raw byte dumps to make comparison platform-independent:
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ dont-require-annotations: NOTE
+
 #![feature(core_intrinsics)]
 #![feature(never_type)]
 
@@ -18,15 +20,15 @@ union MaybeUninit<T: Copy> {
 
 const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
 //~^ ERROR evaluation of constant value failed
-//~| constructing invalid value
+//~| NOTE constructing invalid value
 
 const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
 //~^ ERROR it is undefined behavior to use this value
-//~| constructing invalid value
+//~| NOTE constructing invalid value
 
 const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };
 //~^ ERROR evaluation of constant value failed
-//~| constructing invalid value
+//~| NOTE constructing invalid value
 
 
 const READ_NEVER: () = unsafe {
@@ -34,7 +36,7 @@ const READ_NEVER: () = unsafe {
     let ptr = mem.as_ptr().cast::<!>();
     let _val = intrinsics::read_via_copy(ptr);
     //~^ ERROR evaluation of constant value failed
-    //~| constructing invalid value
+    //~| NOTE constructing invalid value
 };
 
 

--- a/tests/ui/consts/const-eval/ub-uninhabit.stderr
+++ b/tests/ui/consts/const-eval/ub-uninhabit.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-uninhabit.rs:19:35
+  --> $DIR/ub-uninhabit.rs:21:35
    |
 LL | const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a value of uninhabited type `Bar`
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:23:1
+  --> $DIR/ub-uninhabit.rs:25:1
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a reference pointing to uninhabited type Bar
@@ -16,13 +16,13 @@ LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-uninhabit.rs:27:42
+  --> $DIR/ub-uninhabit.rs:29:42
    |
 LL | const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at [0]: encountered a value of uninhabited type `Bar`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-uninhabit.rs:35:16
+  --> $DIR/ub-uninhabit.rs:37:16
    |
 LL |     let _val = intrinsics::read_via_copy(ptr);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a value of the never type `!`

--- a/tests/ui/consts/const-eval/ub-wide-ptr.rs
+++ b/tests/ui/consts/const-eval/ub-wide-ptr.rs
@@ -9,7 +9,7 @@ use std::{ptr, mem};
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
 //@ normalize-stderr: "offset \d+" -> "offset N"
 //@ normalize-stderr: "size \d+" -> "size N"
-
+//@ dont-require-annotations: NOTE
 
 /// A newtype wrapper to prevent MIR generation from inserting reborrows that would affect the error
 /// message.
@@ -62,7 +62,7 @@ const SLICE_VALID: &[u8] = unsafe { mem::transmute((&42u8, 1usize)) };
 // bad slice: length uninit
 const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
 //~^ ERROR evaluation of constant value failed
-//~| uninitialized
+//~| NOTE uninitialized
     let uninit_len = MaybeUninit::<usize> { uninit: () };
     mem::transmute((42, uninit_len))
 };
@@ -85,18 +85,18 @@ const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)) };
 // bad data *inside* the slice
 const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
 //~^ ERROR it is undefined behavior to use this value
-//~| constant
+//~| NOTE constant
 
 // good MySliceBool
 const MYSLICE_GOOD: &MySliceBool = &MySlice(true, [false]);
 // bad: sized field is not okay
 const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
 //~^ ERROR it is undefined behavior to use this value
-//~| constant
+//~| NOTE constant
 // bad: unsized part is not okay
 const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
 //~^ ERROR it is undefined behavior to use this value
-//~| constant
+//~| NOTE constant
 
 // # raw slice
 const RAW_SLICE_VALID: *const [u8] = unsafe { mem::transmute((&42u8, 1usize)) }; // ok
@@ -104,7 +104,7 @@ const RAW_SLICE_TOO_LONG: *const [u8] = unsafe { mem::transmute((&42u8, 999usize
 const RAW_SLICE_MUCH_TOO_LONG: *const [u8] = unsafe { mem::transmute((&42u8, usize::MAX)) }; // ok because raw
 const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
 //~^ ERROR evaluation of constant value failed
-//~| uninitialized
+//~| NOTE uninitialized
     let uninit_len = MaybeUninit::<usize> { uninit: () };
     mem::transmute((42, uninit_len))
 };
@@ -113,40 +113,40 @@ const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
 // bad trait object
 const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
 //~^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 // bad trait object
 const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
 //~^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 // bad trait object
 const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
 //~^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92u8, &[0u8; 128])) };
 //~^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
 //~^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
 //~^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
 //~^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 
 // bad data *inside* the trait object
 const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
 //~^ ERROR it is undefined behavior to use this value
-//~| expected a boolean
+//~| NOTE expected a boolean
 
 // # raw trait object
 const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
 //~^ ERROR it is undefined behavior to use this value
-//~| null pointer
+//~| NOTE null pointer
 const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
 //~^ ERROR it is undefined behavior to use this value
-//~| vtable
+//~| NOTE vtable
 const RAW_TRAIT_OBJ_CONTENT_INVALID: *const dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) } as *const dyn Trait; // ok because raw
 // Officially blessed way to get the vtable
 const DYN_METADATA: ptr::DynMetadata<dyn Send> = ptr::metadata::<dyn Send>(ptr::null::<i32>());
@@ -155,12 +155,12 @@ const DYN_METADATA: ptr::DynMetadata<dyn Send> = ptr::metadata::<dyn Send>(ptr::
 static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe {
     mem::transmute::<_, &dyn Trait>((&92u8, 0usize))
     //~^^ ERROR it is undefined behavior to use this value
-    //~| null pointer
+    //~| NOTE null pointer
 };
 static mut RAW_TRAIT_OBJ_VTABLE_INVALID_THROUGH_REF: *const dyn Trait = unsafe {
     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
     //~^^ ERROR it is undefined behavior to use this value
-    //~| vtable
+    //~| NOTE vtable
 };
 
 fn main() {}

--- a/tests/ui/consts/const-eval/union-const-eval-field.rs
+++ b/tests/ui/consts/const-eval/union-const-eval-field.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 type Field1 = i32;
 type Field2 = f32;
 type Field3 = i64;
@@ -25,7 +27,7 @@ const fn read_field2() -> Field2 {
 const fn read_field3() -> Field3 {
     const FIELD3: Field3 = unsafe { UNION.field3 };
     //~^ ERROR evaluation of constant value failed
-    //~| uninitialized
+    //~| NOTE uninitialized
     FIELD3
 }
 

--- a/tests/ui/consts/const-eval/union-const-eval-field.stderr
+++ b/tests/ui/consts/const-eval/union-const-eval-field.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/union-const-eval-field.rs:26:37
+  --> $DIR/union-const-eval-field.rs:28:37
    |
 LL |     const FIELD3: Field3 = unsafe { UNION.field3 };
    |                                     ^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory
 
 note: erroneous constant encountered
-  --> $DIR/union-const-eval-field.rs:29:5
+  --> $DIR/union-const-eval-field.rs:31:5
    |
 LL |     FIELD3
    |     ^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/union-const-eval-field.rs:29:5
+  --> $DIR/union-const-eval-field.rs:31:5
    |
 LL |     FIELD3
    |     ^^^^^^

--- a/tests/ui/consts/const-eval/union-ub.32bit.stderr
+++ b/tests/ui/consts/const-eval/union-ub.32bit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub.rs:32:1
+  --> $DIR/union-ub.rs:33:1
    |
 LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool};
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0x2a, but expected a boolean
@@ -10,7 +10,7 @@ LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool};
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/union-ub.rs:34:36
+  --> $DIR/union-ub.rs:35:36
    |
 LL | const UNINIT_BOOL: bool = unsafe { DummyUnion { unit: () }.bool};
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory

--- a/tests/ui/consts/const-eval/union-ub.64bit.stderr
+++ b/tests/ui/consts/const-eval/union-ub.64bit.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub.rs:32:1
+  --> $DIR/union-ub.rs:33:1
    |
 LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool};
    | ^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered 0x2a, but expected a boolean
@@ -10,7 +10,7 @@ LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool};
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/union-ub.rs:34:36
+  --> $DIR/union-ub.rs:35:36
    |
 LL | const UNINIT_BOOL: bool = unsafe { DummyUnion { unit: () }.bool};
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ using uninitialized data, but this operation requires initialized memory

--- a/tests/ui/consts/const-eval/union-ub.rs
+++ b/tests/ui/consts/const-eval/union-ub.rs
@@ -1,4 +1,5 @@
 //@ stderr-per-bitwidth
+//@ dont-require-annotations: NOTE
 
 #[repr(C)]
 union DummyUnion {
@@ -33,7 +34,7 @@ const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool};
 //~^ ERROR it is undefined behavior to use this value
 const UNINIT_BOOL: bool = unsafe { DummyUnion { unit: () }.bool};
 //~^ ERROR evaluation of constant value failed
-//~| uninitialized
+//~| NOTE uninitialized
 
 // The value is not valid for any union variant, but that's fine
 // unions are just a convenient way to transmute bits around

--- a/tests/ui/consts/const-eval/unwind-abort.rs
+++ b/tests/ui/consts/const-eval/unwind-abort.rs
@@ -1,5 +1,7 @@
+//@ dont-require-annotations: NOTE
+
 const extern "C" fn foo() {
-    panic!() //~ inside `foo`
+    panic!() //~ NOTE inside `foo`
 }
 
 const _: () = foo(); //~ ERROR evaluation of constant value failed

--- a/tests/ui/consts/const-eval/unwind-abort.stderr
+++ b/tests/ui/consts/const-eval/unwind-abort.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/unwind-abort.rs:5:15
+  --> $DIR/unwind-abort.rs:7:15
    |
 LL | const _: () = foo();
    |               ^^^^^ evaluation panicked: explicit panic
    |
 note: inside `foo`
-  --> $DIR/unwind-abort.rs:2:5
+  --> $DIR/unwind-abort.rs:4:5
    |
 LL |     panic!()
    |     ^^^^^^^^ the failure occurred here

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -1,5 +1,7 @@
+//@ dont-require-annotations: NOTE
+
 const fn foo() -> ! {
-    unsafe { std::mem::transmute(()) } //~ inside `foo`
+    unsafe { std::mem::transmute(()) } //~ NOTE inside `foo`
 }
 
 // Type defined in a submodule, so that it is not "visibly"

--- a/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/tests/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/validate_uninhabited_zsts.rs:15:33
+  --> $DIR/validate_uninhabited_zsts.rs:17:33
    |
 LL | const FOO: [empty::Empty; 3] = [foo(); 3];
    |                                 ^^^^^ constructing invalid value: encountered a value of the never type `!`
    |
 note: inside `foo`
-  --> $DIR/validate_uninhabited_zsts.rs:2:14
+  --> $DIR/validate_uninhabited_zsts.rs:4:14
    |
 LL |     unsafe { std::mem::transmute(()) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/validate_uninhabited_zsts.rs:18:42
+  --> $DIR/validate_uninhabited_zsts.rs:20:42
    |
 LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .0: encountered a value of uninhabited type `Void`

--- a/tests/ui/consts/const-len-underflow-separate-spans.next.stderr
+++ b/tests/ui/consts/const-len-underflow-separate-spans.next.stderr
@@ -5,7 +5,7 @@ LL | const LEN: usize = ONE - TWO;
    |                    ^^^^^^^^^ attempt to compute `1_usize - 2_usize`, which would overflow
 
 note: erroneous constant encountered
-  --> $DIR/const-len-underflow-separate-spans.rs:14:17
+  --> $DIR/const-len-underflow-separate-spans.rs:15:17
    |
 LL |     let a: [i8; LEN] = unimplemented!();
    |                 ^^^

--- a/tests/ui/consts/const-len-underflow-separate-spans.old.stderr
+++ b/tests/ui/consts/const-len-underflow-separate-spans.old.stderr
@@ -5,7 +5,7 @@ LL | const LEN: usize = ONE - TWO;
    |                    ^^^^^^^^^ attempt to compute `1_usize - 2_usize`, which would overflow
 
 note: erroneous constant encountered
-  --> $DIR/const-len-underflow-separate-spans.rs:14:17
+  --> $DIR/const-len-underflow-separate-spans.rs:15:17
    |
 LL |     let a: [i8; LEN] = unimplemented!();
    |                 ^^^

--- a/tests/ui/consts/const-len-underflow-separate-spans.rs
+++ b/tests/ui/consts/const-len-underflow-separate-spans.rs
@@ -9,8 +9,9 @@ const ONE: usize = 1;
 const TWO: usize = 2;
 const LEN: usize = ONE - TWO;
 //~^ ERROR constant
+//~| NOTE attempt to compute `1_usize - 2_usize`, which would overflow
 
 fn main() {
     let a: [i8; LEN] = unimplemented!();
-//~^ constant
+//~^ NOTE constant
 }

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.rs
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.rs
@@ -1,6 +1,7 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "( 0x[0-9a-f][0-9a-f] │)? ([0-9a-f][0-9a-f] |__ |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> " HEX_DUMP"
 //@ normalize-stderr: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+//@ dont-require-annotations: NOTE
 
 use std::cell::UnsafeCell;
 use std::mem;
@@ -25,7 +26,7 @@ const B4: Option<&mut i32> = helper(&mut 42); //~ ERROR temporary value dropped 
 // Not ok, since it points to read-only memory.
 const IMMUT_MUT_REF: &mut u16 = unsafe { mem::transmute(&13) };
 //~^ ERROR undefined behavior to use this value
-//~| pointing to read-only memory
+//~| NOTE pointing to read-only memory
 
 // Ok, because no references to mutable data exist here, since the `{}` moves
 // its value and then takes a reference to that.

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final.stderr
@@ -1,11 +1,11 @@
 error[E0764]: mutable references are not allowed in the final value of constants
-  --> $DIR/mut_ref_in_final.rs:14:21
+  --> $DIR/mut_ref_in_final.rs:15:21
    |
 LL | const B: *mut i32 = &mut 4;
    |                     ^^^^^^
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:20:40
+  --> $DIR/mut_ref_in_final.rs:21:40
    |
 LL | const B3: Option<&mut i32> = Some(&mut 42);
    |                              ----------^^-
@@ -15,7 +15,7 @@ LL | const B3: Option<&mut i32> = Some(&mut 42);
    |                              using this value as a constant requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:23:42
+  --> $DIR/mut_ref_in_final.rs:24:42
    |
 LL | const B4: Option<&mut i32> = helper(&mut 42);
    |                              ------------^^-
@@ -25,7 +25,7 @@ LL | const B4: Option<&mut i32> = helper(&mut 42);
    |                              using this value as a constant requires that borrow lasts for `'static`
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mut_ref_in_final.rs:26:1
+  --> $DIR/mut_ref_in_final.rs:27:1
    |
 LL | const IMMUT_MUT_REF: &mut u16 = unsafe { mem::transmute(&13) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
@@ -36,7 +36,7 @@ LL | const IMMUT_MUT_REF: &mut u16 = unsafe { mem::transmute(&13) };
            }
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:50:65
+  --> $DIR/mut_ref_in_final.rs:51:65
    |
 LL | const FOO: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                  -------------------------------^^--
@@ -46,7 +46,7 @@ LL | const FOO: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                  using this value as a constant requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:53:67
+  --> $DIR/mut_ref_in_final.rs:54:67
    |
 LL | static FOO2: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                    -------------------------------^^--
@@ -56,7 +56,7 @@ LL | static FOO2: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                    using this value as a static requires that borrow lasts for `'static`
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/mut_ref_in_final.rs:56:71
+  --> $DIR/mut_ref_in_final.rs:57:71
    |
 LL | static mut FOO3: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                        -------------------------------^^--
@@ -66,25 +66,25 @@ LL | static mut FOO3: NotAMutex<&mut i32> = NotAMutex(UnsafeCell::new(&mut 42));
    |                                        using this value as a static requires that borrow lasts for `'static`
 
 error[E0764]: mutable references are not allowed in the final value of statics
-  --> $DIR/mut_ref_in_final.rs:69:53
+  --> $DIR/mut_ref_in_final.rs:70:53
    |
 LL | static RAW_MUT_CAST_S: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                     ^^^^^^^
 
 error[E0764]: mutable references are not allowed in the final value of statics
-  --> $DIR/mut_ref_in_final.rs:71:54
+  --> $DIR/mut_ref_in_final.rs:72:54
    |
 LL | static RAW_MUT_COERCE_S: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                      ^^^^^^
 
 error[E0764]: mutable references are not allowed in the final value of constants
-  --> $DIR/mut_ref_in_final.rs:73:52
+  --> $DIR/mut_ref_in_final.rs:74:52
    |
 LL | const RAW_MUT_CAST_C: SyncPtr<i32> = SyncPtr { x : &mut 42 as *mut _ as *const _ };
    |                                                    ^^^^^^^
 
 error[E0764]: mutable references are not allowed in the final value of constants
-  --> $DIR/mut_ref_in_final.rs:75:53
+  --> $DIR/mut_ref_in_final.rs:76:53
    |
 LL | const RAW_MUT_COERCE_C: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                     ^^^^^^

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.rs
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.rs
@@ -1,6 +1,7 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "( 0x[0-9a-f][0-9a-f] │)? ([0-9a-f][0-9a-f] |__ |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> " HEX_DUMP"
 //@ normalize-stderr: "HEX_DUMP\s*\n\s*HEX_DUMP" -> "HEX_DUMP"
+//@ dont-require-annotations: NOTE
 
 use std::sync::Mutex;
 
@@ -16,16 +17,16 @@ const fn helper() -> Option<&'static mut i32> { unsafe {
     Some(&mut *std::ptr::addr_of_mut!(BUFFER))
 } }
 const MUT: Option<&mut i32> = helper(); //~ ERROR it is undefined behavior to use this value
-//~^ encountered reference to mutable
+//~^ NOTE encountered reference to mutable
 
 const fn helper_int2ptr() -> Option<&'static mut i32> { unsafe {
     // Undefined behaviour (integer as pointer), who doesn't love tests like this.
     Some(&mut *(42 as *mut i32))
 } }
 const INT2PTR: Option<&mut i32> = helper_int2ptr(); //~ ERROR it is undefined behavior to use this value
-//~^  encountered a dangling reference
+//~^ NOTE encountered a dangling reference
 static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr(); //~ ERROR it is undefined behavior to use this value
-//~^  encountered a dangling reference
+//~^ NOTE encountered a dangling reference
 
 const fn helper_dangling() -> Option<&'static mut i32> { unsafe {
     // Undefined behaviour (dangling pointer), who doesn't love tests like this.

--- a/tests/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.stderr
+++ b/tests/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mut_ref_in_final_dynamic_check.rs:18:1
+  --> $DIR/mut_ref_in_final_dynamic_check.rs:19:1
    |
 LL | const MUT: Option<&mut i32> = helper();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-variant(Some)>.0: encountered reference to mutable memory in `const`
@@ -10,7 +10,7 @@ LL | const MUT: Option<&mut i32> = helper();
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mut_ref_in_final_dynamic_check.rs:25:1
+  --> $DIR/mut_ref_in_final_dynamic_check.rs:26:1
    |
 LL | const INT2PTR: Option<&mut i32> = helper_int2ptr();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-variant(Some)>.0: encountered a dangling reference (0x2a[noalloc] has no provenance)
@@ -21,7 +21,7 @@ LL | const INT2PTR: Option<&mut i32> = helper_int2ptr();
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mut_ref_in_final_dynamic_check.rs:27:1
+  --> $DIR/mut_ref_in_final_dynamic_check.rs:28:1
    |
 LL | static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-variant(Some)>.0: encountered a dangling reference (0x2a[noalloc] has no provenance)
@@ -32,7 +32,7 @@ LL | static INT2PTR_STATIC: Option<&mut i32> = helper_int2ptr();
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mut_ref_in_final_dynamic_check.rs:34:1
+  --> $DIR/mut_ref_in_final_dynamic_check.rs:35:1
    |
 LL | const DANGLING: Option<&mut i32> = helper_dangling();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-variant(Some)>.0: encountered a dangling reference (use-after-free)
@@ -43,7 +43,7 @@ LL | const DANGLING: Option<&mut i32> = helper_dangling();
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mut_ref_in_final_dynamic_check.rs:35:1
+  --> $DIR/mut_ref_in_final_dynamic_check.rs:36:1
    |
 LL | static DANGLING_STATIC: Option<&mut i32> = helper_dangling();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<enum-variant(Some)>.0: encountered a dangling reference (use-after-free)

--- a/tests/ui/consts/const-pattern-irrefutable.rs
+++ b/tests/ui/consts/const-pattern-irrefutable.rs
@@ -1,15 +1,17 @@
+//@ dont-require-annotations: NOTE
+
 mod foo {
     pub const b: u8 = 2;
-    //~^ missing patterns are not covered because `b` is interpreted as a constant pattern, not a new variable
+    //~^ NOTE missing patterns are not covered because `b` is interpreted as a constant pattern, not a new variable
     pub const d: (u8, u8) = (2, 1);
-    //~^ missing patterns are not covered because `d` is interpreted as a constant pattern, not a new variable
+    //~^ NOTE missing patterns are not covered because `d` is interpreted as a constant pattern, not a new variable
 }
 
 use foo::b as c;
 use foo::d;
 
 const a: u8 = 2;
-//~^ missing patterns are not covered because `a` is interpreted as a constant pattern, not a new variable
+//~^ NOTE missing patterns are not covered because `a` is interpreted as a constant pattern, not a new variable
 
 #[derive(PartialEq)]
 struct S {
@@ -23,19 +25,19 @@ const e: S = S {
 fn main() {
     let a = 4;
     //~^ ERROR refutable pattern in local binding
-    //~| patterns `0_u8..=1_u8` and `3_u8..=u8::MAX` not covered
+    //~| NOTE patterns `0_u8..=1_u8` and `3_u8..=u8::MAX` not covered
     //~| HELP introduce a variable instead
     let c = 4;
     //~^ ERROR refutable pattern in local binding
-    //~| patterns `0_u8..=1_u8` and `3_u8..=u8::MAX` not covered
+    //~| NOTE patterns `0_u8..=1_u8` and `3_u8..=u8::MAX` not covered
     //~| HELP introduce a variable instead
     let d = (4, 4);
     //~^ ERROR refutable pattern in local binding
-    //~| patterns `(0_u8..=1_u8, _)` and `(3_u8..=u8::MAX, _)` not covered
+    //~| NOTE patterns `(0_u8..=1_u8, _)` and `(3_u8..=u8::MAX, _)` not covered
     //~| HELP introduce a variable instead
     let e = S {
     //~^ ERROR refutable pattern in local binding
-    //~| pattern `S { foo: 1_u8..=u8::MAX }` not covered
+    //~| NOTE pattern `S { foo: 1_u8..=u8::MAX }` not covered
     //~| HELP introduce a variable instead
         foo: 1,
     };

--- a/tests/ui/consts/const-pattern-irrefutable.stderr
+++ b/tests/ui/consts/const-pattern-irrefutable.stderr
@@ -1,5 +1,5 @@
 error[E0005]: refutable pattern in local binding
-  --> $DIR/const-pattern-irrefutable.rs:24:9
+  --> $DIR/const-pattern-irrefutable.rs:26:9
    |
 LL | const a: u8 = 2;
    | ----------- missing patterns are not covered because `a` is interpreted as a constant pattern, not a new variable
@@ -16,7 +16,7 @@ LL |     let a_var = 4;
    |          ++++
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/const-pattern-irrefutable.rs:28:9
+  --> $DIR/const-pattern-irrefutable.rs:30:9
    |
 LL |     pub const b: u8 = 2;
    |     --------------- missing patterns are not covered because `b` is interpreted as a constant pattern, not a new variable
@@ -34,7 +34,7 @@ LL +     let b_var = 4;
    |
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/const-pattern-irrefutable.rs:32:9
+  --> $DIR/const-pattern-irrefutable.rs:34:9
    |
 LL |     pub const d: (u8, u8) = (2, 1);
    |     --------------------- missing patterns are not covered because `d` is interpreted as a constant pattern, not a new variable
@@ -51,7 +51,7 @@ LL |     let d_var = (4, 4);
    |          ++++
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/const-pattern-irrefutable.rs:36:9
+  --> $DIR/const-pattern-irrefutable.rs:38:9
    |
 LL | const e: S = S {
    | ---------- missing patterns are not covered because `e` is interpreted as a constant pattern, not a new variable
@@ -62,7 +62,7 @@ LL |     let e = S {
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
 note: `S` defined here
-  --> $DIR/const-pattern-irrefutable.rs:15:8
+  --> $DIR/const-pattern-irrefutable.rs:17:8
    |
 LL | struct S {
    |        ^

--- a/tests/ui/consts/const-tup-index-span.rs
+++ b/tests/ui/consts/const-tup-index-span.rs
@@ -2,7 +2,8 @@
 
 const TUP: (usize,) = 5usize << 64;
 //~^ ERROR mismatched types
-//~| expected `(usize,)`, found `usize`
+//~| NOTE expected `(usize,)`, found `usize`
+//~| NOTE expected tuple `(usize,)`
 const ARR: [i32; TUP.0] = [];
 
 fn main() {

--- a/tests/ui/consts/const_refs_to_static_fail.rs
+++ b/tests/ui/consts/const_refs_to_static_fail.rs
@@ -1,5 +1,6 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ dont-require-annotations: NOTE
 
 #![feature(sync_unsafe_cell)]
 
@@ -9,14 +10,14 @@ static S: SyncUnsafeCell<i32> = SyncUnsafeCell::new(0);
 static mut S_MUT: i32 = 0;
 
 const C1: &SyncUnsafeCell<i32> = &S; //~ERROR undefined behavior
-//~| encountered reference to mutable memory
+//~| NOTE encountered reference to mutable memory
 const C1_READ: () = unsafe {
     assert!(*C1.get() == 0);
 };
 const C2: *const i32 = unsafe { std::ptr::addr_of!(S_MUT) };
 const C2_READ: () = unsafe {
     assert!(*C2 == 0); //~ERROR evaluation of constant value failed
-    //~^ constant accesses mutable global memory
+    //~^ NOTE constant accesses mutable global memory
 };
 
 fn main() {

--- a/tests/ui/consts/const_refs_to_static_fail.stderr
+++ b/tests/ui/consts/const_refs_to_static_fail.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refs_to_static_fail.rs:11:1
+  --> $DIR/const_refs_to_static_fail.rs:12:1
    |
 LL | const C1: &SyncUnsafeCell<i32> = &S;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`
@@ -10,13 +10,13 @@ LL | const C1: &SyncUnsafeCell<i32> = &S;
            }
 
 note: erroneous constant encountered
-  --> $DIR/const_refs_to_static_fail.rs:14:14
+  --> $DIR/const_refs_to_static_fail.rs:15:14
    |
 LL |     assert!(*C1.get() == 0);
    |              ^^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_refs_to_static_fail.rs:18:13
+  --> $DIR/const_refs_to_static_fail.rs:19:13
    |
 LL |     assert!(*C2 == 0);
    |             ^^^ constant accesses mutable global memory

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.rs
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.rs
@@ -1,5 +1,7 @@
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ dont-require-annotations: NOTE
+
 #![allow(static_mut_refs)]
 
 fn invalid() {
@@ -7,7 +9,7 @@ fn invalid() {
 
     const C: &bool = unsafe { std::mem::transmute(&S) };
     //~^ERROR: undefined behavior
-    //~| expected a boolean
+    //~| NOTE expected a boolean
 
     // This must be rejected here (or earlier), since it's not a valid `&bool`.
     match &true {
@@ -23,7 +25,7 @@ fn extern_() {
 
     const C: &i8 = unsafe { &S };
     //~^ERROR: undefined behavior
-    //~| `extern` static
+    //~| NOTE `extern` static
 
     // This must be rejected here (or earlier), since the pattern cannot be read.
     match &0 {
@@ -37,7 +39,7 @@ fn mutable() {
 
     const C: &i32 = unsafe { &S_MUT };
     //~^ERROR: undefined behavior
-    //~| encountered reference to mutable memory
+    //~| NOTE encountered reference to mutable memory
 
     // This *must not build*, the constant we are matching against
     // could change its value!

--- a/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
+++ b/tests/ui/consts/const_refs_to_static_fail_invalid.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refs_to_static_fail_invalid.rs:8:5
+  --> $DIR/const_refs_to_static_fail_invalid.rs:10:5
    |
 LL |     const C: &bool = unsafe { std::mem::transmute(&S) };
    |     ^^^^^^^^^^^^^^ constructing invalid value at .<deref>: encountered 0x0a, but expected a boolean
@@ -10,7 +10,7 @@ LL |     const C: &bool = unsafe { std::mem::transmute(&S) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refs_to_static_fail_invalid.rs:24:5
+  --> $DIR/const_refs_to_static_fail_invalid.rs:26:5
    |
 LL |     const C: &i8 = unsafe { &S };
    |     ^^^^^^^^^^^^ constructing invalid value: encountered reference to `extern` static in `const`
@@ -21,7 +21,7 @@ LL |     const C: &i8 = unsafe { &S };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refs_to_static_fail_invalid.rs:38:5
+  --> $DIR/const_refs_to_static_fail_invalid.rs:40:5
    |
 LL |     const C: &i32 = unsafe { &S_MUT };
    |     ^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`

--- a/tests/ui/consts/issue-17718-const-bad-values.rs
+++ b/tests/ui/consts/issue-17718-const-bad-values.rs
@@ -1,5 +1,6 @@
 //@ normalize-stderr: "\(size: \d+, align: \d+\)" -> "(size: $$PTR, align: $$PTR)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*A(LLOC)?[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ dont-require-annotations: NOTE
 
 #![allow(static_mut_refs)]
 
@@ -9,6 +10,6 @@ const C1: &'static mut [usize] = &mut [];
 static mut S: i32 = 3;
 const C2: &'static mut i32 = unsafe { &mut S };
 //~^ ERROR: it is undefined behavior to use this value
-//~| reference to mutable memory
+//~| NOTE reference to mutable memory
 
 fn main() {}

--- a/tests/ui/consts/issue-17718-const-bad-values.stderr
+++ b/tests/ui/consts/issue-17718-const-bad-values.stderr
@@ -1,11 +1,11 @@
 error[E0764]: mutable references are not allowed in the final value of constants
-  --> $DIR/issue-17718-const-bad-values.rs:6:34
+  --> $DIR/issue-17718-const-bad-values.rs:7:34
    |
 LL | const C1: &'static mut [usize] = &mut [];
    |                                  ^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/issue-17718-const-bad-values.rs:10:1
+  --> $DIR/issue-17718-const-bad-values.rs:11:1
    |
 LL | const C2: &'static mut i32 = unsafe { &mut S };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`

--- a/tests/ui/consts/issue-39974.rs
+++ b/tests/ui/consts/issue-39974.rs
@@ -1,10 +1,11 @@
 const LENGTH: f64 = 2;
 //~^ ERROR mismatched types
+//~| NOTE expected `f64`, found integer
 
 struct Thing {
     f: [[f64; 2]; LENGTH],
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `f64`
+    //~| NOTE expected `usize`, found `f64`
 }
 
 fn main() {

--- a/tests/ui/consts/issue-39974.stderr
+++ b/tests/ui/consts/issue-39974.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-39974.rs:5:19
+  --> $DIR/issue-39974.rs:6:19
    |
 LL |     f: [[f64; 2]; LENGTH],
    |                   ^^^^^^ expected `usize`, found `f64`

--- a/tests/ui/consts/miri_unleashed/assoc_const_2.rs
+++ b/tests/ui/consts/miri_unleashed/assoc_const_2.rs
@@ -1,4 +1,5 @@
 //@ build-fail
+//@ dont-require-annotations: NOTE
 
 // a test demonstrating that const qualification cannot prevent monomorphization time errors
 
@@ -24,5 +25,5 @@ impl Bar<String> for String {}
 fn main() {
     let x = <() as Bar<()>>::F;
     // this test only causes errors due to the line below, so post-monomorphization
-    let y = <String as Bar<String>>::F; //~ constant
+    let y = <String as Bar<String>>::F; //~ NOTE constant
 }

--- a/tests/ui/consts/miri_unleashed/assoc_const_2.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const_2.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of `<std::string::String as Bar<std::string::String>>::F` failed
-  --> $DIR/assoc_const_2.rs:10:20
+  --> $DIR/assoc_const_2.rs:11:20
    |
 LL |     const F: u32 = 100 / U::X;
    |                    ^^^^^^^^^^ attempt to divide `100_u32` by zero
 
 note: erroneous constant encountered
-  --> $DIR/assoc_const_2.rs:27:13
+  --> $DIR/assoc_const_2.rs:28:13
    |
 LL |     let y = <String as Bar<String>>::F;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: erroneous constant encountered
-  --> $DIR/assoc_const_2.rs:27:13
+  --> $DIR/assoc_const_2.rs:28:13
    |
 LL |     let y = <String as Bar<String>>::F;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static.rs
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Zunleash-the-miri-inside-of-you
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ dont-require-annotations: NOTE
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -20,7 +21,7 @@ const READ_MUT: u32 = unsafe { MUTABLE }; //~ERROR evaluation of constant value 
 
 // Evaluating this does not read anything mutable, but validation does, so this should error.
 const REF_INTERIOR_MUT: &usize = { //~ ERROR undefined behavior
-    //~| encountered reference to mutable memory
+    //~| NOTE encountered reference to mutable memory
     static FOO: AtomicUsize = AtomicUsize::new(0);
     unsafe { &*(&FOO as *const _ as *const usize) }
 };

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -1,23 +1,23 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_refers_to_static.rs:10:5
+  --> $DIR/const_refers_to_static.rs:11:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calling non-const function `AtomicUsize::fetch_add`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_refers_to_static.rs:15:14
+  --> $DIR/const_refers_to_static.rs:16:14
    |
 LL |     unsafe { *(&FOO as *const _ as *const usize) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses mutable global memory
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_refers_to_static.rs:19:32
+  --> $DIR/const_refers_to_static.rs:20:32
    |
 LL | const READ_MUT: u32 = unsafe { MUTABLE };
    |                                ^^^^^^^ constant accesses mutable global memory
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static.rs:22:1
+  --> $DIR/const_refers_to_static.rs:23:1
    |
 LL | const REF_INTERIOR_MUT: &usize = {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`
@@ -30,7 +30,7 @@ LL | const REF_INTERIOR_MUT: &usize = {
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static.rs:10:5
+  --> $DIR/const_refers_to_static.rs:11:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -2,6 +2,8 @@
 //@ aux-build:static_cross_crate.rs
 //@ normalize-stderr: "(the raw bytes of the constant) \(size: [0-9]*, align: [0-9]*\)" -> "$1 (size: $$SIZE, align: $$ALIGN)"
 //@ normalize-stderr: "([0-9a-f][0-9a-f] |╾─*ALLOC[0-9]+(\+[a-z0-9]+)?(<imm>)?─*╼ )+ *│.*" -> "HEX_DUMP"
+//@ dont-require-annotations: NOTE
+
 #![feature(half_open_range_patterns_in_slices)]
 #![allow(static_mut_refs)]
 
@@ -10,25 +12,25 @@ extern crate static_cross_crate;
 // Sneaky: reference to a mutable static.
 // Allowing this would be a disaster for pattern matching, we could violate exhaustiveness checking!
 const SLICE_MUT: &[u8; 1] = { //~ ERROR undefined behavior
-    //~| encountered reference to mutable memory
+    //~| NOTE encountered reference to mutable memory
     unsafe { &static_cross_crate::ZERO }
 };
 
 const U8_MUT: &u8 = { //~ ERROR undefined behavior
-    //~| encountered reference to mutable memory
+    //~| NOTE encountered reference to mutable memory
     unsafe { &static_cross_crate::ZERO[0] }
 };
 
 // Also test indirection that reads from other static.
 const U8_MUT2: &u8 = { //~ ERROR undefined behavior
-    //~| encountered reference to mutable memory
+    //~| NOTE encountered reference to mutable memory
     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
 };
 const U8_MUT3: &u8 = {
     unsafe {
         match static_cross_crate::OPT_ZERO {
             //~^ ERROR evaluation of constant value failed
-            //~| constant accesses mutable global memory
+            //~| NOTE constant accesses mutable global memory
             Some(ref u) => u,
             None => panic!(),
         }

--- a/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:12:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:14:1
    |
 LL | const SLICE_MUT: &[u8; 1] = {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`
@@ -10,7 +10,7 @@ LL | const SLICE_MUT: &[u8; 1] = {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:17:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:19:1
    |
 LL | const U8_MUT: &u8 = {
    | ^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`
@@ -21,7 +21,7 @@ LL | const U8_MUT: &u8 = {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:23:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:25:1
    |
 LL | const U8_MUT2: &u8 = {
    | ^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`
@@ -32,7 +32,7 @@ LL | const U8_MUT2: &u8 = {
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const_refers_to_static_cross_crate.rs:29:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:31:15
    |
 LL |         match static_cross_crate::OPT_ZERO {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses mutable global memory

--- a/tests/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/tests/ui/consts/miri_unleashed/mutable_references.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:12:1
+  --> $DIR/mutable_references.rs:13:1
    |
 LL | static FOO: &&mut u32 = &&mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>: encountered mutable reference or box pointing to read-only memory
@@ -10,7 +10,7 @@ LL | static FOO: &&mut u32 = &&mut 42;
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:15:1
+  --> $DIR/mutable_references.rs:16:1
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
@@ -21,19 +21,19 @@ LL | static OH_YES: &mut i32 = &mut 42;
            }
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:18:1
+  --> $DIR/mutable_references.rs:19:1
    |
 LL | static BAR: &mut () = &mut ();
    | ^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of static
-  --> $DIR/mutable_references.rs:23:1
+  --> $DIR/mutable_references.rs:24:1
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:26:1
+  --> $DIR/mutable_references.rs:27:1
    |
 LL | const BLUNT: &mut i32 = &mut 42;
    | ^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
@@ -44,7 +44,7 @@ LL | const BLUNT: &mut i32 = &mut 42;
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:30:1
+  --> $DIR/mutable_references.rs:31:1
    |
 LL | const SUBTLE: &mut i32 = unsafe {
    | ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`
@@ -55,7 +55,7 @@ LL | const SUBTLE: &mut i32 = unsafe {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:43:1
+  --> $DIR/mutable_references.rs:44:1
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^ constructing invalid value at .x.<deref>: encountered `UnsafeCell` in read-only memory
@@ -66,7 +66,7 @@ LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:49:1
+  --> $DIR/mutable_references.rs:50:1
    |
 LL | const MUH: Meh = Meh {
    | ^^^^^^^^^^^^^^ constructing invalid value at .x.<deref>: encountered `UnsafeCell` in read-only memory
@@ -77,7 +77,7 @@ LL | const MUH: Meh = Meh {
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:61:1
+  --> $DIR/mutable_references.rs:62:1
    |
 LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>.<dyn-downcast>.x: encountered `UnsafeCell` in read-only memory
@@ -88,7 +88,7 @@ LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:68:1
+  --> $DIR/mutable_references.rs:69:1
    |
 LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const _ as *mut _) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered mutable reference or box pointing to read-only memory
@@ -99,7 +99,7 @@ LL | static mut MUT_TO_READONLY: &mut i32 = unsafe { &mut *(&READONLY as *const 
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/mutable_references.rs:75:1
+  --> $DIR/mutable_references.rs:76:1
    |
 LL | const POINTS_TO_MUTABLE: &i32 = unsafe { &MUTABLE };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered reference to mutable memory in `const`
@@ -110,37 +110,37 @@ LL | const POINTS_TO_MUTABLE: &i32 = unsafe { &MUTABLE };
            }
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/mutable_references.rs:78:43
+  --> $DIR/mutable_references.rs:79:43
    |
 LL | const POINTS_TO_MUTABLE2: &i32 = unsafe { &*MUTABLE_REF };
    |                                           ^^^^^^^^^^^^^ constant accesses mutable global memory
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references.rs:82:1
+  --> $DIR/mutable_references.rs:83:1
    |
 LL | const POINTS_TO_MUTABLE_INNER: *const i32 = &mut 42 as *mut _ as *const _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references.rs:85:1
+  --> $DIR/mutable_references.rs:86:1
    |
 LL | const POINTS_TO_MUTABLE_INNER2: *const i32 = &mut 42 as *const _;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references.rs:105:1
+  --> $DIR/mutable_references.rs:106:1
    |
 LL | const RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x: &mut 42 as *mut _ as *const _ };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered mutable pointer in final value of constant
-  --> $DIR/mutable_references.rs:108:1
+  --> $DIR/mutable_references.rs:109:1
    |
 LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0594]: cannot assign to `*OH_YES`, as `OH_YES` is an immutable static item
-  --> $DIR/mutable_references.rs:115:5
+  --> $DIR/mutable_references.rs:116:5
    |
 LL |     *OH_YES = 99;
    |     ^^^^^^^^^^^^ cannot assign
@@ -148,72 +148,72 @@ LL |     *OH_YES = 99;
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:12:26
+  --> $DIR/mutable_references.rs:13:26
    |
 LL | static FOO: &&mut u32 = &&mut 42;
    |                          ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:15:27
+  --> $DIR/mutable_references.rs:16:27
    |
 LL | static OH_YES: &mut i32 = &mut 42;
    |                           ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:18:23
+  --> $DIR/mutable_references.rs:19:23
    |
 LL | static BAR: &mut () = &mut ();
    |                       ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:23:28
+  --> $DIR/mutable_references.rs:24:28
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    |                            ^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:26:25
+  --> $DIR/mutable_references.rs:27:25
    |
 LL | const BLUNT: &mut i32 = &mut 42;
    |                         ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:43:28
+  --> $DIR/mutable_references.rs:44:28
    |
 LL | static MEH: Meh = Meh { x: &UnsafeCell::new(42) };
    |                            ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:52:8
+  --> $DIR/mutable_references.rs:53:8
    |
 LL |     x: &UnsafeCell::new(42),
    |        ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:61:27
+  --> $DIR/mutable_references.rs:62:27
    |
 LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:82:45
+  --> $DIR/mutable_references.rs:83:45
    |
 LL | const POINTS_TO_MUTABLE_INNER: *const i32 = &mut 42 as *mut _ as *const _;
    |                                             ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:85:46
+  --> $DIR/mutable_references.rs:86:46
    |
 LL | const POINTS_TO_MUTABLE_INNER2: *const i32 = &mut 42 as *const _;
    |                                              ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:90:47
+  --> $DIR/mutable_references.rs:91:47
    |
 LL | const INTERIOR_MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
    |                                               ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:102:51
+  --> $DIR/mutable_references.rs:103:51
    |
 LL | const RAW_SYNC: SyncPtr<AtomicI32> = SyncPtr { x: &AtomicI32::new(42) };
    |                                                   ^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:105:49
+  --> $DIR/mutable_references.rs:106:49
    |
 LL | const RAW_MUT_CAST: SyncPtr<i32> = SyncPtr { x: &mut 42 as *mut _ as *const _ };
    |                                                 ^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/mutable_references.rs:108:51
+  --> $DIR/mutable_references.rs:109:51
    |
 LL | const RAW_MUT_COERCE: SyncPtr<i32> = SyncPtr { x: &mut 0 };
    |                                                   ^^^^^^

--- a/tests/ui/consts/offset_from_ub.stderr
+++ b/tests/ui/consts/offset_from_ub.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:18:27
+  --> $DIR/offset_from_ub.rs:20:27
    |
 LL |     let offset = unsafe { ptr_offset_from(field_ptr, base_ptr) };
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:24:14
+  --> $DIR/offset_from_ub.rs:26:14
    |
 LL |     unsafe { (42 as *const u8).offset_from(&5u8) as usize }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
@@ -14,67 +14,67 @@ note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:31:14
+  --> $DIR/offset_from_ub.rs:33:14
    |
 LL |     unsafe { ptr_offset_from(field_ptr, base_ptr as *const u16) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ exact_div: 1_isize cannot be divided by 2_isize without remainder
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:38:14
+  --> $DIR/offset_from_ub.rs:40:14
    |
 LL |     unsafe { ptr_offset_from(ptr2, ptr1) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:47:14
+  --> $DIR/offset_from_ub.rs:49:14
    |
 LL |     unsafe { ptr_offset_from(end_ptr, start_ptr) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers where the memory range between them is not in-bounds of an allocation
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:56:14
+  --> $DIR/offset_from_ub.rs:58:14
    |
 LL |     unsafe { ptr_offset_from(start_ptr, end_ptr) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers where the memory range between them is not in-bounds of an allocation
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:65:14
+  --> $DIR/offset_from_ub.rs:67:14
    |
 LL |     unsafe { ptr_offset_from_unsigned(field_ptr, base_ptr) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called on two different pointers that are not both derived from the same allocation
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:72:14
+  --> $DIR/offset_from_ub.rs:74:14
    |
 LL |     unsafe { ptr_offset_from(ptr2, ptr1) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called when first pointer is too far ahead of second
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:78:14
+  --> $DIR/offset_from_ub.rs:80:14
    |
 LL |     unsafe { ptr_offset_from(ptr1, ptr2) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called when first pointer is too far before second
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:86:14
+  --> $DIR/offset_from_ub.rs:88:14
    |
 LL |     unsafe { ptr_offset_from(ptr1, ptr2) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called when first pointer is too far before second
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:93:14
+  --> $DIR/offset_from_ub.rs:95:14
    |
 LL |     unsafe { ptr_offset_from_unsigned(p, p.add(2) ) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called when first pointer has smaller offset than second: 0 < 8
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:100:14
+  --> $DIR/offset_from_ub.rs:102:14
    |
 LL |     unsafe { ptr_offset_from_unsigned(ptr2, ptr1) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from_unsigned` called when first pointer is too far ahead of second
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:109:14
+  --> $DIR/offset_from_ub.rs:111:14
    |
 LL |     unsafe { ptr2.offset_from(ptr1) }
    |              ^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called on two different pointers that are not both derived from the same allocation
@@ -83,7 +83,7 @@ note: inside `std::ptr::const_ptr::<impl *const u8>::offset_from`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/offset_from_ub.rs:115:14
+  --> $DIR/offset_from_ub.rs:117:14
    |
 LL |     unsafe { ptr1.offset_from(ptr2.wrapping_offset(1)) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ptr_offset_from` called when first pointer is too far before second

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.noopt.stderr
@@ -5,7 +5,7 @@ LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
 
 note: erroneous constant encountered
-  --> $DIR/interpret-in-const-called-fn.rs:17:9
+  --> $DIR/interpret-in-const-called-fn.rs:18:9
    |
 LL |         Fail::<T>::C;
    |         ^^^^^^^^^^^^

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.opt.stderr
@@ -5,7 +5,7 @@ LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
 
 note: erroneous constant encountered
-  --> $DIR/interpret-in-const-called-fn.rs:17:9
+  --> $DIR/interpret-in-const-called-fn.rs:18:9
    |
 LL |         Fail::<T>::C;
    |         ^^^^^^^^^^^^

--- a/tests/ui/consts/required-consts/interpret-in-const-called-fn.rs
+++ b/tests/ui/consts/required-consts/interpret-in-const-called-fn.rs
@@ -6,6 +6,7 @@
 struct Fail<T>(T);
 impl<T> Fail<T> {
     const C: () = panic!(); //~ERROR evaluation of `Fail::<i32>::C` failed
+                            //~| NOTE in this expansion of panic!
 }
 
 #[inline(never)]
@@ -14,7 +15,7 @@ const fn no_codegen<T>() {
         // This bad constant is only used in dead code in a no-codegen function... and yet we still
         // must make sure that the build fails.
         // This relies on const-eval evaluating all `required_consts` of `const fn`.
-        Fail::<T>::C; //~ constant
+        Fail::<T>::C; //~ NOTE constant
     }
 }
 

--- a/tests/ui/consts/required-consts/interpret-in-promoted.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.noopt.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/interpret-in-promoted.rs:13:28
+  --> $DIR/interpret-in-promoted.rs:15:28
    |
 LL |     let _x: &'static () = &ub();
    |                            ^^^^ entering unreachable code
    |
 note: inside `ub`
-  --> $DIR/interpret-in-promoted.rs:7:5
+  --> $DIR/interpret-in-promoted.rs:9:5
    |
 LL |     std::hint::unreachable_unchecked();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ note: inside `unreachable_unchecked`
   --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 note: erroneous constant encountered
-  --> $DIR/interpret-in-promoted.rs:13:27
+  --> $DIR/interpret-in-promoted.rs:15:27
    |
 LL |     let _x: &'static () = &ub();
    |                           ^^^^^

--- a/tests/ui/consts/required-consts/interpret-in-promoted.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.opt.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/interpret-in-promoted.rs:13:28
+  --> $DIR/interpret-in-promoted.rs:15:28
    |
 LL |     let _x: &'static () = &ub();
    |                            ^^^^ entering unreachable code
    |
 note: inside `ub`
-  --> $DIR/interpret-in-promoted.rs:7:5
+  --> $DIR/interpret-in-promoted.rs:9:5
    |
 LL |     std::hint::unreachable_unchecked();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ note: inside `unreachable_unchecked`
   --> $SRC_DIR/core/src/hint.rs:LL:COL
 
 note: erroneous constant encountered
-  --> $DIR/interpret-in-promoted.rs:13:27
+  --> $DIR/interpret-in-promoted.rs:15:27
    |
 LL |     let _x: &'static () = &ub();
    |                           ^^^^^

--- a/tests/ui/consts/required-consts/interpret-in-promoted.rs
+++ b/tests/ui/consts/required-consts/interpret-in-promoted.rs
@@ -1,10 +1,12 @@
 //@revisions: noopt opt
 //@[noopt] compile-flags: -Copt-level=0
 //@[opt] compile-flags: -O
+//@ dont-require-annotations: NOTE
+
 //! Make sure we evaluate const fn calls even if they get promoted and their result ignored.
 
 const unsafe fn ub() {
-    std::hint::unreachable_unchecked(); //~ inside `ub`
+    std::hint::unreachable_unchecked(); //~ NOTE inside `ub`
 }
 
 pub const FOO: () = unsafe {

--- a/tests/ui/consts/required-consts/interpret-in-static.noopt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-static.noopt.stderr
@@ -5,7 +5,7 @@ LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
 
 note: erroneous constant encountered
-  --> $DIR/interpret-in-static.rs:16:9
+  --> $DIR/interpret-in-static.rs:17:9
    |
 LL |         Fail::<i32>::C;
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/consts/required-consts/interpret-in-static.opt.stderr
+++ b/tests/ui/consts/required-consts/interpret-in-static.opt.stderr
@@ -5,7 +5,7 @@ LL |     const C: () = panic!();
    |                   ^^^^^^^^ evaluation panicked: explicit panic
 
 note: erroneous constant encountered
-  --> $DIR/interpret-in-static.rs:16:9
+  --> $DIR/interpret-in-static.rs:17:9
    |
 LL |         Fail::<i32>::C;
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/consts/required-consts/interpret-in-static.rs
+++ b/tests/ui/consts/required-consts/interpret-in-static.rs
@@ -6,6 +6,7 @@
 struct Fail<T>(T);
 impl<T> Fail<T> {
     const C: () = panic!(); //~ERROR evaluation of `Fail::<i32>::C` failed
+                            //~| NOTE in this expansion of panic!
 }
 
 pub static FOO: () = {
@@ -13,7 +14,7 @@ pub static FOO: () = {
         // This bad constant is only used in dead code in a static initializer... and yet we still
         // must make sure that the build fails.
         // This relies on const-eval evaluating all `required_consts` of the `static` MIR body.
-        Fail::<i32>::C; //~ constant
+        Fail::<i32>::C; //~ NOTE constant
     }
 };
 

--- a/tests/ui/consts/uninhabited-const-issue-61744.rs
+++ b/tests/ui/consts/uninhabited-const-issue-61744.rs
@@ -1,11 +1,12 @@
 //@ build-fail
+//@ dont-require-annotations: NOTE
 
 pub const unsafe fn fake_type<T>() -> T {
-    hint_unreachable() //~ inside
+    hint_unreachable() //~ NOTE inside
 }
 
 pub const unsafe fn hint_unreachable() -> ! {
-    fake_type() //~ inside
+    fake_type() //~ NOTE inside
 }
 
 trait Const {

--- a/tests/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/tests/ui/consts/uninhabited-const-issue-61744.stderr
@@ -1,641 +1,641 @@
 error[E0080]: evaluation of `fake_type::<!>` failed
-  --> $DIR/uninhabited-const-issue-61744.rs:12:36
+  --> $DIR/uninhabited-const-issue-61744.rs:13:36
    |
 LL |     const CONSTANT: i32 = unsafe { fake_type() };
    |                                    ^^^^^^^^^^^ reached the configured maximum number of stack frames
    |
 note: inside `fake_type::<i32>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^
 note: inside `hint_unreachable`
-  --> $DIR/uninhabited-const-issue-61744.rs:8:5
+  --> $DIR/uninhabited-const-issue-61744.rs:9:5
    |
 LL |     fake_type()
    |     ^^^^^^^^^^^
 note: inside `fake_type::<!>`
-  --> $DIR/uninhabited-const-issue-61744.rs:4:5
+  --> $DIR/uninhabited-const-issue-61744.rs:5:5
    |
 LL |     hint_unreachable()
    |     ^^^^^^^^^^^^^^^^^^ the failure occurred here

--- a/tests/ui/coroutine/drop-tracking-parent-expression.rs
+++ b/tests/ui/coroutine/drop-tracking-parent-expression.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 #![feature(coroutines, negative_impls, rustc_attrs, stmt_expr_attributes)]
 
 macro_rules! type_combinations {
@@ -15,9 +17,9 @@ macro_rules! type_combinations {
         // dropped *after* the yield.
         {
             let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
-            //~^ `significant_drop::Client` which is not `Send`
-            //~| `insignificant_dtor::Client` which is not `Send`
-            //~| `derived_drop::Client` which is not `Send`
+            //~^ NOTE `significant_drop::Client` which is not `Send`
+            //~| NOTE `insignificant_dtor::Client` which is not `Send`
+            //~| NOTE `derived_drop::Client` which is not `Send`
                 _ => yield,
             };
             assert_send(g);

--- a/tests/ui/coroutine/drop-tracking-parent-expression.stderr
+++ b/tests/ui/coroutine/drop-tracking-parent-expression.stderr
@@ -1,5 +1,5 @@
 error: coroutine cannot be sent between threads safely
-  --> $DIR/drop-tracking-parent-expression.rs:23:13
+  --> $DIR/drop-tracking-parent-expression.rs:25:13
    |
 LL |               assert_send(g);
    |               ^^^^^^^^^^^^^^ coroutine is not `Send`
@@ -12,9 +12,9 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `derived_drop::Client`
+   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `derived_drop::Client`
 note: coroutine is not `Send` as this value is used across a yield
-  --> $DIR/drop-tracking-parent-expression.rs:21:22
+  --> $DIR/drop-tracking-parent-expression.rs:23:22
    |
 LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
    |                                                                         ------------------------ has type `derived_drop::Client` which is not `Send`
@@ -30,14 +30,14 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
 note: required by a bound in `assert_send`
-  --> $DIR/drop-tracking-parent-expression.rs:40:19
+  --> $DIR/drop-tracking-parent-expression.rs:42:19
    |
 LL | fn assert_send<T: Send>(_thing: T) {}
    |                   ^^^^ required by this bound in `assert_send`
    = note: this error originates in the macro `type_combinations` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: coroutine cannot be sent between threads safely
-  --> $DIR/drop-tracking-parent-expression.rs:23:13
+  --> $DIR/drop-tracking-parent-expression.rs:25:13
    |
 LL |               assert_send(g);
    |               ^^^^^^^^^^^^^^ coroutine is not `Send`
@@ -50,9 +50,9 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `significant_drop::Client`
+   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `significant_drop::Client`
 note: coroutine is not `Send` as this value is used across a yield
-  --> $DIR/drop-tracking-parent-expression.rs:21:22
+  --> $DIR/drop-tracking-parent-expression.rs:23:22
    |
 LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
    |                                                                         ------------------------ has type `significant_drop::Client` which is not `Send`
@@ -68,14 +68,14 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
 note: required by a bound in `assert_send`
-  --> $DIR/drop-tracking-parent-expression.rs:40:19
+  --> $DIR/drop-tracking-parent-expression.rs:42:19
    |
 LL | fn assert_send<T: Send>(_thing: T) {}
    |                   ^^^^ required by this bound in `assert_send`
    = note: this error originates in the macro `type_combinations` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: coroutine cannot be sent between threads safely
-  --> $DIR/drop-tracking-parent-expression.rs:23:13
+  --> $DIR/drop-tracking-parent-expression.rs:25:13
    |
 LL |               assert_send(g);
    |               ^^^^^^^^^^^^^^ coroutine is not `Send`
@@ -88,9 +88,9 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `insignificant_dtor::Client`
+   = help: within `{coroutine@$DIR/drop-tracking-parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `insignificant_dtor::Client`
 note: coroutine is not `Send` as this value is used across a yield
-  --> $DIR/drop-tracking-parent-expression.rs:21:22
+  --> $DIR/drop-tracking-parent-expression.rs:23:22
    |
 LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
    |                                                                         ------------------------ has type `insignificant_dtor::Client` which is not `Send`
@@ -106,7 +106,7 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
 note: required by a bound in `assert_send`
-  --> $DIR/drop-tracking-parent-expression.rs:40:19
+  --> $DIR/drop-tracking-parent-expression.rs:42:19
    |
 LL | fn assert_send<T: Send>(_thing: T) {}
    |                   ^^^^ required by this bound in `assert_send`

--- a/tests/ui/coroutine/parent-expression.rs
+++ b/tests/ui/coroutine/parent-expression.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 #![feature(coroutines, negative_impls, rustc_attrs, stmt_expr_attributes)]
 
 macro_rules! type_combinations {
@@ -15,9 +17,9 @@ macro_rules! type_combinations {
         // dropped *after* the yield.
         {
             let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
-            //~^ `significant_drop::Client` which is not `Send`
-            //~| `insignificant_dtor::Client` which is not `Send`
-            //~| `derived_drop::Client` which is not `Send`
+            //~^ NOTE `significant_drop::Client` which is not `Send`
+            //~| NOTE `insignificant_dtor::Client` which is not `Send`
+            //~| NOTE `derived_drop::Client` which is not `Send`
                 _ => yield,
             };
             assert_send(g);

--- a/tests/ui/coroutine/parent-expression.stderr
+++ b/tests/ui/coroutine/parent-expression.stderr
@@ -1,5 +1,5 @@
 error: coroutine cannot be sent between threads safely
-  --> $DIR/parent-expression.rs:23:13
+  --> $DIR/parent-expression.rs:25:13
    |
 LL |               assert_send(g);
    |               ^^^^^^^^^^^^^^ coroutine is not `Send`
@@ -12,9 +12,9 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `derived_drop::Client`
+   = help: within `{coroutine@$DIR/parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `derived_drop::Client`
 note: coroutine is not `Send` as this value is used across a yield
-  --> $DIR/parent-expression.rs:21:22
+  --> $DIR/parent-expression.rs:23:22
    |
 LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
    |                                                                         ------------------------ has type `derived_drop::Client` which is not `Send`
@@ -30,14 +30,14 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
 note: required by a bound in `assert_send`
-  --> $DIR/parent-expression.rs:40:19
+  --> $DIR/parent-expression.rs:42:19
    |
 LL | fn assert_send<T: Send>(_thing: T) {}
    |                   ^^^^ required by this bound in `assert_send`
    = note: this error originates in the macro `type_combinations` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: coroutine cannot be sent between threads safely
-  --> $DIR/parent-expression.rs:23:13
+  --> $DIR/parent-expression.rs:25:13
    |
 LL |               assert_send(g);
    |               ^^^^^^^^^^^^^^ coroutine is not `Send`
@@ -50,9 +50,9 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `significant_drop::Client`
+   = help: within `{coroutine@$DIR/parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `significant_drop::Client`
 note: coroutine is not `Send` as this value is used across a yield
-  --> $DIR/parent-expression.rs:21:22
+  --> $DIR/parent-expression.rs:23:22
    |
 LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
    |                                                                         ------------------------ has type `significant_drop::Client` which is not `Send`
@@ -68,14 +68,14 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
 note: required by a bound in `assert_send`
-  --> $DIR/parent-expression.rs:40:19
+  --> $DIR/parent-expression.rs:42:19
    |
 LL | fn assert_send<T: Send>(_thing: T) {}
    |                   ^^^^ required by this bound in `assert_send`
    = note: this error originates in the macro `type_combinations` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: coroutine cannot be sent between threads safely
-  --> $DIR/parent-expression.rs:23:13
+  --> $DIR/parent-expression.rs:25:13
    |
 LL |               assert_send(g);
    |               ^^^^^^^^^^^^^^ coroutine is not `Send`
@@ -88,9 +88,9 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
    |
-   = help: within `{coroutine@$DIR/parent-expression.rs:17:34: 17:41}`, the trait `Send` is not implemented for `insignificant_dtor::Client`
+   = help: within `{coroutine@$DIR/parent-expression.rs:19:34: 19:41}`, the trait `Send` is not implemented for `insignificant_dtor::Client`
 note: coroutine is not `Send` as this value is used across a yield
-  --> $DIR/parent-expression.rs:21:22
+  --> $DIR/parent-expression.rs:23:22
    |
 LL |               let g = #[coroutine] move || match drop($name::Client { ..$name::Client::default() }) {
    |                                                                         ------------------------ has type `insignificant_dtor::Client` which is not `Send`
@@ -106,7 +106,7 @@ LL | |         };
 LL | |     );
    | |_____- in this macro invocation
 note: required by a bound in `assert_send`
-  --> $DIR/parent-expression.rs:40:19
+  --> $DIR/parent-expression.rs:42:19
    |
 LL | fn assert_send<T: Send>(_thing: T) {}
    |                   ^^^^ required by this bound in `assert_send`

--- a/tests/ui/coverage-attr/bad-attr-ice.rs
+++ b/tests/ui/coverage-attr/bad-attr-ice.rs
@@ -10,7 +10,7 @@
 
 #[coverage]
 //~^ ERROR malformed `coverage` attribute input
-//[nofeat]~| the `#[coverage]` attribute is an experimental feature
+//[nofeat]~| ERROR the `#[coverage]` attribute is an experimental feature
 fn main() {}
 
 // FIXME(#130766): When the `#[coverage(..)]` attribute is stabilized,

--- a/tests/ui/cross/cross-borrow-trait.rs
+++ b/tests/ui/cross/cross-borrow-trait.rs
@@ -1,6 +1,8 @@
 // Test that cross-borrowing (implicitly converting from `Box<T>` to `&T`) is
 // forbidden when `T` is a trait.
 
+//@ dont-require-annotations: NOTE
+
 struct Foo;
 trait Trait { fn foo(&self) {} }
 impl Trait for Foo {}
@@ -8,6 +10,6 @@ impl Trait for Foo {}
 pub fn main() {
     let x: Box<dyn Trait> = Box::new(Foo);
     let _y: &dyn Trait = x; //~ ERROR E0308
-                            //~| expected reference `&dyn Trait`
-                            //~| found struct `Box<dyn Trait>`
+                            //~| NOTE expected reference `&dyn Trait`
+                            //~| NOTE found struct `Box<dyn Trait>`
 }

--- a/tests/ui/cross/cross-borrow-trait.stderr
+++ b/tests/ui/cross/cross-borrow-trait.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/cross-borrow-trait.rs:10:26
+  --> $DIR/cross-borrow-trait.rs:12:26
    |
 LL |     let _y: &dyn Trait = x;
    |             ----------   ^ expected `&dyn Trait`, found `Box<dyn Trait>`

--- a/tests/ui/destructure-trait-ref.rs
+++ b/tests/ui/destructure-trait-ref.rs
@@ -1,6 +1,8 @@
 // The regression test for #15031 to make sure destructuring trait
 // reference work properly.
 
+//@ dont-require-annotations: NOTE
+
 #![feature(box_patterns)]
 
 trait T { fn foo(&self) {} }
@@ -31,14 +33,14 @@ fn main() {
     // n > m
     let &&x = &1isize as &dyn T;
     //~^ ERROR mismatched types
-    //~| expected trait object `dyn T`
-    //~| found reference `&_`
+    //~| NOTE expected trait object `dyn T`
+    //~| NOTE found reference `&_`
     let &&&x = &(&1isize as &dyn T);
     //~^ ERROR mismatched types
-    //~| expected trait object `dyn T`
-    //~| found reference `&_`
+    //~| NOTE expected trait object `dyn T`
+    //~| NOTE found reference `&_`
     let box box x = Box::new(1isize) as Box<dyn T>;
     //~^ ERROR mismatched types
-    //~| expected trait object `dyn T`
-    //~| found struct `Box<_>`
+    //~| NOTE expected trait object `dyn T`
+    //~| NOTE found struct `Box<_>`
 }

--- a/tests/ui/destructure-trait-ref.stderr
+++ b/tests/ui/destructure-trait-ref.stderr
@@ -1,23 +1,23 @@
 error[E0033]: type `&dyn T` cannot be dereferenced
-  --> $DIR/destructure-trait-ref.rs:26:9
+  --> $DIR/destructure-trait-ref.rs:28:9
    |
 LL |     let &x = &1isize as &dyn T;
    |         ^^ type `&dyn T` cannot be dereferenced
 
 error[E0033]: type `&dyn T` cannot be dereferenced
-  --> $DIR/destructure-trait-ref.rs:27:10
+  --> $DIR/destructure-trait-ref.rs:29:10
    |
 LL |     let &&x = &(&1isize as &dyn T);
    |          ^^ type `&dyn T` cannot be dereferenced
 
 error[E0033]: type `Box<dyn T>` cannot be dereferenced
-  --> $DIR/destructure-trait-ref.rs:28:9
+  --> $DIR/destructure-trait-ref.rs:30:9
    |
 LL |     let box x = Box::new(1isize) as Box<dyn T>;
    |         ^^^^^ type `Box<dyn T>` cannot be dereferenced
 
 error[E0308]: mismatched types
-  --> $DIR/destructure-trait-ref.rs:32:10
+  --> $DIR/destructure-trait-ref.rs:34:10
    |
 LL |     let &&x = &1isize as &dyn T;
    |          ^^   ----------------- this expression has type `&dyn T`
@@ -33,7 +33,7 @@ LL +     let &x = &1isize as &dyn T;
    |
 
 error[E0308]: mismatched types
-  --> $DIR/destructure-trait-ref.rs:36:11
+  --> $DIR/destructure-trait-ref.rs:38:11
    |
 LL |     let &&&x = &(&1isize as &dyn T);
    |           ^^   -------------------- this expression has type `&&dyn T`
@@ -49,7 +49,7 @@ LL +     let &&x = &(&1isize as &dyn T);
    |
 
 error[E0308]: mismatched types
-  --> $DIR/destructure-trait-ref.rs:40:13
+  --> $DIR/destructure-trait-ref.rs:42:13
    |
 LL |     let box box x = Box::new(1isize) as Box<dyn T>;
    |             ^^^^^   ------------------------------ this expression has type `Box<dyn T>`

--- a/tests/ui/diagnostic-width/long-E0529.rs
+++ b/tests/ui/diagnostic-width/long-E0529.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: --diagnostic-width=60 -Zwrite-long-types-to-disk=yes
+//@ dont-require-annotations: NOTE
 
 type A = (i32, i32, i32, i32);
 type B = (A, A, A, A);
@@ -7,7 +8,7 @@ type D = (C, C, C, C);
 
 fn foo(x: D) {
     let [] = x; //~ ERROR expected an array or slice, found `(...
-    //~^ pattern cannot match with input type `(...
+    //~^ NOTE pattern cannot match with input type `(...
 }
 
 fn main() {}

--- a/tests/ui/diagnostic-width/long-E0529.stderr
+++ b/tests/ui/diagnostic-width/long-E0529.stderr
@@ -1,5 +1,5 @@
 error[E0529]: expected an array or slice, found `(..., ..., ..., ...)`
-  --> $DIR/long-E0529.rs:9:9
+  --> $DIR/long-E0529.rs:10:9
    |
 LL |     let [] = x;
    |         ^^ pattern cannot match with input type `(..., ..., ..., ...)`

--- a/tests/ui/diagnostic-width/long-E0618.rs
+++ b/tests/ui/diagnostic-width/long-E0618.rs
@@ -1,11 +1,12 @@
 //@ compile-flags: --diagnostic-width=60 -Zwrite-long-types-to-disk=yes
+//@ dont-require-annotations: NOTE
 
 type A = (i32, i32, i32, i32);
 type B = (A, A, A, A);
 type C = (B, B, B, B);
 type D = (C, C, C, C);
 
-fn foo(x: D) { //~ `x` has type `(...
+fn foo(x: D) { //~ NOTE `x` has type `(...
     x(); //~ ERROR expected function, found `(...
 }
 

--- a/tests/ui/diagnostic-width/long-E0618.stderr
+++ b/tests/ui/diagnostic-width/long-E0618.stderr
@@ -1,5 +1,5 @@
 error[E0618]: expected function, found `(..., ..., ..., ...)`
-  --> $DIR/long-E0618.rs:9:5
+  --> $DIR/long-E0618.rs:10:5
    |
 LL | fn foo(x: D) {
    |        - `x` has type `(..., ..., ..., ...)`

--- a/tests/ui/diagnostic_namespace/on_unimplemented/custom-on-unimplemented-diagnostic.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/custom-on-unimplemented-diagnostic.rs
@@ -1,5 +1,7 @@
 //@ reference: attributes.diagnostic.on_unimplemented.intro
 //@ reference: attributes.diagnostic.on_unimplemented.keys
+//@ dont-require-annotations: NOTE
+
 #[diagnostic::on_unimplemented(message = "my message", label = "my label", note = "my note")]
 pub trait ProviderLt {}
 
@@ -16,6 +18,6 @@ struct B;
 fn main() {
     B.request();
     //~^ ERROR my message [E0599]
-    //~| my label
-    //~| my note
+    //~| NOTE my label
+    //~| NOTE my note
 }

--- a/tests/ui/diagnostic_namespace/on_unimplemented/custom-on-unimplemented-diagnostic.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/custom-on-unimplemented-diagnostic.stderr
@@ -1,5 +1,5 @@
 error[E0599]: my message
-  --> $DIR/custom-on-unimplemented-diagnostic.rs:17:7
+  --> $DIR/custom-on-unimplemented-diagnostic.rs:19:7
    |
 LL | struct B;
    | -------- method `request` not found for this struct because it doesn't satisfy `B: ProviderExt` or `B: ProviderLt`
@@ -8,7 +8,7 @@ LL |     B.request();
    |       ^^^^^^^ my label
    |
 note: trait bound `B: ProviderLt` was not satisfied
-  --> $DIR/custom-on-unimplemented-diagnostic.rs:12:18
+  --> $DIR/custom-on-unimplemented-diagnostic.rs:14:18
    |
 LL | impl<T: ?Sized + ProviderLt> ProviderExt for T {}
    |                  ^^^^^^^^^^  -----------     -
@@ -16,13 +16,13 @@ LL | impl<T: ?Sized + ProviderLt> ProviderExt for T {}
    |                  unsatisfied trait bound introduced here
    = note: my note
 note: the trait `ProviderLt` must be implemented
-  --> $DIR/custom-on-unimplemented-diagnostic.rs:4:1
+  --> $DIR/custom-on-unimplemented-diagnostic.rs:6:1
    |
 LL | pub trait ProviderLt {}
    | ^^^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `ProviderExt` defines an item `request`, perhaps you need to implement it
-  --> $DIR/custom-on-unimplemented-diagnostic.rs:6:1
+  --> $DIR/custom-on-unimplemented-diagnostic.rs:8:1
    |
 LL | pub trait ProviderExt {
    | ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/dst/dst-bad-assign-3.rs
+++ b/tests/ui/dst/dst-bad-assign-3.rs
@@ -1,5 +1,7 @@
 // Forbid assignment into a dynamically sized type.
 
+//@ dont-require-annotations: NOTE
+
 struct Fat<T: ?Sized>(isize, &'static str, T);
 
 #[derive(PartialEq,Eq)]
@@ -30,8 +32,8 @@ pub fn main() {
     let z: Box<dyn ToBar> = Box::new(Bar1 {f: 36});
     f5.2 = Bar1 {f: 36};
     //~^ ERROR mismatched types
-    //~| expected `dyn ToBar`, found `Bar1`
-    //~| expected trait object `dyn ToBar`
-    //~| found struct `Bar1`
+    //~| NOTE expected `dyn ToBar`, found `Bar1`
+    //~| NOTE expected trait object `dyn ToBar`
+    //~| NOTE found struct `Bar1`
     //~| ERROR the size for values of type
 }

--- a/tests/ui/dst/dst-bad-assign-3.stderr
+++ b/tests/ui/dst/dst-bad-assign-3.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/dst-bad-assign-3.rs:31:12
+  --> $DIR/dst-bad-assign-3.rs:33:12
    |
 LL |     f5.2 = Bar1 {f: 36};
    |     ----   ^^^^^^^^^^^^ expected `dyn ToBar`, found `Bar1`
@@ -11,7 +11,7 @@ LL |     f5.2 = Bar1 {f: 36};
    = help: `Bar1` implements `ToBar` so you could box the found value and coerce it to the trait object `Box<dyn ToBar>`, you will have to change the expected type as well
 
 error[E0277]: the size for values of type `dyn ToBar` cannot be known at compilation time
-  --> $DIR/dst-bad-assign-3.rs:31:5
+  --> $DIR/dst-bad-assign-3.rs:33:5
    |
 LL |     f5.2 = Bar1 {f: 36};
    |     ^^^^ doesn't have a size known at compile-time

--- a/tests/ui/dst/dst-bad-assign.rs
+++ b/tests/ui/dst/dst-bad-assign.rs
@@ -1,5 +1,7 @@
 // Forbid assignment into a dynamically sized type.
 
+//@ dont-require-annotations: NOTE
+
 struct Fat<T: ?Sized> {
     f1: isize,
     f2: &'static str,
@@ -34,8 +36,8 @@ pub fn main() {
     let z: Box<dyn ToBar> = Box::new(Bar1 {f: 36});
     f5.ptr = Bar1 {f: 36};
     //~^ ERROR mismatched types
-    //~| expected `dyn ToBar`, found `Bar1`
-    //~| expected trait object `dyn ToBar`
-    //~| found struct `Bar1`
+    //~| NOTE expected `dyn ToBar`, found `Bar1`
+    //~| NOTE expected trait object `dyn ToBar`
+    //~| NOTE found struct `Bar1`
     //~| ERROR the size for values of type
 }

--- a/tests/ui/dst/dst-bad-assign.stderr
+++ b/tests/ui/dst/dst-bad-assign.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/dst-bad-assign.rs:35:14
+  --> $DIR/dst-bad-assign.rs:37:14
    |
 LL |     f5.ptr = Bar1 {f: 36};
    |     ------   ^^^^^^^^^^^^ expected `dyn ToBar`, found `Bar1`
@@ -11,7 +11,7 @@ LL |     f5.ptr = Bar1 {f: 36};
    = help: `Bar1` implements `ToBar` so you could box the found value and coerce it to the trait object `Box<dyn ToBar>`, you will have to change the expected type as well
 
 error[E0277]: the size for values of type `dyn ToBar` cannot be known at compilation time
-  --> $DIR/dst-bad-assign.rs:35:5
+  --> $DIR/dst-bad-assign.rs:37:5
    |
 LL |     f5.ptr = Bar1 {f: 36};
    |     ^^^^^^ doesn't have a size known at compile-time

--- a/tests/ui/dst/dst-bad-coerce4.rs
+++ b/tests/ui/dst/dst-bad-coerce4.rs
@@ -9,7 +9,8 @@ pub fn main() {
     let f1: &Fat<[isize]> = &Fat { ptr: [1, 2, 3] };
     let f2: &Fat<[isize; 3]> = f1;
     //~^ ERROR mismatched types
-    //~| expected `&Fat<[isize; 3]>`, found `&Fat<[isize]>`
-    //~| expected reference `&Fat<[isize; 3]>`
-    //~| found reference `&Fat<[isize]>`
+    //~| NOTE expected `&Fat<[isize; 3]>`, found `&Fat<[isize]>`
+    //~| NOTE expected reference `&Fat<[isize; 3]>`
+    //~| NOTE found reference `&Fat<[isize]>`
+    //~| NOTE expected due to this
 }

--- a/tests/ui/empty/empty-never-array.rs
+++ b/tests/ui/empty/empty-never-array.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 #![feature(never_type)]
 
 enum Helper<T, U> {
@@ -9,7 +11,7 @@ enum Helper<T, U> {
 fn transmute<T, U>(t: T) -> U {
     let Helper::U(u) = Helper::T(t, []);
     //~^ ERROR refutable pattern in local binding
-    //~| `Helper::T(_, _)` not covered
+    //~| NOTE `Helper::T(_, _)` not covered
     u
 }
 

--- a/tests/ui/empty/empty-never-array.stderr
+++ b/tests/ui/empty/empty-never-array.stderr
@@ -1,5 +1,5 @@
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-never-array.rs:10:9
+  --> $DIR/empty-never-array.rs:12:9
    |
 LL |     let Helper::U(u) = Helper::T(t, []);
    |         ^^^^^^^^^^^^ pattern `Helper::T(_, _)` not covered
@@ -7,7 +7,7 @@ LL |     let Helper::U(u) = Helper::T(t, []);
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
 note: `Helper<T, U>` defined here
-  --> $DIR/empty-never-array.rs:3:6
+  --> $DIR/empty-never-array.rs:5:6
    |
 LL | enum Helper<T, U> {
    |      ^^^^^^

--- a/tests/ui/enum-discriminant/discriminant-overflow.rs
+++ b/tests/ui/enum-discriminant/discriminant-overflow.rs
@@ -1,7 +1,8 @@
 // Issue 23030: Detect overflowing discriminant
-
 // See also run-pass/discrim-explicit-23030.rs where the suggested
 // workaround is tested.
+
+//@ dont-require-annotations: NOTE
 
 fn f_i8() {
     #[repr(i8)]
@@ -42,7 +43,7 @@ fn f_u16() {
         Ok = u16::MAX - 1,
         Ok2,
         OhNo, //~ ERROR enum discriminant overflowed [E0370]
-              //~| overflowed on value after 65535
+              //~| NOTE overflowed on value after 65535
     }
 
     let x = A::Ok;
@@ -54,7 +55,7 @@ fn f_i32() {
         Ok = i32::MAX - 1,
         Ok2,
         OhNo, //~ ERROR enum discriminant overflowed [E0370]
-              //~| overflowed on value after 2147483647
+              //~| NOTE overflowed on value after 2147483647
     }
 
     let x = A::Ok;
@@ -66,7 +67,7 @@ fn f_u32() {
         Ok = u32::MAX - 1,
         Ok2,
         OhNo, //~ ERROR enum discriminant overflowed [E0370]
-              //~| overflowed on value after 4294967295
+              //~| NOTE overflowed on value after 4294967295
     }
 
     let x = A::Ok;
@@ -78,7 +79,7 @@ fn f_i64() {
         Ok = i64::MAX - 1,
         Ok2,
         OhNo, //~ ERROR enum discriminant overflowed [E0370]
-              //~| overflowed on value after 9223372036854775807
+              //~| NOTE overflowed on value after 9223372036854775807
     }
 
     let x = A::Ok;
@@ -90,7 +91,7 @@ fn f_u64() {
         Ok = u64::MAX - 1,
         Ok2,
         OhNo, //~ ERROR enum discriminant overflowed [E0370]
-              //~| overflowed on value after 18446744073709551615
+              //~| NOTE overflowed on value after 18446744073709551615
     }
 
     let x = A::Ok;

--- a/tests/ui/enum-discriminant/discriminant-overflow.stderr
+++ b/tests/ui/enum-discriminant/discriminant-overflow.stderr
@@ -1,5 +1,5 @@
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discriminant-overflow.rs:11:9
+  --> $DIR/discriminant-overflow.rs:12:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 127
@@ -7,7 +7,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -128` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discriminant-overflow.rs:22:9
+  --> $DIR/discriminant-overflow.rs:23:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 255
@@ -15,7 +15,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discriminant-overflow.rs:33:9
+  --> $DIR/discriminant-overflow.rs:34:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 32767
@@ -23,7 +23,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -32768` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discriminant-overflow.rs:44:9
+  --> $DIR/discriminant-overflow.rs:45:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 65535
@@ -31,7 +31,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discriminant-overflow.rs:56:9
+  --> $DIR/discriminant-overflow.rs:57:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 2147483647
@@ -39,7 +39,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -2147483648` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discriminant-overflow.rs:68:9
+  --> $DIR/discriminant-overflow.rs:69:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 4294967295
@@ -47,7 +47,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discriminant-overflow.rs:80:9
+  --> $DIR/discriminant-overflow.rs:81:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 9223372036854775807
@@ -55,7 +55,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -9223372036854775808` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discriminant-overflow.rs:92:9
+  --> $DIR/discriminant-overflow.rs:93:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 18446744073709551615

--- a/tests/ui/error-codes/E0080.rs
+++ b/tests/ui/error-codes/E0080.rs
@@ -1,7 +1,8 @@
 enum Enum {
     X = (1 << 500), //~ ERROR E0080
-    //~| attempt to shift left by `500_i32`, which would overflow
+    //~| NOTE attempt to shift left by `500_i32`, which would overflow
     Y = (1 / 0) //~ ERROR E0080
+                //~| NOTE attempt to divide `1_isize` by zero
 }
 
 fn main() {

--- a/tests/ui/error-codes/E0106.rs
+++ b/tests/ui/error-codes/E0106.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 struct Foo {
     x: &bool,
     //~^ ERROR E0106
@@ -16,10 +18,10 @@ struct Buzz<'a, 'b>(&'a str, &'b str);
 struct Quux {
     baz: Baz,
     //~^ ERROR E0106
-    //~| expected named lifetime parameter
+    //~| NOTE expected named lifetime parameter
     buzz: Buzz,
     //~^ ERROR E0106
-    //~| expected 2 lifetime parameters
+    //~| NOTE expected 2 lifetime parameters
 }
 
 fn main() {

--- a/tests/ui/error-codes/E0106.stderr
+++ b/tests/ui/error-codes/E0106.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/E0106.rs:2:8
+  --> $DIR/E0106.rs:4:8
    |
 LL |     x: &bool,
    |        ^ expected named lifetime parameter
@@ -11,7 +11,7 @@ LL ~     x: &'a bool,
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/E0106.rs:7:7
+  --> $DIR/E0106.rs:9:7
    |
 LL |     B(&bool),
    |       ^ expected named lifetime parameter
@@ -24,7 +24,7 @@ LL ~     B(&'a bool),
    |
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/E0106.rs:10:14
+  --> $DIR/E0106.rs:12:14
    |
 LL | type MyStr = &str;
    |              ^ expected named lifetime parameter
@@ -35,7 +35,7 @@ LL | type MyStr<'a> = &'a str;
    |           ++++    ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/E0106.rs:17:10
+  --> $DIR/E0106.rs:19:10
    |
 LL |     baz: Baz,
    |          ^^^ expected named lifetime parameter
@@ -47,7 +47,7 @@ LL ~     baz: Baz<'a>,
    |
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/E0106.rs:20:11
+  --> $DIR/E0106.rs:22:11
    |
 LL |     buzz: Buzz,
    |           ^^^^ expected 2 lifetime parameters

--- a/tests/ui/error-codes/E0428.rs
+++ b/tests/ui/error-codes/E0428.rs
@@ -1,4 +1,6 @@
-struct Bar; //~ previous definition of the type `Bar` here
+//@ dont-require-annotations: NOTE
+
+struct Bar; //~ NOTE previous definition of the type `Bar` here
 struct Bar; //~ ERROR E0428
 
 fn main () {

--- a/tests/ui/error-codes/E0428.stderr
+++ b/tests/ui/error-codes/E0428.stderr
@@ -1,5 +1,5 @@
 error[E0428]: the name `Bar` is defined multiple times
-  --> $DIR/E0428.rs:2:1
+  --> $DIR/E0428.rs:4:1
    |
 LL | struct Bar;
    | ----------- previous definition of the type `Bar` here

--- a/tests/ui/explicit/explicit-self-lifetime-mismatch.rs
+++ b/tests/ui/explicit/explicit-self-lifetime-mismatch.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 struct Foo<'a,'b> {
     x: &'a isize,
     y: &'b isize,
@@ -7,13 +9,13 @@ impl<'a,'b> Foo<'a,'b> {
     fn bar(self:
            Foo<'b,'a>
     //~^ ERROR mismatched `self` parameter type
-    //~| expected struct `Foo<'a, 'b>`
-    //~| found struct `Foo<'b, 'a>`
-    //~| lifetime mismatch
+    //~| NOTE expected struct `Foo<'a, 'b>`
+    //~| NOTE found struct `Foo<'b, 'a>`
+    //~| NOTE lifetime mismatch
     //~| ERROR mismatched `self` parameter type
-    //~| expected struct `Foo<'a, 'b>`
-    //~| found struct `Foo<'b, 'a>`
-    //~| lifetime mismatch
+    //~| NOTE expected struct `Foo<'a, 'b>`
+    //~| NOTE found struct `Foo<'b, 'a>`
+    //~| NOTE lifetime mismatch
            ) {}
 }
 

--- a/tests/ui/explicit/explicit-self-lifetime-mismatch.stderr
+++ b/tests/ui/explicit/explicit-self-lifetime-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/explicit-self-lifetime-mismatch.rs:8:12
+  --> $DIR/explicit-self-lifetime-mismatch.rs:10:12
    |
 LL |            Foo<'b,'a>
    |            ^^^^^^^^^^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |            Foo<'b,'a>
    = note: expected struct `Foo<'a, 'b>`
               found struct `Foo<'b, 'a>`
 note: the lifetime `'b` as defined here...
-  --> $DIR/explicit-self-lifetime-mismatch.rs:6:9
+  --> $DIR/explicit-self-lifetime-mismatch.rs:8:9
    |
 LL | impl<'a,'b> Foo<'a,'b> {
    |         ^^
 note: ...does not necessarily outlive the lifetime `'a` as defined here
-  --> $DIR/explicit-self-lifetime-mismatch.rs:6:6
+  --> $DIR/explicit-self-lifetime-mismatch.rs:8:6
    |
 LL | impl<'a,'b> Foo<'a,'b> {
    |      ^^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/explicit-self-lifetime-mismatch.rs:8:12
+  --> $DIR/explicit-self-lifetime-mismatch.rs:10:12
    |
 LL |            Foo<'b,'a>
    |            ^^^^^^^^^^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |            Foo<'b,'a>
    = note: expected struct `Foo<'a, 'b>`
               found struct `Foo<'b, 'a>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/explicit-self-lifetime-mismatch.rs:6:6
+  --> $DIR/explicit-self-lifetime-mismatch.rs:8:6
    |
 LL | impl<'a,'b> Foo<'a,'b> {
    |      ^^
 note: ...does not necessarily outlive the lifetime `'b` as defined here
-  --> $DIR/explicit-self-lifetime-mismatch.rs:6:9
+  --> $DIR/explicit-self-lifetime-mismatch.rs:8:9
    |
 LL | impl<'a,'b> Foo<'a,'b> {
    |         ^^

--- a/tests/ui/expr/if/if-branch-types.rs
+++ b/tests/ui/expr/if/if-branch-types.rs
@@ -1,5 +1,6 @@
 fn main() {
     let x = if true { 10i32 } else { 10u32 };
     //~^ ERROR `if` and `else` have incompatible types
-    //~| expected `i32`, found `u32`
+    //~| NOTE expected `i32`, found `u32`
+    //~| NOTE expected because of this
 }

--- a/tests/ui/expr/if/if-without-else-result.rs
+++ b/tests/ui/expr/if/if-without-else-result.rs
@@ -1,6 +1,8 @@
+//@ dont-require-annotations: NOTE
+
 fn main() {
     let a = if true { true };
     //~^ ERROR `if` may be missing an `else` clause [E0317]
-    //~| expected `bool`, found `()`
+    //~| NOTE expected `bool`, found `()`
     println!("{}", a);
 }

--- a/tests/ui/expr/if/if-without-else-result.stderr
+++ b/tests/ui/expr/if/if-without-else-result.stderr
@@ -1,5 +1,5 @@
 error[E0317]: `if` may be missing an `else` clause
-  --> $DIR/if-without-else-result.rs:2:13
+  --> $DIR/if-without-else-result.rs:4:13
    |
 LL |     let a = if true { true };
    |             ^^^^^^^^^^----^^

--- a/tests/ui/expr/if/issue-4201.rs
+++ b/tests/ui/expr/if/issue-4201.rs
@@ -1,9 +1,11 @@
+//@ dont-require-annotations: NOTE
+
 fn main() {
     let a = if true {
         0
     } else if false {
 //~^ ERROR `if` may be missing an `else` clause
-//~| expected integer, found `()`
+//~| NOTE expected integer, found `()`
         1
     };
 }

--- a/tests/ui/expr/if/issue-4201.stderr
+++ b/tests/ui/expr/if/issue-4201.stderr
@@ -1,5 +1,5 @@
 error[E0317]: `if` may be missing an `else` clause
-  --> $DIR/issue-4201.rs:4:12
+  --> $DIR/issue-4201.rs:6:12
    |
 LL |       } else if false {
    |  ____________^

--- a/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.rs
+++ b/tests/ui/feature-gates/feature-gate-cfg-target-thread-local.rs
@@ -7,7 +7,7 @@ extern crate cfg_target_thread_local;
 
 extern "C" {
     #[cfg_attr(target_thread_local, thread_local)]
-    //~^ `cfg(target_thread_local)` is experimental and subject to change
+    //~^ ERROR `cfg(target_thread_local)` is experimental and subject to change
     static FOO: u32;
 }
 

--- a/tests/ui/fn/fn-item-type.rs
+++ b/tests/ui/fn/fn-item-type.rs
@@ -1,6 +1,8 @@
 // Test that the types of distinct fn items are not compatible by
 // default. See also `run-pass/fn-item-type-*.rs`.
 
+//@ dont-require-annotations: NOTE
+
 fn foo<T>(x: isize) -> isize {
     x * 2
 }
@@ -21,31 +23,31 @@ impl<T> Foo for T {
 fn main() {
     eq(foo::<u8>, bar::<u8>);
     //~^ ERROR mismatched types
-    //~| expected fn item `fn(_) -> _ {foo::<u8>}`
-    //~| found fn item `fn(_) -> _ {bar::<u8>}`
-    //~| expected fn item, found a different fn item
-    //~| different fn items have unique types, even if their signatures are the same
+    //~| NOTE expected fn item `fn(_) -> _ {foo::<u8>}`
+    //~| NOTE found fn item `fn(_) -> _ {bar::<u8>}`
+    //~| NOTE expected fn item, found a different fn item
+    //~| NOTE different fn items have unique types, even if their signatures are the same
 
     eq(foo::<u8>, foo::<i8>);
     //~^ ERROR mismatched types
-    //~| expected `u8`, found `i8`
-    //~| different fn items have unique types, even if their signatures are the same
+    //~| NOTE expected `u8`, found `i8`
+    //~| NOTE different fn items have unique types, even if their signatures are the same
 
     eq(bar::<String>, bar::<Vec<u8>>);
     //~^ ERROR mismatched types
-    //~| found fn item `fn(_) -> _ {bar::<Vec<u8>>}`
-    //~| expected `String`, found `Vec<u8>`
+    //~| NOTE found fn item `fn(_) -> _ {bar::<Vec<u8>>}`
+    //~| NOTE expected `String`, found `Vec<u8>`
 
     // Make sure we distinguish between trait methods correctly.
     eq(<u8 as Foo>::foo, <u16 as Foo>::foo);
     //~^ ERROR mismatched types
-    //~| expected `u8`, found `u16`
-    //~| different fn items have unique types, even if their signatures are the same
+    //~| NOTE expected `u8`, found `u16`
+    //~| NOTE different fn items have unique types, even if their signatures are the same
 
     eq(foo::<u8>, bar::<u8> as fn(isize) -> isize);
     //~^ ERROR mismatched types
-    //~| found fn pointer `fn(_) -> _`
-    //~| expected fn item, found fn pointer
+    //~| NOTE found fn pointer `fn(_) -> _`
+    //~| NOTE expected fn item, found fn pointer
 
     eq(foo::<u8> as fn(isize) -> isize, bar::<u8>); // ok!
 }

--- a/tests/ui/fn/fn-item-type.stderr
+++ b/tests/ui/fn/fn-item-type.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/fn-item-type.rs:22:19
+  --> $DIR/fn-item-type.rs:24:19
    |
 LL |     eq(foo::<u8>, bar::<u8>);
    |     -- ---------  ^^^^^^^^^ expected fn item, found a different fn item
@@ -11,7 +11,7 @@ LL |     eq(foo::<u8>, bar::<u8>);
               found fn item `fn(_) -> _ {bar::<u8>}`
    = note: different fn items have unique types, even if their signatures are the same
 note: function defined here
-  --> $DIR/fn-item-type.rs:11:4
+  --> $DIR/fn-item-type.rs:13:4
    |
 LL | fn eq<T>(x: T, y: T) {}
    |    ^^ -  ----  ---- this parameter needs to match the fn item type of `x`
@@ -21,7 +21,7 @@ LL | fn eq<T>(x: T, y: T) {}
    = help: consider casting both fn items to fn pointers using `as fn(isize) -> isize`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-item-type.rs:29:19
+  --> $DIR/fn-item-type.rs:31:19
    |
 LL |     eq(foo::<u8>, foo::<i8>);
    |     -- ---------  ^^^^^^^^^ expected `u8`, found `i8`
@@ -33,7 +33,7 @@ LL |     eq(foo::<u8>, foo::<i8>);
               found fn item `fn(_) -> _ {foo::<i8>}`
    = note: different fn items have unique types, even if their signatures are the same
 note: function defined here
-  --> $DIR/fn-item-type.rs:11:4
+  --> $DIR/fn-item-type.rs:13:4
    |
 LL | fn eq<T>(x: T, y: T) {}
    |    ^^ -  ----  ---- this parameter needs to match the fn item type of `x`
@@ -43,7 +43,7 @@ LL | fn eq<T>(x: T, y: T) {}
    = help: consider casting both fn items to fn pointers using `as fn(isize) -> isize`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-item-type.rs:34:23
+  --> $DIR/fn-item-type.rs:36:23
    |
 LL |     eq(bar::<String>, bar::<Vec<u8>>);
    |     -- -------------  ^^^^^^^^^^^^^^ expected `String`, found `Vec<u8>`
@@ -55,7 +55,7 @@ LL |     eq(bar::<String>, bar::<Vec<u8>>);
               found fn item `fn(_) -> _ {bar::<Vec<u8>>}`
    = note: different fn items have unique types, even if their signatures are the same
 note: function defined here
-  --> $DIR/fn-item-type.rs:11:4
+  --> $DIR/fn-item-type.rs:13:4
    |
 LL | fn eq<T>(x: T, y: T) {}
    |    ^^ -  ----  ---- this parameter needs to match the fn item type of `x`
@@ -65,7 +65,7 @@ LL | fn eq<T>(x: T, y: T) {}
    = help: consider casting both fn items to fn pointers using `as fn(isize) -> isize`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-item-type.rs:40:26
+  --> $DIR/fn-item-type.rs:42:26
    |
 LL |     eq(<u8 as Foo>::foo, <u16 as Foo>::foo);
    |     -- ----------------  ^^^^^^^^^^^^^^^^^ expected `u8`, found `u16`
@@ -77,7 +77,7 @@ LL |     eq(<u8 as Foo>::foo, <u16 as Foo>::foo);
               found fn item `fn() {<u16 as Foo>::foo}`
    = note: different fn items have unique types, even if their signatures are the same
 note: function defined here
-  --> $DIR/fn-item-type.rs:11:4
+  --> $DIR/fn-item-type.rs:13:4
    |
 LL | fn eq<T>(x: T, y: T) {}
    |    ^^ -  ----  ---- this parameter needs to match the fn item type of `x`
@@ -87,7 +87,7 @@ LL | fn eq<T>(x: T, y: T) {}
    = help: consider casting both fn items to fn pointers using `as fn()`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-item-type.rs:45:19
+  --> $DIR/fn-item-type.rs:47:19
    |
 LL |     eq(foo::<u8>, bar::<u8> as fn(isize) -> isize);
    |     -- ---------  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected fn item, found fn pointer
@@ -99,7 +99,7 @@ LL |     eq(foo::<u8>, bar::<u8> as fn(isize) -> isize);
            found fn pointer `fn(_) -> _`
    = help: consider casting the fn item to a fn pointer: `foo::<u8> as fn(isize) -> isize`
 note: function defined here
-  --> $DIR/fn-item-type.rs:11:4
+  --> $DIR/fn-item-type.rs:13:4
    |
 LL | fn eq<T>(x: T, y: T) {}
    |    ^^ -  ----  ---- this parameter needs to match the fn item type of `x`

--- a/tests/ui/fn/fn-pointer-mismatch.rs
+++ b/tests/ui/fn/fn-pointer-mismatch.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 fn foo(x: u32) -> u32 {
     x * 2
 }
@@ -10,7 +12,7 @@ fn bar(x: u32) -> u32 {
 fn foobar(n: u32) -> u32 {
     let g = if n % 2 == 0 { &foo } else { &bar };
     //~^ ERROR `if` and `else` have incompatible types
-    //~| different fn items have unique types, even if their signatures are the same
+    //~| NOTE different fn items have unique types, even if their signatures are the same
     g(n)
 }
 
@@ -22,33 +24,33 @@ fn main() {
     let mut a = foo;
     a = bar;
     //~^ ERROR mismatched types
-    //~| expected fn item `fn(_) -> _ {foo}`
-    //~| found fn item `fn(_) -> _ {bar}`
-    //~| different fn items have unique types, even if their signatures are the same
+    //~| NOTE expected fn item `fn(_) -> _ {foo}`
+    //~| NOTE found fn item `fn(_) -> _ {bar}`
+    //~| NOTE different fn items have unique types, even if their signatures are the same
 
     // display note even when boxed
     let mut b = Box::new(foo);
     b = Box::new(bar);
     //~^ ERROR mismatched types
-    //~| different fn items have unique types, even if their signatures are the same
+    //~| NOTE different fn items have unique types, even if their signatures are the same
 
     // suggest removing reference
     let c: fn(u32) -> u32 = &foo;
     //~^ ERROR mismatched types
-    //~| expected fn pointer `fn(_) -> _`
-    //~| found reference `&fn(_) -> _ {foo}`
+    //~| NOTE expected fn pointer `fn(_) -> _`
+    //~| NOTE found reference `&fn(_) -> _ {foo}`
 
     // suggest using reference
     let d: &fn(u32) -> u32 = foo;
     //~^ ERROR mismatched types
-    //~| expected reference `&fn(_) -> _`
-    //~| found fn item `fn(_) -> _ {foo}`
+    //~| NOTE expected reference `&fn(_) -> _`
+    //~| NOTE found fn item `fn(_) -> _ {foo}`
 
     // suggest casting with reference
     let e: &fn(u32) -> u32 = &foo;
     //~^ ERROR mismatched types
-    //~| expected reference `&fn(_) -> _`
-    //~| found reference `&fn(_) -> _ {foo}`
+    //~| NOTE expected reference `&fn(_) -> _`
+    //~| NOTE found reference `&fn(_) -> _ {foo}`
 
     // OK
     let mut z: fn(u32) -> u32 = foo as fn(u32) -> u32;

--- a/tests/ui/fn/fn-pointer-mismatch.stderr
+++ b/tests/ui/fn/fn-pointer-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: `if` and `else` have incompatible types
-  --> $DIR/fn-pointer-mismatch.rs:11:43
+  --> $DIR/fn-pointer-mismatch.rs:13:43
    |
 LL |     let g = if n % 2 == 0 { &foo } else { &bar };
    |                             ----          ^^^^ expected `&fn(u32) -> u32 {foo}`, found `&fn(u32) -> u32 {bar}`
@@ -12,7 +12,7 @@ LL |     let g = if n % 2 == 0 { &foo } else { &bar };
    = help: consider casting both fn items to fn pointers using `as fn(u32) -> u32`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-pointer-mismatch.rs:23:9
+  --> $DIR/fn-pointer-mismatch.rs:25:9
    |
 LL |     let mut a = foo;
    |                 --- expected due to this value
@@ -25,7 +25,7 @@ LL |     a = bar;
    = help: consider casting both fn items to fn pointers using `as fn(u32) -> u32`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-pointer-mismatch.rs:31:18
+  --> $DIR/fn-pointer-mismatch.rs:33:18
    |
 LL |     b = Box::new(bar);
    |         -------- ^^^ expected fn item, found a different fn item
@@ -40,7 +40,7 @@ note: associated function defined here
    = help: consider casting both fn items to fn pointers using `as fn(u32) -> u32`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-pointer-mismatch.rs:36:29
+  --> $DIR/fn-pointer-mismatch.rs:38:29
    |
 LL |     let c: fn(u32) -> u32 = &foo;
    |            --------------   ^^^^ expected fn pointer, found `&fn(u32) -> u32 {foo}`
@@ -56,7 +56,7 @@ LL +     let c: fn(u32) -> u32 = foo;
    |
 
 error[E0308]: mismatched types
-  --> $DIR/fn-pointer-mismatch.rs:42:30
+  --> $DIR/fn-pointer-mismatch.rs:44:30
    |
 LL |     let d: &fn(u32) -> u32 = foo;
    |            ---------------   ^^^ expected `&fn(u32) -> u32`, found fn item
@@ -71,7 +71,7 @@ LL |     let d: &fn(u32) -> u32 = &foo;
    |                              +
 
 error[E0308]: mismatched types
-  --> $DIR/fn-pointer-mismatch.rs:48:30
+  --> $DIR/fn-pointer-mismatch.rs:50:30
    |
 LL |     let e: &fn(u32) -> u32 = &foo;
    |            ---------------   ^^^^ expected `&fn(u32) -> u32`, found `&fn(u32) -> u32 {foo}`

--- a/tests/ui/fn/fn-trait-formatting.rs
+++ b/tests/ui/fn/fn-trait-formatting.rs
@@ -1,20 +1,20 @@
+//@ dont-require-annotations: NOTE
+
 fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
-
-
 
 fn main() {
     let _: () = Box::new(|_: isize| {}) as Box<dyn FnOnce(isize)>;
     //~^ ERROR mismatched types
-    //~| expected unit type `()`
-    //~| found struct `Box<dyn FnOnce(isize)>`
+    //~| NOTE expected unit type `()`
+    //~| NOTE found struct `Box<dyn FnOnce(isize)>`
     let _: () = Box::new(|_: isize, isize| {}) as Box<dyn Fn(isize, isize)>;
     //~^ ERROR mismatched types
-    //~| expected unit type `()`
-    //~| found struct `Box<dyn Fn(isize, isize)>`
+    //~| NOTE expected unit type `()`
+    //~| NOTE found struct `Box<dyn Fn(isize, isize)>`
     let _: () = Box::new(|| -> isize { unimplemented!() }) as Box<dyn FnMut() -> isize>;
     //~^ ERROR mismatched types
-    //~| expected unit type `()`
-    //~| found struct `Box<dyn FnMut() -> isize>`
+    //~| NOTE expected unit type `()`
+    //~| NOTE found struct `Box<dyn FnMut() -> isize>`
 
     needs_fn(1);
     //~^ ERROR expected a `Fn(isize)` closure, found `{integer}`

--- a/tests/ui/fn/fn-trait-formatting.stderr
+++ b/tests/ui/fn/fn-trait-formatting.stderr
@@ -49,7 +49,7 @@ LL |     needs_fn(1);
    |
    = help: the trait `Fn(isize)` is not implemented for `{integer}`
 note: required by a bound in `needs_fn`
-  --> $DIR/fn-trait-formatting.rs:1:31
+  --> $DIR/fn-trait-formatting.rs:3:31
    |
 LL | fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
    |                               ^^^^^^^^^^^^^^^^^^ required by this bound in `needs_fn`

--- a/tests/ui/foreign/issue-91370-foreign-fn-block-impl.rs
+++ b/tests/ui/foreign/issue-91370-foreign-fn-block-impl.rs
@@ -1,10 +1,11 @@
 // Regression test for issue #91370.
 
 extern "C" {
-    //~^ `extern` blocks define existing foreign functions
+    //~^ NOTE `extern` blocks define existing foreign functions
     fn f() {
         //~^ ERROR incorrect function inside `extern` block
-        //~| cannot have a body
+        //~| NOTE cannot have a body
+        //~| NOTE for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
         impl Copy for u8 {}
     }
 }

--- a/tests/ui/foreign/issue-91370-foreign-fn-block-impl.stderr
+++ b/tests/ui/foreign/issue-91370-foreign-fn-block-impl.stderr
@@ -8,9 +8,7 @@ LL |       fn f() {
    |  ________^___-
    | |        |
    | |        cannot have a body
-LL | |
-LL | |
-LL | |         impl Copy for u8 {}
+...  |
 LL | |     }
    | |_____- help: remove the invalid body: `;`
    |

--- a/tests/ui/fully-qualified-type/fully-qualified-type-name2.rs
+++ b/tests/ui/fully-qualified-type/fully-qualified-type-name2.rs
@@ -1,5 +1,7 @@
 // Test that we use fully-qualified type names in error messages.
 
+//@ dont-require-annotations: NOTE
+
 mod x {
     pub enum Foo { }
 }
@@ -11,7 +13,7 @@ mod y {
 fn bar(x: x::Foo) -> y::Foo {
     return x;
     //~^ ERROR mismatched types
-    //~| expected `y::Foo`, found `x::Foo`
+    //~| NOTE expected `y::Foo`, found `x::Foo`
 }
 
 fn main() {

--- a/tests/ui/fully-qualified-type/fully-qualified-type-name2.stderr
+++ b/tests/ui/fully-qualified-type/fully-qualified-type-name2.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/fully-qualified-type-name2.rs:12:12
+  --> $DIR/fully-qualified-type-name2.rs:14:12
    |
 LL | fn bar(x: x::Foo) -> y::Foo {
    |                      ------ expected `y::Foo` because of return type
@@ -8,12 +8,12 @@ LL |     return x;
    |
    = note: `x::Foo` and `y::Foo` have similar names, but are actually distinct types
 note: `x::Foo` is defined in module `crate::x` of the current crate
-  --> $DIR/fully-qualified-type-name2.rs:4:5
+  --> $DIR/fully-qualified-type-name2.rs:6:5
    |
 LL |     pub enum Foo { }
    |     ^^^^^^^^^^^^
 note: `y::Foo` is defined in module `crate::y` of the current crate
-  --> $DIR/fully-qualified-type-name2.rs:8:5
+  --> $DIR/fully-qualified-type-name2.rs:10:5
    |
 LL |     pub enum Foo { }
    |     ^^^^^^^^^^^^

--- a/tests/ui/fully-qualified-type/fully-qualified-type-name4.rs
+++ b/tests/ui/fully-qualified-type/fully-qualified-type-name4.rs
@@ -2,12 +2,12 @@
 
 use std::option::Option;
 
-fn bar(x: usize) -> Option<usize> {
+fn bar(x: usize) -> Option<usize> { //~ NOTE expected `Option<usize>` because of return type
     return x;
     //~^ ERROR mismatched types
-    //~| expected enum `Option<usize>`
-    //~| found type `usize`
-    //~| expected `Option<usize>`, found `usize`
+    //~| NOTE expected enum `Option<usize>`
+    //~| NOTE found type `usize`
+    //~| NOTE expected `Option<usize>`, found `usize`
 }
 
 fn main() {

--- a/tests/ui/generics/generic-type-params-name-repr.rs
+++ b/tests/ui/generics/generic-type-params-name-repr.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 use std::marker;
 
 struct A;
@@ -12,40 +14,40 @@ fn main() {
     // Ensure that the printed type doesn't include the default type params...
     let _: Foo<isize> = ();
     //~^ ERROR mismatched types
-    //~| expected `Foo<isize>`, found `()`
-    //~| expected struct `Foo<isize>`
-    //~| found unit type `()`
+    //~| NOTE expected `Foo<isize>`, found `()`
+    //~| NOTE expected struct `Foo<isize>`
+    //~| NOTE found unit type `()`
 
     // ...even when they're present, but the same types as the defaults.
     let _: Foo<isize, B, C> = ();
     //~^ ERROR mismatched types
-    //~| expected `Foo<isize>`, found `()`
-    //~| expected struct `Foo<isize>`
-    //~| found unit type `()`
+    //~| NOTE expected `Foo<isize>`, found `()`
+    //~| NOTE expected struct `Foo<isize>`
+    //~| NOTE found unit type `()`
 
     // Including cases where the default is using previous type params.
     let _: HashMap<String, isize> = ();
     //~^ ERROR mismatched types
-    //~| expected `HashMap<String, isize>`, found `()`
-    //~| expected struct `HashMap<String, isize>`
-    //~| found unit type `()`
+    //~| NOTE expected `HashMap<String, isize>`, found `()`
+    //~| NOTE expected struct `HashMap<String, isize>`
+    //~| NOTE found unit type `()`
     let _: HashMap<String, isize, Hash<String>> = ();
     //~^ ERROR mismatched types
-    //~| expected `HashMap<String, isize>`, found `()`
-    //~| expected struct `HashMap<String, isize>`
-    //~| found unit type `()`
+    //~| NOTE expected `HashMap<String, isize>`, found `()`
+    //~| NOTE expected struct `HashMap<String, isize>`
+    //~| NOTE found unit type `()`
 
     // But not when there's a different type in between.
     let _: Foo<A, isize, C> = ();
     //~^ ERROR mismatched types
-    //~| expected `Foo<A, isize>`, found `()`
-    //~| expected struct `Foo<A, isize>`
-    //~| found unit type `()`
+    //~| NOTE expected `Foo<A, isize>`, found `()`
+    //~| NOTE expected struct `Foo<A, isize>`
+    //~| NOTE found unit type `()`
 
     // And don't print <> at all when there's just defaults.
     let _: Foo<A, B, C> = ();
     //~^ ERROR mismatched types
-    //~| expected `Foo`, found `()`
-    //~| expected struct `Foo`
-    //~| found unit type `()`
+    //~| NOTE expected `Foo`, found `()`
+    //~| NOTE expected struct `Foo`
+    //~| NOTE found unit type `()`
 }

--- a/tests/ui/generics/generic-type-params-name-repr.stderr
+++ b/tests/ui/generics/generic-type-params-name-repr.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/generic-type-params-name-repr.rs:13:25
+  --> $DIR/generic-type-params-name-repr.rs:15:25
    |
 LL |     let _: Foo<isize> = ();
    |            ----------   ^^ expected `Foo<isize>`, found `()`
@@ -10,7 +10,7 @@ LL |     let _: Foo<isize> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/generic-type-params-name-repr.rs:20:31
+  --> $DIR/generic-type-params-name-repr.rs:22:31
    |
 LL |     let _: Foo<isize, B, C> = ();
    |            ----------------   ^^ expected `Foo<isize>`, found `()`
@@ -21,7 +21,7 @@ LL |     let _: Foo<isize, B, C> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/generic-type-params-name-repr.rs:27:37
+  --> $DIR/generic-type-params-name-repr.rs:29:37
    |
 LL |     let _: HashMap<String, isize> = ();
    |            ----------------------   ^^ expected `HashMap<String, isize>`, found `()`
@@ -32,7 +32,7 @@ LL |     let _: HashMap<String, isize> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/generic-type-params-name-repr.rs:32:51
+  --> $DIR/generic-type-params-name-repr.rs:34:51
    |
 LL |     let _: HashMap<String, isize, Hash<String>> = ();
    |            ------------------------------------   ^^ expected `HashMap<String, isize>`, found `()`
@@ -43,7 +43,7 @@ LL |     let _: HashMap<String, isize, Hash<String>> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/generic-type-params-name-repr.rs:39:31
+  --> $DIR/generic-type-params-name-repr.rs:41:31
    |
 LL |     let _: Foo<A, isize, C> = ();
    |            ----------------   ^^ expected `Foo<A, isize>`, found `()`
@@ -54,7 +54,7 @@ LL |     let _: Foo<A, isize, C> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/generic-type-params-name-repr.rs:46:27
+  --> $DIR/generic-type-params-name-repr.rs:48:27
    |
 LL |     let _: Foo<A, B, C> = ();
    |            ------------   ^^ expected `Foo`, found `()`

--- a/tests/ui/generics/slightly-nice-generic-literal-messages.rs
+++ b/tests/ui/generics/slightly-nice-generic-literal-messages.rs
@@ -3,12 +3,12 @@ use std::marker;
 struct Foo<T,U>(T, marker::PhantomData<U>);
 
 fn main() {
-    match Foo(1.1, marker::PhantomData) {
+    match Foo(1.1, marker::PhantomData) { //~ NOTE this expression has type `Foo<{float}, _>`
         1 => {}
     //~^ ERROR mismatched types
-    //~| expected struct `Foo<{float}, _>`
-    //~| found type `{integer}`
-    //~| expected `Foo<{float}, _>`, found integer
+    //~| NOTE expected struct `Foo<{float}, _>`
+    //~| NOTE found type `{integer}`
+    //~| NOTE expected `Foo<{float}, _>`, found integer
     }
 
 }

--- a/tests/ui/impl-trait/equality.rs
+++ b/tests/ui/impl-trait/equality.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 #![feature(specialization)] //~ WARN the feature `specialization` is incomplete
 
 trait Foo: Copy + ToString {}
@@ -14,7 +16,7 @@ fn two(x: bool) -> impl Foo {
     }
     0_u32
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `u32`
+    //~| NOTE expected `i32`, found `u32`
 }
 
 fn sum_to(n: u32) -> impl Foo {

--- a/tests/ui/impl-trait/equality.stderr
+++ b/tests/ui/impl-trait/equality.stderr
@@ -1,5 +1,5 @@
 warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/equality.rs:1:12
+  --> $DIR/equality.rs:3:12
    |
 LL | #![feature(specialization)]
    |            ^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | #![feature(specialization)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0308]: mismatched types
-  --> $DIR/equality.rs:15:5
+  --> $DIR/equality.rs:17:5
    |
 LL | fn two(x: bool) -> impl Foo {
    |                    -------- expected `i32` because of return type
@@ -24,7 +24,7 @@ LL +     0_i32
    |
 
 error[E0277]: cannot add `impl Foo` to `u32`
-  --> $DIR/equality.rs:24:11
+  --> $DIR/equality.rs:26:11
    |
 LL |         n + sum_to(n - 1)
    |           ^ no implementation for `u32 + impl Foo`

--- a/tests/ui/impl-trait/equality2.rs
+++ b/tests/ui/impl-trait/equality2.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 #![feature(specialization)] //~ WARN the feature `specialization` is incomplete
 
 trait Foo: Copy + ToString {}
@@ -24,21 +26,21 @@ impl Leak for i32 {
 fn main() {
     let _: u32 = hide(0_u32);
     //~^ ERROR mismatched types
-    //~| expected type `u32`
-    //~| found opaque type `impl Foo`
-    //~| expected `u32`, found opaque type
+    //~| NOTE expected type `u32`
+    //~| NOTE found opaque type `impl Foo`
+    //~| NOTE expected `u32`, found opaque type
 
     let _: i32 = Leak::leak(hide(0_i32));
     //~^ ERROR mismatched types
-    //~| expected type `i32`
-    //~| found associated type `<impl Foo as Leak>::T`
-    //~| expected `i32`, found associated type
+    //~| NOTE expected type `i32`
+    //~| NOTE found associated type `<impl Foo as Leak>::T`
+    //~| NOTE expected `i32`, found associated type
 
     let mut x = (hide(0_u32), hide(0_i32));
     x = (x.1,
     //~^ ERROR mismatched types
-    //~| expected `u32`, found `i32`
+    //~| NOTE expected `u32`, found `i32`
          x.0);
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `u32`
+    //~| NOTE expected `i32`, found `u32`
 }

--- a/tests/ui/impl-trait/equality2.stderr
+++ b/tests/ui/impl-trait/equality2.stderr
@@ -1,5 +1,5 @@
 warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/equality2.rs:1:12
+  --> $DIR/equality2.rs:3:12
    |
 LL | #![feature(specialization)]
    |            ^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | #![feature(specialization)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0308]: mismatched types
-  --> $DIR/equality2.rs:25:18
+  --> $DIR/equality2.rs:27:18
    |
 LL | fn hide<T: Foo>(x: T) -> impl Foo {
    |                          -------- the found opaque type
@@ -23,7 +23,7 @@ LL |     let _: u32 = hide(0_u32);
            found opaque type `impl Foo`
 
 error[E0308]: mismatched types
-  --> $DIR/equality2.rs:31:18
+  --> $DIR/equality2.rs:33:18
    |
 LL | fn hide<T: Foo>(x: T) -> impl Foo {
    |                          -------- the found opaque type
@@ -41,7 +41,7 @@ LL | fn hide<T: Foo>(x: T) -> impl Foo<T = i32> {
    |                                  +++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/equality2.rs:38:10
+  --> $DIR/equality2.rs:40:10
    |
 LL | fn hide<T: Foo>(x: T) -> impl Foo {
    |                          --------
@@ -57,7 +57,7 @@ LL |     x = (x.1,
    = note: distinct uses of `impl Trait` result in different opaque types
 
 error[E0308]: mismatched types
-  --> $DIR/equality2.rs:41:10
+  --> $DIR/equality2.rs:43:10
    |
 LL | fn hide<T: Foo>(x: T) -> impl Foo {
    |                          --------

--- a/tests/ui/impl-trait/no-method-suggested-traits.rs
+++ b/tests/ui/impl-trait/no-method-suggested-traits.rs
@@ -1,4 +1,6 @@
 //@ aux-build:no_method_suggested_traits.rs
+//@ dont-require-annotations: HELP
+
 extern crate no_method_suggested_traits;
 
 struct Foo;
@@ -22,9 +24,9 @@ fn main() {
 
     1u32.method();
     //~^ ERROR no method named
-    //~|items from traits can only be used if the trait is in scope
+    //~| HELP items from traits can only be used if the trait is in scope
     std::rc::Rc::new(&mut Box::new(&1u32)).method();
-    //~^items from traits can only be used if the trait is in scope
+    //~^ HELP items from traits can only be used if the trait is in scope
     //~| ERROR no method named `method` found for struct
 
     'a'.method();

--- a/tests/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/tests/ui/impl-trait/no-method-suggested-traits.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `method` found for type `u32` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:23:10
+  --> $DIR/no-method-suggested-traits.rs:25:10
    |
 LL |     1u32.method();
    |          ^^^^^^
@@ -21,7 +21,7 @@ LL |     1u32.method2();
    |                +
 
 error[E0599]: no method named `method` found for struct `Rc<&mut Box<&u32>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:26:44
+  --> $DIR/no-method-suggested-traits.rs:28:44
    |
 LL |     std::rc::Rc::new(&mut Box::new(&1u32)).method();
    |                                            ^^^^^^
@@ -43,7 +43,7 @@ LL |     std::rc::Rc::new(&mut Box::new(&1u32)).method2();
    |                                                  +
 
 error[E0599]: no method named `method` found for type `char` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:30:9
+  --> $DIR/no-method-suggested-traits.rs:32:9
    |
 LL |         fn method(&self) {}
    |            ------ the method is available for `char` here
@@ -62,7 +62,7 @@ LL |     'a'.method2();
    |               +
 
 error[E0599]: no method named `method` found for struct `Rc<&mut Box<&char>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:32:43
+  --> $DIR/no-method-suggested-traits.rs:34:43
    |
 LL |     std::rc::Rc::new(&mut Box::new(&'a')).method();
    |                                           ^^^^^^
@@ -78,7 +78,7 @@ LL |     std::rc::Rc::new(&mut Box::new(&'a')).method2();
    |                                                 +
 
 error[E0599]: no method named `method` found for type `i32` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:35:10
+  --> $DIR/no-method-suggested-traits.rs:37:10
    |
 LL |     1i32.method();
    |          ^^^^^^
@@ -99,7 +99,7 @@ LL |     1i32.method3();
    |                +
 
 error[E0599]: no method named `method` found for struct `Rc<&mut Box<&i32>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:37:44
+  --> $DIR/no-method-suggested-traits.rs:39:44
    |
 LL |     std::rc::Rc::new(&mut Box::new(&1i32)).method();
    |                                            ^^^^^^
@@ -115,7 +115,7 @@ LL |     std::rc::Rc::new(&mut Box::new(&1i32)).method3();
    |                                                  +
 
 error[E0599]: no method named `method` found for struct `Foo` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:40:9
+  --> $DIR/no-method-suggested-traits.rs:42:9
    |
 LL | struct Foo;
    | ---------- method `method` not found for this struct
@@ -131,7 +131,7 @@ LL |     Foo.method();
            candidate #4: `no_method_suggested_traits::qux::PrivPub`
 
 error[E0599]: no method named `method` found for struct `Rc<&mut Box<&Foo>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:42:43
+  --> $DIR/no-method-suggested-traits.rs:44:43
    |
 LL |     std::rc::Rc::new(&mut Box::new(&Foo)).method();
    |                                           ^^^^^^ method not found in `Rc<&mut Box<&Foo>>`
@@ -144,85 +144,85 @@ LL |     std::rc::Rc::new(&mut Box::new(&Foo)).method();
            candidate #4: `no_method_suggested_traits::qux::PrivPub`
 
 error[E0599]: no method named `method2` found for type `u64` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:45:10
+  --> $DIR/no-method-suggested-traits.rs:47:10
    |
 LL |     1u64.method2();
    |          ^^^^^^^ method not found in `u64`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `foo::Bar` defines an item `method2`, perhaps you need to implement it
-  --> $DIR/no-method-suggested-traits.rs:8:5
+  --> $DIR/no-method-suggested-traits.rs:10:5
    |
 LL |     pub trait Bar {
    |     ^^^^^^^^^^^^^
 
 error[E0599]: no method named `method2` found for struct `Rc<&mut Box<&u64>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:47:44
+  --> $DIR/no-method-suggested-traits.rs:49:44
    |
 LL |     std::rc::Rc::new(&mut Box::new(&1u64)).method2();
    |                                            ^^^^^^^ method not found in `Rc<&mut Box<&u64>>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `foo::Bar` defines an item `method2`, perhaps you need to implement it
-  --> $DIR/no-method-suggested-traits.rs:8:5
+  --> $DIR/no-method-suggested-traits.rs:10:5
    |
 LL |     pub trait Bar {
    |     ^^^^^^^^^^^^^
 
 error[E0599]: no method named `method2` found for struct `no_method_suggested_traits::Foo` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:50:37
+  --> $DIR/no-method-suggested-traits.rs:52:37
    |
 LL |     no_method_suggested_traits::Foo.method2();
    |                                     ^^^^^^^ method not found in `Foo`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `foo::Bar` defines an item `method2`, perhaps you need to implement it
-  --> $DIR/no-method-suggested-traits.rs:8:5
+  --> $DIR/no-method-suggested-traits.rs:10:5
    |
 LL |     pub trait Bar {
    |     ^^^^^^^^^^^^^
 
 error[E0599]: no method named `method2` found for struct `Rc<&mut Box<&no_method_suggested_traits::Foo>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:52:71
+  --> $DIR/no-method-suggested-traits.rs:54:71
    |
 LL |     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Foo)).method2();
    |                                                                       ^^^^^^^ method not found in `Rc<&mut Box<&Foo>>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `foo::Bar` defines an item `method2`, perhaps you need to implement it
-  --> $DIR/no-method-suggested-traits.rs:8:5
+  --> $DIR/no-method-suggested-traits.rs:10:5
    |
 LL |     pub trait Bar {
    |     ^^^^^^^^^^^^^
 
 error[E0599]: no method named `method2` found for enum `no_method_suggested_traits::Bar` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:54:40
+  --> $DIR/no-method-suggested-traits.rs:56:40
    |
 LL |     no_method_suggested_traits::Bar::X.method2();
    |                                        ^^^^^^^ method not found in `Bar`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `foo::Bar` defines an item `method2`, perhaps you need to implement it
-  --> $DIR/no-method-suggested-traits.rs:8:5
+  --> $DIR/no-method-suggested-traits.rs:10:5
    |
 LL |     pub trait Bar {
    |     ^^^^^^^^^^^^^
 
 error[E0599]: no method named `method2` found for struct `Rc<&mut Box<&no_method_suggested_traits::Bar>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:56:74
+  --> $DIR/no-method-suggested-traits.rs:58:74
    |
 LL |     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Bar::X)).method2();
    |                                                                          ^^^^^^^ method not found in `Rc<&mut Box<&Bar>>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `foo::Bar` defines an item `method2`, perhaps you need to implement it
-  --> $DIR/no-method-suggested-traits.rs:8:5
+  --> $DIR/no-method-suggested-traits.rs:10:5
    |
 LL |     pub trait Bar {
    |     ^^^^^^^^^^^^^
 
 error[E0599]: no method named `method3` found for struct `Foo` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:59:9
+  --> $DIR/no-method-suggested-traits.rs:61:9
    |
 LL | struct Foo;
    | ---------- method `method3` not found for this struct
@@ -235,7 +235,7 @@ LL |     Foo.method3();
            candidate #1: `PubPub`
 
 error[E0599]: no method named `method3` found for struct `Rc<&mut Box<&Foo>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:61:43
+  --> $DIR/no-method-suggested-traits.rs:63:43
    |
 LL |     std::rc::Rc::new(&mut Box::new(&Foo)).method3();
    |                                           ^^^^^^^ method not found in `Rc<&mut Box<&Foo>>`
@@ -245,7 +245,7 @@ LL |     std::rc::Rc::new(&mut Box::new(&Foo)).method3();
            candidate #1: `PubPub`
 
 error[E0599]: no method named `method3` found for enum `Bar` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:63:12
+  --> $DIR/no-method-suggested-traits.rs:65:12
    |
 LL | enum Bar { X }
    | -------- method `method3` not found for this enum
@@ -258,7 +258,7 @@ LL |     Bar::X.method3();
            candidate #1: `PubPub`
 
 error[E0599]: no method named `method3` found for struct `Rc<&mut Box<&Bar>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:65:46
+  --> $DIR/no-method-suggested-traits.rs:67:46
    |
 LL |     std::rc::Rc::new(&mut Box::new(&Bar::X)).method3();
    |                                              ^^^^^^^ method not found in `Rc<&mut Box<&Bar>>`
@@ -268,37 +268,37 @@ LL |     std::rc::Rc::new(&mut Box::new(&Bar::X)).method3();
            candidate #1: `PubPub`
 
 error[E0599]: no method named `method3` found for type `usize` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:69:13
+  --> $DIR/no-method-suggested-traits.rs:71:13
    |
 LL |     1_usize.method3();
    |             ^^^^^^^ method not found in `usize`
 
 error[E0599]: no method named `method3` found for struct `Rc<&mut Box<&usize>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:70:47
+  --> $DIR/no-method-suggested-traits.rs:72:47
    |
 LL |     std::rc::Rc::new(&mut Box::new(&1_usize)).method3();
    |                                               ^^^^^^^ method not found in `Rc<&mut Box<&usize>>`
 
 error[E0599]: no method named `method3` found for struct `no_method_suggested_traits::Foo` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:71:37
+  --> $DIR/no-method-suggested-traits.rs:73:37
    |
 LL |     no_method_suggested_traits::Foo.method3();
    |                                     ^^^^^^^ method not found in `Foo`
 
 error[E0599]: no method named `method3` found for struct `Rc<&mut Box<&no_method_suggested_traits::Foo>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:72:71
+  --> $DIR/no-method-suggested-traits.rs:74:71
    |
 LL |     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Foo)).method3();
    |                                                                       ^^^^^^^ method not found in `Rc<&mut Box<&Foo>>`
 
 error[E0599]: no method named `method3` found for enum `no_method_suggested_traits::Bar` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:74:40
+  --> $DIR/no-method-suggested-traits.rs:76:40
    |
 LL |     no_method_suggested_traits::Bar::X.method3();
    |                                        ^^^^^^^ method not found in `Bar`
 
 error[E0599]: no method named `method3` found for struct `Rc<&mut Box<&no_method_suggested_traits::Bar>>` in the current scope
-  --> $DIR/no-method-suggested-traits.rs:75:74
+  --> $DIR/no-method-suggested-traits.rs:77:74
    |
 LL |     std::rc::Rc::new(&mut Box::new(&no_method_suggested_traits::Bar::X)).method3();
    |                                                                          ^^^^^^^ method not found in `Rc<&mut Box<&Bar>>`

--- a/tests/ui/implied-bounds/sod_service_chain.rs
+++ b/tests/ui/implied-bounds/sod_service_chain.rs
@@ -1,5 +1,7 @@
 // Found in a crater run on #118553
 
+//@ dont-require-annotations: NOTE
+
 pub trait Debug {}
 
 pub trait Service {
@@ -30,16 +32,16 @@ impl<P: Service, S: Service<Input = P::Output>> ServiceChainBuilder<P, S> {
         //~^ ERROR the associated type
         //~| ERROR the associated type
         //~| ERROR the associated type
-        //~| the associated type
-        //~| the associated type
-        //~| the associated type
+        //~| NOTE the associated type
+        //~| NOTE the associated type
+        //~| NOTE the associated type
         //~| ERROR may not live long enough
         self,
     ) -> ServiceChainBuilder<ServiceChain<P, S>, NS> {
         //~^ ERROR the associated type
         //~| ERROR the associated type
-        //~| the associated type
-        //~| the associated type
+        //~| NOTE the associated type
+        //~| NOTE the associated type
         panic!();
     }
 }

--- a/tests/ui/implied-bounds/sod_service_chain.stderr
+++ b/tests/ui/implied-bounds/sod_service_chain.stderr
@@ -1,5 +1,5 @@
 error[E0310]: the associated type `<P as Service>::Error` may not live long enough
-  --> $DIR/sod_service_chain.rs:29:5
+  --> $DIR/sod_service_chain.rs:31:5
    |
 LL | /     pub fn next<NS: Service<Input = S::Output>>(
 ...  |
@@ -16,7 +16,7 @@ LL |     ) -> ServiceChainBuilder<ServiceChain<P, S>, NS> where <P as Service>::
    |                                                      ++++++++++++++++++++++++++++++++++++
 
 error[E0310]: the associated type `<S as Service>::Error` may not live long enough
-  --> $DIR/sod_service_chain.rs:29:5
+  --> $DIR/sod_service_chain.rs:31:5
    |
 LL | /     pub fn next<NS: Service<Input = S::Output>>(
 ...  |
@@ -33,7 +33,7 @@ LL |     ) -> ServiceChainBuilder<ServiceChain<P, S>, NS> where <S as Service>::
    |                                                      ++++++++++++++++++++++++++++++++++++
 
 error[E0310]: the associated type `<P as Service>::Error` may not live long enough
-  --> $DIR/sod_service_chain.rs:38:10
+  --> $DIR/sod_service_chain.rs:40:10
    |
 LL |     ) -> ServiceChainBuilder<ServiceChain<P, S>, NS> {
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     ) -> ServiceChainBuilder<ServiceChain<P, S>, NS> where <P as Service>::
    |                                                      ++++++++++++++++++++++++++++++++++++
 
 error[E0310]: the associated type `<S as Service>::Error` may not live long enough
-  --> $DIR/sod_service_chain.rs:38:10
+  --> $DIR/sod_service_chain.rs:40:10
    |
 LL |     ) -> ServiceChainBuilder<ServiceChain<P, S>, NS> {
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL |     ) -> ServiceChainBuilder<ServiceChain<P, S>, NS> where <S as Service>::
    |                                                      ++++++++++++++++++++++++++++++++++++
 
 error[E0310]: the associated type `<P as Service>::Error` may not live long enough
-  --> $DIR/sod_service_chain.rs:29:5
+  --> $DIR/sod_service_chain.rs:31:5
    |
 LL | /     pub fn next<NS: Service<Input = S::Output>>(
 ...  |
@@ -79,7 +79,7 @@ LL |     ) -> ServiceChainBuilder<ServiceChain<P, S>, NS> where <P as Service>::
    |                                                      ++++++++++++++++++++++++++++++++++++
 
 error[E0310]: the associated type `<S as Service>::Error` may not live long enough
-  --> $DIR/sod_service_chain.rs:29:5
+  --> $DIR/sod_service_chain.rs:31:5
    |
 LL | /     pub fn next<NS: Service<Input = S::Output>>(
 ...  |

--- a/tests/ui/imports/import.rs
+++ b/tests/ui/imports/import.rs
@@ -1,6 +1,8 @@
+//@ dont-require-annotations: NOTE
+
 use zed::bar;
 use zed::baz; //~ ERROR unresolved import `zed::baz` [E0432]
-              //~| no `baz` in `zed`
+              //~| NOTE no `baz` in `zed`
               //~| HELP a similar name exists in the module
               //~| SUGGESTION bar
 
@@ -8,7 +10,7 @@ use zed::baz; //~ ERROR unresolved import `zed::baz` [E0432]
 mod zed {
     pub fn bar() { println!("bar"); }
     use foo; //~ ERROR unresolved import `foo` [E0432]
-             //~^ no `foo` in the root
+             //~^ NOTE no `foo` in the root
 }
 
 fn main() {

--- a/tests/ui/imports/import.stderr
+++ b/tests/ui/imports/import.stderr
@@ -1,5 +1,5 @@
 error[E0432]: unresolved import `zed::baz`
-  --> $DIR/import.rs:2:5
+  --> $DIR/import.rs:4:5
    |
 LL | use zed::baz;
    |     ^^^^^---
@@ -8,19 +8,19 @@ LL | use zed::baz;
    |     no `baz` in `zed`
 
 error[E0432]: unresolved import `foo`
-  --> $DIR/import.rs:10:9
+  --> $DIR/import.rs:12:9
    |
 LL |     use foo;
    |         ^^^ no `foo` in the root
 
 error[E0603]: unresolved item import `foo` is private
-  --> $DIR/import.rs:15:10
+  --> $DIR/import.rs:17:10
    |
 LL |     zed::foo();
    |          ^^^ private unresolved item import
    |
 note: the unresolved item import `foo` is defined here
-  --> $DIR/import.rs:10:9
+  --> $DIR/import.rs:12:9
    |
 LL |     use foo;
    |         ^^^

--- a/tests/ui/imports/issue-19498.rs
+++ b/tests/ui/imports/issue-19498.rs
@@ -1,13 +1,15 @@
+//@ dont-require-annotations: NOTE
+
 use self::A;
 use self::B;
 mod A {} //~ ERROR the name `A` is defined multiple times
-//~| `A` redefined here
+//~| NOTE `A` redefined here
 pub mod B {} //~ ERROR the name `B` is defined multiple times
-//~| `B` redefined here
+//~| NOTE `B` redefined here
 mod C {
     use C::D;
     mod D {} //~ ERROR the name `D` is defined multiple times
-    //~| `D` redefined here
+    //~| NOTE `D` redefined here
 }
 
 fn main() {}

--- a/tests/ui/imports/issue-19498.stderr
+++ b/tests/ui/imports/issue-19498.stderr
@@ -1,5 +1,5 @@
 error[E0255]: the name `A` is defined multiple times
-  --> $DIR/issue-19498.rs:3:1
+  --> $DIR/issue-19498.rs:5:1
    |
 LL | use self::A;
    |     ------- previous import of the module `A` here
@@ -14,7 +14,7 @@ LL | use self::A as OtherA;
    |             +++++++++
 
 error[E0255]: the name `B` is defined multiple times
-  --> $DIR/issue-19498.rs:5:1
+  --> $DIR/issue-19498.rs:7:1
    |
 LL | use self::B;
    |     ------- previous import of the module `B` here
@@ -29,7 +29,7 @@ LL | use self::B as OtherB;
    |             +++++++++
 
 error[E0255]: the name `D` is defined multiple times
-  --> $DIR/issue-19498.rs:9:5
+  --> $DIR/issue-19498.rs:11:5
    |
 LL |     use C::D;
    |         ---- previous import of the module `D` here

--- a/tests/ui/imports/issue-24081.rs
+++ b/tests/ui/imports/issue-24081.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 use std::ops::Add;
 use std::ops::Sub;
 use std::ops::Mul;
@@ -5,14 +7,14 @@ use std::ops::Div;
 use std::ops::Rem;
 
 type Add = bool; //~ ERROR the name `Add` is defined multiple times
-//~| `Add` redefined here
+//~| NOTE `Add` redefined here
 struct Sub { x: f32 } //~ ERROR the name `Sub` is defined multiple times
-//~| `Sub` redefined here
+//~| NOTE `Sub` redefined here
 enum Mul { A, B } //~ ERROR the name `Mul` is defined multiple times
-//~| `Mul` redefined here
+//~| NOTE `Mul` redefined here
 mod Div { } //~ ERROR the name `Div` is defined multiple times
-//~| `Div` redefined here
+//~| NOTE `Div` redefined here
 trait Rem {  } //~ ERROR the name `Rem` is defined multiple times
-//~| `Rem` redefined here
+//~| NOTE `Rem` redefined here
 
 fn main() {}

--- a/tests/ui/imports/issue-24081.stderr
+++ b/tests/ui/imports/issue-24081.stderr
@@ -1,5 +1,5 @@
 error[E0255]: the name `Add` is defined multiple times
-  --> $DIR/issue-24081.rs:7:1
+  --> $DIR/issue-24081.rs:9:1
    |
 LL | use std::ops::Add;
    |     ------------- previous import of the trait `Add` here
@@ -14,7 +14,7 @@ LL | use std::ops::Add as OtherAdd;
    |                   +++++++++++
 
 error[E0255]: the name `Sub` is defined multiple times
-  --> $DIR/issue-24081.rs:9:1
+  --> $DIR/issue-24081.rs:11:1
    |
 LL | use std::ops::Sub;
    |     ------------- previous import of the trait `Sub` here
@@ -29,7 +29,7 @@ LL | use std::ops::Sub as OtherSub;
    |                   +++++++++++
 
 error[E0255]: the name `Mul` is defined multiple times
-  --> $DIR/issue-24081.rs:11:1
+  --> $DIR/issue-24081.rs:13:1
    |
 LL | use std::ops::Mul;
    |     ------------- previous import of the trait `Mul` here
@@ -44,7 +44,7 @@ LL | use std::ops::Mul as OtherMul;
    |                   +++++++++++
 
 error[E0255]: the name `Div` is defined multiple times
-  --> $DIR/issue-24081.rs:13:1
+  --> $DIR/issue-24081.rs:15:1
    |
 LL | use std::ops::Div;
    |     ------------- previous import of the trait `Div` here
@@ -59,7 +59,7 @@ LL | use std::ops::Div as OtherDiv;
    |                   +++++++++++
 
 error[E0255]: the name `Rem` is defined multiple times
-  --> $DIR/issue-24081.rs:15:1
+  --> $DIR/issue-24081.rs:17:1
    |
 LL | use std::ops::Rem;
    |     ------------- previous import of the trait `Rem` here

--- a/tests/ui/imports/issue-26886.rs
+++ b/tests/ui/imports/issue-26886.rs
@@ -1,8 +1,10 @@
+//@ dont-require-annotations: NOTE
+
 use std::sync::{self, Arc};
 use std::sync::Arc; //~ ERROR the name `Arc` is defined multiple times
-                    //~| `Arc` must be defined only once in the type namespace of this module
+                    //~| NOTE `Arc` must be defined only once in the type namespace of this module
 use std::sync; //~ ERROR the name `sync` is defined multiple times
-               //~| `sync` must be defined only once in the type namespace of this module
+               //~| NOTE `sync` must be defined only once in the type namespace of this module
 
 fn main() {
 }

--- a/tests/ui/imports/issue-26886.stderr
+++ b/tests/ui/imports/issue-26886.stderr
@@ -1,5 +1,5 @@
 error[E0252]: the name `Arc` is defined multiple times
-  --> $DIR/issue-26886.rs:2:5
+  --> $DIR/issue-26886.rs:4:5
    |
 LL | use std::sync::{self, Arc};
    |                       --- previous import of the type `Arc` here
@@ -9,7 +9,7 @@ LL | use std::sync::Arc;
    = note: `Arc` must be defined only once in the type namespace of this module
 
 error[E0252]: the name `sync` is defined multiple times
-  --> $DIR/issue-26886.rs:4:5
+  --> $DIR/issue-26886.rs:6:5
    |
 LL | use std::sync::{self, Arc};
    |                 ---- previous import of the module `sync` here

--- a/tests/ui/inference/tutorial-suffix-inference-test.rs
+++ b/tests/ui/inference/tutorial-suffix-inference-test.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 fn main() {
     let x = 3;
     let y: i32 = 3;
@@ -8,10 +10,10 @@ fn main() {
     identity_u8(x);  // after this, `x` is assumed to have type `u8`
     identity_u16(x);
     //~^ ERROR mismatched types
-    //~| expected `u16`, found `u8`
+    //~| NOTE expected `u16`, found `u8`
     identity_u16(y);
     //~^ ERROR mismatched types
-    //~| expected `u16`, found `i32`
+    //~| NOTE expected `u16`, found `i32`
 
     let a = 3;
 
@@ -20,5 +22,5 @@ fn main() {
     identity_i(a); // ok
     identity_u16(a);
     //~^ ERROR mismatched types
-    //~| expected `u16`, found `isize`
+    //~| NOTE expected `u16`, found `isize`
 }

--- a/tests/ui/inference/tutorial-suffix-inference-test.stderr
+++ b/tests/ui/inference/tutorial-suffix-inference-test.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/tutorial-suffix-inference-test.rs:9:18
+  --> $DIR/tutorial-suffix-inference-test.rs:11:18
    |
 LL |     identity_u16(x);
    |     ------------ ^ expected `u16`, found `u8`
@@ -7,7 +7,7 @@ LL |     identity_u16(x);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/tutorial-suffix-inference-test.rs:6:8
+  --> $DIR/tutorial-suffix-inference-test.rs:8:8
    |
 LL |     fn identity_u16(n: u16) -> u16 { n }
    |        ^^^^^^^^^^^^ ------
@@ -17,7 +17,7 @@ LL |     identity_u16(x.into());
    |                   +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/tutorial-suffix-inference-test.rs:12:18
+  --> $DIR/tutorial-suffix-inference-test.rs:14:18
    |
 LL |     identity_u16(y);
    |     ------------ ^ expected `u16`, found `i32`
@@ -25,7 +25,7 @@ LL |     identity_u16(y);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/tutorial-suffix-inference-test.rs:6:8
+  --> $DIR/tutorial-suffix-inference-test.rs:8:8
    |
 LL |     fn identity_u16(n: u16) -> u16 { n }
    |        ^^^^^^^^^^^^ ------
@@ -35,7 +35,7 @@ LL |     identity_u16(y.try_into().unwrap());
    |                   ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/tutorial-suffix-inference-test.rs:21:18
+  --> $DIR/tutorial-suffix-inference-test.rs:23:18
    |
 LL |     identity_u16(a);
    |     ------------ ^ expected `u16`, found `isize`
@@ -43,7 +43,7 @@ LL |     identity_u16(a);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/tutorial-suffix-inference-test.rs:6:8
+  --> $DIR/tutorial-suffix-inference-test.rs:8:8
    |
 LL |     fn identity_u16(n: u16) -> u16 { n }
    |        ^^^^^^^^^^^^ ------

--- a/tests/ui/issues/issue-13359.rs
+++ b/tests/ui/issues/issue-13359.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 fn foo(_s: i16) { }
 
 fn bar(_s: u32) { }
@@ -5,9 +7,9 @@ fn bar(_s: u32) { }
 fn main() {
     foo(1*(1 as isize));
     //~^ ERROR mismatched types
-    //~| expected `i16`, found `isize`
+    //~| NOTE expected `i16`, found `isize`
 
     bar(1*(1 as usize));
     //~^ ERROR mismatched types
-    //~| expected `u32`, found `usize`
+    //~| NOTE expected `u32`, found `usize`
 }

--- a/tests/ui/issues/issue-13359.stderr
+++ b/tests/ui/issues/issue-13359.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-13359.rs:6:9
+  --> $DIR/issue-13359.rs:8:9
    |
 LL |     foo(1*(1 as isize));
    |     --- ^^^^^^^^^^^^^^ expected `i16`, found `isize`
@@ -7,7 +7,7 @@ LL |     foo(1*(1 as isize));
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/issue-13359.rs:1:4
+  --> $DIR/issue-13359.rs:3:4
    |
 LL | fn foo(_s: i16) { }
    |    ^^^ -------
@@ -17,7 +17,7 @@ LL |     foo((1*(1 as isize)).try_into().unwrap());
    |         +              +++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/issue-13359.rs:10:9
+  --> $DIR/issue-13359.rs:12:9
    |
 LL |     bar(1*(1 as usize));
    |     --- ^^^^^^^^^^^^^^ expected `u32`, found `usize`
@@ -25,7 +25,7 @@ LL |     bar(1*(1 as usize));
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/issue-13359.rs:3:4
+  --> $DIR/issue-13359.rs:5:4
    |
 LL | fn bar(_s: u32) { }
    |    ^^^ -------

--- a/tests/ui/issues/issue-13466.rs
+++ b/tests/ui/issues/issue-13466.rs
@@ -1,5 +1,7 @@
 // Regression test for #13466
 
+//@ dont-require-annotations: NOTE
+
 pub fn main() {
     // The expected arm type `Option<T>` has one type parameter, while
     // the actual arm `Result<T, E>` has two. typeck should not be
@@ -7,14 +9,14 @@ pub fn main() {
     let _x: usize = match Some(1) {
         Ok(u) => u,
         //~^ ERROR mismatched types
-        //~| expected enum `Option<{integer}>`
-        //~| found enum `Result<_, _>`
-        //~| expected `Option<{integer}>`, found `Result<_, _>`
+        //~| NOTE expected enum `Option<{integer}>`
+        //~| NOTE found enum `Result<_, _>`
+        //~| NOTE expected `Option<{integer}>`, found `Result<_, _>`
 
         Err(e) => panic!(e)
         //~^ ERROR mismatched types
-        //~| expected enum `Option<{integer}>`
-        //~| found enum `Result<_, _>`
-        //~| expected `Option<{integer}>`, found `Result<_, _>`
+        //~| NOTE expected enum `Option<{integer}>`
+        //~| NOTE found enum `Result<_, _>`
+        //~| NOTE expected `Option<{integer}>`, found `Result<_, _>`
     };
 }

--- a/tests/ui/issues/issue-13466.stderr
+++ b/tests/ui/issues/issue-13466.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-13466.rs:8:9
+  --> $DIR/issue-13466.rs:10:9
    |
 LL |     let _x: usize = match Some(1) {
    |                           ------- this expression has type `Option<{integer}>`
@@ -10,7 +10,7 @@ LL |         Ok(u) => u,
               found enum `Result<_, _>`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-13466.rs:14:9
+  --> $DIR/issue-13466.rs:16:9
    |
 LL |     let _x: usize = match Some(1) {
    |                           ------- this expression has type `Option<{integer}>`

--- a/tests/ui/issues/issue-14541.rs
+++ b/tests/ui/issues/issue-14541.rs
@@ -4,7 +4,8 @@ struct Vec3 { y: f32, z: f32 }
 fn make(v: Vec2) {
     let Vec3 { y: _, z: _ } = v;
     //~^ ERROR mismatched types
-    //~| expected `Vec2`, found `Vec3`
+    //~| NOTE expected `Vec2`, found `Vec3`
+    //~| NOTE this expression has type `Vec2`
 }
 
 fn main() { }

--- a/tests/ui/issues/issue-15094.rs
+++ b/tests/ui/issues/issue-15094.rs
@@ -10,8 +10,9 @@ impl<T: fmt::Debug> ops::FnOnce<(),> for Debuger<T> {
     type Output = ();
     fn call_once(self, _args: ()) {
     //~^ ERROR `call_once` has an incompatible type for trait
-    //~| expected signature `extern "rust-call" fn
-    //~| found signature `fn
+    //~| NOTE expected signature `extern "rust-call" fn
+    //~| NOTE found signature `fn
+    //~| NOTE expected "rust-call" fn, found "Rust" fn
         println!("{:?}", self.x);
     }
 }

--- a/tests/ui/issues/issue-15381.rs
+++ b/tests/ui/issues/issue-15381.rs
@@ -3,7 +3,8 @@ fn main() {
 
     for &[x,y,z] in values.chunks(3).filter(|&xs| xs.len() == 3) {
         //~^ ERROR refutable pattern in `for` loop binding
-        //~| patterns `&[]`, `&[_]`, `&[_, _]` and 1 more not covered
+        //~| NOTE patterns `&[]`, `&[_]`, `&[_, _]` and 1 more not covered
+        //~| NOTE the matched value is of type `&[u8]`
         println!("y={}", y);
     }
 }

--- a/tests/ui/issues/issue-15783.rs
+++ b/tests/ui/issues/issue-15783.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 pub fn foo(params: Option<&[&str]>) -> usize {
     params.unwrap().first().unwrap().len()
 }
@@ -7,8 +9,8 @@ fn main() {
     let x = Some(&[name]);
     let msg = foo(x);
     //~^ ERROR mismatched types
-    //~| expected enum `Option<&[&str]>`
-    //~| found enum `Option<&[&str; 1]>`
-    //~| expected `Option<&[&str]>`, found `Option<&[&str; 1]>`
+    //~| NOTE expected enum `Option<&[&str]>`
+    //~| NOTE found enum `Option<&[&str; 1]>`
+    //~| NOTE expected `Option<&[&str]>`, found `Option<&[&str; 1]>`
     assert_eq!(msg, 3);
 }

--- a/tests/ui/issues/issue-15783.stderr
+++ b/tests/ui/issues/issue-15783.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-15783.rs:8:19
+  --> $DIR/issue-15783.rs:10:19
    |
 LL |     let msg = foo(x);
    |               --- ^ expected `Option<&[&str]>`, found `Option<&[&str; 1]>`
@@ -9,7 +9,7 @@ LL |     let msg = foo(x);
    = note: expected enum `Option<&[&str]>`
               found enum `Option<&[&str; 1]>`
 note: function defined here
-  --> $DIR/issue-15783.rs:1:8
+  --> $DIR/issue-15783.rs:3:8
    |
 LL | pub fn foo(params: Option<&[&str]>) -> usize {
    |        ^^^ -----------------------

--- a/tests/ui/issues/issue-16401.rs
+++ b/tests/ui/issues/issue-16401.rs
@@ -4,12 +4,12 @@ struct Slice<T> {
 }
 
 fn main() {
-    match () {
+    match () { //~ NOTE this expression has type `()`
         Slice { data: data, len: len } => (),
         //~^ ERROR mismatched types
-        //~| expected unit type `()`
-        //~| found struct `Slice<_>`
-        //~| expected `()`, found `Slice<_>`
+        //~| NOTE expected unit type `()`
+        //~| NOTE found struct `Slice<_>`
+        //~| NOTE expected `()`, found `Slice<_>`
         _ => unreachable!()
     }
 }

--- a/tests/ui/issues/issue-17033.rs
+++ b/tests/ui/issues/issue-17033.rs
@@ -1,6 +1,7 @@
 fn f<'r>(p: &'r mut fn(p: &mut ())) {
     (*p)(()) //~  ERROR mismatched types
-             //~| expected `&mut ()`, found `()`
+             //~| NOTE expected `&mut ()`, found `()`
+             //~| NOTE arguments to this function are incorrect
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-17740.rs
+++ b/tests/ui/issues/issue-17740.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 struct Foo<'a> {
     data: &'a[u8],
 }
@@ -5,13 +7,13 @@ struct Foo<'a> {
 impl <'a> Foo<'a>{
     fn bar(self: &mut Foo) {
     //~^ ERROR mismatched `self` parameter type
-    //~| expected struct `Foo<'a>`
-    //~| found struct `Foo<'_>`
-    //~| lifetime mismatch
+    //~| NOTE expected struct `Foo<'a>`
+    //~| NOTE found struct `Foo<'_>`
+    //~| NOTE lifetime mismatch
     //~| ERROR mismatched `self` parameter type
-    //~| expected struct `Foo<'a>`
-    //~| found struct `Foo<'_>`
-    //~| lifetime mismatch
+    //~| NOTE expected struct `Foo<'a>`
+    //~| NOTE found struct `Foo<'_>`
+    //~| NOTE lifetime mismatch
     }
 }
 

--- a/tests/ui/issues/issue-17740.stderr
+++ b/tests/ui/issues/issue-17740.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/issue-17740.rs:6:18
+  --> $DIR/issue-17740.rs:8:18
    |
 LL |     fn bar(self: &mut Foo) {
    |                  ^^^^^^^^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     fn bar(self: &mut Foo) {
    = note: expected struct `Foo<'a>`
               found struct `Foo<'_>`
 note: the anonymous lifetime defined here...
-  --> $DIR/issue-17740.rs:6:23
+  --> $DIR/issue-17740.rs:8:23
    |
 LL |     fn bar(self: &mut Foo) {
    |                       ^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined here
-  --> $DIR/issue-17740.rs:5:7
+  --> $DIR/issue-17740.rs:7:7
    |
 LL | impl <'a> Foo<'a>{
    |       ^^
 
 error[E0308]: mismatched `self` parameter type
-  --> $DIR/issue-17740.rs:6:18
+  --> $DIR/issue-17740.rs:8:18
    |
 LL |     fn bar(self: &mut Foo) {
    |                  ^^^^^^^^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     fn bar(self: &mut Foo) {
    = note: expected struct `Foo<'a>`
               found struct `Foo<'_>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/issue-17740.rs:5:7
+  --> $DIR/issue-17740.rs:7:7
    |
 LL | impl <'a> Foo<'a>{
    |       ^^
 note: ...does not necessarily outlive the anonymous lifetime defined here
-  --> $DIR/issue-17740.rs:6:23
+  --> $DIR/issue-17740.rs:8:23
    |
 LL |     fn bar(self: &mut Foo) {
    |                       ^^^

--- a/tests/ui/issues/issue-19991.rs
+++ b/tests/ui/issues/issue-19991.rs
@@ -1,9 +1,11 @@
 // Test if the sugared `if let` construct correctly prints "missing an else clause" when an else
 // clause does not exist, instead of the unsympathetic "`match` arms have incompatible types"
 
+//@ dont-require-annotations: NOTE
+
 fn main() {
     if let Some(homura) = Some("madoka") { //~  ERROR missing an `else` clause
-                                           //~| expected integer, found `()`
+                                           //~| NOTE expected integer, found `()`
         765
     };
 }

--- a/tests/ui/issues/issue-19991.stderr
+++ b/tests/ui/issues/issue-19991.stderr
@@ -1,5 +1,5 @@
 error[E0317]: `if` may be missing an `else` clause
-  --> $DIR/issue-19991.rs:5:5
+  --> $DIR/issue-19991.rs:7:5
    |
 LL | /     if let Some(homura) = Some("madoka") {
 LL | |

--- a/tests/ui/issues/issue-21332.rs
+++ b/tests/ui/issues/issue-21332.rs
@@ -4,7 +4,8 @@ impl Iterator for S {
     type Item = i32;
     fn next(&mut self) -> Result<i32, i32> { Ok(7) }
     //~^ ERROR method `next` has an incompatible type for trait
-    //~| expected `Option<i32>`, found `Result<i32, i32>`
+    //~| NOTE expected `Option<i32>`, found `Result<i32, i32>`
+    //~| NOTE expected signature `fn(&mut S) -> Option<i32>`
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-24819.rs
+++ b/tests/ui/issues/issue-24819.rs
@@ -1,10 +1,12 @@
+//@ dont-require-annotations: NOTE
+
 use std::collections::HashSet;
 
 fn main() {
     let mut v = Vec::new();
     foo(&mut v);
     //~^ ERROR mismatched types
-    //~| expected `&mut HashSet<u32>`, found `&mut Vec<_>`
+    //~| NOTE expected `&mut HashSet<u32>`, found `&mut Vec<_>`
 }
 
 fn foo(h: &mut HashSet<u32>) {

--- a/tests/ui/issues/issue-24819.stderr
+++ b/tests/ui/issues/issue-24819.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-24819.rs:5:9
+  --> $DIR/issue-24819.rs:7:9
    |
 LL |     foo(&mut v);
    |     --- ^^^^^^ expected `&mut HashSet<u32>`, found `&mut Vec<_>`
@@ -9,7 +9,7 @@ LL |     foo(&mut v);
    = note: expected mutable reference `&mut HashSet<u32>`
               found mutable reference `&mut Vec<_>`
 note: function defined here
-  --> $DIR/issue-24819.rs:10:4
+  --> $DIR/issue-24819.rs:12:4
    |
 LL | fn foo(h: &mut HashSet<u32>) {
    |    ^^^ --------------------

--- a/tests/ui/issues/issue-27942.rs
+++ b/tests/ui/issues/issue-27942.rs
@@ -1,12 +1,14 @@
+//@ dont-require-annotations: NOTE
+
 pub trait Resources<'a> {}
 
 pub trait Buffer<'a, R: Resources<'a>> {
 
     fn select(&self) -> BufferViewHandle<R>;
     //~^ ERROR mismatched types
-    //~| lifetime mismatch
+    //~| NOTE lifetime mismatch
     //~| ERROR mismatched types
-    //~| lifetime mismatch
+    //~| NOTE lifetime mismatch
 }
 
 pub struct BufferViewHandle<'a, R: 'a+Resources<'a>>(&'a R);

--- a/tests/ui/issues/issue-27942.stderr
+++ b/tests/ui/issues/issue-27942.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-27942.rs:5:25
+  --> $DIR/issue-27942.rs:7:25
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |                         ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     fn select(&self) -> BufferViewHandle<R>;
    = note: expected trait `Resources<'_>`
               found trait `Resources<'a>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/issue-27942.rs:3:18
+  --> $DIR/issue-27942.rs:5:18
    |
 LL | pub trait Buffer<'a, R: Resources<'a>> {
    |                  ^^
 note: ...does not necessarily outlive the anonymous lifetime defined here
-  --> $DIR/issue-27942.rs:5:15
+  --> $DIR/issue-27942.rs:7:15
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |               ^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/issue-27942.rs:5:25
+  --> $DIR/issue-27942.rs:7:25
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |                         ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     fn select(&self) -> BufferViewHandle<R>;
    = note: expected trait `Resources<'_>`
               found trait `Resources<'a>`
 note: the anonymous lifetime defined here...
-  --> $DIR/issue-27942.rs:5:15
+  --> $DIR/issue-27942.rs:7:15
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |               ^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined here
-  --> $DIR/issue-27942.rs:3:18
+  --> $DIR/issue-27942.rs:5:18
    |
 LL | pub trait Buffer<'a, R: Resources<'a>> {
    |                  ^^

--- a/tests/ui/issues/issue-2951.rs
+++ b/tests/ui/issues/issue-2951.rs
@@ -1,10 +1,12 @@
+//@ dont-require-annotations: NOTE
+
 fn foo<T, U>(x: T, y: U) {
     let mut xx = x;
     xx = y;
     //~^  ERROR mismatched types
-    //~| expected type parameter `T`, found type parameter `U`
-    //~| expected type parameter `T`
-    //~| found type parameter `U`
+    //~| NOTE expected type parameter `T`, found type parameter `U`
+    //~| NOTE expected type parameter `T`
+    //~| NOTE found type parameter `U`
 }
 
 fn main() {

--- a/tests/ui/issues/issue-2951.stderr
+++ b/tests/ui/issues/issue-2951.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-2951.rs:3:10
+  --> $DIR/issue-2951.rs:5:10
    |
 LL | fn foo<T, U>(x: T, y: U) {
    |        -  - found type parameter

--- a/tests/ui/issues/issue-31011.rs
+++ b/tests/ui/issues/issue-31011.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 macro_rules! log {
     ( $ctx:expr, $( $args:expr),* ) => {
         if $ctx.trace {
@@ -16,7 +18,7 @@ struct Foo {
 fn wrap<T>(context: &T) -> ()
 {
     log!(context, "entered wrapper");
-    //~^ in this expansion of log!
+    //~^ NOTE in this expansion of log!
 }
 
 fn main() {

--- a/tests/ui/issues/issue-31011.stderr
+++ b/tests/ui/issues/issue-31011.stderr
@@ -1,5 +1,5 @@
 error[E0609]: no field `trace` on type `&T`
-  --> $DIR/issue-31011.rs:3:17
+  --> $DIR/issue-31011.rs:5:17
    |
 LL |         if $ctx.trace {
    |                 ^^^^^ unknown field

--- a/tests/ui/issues/issue-31910.rs
+++ b/tests/ui/issues/issue-31910.rs
@@ -1,8 +1,9 @@
 enum Enum<T: Trait> {
-    //~^ ERROR: `T` is never used
+    //~^ ERROR `T` is never used
+    //~| NOTE unused type parameter
     X = Trait::Number,
     //~^ ERROR mismatched types
-    //~| expected `isize`, found `i32`
+    //~| NOTE expected `isize`, found `i32`
 }
 
 trait Trait {

--- a/tests/ui/issues/issue-31910.stderr
+++ b/tests/ui/issues/issue-31910.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-31910.rs:3:9
+  --> $DIR/issue-31910.rs:4:9
    |
 LL |     X = Trait::Number,
    |         ^^^^^^^^^^^^^ expected `isize`, found `i32`

--- a/tests/ui/issues/issue-3477.rs
+++ b/tests/ui/issues/issue-3477.rs
@@ -1,5 +1,6 @@
 fn main() {
     let _p: char = 100;
     //~^ ERROR mismatched types
-    //~| expected `char`, found `u8`
+    //~| NOTE expected `char`, found `u8`
+    //~| NOTE expected due to this
 }

--- a/tests/ui/issues/issue-3680.rs
+++ b/tests/ui/issues/issue-3680.rs
@@ -1,9 +1,9 @@
 fn main() {
-    match None {
+    match None { //~ NOTE this expression has type `Option<_>`
         Err(_) => ()
         //~^ ERROR mismatched types
-        //~| expected enum `Option<_>`
-        //~| found enum `Result<_, _>`
-        //~| expected `Option<_>`, found `Result<_, _>`
+        //~| NOTE expected enum `Option<_>`
+        //~| NOTE found enum `Result<_, _>`
+        //~| NOTE expected `Option<_>`, found `Result<_, _>`
     }
 }

--- a/tests/ui/issues/issue-37884.rs
+++ b/tests/ui/issues/issue-37884.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 struct RepeatMut<'a, T>(T, &'a ());
 
 impl<'a, T: 'a> Iterator for RepeatMut<'a, T> {
@@ -5,7 +7,7 @@ impl<'a, T: 'a> Iterator for RepeatMut<'a, T> {
     type Item = &'a mut T;
     fn next(&'a mut self) -> Option<Self::Item>
     //~^ ERROR method not compatible with trait
-    //~| lifetime mismatch
+    //~| NOTE lifetime mismatch
     {
         Some(&mut self.0)
     }

--- a/tests/ui/issues/issue-37884.stderr
+++ b/tests/ui/issues/issue-37884.stderr
@@ -1,5 +1,5 @@
 error[E0308]: method not compatible with trait
-  --> $DIR/issue-37884.rs:6:5
+  --> $DIR/issue-37884.rs:8:5
    |
 LL |     fn next(&'a mut self) -> Option<Self::Item>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -9,7 +9,7 @@ LL |     fn next(&'a mut self) -> Option<Self::Item>
 note: the anonymous lifetime as defined here...
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 note: ...does not necessarily outlive the lifetime `'a` as defined here
-  --> $DIR/issue-37884.rs:3:6
+  --> $DIR/issue-37884.rs:5:6
    |
 LL | impl<'a, T: 'a> Iterator for RepeatMut<'a, T> {
    |      ^^

--- a/tests/ui/issues/issue-43355.rs
+++ b/tests/ui/issues/issue-43355.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 pub trait Trait1<X> {
     type Output;
 }
@@ -12,7 +14,7 @@ impl<X, T> Trait1<X> for T where T: Trait2<X> {
 
 impl<X> Trait1<Box<X>> for A {
 //~^ ERROR conflicting implementations of trait
-//~| downstream crates may implement trait `Trait2<std::boxed::Box<_>>` for type `A`
+//~| NOTE downstream crates may implement trait `Trait2<std::boxed::Box<_>>` for type `A`
     type Output = i32;
 }
 

--- a/tests/ui/issues/issue-43355.stderr
+++ b/tests/ui/issues/issue-43355.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `Trait1<Box<_>>` for type `A`
-  --> $DIR/issue-43355.rs:13:1
+  --> $DIR/issue-43355.rs:15:1
    |
 LL | impl<X, T> Trait1<X> for T where T: Trait2<X> {
    | --------------------------------------------- first implementation here

--- a/tests/ui/issues/issue-4517.rs
+++ b/tests/ui/issues/issue-4517.rs
@@ -1,8 +1,10 @@
+//@ dont-require-annotations: NOTE
+
 fn bar(int_param: usize) {}
 
 fn main() {
     let foo: [u8; 4] = [1; 4];
     bar(foo);
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `[u8; 4]`
+    //~| NOTE expected `usize`, found `[u8; 4]`
 }

--- a/tests/ui/issues/issue-4517.stderr
+++ b/tests/ui/issues/issue-4517.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-4517.rs:5:9
+  --> $DIR/issue-4517.rs:7:9
    |
 LL |     bar(foo);
    |     --- ^^^ expected `usize`, found `[u8; 4]`
@@ -7,7 +7,7 @@ LL |     bar(foo);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/issue-4517.rs:1:4
+  --> $DIR/issue-4517.rs:3:4
    |
 LL | fn bar(int_param: usize) {}
    |    ^^^ ----------------

--- a/tests/ui/issues/issue-4935.rs
+++ b/tests/ui/issues/issue-4935.rs
@@ -1,6 +1,7 @@
 // Regression test for issue #4935
 
 fn foo(a: usize) {}
-//~^ defined here
+//~^ NOTE defined here
 fn main() { foo(5, 6) }
 //~^ ERROR function takes 1 argument but 2 arguments were supplied
+//~| NOTE unexpected argument #2 of type `{integer}`

--- a/tests/ui/issues/issue-4968.rs
+++ b/tests/ui/issues/issue-4968.rs
@@ -1,10 +1,12 @@
 // Regression test for issue #4968
 
+//@ dont-require-annotations: NOTE
+
 const A: (isize,isize) = (4,2);
 fn main() {
     match 42 { A => () }
     //~^ ERROR mismatched types
-    //~| expected type `{integer}`
-    //~| found tuple `(isize, isize)`
-    //~| expected integer, found `(isize, isize)`
+    //~| NOTE expected type `{integer}`
+    //~| NOTE found tuple `(isize, isize)`
+    //~| NOTE expected integer, found `(isize, isize)`
 }

--- a/tests/ui/issues/issue-4968.stderr
+++ b/tests/ui/issues/issue-4968.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-4968.rs:5:16
+  --> $DIR/issue-4968.rs:7:16
    |
 LL | const A: (isize,isize) = (4,2);
    | ---------------------- constant defined here

--- a/tests/ui/issues/issue-5100.rs
+++ b/tests/ui/issues/issue-5100.rs
@@ -1,5 +1,6 @@
-#![feature(box_patterns)]
+//@ dont-require-annotations: NOTE
 
+#![feature(box_patterns)]
 
 enum A { B, C }
 
@@ -7,41 +8,41 @@ fn main() {
     match (true, false) {
         A::B => (),
 //~^ ERROR mismatched types
-//~| expected `(bool, bool)`, found `A`
-//~| expected tuple `(bool, bool)`
-//~| found enum `A`
+//~| NOTE expected `(bool, bool)`, found `A`
+//~| NOTE expected tuple `(bool, bool)`
+//~| NOTE found enum `A`
         _ => ()
     }
 
     match (true, false) {
         (true, false, false) => ()
 //~^ ERROR mismatched types
-//~| expected a tuple with 2 elements, found one with 3 elements
-//~| expected tuple `(bool, bool)`
-//~| found tuple `(_, _, _)`
+//~| NOTE expected a tuple with 2 elements, found one with 3 elements
+//~| NOTE expected tuple `(bool, bool)`
+//~| NOTE found tuple `(_, _, _)`
     }
 
     match (true, false) {
         (true, false, false) => ()
 //~^ ERROR mismatched types
-//~| expected a tuple with 2 elements, found one with 3 elements
-//~| expected tuple `(bool, bool)`
-//~| found tuple `(_, _, _)`
+//~| NOTE expected a tuple with 2 elements, found one with 3 elements
+//~| NOTE expected tuple `(bool, bool)`
+//~| NOTE found tuple `(_, _, _)`
     }
 
     match (true, false) {
         box (true, false) => ()
 //~^ ERROR mismatched types
-//~| expected tuple `(bool, bool)`
-//~| found struct `Box<_>`
+//~| NOTE expected tuple `(bool, bool)`
+//~| NOTE found struct `Box<_>`
     }
 
     match (true, false) {
         &(true, false) => ()
 //~^ ERROR mismatched types
-//~| expected `(bool, bool)`, found `&_`
-//~| expected tuple `(bool, bool)`
-//~| found reference `&_`
+//~| NOTE expected `(bool, bool)`, found `&_`
+//~| NOTE expected tuple `(bool, bool)`
+//~| NOTE found reference `&_`
     }
 
 
@@ -53,5 +54,5 @@ fn main() {
 
     // Make sure none of the errors above were fatal
     let x: char = true; //~  ERROR mismatched types
-                        //~| expected `char`, found `bool`
+                        //~| NOTE expected `char`, found `bool`
 }

--- a/tests/ui/issues/issue-5100.stderr
+++ b/tests/ui/issues/issue-5100.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-5100.rs:8:9
+  --> $DIR/issue-5100.rs:9:9
    |
 LL | enum A { B, C }
    |          - unit variant defined here
@@ -13,7 +13,7 @@ LL |         A::B => (),
                found enum `A`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-5100.rs:17:9
+  --> $DIR/issue-5100.rs:18:9
    |
 LL |     match (true, false) {
    |           ------------- this expression has type `(bool, bool)`
@@ -24,7 +24,7 @@ LL |         (true, false, false) => ()
               found tuple `(_, _, _)`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-5100.rs:25:9
+  --> $DIR/issue-5100.rs:26:9
    |
 LL |     match (true, false) {
    |           ------------- this expression has type `(bool, bool)`
@@ -35,7 +35,7 @@ LL |         (true, false, false) => ()
               found tuple `(_, _, _)`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-5100.rs:33:9
+  --> $DIR/issue-5100.rs:34:9
    |
 LL |     match (true, false) {
    |           ------------- this expression has type `(bool, bool)`
@@ -46,7 +46,7 @@ LL |         box (true, false) => ()
              found struct `Box<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-5100.rs:40:9
+  --> $DIR/issue-5100.rs:41:9
    |
 LL |     match (true, false) {
    |           ------------- this expression has type `(bool, bool)`
@@ -57,13 +57,13 @@ LL |         &(true, false) => ()
            found reference `&_`
 
 error[E0618]: expected function, found `(char, char)`
-  --> $DIR/issue-5100.rs:48:14
+  --> $DIR/issue-5100.rs:49:14
    |
 LL |     let v = [('a', 'b')
    |              ^^^^^^^^^^- help: consider separating array elements with a comma: `,`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-5100.rs:55:19
+  --> $DIR/issue-5100.rs:56:19
    |
 LL |     let x: char = true;
    |            ----   ^^^^ expected `char`, found `bool`

--- a/tests/ui/issues/issue-5358-1.rs
+++ b/tests/ui/issues/issue-5358-1.rs
@@ -2,12 +2,12 @@ enum Either<T, U> { Left(T), Right(U) }
 struct S(Either<usize, usize>);
 
 fn main() {
-    match S(Either::Left(5)) {
+    match S(Either::Left(5)) { //~ NOTE this expression has type `S`
         Either::Right(_) => {}
         //~^ ERROR mismatched types
-        //~| expected `S`, found `Either<_, _>`
-        //~| expected struct `S`
-        //~| found enum `Either<_, _>`
+        //~| NOTE expected `S`, found `Either<_, _>`
+        //~| NOTE expected struct `S`
+        //~| NOTE found enum `Either<_, _>`
         _ => {}
     }
 }

--- a/tests/ui/issues/issue-7061.rs
+++ b/tests/ui/issues/issue-7061.rs
@@ -1,10 +1,12 @@
+//@ dont-require-annotations: NOTE
+
 struct BarStruct;
 
 impl<'a> BarStruct {
     fn foo(&'a mut self) -> Box<BarStruct> { self }
     //~^ ERROR mismatched types
-    //~| expected struct `Box<BarStruct>`
-    //~| found mutable reference `&'a mut BarStruct`
+    //~| NOTE expected struct `Box<BarStruct>`
+    //~| NOTE found mutable reference `&'a mut BarStruct`
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-7061.stderr
+++ b/tests/ui/issues/issue-7061.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-7061.rs:4:46
+  --> $DIR/issue-7061.rs:6:46
    |
 LL |     fn foo(&'a mut self) -> Box<BarStruct> { self }
    |                             --------------   ^^^^ expected `Box<BarStruct>`, found `&mut BarStruct`

--- a/tests/ui/issues/issue-7092.rs
+++ b/tests/ui/issues/issue-7092.rs
@@ -2,12 +2,12 @@ enum Whatever {
 }
 
 fn foo(x: Whatever) {
-    match x {
+    match x { //~ NOTE this expression has type `Whatever`
         Some(field) =>
 //~^ ERROR mismatched types
-//~| expected `Whatever`, found `Option<_>`
-//~| expected enum `Whatever`
-//~| found enum `Option<_>`
+//~| NOTE expected `Whatever`, found `Option<_>`
+//~| NOTE expected enum `Whatever`
+//~| NOTE found enum `Option<_>`
             field.access(),
     }
 }

--- a/tests/ui/issues/issue-7867.rs
+++ b/tests/ui/issues/issue-7867.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 enum A { B, C }
 
 mod foo { pub fn bar() {} }
@@ -6,9 +8,9 @@ fn main() {
     match (true, false) {
         A::B => (),
         //~^ ERROR mismatched types
-        //~| expected `(bool, bool)`, found `A`
-        //~| expected tuple `(bool, bool)`
-        //~| found enum `A`
+        //~| NOTE expected `(bool, bool)`, found `A`
+        //~| NOTE expected tuple `(bool, bool)`
+        //~| NOTE found enum `A`
         _ => ()
     }
 }

--- a/tests/ui/issues/issue-7867.stderr
+++ b/tests/ui/issues/issue-7867.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-7867.rs:7:9
+  --> $DIR/issue-7867.rs:9:9
    |
 LL | enum A { B, C }
    |          - unit variant defined here

--- a/tests/ui/macros/issue-118786.rs
+++ b/tests/ui/macros/issue-118786.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: --crate-type lib -O -C debug-assertions=yes
+//@ dont-require-annotations: NOTE
 
 // Regression test for issue 118786
 
@@ -7,7 +8,7 @@ macro_rules! make_macro {
         macro_rules! $macro_name {
         //~^ ERROR macro expansion ignores `{` and any tokens following
         //~| ERROR cannot find macro `macro_rules` in this scope
-        //~| put a macro name here
+        //~| NOTE put a macro name here
             () => {}
         }
     }

--- a/tests/ui/macros/issue-118786.stderr
+++ b/tests/ui/macros/issue-118786.stderr
@@ -1,5 +1,5 @@
 error: macros that expand to items must be delimited with braces or followed by a semicolon
-  --> $DIR/issue-118786.rs:16:13
+  --> $DIR/issue-118786.rs:17:13
    |
 LL | make_macro!((meow));
    |             ^^^^^^
@@ -15,7 +15,7 @@ LL |         macro_rules! $macro_name; {
    |                                 +
 
 error: macro expansion ignores `{` and any tokens following
-  --> $DIR/issue-118786.rs:7:34
+  --> $DIR/issue-118786.rs:8:34
    |
 LL |         macro_rules! $macro_name {
    |                                  ^
@@ -26,7 +26,7 @@ LL | make_macro!((meow));
    = note: the usage of `make_macro!` is likely invalid in item context
 
 error: cannot find macro `macro_rules` in this scope
-  --> $DIR/issue-118786.rs:7:9
+  --> $DIR/issue-118786.rs:8:9
    |
 LL |         macro_rules! $macro_name {
    |         ^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL | make_macro!((meow));
    | ------------------- in this macro invocation
    |
 note: maybe you have forgotten to define a name for this `macro_rules!`
-  --> $DIR/issue-118786.rs:7:20
+  --> $DIR/issue-118786.rs:8:20
    |
 LL |         macro_rules! $macro_name {
    |                    ^ put a macro name here

--- a/tests/ui/macros/issue-29084.rs
+++ b/tests/ui/macros/issue-29084.rs
@@ -1,13 +1,15 @@
+//@ dont-require-annotations: NOTE
+
 macro_rules! foo {
     ($d:expr) => {{
         fn bar(d: u8) { }
         bar(&mut $d);
         //~^ ERROR mismatched types
-        //~| expected `u8`, found `&mut u8`
+        //~| NOTE expected `u8`, found `&mut u8`
     }}
 }
 
 fn main() {
     foo!(0u8);
-    //~^ in this expansion of foo!
+    //~^ NOTE in this expansion of foo!
 }

--- a/tests/ui/macros/issue-29084.stderr
+++ b/tests/ui/macros/issue-29084.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-29084.rs:4:13
+  --> $DIR/issue-29084.rs:6:13
    |
 LL |         bar(&mut $d);
    |         --- ^^^^^^^ expected `u8`, found `&mut u8`
@@ -10,7 +10,7 @@ LL |     foo!(0u8);
    |     --------- in this macro invocation
    |
 note: function defined here
-  --> $DIR/issue-29084.rs:3:12
+  --> $DIR/issue-29084.rs:5:12
    |
 LL |         fn bar(d: u8) { }
    |            ^^^ -----

--- a/tests/ui/match/match-struct.rs
+++ b/tests/ui/match/match-struct.rs
@@ -2,10 +2,10 @@ struct S { a: isize }
 enum E { C(isize) }
 
 fn main() {
-    match (S { a: 1 }) {
+    match (S { a: 1 }) { //~ NOTE this expression has type `S`
         E::C(_) => (),
         //~^ ERROR mismatched types
-        //~| expected `S`, found `E`
+        //~| NOTE expected `S`, found `E`
         _ => ()
     }
 }

--- a/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.rs
+++ b/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 #![feature(arbitrary_self_types, coerce_unsized, dispatch_from_dyn, unsize)]
 #![feature(unsized_locals, unsized_fn_params)]
 //~^ WARN the feature `unsized_locals` is incomplete
@@ -85,7 +87,7 @@ fn objectcandidate_impl() {
 
     // Observe the type of `z` is `u32`
     let _seetype: () = z; //~ ERROR mismatched types
-    //~| expected `()`, found `u32`
+    //~| NOTE expected `()`, found `u32`
 }
 
 fn traitcandidate_impl() {
@@ -102,7 +104,7 @@ fn traitcandidate_impl() {
 
     // Observe the type of `z` is `u64`
     let _seetype: () = z; //~ ERROR mismatched types
-    //~| expected `()`, found `u64`
+    //~| NOTE expected `()`, found `u64`
 }
 
 fn traitcandidate_impl_with_nuisance() {
@@ -137,7 +139,7 @@ fn neither_impl() {
 
     // Observe the type of `z` is `u8`
     let _seetype: () = z; //~ ERROR mismatched types
-    //~| expected `()`, found `u8`
+    //~| NOTE expected `()`, found `u8`
 }
 
 fn both_impls() {
@@ -155,7 +157,7 @@ fn both_impls() {
 
     // Observe the type of `z` is `u32`
     let _seetype: () = z; //~ ERROR mismatched types
-    //~| expected `()`, found `u32`
+    //~| NOTE expected `()`, found `u32`
 }
 
 
@@ -172,7 +174,7 @@ fn both_impls_with_nuisance() {
 
     // Observe the type of `z` is `u32`
     let _seetype: () = z; //~ ERROR mismatched types
-    //~| expected `()`, found `u32`
+    //~| NOTE expected `()`, found `u32`
 }
 
 fn main() {

--- a/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.stderr
+++ b/tests/ui/methods/method-deref-to-same-trait-object-with-separate-params.stderr
@@ -1,5 +1,5 @@
 warning: the feature `unsized_locals` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:2:12
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:4:12
    |
 LL | #![feature(unsized_locals, unsized_fn_params)]
    |            ^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL | #![feature(unsized_locals, unsized_fn_params)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0308]: mismatched types
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:87:24
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:89:24
    |
 LL |     let _seetype: () = z;
    |                   --   ^ expected `()`, found `u32`
@@ -16,7 +16,7 @@ LL |     let _seetype: () = z;
    |                   expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:104:24
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:106:24
    |
 LL |     let _seetype: () = z;
    |                   --   ^ expected `()`, found `u64`
@@ -24,23 +24,23 @@ LL |     let _seetype: () = z;
    |                   expected due to this
 
 error[E0034]: multiple applicable items in scope
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:122:15
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:124:15
    |
 LL |     let z = x.foo();
    |               ^^^ multiple `foo` found
    |
 note: candidate #1 is defined in the trait `FinalFoo`
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:59:5
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:61:5
    |
 LL |     fn foo(&self) -> u8;
    |     ^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl of the trait `NuisanceFoo` for the type `T`
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:72:9
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:74:9
    |
 LL |         fn foo(self) {}
    |         ^^^^^^^^^^^^
 note: candidate #3 is defined in an impl of the trait `X` for the type `T`
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:45:9
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:47:9
    |
 LL |         fn foo(self: Smaht<Self, u64>) -> u64 {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL +     let z = X::foo(x);
    |
 
 error[E0308]: mismatched types
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:139:24
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:141:24
    |
 LL |     let _seetype: () = z;
    |                   --   ^ expected `()`, found `u8`
@@ -69,7 +69,7 @@ LL |     let _seetype: () = z;
    |                   expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:157:24
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:159:24
    |
 LL |     let _seetype: () = z;
    |                   --   ^ expected `()`, found `u32`
@@ -77,7 +77,7 @@ LL |     let _seetype: () = z;
    |                   expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:174:24
+  --> $DIR/method-deref-to-same-trait-object-with-separate-params.rs:176:24
    |
 LL |     let _seetype: () = z;
    |                   --   ^ expected `()`, found `u32`

--- a/tests/ui/methods/method-self-arg-1.rs
+++ b/tests/ui/methods/method-self-arg-1.rs
@@ -1,5 +1,7 @@
 // Test method calls with self as an argument cannot subvert type checking.
 
+//@ dont-require-annotations: NOTE
+
 struct Foo;
 
 impl Foo {
@@ -9,9 +11,9 @@ impl Foo {
 fn main() {
     let x = Foo;
     Foo::bar(x); //~  ERROR mismatched types
-                 //~| expected `&Foo`, found `Foo`
+                 //~| NOTE expected `&Foo`, found `Foo`
     Foo::bar(&42); //~  ERROR mismatched types
-                      //~| expected `&Foo`, found `&{integer}`
-                      //~| expected reference `&Foo`
-                      //~| found reference `&{integer}`
+                      //~| NOTE expected `&Foo`, found `&{integer}`
+                      //~| NOTE expected reference `&Foo`
+                      //~| NOTE found reference `&{integer}`
 }

--- a/tests/ui/methods/method-self-arg-1.stderr
+++ b/tests/ui/methods/method-self-arg-1.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/method-self-arg-1.rs:11:14
+  --> $DIR/method-self-arg-1.rs:13:14
    |
 LL |     Foo::bar(x);
    |     -------- ^ expected `&Foo`, found `Foo`
@@ -7,7 +7,7 @@ LL |     Foo::bar(x);
    |     arguments to this function are incorrect
    |
 note: method defined here
-  --> $DIR/method-self-arg-1.rs:6:8
+  --> $DIR/method-self-arg-1.rs:8:8
    |
 LL |     fn bar(&self) {}
    |        ^^^ -----
@@ -17,7 +17,7 @@ LL |     Foo::bar(&x);
    |              +
 
 error[E0308]: mismatched types
-  --> $DIR/method-self-arg-1.rs:13:14
+  --> $DIR/method-self-arg-1.rs:15:14
    |
 LL |     Foo::bar(&42);
    |     -------- ^^^ expected `&Foo`, found `&{integer}`
@@ -27,7 +27,7 @@ LL |     Foo::bar(&42);
    = note: expected reference `&Foo`
               found reference `&{integer}`
 note: method defined here
-  --> $DIR/method-self-arg-1.rs:6:8
+  --> $DIR/method-self-arg-1.rs:8:8
    |
 LL |     fn bar(&self) {}
    |        ^^^ -----

--- a/tests/ui/mismatched_types/issue-13033.rs
+++ b/tests/ui/mismatched_types/issue-13033.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 trait Foo {
     fn bar(&mut self, other: &mut dyn Foo);
 }
@@ -7,8 +9,8 @@ struct Baz;
 impl Foo for Baz {
     fn bar(&mut self, other: &dyn Foo) {}
     //~^ ERROR method `bar` has an incompatible type for trait
-    //~| expected signature `fn(&mut Baz, &mut dyn Foo)`
-    //~| found signature `fn(&mut Baz, &dyn Foo)`
+    //~| NOTE expected signature `fn(&mut Baz, &mut dyn Foo)`
+    //~| NOTE found signature `fn(&mut Baz, &dyn Foo)`
 }
 
 fn main() {}

--- a/tests/ui/mismatched_types/issue-13033.stderr
+++ b/tests/ui/mismatched_types/issue-13033.stderr
@@ -1,11 +1,11 @@
 error[E0053]: method `bar` has an incompatible type for trait
-  --> $DIR/issue-13033.rs:8:30
+  --> $DIR/issue-13033.rs:10:30
    |
 LL |     fn bar(&mut self, other: &dyn Foo) {}
    |                              ^^^^^^^^ types differ in mutability
    |
 note: type in trait
-  --> $DIR/issue-13033.rs:2:30
+  --> $DIR/issue-13033.rs:4:30
    |
 LL |     fn bar(&mut self, other: &mut dyn Foo);
    |                              ^^^^^^^^^^^^

--- a/tests/ui/moves/moves-based-on-type-match-bindings.rs
+++ b/tests/ui/moves/moves-based-on-type-match-bindings.rs
@@ -10,12 +10,12 @@ fn f10() {
     let x = Foo {f: "hi".to_string()};
 
     let y = match x {
-        Foo {f} => {}
+        Foo {f} => {} //~ NOTE value partially moved here
     };
 
     touch(&x); //~ ERROR borrow of partially moved value: `x`
-    //~^ value borrowed here after partial move
-    //~| partial move occurs because `x.f` has type `String`
+    //~^ NOTE value borrowed here after partial move
+    //~| NOTE partial move occurs because `x.f` has type `String`
 }
 
 fn main() {}

--- a/tests/ui/mut/mut-pattern-mismatched.rs
+++ b/tests/ui/mut/mut-pattern-mismatched.rs
@@ -1,20 +1,22 @@
+//@ dont-require-annotations: NOTE
+
 fn main() {
     let foo = &mut 1;
 
     // (separate lines to ensure the spans are accurate)
 
      let &_ //~  ERROR mismatched types
-            //~| expected mutable reference `&mut {integer}`
-            //~| found reference `&_`
-            //~| types differ in mutability
+            //~| NOTE expected mutable reference `&mut {integer}`
+            //~| NOTE found reference `&_`
+            //~| NOTE types differ in mutability
         = foo;
     let &mut _ = foo;
 
     let bar = &1;
     let &_ = bar;
     let &mut _ //~  ERROR mismatched types
-               //~| expected reference `&{integer}`
-               //~| found mutable reference `&mut _`
-               //~| types differ in mutability
+               //~| NOTE expected reference `&{integer}`
+               //~| NOTE found mutable reference `&mut _`
+               //~| NOTE types differ in mutability
          = bar;
 }

--- a/tests/ui/mut/mut-pattern-mismatched.stderr
+++ b/tests/ui/mut/mut-pattern-mismatched.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/mut-pattern-mismatched.rs:6:10
+  --> $DIR/mut-pattern-mismatched.rs:8:10
    |
 LL |      let &_
    |          ^^ types differ in mutability
@@ -11,7 +11,7 @@ LL |         = foo;
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/mut-pattern-mismatched.rs:15:9
+  --> $DIR/mut-pattern-mismatched.rs:17:9
    |
 LL |     let &mut _
    |         ^^^^^^ types differ in mutability

--- a/tests/ui/never_type/issue-10176.rs
+++ b/tests/ui/never_type/issue-10176.rs
@@ -1,9 +1,9 @@
-fn f() -> isize {
+fn f() -> isize { //~ NOTE expected `isize` because of return type
     (return 1, return 2)
 //~^ ERROR mismatched types
-//~| expected type `isize`
-//~| found tuple `(!, !)`
-//~| expected `isize`, found `(!, !)`
+//~| NOTE expected type `isize`
+//~| NOTE found tuple `(!, !)`
+//~| NOTE expected `isize`, found `(!, !)`
 }
 
 fn main() {}

--- a/tests/ui/noexporttypeexe.rs
+++ b/tests/ui/noexporttypeexe.rs
@@ -9,7 +9,8 @@ fn main() {
     // not convertible to a path.
   let x: isize = noexporttypelib::foo();
     //~^ ERROR mismatched types
-    //~| expected type `isize`
-    //~| found enum `Option<isize>`
-    //~| expected `isize`, found `Option<isize>`
+    //~| NOTE expected type `isize`
+    //~| NOTE found enum `Option<isize>`
+    //~| NOTE expected `isize`, found `Option<isize>`
+    //~| NOTE expected due to this
 }

--- a/tests/ui/numeric/integer-literal-suffix-inference.rs
+++ b/tests/ui/numeric/integer-literal-suffix-inference.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 fn main() {
 
     // the smallest positive values that need these types
@@ -37,184 +39,184 @@ fn main() {
     id_i8(a8); // ok
     id_i8(a16);
     //~^ ERROR mismatched types
-    //~| expected `i8`, found `i16`
+    //~| NOTE expected `i8`, found `i16`
     id_i8(a32);
     //~^ ERROR mismatched types
-    //~| expected `i8`, found `i32`
+    //~| NOTE expected `i8`, found `i32`
     id_i8(a64);
     //~^ ERROR mismatched types
-    //~| expected `i8`, found `i64`
+    //~| NOTE expected `i8`, found `i64`
     id_i8(asize);
     //~^ ERROR mismatched types
-    //~| expected `i8`, found `isize`
+    //~| NOTE expected `i8`, found `isize`
 
     id_i16(a8);
     //~^ ERROR mismatched types
-    //~| expected `i16`, found `i8`
+    //~| NOTE expected `i16`, found `i8`
     id_i16(a16); // ok
     id_i16(a32);
     //~^ ERROR mismatched types
-    //~| expected `i16`, found `i32`
+    //~| NOTE expected `i16`, found `i32`
     id_i16(a64);
     //~^ ERROR mismatched types
-    //~| expected `i16`, found `i64`
+    //~| NOTE expected `i16`, found `i64`
     id_i16(asize);
     //~^ ERROR mismatched types
-    //~| expected `i16`, found `isize`
+    //~| NOTE expected `i16`, found `isize`
 
     id_i32(a8);
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `i8`
+    //~| NOTE expected `i32`, found `i8`
     id_i32(a16);
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `i16`
+    //~| NOTE expected `i32`, found `i16`
     id_i32(a32); // ok
     id_i32(a64);
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `i64`
+    //~| NOTE expected `i32`, found `i64`
     id_i32(asize);
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `isize`
+    //~| NOTE expected `i32`, found `isize`
 
     id_i64(a8);
     //~^ ERROR mismatched types
-    //~| expected `i64`, found `i8`
+    //~| NOTE expected `i64`, found `i8`
     id_i64(a16);
     //~^ ERROR mismatched types
-    //~| expected `i64`, found `i16`
+    //~| NOTE expected `i64`, found `i16`
     id_i64(a32);
     //~^ ERROR mismatched types
-    //~| expected `i64`, found `i32`
+    //~| NOTE expected `i64`, found `i32`
     id_i64(a64); // ok
     id_i64(asize);
     //~^ ERROR mismatched types
-    //~| expected `i64`, found `isize`
+    //~| NOTE expected `i64`, found `isize`
 
     id_isize(a8);
     //~^ ERROR mismatched types
-    //~| expected `isize`, found `i8`
+    //~| NOTE expected `isize`, found `i8`
     id_isize(a16);
     //~^ ERROR mismatched types
-    //~| expected `isize`, found `i16`
+    //~| NOTE expected `isize`, found `i16`
     id_isize(a32);
     //~^ ERROR mismatched types
-    //~| expected `isize`, found `i32`
+    //~| NOTE expected `isize`, found `i32`
     id_isize(a64);
     //~^ ERROR mismatched types
-    //~| expected `isize`, found `i64`
+    //~| NOTE expected `isize`, found `i64`
     id_isize(asize); //ok
 
     id_i8(c8); // ok
     id_i8(c16);
     //~^ ERROR mismatched types
-    //~| expected `i8`, found `i16`
+    //~| NOTE expected `i8`, found `i16`
     id_i8(c32);
     //~^ ERROR mismatched types
-    //~| expected `i8`, found `i32`
+    //~| NOTE expected `i8`, found `i32`
     id_i8(c64);
     //~^ ERROR mismatched types
-    //~| expected `i8`, found `i64`
+    //~| NOTE expected `i8`, found `i64`
 
     id_i16(c8);
     //~^ ERROR mismatched types
-    //~| expected `i16`, found `i8`
+    //~| NOTE expected `i16`, found `i8`
     id_i16(c16); // ok
     id_i16(c32);
     //~^ ERROR mismatched types
-    //~| expected `i16`, found `i32`
+    //~| NOTE expected `i16`, found `i32`
     id_i16(c64);
     //~^ ERROR mismatched types
-    //~| expected `i16`, found `i64`
+    //~| NOTE expected `i16`, found `i64`
 
     id_i32(c8);
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `i8`
+    //~| NOTE expected `i32`, found `i8`
     id_i32(c16);
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `i16`
+    //~| NOTE expected `i32`, found `i16`
     id_i32(c32); // ok
     id_i32(c64);
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `i64`
+    //~| NOTE expected `i32`, found `i64`
 
     id_i64(a8);
     //~^ ERROR mismatched types
-    //~| expected `i64`, found `i8`
+    //~| NOTE expected `i64`, found `i8`
     id_i64(a16);
     //~^ ERROR mismatched types
-    //~| expected `i64`, found `i16`
+    //~| NOTE expected `i64`, found `i16`
     id_i64(a32);
     //~^ ERROR mismatched types
-    //~| expected `i64`, found `i32`
+    //~| NOTE expected `i64`, found `i32`
     id_i64(a64); // ok
 
     id_u8(b8); // ok
     id_u8(b16);
     //~^ ERROR mismatched types
-    //~| expected `u8`, found `u16`
+    //~| NOTE expected `u8`, found `u16`
     id_u8(b32);
     //~^ ERROR mismatched types
-    //~| expected `u8`, found `u32`
+    //~| NOTE expected `u8`, found `u32`
     id_u8(b64);
     //~^ ERROR mismatched types
-    //~| expected `u8`, found `u64`
+    //~| NOTE expected `u8`, found `u64`
     id_u8(bsize);
     //~^ ERROR mismatched types
-    //~| expected `u8`, found `usize`
+    //~| NOTE expected `u8`, found `usize`
 
     id_u16(b8);
     //~^ ERROR mismatched types
-    //~| expected `u16`, found `u8`
+    //~| NOTE expected `u16`, found `u8`
     id_u16(b16); // ok
     id_u16(b32);
     //~^ ERROR mismatched types
-    //~| expected `u16`, found `u32`
+    //~| NOTE expected `u16`, found `u32`
     id_u16(b64);
     //~^ ERROR mismatched types
-    //~| expected `u16`, found `u64`
+    //~| NOTE expected `u16`, found `u64`
     id_u16(bsize);
     //~^ ERROR mismatched types
-    //~| expected `u16`, found `usize`
+    //~| NOTE expected `u16`, found `usize`
 
     id_u32(b8);
     //~^ ERROR mismatched types
-    //~| expected `u32`, found `u8`
+    //~| NOTE expected `u32`, found `u8`
     id_u32(b16);
     //~^ ERROR mismatched types
-    //~| expected `u32`, found `u16`
+    //~| NOTE expected `u32`, found `u16`
     id_u32(b32); // ok
     id_u32(b64);
     //~^ ERROR mismatched types
-    //~| expected `u32`, found `u64`
+    //~| NOTE expected `u32`, found `u64`
     id_u32(bsize);
     //~^ ERROR mismatched types
-    //~| expected `u32`, found `usize`
+    //~| NOTE expected `u32`, found `usize`
 
     id_u64(b8);
     //~^ ERROR mismatched types
-    //~| expected `u64`, found `u8`
+    //~| NOTE expected `u64`, found `u8`
     id_u64(b16);
     //~^ ERROR mismatched types
-    //~| expected `u64`, found `u16`
+    //~| NOTE expected `u64`, found `u16`
     id_u64(b32);
     //~^ ERROR mismatched types
-    //~| expected `u64`, found `u32`
+    //~| NOTE expected `u64`, found `u32`
     id_u64(b64); // ok
     id_u64(bsize);
     //~^ ERROR mismatched types
-    //~| expected `u64`, found `usize`
+    //~| NOTE expected `u64`, found `usize`
 
     id_usize(b8);
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `u8`
+    //~| NOTE expected `usize`, found `u8`
     id_usize(b16);
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `u16`
+    //~| NOTE expected `usize`, found `u16`
     id_usize(b32);
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `u32`
+    //~| NOTE expected `usize`, found `u32`
     id_usize(b64);
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `u64`
+    //~| NOTE expected `usize`, found `u64`
     id_usize(bsize); //ok
 }

--- a/tests/ui/numeric/integer-literal-suffix-inference.stderr
+++ b/tests/ui/numeric/integer-literal-suffix-inference.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:38:11
+  --> $DIR/integer-literal-suffix-inference.rs:40:11
    |
 LL |     id_i8(a16);
    |     ----- ^^^ expected `i8`, found `i16`
@@ -7,7 +7,7 @@ LL |     id_i8(a16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:15:8
+  --> $DIR/integer-literal-suffix-inference.rs:17:8
    |
 LL |     fn id_i8(n: i8) -> i8 { n }
    |        ^^^^^ -----
@@ -17,7 +17,7 @@ LL |     id_i8(a16.try_into().unwrap());
    |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:41:11
+  --> $DIR/integer-literal-suffix-inference.rs:43:11
    |
 LL |     id_i8(a32);
    |     ----- ^^^ expected `i8`, found `i32`
@@ -25,7 +25,7 @@ LL |     id_i8(a32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:15:8
+  --> $DIR/integer-literal-suffix-inference.rs:17:8
    |
 LL |     fn id_i8(n: i8) -> i8 { n }
    |        ^^^^^ -----
@@ -35,7 +35,7 @@ LL |     id_i8(a32.try_into().unwrap());
    |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:44:11
+  --> $DIR/integer-literal-suffix-inference.rs:46:11
    |
 LL |     id_i8(a64);
    |     ----- ^^^ expected `i8`, found `i64`
@@ -43,7 +43,7 @@ LL |     id_i8(a64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:15:8
+  --> $DIR/integer-literal-suffix-inference.rs:17:8
    |
 LL |     fn id_i8(n: i8) -> i8 { n }
    |        ^^^^^ -----
@@ -53,7 +53,7 @@ LL |     id_i8(a64.try_into().unwrap());
    |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:47:11
+  --> $DIR/integer-literal-suffix-inference.rs:49:11
    |
 LL |     id_i8(asize);
    |     ----- ^^^^^ expected `i8`, found `isize`
@@ -61,7 +61,7 @@ LL |     id_i8(asize);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:15:8
+  --> $DIR/integer-literal-suffix-inference.rs:17:8
    |
 LL |     fn id_i8(n: i8) -> i8 { n }
    |        ^^^^^ -----
@@ -71,7 +71,7 @@ LL |     id_i8(asize.try_into().unwrap());
    |                ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:51:12
+  --> $DIR/integer-literal-suffix-inference.rs:53:12
    |
 LL |     id_i16(a8);
    |     ------ ^^ expected `i16`, found `i8`
@@ -79,7 +79,7 @@ LL |     id_i16(a8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:16:8
+  --> $DIR/integer-literal-suffix-inference.rs:18:8
    |
 LL |     fn id_i16(n: i16) -> i16 { n }
    |        ^^^^^^ ------
@@ -89,7 +89,7 @@ LL |     id_i16(a8.into());
    |              +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:55:12
+  --> $DIR/integer-literal-suffix-inference.rs:57:12
    |
 LL |     id_i16(a32);
    |     ------ ^^^ expected `i16`, found `i32`
@@ -97,7 +97,7 @@ LL |     id_i16(a32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:16:8
+  --> $DIR/integer-literal-suffix-inference.rs:18:8
    |
 LL |     fn id_i16(n: i16) -> i16 { n }
    |        ^^^^^^ ------
@@ -107,7 +107,7 @@ LL |     id_i16(a32.try_into().unwrap());
    |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:58:12
+  --> $DIR/integer-literal-suffix-inference.rs:60:12
    |
 LL |     id_i16(a64);
    |     ------ ^^^ expected `i16`, found `i64`
@@ -115,7 +115,7 @@ LL |     id_i16(a64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:16:8
+  --> $DIR/integer-literal-suffix-inference.rs:18:8
    |
 LL |     fn id_i16(n: i16) -> i16 { n }
    |        ^^^^^^ ------
@@ -125,7 +125,7 @@ LL |     id_i16(a64.try_into().unwrap());
    |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:61:12
+  --> $DIR/integer-literal-suffix-inference.rs:63:12
    |
 LL |     id_i16(asize);
    |     ------ ^^^^^ expected `i16`, found `isize`
@@ -133,7 +133,7 @@ LL |     id_i16(asize);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:16:8
+  --> $DIR/integer-literal-suffix-inference.rs:18:8
    |
 LL |     fn id_i16(n: i16) -> i16 { n }
    |        ^^^^^^ ------
@@ -143,7 +143,7 @@ LL |     id_i16(asize.try_into().unwrap());
    |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:65:12
+  --> $DIR/integer-literal-suffix-inference.rs:67:12
    |
 LL |     id_i32(a8);
    |     ------ ^^ expected `i32`, found `i8`
@@ -151,7 +151,7 @@ LL |     id_i32(a8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:17:8
+  --> $DIR/integer-literal-suffix-inference.rs:19:8
    |
 LL |     fn id_i32(n: i32) -> i32 { n }
    |        ^^^^^^ ------
@@ -161,7 +161,7 @@ LL |     id_i32(a8.into());
    |              +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:68:12
+  --> $DIR/integer-literal-suffix-inference.rs:70:12
    |
 LL |     id_i32(a16);
    |     ------ ^^^ expected `i32`, found `i16`
@@ -169,7 +169,7 @@ LL |     id_i32(a16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:17:8
+  --> $DIR/integer-literal-suffix-inference.rs:19:8
    |
 LL |     fn id_i32(n: i32) -> i32 { n }
    |        ^^^^^^ ------
@@ -179,7 +179,7 @@ LL |     id_i32(a16.into());
    |               +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:72:12
+  --> $DIR/integer-literal-suffix-inference.rs:74:12
    |
 LL |     id_i32(a64);
    |     ------ ^^^ expected `i32`, found `i64`
@@ -187,7 +187,7 @@ LL |     id_i32(a64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:17:8
+  --> $DIR/integer-literal-suffix-inference.rs:19:8
    |
 LL |     fn id_i32(n: i32) -> i32 { n }
    |        ^^^^^^ ------
@@ -197,7 +197,7 @@ LL |     id_i32(a64.try_into().unwrap());
    |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:75:12
+  --> $DIR/integer-literal-suffix-inference.rs:77:12
    |
 LL |     id_i32(asize);
    |     ------ ^^^^^ expected `i32`, found `isize`
@@ -205,7 +205,7 @@ LL |     id_i32(asize);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:17:8
+  --> $DIR/integer-literal-suffix-inference.rs:19:8
    |
 LL |     fn id_i32(n: i32) -> i32 { n }
    |        ^^^^^^ ------
@@ -215,7 +215,7 @@ LL |     id_i32(asize.try_into().unwrap());
    |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:79:12
+  --> $DIR/integer-literal-suffix-inference.rs:81:12
    |
 LL |     id_i64(a8);
    |     ------ ^^ expected `i64`, found `i8`
@@ -223,7 +223,7 @@ LL |     id_i64(a8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:18:8
+  --> $DIR/integer-literal-suffix-inference.rs:20:8
    |
 LL |     fn id_i64(n: i64) -> i64 { n }
    |        ^^^^^^ ------
@@ -233,7 +233,7 @@ LL |     id_i64(a8.into());
    |              +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:82:12
+  --> $DIR/integer-literal-suffix-inference.rs:84:12
    |
 LL |     id_i64(a16);
    |     ------ ^^^ expected `i64`, found `i16`
@@ -241,7 +241,7 @@ LL |     id_i64(a16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:18:8
+  --> $DIR/integer-literal-suffix-inference.rs:20:8
    |
 LL |     fn id_i64(n: i64) -> i64 { n }
    |        ^^^^^^ ------
@@ -251,7 +251,7 @@ LL |     id_i64(a16.into());
    |               +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:85:12
+  --> $DIR/integer-literal-suffix-inference.rs:87:12
    |
 LL |     id_i64(a32);
    |     ------ ^^^ expected `i64`, found `i32`
@@ -259,7 +259,7 @@ LL |     id_i64(a32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:18:8
+  --> $DIR/integer-literal-suffix-inference.rs:20:8
    |
 LL |     fn id_i64(n: i64) -> i64 { n }
    |        ^^^^^^ ------
@@ -269,7 +269,7 @@ LL |     id_i64(a32.into());
    |               +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:89:12
+  --> $DIR/integer-literal-suffix-inference.rs:91:12
    |
 LL |     id_i64(asize);
    |     ------ ^^^^^ expected `i64`, found `isize`
@@ -277,7 +277,7 @@ LL |     id_i64(asize);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:18:8
+  --> $DIR/integer-literal-suffix-inference.rs:20:8
    |
 LL |     fn id_i64(n: i64) -> i64 { n }
    |        ^^^^^^ ------
@@ -287,7 +287,7 @@ LL |     id_i64(asize.try_into().unwrap());
    |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:93:14
+  --> $DIR/integer-literal-suffix-inference.rs:95:14
    |
 LL |     id_isize(a8);
    |     -------- ^^ expected `isize`, found `i8`
@@ -295,7 +295,7 @@ LL |     id_isize(a8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:19:8
+  --> $DIR/integer-literal-suffix-inference.rs:21:8
    |
 LL |     fn id_isize(n: isize) -> isize { n }
    |        ^^^^^^^^ --------
@@ -305,7 +305,7 @@ LL |     id_isize(a8.into());
    |                +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:96:14
+  --> $DIR/integer-literal-suffix-inference.rs:98:14
    |
 LL |     id_isize(a16);
    |     -------- ^^^ expected `isize`, found `i16`
@@ -313,7 +313,7 @@ LL |     id_isize(a16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:19:8
+  --> $DIR/integer-literal-suffix-inference.rs:21:8
    |
 LL |     fn id_isize(n: isize) -> isize { n }
    |        ^^^^^^^^ --------
@@ -323,7 +323,7 @@ LL |     id_isize(a16.into());
    |                 +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:99:14
+  --> $DIR/integer-literal-suffix-inference.rs:101:14
    |
 LL |     id_isize(a32);
    |     -------- ^^^ expected `isize`, found `i32`
@@ -331,7 +331,7 @@ LL |     id_isize(a32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:19:8
+  --> $DIR/integer-literal-suffix-inference.rs:21:8
    |
 LL |     fn id_isize(n: isize) -> isize { n }
    |        ^^^^^^^^ --------
@@ -341,7 +341,7 @@ LL |     id_isize(a32.try_into().unwrap());
    |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:102:14
+  --> $DIR/integer-literal-suffix-inference.rs:104:14
    |
 LL |     id_isize(a64);
    |     -------- ^^^ expected `isize`, found `i64`
@@ -349,7 +349,7 @@ LL |     id_isize(a64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:19:8
+  --> $DIR/integer-literal-suffix-inference.rs:21:8
    |
 LL |     fn id_isize(n: isize) -> isize { n }
    |        ^^^^^^^^ --------
@@ -359,7 +359,7 @@ LL |     id_isize(a64.try_into().unwrap());
    |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:108:11
+  --> $DIR/integer-literal-suffix-inference.rs:110:11
    |
 LL |     id_i8(c16);
    |     ----- ^^^ expected `i8`, found `i16`
@@ -367,7 +367,7 @@ LL |     id_i8(c16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:15:8
+  --> $DIR/integer-literal-suffix-inference.rs:17:8
    |
 LL |     fn id_i8(n: i8) -> i8 { n }
    |        ^^^^^ -----
@@ -377,7 +377,7 @@ LL |     id_i8(c16.try_into().unwrap());
    |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:111:11
+  --> $DIR/integer-literal-suffix-inference.rs:113:11
    |
 LL |     id_i8(c32);
    |     ----- ^^^ expected `i8`, found `i32`
@@ -385,7 +385,7 @@ LL |     id_i8(c32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:15:8
+  --> $DIR/integer-literal-suffix-inference.rs:17:8
    |
 LL |     fn id_i8(n: i8) -> i8 { n }
    |        ^^^^^ -----
@@ -395,7 +395,7 @@ LL |     id_i8(c32.try_into().unwrap());
    |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:114:11
+  --> $DIR/integer-literal-suffix-inference.rs:116:11
    |
 LL |     id_i8(c64);
    |     ----- ^^^ expected `i8`, found `i64`
@@ -403,7 +403,7 @@ LL |     id_i8(c64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:15:8
+  --> $DIR/integer-literal-suffix-inference.rs:17:8
    |
 LL |     fn id_i8(n: i8) -> i8 { n }
    |        ^^^^^ -----
@@ -413,7 +413,7 @@ LL |     id_i8(c64.try_into().unwrap());
    |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:118:12
+  --> $DIR/integer-literal-suffix-inference.rs:120:12
    |
 LL |     id_i16(c8);
    |     ------ ^^ expected `i16`, found `i8`
@@ -421,7 +421,7 @@ LL |     id_i16(c8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:16:8
+  --> $DIR/integer-literal-suffix-inference.rs:18:8
    |
 LL |     fn id_i16(n: i16) -> i16 { n }
    |        ^^^^^^ ------
@@ -431,7 +431,7 @@ LL |     id_i16(c8.into());
    |              +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:122:12
+  --> $DIR/integer-literal-suffix-inference.rs:124:12
    |
 LL |     id_i16(c32);
    |     ------ ^^^ expected `i16`, found `i32`
@@ -439,7 +439,7 @@ LL |     id_i16(c32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:16:8
+  --> $DIR/integer-literal-suffix-inference.rs:18:8
    |
 LL |     fn id_i16(n: i16) -> i16 { n }
    |        ^^^^^^ ------
@@ -449,7 +449,7 @@ LL |     id_i16(c32.try_into().unwrap());
    |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:125:12
+  --> $DIR/integer-literal-suffix-inference.rs:127:12
    |
 LL |     id_i16(c64);
    |     ------ ^^^ expected `i16`, found `i64`
@@ -457,7 +457,7 @@ LL |     id_i16(c64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:16:8
+  --> $DIR/integer-literal-suffix-inference.rs:18:8
    |
 LL |     fn id_i16(n: i16) -> i16 { n }
    |        ^^^^^^ ------
@@ -467,7 +467,7 @@ LL |     id_i16(c64.try_into().unwrap());
    |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:129:12
+  --> $DIR/integer-literal-suffix-inference.rs:131:12
    |
 LL |     id_i32(c8);
    |     ------ ^^ expected `i32`, found `i8`
@@ -475,7 +475,7 @@ LL |     id_i32(c8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:17:8
+  --> $DIR/integer-literal-suffix-inference.rs:19:8
    |
 LL |     fn id_i32(n: i32) -> i32 { n }
    |        ^^^^^^ ------
@@ -485,7 +485,7 @@ LL |     id_i32(c8.into());
    |              +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:132:12
+  --> $DIR/integer-literal-suffix-inference.rs:134:12
    |
 LL |     id_i32(c16);
    |     ------ ^^^ expected `i32`, found `i16`
@@ -493,7 +493,7 @@ LL |     id_i32(c16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:17:8
+  --> $DIR/integer-literal-suffix-inference.rs:19:8
    |
 LL |     fn id_i32(n: i32) -> i32 { n }
    |        ^^^^^^ ------
@@ -503,7 +503,7 @@ LL |     id_i32(c16.into());
    |               +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:136:12
+  --> $DIR/integer-literal-suffix-inference.rs:138:12
    |
 LL |     id_i32(c64);
    |     ------ ^^^ expected `i32`, found `i64`
@@ -511,7 +511,7 @@ LL |     id_i32(c64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:17:8
+  --> $DIR/integer-literal-suffix-inference.rs:19:8
    |
 LL |     fn id_i32(n: i32) -> i32 { n }
    |        ^^^^^^ ------
@@ -521,7 +521,7 @@ LL |     id_i32(c64.try_into().unwrap());
    |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:140:12
+  --> $DIR/integer-literal-suffix-inference.rs:142:12
    |
 LL |     id_i64(a8);
    |     ------ ^^ expected `i64`, found `i8`
@@ -529,7 +529,7 @@ LL |     id_i64(a8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:18:8
+  --> $DIR/integer-literal-suffix-inference.rs:20:8
    |
 LL |     fn id_i64(n: i64) -> i64 { n }
    |        ^^^^^^ ------
@@ -539,7 +539,7 @@ LL |     id_i64(a8.into());
    |              +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:143:12
+  --> $DIR/integer-literal-suffix-inference.rs:145:12
    |
 LL |     id_i64(a16);
    |     ------ ^^^ expected `i64`, found `i16`
@@ -547,7 +547,7 @@ LL |     id_i64(a16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:18:8
+  --> $DIR/integer-literal-suffix-inference.rs:20:8
    |
 LL |     fn id_i64(n: i64) -> i64 { n }
    |        ^^^^^^ ------
@@ -557,7 +557,7 @@ LL |     id_i64(a16.into());
    |               +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:146:12
+  --> $DIR/integer-literal-suffix-inference.rs:148:12
    |
 LL |     id_i64(a32);
    |     ------ ^^^ expected `i64`, found `i32`
@@ -565,7 +565,7 @@ LL |     id_i64(a32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:18:8
+  --> $DIR/integer-literal-suffix-inference.rs:20:8
    |
 LL |     fn id_i64(n: i64) -> i64 { n }
    |        ^^^^^^ ------
@@ -575,7 +575,7 @@ LL |     id_i64(a32.into());
    |               +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:152:11
+  --> $DIR/integer-literal-suffix-inference.rs:154:11
    |
 LL |     id_u8(b16);
    |     ----- ^^^ expected `u8`, found `u16`
@@ -583,7 +583,7 @@ LL |     id_u8(b16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:27:8
+  --> $DIR/integer-literal-suffix-inference.rs:29:8
    |
 LL |     fn id_u8(n: u8) -> u8 { n }
    |        ^^^^^ -----
@@ -593,7 +593,7 @@ LL |     id_u8(b16.try_into().unwrap());
    |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:155:11
+  --> $DIR/integer-literal-suffix-inference.rs:157:11
    |
 LL |     id_u8(b32);
    |     ----- ^^^ expected `u8`, found `u32`
@@ -601,7 +601,7 @@ LL |     id_u8(b32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:27:8
+  --> $DIR/integer-literal-suffix-inference.rs:29:8
    |
 LL |     fn id_u8(n: u8) -> u8 { n }
    |        ^^^^^ -----
@@ -611,7 +611,7 @@ LL |     id_u8(b32.try_into().unwrap());
    |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:158:11
+  --> $DIR/integer-literal-suffix-inference.rs:160:11
    |
 LL |     id_u8(b64);
    |     ----- ^^^ expected `u8`, found `u64`
@@ -619,7 +619,7 @@ LL |     id_u8(b64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:27:8
+  --> $DIR/integer-literal-suffix-inference.rs:29:8
    |
 LL |     fn id_u8(n: u8) -> u8 { n }
    |        ^^^^^ -----
@@ -629,7 +629,7 @@ LL |     id_u8(b64.try_into().unwrap());
    |              ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:161:11
+  --> $DIR/integer-literal-suffix-inference.rs:163:11
    |
 LL |     id_u8(bsize);
    |     ----- ^^^^^ expected `u8`, found `usize`
@@ -637,7 +637,7 @@ LL |     id_u8(bsize);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:27:8
+  --> $DIR/integer-literal-suffix-inference.rs:29:8
    |
 LL |     fn id_u8(n: u8) -> u8 { n }
    |        ^^^^^ -----
@@ -647,7 +647,7 @@ LL |     id_u8(bsize.try_into().unwrap());
    |                ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:165:12
+  --> $DIR/integer-literal-suffix-inference.rs:167:12
    |
 LL |     id_u16(b8);
    |     ------ ^^ expected `u16`, found `u8`
@@ -655,7 +655,7 @@ LL |     id_u16(b8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:28:8
+  --> $DIR/integer-literal-suffix-inference.rs:30:8
    |
 LL |     fn id_u16(n: u16) -> u16 { n }
    |        ^^^^^^ ------
@@ -665,7 +665,7 @@ LL |     id_u16(b8.into());
    |              +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:169:12
+  --> $DIR/integer-literal-suffix-inference.rs:171:12
    |
 LL |     id_u16(b32);
    |     ------ ^^^ expected `u16`, found `u32`
@@ -673,7 +673,7 @@ LL |     id_u16(b32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:28:8
+  --> $DIR/integer-literal-suffix-inference.rs:30:8
    |
 LL |     fn id_u16(n: u16) -> u16 { n }
    |        ^^^^^^ ------
@@ -683,7 +683,7 @@ LL |     id_u16(b32.try_into().unwrap());
    |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:172:12
+  --> $DIR/integer-literal-suffix-inference.rs:174:12
    |
 LL |     id_u16(b64);
    |     ------ ^^^ expected `u16`, found `u64`
@@ -691,7 +691,7 @@ LL |     id_u16(b64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:28:8
+  --> $DIR/integer-literal-suffix-inference.rs:30:8
    |
 LL |     fn id_u16(n: u16) -> u16 { n }
    |        ^^^^^^ ------
@@ -701,7 +701,7 @@ LL |     id_u16(b64.try_into().unwrap());
    |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:175:12
+  --> $DIR/integer-literal-suffix-inference.rs:177:12
    |
 LL |     id_u16(bsize);
    |     ------ ^^^^^ expected `u16`, found `usize`
@@ -709,7 +709,7 @@ LL |     id_u16(bsize);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:28:8
+  --> $DIR/integer-literal-suffix-inference.rs:30:8
    |
 LL |     fn id_u16(n: u16) -> u16 { n }
    |        ^^^^^^ ------
@@ -719,7 +719,7 @@ LL |     id_u16(bsize.try_into().unwrap());
    |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:179:12
+  --> $DIR/integer-literal-suffix-inference.rs:181:12
    |
 LL |     id_u32(b8);
    |     ------ ^^ expected `u32`, found `u8`
@@ -727,7 +727,7 @@ LL |     id_u32(b8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:29:8
+  --> $DIR/integer-literal-suffix-inference.rs:31:8
    |
 LL |     fn id_u32(n: u32) -> u32 { n }
    |        ^^^^^^ ------
@@ -737,7 +737,7 @@ LL |     id_u32(b8.into());
    |              +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:182:12
+  --> $DIR/integer-literal-suffix-inference.rs:184:12
    |
 LL |     id_u32(b16);
    |     ------ ^^^ expected `u32`, found `u16`
@@ -745,7 +745,7 @@ LL |     id_u32(b16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:29:8
+  --> $DIR/integer-literal-suffix-inference.rs:31:8
    |
 LL |     fn id_u32(n: u32) -> u32 { n }
    |        ^^^^^^ ------
@@ -755,7 +755,7 @@ LL |     id_u32(b16.into());
    |               +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:186:12
+  --> $DIR/integer-literal-suffix-inference.rs:188:12
    |
 LL |     id_u32(b64);
    |     ------ ^^^ expected `u32`, found `u64`
@@ -763,7 +763,7 @@ LL |     id_u32(b64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:29:8
+  --> $DIR/integer-literal-suffix-inference.rs:31:8
    |
 LL |     fn id_u32(n: u32) -> u32 { n }
    |        ^^^^^^ ------
@@ -773,7 +773,7 @@ LL |     id_u32(b64.try_into().unwrap());
    |               ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:189:12
+  --> $DIR/integer-literal-suffix-inference.rs:191:12
    |
 LL |     id_u32(bsize);
    |     ------ ^^^^^ expected `u32`, found `usize`
@@ -781,7 +781,7 @@ LL |     id_u32(bsize);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:29:8
+  --> $DIR/integer-literal-suffix-inference.rs:31:8
    |
 LL |     fn id_u32(n: u32) -> u32 { n }
    |        ^^^^^^ ------
@@ -791,7 +791,7 @@ LL |     id_u32(bsize.try_into().unwrap());
    |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:193:12
+  --> $DIR/integer-literal-suffix-inference.rs:195:12
    |
 LL |     id_u64(b8);
    |     ------ ^^ expected `u64`, found `u8`
@@ -799,7 +799,7 @@ LL |     id_u64(b8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:30:8
+  --> $DIR/integer-literal-suffix-inference.rs:32:8
    |
 LL |     fn id_u64(n: u64) -> u64 { n }
    |        ^^^^^^ ------
@@ -809,7 +809,7 @@ LL |     id_u64(b8.into());
    |              +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:196:12
+  --> $DIR/integer-literal-suffix-inference.rs:198:12
    |
 LL |     id_u64(b16);
    |     ------ ^^^ expected `u64`, found `u16`
@@ -817,7 +817,7 @@ LL |     id_u64(b16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:30:8
+  --> $DIR/integer-literal-suffix-inference.rs:32:8
    |
 LL |     fn id_u64(n: u64) -> u64 { n }
    |        ^^^^^^ ------
@@ -827,7 +827,7 @@ LL |     id_u64(b16.into());
    |               +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:199:12
+  --> $DIR/integer-literal-suffix-inference.rs:201:12
    |
 LL |     id_u64(b32);
    |     ------ ^^^ expected `u64`, found `u32`
@@ -835,7 +835,7 @@ LL |     id_u64(b32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:30:8
+  --> $DIR/integer-literal-suffix-inference.rs:32:8
    |
 LL |     fn id_u64(n: u64) -> u64 { n }
    |        ^^^^^^ ------
@@ -845,7 +845,7 @@ LL |     id_u64(b32.into());
    |               +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:203:12
+  --> $DIR/integer-literal-suffix-inference.rs:205:12
    |
 LL |     id_u64(bsize);
    |     ------ ^^^^^ expected `u64`, found `usize`
@@ -853,7 +853,7 @@ LL |     id_u64(bsize);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:30:8
+  --> $DIR/integer-literal-suffix-inference.rs:32:8
    |
 LL |     fn id_u64(n: u64) -> u64 { n }
    |        ^^^^^^ ------
@@ -863,7 +863,7 @@ LL |     id_u64(bsize.try_into().unwrap());
    |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:207:14
+  --> $DIR/integer-literal-suffix-inference.rs:209:14
    |
 LL |     id_usize(b8);
    |     -------- ^^ expected `usize`, found `u8`
@@ -871,7 +871,7 @@ LL |     id_usize(b8);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:31:8
+  --> $DIR/integer-literal-suffix-inference.rs:33:8
    |
 LL |     fn id_usize(n: usize) -> usize { n }
    |        ^^^^^^^^ --------
@@ -881,7 +881,7 @@ LL |     id_usize(b8.into());
    |                +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:210:14
+  --> $DIR/integer-literal-suffix-inference.rs:212:14
    |
 LL |     id_usize(b16);
    |     -------- ^^^ expected `usize`, found `u16`
@@ -889,7 +889,7 @@ LL |     id_usize(b16);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:31:8
+  --> $DIR/integer-literal-suffix-inference.rs:33:8
    |
 LL |     fn id_usize(n: usize) -> usize { n }
    |        ^^^^^^^^ --------
@@ -899,7 +899,7 @@ LL |     id_usize(b16.into());
    |                 +++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:213:14
+  --> $DIR/integer-literal-suffix-inference.rs:215:14
    |
 LL |     id_usize(b32);
    |     -------- ^^^ expected `usize`, found `u32`
@@ -907,7 +907,7 @@ LL |     id_usize(b32);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:31:8
+  --> $DIR/integer-literal-suffix-inference.rs:33:8
    |
 LL |     fn id_usize(n: usize) -> usize { n }
    |        ^^^^^^^^ --------
@@ -917,7 +917,7 @@ LL |     id_usize(b32.try_into().unwrap());
    |                 ++++++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/integer-literal-suffix-inference.rs:216:14
+  --> $DIR/integer-literal-suffix-inference.rs:218:14
    |
 LL |     id_usize(b64);
    |     -------- ^^^ expected `usize`, found `u64`
@@ -925,7 +925,7 @@ LL |     id_usize(b64);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/integer-literal-suffix-inference.rs:31:8
+  --> $DIR/integer-literal-suffix-inference.rs:33:8
    |
 LL |     fn id_usize(n: usize) -> usize { n }
    |        ^^^^^^^^ --------

--- a/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs
+++ b/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs
@@ -1,7 +1,9 @@
+//@ dont-require-annotations: NOTE
+
 fn main() {
     unsafe {
         dealloc(ptr2, Layout::(x: !)(1, 1)); //~ ERROR: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `:`
         //~^ ERROR: expected one of `.`, `;`, `?`, `}`, or an operator, found `)`
-        //~| while parsing this parenthesized list of type arguments starting here
+        //~| NOTE while parsing this parenthesized list of type arguments starting here
     }
 }

--- a/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.stderr
+++ b/tests/ui/parser/diagnostics-parenthesized-type-arguments-ice-issue-122345.stderr
@@ -1,5 +1,5 @@
 error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `:`
-  --> $DIR/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs:3:33
+  --> $DIR/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs:5:33
    |
 LL |         dealloc(ptr2, Layout::(x: !)(1, 1));
    |                             --- ^ expected one of 7 possible tokens
@@ -7,7 +7,7 @@ LL |         dealloc(ptr2, Layout::(x: !)(1, 1));
    |                             while parsing this parenthesized list of type arguments starting here
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `)`
-  --> $DIR/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs:3:43
+  --> $DIR/diagnostics-parenthesized-type-arguments-ice-issue-122345.rs:5:43
    |
 LL |         dealloc(ptr2, Layout::(x: !)(1, 1));
    |                                           ^ expected one of `.`, `;`, `?`, `}`, or an operator

--- a/tests/ui/parser/do-catch-suggests-try.rs
+++ b/tests/ui/parser/do-catch-suggests-try.rs
@@ -1,10 +1,12 @@
+//@ dont-require-annotations: NOTE
+
 #![feature(try_blocks)]
 
 fn main() {
     let _: Option<()> = do catch {};
     //~^ ERROR found removed `do catch` syntax
     //~| HELP replace with the new syntax
-    //~| following RFC #2388, the new non-placeholder syntax is `try`
+    //~| NOTE following RFC #2388, the new non-placeholder syntax is `try`
 
     let _recovery_witness: () = 1; //~ ERROR mismatched types
 }

--- a/tests/ui/parser/do-catch-suggests-try.stderr
+++ b/tests/ui/parser/do-catch-suggests-try.stderr
@@ -1,5 +1,5 @@
 error: found removed `do catch` syntax
-  --> $DIR/do-catch-suggests-try.rs:4:25
+  --> $DIR/do-catch-suggests-try.rs:6:25
    |
 LL |     let _: Option<()> = do catch {};
    |                         ^^^^^^^^
@@ -12,7 +12,7 @@ LL +     let _: Option<()> = try {};
    |
 
 error[E0308]: mismatched types
-  --> $DIR/do-catch-suggests-try.rs:9:33
+  --> $DIR/do-catch-suggests-try.rs:11:33
    |
 LL |     let _recovery_witness: () = 1;
    |                            --   ^ expected `()`, found integer

--- a/tests/ui/parser/mut-patterns.rs
+++ b/tests/ui/parser/mut-patterns.rs
@@ -1,6 +1,7 @@
 // Can't put mut in non-ident pattern
 
 //@ edition:2018
+//@ dont-require-annotations: HELP
 
 #![feature(box_patterns)]
 #![allow(warnings)]
@@ -13,20 +14,20 @@ pub fn main() {
 
     let mut mut x = 0;
     //~^ ERROR `mut` on a binding may not be repeated
-    //~| remove the additional `mut`s
+    //~| HELP remove the additional `mut`s
 
     let mut mut mut mut mut x = 0;
     //~^ ERROR `mut` on a binding may not be repeated
-    //~| remove the additional `mut`s
+    //~| HELP remove the additional `mut`s
 
     struct Foo { x: isize }
     let mut Foo { x: x } = Foo { x: 3 };
     //~^ ERROR `mut` must be attached to each individual binding
-    //~| add `mut` to each binding
+    //~| HELP add `mut` to each binding
 
     let mut Foo { x } = Foo { x: 3 };
     //~^ ERROR `mut` must be attached to each individual binding
-    //~| add `mut` to each binding
+    //~| HELP add `mut` to each binding
 
     struct r#yield(u8, u8);
     let mut mut yield(become, await) = r#yield(0, 0);

--- a/tests/ui/parser/mut-patterns.stderr
+++ b/tests/ui/parser/mut-patterns.stderr
@@ -1,5 +1,5 @@
 error: `mut` must be followed by a named binding
-  --> $DIR/mut-patterns.rs:9:9
+  --> $DIR/mut-patterns.rs:10:9
    |
 LL |     let mut _ = 0;
    |         ^^^^
@@ -12,7 +12,7 @@ LL +     let _ = 0;
    |
 
 error: `mut` must be followed by a named binding
-  --> $DIR/mut-patterns.rs:10:9
+  --> $DIR/mut-patterns.rs:11:9
    |
 LL |     let mut (_, _) = (0, 0);
    |         ^^^^
@@ -25,7 +25,7 @@ LL +     let (_, _) = (0, 0);
    |
 
 error: `mut` must be attached to each individual binding
-  --> $DIR/mut-patterns.rs:12:9
+  --> $DIR/mut-patterns.rs:13:9
    |
 LL |     let mut (x @ y) = 0;
    |         ^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL +     let (mut x @ mut y) = 0;
    |
 
 error: `mut` on a binding may not be repeated
-  --> $DIR/mut-patterns.rs:14:13
+  --> $DIR/mut-patterns.rs:15:13
    |
 LL |     let mut mut x = 0;
    |             ^^^
@@ -50,7 +50,7 @@ LL +     let mut x = 0;
    |
 
 error: `mut` on a binding may not be repeated
-  --> $DIR/mut-patterns.rs:18:13
+  --> $DIR/mut-patterns.rs:19:13
    |
 LL |     let mut mut mut mut mut x = 0;
    |             ^^^^^^^^^^^^^^^
@@ -62,7 +62,7 @@ LL +     let mut x = 0;
    |
 
 error: `mut` must be attached to each individual binding
-  --> $DIR/mut-patterns.rs:23:9
+  --> $DIR/mut-patterns.rs:24:9
    |
 LL |     let mut Foo { x: x } = Foo { x: 3 };
    |         ^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL +     let Foo { x: mut x } = Foo { x: 3 };
    |
 
 error: `mut` must be attached to each individual binding
-  --> $DIR/mut-patterns.rs:27:9
+  --> $DIR/mut-patterns.rs:28:9
    |
 LL |     let mut Foo { x } = Foo { x: 3 };
    |         ^^^^^^^^^^^^^
@@ -88,7 +88,7 @@ LL +     let Foo { mut x } = Foo { x: 3 };
    |
 
 error: `mut` on a binding may not be repeated
-  --> $DIR/mut-patterns.rs:32:13
+  --> $DIR/mut-patterns.rs:33:13
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |             ^^^
@@ -100,7 +100,7 @@ LL +     let mut yield(become, await) = r#yield(0, 0);
    |
 
 error: expected identifier, found reserved keyword `yield`
-  --> $DIR/mut-patterns.rs:32:17
+  --> $DIR/mut-patterns.rs:33:17
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |                 ^^^^^ expected identifier, found reserved keyword
@@ -111,7 +111,7 @@ LL |     let mut mut r#yield(become, await) = r#yield(0, 0);
    |                 ++
 
 error: expected identifier, found reserved keyword `become`
-  --> $DIR/mut-patterns.rs:32:23
+  --> $DIR/mut-patterns.rs:33:23
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |                       ^^^^^^ expected identifier, found reserved keyword
@@ -122,7 +122,7 @@ LL |     let mut mut yield(r#become, await) = r#yield(0, 0);
    |                       ++
 
 error: expected identifier, found keyword `await`
-  --> $DIR/mut-patterns.rs:32:31
+  --> $DIR/mut-patterns.rs:33:31
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |                               ^^^^^ expected identifier, found keyword
@@ -133,7 +133,7 @@ LL |     let mut mut yield(become, r#await) = r#yield(0, 0);
    |                               ++
 
 error: `mut` must be followed by a named binding
-  --> $DIR/mut-patterns.rs:32:9
+  --> $DIR/mut-patterns.rs:33:9
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |         ^^^^^^^^
@@ -146,7 +146,7 @@ LL +     let yield(become, await) = r#yield(0, 0);
    |
 
 error: `mut` must be attached to each individual binding
-  --> $DIR/mut-patterns.rs:41:9
+  --> $DIR/mut-patterns.rs:42:9
    |
 LL |     let mut W(mut a, W(b, W(ref c, W(d, B { box f }))))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,7 +159,7 @@ LL +     let W(mut a, W(mut b, W(ref c, W(mut d, B { box mut f }))))
    |
 
 error: expected identifier, found metavariable
-  --> $DIR/mut-patterns.rs:48:21
+  --> $DIR/mut-patterns.rs:49:21
    |
 LL |             let mut $p = 0;
    |                     ^^ expected identifier, found metavariable

--- a/tests/ui/parser/recover/recover-pat-exprs.rs
+++ b/tests/ui/parser/recover/recover-pat-exprs.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: HELP
+
 // FieldExpression, TupleIndexingExpression
 fn field_access() {
     match 0 {
@@ -28,7 +30,7 @@ fn array_indexing() {
     { let x[0; 20]; } //~ error: expected one of `:`, `;`, `=`, `@`, or `|`, found `[`
     { let x[]; } //~ error: expected one of `:`, `;`, `=`, `@`, or `|`, found `[`
     { let (x[]); } //~ error: expected one of `)`, `,`, `@`, `if`, or `|`, found `[`
-    //~^ missing `,`
+    //~^ HELP missing `,`
 }
 
 // MethodCallExpression, CallExpression, ErrorPropagationExpression

--- a/tests/ui/parser/recover/recover-pat-exprs.stderr
+++ b/tests/ui/parser/recover/recover-pat-exprs.stderr
@@ -1,5 +1,5 @@
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:5:9
+  --> $DIR/recover-pat-exprs.rs:7:9
    |
 LL |         x.y => (),
    |         ^^^ not a pattern
@@ -19,7 +19,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:6:9
+  --> $DIR/recover-pat-exprs.rs:8:9
    |
 LL |         x.0 => (),
    |         ^^^ not a pattern
@@ -40,7 +40,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:7:9
+  --> $DIR/recover-pat-exprs.rs:9:9
    |
 LL |         x._0 => (),
    |         ^^^^ not a pattern
@@ -62,7 +62,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:8:9
+  --> $DIR/recover-pat-exprs.rs:10:9
    |
 LL |         x.0.1 => (),
    |         ^^^^^ not a pattern
@@ -84,7 +84,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:9:9
+  --> $DIR/recover-pat-exprs.rs:11:9
    |
 LL |         x.4.y.17.__z => (),
    |         ^^^^^^^^^^^^ not a pattern
@@ -106,37 +106,37 @@ LL ~         VAL => (),
    |
 
 error: expected one of `:`, `;`, `=`, `@`, or `|`, found `.`
-  --> $DIR/recover-pat-exprs.rs:12:12
+  --> $DIR/recover-pat-exprs.rs:14:12
    |
 LL |     { let x.0e0; }
    |            ^ expected one of `:`, `;`, `=`, `@`, or `|`
 
 error: expected one of `:`, `;`, `=`, `@`, or `|`, found `.`
-  --> $DIR/recover-pat-exprs.rs:13:12
+  --> $DIR/recover-pat-exprs.rs:15:12
    |
 LL |     { let x.-0.0; }
    |            ^ expected one of `:`, `;`, `=`, `@`, or `|`
 
 error: expected one of `:`, `;`, `=`, `@`, or `|`, found `.`
-  --> $DIR/recover-pat-exprs.rs:14:12
+  --> $DIR/recover-pat-exprs.rs:16:12
    |
 LL |     { let x.-0; }
    |            ^ expected one of `:`, `;`, `=`, `@`, or `|`
 
 error: expected one of `:`, `;`, `=`, `@`, or `|`, found `.`
-  --> $DIR/recover-pat-exprs.rs:16:12
+  --> $DIR/recover-pat-exprs.rs:18:12
    |
 LL |     { let x.0u32; }
    |            ^ expected one of `:`, `;`, `=`, `@`, or `|`
 
 error: expected one of `:`, `;`, `=`, `@`, or `|`, found `.`
-  --> $DIR/recover-pat-exprs.rs:17:12
+  --> $DIR/recover-pat-exprs.rs:19:12
    |
 LL |     { let x.0.0_f64; }
    |            ^ expected one of `:`, `;`, `=`, `@`, or `|`
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:23:9
+  --> $DIR/recover-pat-exprs.rs:25:9
    |
 LL |         x[0] => (),
    |         ^^^^ not a pattern
@@ -155,7 +155,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:24:9
+  --> $DIR/recover-pat-exprs.rs:26:9
    |
 LL |         x[..] => (),
    |         ^^^^^ not a pattern
@@ -175,25 +175,25 @@ LL ~         VAL => (),
    |
 
 error: expected one of `:`, `;`, `=`, `@`, or `|`, found `[`
-  --> $DIR/recover-pat-exprs.rs:27:12
+  --> $DIR/recover-pat-exprs.rs:29:12
    |
 LL |     { let x[0, 1, 2]; }
    |            ^ expected one of `:`, `;`, `=`, `@`, or `|`
 
 error: expected one of `:`, `;`, `=`, `@`, or `|`, found `[`
-  --> $DIR/recover-pat-exprs.rs:28:12
+  --> $DIR/recover-pat-exprs.rs:30:12
    |
 LL |     { let x[0; 20]; }
    |            ^ expected one of `:`, `;`, `=`, `@`, or `|`
 
 error: expected one of `:`, `;`, `=`, `@`, or `|`, found `[`
-  --> $DIR/recover-pat-exprs.rs:29:12
+  --> $DIR/recover-pat-exprs.rs:31:12
    |
 LL |     { let x[]; }
    |            ^ expected one of `:`, `;`, `=`, `@`, or `|`
 
 error: expected one of `)`, `,`, `@`, `if`, or `|`, found `[`
-  --> $DIR/recover-pat-exprs.rs:30:13
+  --> $DIR/recover-pat-exprs.rs:32:13
    |
 LL |     { let (x[]); }
    |             ^
@@ -202,7 +202,7 @@ LL |     { let (x[]); }
    |             help: missing `,`
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:37:9
+  --> $DIR/recover-pat-exprs.rs:39:9
    |
 LL |         x.f() => (),
    |         ^^^^^ not a pattern
@@ -221,7 +221,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:38:9
+  --> $DIR/recover-pat-exprs.rs:40:9
    |
 LL |         x._f() => (),
    |         ^^^^^^ not a pattern
@@ -241,7 +241,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:39:9
+  --> $DIR/recover-pat-exprs.rs:41:9
    |
 LL |         x? => (),
    |         ^^ not a pattern
@@ -262,7 +262,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:40:9
+  --> $DIR/recover-pat-exprs.rs:42:9
    |
 LL |         ().f() => (),
    |         ^^^^^^ not a pattern
@@ -284,7 +284,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:41:9
+  --> $DIR/recover-pat-exprs.rs:43:9
    |
 LL |         (0, x)?.f() => (),
    |         ^^^^^^^^^^^ not a pattern
@@ -306,7 +306,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:42:9
+  --> $DIR/recover-pat-exprs.rs:44:9
    |
 LL |         x.f().g() => (),
    |         ^^^^^^^^^ not a pattern
@@ -328,7 +328,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:43:9
+  --> $DIR/recover-pat-exprs.rs:45:9
    |
 LL |         0.f()?.g()?? => (),
    |         ^^^^^^^^^^^^ not a pattern
@@ -350,7 +350,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:50:9
+  --> $DIR/recover-pat-exprs.rs:52:9
    |
 LL |         x as usize => (),
    |         ^^^^^^^^^^ not a pattern
@@ -369,7 +369,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:51:9
+  --> $DIR/recover-pat-exprs.rs:53:9
    |
 LL |         0 as usize => (),
    |         ^^^^^^^^^^ not a pattern
@@ -389,7 +389,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:52:9
+  --> $DIR/recover-pat-exprs.rs:54:9
    |
 LL |         x.f().0.4 as f32 => (),
    |         ^^^^^^^^^^^^^^^^ not a pattern
@@ -410,7 +410,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:59:9
+  --> $DIR/recover-pat-exprs.rs:61:9
    |
 LL |         1 + 1 => (),
    |         ^^^^^ not a pattern
@@ -429,7 +429,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:60:9
+  --> $DIR/recover-pat-exprs.rs:62:9
    |
 LL |         (1 + 2) * 3 => (),
    |         ^^^^^^^^^^^ not a pattern
@@ -449,7 +449,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:63:9
+  --> $DIR/recover-pat-exprs.rs:65:9
    |
 LL |         x.0 > 2 => (),
    |         ^^^^^^^ not a pattern
@@ -471,7 +471,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:64:9
+  --> $DIR/recover-pat-exprs.rs:66:9
    |
 LL |         x.0 == 2 => (),
    |         ^^^^^^^^ not a pattern
@@ -493,7 +493,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:69:13
+  --> $DIR/recover-pat-exprs.rs:71:13
    |
 LL |         (x, y.0 > 2) if x != 0 => (),
    |             ^^^^^^^ not a pattern
@@ -512,7 +512,7 @@ LL ~         (x, VAL) if x != 0 => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:70:13
+  --> $DIR/recover-pat-exprs.rs:72:13
    |
 LL |         (x, y.0 > 2) if x != 0 || x != 1 => (),
    |             ^^^^^^^ not a pattern
@@ -532,7 +532,7 @@ LL ~         (x, VAL) if x != 0 || x != 1 => (),
    |
 
 error: left-hand side of `@` must be a binding
-  --> $DIR/recover-pat-exprs.rs:83:9
+  --> $DIR/recover-pat-exprs.rs:85:9
    |
 LL |         x.sqrt() @ .. => (),
    |         --------^^^--
@@ -543,13 +543,13 @@ LL |         x.sqrt() @ .. => (),
    = note: bindings are `x`, `mut x`, `ref x`, and `ref mut x`
 
 error: expected one of `)`, `,`, `if`, or `|`, found `+`
-  --> $DIR/recover-pat-exprs.rs:97:12
+  --> $DIR/recover-pat-exprs.rs:99:12
    |
 LL |         (_ + 1) => (),
    |            ^ expected one of `)`, `,`, `if`, or `|`
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:81:9
+  --> $DIR/recover-pat-exprs.rs:83:9
    |
 LL |         u8::MAX.abs() => (),
    |         ^^^^^^^^^^^^^ not a pattern
@@ -568,7 +568,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:86:17
+  --> $DIR/recover-pat-exprs.rs:88:17
    |
 LL |         z @ w @ v.u() => (),
    |                 ^^^^^ not a pattern
@@ -590,7 +590,7 @@ LL ~         z @ w @ VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:88:9
+  --> $DIR/recover-pat-exprs.rs:90:9
    |
 LL |         y.ilog(3) => (),
    |         ^^^^^^^^^ not a pattern
@@ -612,7 +612,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:90:9
+  --> $DIR/recover-pat-exprs.rs:92:9
    |
 LL |         n + 1 => (),
    |         ^^^^^ not a pattern
@@ -634,7 +634,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:92:10
+  --> $DIR/recover-pat-exprs.rs:94:10
    |
 LL |         ("".f() + 14 * 8) => (),
    |          ^^^^^^^^^^^^^^^ not a pattern
@@ -656,7 +656,7 @@ LL ~         (VAL) => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:95:9
+  --> $DIR/recover-pat-exprs.rs:97:9
    |
 LL |         f?() => (),
    |         ^^^^ not a pattern
@@ -678,7 +678,7 @@ LL ~         VAL => (),
    |
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:101:9
+  --> $DIR/recover-pat-exprs.rs:103:9
    |
 LL |     let 1 + 1 = 2;
    |         ^^^^^ not a pattern
@@ -686,7 +686,7 @@ LL |     let 1 + 1 = 2;
    = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
 
 error: expected one of `)`, `,`, `@`, `if`, or `|`, found `*`
-  --> $DIR/recover-pat-exprs.rs:104:28
+  --> $DIR/recover-pat-exprs.rs:106:28
    |
 LL |     let b = matches!(x, (x * x | x.f()) | x[0]);
    |                            ^ expected one of `)`, `,`, `@`, `if`, or `|`
@@ -695,7 +695,7 @@ LL |     let b = matches!(x, (x * x | x.f()) | x[0]);
    = note: while parsing argument for this `pat` macro fragment
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:60:10
+  --> $DIR/recover-pat-exprs.rs:62:10
    |
 LL |         (1 + 2) * 3 => (),
    |          ^^^^^ not a pattern
@@ -703,7 +703,7 @@ LL |         (1 + 2) * 3 => (),
    = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:75:5
+  --> $DIR/recover-pat-exprs.rs:77:5
    |
 LL |     1 + 2 * PI.cos() => 2,
    |     ^^^^^^^^^^^^^^^^ not a pattern
@@ -711,7 +711,7 @@ LL |     1 + 2 * PI.cos() => 2,
    = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch19-00-patterns.html>
 
 error: expected a pattern, found an expression
-  --> $DIR/recover-pat-exprs.rs:83:9
+  --> $DIR/recover-pat-exprs.rs:85:9
    |
 LL |         x.sqrt() @ .. => (),
    |         ^^^^^^^^ not a pattern

--- a/tests/ui/pattern/byte-string-mutability-mismatch.rs
+++ b/tests/ui/pattern/byte-string-mutability-mismatch.rs
@@ -2,18 +2,20 @@
 //! the pattern's scrutinee. Since byte string literals are always shared references, it's a
 //! mismatch to use a byte string literal pattern to match on a mutable array or slice reference.
 
+//@ dont-require-annotations: NOTE
+
 fn main() {
     let mut val = [97u8, 10u8];
     match &mut val {
         b"a\n" => {},
         //~^ ERROR mismatched types
-        //~| types differ in mutability
+        //~| NOTE types differ in mutability
         _ => {},
     }
     match &mut val[..] {
          b"a\n" => {},
         //~^ ERROR mismatched types
-        //~| types differ in mutability
+        //~| NOTE types differ in mutability
          _ => {},
     }
 }

--- a/tests/ui/pattern/byte-string-mutability-mismatch.stderr
+++ b/tests/ui/pattern/byte-string-mutability-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/byte-string-mutability-mismatch.rs:8:9
+  --> $DIR/byte-string-mutability-mismatch.rs:10:9
    |
 LL |     match &mut val {
    |           -------- this expression has type `&mut [u8; 2]`
@@ -10,7 +10,7 @@ LL |         b"a\n" => {},
                       found reference `&'static _`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-mutability-mismatch.rs:14:10
+  --> $DIR/byte-string-mutability-mismatch.rs:16:10
    |
 LL |     match &mut val[..] {
    |           ------------ this expression has type `&mut [u8]`

--- a/tests/ui/pattern/deref-patterns/byte-string-type-errors.rs
+++ b/tests/ui/pattern/deref-patterns/byte-string-type-errors.rs
@@ -2,6 +2,8 @@
 //! patterns to have type `[u8]` or `[u8; N]` when matching on a slice or array; this can affect the
 //! "found" type reported in error messages when matching on a slice or array of the wrong type.
 
+//@ dont-require-annotations: NOTE
+
 #![feature(deref_patterns)]
 #![expect(incomplete_features)]
 
@@ -10,25 +12,25 @@ fn main() {
     // the same as byte string literals.
     if let b"test" = () {}
     //~^ ERROR mismatched types
-    //~| expected `()`, found `&[u8; 4]`
+    //~| NOTE expected `()`, found `&[u8; 4]`
 
     // Baseline 2: there's a special case for byte string patterns in stable rust, allowing them to
     // match on slice references. This affects the error when matching on a non-`&[u8]` slice ref,
     // reporting the "found" type as `&[u8]`.
     if let b"test" = &[] as &[i8] {}
     //~^ ERROR mismatched types
-    //~| expected `&[i8]`, found `&[u8]`
+    //~| NOTE expected `&[i8]`, found `&[u8]`
 
     // Test matching on a non-`[u8]` slice: the pattern has type `[u8]` if a slice is expected.
     if let b"test" = *(&[] as &[i8]) {}
     //~^ ERROR mismatched types
-    //~| expected `[i8]`, found `[u8]`
+    //~| NOTE expected `[i8]`, found `[u8]`
 
     // Test matching on a non-`[u8;4]` array: the pattern has type `[u8;4]` if an array is expected.
     if let b"test" = [()] {}
     //~^ ERROR mismatched types
-    //~| expected `[(); 1]`, found `[u8; 4]`
+    //~| NOTE expected `[(); 1]`, found `[u8; 4]`
     if let b"test" = *b"this array is too long" {}
     //~^ ERROR mismatched types
-    //~| expected an array with a size of 22, found one with a size of 4
+    //~| NOTE expected an array with a size of 22, found one with a size of 4
 }

--- a/tests/ui/pattern/deref-patterns/byte-string-type-errors.stderr
+++ b/tests/ui/pattern/deref-patterns/byte-string-type-errors.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:11:12
+  --> $DIR/byte-string-type-errors.rs:13:12
    |
 LL |     if let b"test" = () {}
    |            ^^^^^^^   -- this expression has type `()`
@@ -7,7 +7,7 @@ LL |     if let b"test" = () {}
    |            expected `()`, found `&[u8; 4]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:18:12
+  --> $DIR/byte-string-type-errors.rs:20:12
    |
 LL |     if let b"test" = &[] as &[i8] {}
    |            ^^^^^^^   ------------ this expression has type `&[i8]`
@@ -18,7 +18,7 @@ LL |     if let b"test" = &[] as &[i8] {}
               found reference `&'static [u8]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:23:12
+  --> $DIR/byte-string-type-errors.rs:25:12
    |
 LL |     if let b"test" = *(&[] as &[i8]) {}
    |            ^^^^^^^   --------------- this expression has type `[i8]`
@@ -29,7 +29,7 @@ LL |     if let b"test" = *(&[] as &[i8]) {}
               found slice `[u8]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:28:12
+  --> $DIR/byte-string-type-errors.rs:30:12
    |
 LL |     if let b"test" = [()] {}
    |            ^^^^^^^   ---- this expression has type `[(); 1]`
@@ -40,7 +40,7 @@ LL |     if let b"test" = [()] {}
               found array `[u8; 4]`
 
 error[E0308]: mismatched types
-  --> $DIR/byte-string-type-errors.rs:31:12
+  --> $DIR/byte-string-type-errors.rs:33:12
    |
 LL |     if let b"test" = *b"this array is too long" {}
    |            ^^^^^^^   -------------------------- this expression has type `[u8; 22]`

--- a/tests/ui/pattern/deref-patterns/unsatisfied-bounds.rs
+++ b/tests/ui/pattern/deref-patterns/unsatisfied-bounds.rs
@@ -15,7 +15,7 @@ fn main() {
     // FIXME(deref_patterns): there should be a special diagnostic for missing `DerefPure`.
     match MyPointer {
         () => {}
-        //~^ the trait bound `MyPointer: DerefPure` is not satisfied
+        //~^ ERROR the trait bound `MyPointer: DerefPure` is not satisfied
         _ => {}
     }
 }

--- a/tests/ui/pattern/pattern-error-continue.rs
+++ b/tests/ui/pattern/pattern-error-continue.rs
@@ -1,5 +1,7 @@
 // Test that certain pattern-match type errors are non-fatal
 
+//@ dont-require-annotations: NOTE
+
 enum A {
     B(isize, isize),
     C(isize, isize, isize),
@@ -21,13 +23,13 @@ fn main() {
     match 'c' {
         S { .. } => (),
         //~^ ERROR mismatched types
-        //~| expected `char`, found `S`
+        //~| NOTE expected `char`, found `S`
 
         _ => ()
     }
     f(true);
     //~^ ERROR mismatched types
-    //~| expected `char`, found `bool`
+    //~| NOTE expected `char`, found `bool`
 
     match () {
         E::V => {} //~ ERROR failed to resolve: use of undeclared type `E`

--- a/tests/ui/pattern/pattern-error-continue.stderr
+++ b/tests/ui/pattern/pattern-error-continue.stderr
@@ -1,5 +1,5 @@
 error[E0532]: expected tuple struct or tuple variant, found unit variant `A::D`
-  --> $DIR/pattern-error-continue.rs:18:9
+  --> $DIR/pattern-error-continue.rs:20:9
    |
 LL |     B(isize, isize),
    |     --------------- similarly named tuple variant `B` defined here
@@ -22,7 +22,7 @@ LL +         A::B(_) => (),
    |
 
 error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has 2 fields
-  --> $DIR/pattern-error-continue.rs:17:14
+  --> $DIR/pattern-error-continue.rs:19:14
    |
 LL |     B(isize, isize),
    |       -----  ----- tuple variant has 2 fields
@@ -31,7 +31,7 @@ LL |         A::B(_, _, _) => (),
    |              ^  ^  ^ expected 2 fields, found 3
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-error-continue.rs:22:9
+  --> $DIR/pattern-error-continue.rs:24:9
    |
 LL |     match 'c' {
    |           --- this expression has type `char`
@@ -39,7 +39,7 @@ LL |         S { .. } => (),
    |         ^^^^^^^^ expected `char`, found `S`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-error-continue.rs:28:7
+  --> $DIR/pattern-error-continue.rs:30:7
    |
 LL |     f(true);
    |     - ^^^^ expected `char`, found `bool`
@@ -47,13 +47,13 @@ LL |     f(true);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/pattern-error-continue.rs:13:4
+  --> $DIR/pattern-error-continue.rs:15:4
    |
 LL | fn f(_c: char) {}
    |    ^ --------
 
 error[E0433]: failed to resolve: use of undeclared type `E`
-  --> $DIR/pattern-error-continue.rs:33:9
+  --> $DIR/pattern-error-continue.rs:35:9
    |
 LL |         E::V => {}
    |         ^

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2021.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/borrowck-errors.rs:31:29
+  --> $DIR/borrowck-errors.rs:33:29
    |
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
@@ -14,19 +14,19 @@ LL +     if let Some(Some(x)) = Some(&Some(&mut 0)) {
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:36:10
+  --> $DIR/borrowck-errors.rs:38:10
    |
 LL |     let &ref mut x = &0;
    |          ^^^^^^^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:41:23
+  --> $DIR/borrowck-errors.rs:43:23
    |
 LL |     if let &Some(Some(x)) = &Some(&mut Some(0)) {
    |                       ^ cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:46:11
+  --> $DIR/borrowck-errors.rs:48:11
    |
 LL |     let &[x] = &&mut [0];
    |           ^ cannot borrow as mutable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.classic2024.stderr
@@ -1,5 +1,5 @@
 error[E0508]: cannot move out of type `[&mut i32; 1]`, a non-copy array
-  --> $DIR/borrowck-errors.rs:15:16
+  --> $DIR/borrowck-errors.rs:17:16
    |
 LL |     let [&x] = &[&mut 0];
    |           -    ^^^^^^^^^ cannot move out of here
@@ -13,7 +13,7 @@ LL |     let [&ref x] = &[&mut 0];
    |           +++
 
 error[E0508]: cannot move out of type `[&mut i32; 1]`, a non-copy array
-  --> $DIR/borrowck-errors.rs:22:16
+  --> $DIR/borrowck-errors.rs:24:16
    |
 LL |     let [&x] = &mut [&mut 0];
    |           -    ^^^^^^^^^^^^^ cannot move out of here
@@ -27,7 +27,7 @@ LL |     let [&ref x] = &mut [&mut 0];
    |           +++
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/borrowck-errors.rs:31:29
+  --> $DIR/borrowck-errors.rs:33:29
    |
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
@@ -42,25 +42,25 @@ LL +     if let Some(Some(x)) = Some(&Some(&mut 0)) {
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:36:10
+  --> $DIR/borrowck-errors.rs:38:10
    |
 LL |     let &ref mut x = &0;
    |          ^^^^^^^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:41:23
+  --> $DIR/borrowck-errors.rs:43:23
    |
 LL |     if let &Some(Some(x)) = &Some(&mut Some(0)) {
    |                       ^ cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:46:11
+  --> $DIR/borrowck-errors.rs:48:11
    |
 LL |     let &[x] = &&mut [0];
    |           ^ cannot borrow as mutable
 
 error[E0508]: cannot move out of type `[&mut i32; 1]`, a non-copy array
-  --> $DIR/borrowck-errors.rs:50:20
+  --> $DIR/borrowck-errors.rs:52:20
    |
 LL |     let [&mut x] = &mut [&mut 0];
    |               -    ^^^^^^^^^^^^^ cannot move out of here

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.rs
@@ -4,6 +4,8 @@
 //@[structural2021] edition: 2021
 //@[classic2024] edition: 2024
 //@[structural2024] edition: 2024
+//@ dont-require-annotations: NOTE
+
 //! Tests for pattern errors not handled by the pattern typing rules, but by borrowck.
 #![allow(incomplete_features)]
 #![cfg_attr(any(classic2021, classic2024), feature(ref_pat_eat_one_layer_2024))]
@@ -14,14 +16,14 @@
 fn errors_caught_in_hir_typeck_on_stable() {
     let [&x] = &[&mut 0];
     //[stable2021]~^ ERROR mismatched types
-    //[stable2021]~| types differ in mutability
+    //[stable2021]~| NOTE types differ in mutability
     //[classic2024]~^^^ ERROR: cannot move out of type
     #[cfg(any(classic2021, structural2021))] let _: u32 = x;
     #[cfg(structural2024)] let _: &u32 = x;
 
     let [&x] = &mut [&mut 0];
     //[stable2021]~^ ERROR mismatched types
-    //[stable2021]~| types differ in mutability
+    //[stable2021]~| NOTE types differ in mutability
     //[classic2024]~^^^ ERROR: cannot move out of type
     #[cfg(any(classic2021, structural2021))] let _: u32 = x;
     #[cfg(structural2024)] let _: &u32 = x;

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.stable2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.stable2021.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/borrowck-errors.rs:15:10
+  --> $DIR/borrowck-errors.rs:17:10
    |
 LL |     let [&x] = &[&mut 0];
    |          ^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -15,7 +15,7 @@ LL +     let [x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/borrowck-errors.rs:22:10
+  --> $DIR/borrowck-errors.rs:24:10
    |
 LL |     let [&x] = &mut [&mut 0];
    |          ^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -31,7 +31,7 @@ LL +     let [x] = &mut [&mut 0];
    |
 
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/borrowck-errors.rs:31:29
+  --> $DIR/borrowck-errors.rs:33:29
    |
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
@@ -46,19 +46,19 @@ LL +     if let Some(Some(x)) = Some(&Some(&mut 0)) {
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:36:10
+  --> $DIR/borrowck-errors.rs:38:10
    |
 LL |     let &ref mut x = &0;
    |          ^^^^^^^^^ cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:41:23
+  --> $DIR/borrowck-errors.rs:43:23
    |
 LL |     if let &Some(Some(x)) = &Some(&mut Some(0)) {
    |                       ^ cannot borrow as mutable
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:46:11
+  --> $DIR/borrowck-errors.rs:48:11
    |
 LL |     let &[x] = &&mut [0];
    |           ^ cannot borrow as mutable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2021.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/borrowck-errors.rs:31:29
+  --> $DIR/borrowck-errors.rs:33:29
    |
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ LL +     if let Some(Some(x)) = Some(&Some(&mut 0)) {
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:36:10
+  --> $DIR/borrowck-errors.rs:38:10
    |
 LL |     let &ref mut x = &0;
    |          ^^^^^^^^^ cannot borrow as mutable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/borrowck-errors.structural2024.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/borrowck-errors.rs:31:29
+  --> $DIR/borrowck-errors.rs:33:29
    |
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ LL +     if let Some(Some(x)) = Some(&Some(&mut 0)) {
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/borrowck-errors.rs:36:10
+  --> $DIR/borrowck-errors.rs:38:10
    |
 LL |     let &ref mut x = &0;
    |          ^^^^^^^^^ cannot borrow as mutable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mut-ref-mut.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mut-ref-mut.classic2024.stderr
@@ -1,5 +1,5 @@
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/mut-ref-mut.rs:18:13
+  --> $DIR/mut-ref-mut.rs:20:13
    |
 LL |     let Foo(mut a) = &Foo(0);
    |             ^^^^
@@ -9,7 +9,7 @@ LL |     let Foo(mut a) = &Foo(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/mut-ref-mut.rs:23:13
+  --> $DIR/mut-ref-mut.rs:25:13
    |
 LL |     let Foo(mut a) = &mut Foo(0);
    |             ^^^^
@@ -19,7 +19,7 @@ LL |     let Foo(mut a) = &mut Foo(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0308]: mismatched types
-  --> $DIR/mut-ref-mut.rs:28:10
+  --> $DIR/mut-ref-mut.rs:30:10
    |
 LL |     let [&mut mut x] = &[&mut 0];
    |          ^^^^^

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mut-ref-mut.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mut-ref-mut.rs
@@ -7,6 +7,8 @@
 //@[stable2021] run-pass
 //@[classic2021] run-pass
 //@[structural2021] run-pass
+//@ dont-require-annotations: NOTE
+
 //! Test diagnostics for binding with `mut` when the default binding mode is by-ref.
 #![allow(incomplete_features, unused_assignments, unused_variables)]
 #![cfg_attr(any(classic2021, classic2024), feature(ref_pat_eat_one_layer_2024))]
@@ -27,7 +29,7 @@ pub fn main() {
 
     let [&mut mut x] = &[&mut 0];
     //[classic2024]~^ ERROR: mismatched types
-    //[classic2024]~| cannot match inherited `&` with `&mut` pattern
+    //[classic2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     //[structural2024]~^^^ ERROR binding cannot be both mutable and by-reference
     #[cfg(any(stable2021, classic2021, structural2021))] { x = 0 }
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mut-ref-mut.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/mut-ref-mut.structural2024.stderr
@@ -1,5 +1,5 @@
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/mut-ref-mut.rs:18:13
+  --> $DIR/mut-ref-mut.rs:20:13
    |
 LL |     let Foo(mut a) = &Foo(0);
    |             ^^^^
@@ -9,7 +9,7 @@ LL |     let Foo(mut a) = &Foo(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/mut-ref-mut.rs:23:13
+  --> $DIR/mut-ref-mut.rs:25:13
    |
 LL |     let Foo(mut a) = &mut Foo(0);
    |             ^^^^
@@ -19,7 +19,7 @@ LL |     let Foo(mut a) = &mut Foo(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/mut-ref-mut.rs:28:15
+  --> $DIR/mut-ref-mut.rs:30:15
    |
 LL |     let [&mut mut x] = &[&mut 0];
    |               ^^^^

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.classic2021.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:20:27
+  --> $DIR/pattern-errors.rs:22:27
    |
 LL |     if let Some(&mut Some(&x)) = &Some(&mut Some(0)) {
    |                           ^^     ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -15,7 +15,7 @@ LL +     if let Some(&mut Some(x)) = &Some(&mut Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:33:17
+  --> $DIR/pattern-errors.rs:35:17
    |
 LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
    |                 ^^^^^^^^^^^^^    --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -26,7 +26,7 @@ LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:38:23
+  --> $DIR/pattern-errors.rs:40:23
    |
 LL |     if let Some(&Some(&mut x)) = &Some(&mut Some(0)) {
    |                       ^^^^^^     ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -36,7 +36,7 @@ LL |     if let Some(&Some(&mut x)) = &Some(&mut Some(0)) {
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/pattern-errors.rs:38:23
+  --> $DIR/pattern-errors.rs:40:23
    |
 LL |     if let Some(&Some(&mut x)) = &Some(&mut Some(0)) {
    |                       ^^^^^^
@@ -47,7 +47,7 @@ LL +     if let Some(&Some(x)) = &Some(&mut Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:45:23
+  --> $DIR/pattern-errors.rs:47:23
    |
 LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
    |                       ^^^^^^     ------------------- this expression has type `&mut Option<&Option<{integer}>>`
@@ -58,7 +58,7 @@ LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:56:17
+  --> $DIR/pattern-errors.rs:58:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^
@@ -71,7 +71,7 @@ LL +     if let Some(&Some(x)) = &Some(Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:114:11
+  --> $DIR/pattern-errors.rs:116:11
    |
 LL |     let [&&mut x] = &[&mut 0];
    |           ^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -87,7 +87,7 @@ LL +     let [&x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:121:11
+  --> $DIR/pattern-errors.rs:123:11
    |
 LL |     let [&&mut x] = &mut [&mut 0];
    |           ^^^^^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -103,7 +103,7 @@ LL +     let [&x] = &mut [&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:128:11
+  --> $DIR/pattern-errors.rs:130:11
    |
 LL |     let [&&mut ref x] = &[&mut 0];
    |           ^^^^^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -119,7 +119,7 @@ LL +     let [&ref x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:135:11
+  --> $DIR/pattern-errors.rs:137:11
    |
 LL |     let [&&mut ref x] = &mut [&mut 0];
    |           ^^^^^^^^^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -135,7 +135,7 @@ LL +     let [&ref x] = &mut [&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:142:11
+  --> $DIR/pattern-errors.rs:144:11
    |
 LL |     let [&&mut mut x] = &[&mut 0];
    |           ^^^^^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -151,7 +151,7 @@ LL +     let [&mut x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:149:11
+  --> $DIR/pattern-errors.rs:151:11
    |
 LL |     let [&&mut mut x] = &mut [&mut 0];
    |           ^^^^^^^^^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -167,7 +167,7 @@ LL +     let [&mut x] = &mut [&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:164:15
+  --> $DIR/pattern-errors.rs:166:15
    |
 LL |     let [&mut &x] = &[&mut 0];
    |               ^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -183,7 +183,7 @@ LL +     let [&mut x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:170:15
+  --> $DIR/pattern-errors.rs:172:15
    |
 LL |     let [&mut &ref x] = &[&mut 0];
    |               ^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -199,7 +199,7 @@ LL +     let [&mut ref x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:176:15
+  --> $DIR/pattern-errors.rs:178:15
    |
 LL |     let [&mut &(mut x)] = &[&mut 0];
    |               ^^^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.classic2024.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:14:17
+  --> $DIR/pattern-errors.rs:16:17
    |
 LL |     if let Some(&mut x) = &Some(&mut 0) {
    |                 ^^^^^
@@ -12,7 +12,7 @@ LL +     if let Some(&x) = &Some(&mut 0) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:20:17
+  --> $DIR/pattern-errors.rs:22:17
    |
 LL |     if let Some(&mut Some(&x)) = &Some(&mut Some(0)) {
    |                 ^^^^^
@@ -25,7 +25,7 @@ LL +     if let Some(&Some(&x)) = &Some(&mut Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:26:22
+  --> $DIR/pattern-errors.rs:28:22
    |
 LL |     if let Some(Some(&mut x)) = &Some(Some(&mut 0)) {
    |                      ^^^^^
@@ -38,7 +38,7 @@ LL +     if let Some(Some(&x)) = &Some(Some(&mut 0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:33:17
+  --> $DIR/pattern-errors.rs:35:17
    |
 LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
    |                 ^^^^^
@@ -51,7 +51,7 @@ LL +     if let Some(&Some(&_)) = &Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:45:23
+  --> $DIR/pattern-errors.rs:47:23
    |
 LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
    |                       ^^^^^
@@ -64,7 +64,7 @@ LL +     if let Some(&Some(&_)) = &mut Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:56:17
+  --> $DIR/pattern-errors.rs:58:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^
@@ -77,7 +77,7 @@ LL +     if let Some(&Some(x)) = &Some(Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:158:10
+  --> $DIR/pattern-errors.rs:160:10
    |
 LL |     let [&mut x] = &[&mut 0];
    |          ^^^^^
@@ -90,7 +90,7 @@ LL +     let [&x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:164:10
+  --> $DIR/pattern-errors.rs:166:10
    |
 LL |     let [&mut &x] = &[&mut 0];
    |          ^^^^^
@@ -103,7 +103,7 @@ LL +     let [&&x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:170:10
+  --> $DIR/pattern-errors.rs:172:10
    |
 LL |     let [&mut &ref x] = &[&mut 0];
    |          ^^^^^
@@ -116,7 +116,7 @@ LL +     let [&&ref x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:176:10
+  --> $DIR/pattern-errors.rs:178:10
    |
 LL |     let [&mut &(mut x)] = &[&mut 0];
    |          ^^^^^

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.rs
@@ -4,6 +4,8 @@
 //@[structural2021] edition: 2021
 //@[classic2024] edition: 2024
 //@[structural2024] edition: 2024
+//@ dont-require-annotations: NOTE
+
 //! Test cases for poorly-typed patterns in edition 2024 which are caught by HIR typeck. These must
 //! be separate from cases caught by MIR borrowck or the latter errors may not be emitted.
 #![allow(incomplete_features)]
@@ -13,88 +15,88 @@
 pub fn main() {
     if let Some(&mut x) = &Some(&mut 0) {
         //[classic2024]~^ ERROR: mismatched types
-        //[classic2024]~| cannot match inherited `&` with `&mut` pattern
+        //[classic2024]~| NOTE cannot match inherited `&` with `&mut` pattern
         #[cfg(any(stable2021, classic2021, structural2021))] let _: u32 = x;
         #[cfg(structural2024)] let _: &u32 = x;
     }
     if let Some(&mut Some(&x)) = &Some(&mut Some(0)) {
         //[stable2021,classic2021,structural2021,classic2024]~^ ERROR: mismatched types
-        //[stable2021,classic2021,structural2021]~| expected integer, found `&_`
-        //[classic2024]~| cannot match inherited `&` with `&mut` pattern
+        //[stable2021,classic2021,structural2021]~| NOTE expected integer, found `&_`
+        //[classic2024]~| NOTE cannot match inherited `&` with `&mut` pattern
         #[cfg(structural2024)] let _: u32 = x;
     }
     if let Some(Some(&mut x)) = &Some(Some(&mut 0)) {
         //[classic2024]~^ ERROR: mismatched types
-        //[classic2024]~| cannot match inherited `&` with `&mut` pattern
+        //[classic2024]~| NOTE cannot match inherited `&` with `&mut` pattern
         #[cfg(any(stable2021, classic2021, structural2021))] let _: u32 = x;
         #[cfg(structural2024)] let _: &u32 = x;
     }
 
     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
         //~^ ERROR: mismatched types
-        //[stable2021,classic2021,structural2021]~| types differ in mutability
-        //[classic2024,structural2024]~| cannot match inherited `&` with `&mut` pattern
+        //[stable2021,classic2021,structural2021]~| NOTE types differ in mutability
+        //[classic2024,structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     }
     if let Some(&Some(&mut x)) = &Some(&mut Some(0)) {
         //[stable2021,classic2021,structural2021,structural2024]~^ ERROR: mismatched types
-        //[stable2021]~| types differ in mutability
-        //[classic2021,structural2021]~| expected integer, found `&mut _`
-        //[structural2024]~| cannot match inherited `&` with `&mut` pattern
+        //[stable2021]~| NOTE types differ in mutability
+        //[classic2021,structural2021]~| NOTE expected integer, found `&mut _`
+        //[structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
         #[cfg(classic2024)] let _: u32 = x;
     }
     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
         //~^ ERROR: mismatched types
-        //[stable2021,classic2021,structural2021]~| expected integer, found `&mut _`
-        //[classic2024,structural2024]~| cannot match inherited `&` with `&mut` pattern
+        //[stable2021,classic2021,structural2021]~| NOTE expected integer, found `&mut _`
+        //[classic2024,structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     }
     if let Some(&Some(Some(&mut x))) = &Some(Some(&mut Some(0))) {
         //[stable2021,structural2021,structural2024]~^ ERROR: mismatched types
-        //[stable2021]~| expected `Option<&mut Option<{integer}>>`, found `&_`
-        //[structural2021,structural2024]~| cannot match inherited `&` with `&mut` pattern
+        //[stable2021]~| NOTE expected `Option<&mut Option<{integer}>>`, found `&_`
+        //[structural2021,structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
         #[cfg(any(classic2021, classic2024))] let _: u32 = x;
     }
     if let Some(&mut Some(x)) = &Some(Some(0)) {
         //~^ ERROR: mismatched types
-        //[stable2021]~| expected `Option<{integer}>`, found `&mut _`
-        //[classic2021,structural2021,classic2024,structural2024]~| cannot match inherited `&` with `&mut` pattern
+        //[stable2021]~| NOTE expected `Option<{integer}>`, found `&mut _`
+        //[classic2021,structural2021,classic2024,structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     }
 }
 
 fn structural_errors_0() {
     let &[&mut x] = &&mut [0];
     //[stable2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| expected integer, found `&mut _`
-    //[structural2021,structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE expected integer, found `&mut _`
+    //[structural2021,structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(any(classic2021, classic2024))] let _: u32 = x;
 
     let &[&mut x] = &mut &mut [0];
     //[stable2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
-    //[structural2021,structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE types differ in mutability
+    //[structural2021,structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(any(classic2021, classic2024))] let _: u32 = x;
 
     let &[&mut ref x] = &&mut [0];
     //[stable2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| expected integer, found `&mut _`
-    //[structural2021,structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE expected integer, found `&mut _`
+    //[structural2021,structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(any(classic2021, classic2024))] let _: &u32 = x;
 
     let &[&mut ref x] = &mut &mut [0];
     //[stable2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
-    //[structural2021,structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE types differ in mutability
+    //[structural2021,structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(any(classic2021, classic2024))] let _: &u32 = x;
 
     let &[&mut mut x] = &&mut [0];
     //[stable2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| expected integer, found `&mut _`
-    //[structural2021,structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE expected integer, found `&mut _`
+    //[structural2021,structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(any(classic2021, classic2024))] let _: u32 = x;
 
     let &[&mut mut x] = &mut &mut [0];
     //[stable2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
-    //[structural2021,structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE types differ in mutability
+    //[structural2021,structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(any(classic2021, classic2024))] let _: u32 = x;
 }
 
@@ -113,69 +115,69 @@ fn structural_errors_1() {
 fn structural_errors_2() {
     let [&&mut x] = &[&mut 0];
     //[stable2021,classic2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
-    //[classic2021,structural2021] expected integer, found `&mut _`
-    //[structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE types differ in mutability
+    //[classic2021,structural2021] NOTE expected integer, found `&mut _`
+    //[structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(classic2024)] let _: u32 = x;
 
     let [&&mut x] = &mut [&mut 0];
     //[stable2021,classic2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
-    //[classic2021,structural2021] expected integer, found `&mut _`
-    //[structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE types differ in mutability
+    //[classic2021,structural2021] NOTE expected integer, found `&mut _`
+    //[structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(classic2024)] let _: u32 = x;
 
     let [&&mut ref x] = &[&mut 0];
     //[stable2021,classic2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
-    //[classic2021,structural2021] expected integer, found `&mut _`
-    //[structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE types differ in mutability
+    //[classic2021,structural2021] NOTE expected integer, found `&mut _`
+    //[structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(classic2024)] let _: &u32 = x;
 
     let [&&mut ref x] = &mut [&mut 0];
     //[stable2021,classic2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
-    //[classic2021,structural2021] expected integer, found `&mut _`
-    //[structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE types differ in mutability
+    //[classic2021,structural2021] NOTE expected integer, found `&mut _`
+    //[structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(classic2024)] let _: &u32 = x;
 
     let [&&mut mut x] = &[&mut 0];
     //[stable2021,classic2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
-    //[classic2021,structural2021] expected integer, found `&mut _`
-    //[structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE types differ in mutability
+    //[classic2021,structural2021] NOTE expected integer, found `&mut _`
+    //[structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(classic2024)] let _: u32 = x;
 
     let [&&mut mut x] = &mut [&mut 0];
     //[stable2021,classic2021,structural2021,structural2024]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
-    //[classic2021,structural2021] expected integer, found `&mut _`
-    //[structural2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE types differ in mutability
+    //[classic2021,structural2021] NOTE expected integer, found `&mut _`
+    //[structural2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(classic2024)] let _: u32 = x;
 }
 
 fn classic_errors_0() {
     let [&mut x] = &[&mut 0];
     //[classic2024]~^ ERROR: mismatched types
-    //[classic2024]~| cannot match inherited `&` with `&mut` pattern
+    //[classic2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(any(stable2021, classic2021, structural2021))] let _: u32 = x;
     #[cfg(structural2024)] let _: &u32 = x;
 
     let [&mut &x] = &[&mut 0];
     //[stable2021,classic2021,structural2021,classic2024]~^ ERROR: mismatched types
-    //[stable2021]~| expected integer, found `&_`
-    //[classic2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE expected integer, found `&_`
+    //[classic2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(structural2024)] let _: u32 = x;
 
     let [&mut &ref x] = &[&mut 0];
     //[stable2021,classic2021,structural2021,classic2024]~^ ERROR: mismatched types
-    //[stable2021]~| expected integer, found `&_`
-    //[classic2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE expected integer, found `&_`
+    //[classic2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(structural2024)] let _: &u32 = x;
 
     let [&mut &(mut x)] = &[&mut 0];
     //[stable2021,classic2021,structural2021,classic2024]~^ ERROR: mismatched types
-    //[stable2021]~| expected integer, found `&_`
-    //[classic2024]~| cannot match inherited `&` with `&mut` pattern
+    //[stable2021]~| NOTE expected integer, found `&_`
+    //[classic2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     #[cfg(structural2024)] let _: u32 = x;
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.stable2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.stable2021.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:20:27
+  --> $DIR/pattern-errors.rs:22:27
    |
 LL |     if let Some(&mut Some(&x)) = &Some(&mut Some(0)) {
    |                           ^^     ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -15,7 +15,7 @@ LL +     if let Some(&mut Some(x)) = &Some(&mut Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:33:17
+  --> $DIR/pattern-errors.rs:35:17
    |
 LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
    |                 ^^^^^^^^^^^^^    --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -26,7 +26,7 @@ LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:38:17
+  --> $DIR/pattern-errors.rs:40:17
    |
 LL |     if let Some(&Some(&mut x)) = &Some(&mut Some(0)) {
    |                 ^^^^^^^^^^^^^    ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -37,7 +37,7 @@ LL |     if let Some(&Some(&mut x)) = &Some(&mut Some(0)) {
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:45:23
+  --> $DIR/pattern-errors.rs:47:23
    |
 LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
    |                       ^^^^^^     ------------------- this expression has type `&mut Option<&Option<{integer}>>`
@@ -48,7 +48,7 @@ LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:50:17
+  --> $DIR/pattern-errors.rs:52:17
    |
 LL |     if let Some(&Some(Some(&mut x))) = &Some(Some(&mut Some(0))) {
    |                 ^^^^^^^^^^^^^^^^^^^    ------------------------- this expression has type `&Option<Option<&mut Option<{integer}>>>`
@@ -59,7 +59,7 @@ LL |     if let Some(&Some(Some(&mut x))) = &Some(Some(&mut Some(0))) {
            found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:56:17
+  --> $DIR/pattern-errors.rs:58:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^^^^^^^^    -------------- this expression has type `&Option<Option<{integer}>>`
@@ -70,7 +70,7 @@ LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:64:11
+  --> $DIR/pattern-errors.rs:66:11
    |
 LL |     let &[&mut x] = &&mut [0];
    |           ^^^^^^    --------- this expression has type `&&mut [{integer}; 1]`
@@ -80,7 +80,7 @@ LL |     let &[&mut x] = &&mut [0];
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/pattern-errors.rs:64:11
+  --> $DIR/pattern-errors.rs:66:11
    |
 LL |     let &[&mut x] = &&mut [0];
    |           ^^^^^^
@@ -91,7 +91,7 @@ LL +     let &[x] = &&mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:70:9
+  --> $DIR/pattern-errors.rs:72:9
    |
 LL |     let &[&mut x] = &mut &mut [0];
    |         ^^^^^^^^^   ------------- this expression has type `&mut &mut [{integer}; 1]`
@@ -102,7 +102,7 @@ LL |     let &[&mut x] = &mut &mut [0];
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:76:11
+  --> $DIR/pattern-errors.rs:78:11
    |
 LL |     let &[&mut ref x] = &&mut [0];
    |           ^^^^^^^^^^    --------- this expression has type `&&mut [{integer}; 1]`
@@ -112,7 +112,7 @@ LL |     let &[&mut ref x] = &&mut [0];
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/pattern-errors.rs:76:11
+  --> $DIR/pattern-errors.rs:78:11
    |
 LL |     let &[&mut ref x] = &&mut [0];
    |           ^^^^^^^^^^
@@ -123,7 +123,7 @@ LL +     let &[ref x] = &&mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:82:9
+  --> $DIR/pattern-errors.rs:84:9
    |
 LL |     let &[&mut ref x] = &mut &mut [0];
    |         ^^^^^^^^^^^^^   ------------- this expression has type `&mut &mut [{integer}; 1]`
@@ -134,7 +134,7 @@ LL |     let &[&mut ref x] = &mut &mut [0];
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:88:11
+  --> $DIR/pattern-errors.rs:90:11
    |
 LL |     let &[&mut mut x] = &&mut [0];
    |           ^^^^^^^^^^    --------- this expression has type `&&mut [{integer}; 1]`
@@ -144,7 +144,7 @@ LL |     let &[&mut mut x] = &&mut [0];
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/pattern-errors.rs:88:11
+  --> $DIR/pattern-errors.rs:90:11
    |
 LL |     let &[&mut mut x] = &&mut [0];
    |           ^^^^^^^^^^
@@ -155,7 +155,7 @@ LL +     let &[mut x] = &&mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:94:9
+  --> $DIR/pattern-errors.rs:96:9
    |
 LL |     let &[&mut mut x] = &mut &mut [0];
    |         ^^^^^^^^^^^^^   ------------- this expression has type `&mut &mut [{integer}; 1]`
@@ -166,7 +166,7 @@ LL |     let &[&mut mut x] = &mut &mut [0];
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:114:10
+  --> $DIR/pattern-errors.rs:116:10
    |
 LL |     let [&&mut x] = &[&mut 0];
    |          ^^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -177,7 +177,7 @@ LL |     let [&&mut x] = &[&mut 0];
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:121:10
+  --> $DIR/pattern-errors.rs:123:10
    |
 LL |     let [&&mut x] = &mut [&mut 0];
    |          ^^^^^^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -188,7 +188,7 @@ LL |     let [&&mut x] = &mut [&mut 0];
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:128:10
+  --> $DIR/pattern-errors.rs:130:10
    |
 LL |     let [&&mut ref x] = &[&mut 0];
    |          ^^^^^^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -199,7 +199,7 @@ LL |     let [&&mut ref x] = &[&mut 0];
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:135:10
+  --> $DIR/pattern-errors.rs:137:10
    |
 LL |     let [&&mut ref x] = &mut [&mut 0];
    |          ^^^^^^^^^^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -210,7 +210,7 @@ LL |     let [&&mut ref x] = &mut [&mut 0];
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:142:10
+  --> $DIR/pattern-errors.rs:144:10
    |
 LL |     let [&&mut mut x] = &[&mut 0];
    |          ^^^^^^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -221,7 +221,7 @@ LL |     let [&&mut mut x] = &[&mut 0];
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:149:10
+  --> $DIR/pattern-errors.rs:151:10
    |
 LL |     let [&&mut mut x] = &mut [&mut 0];
    |          ^^^^^^^^^^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -232,7 +232,7 @@ LL |     let [&&mut mut x] = &mut [&mut 0];
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:164:15
+  --> $DIR/pattern-errors.rs:166:15
    |
 LL |     let [&mut &x] = &[&mut 0];
    |               ^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -248,7 +248,7 @@ LL +     let [&mut x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:170:15
+  --> $DIR/pattern-errors.rs:172:15
    |
 LL |     let [&mut &ref x] = &[&mut 0];
    |               ^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -264,7 +264,7 @@ LL +     let [&mut ref x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:176:15
+  --> $DIR/pattern-errors.rs:178:15
    |
 LL |     let [&mut &(mut x)] = &[&mut 0];
    |               ^^^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2021.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:20:27
+  --> $DIR/pattern-errors.rs:22:27
    |
 LL |     if let Some(&mut Some(&x)) = &Some(&mut Some(0)) {
    |                           ^^     ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -15,7 +15,7 @@ LL +     if let Some(&mut Some(x)) = &Some(&mut Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:33:17
+  --> $DIR/pattern-errors.rs:35:17
    |
 LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
    |                 ^^^^^^^^^^^^^    --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -26,7 +26,7 @@ LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:38:23
+  --> $DIR/pattern-errors.rs:40:23
    |
 LL |     if let Some(&Some(&mut x)) = &Some(&mut Some(0)) {
    |                       ^^^^^^     ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -36,7 +36,7 @@ LL |     if let Some(&Some(&mut x)) = &Some(&mut Some(0)) {
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/pattern-errors.rs:38:23
+  --> $DIR/pattern-errors.rs:40:23
    |
 LL |     if let Some(&Some(&mut x)) = &Some(&mut Some(0)) {
    |                       ^^^^^^
@@ -47,7 +47,7 @@ LL +     if let Some(&Some(x)) = &Some(&mut Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:45:23
+  --> $DIR/pattern-errors.rs:47:23
    |
 LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
    |                       ^^^^^^     ------------------- this expression has type `&mut Option<&Option<{integer}>>`
@@ -58,7 +58,7 @@ LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:50:28
+  --> $DIR/pattern-errors.rs:52:28
    |
 LL |     if let Some(&Some(Some(&mut x))) = &Some(Some(&mut Some(0))) {
    |                            ^^^^^
@@ -71,7 +71,7 @@ LL +     if let Some(&Some(Some(&x))) = &Some(Some(&mut Some(0))) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:56:17
+  --> $DIR/pattern-errors.rs:58:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^
@@ -84,7 +84,7 @@ LL +     if let Some(&Some(x)) = &Some(Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:64:11
+  --> $DIR/pattern-errors.rs:66:11
    |
 LL |     let &[&mut x] = &&mut [0];
    |           ^^^^^
@@ -97,7 +97,7 @@ LL +     let &[&x] = &&mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:70:11
+  --> $DIR/pattern-errors.rs:72:11
    |
 LL |     let &[&mut x] = &mut &mut [0];
    |           ^^^^^
@@ -110,7 +110,7 @@ LL +     let &[&x] = &mut &mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:76:11
+  --> $DIR/pattern-errors.rs:78:11
    |
 LL |     let &[&mut ref x] = &&mut [0];
    |           ^^^^^
@@ -123,7 +123,7 @@ LL +     let &[&ref x] = &&mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:82:11
+  --> $DIR/pattern-errors.rs:84:11
    |
 LL |     let &[&mut ref x] = &mut &mut [0];
    |           ^^^^^
@@ -136,7 +136,7 @@ LL +     let &[&ref x] = &mut &mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:88:11
+  --> $DIR/pattern-errors.rs:90:11
    |
 LL |     let &[&mut mut x] = &&mut [0];
    |           ^^^^^
@@ -149,7 +149,7 @@ LL +     let &[&mut x] = &&mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:94:11
+  --> $DIR/pattern-errors.rs:96:11
    |
 LL |     let &[&mut mut x] = &mut &mut [0];
    |           ^^^^^
@@ -162,7 +162,7 @@ LL +     let &[&mut x] = &mut &mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:114:11
+  --> $DIR/pattern-errors.rs:116:11
    |
 LL |     let [&&mut x] = &[&mut 0];
    |           ^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -178,7 +178,7 @@ LL +     let [&x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:121:11
+  --> $DIR/pattern-errors.rs:123:11
    |
 LL |     let [&&mut x] = &mut [&mut 0];
    |           ^^^^^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -194,7 +194,7 @@ LL +     let [&x] = &mut [&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:128:11
+  --> $DIR/pattern-errors.rs:130:11
    |
 LL |     let [&&mut ref x] = &[&mut 0];
    |           ^^^^^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -210,7 +210,7 @@ LL +     let [&ref x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:135:11
+  --> $DIR/pattern-errors.rs:137:11
    |
 LL |     let [&&mut ref x] = &mut [&mut 0];
    |           ^^^^^^^^^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -226,7 +226,7 @@ LL +     let [&ref x] = &mut [&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:142:11
+  --> $DIR/pattern-errors.rs:144:11
    |
 LL |     let [&&mut mut x] = &[&mut 0];
    |           ^^^^^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -242,7 +242,7 @@ LL +     let [&mut x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:149:11
+  --> $DIR/pattern-errors.rs:151:11
    |
 LL |     let [&&mut mut x] = &mut [&mut 0];
    |           ^^^^^^^^^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -258,7 +258,7 @@ LL +     let [&mut x] = &mut [&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:164:15
+  --> $DIR/pattern-errors.rs:166:15
    |
 LL |     let [&mut &x] = &[&mut 0];
    |               ^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -274,7 +274,7 @@ LL +     let [&mut x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:170:15
+  --> $DIR/pattern-errors.rs:172:15
    |
 LL |     let [&mut &ref x] = &[&mut 0];
    |               ^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -290,7 +290,7 @@ LL +     let [&mut ref x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:176:15
+  --> $DIR/pattern-errors.rs:178:15
    |
 LL |     let [&mut &(mut x)] = &[&mut 0];
    |               ^^^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/pattern-errors.structural2024.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:33:17
+  --> $DIR/pattern-errors.rs:35:17
    |
 LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
    |                 ^^^^^
@@ -12,7 +12,7 @@ LL +     if let Some(&Some(&_)) = &Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:38:23
+  --> $DIR/pattern-errors.rs:40:23
    |
 LL |     if let Some(&Some(&mut x)) = &Some(&mut Some(0)) {
    |                       ^^^^^
@@ -25,7 +25,7 @@ LL +     if let Some(&Some(&x)) = &Some(&mut Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:45:23
+  --> $DIR/pattern-errors.rs:47:23
    |
 LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
    |                       ^^^^^
@@ -38,7 +38,7 @@ LL +     if let Some(&Some(&_)) = &mut Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:50:28
+  --> $DIR/pattern-errors.rs:52:28
    |
 LL |     if let Some(&Some(Some(&mut x))) = &Some(Some(&mut Some(0))) {
    |                            ^^^^^
@@ -51,7 +51,7 @@ LL +     if let Some(&Some(Some(&x))) = &Some(Some(&mut Some(0))) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:56:17
+  --> $DIR/pattern-errors.rs:58:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^
@@ -64,7 +64,7 @@ LL +     if let Some(&Some(x)) = &Some(Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:64:11
+  --> $DIR/pattern-errors.rs:66:11
    |
 LL |     let &[&mut x] = &&mut [0];
    |           ^^^^^
@@ -77,7 +77,7 @@ LL +     let &[&x] = &&mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:70:11
+  --> $DIR/pattern-errors.rs:72:11
    |
 LL |     let &[&mut x] = &mut &mut [0];
    |           ^^^^^
@@ -90,7 +90,7 @@ LL +     let &[&x] = &mut &mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:76:11
+  --> $DIR/pattern-errors.rs:78:11
    |
 LL |     let &[&mut ref x] = &&mut [0];
    |           ^^^^^
@@ -103,7 +103,7 @@ LL +     let &[&ref x] = &&mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:82:11
+  --> $DIR/pattern-errors.rs:84:11
    |
 LL |     let &[&mut ref x] = &mut &mut [0];
    |           ^^^^^
@@ -116,7 +116,7 @@ LL +     let &[&ref x] = &mut &mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:88:11
+  --> $DIR/pattern-errors.rs:90:11
    |
 LL |     let &[&mut mut x] = &&mut [0];
    |           ^^^^^
@@ -129,7 +129,7 @@ LL +     let &[&mut x] = &&mut [0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:94:11
+  --> $DIR/pattern-errors.rs:96:11
    |
 LL |     let &[&mut mut x] = &mut &mut [0];
    |           ^^^^^
@@ -142,7 +142,7 @@ LL +     let &[&mut x] = &mut &mut [0];
    |
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/pattern-errors.rs:102:12
+  --> $DIR/pattern-errors.rs:104:12
    |
 LL |     let [&(mut x)] = &[&0];
    |            ^^^^
@@ -152,7 +152,7 @@ LL |     let [&(mut x)] = &[&0];
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/pattern-errors.rs:107:12
+  --> $DIR/pattern-errors.rs:109:12
    |
 LL |     let [&(mut x)] = &mut [&0];
    |            ^^^^
@@ -162,7 +162,7 @@ LL |     let [&(mut x)] = &mut [&0];
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:114:11
+  --> $DIR/pattern-errors.rs:116:11
    |
 LL |     let [&&mut x] = &[&mut 0];
    |           ^^^^^
@@ -175,7 +175,7 @@ LL +     let [&&x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:121:11
+  --> $DIR/pattern-errors.rs:123:11
    |
 LL |     let [&&mut x] = &mut [&mut 0];
    |           ^^^^^
@@ -188,7 +188,7 @@ LL +     let [&&x] = &mut [&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:128:11
+  --> $DIR/pattern-errors.rs:130:11
    |
 LL |     let [&&mut ref x] = &[&mut 0];
    |           ^^^^^
@@ -201,7 +201,7 @@ LL +     let [&&ref x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:135:11
+  --> $DIR/pattern-errors.rs:137:11
    |
 LL |     let [&&mut ref x] = &mut [&mut 0];
    |           ^^^^^
@@ -214,7 +214,7 @@ LL +     let [&&ref x] = &mut [&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:142:11
+  --> $DIR/pattern-errors.rs:144:11
    |
 LL |     let [&&mut mut x] = &[&mut 0];
    |           ^^^^^
@@ -227,7 +227,7 @@ LL +     let [&&mut x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pattern-errors.rs:149:11
+  --> $DIR/pattern-errors.rs:151:11
    |
 LL |     let [&&mut mut x] = &mut [&mut 0];
    |           ^^^^^

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2021.stderr
@@ -1,5 +1,5 @@
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:71:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
    |          ^^^^^^^^^ cannot borrow as mutable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.classic2024.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:58:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:60:10
    |
 LL |     let [&mut ref x] = &[&mut 0];
    |          ^^^^^
@@ -12,14 +12,14 @@ LL +     let [&ref x] = &[&mut 0];
    |
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:71:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
    |          ^^^^^^^ binding modifier not allowed under `ref` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:71:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:73:9
    |
 LL |     let [ref mut x] = &[0];
    |         ^^^^^^^^^^^ this matches on type `&_`
@@ -29,20 +29,20 @@ LL |     let &[ref mut x] = &[0];
    |         +
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:71:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
    |          ^^^^^^^^^ cannot borrow as mutable
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:79:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:81:10
    |
 LL |     let [ref x] = &[0];
    |          ^^^ binding modifier not allowed under `ref` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:79:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:81:9
    |
 LL |     let [ref x] = &[0];
    |         ^^^^^^^ this matches on type `&_`
@@ -52,14 +52,14 @@ LL |     let &[ref x] = &[0];
    |         +
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:83:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:85:10
    |
 LL |     let [ref x] = &mut [0];
    |          ^^^ binding modifier not allowed under `ref mut` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:83:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:85:9
    |
 LL |     let [ref x] = &mut [0];
    |         ^^^^^^^ this matches on type `&mut _`
@@ -69,14 +69,14 @@ LL |     let &mut [ref x] = &mut [0];
    |         ++++
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:87:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:89:10
    |
 LL |     let [ref mut x] = &mut [0];
    |          ^^^^^^^ binding modifier not allowed under `ref mut` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:87:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:89:9
    |
 LL |     let [ref mut x] = &mut [0];
    |         ^^^^^^^^^^^ this matches on type `&mut _`

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.rs
@@ -4,6 +4,8 @@
 //@[structural2021] edition: 2021
 //@[classic2024] edition: 2024
 //@[structural2024] edition: 2024
+//@ dont-require-annotations: NOTE
+
 //! Tests for errors from binding with `ref x` under a by-ref default binding mode in edition 2024.
 //! These can't be in the same body as tests for other errors, since they're emitted during THIR
 //! construction. The errors on stable edition 2021 Rust are unrelated.
@@ -40,14 +42,14 @@ fn errors_from_eating_the_real_reference() {
 fn errors_from_eating_the_real_reference_caught_in_hir_typeck_on_stable() {
     let [&ref x] = &[&mut 0];
     //[stable2021]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
+    //[stable2021]~| NOTE types differ in mutability
     //[structural2024]~^^^ ERROR: binding modifiers may only be written when the default binding mode is `move`
     #[cfg(any(classic2021, structural2021))] let _: &u32 = x;
     #[cfg(classic2024)] let _: &&mut u32 = x;
 
     let [&ref x] = &mut [&mut 0];
     //[stable2021]~^ ERROR: mismatched types
-    //[stable2021]~| types differ in mutability
+    //[stable2021]~| NOTE types differ in mutability
     //[structural2024]~^^^ ERROR: binding modifiers may only be written when the default binding mode is `move`
     #[cfg(any(classic2021, structural2021))] let _: &u32 = x;
     #[cfg(classic2024)] let _: &&mut u32 = x;
@@ -57,7 +59,7 @@ fn errors_from_eating_the_real_reference_caught_in_hir_typeck_on_stable() {
 fn errors_dependent_on_eating_order_caught_in_hir_typeck_when_eating_outer() {
     let [&mut ref x] = &[&mut 0];
     //[classic2024]~^ ERROR: mismatched types
-    //[classic2024]~| cannot match inherited `&` with `&mut` pattern
+    //[classic2024]~| NOTE cannot match inherited `&` with `&mut` pattern
     //[structural2024]~^^^ ERROR: binding modifiers may only be written when the default binding mode is `move`
     #[cfg(any(stable2021, classic2021, structural2021))] let _: &u32 = x;
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.stable2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.stable2021.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:41:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:43:10
    |
 LL |     let [&ref x] = &[&mut 0];
    |          ^^^^^^    --------- this expression has type `&[&mut {integer}; 1]`
@@ -15,7 +15,7 @@ LL +     let [ref x] = &[&mut 0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:48:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:50:10
    |
 LL |     let [&ref x] = &mut [&mut 0];
    |          ^^^^^^    ------------- this expression has type `&mut [&mut {integer}; 1]`
@@ -31,7 +31,7 @@ LL +     let [ref x] = &mut [&mut 0];
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:71:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
    |          ^^^^^^^^^ cannot borrow as mutable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2021.stderr
@@ -1,5 +1,5 @@
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:71:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
    |          ^^^^^^^^^ cannot borrow as mutable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2024.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/ref-binding-on-inh-ref-errors.structural2024.stderr
@@ -1,12 +1,12 @@
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:17:11
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:19:11
    |
 LL |     let [&ref x] = &[&0];
    |           ^^^ binding modifier not allowed under `ref` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:17:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:19:9
    |
 LL |     let [&ref x] = &[&0];
    |         ^^^^^^^^ this matches on type `&_`
@@ -16,14 +16,14 @@ LL |     let &[&ref x] = &[&0];
    |         +
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:22:11
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:24:11
    |
 LL |     let [&ref x] = &mut [&0];
    |           ^^^ binding modifier not allowed under `ref` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:22:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:24:9
    |
 LL |     let [&ref x] = &mut [&0];
    |         ^^^^^^^^ this matches on type `&mut _`
@@ -33,14 +33,14 @@ LL |     let &mut [&ref x] = &mut [&0];
    |         ++++
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:27:15
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:29:15
    |
 LL |     let [&mut ref x] = &mut [&mut 0];
    |               ^^^ binding modifier not allowed under `ref mut` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:27:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:29:9
    |
 LL |     let [&mut ref x] = &mut [&mut 0];
    |         ^^^^^^^^^^^^ this matches on type `&mut _`
@@ -50,14 +50,14 @@ LL |     let &mut [&mut ref x] = &mut [&mut 0];
    |         ++++
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:32:15
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:34:15
    |
 LL |     let [&mut ref mut x] = &mut [&mut 0];
    |               ^^^^^^^ binding modifier not allowed under `ref mut` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:32:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:34:9
    |
 LL |     let [&mut ref mut x] = &mut [&mut 0];
    |         ^^^^^^^^^^^^^^^^ this matches on type `&mut _`
@@ -67,14 +67,14 @@ LL |     let &mut [&mut ref mut x] = &mut [&mut 0];
    |         ++++
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:41:11
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:43:11
    |
 LL |     let [&ref x] = &[&mut 0];
    |           ^^^ binding modifier not allowed under `ref` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:41:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:43:9
    |
 LL |     let [&ref x] = &[&mut 0];
    |         ^^^^^^^^ this matches on type `&_`
@@ -84,14 +84,14 @@ LL |     let &[&ref x] = &[&mut 0];
    |         +
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:48:11
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:50:11
    |
 LL |     let [&ref x] = &mut [&mut 0];
    |           ^^^ binding modifier not allowed under `ref` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:48:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:50:9
    |
 LL |     let [&ref x] = &mut [&mut 0];
    |         ^^^^^^^^ this matches on type `&mut _`
@@ -101,14 +101,14 @@ LL |     let &mut [&ref x] = &mut [&mut 0];
    |         ++++
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:58:15
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:60:15
    |
 LL |     let [&mut ref x] = &[&mut 0];
    |               ^^^ binding modifier not allowed under `ref` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:58:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:60:9
    |
 LL |     let [&mut ref x] = &[&mut 0];
    |         ^^^^^^^^^^^^ this matches on type `&_`
@@ -118,14 +118,14 @@ LL |     let &[&mut ref x] = &[&mut 0];
    |         +
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:71:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
    |          ^^^^^^^ binding modifier not allowed under `ref` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:71:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:73:9
    |
 LL |     let [ref mut x] = &[0];
    |         ^^^^^^^^^^^ this matches on type `&_`
@@ -135,20 +135,20 @@ LL |     let &[ref mut x] = &[0];
    |         +
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:71:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:73:10
    |
 LL |     let [ref mut x] = &[0];
    |          ^^^^^^^^^ cannot borrow as mutable
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:79:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:81:10
    |
 LL |     let [ref x] = &[0];
    |          ^^^ binding modifier not allowed under `ref` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:79:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:81:9
    |
 LL |     let [ref x] = &[0];
    |         ^^^^^^^ this matches on type `&_`
@@ -158,14 +158,14 @@ LL |     let &[ref x] = &[0];
    |         +
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:83:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:85:10
    |
 LL |     let [ref x] = &mut [0];
    |          ^^^ binding modifier not allowed under `ref mut` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:83:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:85:9
    |
 LL |     let [ref x] = &mut [0];
    |         ^^^^^^^ this matches on type `&mut _`
@@ -175,14 +175,14 @@ LL |     let &mut [ref x] = &mut [0];
    |         ++++
 
 error: binding modifiers may only be written when the default binding mode is `move`
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:87:10
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:89:10
    |
 LL |     let [ref mut x] = &mut [0];
    |          ^^^^^^^ binding modifier not allowed under `ref mut` default binding mode
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: matching on a reference type with a non-reference pattern changes the default binding mode
-  --> $DIR/ref-binding-on-inh-ref-errors.rs:87:9
+  --> $DIR/ref-binding-on-inh-ref-errors.rs:89:9
    |
 LL |     let [ref mut x] = &mut [0];
    |         ^^^^^^^^^^^ this matches on type `&mut _`

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.classic2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.classic2021.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:32:23
+  --> $DIR/well-typed-edition-2024.rs:34:23
    |
 LL |     if let Some(Some(&&x)) = &Some(Some(&0)) {
    |                       ^^     --------------- this expression has type `&Option<Option<&{integer}>>`
@@ -15,7 +15,7 @@ LL +     if let Some(Some(&x)) = &Some(Some(&0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:63:23
+  --> $DIR/well-typed-edition-2024.rs:65:23
    |
 LL |     if let Some(&Some(&x)) = &Some(&Some(0)) {
    |                       ^^     --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -31,7 +31,7 @@ LL +     if let Some(&Some(x)) = &Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:82:23
+  --> $DIR/well-typed-edition-2024.rs:84:23
    |
 LL |     if let Some(&Some(&x)) = &Some(&mut Some(0)) {
    |                       ^^     ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -47,7 +47,7 @@ LL +     if let Some(&Some(x)) = &Some(&mut Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:88:23
+  --> $DIR/well-typed-edition-2024.rs:90:23
    |
 LL |     if let Some(&Some(&x)) = &mut Some(&Some(0)) {
    |                       ^^     ------------------- this expression has type `&mut Option<&Option<{integer}>>`
@@ -63,7 +63,7 @@ LL +     if let Some(&Some(x)) = &mut Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:123:15
+  --> $DIR/well-typed-edition-2024.rs:125:15
    |
 LL |     let [&mut &x] = &mut [&0];
    |               ^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -79,7 +79,7 @@ LL +     let [&mut x] = &mut [&0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:129:15
+  --> $DIR/well-typed-edition-2024.rs:131:15
    |
 LL |     let [&mut &ref x] = &mut [&0];
    |               ^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -95,7 +95,7 @@ LL +     let [&mut ref x] = &mut [&0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:135:15
+  --> $DIR/well-typed-edition-2024.rs:137:15
    |
 LL |     let [&mut &(mut x)] = &mut [&0];
    |               ^^^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -111,7 +111,7 @@ LL +     let [&mut mut x)] = &mut [&0];
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/well-typed-edition-2024.rs:109:19
+  --> $DIR/well-typed-edition-2024.rs:111:19
    |
 LL |         let [&mut ref mut x] = &mut [&0];
    |                   ^^^^^^^^^ cannot borrow as mutable

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.rs
@@ -6,6 +6,8 @@
 //@[structural2024] edition: 2024
 //@[classic2024] run-pass
 //@[structural2024] run-pass
+//@ dont-require-annotations: NOTE
+
 //! Test cases for well-typed patterns in edition 2024. These are in their own file to ensure we
 //! pass both HIR typeck and MIR borrowck, as we may skip the latter if grouped with failing tests.
 #![allow(incomplete_features, unused_mut)]
@@ -31,63 +33,63 @@ pub fn main() {
     }
     if let Some(Some(&&x)) = &Some(Some(&0)) {
         //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
-        //[stable2021,classic2021,structural2021]~| expected integer, found `&_`
+        //[stable2021,classic2021,structural2021]~| NOTE expected integer, found `&_`
         #[cfg(any(classic2024, structural2024))] let _: u32 = x;
     }
 
     // Tests for eating a lone inherited reference
     if let Some(Some(&x)) = &Some(&Some(0)) {
         //[stable2021]~^ ERROR mismatched types
-        //[stable2021]~| expected integer, found `&_`
+        //[stable2021]~| NOTE expected integer, found `&_`
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
     if let Some(&Some(x)) = &Some(Some(0)) {
         //[stable2021]~^ ERROR mismatched types
-        //[stable2021]~| expected `Option<{integer}>`, found `&_`
+        //[stable2021]~| NOTE expected `Option<{integer}>`, found `&_`
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
     if let Some(Some(&mut x)) = &mut Some(&mut Some(0)) {
         //[stable2021]~^ ERROR mismatched types
-        //[stable2021]~| expected integer, found `&mut _`
+        //[stable2021]~| NOTE expected integer, found `&mut _`
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
 
     // Tests for `&` patterns matching real `&mut` reference types
     if let Some(&Some(&x)) = Some(&Some(&mut 0)) {
         //[stable2021]~^ ERROR mismatched types
-        //[stable2021]~| types differ in mutability
+        //[stable2021]~| NOTE types differ in mutability
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
 
     // Tests for eating only one layer and also eating a lone inherited reference
     if let Some(&Some(&x)) = &Some(&Some(0)) {
         //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
-        //[stable2021,classic2021,structural2021]~| expected integer, found `&_`
+        //[stable2021,classic2021,structural2021]~| NOTE expected integer, found `&_`
         #[cfg(any(classic2024, structural2024))] let _: u32 = x;
     }
 
     // Tests for `&` matching a lone inherited possibly-`&mut` reference
     if let Some(&Some(Some(&x))) = &Some(Some(&mut Some(0))) {
         //[stable2021]~^ ERROR mismatched types
-        //[stable2021]~| expected `Option<&mut Option<{integer}>>`, found `&_`
+        //[stable2021]~| NOTE expected `Option<&mut Option<{integer}>>`, found `&_`
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
     if let Some(&Some(x)) = &mut Some(Some(0)) {
         //[stable2021]~^ ERROR mismatched types
-        //[stable2021]~| expected `Option<{integer}>`, found `&_`
+        //[stable2021]~| NOTE expected `Option<{integer}>`, found `&_`
         #[cfg(any(classic2021, structural2021, classic2024, structural2024))] let _: u32 = x;
     }
 
     // Tests eating one layer, eating a lone inherited ref, and `&` eating `&mut` (realness varies)
     if let Some(&Some(&x)) = &Some(&mut Some(0)) {
         //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
-        //[stable2021]~| types differ in mutability
-        //[classic2021,structural2021]~| expected integer, found `&_`
+        //[stable2021]~| NOTE types differ in mutability
+        //[classic2021,structural2021]~| NOTE expected integer, found `&_`
         #[cfg(any(classic2024, structural2024))] let _: u32 = x;
     }
     if let Some(&Some(&x)) = &mut Some(&Some(0)) {
         //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
-        //[stable2021,classic2021,structural2021]~| expected integer, found `&_`
+        //[stable2021,classic2021,structural2021]~| NOTE expected integer, found `&_`
         #[cfg(any(classic2024, structural2024))] let _: u32 = x;
     }
 
@@ -95,20 +97,20 @@ pub fn main() {
     // inner reference causes a mutability mismatch. i.e. tests for "fallback-to-outer" deref rules.
     let [&mut x] = &mut [&0];
     //[stable2021]~^ ERROR mismatched types
-    //[stable2021]~| types differ in mutability
+    //[stable2021]~| NOTE types differ in mutability
     #[cfg(any(classic2021, structural2021))] let _: u32 = x;
     #[cfg(any(classic2024, structural2024))] let _: &u32 = x;
 
     let [&mut ref x] = &mut [&0];
     //[stable2021]~^ ERROR mismatched types
-    //[stable2021]~| types differ in mutability
+    //[stable2021]~| NOTE types differ in mutability
     #[cfg(any(classic2021, structural2021))] let _: &u32 = x;
     #[cfg(any(classic2024, structural2024))] let _: &&u32 = x;
 
     fn borrowck_error_on_structural2021() {
         let [&mut ref mut x] = &mut [&0];
         //[stable2021]~^ ERROR mismatched types
-        //[stable2021]~| types differ in mutability
+        //[stable2021]~| NOTE types differ in mutability
         //[classic2021,structural2021]~^^^ ERROR cannot borrow data in a `&` reference as mutable
         #[cfg(any(classic2024, structural2024))] let _: &mut &u32 = x;
     }
@@ -116,25 +118,25 @@ pub fn main() {
 
     let [&mut mut x] = &mut [&0];
     //[stable2021]~^ ERROR mismatched types
-    //[stable2021]~| types differ in mutability
+    //[stable2021]~| NOTE types differ in mutability
     #[cfg(any(classic2021, structural2021))] let _: u32 = x;
     #[cfg(any(classic2024, structural2024))] let _: &u32 = x;
 
     let [&mut &x] = &mut [&0];
     //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
-    //[stable2021]~| types differ in mutability
-    //[classic2021,structural2021]~| expected integer, found `&_`
+    //[stable2021]~| NOTE types differ in mutability
+    //[classic2021,structural2021]~| NOTE expected integer, found `&_`
     #[cfg(any(classic2024, structural2024))] let _: u32 = x;
 
     let [&mut &ref x] = &mut [&0];
     //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
-    //[stable2021]~| types differ in mutability
-    //[classic2021,structural2021]~| expected integer, found `&_`
+    //[stable2021]~| NOTE types differ in mutability
+    //[classic2021,structural2021]~| NOTE expected integer, found `&_`
     #[cfg(any(classic2024, structural2024))] let _: &u32 = x;
 
     let [&mut &(mut x)] = &mut [&0];
     //[stable2021,classic2021,structural2021]~^ ERROR mismatched types
-    //[stable2021]~| types differ in mutability
-    //[classic2021,structural2021]~| expected integer, found `&_`
+    //[stable2021]~| NOTE types differ in mutability
+    //[classic2021,structural2021]~| NOTE expected integer, found `&_`
     #[cfg(any(classic2024, structural2024))] let _: u32 = x;
 }

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.stable2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.stable2021.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:32:23
+  --> $DIR/well-typed-edition-2024.rs:34:23
    |
 LL |     if let Some(Some(&&x)) = &Some(Some(&0)) {
    |                       ^^     --------------- this expression has type `&Option<Option<&{integer}>>`
@@ -15,7 +15,7 @@ LL +     if let Some(Some(&x)) = &Some(Some(&0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:39:22
+  --> $DIR/well-typed-edition-2024.rs:41:22
    |
 LL |     if let Some(Some(&x)) = &Some(&Some(0)) {
    |                      ^^     --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -31,7 +31,7 @@ LL +     if let Some(Some(x)) = &Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:44:17
+  --> $DIR/well-typed-edition-2024.rs:46:17
    |
 LL |     if let Some(&Some(x)) = &Some(Some(0)) {
    |                 ^^^^^^^^    -------------- this expression has type `&Option<Option<{integer}>>`
@@ -42,7 +42,7 @@ LL |     if let Some(&Some(x)) = &Some(Some(0)) {
            found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:49:22
+  --> $DIR/well-typed-edition-2024.rs:51:22
    |
 LL |     if let Some(Some(&mut x)) = &mut Some(&mut Some(0)) {
    |                      ^^^^^^     ----------------------- this expression has type `&mut Option<&mut Option<{integer}>>`
@@ -52,7 +52,7 @@ LL |     if let Some(Some(&mut x)) = &mut Some(&mut Some(0)) {
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/well-typed-edition-2024.rs:49:22
+  --> $DIR/well-typed-edition-2024.rs:51:22
    |
 LL |     if let Some(Some(&mut x)) = &mut Some(&mut Some(0)) {
    |                      ^^^^^^
@@ -63,7 +63,7 @@ LL +     if let Some(Some(x)) = &mut Some(&mut Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:56:23
+  --> $DIR/well-typed-edition-2024.rs:58:23
    |
 LL |     if let Some(&Some(&x)) = Some(&Some(&mut 0)) {
    |                       ^^     ------------------- this expression has type `Option<&Option<&mut {integer}>>`
@@ -79,7 +79,7 @@ LL +     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:63:23
+  --> $DIR/well-typed-edition-2024.rs:65:23
    |
 LL |     if let Some(&Some(&x)) = &Some(&Some(0)) {
    |                       ^^     --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -95,7 +95,7 @@ LL +     if let Some(&Some(x)) = &Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:70:17
+  --> $DIR/well-typed-edition-2024.rs:72:17
    |
 LL |     if let Some(&Some(Some(&x))) = &Some(Some(&mut Some(0))) {
    |                 ^^^^^^^^^^^^^^^    ------------------------- this expression has type `&Option<Option<&mut Option<{integer}>>>`
@@ -106,7 +106,7 @@ LL |     if let Some(&Some(Some(&x))) = &Some(Some(&mut Some(0))) {
            found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:75:17
+  --> $DIR/well-typed-edition-2024.rs:77:17
    |
 LL |     if let Some(&Some(x)) = &mut Some(Some(0)) {
    |                 ^^^^^^^^    ------------------ this expression has type `&mut Option<Option<{integer}>>`
@@ -117,7 +117,7 @@ LL |     if let Some(&Some(x)) = &mut Some(Some(0)) {
            found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:82:17
+  --> $DIR/well-typed-edition-2024.rs:84:17
    |
 LL |     if let Some(&Some(&x)) = &Some(&mut Some(0)) {
    |                 ^^^^^^^^^    ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -128,7 +128,7 @@ LL |     if let Some(&Some(&x)) = &Some(&mut Some(0)) {
                       found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:88:23
+  --> $DIR/well-typed-edition-2024.rs:90:23
    |
 LL |     if let Some(&Some(&x)) = &mut Some(&Some(0)) {
    |                       ^^     ------------------- this expression has type `&mut Option<&Option<{integer}>>`
@@ -144,7 +144,7 @@ LL +     if let Some(&Some(x)) = &mut Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:96:10
+  --> $DIR/well-typed-edition-2024.rs:98:10
    |
 LL |     let [&mut x] = &mut [&0];
    |          ^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -154,7 +154,7 @@ LL |     let [&mut x] = &mut [&0];
    = note:      expected reference `&{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/well-typed-edition-2024.rs:96:10
+  --> $DIR/well-typed-edition-2024.rs:98:10
    |
 LL |     let [&mut x] = &mut [&0];
    |          ^^^^^^
@@ -165,7 +165,7 @@ LL +     let [x] = &mut [&0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:102:10
+  --> $DIR/well-typed-edition-2024.rs:104:10
    |
 LL |     let [&mut ref x] = &mut [&0];
    |          ^^^^^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -175,7 +175,7 @@ LL |     let [&mut ref x] = &mut [&0];
    = note:      expected reference `&{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/well-typed-edition-2024.rs:102:10
+  --> $DIR/well-typed-edition-2024.rs:104:10
    |
 LL |     let [&mut ref x] = &mut [&0];
    |          ^^^^^^^^^^
@@ -186,7 +186,7 @@ LL +     let [ref x] = &mut [&0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:117:10
+  --> $DIR/well-typed-edition-2024.rs:119:10
    |
 LL |     let [&mut mut x] = &mut [&0];
    |          ^^^^^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -196,7 +196,7 @@ LL |     let [&mut mut x] = &mut [&0];
    = note:      expected reference `&{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/well-typed-edition-2024.rs:117:10
+  --> $DIR/well-typed-edition-2024.rs:119:10
    |
 LL |     let [&mut mut x] = &mut [&0];
    |          ^^^^^^^^^^
@@ -207,7 +207,7 @@ LL +     let [mut x] = &mut [&0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:123:10
+  --> $DIR/well-typed-edition-2024.rs:125:10
    |
 LL |     let [&mut &x] = &mut [&0];
    |          ^^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -218,7 +218,7 @@ LL |     let [&mut &x] = &mut [&0];
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:129:10
+  --> $DIR/well-typed-edition-2024.rs:131:10
    |
 LL |     let [&mut &ref x] = &mut [&0];
    |          ^^^^^^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -229,7 +229,7 @@ LL |     let [&mut &ref x] = &mut [&0];
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:135:10
+  --> $DIR/well-typed-edition-2024.rs:137:10
    |
 LL |     let [&mut &(mut x)] = &mut [&0];
    |          ^^^^^^^^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -240,7 +240,7 @@ LL |     let [&mut &(mut x)] = &mut [&0];
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:109:14
+  --> $DIR/well-typed-edition-2024.rs:111:14
    |
 LL |         let [&mut ref mut x] = &mut [&0];
    |              ^^^^^^^^^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -250,7 +250,7 @@ LL |         let [&mut ref mut x] = &mut [&0];
    = note:      expected reference `&{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/well-typed-edition-2024.rs:109:14
+  --> $DIR/well-typed-edition-2024.rs:111:14
    |
 LL |         let [&mut ref mut x] = &mut [&0];
    |              ^^^^^^^^^^^^^^

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.structural2021.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/experimental/well-typed-edition-2024.structural2021.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:32:23
+  --> $DIR/well-typed-edition-2024.rs:34:23
    |
 LL |     if let Some(Some(&&x)) = &Some(Some(&0)) {
    |                       ^^     --------------- this expression has type `&Option<Option<&{integer}>>`
@@ -15,7 +15,7 @@ LL +     if let Some(Some(&x)) = &Some(Some(&0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:63:23
+  --> $DIR/well-typed-edition-2024.rs:65:23
    |
 LL |     if let Some(&Some(&x)) = &Some(&Some(0)) {
    |                       ^^     --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -31,7 +31,7 @@ LL +     if let Some(&Some(x)) = &Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:82:23
+  --> $DIR/well-typed-edition-2024.rs:84:23
    |
 LL |     if let Some(&Some(&x)) = &Some(&mut Some(0)) {
    |                       ^^     ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -47,7 +47,7 @@ LL +     if let Some(&Some(x)) = &Some(&mut Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:88:23
+  --> $DIR/well-typed-edition-2024.rs:90:23
    |
 LL |     if let Some(&Some(&x)) = &mut Some(&Some(0)) {
    |                       ^^     ------------------- this expression has type `&mut Option<&Option<{integer}>>`
@@ -63,7 +63,7 @@ LL +     if let Some(&Some(x)) = &mut Some(&Some(0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:123:15
+  --> $DIR/well-typed-edition-2024.rs:125:15
    |
 LL |     let [&mut &x] = &mut [&0];
    |               ^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -79,7 +79,7 @@ LL +     let [&mut x] = &mut [&0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:129:15
+  --> $DIR/well-typed-edition-2024.rs:131:15
    |
 LL |     let [&mut &ref x] = &mut [&0];
    |               ^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -95,7 +95,7 @@ LL +     let [&mut ref x] = &mut [&0];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/well-typed-edition-2024.rs:135:15
+  --> $DIR/well-typed-edition-2024.rs:137:15
    |
 LL |     let [&mut &(mut x)] = &mut [&0];
    |               ^^^^^^^^    --------- this expression has type `&mut [&{integer}; 1]`
@@ -111,7 +111,7 @@ LL +     let [&mut mut x)] = &mut [&0];
    |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/well-typed-edition-2024.rs:109:19
+  --> $DIR/well-typed-edition-2024.rs:111:19
    |
 LL |         let [&mut ref mut x] = &mut [&0];
    |                   ^^^^^^^^^ cannot borrow as mutable

--- a/tests/ui/pattern/usefulness/issue-31561.rs
+++ b/tests/ui/pattern/usefulness/issue-31561.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 enum Thing {
     Foo(u8),
     Bar,
@@ -7,5 +9,5 @@ enum Thing {
 fn main() {
     let Thing::Foo(y) = Thing::Foo(1);
     //~^ ERROR refutable pattern in local binding
-    //~| `Thing::Bar` and `Thing::Baz` not covered
+    //~| NOTE `Thing::Bar` and `Thing::Baz` not covered
 }

--- a/tests/ui/pattern/usefulness/issue-31561.stderr
+++ b/tests/ui/pattern/usefulness/issue-31561.stderr
@@ -1,5 +1,5 @@
 error[E0005]: refutable pattern in local binding
-  --> $DIR/issue-31561.rs:8:9
+  --> $DIR/issue-31561.rs:10:9
    |
 LL |     let Thing::Foo(y) = Thing::Foo(1);
    |         ^^^^^^^^^^^^^ patterns `Thing::Bar` and `Thing::Baz` not covered
@@ -7,7 +7,7 @@ LL |     let Thing::Foo(y) = Thing::Foo(1);
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-02-refutability.html
 note: `Thing` defined here
-  --> $DIR/issue-31561.rs:1:6
+  --> $DIR/issue-31561.rs:3:6
    |
 LL | enum Thing {
    |      ^^^^^

--- a/tests/ui/pattern/usefulness/issue-39362.rs
+++ b/tests/ui/pattern/usefulness/issue-39362.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 enum Foo {
     Bar { bar: Bar, id: usize }
 }
@@ -9,7 +11,7 @@ enum Bar {
 fn test(f: Foo) {
     match f {
         //~^ ERROR non-exhaustive patterns
-        //~| patterns
+        //~| NOTE patterns
         Foo::Bar { bar: Bar::A, .. } => (),
         Foo::Bar { bar: Bar::B, .. } => (),
     }

--- a/tests/ui/pattern/usefulness/issue-39362.stderr
+++ b/tests/ui/pattern/usefulness/issue-39362.stderr
@@ -1,11 +1,11 @@
 error[E0004]: non-exhaustive patterns: `Foo::Bar { bar: Bar::C, .. }`, `Foo::Bar { bar: Bar::D, .. }`, `Foo::Bar { bar: Bar::E, .. }` and 1 more not covered
-  --> $DIR/issue-39362.rs:10:11
+  --> $DIR/issue-39362.rs:12:11
    |
 LL |     match f {
    |           ^ patterns `Foo::Bar { bar: Bar::C, .. }`, `Foo::Bar { bar: Bar::D, .. }`, `Foo::Bar { bar: Bar::E, .. }` and 1 more not covered
    |
 note: `Foo` defined here
-  --> $DIR/issue-39362.rs:1:6
+  --> $DIR/issue-39362.rs:3:6
    |
 LL | enum Foo {
    |      ^^^

--- a/tests/ui/pattern/usefulness/issue-72377.rs
+++ b/tests/ui/pattern/usefulness/issue-72377.rs
@@ -7,7 +7,8 @@ fn main() {
 
     match (x, y) {
         //~^ ERROR non-exhaustive patterns: `(X::A, Some(X::A))`, `(X::A, Some(X::B))`, `(X::B, Some(X::B))` and 2
-        //~| more not covered
+        //~| NOTE more not covered
+        //~| NOTE the matched value is of type `(X, Option<X>)`
         (_, None) => false,
         (v, Some(w)) if v == w => true,
         (X::B, Some(X::C)) => false,

--- a/tests/ui/pattern/usefulness/refutable-pattern-errors.rs
+++ b/tests/ui/pattern/usefulness/refutable-pattern-errors.rs
@@ -1,9 +1,11 @@
+//@ dont-require-annotations: NOTE
+
 fn func((1, (Some(1), 2..=3)): (isize, (Option<isize>, isize))) {}
 //~^ ERROR refutable pattern in function argument
-//~| `(..=0_isize, _)` and `(2_isize.., _)` not covered
+//~| NOTE `(..=0_isize, _)` and `(2_isize.., _)` not covered
 
 fn main() {
     let (1, (Some(1), 2..=3)) = (1, (None, 2));
     //~^ ERROR refutable pattern in local binding
-    //~| `(i32::MIN..=0_i32, _)` and `(2_i32..=i32::MAX, _)` not covered
+    //~| NOTE `(i32::MIN..=0_i32, _)` and `(2_i32..=i32::MAX, _)` not covered
 }

--- a/tests/ui/pattern/usefulness/refutable-pattern-errors.stderr
+++ b/tests/ui/pattern/usefulness/refutable-pattern-errors.stderr
@@ -1,5 +1,5 @@
 error[E0005]: refutable pattern in function argument
-  --> $DIR/refutable-pattern-errors.rs:1:9
+  --> $DIR/refutable-pattern-errors.rs:3:9
    |
 LL | fn func((1, (Some(1), 2..=3)): (isize, (Option<isize>, isize))) {}
    |         ^^^^^^^^^^^^^^^^^^^^^ patterns `(..=0_isize, _)` and `(2_isize.., _)` not covered
@@ -7,7 +7,7 @@ LL | fn func((1, (Some(1), 2..=3)): (isize, (Option<isize>, isize))) {}
    = note: the matched value is of type `(isize, (Option<isize>, isize))`
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/refutable-pattern-errors.rs:6:9
+  --> $DIR/refutable-pattern-errors.rs:8:9
    |
 LL |     let (1, (Some(1), 2..=3)) = (1, (None, 2));
    |         ^^^^^^^^^^^^^^^^^^^^^ patterns `(i32::MIN..=0_i32, _)` and `(2_i32..=i32::MAX, _)` not covered

--- a/tests/ui/pattern/usefulness/refutable-pattern-in-fn-arg.rs
+++ b/tests/ui/pattern/usefulness/refutable-pattern-in-fn-arg.rs
@@ -1,6 +1,7 @@
 fn main() {
     let f = |3: isize| println!("hello");
     //~^ ERROR refutable pattern in closure argument
-    //~| `..=2_isize` and `4_isize..` not covered
+    //~| NOTE `..=2_isize` and `4_isize..` not covered
+    //~| NOTE the matched value is of type `isize`
     f(4);
 }

--- a/tests/ui/pptypedef.rs
+++ b/tests/ui/pptypedef.rs
@@ -1,11 +1,13 @@
+//@ dont-require-annotations: NOTE
+
 fn let_in<T, F>(x: T, f: F) where F: FnOnce(T) {}
 
 fn main() {
     let_in(3u32, |i| { assert!(i == 3i32); });
     //~^ ERROR mismatched types
-    //~| expected `u32`, found `i32`
+    //~| NOTE expected `u32`, found `i32`
 
     let_in(3i32, |i| { assert!(i == 3u32); });
     //~^ ERROR mismatched types
-    //~| expected `i32`, found `u32`
+    //~| NOTE expected `i32`, found `u32`
 }

--- a/tests/ui/pptypedef.stderr
+++ b/tests/ui/pptypedef.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/pptypedef.rs:4:37
+  --> $DIR/pptypedef.rs:6:37
    |
 LL |     let_in(3u32, |i| { assert!(i == 3i32); });
    |                                -    ^^^^ expected `u32`, found `i32`
@@ -13,7 +13,7 @@ LL +     let_in(3u32, |i| { assert!(i == 3u32); });
    |
 
 error[E0308]: mismatched types
-  --> $DIR/pptypedef.rs:8:37
+  --> $DIR/pptypedef.rs:10:37
    |
 LL |     let_in(3i32, |i| { assert!(i == 3u32); });
    |                                -    ^^^^ expected `i32`, found `u32`

--- a/tests/ui/privacy/privacy2.rs
+++ b/tests/ui/privacy/privacy2.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -Zdeduplicate-diagnostics=yes
+//@ dont-require-annotations: NOTE
 
 #![feature(no_core)]
 #![no_core] // makes debugging this test *a lot* easier (during resolve)
@@ -20,7 +21,7 @@ fn test1() {
     //~^ ERROR requires `sized` lang_item
     use bar::foo;
     //~^ ERROR unresolved import `bar::foo` [E0432]
-    //~| no `foo` in `bar`
+    //~| NOTE no `foo` in `bar`
 }
 
 fn test2() {

--- a/tests/ui/privacy/privacy2.stderr
+++ b/tests/ui/privacy/privacy2.stderr
@@ -1,34 +1,34 @@
 error[E0432]: unresolved import `bar::foo`
-  --> $DIR/privacy2.rs:21:9
+  --> $DIR/privacy2.rs:22:9
    |
 LL |     use bar::foo;
    |         ^^^^^^^^ no `foo` in `bar`
 
 error[E0603]: function import `foo` is private
-  --> $DIR/privacy2.rs:28:20
+  --> $DIR/privacy2.rs:29:20
    |
 LL |     use bar::glob::foo;
    |                    ^^^ private function import
    |
 note: the function import `foo` is defined here...
-  --> $DIR/privacy2.rs:12:13
+  --> $DIR/privacy2.rs:13:13
    |
 LL |         use foo;
    |             ^^^
 note: ...and refers to the function `foo` which is defined here
-  --> $DIR/privacy2.rs:16:1
+  --> $DIR/privacy2.rs:17:1
    |
 LL | pub fn foo() {}
    | ^^^^^^^^^^^^ you could import this directly
 
 error: requires `sized` lang_item
-  --> $DIR/privacy2.rs:16:14
+  --> $DIR/privacy2.rs:17:14
    |
 LL | pub fn foo() {}
    |              ^^
 
 error: requires `sized` lang_item
-  --> $DIR/privacy2.rs:19:12
+  --> $DIR/privacy2.rs:20:12
    |
 LL |   fn test1() {
    |  ____________^
@@ -39,7 +39,7 @@ LL | | }
    | |_^
 
 error: requires `sized` lang_item
-  --> $DIR/privacy2.rs:26:12
+  --> $DIR/privacy2.rs:27:12
    |
 LL |   fn test2() {
    |  ____________^
@@ -50,7 +50,7 @@ LL | | }
    | |_^
 
 error: requires `sized` lang_item
-  --> $DIR/privacy2.rs:32:11
+  --> $DIR/privacy2.rs:33:11
    |
 LL | fn main() {}
    |           ^^

--- a/tests/ui/ptr-coercion.rs
+++ b/tests/ui/ptr-coercion.rs
@@ -1,23 +1,25 @@
 // Test coercions between pointers which don't do anything fancy like unsizing.
 // These are testing that we don't lose mutability when converting to raw pointers.
 
+//@ dont-require-annotations: NOTE
+
 pub fn main() {
     // *const -> *mut
     let x: *const isize = &42;
     let x: *mut isize = x; //~  ERROR mismatched types
-                           //~| expected raw pointer `*mut isize`
-                           //~| found raw pointer `*const isize`
-                           //~| types differ in mutability
+                           //~| NOTE expected raw pointer `*mut isize`
+                           //~| NOTE found raw pointer `*const isize`
+                           //~| NOTE types differ in mutability
 
     // & -> *mut
     let x: *mut isize = &42; //~  ERROR mismatched types
-                             //~| expected raw pointer `*mut isize`
-                             //~| found reference `&isize`
-                             //~| types differ in mutability
+                             //~| NOTE expected raw pointer `*mut isize`
+                             //~| NOTE found reference `&isize`
+                             //~| NOTE types differ in mutability
 
     let x: *const isize = &42;
     let x: *mut isize = x; //~  ERROR mismatched types
-                           //~| expected raw pointer `*mut isize`
-                           //~| found raw pointer `*const isize`
-                           //~| types differ in mutability
+                           //~| NOTE expected raw pointer `*mut isize`
+                           //~| NOTE found raw pointer `*const isize`
+                           //~| NOTE types differ in mutability
 }

--- a/tests/ui/ptr-coercion.stderr
+++ b/tests/ui/ptr-coercion.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/ptr-coercion.rs:7:25
+  --> $DIR/ptr-coercion.rs:9:25
    |
 LL |     let x: *mut isize = x;
    |            ----------   ^ types differ in mutability
@@ -10,7 +10,7 @@ LL |     let x: *mut isize = x;
               found raw pointer `*const isize`
 
 error[E0308]: mismatched types
-  --> $DIR/ptr-coercion.rs:13:25
+  --> $DIR/ptr-coercion.rs:15:25
    |
 LL |     let x: *mut isize = &42;
    |            ----------   ^^^ types differ in mutability
@@ -21,7 +21,7 @@ LL |     let x: *mut isize = &42;
                 found reference `&isize`
 
 error[E0308]: mismatched types
-  --> $DIR/ptr-coercion.rs:19:25
+  --> $DIR/ptr-coercion.rs:21:25
    |
 LL |     let x: *mut isize = x;
    |            ----------   ^ types differ in mutability

--- a/tests/ui/recursion_limit/empty.rs
+++ b/tests/ui/recursion_limit/empty.rs
@@ -1,8 +1,9 @@
 // Test the parse error for an empty recursion_limit
 
 #![recursion_limit = ""] //~ ERROR `limit` must be a non-negative integer
-                         //~| `limit` must be a non-negative integer
+                         //~| NOTE `limit` must be a non-negative integer
                          //~| ERROR `limit` must be a non-negative integer
-                         //~| `limit` must be a non-negative integer
+                         //~| NOTE `limit` must be a non-negative integer
+                         //~| NOTE duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 fn main() {}

--- a/tests/ui/recursion_limit/invalid_digit.rs
+++ b/tests/ui/recursion_limit/invalid_digit.rs
@@ -1,7 +1,8 @@
 // Test the parse error for an invalid digit in recursion_limit
 
 #![recursion_limit = "-100"] //~ ERROR `limit` must be a non-negative integer
-                             //~| not a valid integer
+                             //~| NOTE not a valid integer
                              //~| ERROR `limit` must be a non-negative integer
-                             //~| not a valid integer
+                             //~| NOTE not a valid integer
+                             //~| NOTE duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 fn main() {}

--- a/tests/ui/recursion_limit/overflow.rs
+++ b/tests/ui/recursion_limit/overflow.rs
@@ -2,8 +2,9 @@
 
 #![recursion_limit = "999999999999999999999999"]
 //~^ ERROR `limit` must be a non-negative integer
-//~| `limit` is too large
+//~| NOTE `limit` is too large
 //~| ERROR `limit` must be a non-negative integer
-//~| `limit` is too large
+//~| NOTE `limit` is too large
+//~| NOTE duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 fn main() {}

--- a/tests/ui/repeat-expr/repeat_count.rs
+++ b/tests/ui/repeat-expr/repeat_count.rs
@@ -1,34 +1,36 @@
 // Regression test for issue #3645
 
+//@ dont-require-annotations: NOTE
+
 fn main() {
     let n = 1;
     let a = [0; n];
     //~^ ERROR attempt to use a non-constant value in a constant [E0435]
     let b = [0; ()];
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `()`
+    //~| NOTE expected `usize`, found `()`
     let c = [0; true];
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `bool`
+    //~| NOTE expected `usize`, found `bool`
     let d = [0; 0.5];
     //~^ ERROR mismatched types
-    //~| expected `usize`, found floating-point number
+    //~| NOTE expected `usize`, found floating-point number
     let e = [0; "foo"];
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `&str`
+    //~| NOTE expected `usize`, found `&str`
     let f = [0; -4_isize];
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `isize`
+    //~| NOTE expected `usize`, found `isize`
     let f = [0_usize; -1_isize];
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `isize`
+    //~| NOTE expected `usize`, found `isize`
     let f = [0; 4u8];
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `u8`
+    //~| NOTE expected `usize`, found `u8`
     struct G {
         g: (),
     }
     let g = [0; G { g: () }];
     //~^ ERROR mismatched types
-    //~| expected `usize`, found `G`
+    //~| NOTE expected `usize`, found `G`
 }

--- a/tests/ui/repeat-expr/repeat_count.stderr
+++ b/tests/ui/repeat-expr/repeat_count.stderr
@@ -1,5 +1,5 @@
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/repeat_count.rs:5:17
+  --> $DIR/repeat_count.rs:7:17
    |
 LL |     let a = [0; n];
    |                 ^ non-constant value
@@ -11,37 +11,37 @@ LL +     const n: /* Type */ = 1;
    |
 
 error[E0308]: mismatched types
-  --> $DIR/repeat_count.rs:7:17
+  --> $DIR/repeat_count.rs:9:17
    |
 LL |     let b = [0; ()];
    |                 ^^ expected `usize`, found `()`
 
 error[E0308]: mismatched types
-  --> $DIR/repeat_count.rs:31:17
+  --> $DIR/repeat_count.rs:33:17
    |
 LL |     let g = [0; G { g: () }];
    |                 ^^^^^^^^^^^ expected `usize`, found `G`
 
 error[E0308]: mismatched types
-  --> $DIR/repeat_count.rs:10:17
+  --> $DIR/repeat_count.rs:12:17
    |
 LL |     let c = [0; true];
    |                 ^^^^ expected `usize`, found `bool`
 
 error[E0308]: mismatched types
-  --> $DIR/repeat_count.rs:13:17
+  --> $DIR/repeat_count.rs:15:17
    |
 LL |     let d = [0; 0.5];
    |                 ^^^ expected `usize`, found floating-point number
 
 error[E0308]: mismatched types
-  --> $DIR/repeat_count.rs:16:17
+  --> $DIR/repeat_count.rs:18:17
    |
 LL |     let e = [0; "foo"];
    |                 ^^^^^ expected `usize`, found `&str`
 
 error[E0308]: mismatched types
-  --> $DIR/repeat_count.rs:19:17
+  --> $DIR/repeat_count.rs:21:17
    |
 LL |     let f = [0; -4_isize];
    |                 ^^^^^^^^ expected `usize`, found `isize`
@@ -49,7 +49,7 @@ LL |     let f = [0; -4_isize];
    = note: `-4_isize` cannot fit into type `usize`
 
 error[E0308]: mismatched types
-  --> $DIR/repeat_count.rs:22:23
+  --> $DIR/repeat_count.rs:24:23
    |
 LL |     let f = [0_usize; -1_isize];
    |                       ^^^^^^^^ expected `usize`, found `isize`
@@ -57,7 +57,7 @@ LL |     let f = [0_usize; -1_isize];
    = note: `-1_isize` cannot fit into type `usize`
 
 error[E0308]: mismatched types
-  --> $DIR/repeat_count.rs:25:17
+  --> $DIR/repeat_count.rs:27:17
    |
 LL |     let f = [0; 4u8];
    |                 ^^^ expected `usize`, found `u8`

--- a/tests/ui/resolve/issue-23716.rs
+++ b/tests/ui/resolve/issue-23716.rs
@@ -1,8 +1,10 @@
+//@ dont-require-annotations: NOTE
+
 static foo: i32 = 0;
 
 fn bar(foo: i32) {}
 //~^ ERROR function parameters cannot shadow statics
-//~| cannot be named the same as a static
+//~| NOTE cannot be named the same as a static
 
 mod submod {
     pub static answer: i32 = 42;
@@ -12,6 +14,6 @@ use self::submod::answer;
 
 fn question(answer: i32) {}
 //~^ ERROR function parameters cannot shadow statics
-//~| cannot be named the same as a static
+//~| NOTE cannot be named the same as a static
 fn main() {
 }

--- a/tests/ui/resolve/issue-23716.stderr
+++ b/tests/ui/resolve/issue-23716.stderr
@@ -1,5 +1,5 @@
 error[E0530]: function parameters cannot shadow statics
-  --> $DIR/issue-23716.rs:3:8
+  --> $DIR/issue-23716.rs:5:8
    |
 LL | static foo: i32 = 0;
    | -------------------- the static `foo` is defined here
@@ -8,7 +8,7 @@ LL | fn bar(foo: i32) {}
    |        ^^^ cannot be named the same as a static
 
 error[E0530]: function parameters cannot shadow statics
-  --> $DIR/issue-23716.rs:13:13
+  --> $DIR/issue-23716.rs:15:13
    |
 LL | use self::submod::answer;
    |     -------------------- the static `answer` is imported here

--- a/tests/ui/resolve/issue-5035.rs
+++ b/tests/ui/resolve/issue-5035.rs
@@ -1,9 +1,11 @@
+//@ dont-require-annotations: NOTE
+
 trait I {}
 type K = dyn I;
 impl K for isize {} //~ ERROR expected trait, found type alias `K`
 
 use ImportError; //~ ERROR unresolved import `ImportError` [E0432]
-                 //~^ no `ImportError` in the root
+                 //~^ NOTE no `ImportError` in the root
 impl ImportError for () {} // check that this is not an additional error (cf. issue #35142)
 
 fn main() {}

--- a/tests/ui/resolve/issue-5035.stderr
+++ b/tests/ui/resolve/issue-5035.stderr
@@ -1,11 +1,11 @@
 error[E0432]: unresolved import `ImportError`
-  --> $DIR/issue-5035.rs:5:5
+  --> $DIR/issue-5035.rs:7:5
    |
 LL | use ImportError;
    |     ^^^^^^^^^^^ no `ImportError` in the root
 
 error[E0404]: expected trait, found type alias `K`
-  --> $DIR/issue-5035.rs:3:6
+  --> $DIR/issue-5035.rs:5:6
    |
 LL | trait I {}
    | ------- similarly named trait `I` defined here

--- a/tests/ui/resolve/resolve-conflict-item-vs-import.rs
+++ b/tests/ui/resolve/resolve-conflict-item-vs-import.rs
@@ -1,8 +1,8 @@
-use std::mem::transmute;
+use std::mem::transmute; //~ NOTE previous import of the value `transmute` here
 
 fn transmute() {}
 //~^ ERROR the name `transmute` is defined multiple times
-//~| `transmute` redefined here
-//~| `transmute` must be defined only once in the value namespace of this module
+//~| NOTE `transmute` redefined here
+//~| NOTE `transmute` must be defined only once in the value namespace of this module
 fn main() {
 }

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.rs
@@ -1,22 +1,24 @@
+//@ dont-require-annotations: NOTE
+
 #![deny(unreachable_patterns)]
 
 #[non_exhaustive]
 pub enum NonExhaustiveEnum {
     Unit,
-    //~^ not covered
+    //~^ NOTE not covered
     Tuple(u32),
-    //~^ not covered
+    //~^ NOTE not covered
     Struct { field: u32 }
-    //~^ not covered
+    //~^ NOTE not covered
 }
 
 pub enum NormalEnum {
     Unit,
-    //~^ not covered
+    //~^ NOTE not covered
     Tuple(u32),
-    //~^ not covered
+    //~^ NOTE not covered
     Struct { field: u32 }
-    //~^ not covered
+    //~^ NOTE not covered
 }
 
 #[non_exhaustive]

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/enum_same_crate_empty_match.rs:28:9
+  --> $DIR/enum_same_crate_empty_match.rs:30:9
    |
 LL |         _ => {}
    |         ^------
@@ -9,19 +9,19 @@ LL |         _ => {}
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/enum_same_crate_empty_match.rs:1:9
+  --> $DIR/enum_same_crate_empty_match.rs:3:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error[E0004]: non-exhaustive patterns: `NonExhaustiveEnum::Unit`, `NonExhaustiveEnum::Tuple(_)` and `NonExhaustiveEnum::Struct { .. }` not covered
-  --> $DIR/enum_same_crate_empty_match.rs:33:11
+  --> $DIR/enum_same_crate_empty_match.rs:35:11
    |
 LL |     match NonExhaustiveEnum::Unit {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^ patterns `NonExhaustiveEnum::Unit`, `NonExhaustiveEnum::Tuple(_)` and `NonExhaustiveEnum::Struct { .. }` not covered
    |
 note: `NonExhaustiveEnum` defined here
-  --> $DIR/enum_same_crate_empty_match.rs:4:10
+  --> $DIR/enum_same_crate_empty_match.rs:6:10
    |
 LL | pub enum NonExhaustiveEnum {
    |          ^^^^^^^^^^^^^^^^^
@@ -42,13 +42,13 @@ LL ~     }
    |
 
 error[E0004]: non-exhaustive patterns: `NormalEnum::Unit`, `NormalEnum::Tuple(_)` and `NormalEnum::Struct { .. }` not covered
-  --> $DIR/enum_same_crate_empty_match.rs:35:11
+  --> $DIR/enum_same_crate_empty_match.rs:37:11
    |
 LL |     match NormalEnum::Unit {}
    |           ^^^^^^^^^^^^^^^^ patterns `NormalEnum::Unit`, `NormalEnum::Tuple(_)` and `NormalEnum::Struct { .. }` not covered
    |
 note: `NormalEnum` defined here
-  --> $DIR/enum_same_crate_empty_match.rs:13:10
+  --> $DIR/enum_same_crate_empty_match.rs:15:10
    |
 LL | pub enum NormalEnum {
    |          ^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.rs
@@ -1,5 +1,7 @@
 // Test that the `non_exhaustive_omitted_patterns` lint is triggered correctly.
 
+//@ dont-require-annotations: NOTE
+
 #![feature(non_exhaustive_omitted_patterns_lint, unstable_test_feature)]
 #![deny(unreachable_patterns)]
 
@@ -231,7 +233,7 @@ fn main() {
     // Check that matching on a reference results in a correct diagnostic
     match &non_enum {
         //~^ ERROR some variants are not matched explicitly
-        //~| pattern `&NonExhaustiveEnum::Struct { .. }` not covered
+        //~| NOTE pattern `&NonExhaustiveEnum::Struct { .. }` not covered
         NonExhaustiveEnum::Unit => {}
         NonExhaustiveEnum::Tuple(_) => {}
         _ => {}
@@ -239,21 +241,21 @@ fn main() {
 
     match (true, &non_enum) {
         //~^ ERROR some variants are not matched explicitly
-        //~| patterns `(_, &NonExhaustiveEnum::Tuple(_))` and `(_, &NonExhaustiveEnum::Struct { .. })` not covered
+        //~| NOTE patterns `(_, &NonExhaustiveEnum::Tuple(_))` and `(_, &NonExhaustiveEnum::Struct { .. })` not covered
         (true, NonExhaustiveEnum::Unit) => {}
         _ => {}
     }
 
     match (&non_enum, true) {
         //~^ ERROR some variants are not matched explicitly
-        //~| patterns `(&NonExhaustiveEnum::Tuple(_), _)` and `(&NonExhaustiveEnum::Struct { .. }, _)` not covered
+        //~| NOTE patterns `(&NonExhaustiveEnum::Tuple(_), _)` and `(&NonExhaustiveEnum::Struct { .. }, _)` not covered
         (NonExhaustiveEnum::Unit, true) => {}
         _ => {}
     }
 
     match Some(&non_enum) {
         //~^ ERROR some variants are not matched explicitly
-        //~| pattern `Some(&NonExhaustiveEnum::Struct { .. })` not covered
+        //~| NOTE pattern `Some(&NonExhaustiveEnum::Struct { .. })` not covered
         Some(NonExhaustiveEnum::Unit | NonExhaustiveEnum::Tuple(_)) => {}
         _ => {}
     }

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/omitted-patterns.stderr
@@ -1,5 +1,5 @@
 error: some fields are not explicitly listed
-  --> $DIR/omitted-patterns.rs:139:9
+  --> $DIR/omitted-patterns.rs:141:9
    |
 LL |         VariantNonExhaustive::Bar { x, .. } => {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `y` not listed
@@ -7,13 +7,13 @@ LL |         VariantNonExhaustive::Bar { x, .. } => {}
    = help: ensure that all fields are mentioned explicitly by adding the suggested fields
    = note: the pattern is of type `VariantNonExhaustive` and the `non_exhaustive_omitted_patterns` attribute was found
 note: the lint level is defined here
-  --> $DIR/omitted-patterns.rs:45:8
+  --> $DIR/omitted-patterns.rs:47:8
    |
 LL | #[deny(non_exhaustive_omitted_patterns)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: some fields are not explicitly listed
-  --> $DIR/omitted-patterns.rs:143:9
+  --> $DIR/omitted-patterns.rs:145:9
    |
 LL |     let FunctionalRecord { first_field, second_field, .. } = FunctionalRecord::default();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `third_field` not listed
@@ -22,7 +22,7 @@ LL |     let FunctionalRecord { first_field, second_field, .. } = FunctionalReco
    = note: the pattern is of type `FunctionalRecord` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some fields are not explicitly listed
-  --> $DIR/omitted-patterns.rs:149:29
+  --> $DIR/omitted-patterns.rs:151:29
    |
 LL |     let NestedStruct { bar: NormalStruct { first_field, .. }, .. } = NestedStruct::default();
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `second_field` not listed
@@ -31,7 +31,7 @@ LL |     let NestedStruct { bar: NormalStruct { first_field, .. }, .. } = Nested
    = note: the pattern is of type `NormalStruct` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some fields are not explicitly listed
-  --> $DIR/omitted-patterns.rs:149:9
+  --> $DIR/omitted-patterns.rs:151:9
    |
 LL |     let NestedStruct { bar: NormalStruct { first_field, .. }, .. } = NestedStruct::default();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `foo` not listed
@@ -40,7 +40,7 @@ LL |     let NestedStruct { bar: NormalStruct { first_field, .. }, .. } = Nested
    = note: the pattern is of type `NestedStruct` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some fields are not explicitly listed
-  --> $DIR/omitted-patterns.rs:212:9
+  --> $DIR/omitted-patterns.rs:214:9
    |
 LL |     let OnlyUnstableStruct { unstable, .. } = OnlyUnstableStruct::new();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `unstable2` not listed
@@ -49,7 +49,7 @@ LL |     let OnlyUnstableStruct { unstable, .. } = OnlyUnstableStruct::new();
    = note: the pattern is of type `OnlyUnstableStruct` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some fields are not explicitly listed
-  --> $DIR/omitted-patterns.rs:218:9
+  --> $DIR/omitted-patterns.rs:220:9
    |
 LL |     let UnstableStruct { stable, stable2, .. } = UnstableStruct::default();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `unstable` not listed
@@ -58,7 +58,7 @@ LL |     let UnstableStruct { stable, stable2, .. } = UnstableStruct::default();
    = note: the pattern is of type `UnstableStruct` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:65:11
+  --> $DIR/omitted-patterns.rs:67:11
    |
 LL |     match non_enum {
    |           ^^^^^^^^ pattern `NonExhaustiveEnum::Struct { .. }` not covered
@@ -67,7 +67,7 @@ LL |     match non_enum {
    = note: the matched value is of type `NonExhaustiveEnum` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:72:11
+  --> $DIR/omitted-patterns.rs:74:11
    |
 LL |     match non_enum {
    |           ^^^^^^^^ pattern `NonExhaustiveEnum::Tuple(_)` not covered
@@ -76,7 +76,7 @@ LL |     match non_enum {
    = note: the matched value is of type `NonExhaustiveEnum` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:93:11
+  --> $DIR/omitted-patterns.rs:95:11
    |
 LL |     match (non_enum, true) {
    |           ^^^^^^^^^^^^^^^^ pattern `(NonExhaustiveEnum::Struct { .. }, _)` not covered
@@ -85,7 +85,7 @@ LL |     match (non_enum, true) {
    = note: the matched value is of type `(NonExhaustiveEnum, bool)` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:106:11
+  --> $DIR/omitted-patterns.rs:108:11
    |
 LL |     match (true, non_enum) {
    |           ^^^^^^^^^^^^^^^^ pattern `(_, NonExhaustiveEnum::Struct { .. })` not covered
@@ -94,7 +94,7 @@ LL |     match (true, non_enum) {
    = note: the matched value is of type `(bool, NonExhaustiveEnum)` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:113:11
+  --> $DIR/omitted-patterns.rs:115:11
    |
 LL |     match Some(non_enum) {
    |           ^^^^^^^^^^^^^^ pattern `Some(NonExhaustiveEnum::Struct { .. })` not covered
@@ -103,7 +103,7 @@ LL |     match Some(non_enum) {
    = note: the matched value is of type `Option<NonExhaustiveEnum>` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:129:11
+  --> $DIR/omitted-patterns.rs:131:11
    |
 LL |     match NestedNonExhaustive::B {
    |           ^^^^^^^^^^^^^^^^^^^^^^ patterns `NestedNonExhaustive::C`, `NestedNonExhaustive::A(NonExhaustiveEnum::Tuple(_))` and `NestedNonExhaustive::A(NonExhaustiveEnum::Struct { .. })` not covered
@@ -112,7 +112,7 @@ LL |     match NestedNonExhaustive::B {
    = note: the matched value is of type `NestedNonExhaustive` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:184:11
+  --> $DIR/omitted-patterns.rs:186:11
    |
 LL |     match UnstableEnum::Stable {
    |           ^^^^^^^^^^^^^^^^^^^^ pattern `UnstableEnum::Unstable` not covered
@@ -121,7 +121,7 @@ LL |     match UnstableEnum::Stable {
    = note: the matched value is of type `UnstableEnum` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:206:11
+  --> $DIR/omitted-patterns.rs:208:11
    |
 LL |     match OnlyUnstableEnum::Unstable {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^ pattern `OnlyUnstableEnum::Unstable2` not covered
@@ -130,7 +130,7 @@ LL |     match OnlyUnstableEnum::Unstable {
    = note: the matched value is of type `OnlyUnstableEnum` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/omitted-patterns.rs:228:9
+  --> $DIR/omitted-patterns.rs:230:9
    |
 LL |     let local_refutable @ NonExhaustiveEnum::Unit = NonExhaustiveEnum::Unit;
    |         ^^^^^^^^^^^^^^^ pattern `_` not covered
@@ -144,7 +144,7 @@ LL |     let local_refutable @ NonExhaustiveEnum::Unit = NonExhaustiveEnum::Unit
    |                                                                             ++++++++++++++++
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:232:11
+  --> $DIR/omitted-patterns.rs:234:11
    |
 LL |     match &non_enum {
    |           ^^^^^^^^^ pattern `&NonExhaustiveEnum::Struct { .. }` not covered
@@ -153,7 +153,7 @@ LL |     match &non_enum {
    = note: the matched value is of type `&NonExhaustiveEnum` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:240:11
+  --> $DIR/omitted-patterns.rs:242:11
    |
 LL |     match (true, &non_enum) {
    |           ^^^^^^^^^^^^^^^^^ patterns `(_, &NonExhaustiveEnum::Tuple(_))` and `(_, &NonExhaustiveEnum::Struct { .. })` not covered
@@ -162,7 +162,7 @@ LL |     match (true, &non_enum) {
    = note: the matched value is of type `(bool, &NonExhaustiveEnum)` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:247:11
+  --> $DIR/omitted-patterns.rs:249:11
    |
 LL |     match (&non_enum, true) {
    |           ^^^^^^^^^^^^^^^^^ patterns `(&NonExhaustiveEnum::Tuple(_), _)` and `(&NonExhaustiveEnum::Struct { .. }, _)` not covered
@@ -171,7 +171,7 @@ LL |     match (&non_enum, true) {
    = note: the matched value is of type `(&NonExhaustiveEnum, bool)` and the `non_exhaustive_omitted_patterns` attribute was found
 
 error: some variants are not matched explicitly
-  --> $DIR/omitted-patterns.rs:254:11
+  --> $DIR/omitted-patterns.rs:256:11
    |
 LL |     match Some(&non_enum) {
    |           ^^^^^^^^^^^^^^^ pattern `Some(&NonExhaustiveEnum::Struct { .. })` not covered

--- a/tests/ui/simd/const-err-trumps-simd-err.rs
+++ b/tests/ui/simd/const-err-trumps-simd-err.rs
@@ -1,4 +1,6 @@
 //@build-fail
+//@ dont-require-annotations: NOTE
+
 //! Make sure that monomorphization-time const errors from `static_assert` take priority over the
 //! error from simd_extract. Basically this checks that if a const fails to evaluate in some
 //! function, we don't bother codegen'ing the function.
@@ -15,7 +17,7 @@ struct int8x4_t([u8; 4]);
 fn get_elem<const LANE: u32>(a: int8x4_t) -> u8 {
     const { assert!(LANE < 4); } // the error should be here...
     //~^ ERROR failed
-    //~| assertion failed
+    //~| NOTE assertion failed
     unsafe { simd_extract(a, LANE) } // ...not here
 }
 

--- a/tests/ui/simd/const-err-trumps-simd-err.stderr
+++ b/tests/ui/simd/const-err-trumps-simd-err.stderr
@@ -1,17 +1,17 @@
 error[E0080]: evaluation of `get_elem::<4>::{constant#0}` failed
-  --> $DIR/const-err-trumps-simd-err.rs:16:13
+  --> $DIR/const-err-trumps-simd-err.rs:18:13
    |
 LL |     const { assert!(LANE < 4); } // the error should be here...
    |             ^^^^^^^^^^^^^^^^^ evaluation panicked: assertion failed: LANE < 4
 
 note: erroneous constant encountered
-  --> $DIR/const-err-trumps-simd-err.rs:16:5
+  --> $DIR/const-err-trumps-simd-err.rs:18:5
    |
 LL |     const { assert!(LANE < 4); } // the error should be here...
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: the above error was encountered while instantiating `fn get_elem::<4>`
-  --> $DIR/const-err-trumps-simd-err.rs:23:5
+  --> $DIR/const-err-trumps-simd-err.rs:25:5
    |
 LL |     get_elem::<4>(int8x4_t([0, 0, 0, 0]));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/structs/default-field-values/failures.rs
+++ b/tests/ui/structs/default-field-values/failures.rs
@@ -1,4 +1,6 @@
- #![feature(default_field_values)]
+//@ dont-require-annotations: HELP
+
+#![feature(default_field_values)]
 
 #[derive(Debug)]
 pub struct S;
@@ -56,10 +58,10 @@ fn main () {
     let _ = Bar { bar: S, .. }; // ok
     let _ = Qux::<4> { .. };
     let _ = Rak(..); //~ ERROR E0308
-    //~^ you might have meant to use `..` to skip providing
+    //~^ HELP you might have meant to use `..` to skip providing
     let _ = Rak(0, ..); //~ ERROR E0061
-    //~^ you might have meant to use `..` to skip providing
+    //~^ HELP you might have meant to use `..` to skip providing
     let _ = Rak(.., 0); //~ ERROR E0061
-    //~^ you might have meant to use `..` to skip providing
+    //~^ HELP you might have meant to use `..` to skip providing
     let _ = Rak { .. }; // ok
 }

--- a/tests/ui/structs/default-field-values/failures.stderr
+++ b/tests/ui/structs/default-field-values/failures.stderr
@@ -1,5 +1,5 @@
 error: the `#[default]` attribute may only be used on unit enum variants or variants where every field has a default value
-  --> $DIR/failures.rs:47:5
+  --> $DIR/failures.rs:49:5
    |
 LL |     Variant {}
    |     ^^^^^^^
@@ -7,13 +7,13 @@ LL |     Variant {}
    = help: consider a manual implementation of `Default`
 
 error: default fields are not supported in tuple structs
-  --> $DIR/failures.rs:26:22
+  --> $DIR/failures.rs:28:22
    |
 LL | pub struct Rak(i32 = 42);
    |                      ^^ default fields are only supported on structs
 
 error[E0277]: the trait bound `S: Default` is not satisfied
-  --> $DIR/failures.rs:14:5
+  --> $DIR/failures.rs:16:5
    |
 LL | #[derive(Debug, Default)]
    |                 ------- in this derive macro expansion
@@ -28,19 +28,19 @@ LL | pub struct S;
    |
 
 error: missing field `bar` in initializer
-  --> $DIR/failures.rs:53:19
+  --> $DIR/failures.rs:55:19
    |
 LL |     let _ = Bar { .. };
    |                   ^ fields that do not have a defaulted value must be provided explicitly
 
 error: missing field `bar` in initializer
-  --> $DIR/failures.rs:54:27
+  --> $DIR/failures.rs:56:27
    |
 LL |     let _ = Bar { baz: 0, .. };
    |                           ^ fields that do not have a defaulted value must be provided explicitly
 
 error[E0308]: mismatched types
-  --> $DIR/failures.rs:58:17
+  --> $DIR/failures.rs:60:17
    |
 LL |     let _ = Rak(..);
    |             --- ^^ expected `i32`, found `RangeFull`
@@ -48,29 +48,29 @@ LL |     let _ = Rak(..);
    |             arguments to this struct are incorrect
    |
 note: tuple struct defined here
-  --> $DIR/failures.rs:26:12
+  --> $DIR/failures.rs:28:12
    |
 LL | pub struct Rak(i32 = 42);
    |            ^^^
 help: you might have meant to use `..` to skip providing a value for expected fields, but this is only supported on non-tuple struct literals; it is instead interpreted as a `std::ops::RangeFull` literal
-  --> $DIR/failures.rs:58:17
+  --> $DIR/failures.rs:60:17
    |
 LL |     let _ = Rak(..);
    |                 ^^
 
 error[E0061]: this struct takes 1 argument but 2 arguments were supplied
-  --> $DIR/failures.rs:60:13
+  --> $DIR/failures.rs:62:13
    |
 LL |     let _ = Rak(0, ..);
    |             ^^^    -- unexpected argument #2 of type `RangeFull`
    |
 help: you might have meant to use `..` to skip providing a value for expected fields, but this is only supported on non-tuple struct literals; it is instead interpreted as a `std::ops::RangeFull` literal
-  --> $DIR/failures.rs:60:20
+  --> $DIR/failures.rs:62:20
    |
 LL |     let _ = Rak(0, ..);
    |                    ^^
 note: tuple struct defined here
-  --> $DIR/failures.rs:26:12
+  --> $DIR/failures.rs:28:12
    |
 LL | pub struct Rak(i32 = 42);
    |            ^^^
@@ -81,18 +81,18 @@ LL +     let _ = Rak(0);
    |
 
 error[E0061]: this struct takes 1 argument but 2 arguments were supplied
-  --> $DIR/failures.rs:62:13
+  --> $DIR/failures.rs:64:13
    |
 LL |     let _ = Rak(.., 0);
    |             ^^^ -- unexpected argument #1 of type `RangeFull`
    |
 help: you might have meant to use `..` to skip providing a value for expected fields, but this is only supported on non-tuple struct literals; it is instead interpreted as a `std::ops::RangeFull` literal
-  --> $DIR/failures.rs:62:17
+  --> $DIR/failures.rs:64:17
    |
 LL |     let _ = Rak(.., 0);
    |                 ^^
 note: tuple struct defined here
-  --> $DIR/failures.rs:26:12
+  --> $DIR/failures.rs:28:12
    |
 LL | pub struct Rak(i32 = 42);
    |            ^^^

--- a/tests/ui/structs/structure-constructor-type-mismatch.rs
+++ b/tests/ui/structs/structure-constructor-type-mismatch.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 struct Point<T> {
     x: T,
     y: T,
@@ -16,32 +18,32 @@ fn main() {
     let pt = PointF {
         x: 1,
         //~^ ERROR mismatched types
-        //~| expected `f32`, found integer
+        //~| NOTE expected `f32`, found integer
         y: 2,
         //~^ ERROR mismatched types
-        //~| expected `f32`, found integer
+        //~| NOTE expected `f32`, found integer
     };
 
     let pt2 = Point::<f32> {
         x: 3,
         //~^ ERROR mismatched types
-        //~| expected `f32`, found integer
+        //~| NOTE expected `f32`, found integer
         y: 4,
         //~^ ERROR mismatched types
-        //~| expected `f32`, found integer
+        //~| NOTE expected `f32`, found integer
     };
 
     let pair = PairF {
         x: 5,
         //~^ ERROR mismatched types
-        //~| expected `f32`, found integer
+        //~| NOTE expected `f32`, found integer
         y: 6,
     };
 
     let pair2 = PairF::<i32> {
         x: 7,
         //~^ ERROR mismatched types
-        //~| expected `f32`, found integer
+        //~| NOTE expected `f32`, found integer
         y: 8,
     };
 

--- a/tests/ui/structs/structure-constructor-type-mismatch.stderr
+++ b/tests/ui/structs/structure-constructor-type-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:17:12
+  --> $DIR/structure-constructor-type-mismatch.rs:19:12
    |
 LL |         x: 1,
    |            ^ expected `f32`, found integer
@@ -10,7 +10,7 @@ LL |         x: 1.0,
    |             ++
 
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:20:12
+  --> $DIR/structure-constructor-type-mismatch.rs:22:12
    |
 LL |         y: 2,
    |            ^ expected `f32`, found integer
@@ -21,7 +21,7 @@ LL |         y: 2.0,
    |             ++
 
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:26:12
+  --> $DIR/structure-constructor-type-mismatch.rs:28:12
    |
 LL |         x: 3,
    |            ^ expected `f32`, found integer
@@ -32,7 +32,7 @@ LL |         x: 3.0,
    |             ++
 
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:29:12
+  --> $DIR/structure-constructor-type-mismatch.rs:31:12
    |
 LL |         y: 4,
    |            ^ expected `f32`, found integer
@@ -43,7 +43,7 @@ LL |         y: 4.0,
    |             ++
 
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:35:12
+  --> $DIR/structure-constructor-type-mismatch.rs:37:12
    |
 LL |         x: 5,
    |            ^ expected `f32`, found integer
@@ -54,7 +54,7 @@ LL |         x: 5.0,
    |             ++
 
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:42:12
+  --> $DIR/structure-constructor-type-mismatch.rs:44:12
    |
 LL |         x: 7,
    |            ^ expected `f32`, found integer
@@ -65,7 +65,7 @@ LL |         x: 7.0,
    |             ++
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/structure-constructor-type-mismatch.rs:48:15
+  --> $DIR/structure-constructor-type-mismatch.rs:50:15
    |
 LL |     let pt3 = PointF::<i32> {
    |               ^^^^^^------- help: remove the unnecessary generics
@@ -73,13 +73,13 @@ LL |     let pt3 = PointF::<i32> {
    |               expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
-  --> $DIR/structure-constructor-type-mismatch.rs:6:6
+  --> $DIR/structure-constructor-type-mismatch.rs:8:6
    |
 LL | type PointF = Point<f32>;
    |      ^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:49:12
+  --> $DIR/structure-constructor-type-mismatch.rs:51:12
    |
 LL |         x: 9,
    |            ^ expected `f32`, found integer
@@ -90,7 +90,7 @@ LL |         x: 9.0,
    |             ++
 
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:50:12
+  --> $DIR/structure-constructor-type-mismatch.rs:52:12
    |
 LL |         y: 10,
    |            ^^ expected `f32`, found integer
@@ -101,7 +101,7 @@ LL |         y: 10.0,
    |              ++
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/structure-constructor-type-mismatch.rs:54:9
+  --> $DIR/structure-constructor-type-mismatch.rs:56:9
    |
 LL |         PointF::<u32> { .. } => {}
    |         ^^^^^^------- help: remove the unnecessary generics
@@ -109,13 +109,13 @@ LL |         PointF::<u32> { .. } => {}
    |         expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
-  --> $DIR/structure-constructor-type-mismatch.rs:6:6
+  --> $DIR/structure-constructor-type-mismatch.rs:8:6
    |
 LL | type PointF = Point<f32>;
    |      ^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:54:9
+  --> $DIR/structure-constructor-type-mismatch.rs:56:9
    |
 LL |     match (Point { x: 1, y: 2 }) {
    |           ---------------------- this expression has type `Point<{integer}>`
@@ -126,7 +126,7 @@ LL |         PointF::<u32> { .. } => {}
               found struct `Point<f32>`
 
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:59:9
+  --> $DIR/structure-constructor-type-mismatch.rs:61:9
    |
 LL |     match (Point { x: 1, y: 2 }) {
    |           ---------------------- this expression has type `Point<{integer}>`
@@ -137,7 +137,7 @@ LL |         PointF { .. } => {}
               found struct `Point<f32>`
 
 error[E0308]: mismatched types
-  --> $DIR/structure-constructor-type-mismatch.rs:67:9
+  --> $DIR/structure-constructor-type-mismatch.rs:69:9
    |
 LL |     match (Pair { x: 1, y: 2 }) {
    |           --------------------- this expression has type `Pair<{integer}, {integer}>`

--- a/tests/ui/suggestions/const-pat-non-exaustive-let-new-var.rs
+++ b/tests/ui/suggestions/const-pat-non-exaustive-let-new-var.rs
@@ -1,10 +1,12 @@
+//@ dont-require-annotations: NOTE
+
 fn main() {
     let A = 3;
     //~^ ERROR refutable pattern in local binding
-    //~| patterns `i32::MIN..=1_i32` and `3_i32..=i32::MAX` not covered
+    //~| NOTE patterns `i32::MIN..=1_i32` and `3_i32..=i32::MAX` not covered
     //~| HELP introduce a variable instead
     //~| SUGGESTION A_var
 
     const A: i32 = 2;
-    //~^ missing patterns are not covered because `A` is interpreted as a constant pattern, not a new variable
+    //~^ NOTE missing patterns are not covered because `A` is interpreted as a constant pattern, not a new variable
 }

--- a/tests/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
+++ b/tests/ui/suggestions/const-pat-non-exaustive-let-new-var.stderr
@@ -1,5 +1,5 @@
 error[E0005]: refutable pattern in local binding
-  --> $DIR/const-pat-non-exaustive-let-new-var.rs:2:9
+  --> $DIR/const-pat-non-exaustive-let-new-var.rs:4:9
    |
 LL |     let A = 3;
    |         ^ patterns `i32::MIN..=1_i32` and `3_i32..=i32::MAX` not covered

--- a/tests/ui/traits/bound/same-crate-name.rs
+++ b/tests/ui/traits/bound/same-crate-name.rs
@@ -1,5 +1,7 @@
 //@ aux-build:crate_a1.rs
 //@ aux-build:crate_a2.rs
+//@ dont-require-annotations: HELP
+//@ dont-require-annotations: NOTE
 
 // Issue 22750
 // This tests the extra help message reported when a trait bound
@@ -30,8 +32,8 @@ fn main() {
         extern crate crate_a1 as a;
         a::try_foo(foo);
         //~^ ERROR E0277
-        //~| trait impl with same name found
-        //~| perhaps two different versions of crate `crate_a2`
+        //~| HELP trait impl with same name found
+        //~| NOTE perhaps two different versions of crate `crate_a2`
 
         // We don't want to see the "version mismatch" help message here
         // because `implements_no_traits` has no impl for `Foo`
@@ -50,6 +52,6 @@ fn main() {
         // impls for the correct trait where the path is not misleading.
         a::try_foo(other_variant_implements_correct_trait);
         //~^ ERROR E0277
-        //~| the trait `main::a::Bar` is implemented for `ImplementsTraitForUsize<usize>`
+        //~| HELP the trait `main::a::Bar` is implemented for `ImplementsTraitForUsize<usize>`
     }
 }

--- a/tests/ui/traits/bound/same-crate-name.stderr
+++ b/tests/ui/traits/bound/same-crate-name.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Foo: main::a::Bar` is not satisfied
-  --> $DIR/same-crate-name.rs:31:20
+  --> $DIR/same-crate-name.rs:33:20
    |
 LL |         a::try_foo(foo);
    |         ---------- ^^^ the trait `main::a::Bar` is not implemented for `Foo`
@@ -20,7 +20,7 @@ LL | pub fn try_foo(x: impl Bar) {}
    |                        ^^^ required by this bound in `try_foo`
 
 error[E0277]: the trait bound `DoesNotImplementTrait: main::a::Bar` is not satisfied
-  --> $DIR/same-crate-name.rs:38:20
+  --> $DIR/same-crate-name.rs:40:20
    |
 LL |         a::try_foo(implements_no_traits);
    |         ---------- ^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `DoesNotImplementTrait`
@@ -35,7 +35,7 @@ LL | pub fn try_foo(x: impl Bar) {}
    |                        ^^^ required by this bound in `try_foo`
 
 error[E0277]: the trait bound `ImplementsWrongTraitConditionally<isize>: main::a::Bar` is not satisfied
-  --> $DIR/same-crate-name.rs:45:20
+  --> $DIR/same-crate-name.rs:47:20
    |
 LL |         a::try_foo(other_variant_implements_mismatched_trait);
    |         ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `ImplementsWrongTraitConditionally<isize>`
@@ -56,7 +56,7 @@ LL | pub fn try_foo(x: impl Bar) {}
    |                        ^^^ required by this bound in `try_foo`
 
 error[E0277]: the trait bound `ImplementsTraitForUsize<isize>: main::a::Bar` is not satisfied
-  --> $DIR/same-crate-name.rs:51:20
+  --> $DIR/same-crate-name.rs:53:20
    |
 LL |         a::try_foo(other_variant_implements_correct_trait);
    |         ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `main::a::Bar` is not implemented for `ImplementsTraitForUsize<isize>`

--- a/tests/ui/traits/impl-method-mismatch.rs
+++ b/tests/ui/traits/impl-method-mismatch.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 trait Mumbo {
     fn jumbo(&self, x: &usize) -> usize;
 }
@@ -6,8 +8,8 @@ impl Mumbo for usize {
     // Cannot have a larger effect than the trait:
     unsafe fn jumbo(&self, x: &usize) { *self + *x; }
     //~^ ERROR method `jumbo` has an incompatible type for trait
-    //~| expected signature `fn
-    //~| found signature `unsafe fn
+    //~| NOTE expected signature `fn
+    //~| NOTE found signature `unsafe fn
 }
 
 fn main() {}

--- a/tests/ui/traits/impl-method-mismatch.stderr
+++ b/tests/ui/traits/impl-method-mismatch.stderr
@@ -1,11 +1,11 @@
 error[E0053]: method `jumbo` has an incompatible type for trait
-  --> $DIR/impl-method-mismatch.rs:7:5
+  --> $DIR/impl-method-mismatch.rs:9:5
    |
 LL |     unsafe fn jumbo(&self, x: &usize) { *self + *x; }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected safe fn, found unsafe fn
    |
 note: type in trait
-  --> $DIR/impl-method-mismatch.rs:2:5
+  --> $DIR/impl-method-mismatch.rs:4:5
    |
 LL |     fn jumbo(&self, x: &usize) -> usize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/tuple/tuple-arity-mismatch.rs
+++ b/tests/ui/tuple/tuple-arity-mismatch.rs
@@ -1,17 +1,19 @@
 // Issue #6155
 
+//@ dont-require-annotations: NOTE
+
 fn first((value, _): (isize, f64)) -> isize { value }
 
 fn main() {
     let y = first ((1,2.0,3));
     //~^ ERROR mismatched types
-    //~| expected tuple `(isize, f64)`
-    //~| found tuple `(isize, f64, {integer})`
-    //~| expected a tuple with 2 elements, found one with 3 elements
+    //~| NOTE expected tuple `(isize, f64)`
+    //~| NOTE found tuple `(isize, f64, {integer})`
+    //~| NOTE expected a tuple with 2 elements, found one with 3 elements
 
     let y = first ((1,));
     //~^ ERROR mismatched types
-    //~| expected tuple `(isize, f64)`
-    //~| found tuple `(isize,)`
-    //~| expected a tuple with 2 elements, found one with 1 element
+    //~| NOTE expected tuple `(isize, f64)`
+    //~| NOTE found tuple `(isize,)`
+    //~| NOTE expected a tuple with 2 elements, found one with 1 element
 }

--- a/tests/ui/tuple/tuple-arity-mismatch.stderr
+++ b/tests/ui/tuple/tuple-arity-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/tuple-arity-mismatch.rs:6:20
+  --> $DIR/tuple-arity-mismatch.rs:8:20
    |
 LL |     let y = first ((1,2.0,3));
    |             -----  ^^^^^^^^^ expected a tuple with 2 elements, found one with 3 elements
@@ -9,13 +9,13 @@ LL |     let y = first ((1,2.0,3));
    = note: expected tuple `(isize, f64)`
               found tuple `(isize, f64, {integer})`
 note: function defined here
-  --> $DIR/tuple-arity-mismatch.rs:3:4
+  --> $DIR/tuple-arity-mismatch.rs:5:4
    |
 LL | fn first((value, _): (isize, f64)) -> isize { value }
    |    ^^^^^ ------------------------
 
 error[E0308]: mismatched types
-  --> $DIR/tuple-arity-mismatch.rs:12:20
+  --> $DIR/tuple-arity-mismatch.rs:14:20
    |
 LL |     let y = first ((1,));
    |             -----  ^^^^ expected a tuple with 2 elements, found one with 1 element
@@ -25,7 +25,7 @@ LL |     let y = first ((1,));
    = note: expected tuple `(isize, f64)`
               found tuple `(isize,)`
 note: function defined here
-  --> $DIR/tuple-arity-mismatch.rs:3:4
+  --> $DIR/tuple-arity-mismatch.rs:5:4
    |
 LL | fn first((value, _): (isize, f64)) -> isize { value }
    |    ^^^^^ ------------------------

--- a/tests/ui/type/type-mismatch-multiple.rs
+++ b/tests/ui/type/type-mismatch-multiple.rs
@@ -1,7 +1,9 @@
 // Checking that the compiler reports multiple type errors at once
 
+//@ dont-require-annotations: NOTE
+
 fn main() { let a: bool = 1; let b: i32 = true; }
 //~^ ERROR mismatched types
-//~| expected `bool`, found integer
+//~| NOTE expected `bool`, found integer
 //~| ERROR mismatched types
-//~| expected `i32`, found `bool`
+//~| NOTE expected `i32`, found `bool`

--- a/tests/ui/type/type-mismatch-multiple.stderr
+++ b/tests/ui/type/type-mismatch-multiple.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch-multiple.rs:3:27
+  --> $DIR/type-mismatch-multiple.rs:5:27
    |
 LL | fn main() { let a: bool = 1; let b: i32 = true; }
    |                    ----   ^ expected `bool`, found integer
@@ -7,7 +7,7 @@ LL | fn main() { let a: bool = 1; let b: i32 = true; }
    |                    expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch-multiple.rs:3:43
+  --> $DIR/type-mismatch-multiple.rs:5:43
    |
 LL | fn main() { let a: bool = 1; let b: i32 = true; }
    |                                     ---   ^^^^ expected `i32`, found `bool`

--- a/tests/ui/type/type-parameter-names.rs
+++ b/tests/ui/type/type-parameter-names.rs
@@ -1,12 +1,14 @@
 // Test that we print out the names of type parameters correctly in
 // our error messages.
 
+//@ dont-require-annotations: NOTE
+
 fn foo<Foo, Bar>(x: Foo) -> Bar {
     x
 //~^ ERROR mismatched types
-//~| expected type parameter `Bar`, found type parameter `Foo`
-//~| expected type parameter `Bar`
-//~| found type parameter `Foo`
+//~| NOTE expected type parameter `Bar`, found type parameter `Foo`
+//~| NOTE expected type parameter `Bar`
+//~| NOTE found type parameter `Foo`
 }
 
 fn main() {}

--- a/tests/ui/type/type-parameter-names.stderr
+++ b/tests/ui/type/type-parameter-names.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/type-parameter-names.rs:5:5
+  --> $DIR/type-parameter-names.rs:7:5
    |
 LL | fn foo<Foo, Bar>(x: Foo) -> Bar {
    |        ---  ---             --- expected `Bar` because of return type

--- a/tests/ui/type/type-params-in-different-spaces-1.rs
+++ b/tests/ui/type/type-params-in-different-spaces-1.rs
@@ -1,11 +1,13 @@
+//@ dont-require-annotations: NOTE
+
 use std::ops::Add;
 
 trait BrokenAdd: Copy + Add<Output=Self> {
     fn broken_add<T>(&self, rhs: T) -> Self {
         *self + rhs //~  ERROR mismatched types
-                    //~| expected type parameter `Self`, found type parameter `T`
-                    //~| expected type parameter `Self`
-                    //~| found type parameter `T`
+                    //~| NOTE expected type parameter `Self`, found type parameter `T`
+                    //~| NOTE expected type parameter `Self`
+                    //~| NOTE found type parameter `T`
     }
 }
 

--- a/tests/ui/type/type-params-in-different-spaces-1.stderr
+++ b/tests/ui/type/type-params-in-different-spaces-1.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/type-params-in-different-spaces-1.rs:5:17
+  --> $DIR/type-params-in-different-spaces-1.rs:7:17
    |
 LL | trait BrokenAdd: Copy + Add<Output=Self> {
    | ---------------------------------------- expected type parameter

--- a/tests/ui/typeck/issue-16338.rs
+++ b/tests/ui/typeck/issue-16338.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 struct Slice<T> {
     data: *const T,
     len: usize,
@@ -6,5 +8,5 @@ struct Slice<T> {
 fn main() {
     let Slice { data: data, len: len } = "foo";
     //~^ ERROR mismatched types
-    //~| found struct `Slice<_>`
+    //~| NOTE found struct `Slice<_>`
 }

--- a/tests/ui/typeck/issue-16338.stderr
+++ b/tests/ui/typeck/issue-16338.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-16338.rs:7:9
+  --> $DIR/issue-16338.rs:9:9
    |
 LL |     let Slice { data: data, len: len } = "foo";
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ----- this expression has type `&str`

--- a/tests/ui/typeck/suppressed-error.rs
+++ b/tests/ui/typeck/suppressed-error.rs
@@ -1,8 +1,9 @@
 fn main() {
     let (x, y) = ();
 //~^ ERROR mismatched types
-//~| expected unit type `()`
-//~| found tuple `(_, _)`
-//~| expected `()`, found
+//~| NOTE expected unit type `()`
+//~| NOTE found tuple `(_, _)`
+//~| NOTE expected `()`, found
+//~| NOTE this expression has type `()`
     return x;
 }

--- a/tests/ui/typeck/tag-that-dare-not-speak-its-name.rs
+++ b/tests/ui/typeck/tag-that-dare-not-speak-its-name.rs
@@ -10,7 +10,8 @@ fn main() {
     let y;
     let x : char = last(y);
     //~^ ERROR mismatched types
-    //~| expected type `char`
-    //~| found enum `Option<_>`
-    //~| expected `char`, found `Option<_>`
+    //~| NOTE expected type `char`
+    //~| NOTE found enum `Option<_>`
+    //~| NOTE expected `char`, found `Option<_>`
+    //~| NOTE expected due to this
 }

--- a/tests/ui/typeck/terr-in-field.rs
+++ b/tests/ui/typeck/terr-in-field.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 struct Foo {
     a: isize,
     b: isize,
@@ -11,7 +13,7 @@ struct Bar {
 fn want_foo(f: Foo) {}
 fn have_bar(b: Bar) {
     want_foo(b); //~  ERROR mismatched types
-                 //~| expected `Foo`, found `Bar`
+                 //~| NOTE expected `Foo`, found `Bar`
 }
 
 fn main() {}

--- a/tests/ui/typeck/terr-in-field.stderr
+++ b/tests/ui/typeck/terr-in-field.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/terr-in-field.rs:13:14
+  --> $DIR/terr-in-field.rs:15:14
    |
 LL |     want_foo(b);
    |     -------- ^ expected `Foo`, found `Bar`
@@ -7,7 +7,7 @@ LL |     want_foo(b);
    |     arguments to this function are incorrect
    |
 note: function defined here
-  --> $DIR/terr-in-field.rs:11:4
+  --> $DIR/terr-in-field.rs:13:4
    |
 LL | fn want_foo(f: Foo) {}
    |    ^^^^^^^^ ------

--- a/tests/ui/typeck/terr-sorts.rs
+++ b/tests/ui/typeck/terr-sorts.rs
@@ -1,3 +1,5 @@
+//@ dont-require-annotations: NOTE
+
 struct Foo {
     a: isize,
     b: isize,
@@ -8,8 +10,8 @@ type Bar = Box<Foo>;
 fn want_foo(f: Foo) {}
 fn have_bar(b: Bar) {
     want_foo(b); //~  ERROR mismatched types
-                 //~| expected struct `Foo`
-                 //~| found struct `Box<Foo>`
+                 //~| NOTE expected struct `Foo`
+                 //~| NOTE found struct `Box<Foo>`
 }
 
 fn main() {}

--- a/tests/ui/typeck/terr-sorts.stderr
+++ b/tests/ui/typeck/terr-sorts.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/terr-sorts.rs:10:14
+  --> $DIR/terr-sorts.rs:12:14
    |
 LL |     want_foo(b);
    |     -------- ^ expected `Foo`, found `Box<Foo>`
@@ -9,7 +9,7 @@ LL |     want_foo(b);
    = note: expected struct `Foo`
               found struct `Box<Foo>`
 note: function defined here
-  --> $DIR/terr-sorts.rs:8:4
+  --> $DIR/terr-sorts.rs:10:4
    |
 LL | fn want_foo(f: Foo) {}
    |    ^^^^^^^^ ------

--- a/tests/ui/typeck/typeck_type_placeholder_mismatch.rs
+++ b/tests/ui/typeck/typeck_type_placeholder_mismatch.rs
@@ -1,6 +1,8 @@
 // This test checks that genuine type errors with partial
 // type hints are understandable.
 
+//@ dont-require-annotations: NOTE
+
 use std::marker::PhantomData;
 
 struct Foo<T>(PhantomData<T>);
@@ -12,16 +14,16 @@ pub fn main() {
 fn test1() {
     let x: Foo<_> = Bar::<usize>(PhantomData);
     //~^ ERROR mismatched types
-    //~| expected struct `Foo<_>`
-    //~| found struct `Bar<usize>`
-    //~| expected `Foo<_>`, found `Bar<usize>`
+    //~| NOTE expected struct `Foo<_>`
+    //~| NOTE found struct `Bar<usize>`
+    //~| NOTE expected `Foo<_>`, found `Bar<usize>`
     let y: Foo<usize> = x;
 }
 
 fn test2() {
     let x: Foo<_> = Bar::<usize>(PhantomData);
     //~^ ERROR mismatched types
-    //~| expected struct `Foo<_>`
-    //~| found struct `Bar<usize>`
-    //~| expected `Foo<_>`, found `Bar<usize>`
+    //~| NOTE expected struct `Foo<_>`
+    //~| NOTE found struct `Bar<usize>`
+    //~| NOTE expected `Foo<_>`, found `Bar<usize>`
 }

--- a/tests/ui/typeck/typeck_type_placeholder_mismatch.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/typeck_type_placeholder_mismatch.rs:13:21
+  --> $DIR/typeck_type_placeholder_mismatch.rs:15:21
    |
 LL |     let x: Foo<_> = Bar::<usize>(PhantomData);
    |            ------   ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Foo<_>`, found `Bar<usize>`
@@ -10,7 +10,7 @@ LL |     let x: Foo<_> = Bar::<usize>(PhantomData);
               found struct `Bar<usize>`
 
 error[E0308]: mismatched types
-  --> $DIR/typeck_type_placeholder_mismatch.rs:22:21
+  --> $DIR/typeck_type_placeholder_mismatch.rs:24:21
    |
 LL |     let x: Foo<_> = Bar::<usize>(PhantomData);
    |            ------   ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Foo<_>`, found `Bar<usize>`

--- a/tests/ui/typeof/type_mismatch.rs
+++ b/tests/ui/typeof/type_mismatch.rs
@@ -1,9 +1,12 @@
 // Test that using typeof results in the correct type mismatch errors instead of always assuming
 // `usize`, in addition to the pre-existing "typeof is reserved and unimplemented" error
+
+//@ dont-require-annotations: NOTE
+
 fn main() {
     const a: u8 = 1;
     let b: typeof(a) = 1i8;
     //~^ ERROR `typeof` is a reserved keyword but unimplemented
     //~| ERROR mismatched types
-    //~| expected `u8`, found `i8`
+    //~| NOTE expected `u8`, found `i8`
 }

--- a/tests/ui/typeof/type_mismatch.stderr
+++ b/tests/ui/typeof/type_mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0516]: `typeof` is a reserved keyword but unimplemented
-  --> $DIR/type_mismatch.rs:5:12
+  --> $DIR/type_mismatch.rs:8:12
    |
 LL |     let b: typeof(a) = 1i8;
    |            ^^^^^^^^^ reserved keyword
@@ -11,7 +11,7 @@ LL +     let b: u8 = 1i8;
    |
 
 error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:5:24
+  --> $DIR/type_mismatch.rs:8:24
    |
 LL |     let b: typeof(a) = 1i8;
    |            ---------   ^^^ expected `u8`, found `i8`

--- a/tests/ui/ufcs/ufcs-explicit-self-bad.rs
+++ b/tests/ui/ufcs/ufcs-explicit-self-bad.rs
@@ -1,13 +1,13 @@
+//@ dont-require-annotations: NOTE
+
 struct Foo {
     f: isize,
 }
 
-
-
 impl Foo {
     fn foo(self: isize, x: isize) -> isize {
         //~^ ERROR invalid `self` parameter type
-        self.f + x //~ ERROR: doesn't have fields
+        self.f + x //~ ERROR doesn't have fields
     }
 }
 
@@ -39,13 +39,13 @@ impl<'a, T> SomeTrait for &'a Bar<T> {
     //~| ERROR has an incompatible type for trait
     fn dummy3(self: &&Bar<T>) {}
     //~^ ERROR mismatched `self` parameter type
-    //~| expected reference `&'a Bar<_>`
-    //~| found reference `&Bar<_>`
-    //~| lifetime mismatch
+    //~| NOTE expected reference `&'a Bar<_>`
+    //~| NOTE found reference `&Bar<_>`
+    //~| NOTE lifetime mismatch
     //~| ERROR mismatched `self` parameter type
-    //~| expected reference `&'a Bar<_>`
-    //~| found reference `&Bar<_>`
-    //~| lifetime mismatch
+    //~| NOTE expected reference `&'a Bar<_>`
+    //~| NOTE found reference `&Bar<_>`
+    //~| NOTE lifetime mismatch
 }
 
 fn main() {

--- a/tests/ui/unsafe/unsafe-trait-impl.rs
+++ b/tests/ui/unsafe/unsafe-trait-impl.rs
@@ -1,5 +1,7 @@
 // Check that safe fns are not a subtype of unsafe fns.
 
+//@ dont-require-annotations: NOTE
+
 trait Foo {
     unsafe fn len(&self) -> u32;
 }
@@ -7,8 +9,8 @@ trait Foo {
 impl Foo for u32 {
     fn len(&self) -> u32 { *self }
     //~^ ERROR method `len` has an incompatible type for trait
-    //~| expected signature `unsafe fn(&_) -> _`
-    //~| found signature `fn(&_) -> _`
+    //~| NOTE expected signature `unsafe fn(&_) -> _`
+    //~| NOTE found signature `fn(&_) -> _`
 }
 
 fn main() { }

--- a/tests/ui/unsafe/unsafe-trait-impl.stderr
+++ b/tests/ui/unsafe/unsafe-trait-impl.stderr
@@ -1,11 +1,11 @@
 error[E0053]: method `len` has an incompatible type for trait
-  --> $DIR/unsafe-trait-impl.rs:8:5
+  --> $DIR/unsafe-trait-impl.rs:10:5
    |
 LL |     fn len(&self) -> u32 { *self }
    |     ^^^^^^^^^^^^^^^^^^^^ expected unsafe fn, found safe fn
    |
 note: type in trait
-  --> $DIR/unsafe-trait-impl.rs:4:5
+  --> $DIR/unsafe-trait-impl.rs:6:5
    |
 LL |     unsafe fn len(&self) -> u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/wf/range-expr-root-of-constant-issue-40749.rs
+++ b/tests/ui/wf/range-expr-root-of-constant-issue-40749.rs
@@ -1,6 +1,7 @@
 fn main() {
     [0; ..10];
     //~^ ERROR mismatched types
-    //~| expected type `usize`
-    //~| found struct `RangeTo<{integer}>`
+    //~| NOTE expected type `usize`
+    //~| NOTE found struct `RangeTo<{integer}>`
+    //~| NOTE expected `usize`, found `RangeTo<{integer}>
 }


### PR DESCRIPTION
Compiletest currently accepts line annotations without kind in UI tests.
```
    let a = b + c; //~ my message
```

Such annotations have two effects.
- First, they match any compiler-produced diagnostic kind. This functionality is never used in practice, there are no target-dependent diagnostic kinds of something like that.
- Second, they are not "viral". For example, any explicit `//~ NOTE my msg` in a test requires all other `NOTE` diagnostics in the same test to be annotated. Implicit `//~ my msg` will just match the note and won't require other annotations.

The second functionality has a replacement since recently - directive `//@ dont-require-annotations: NOTE`.

This PR removes support for `//~ my message` and makes the explicit diagnostic kind mandatory.
Unwanted additional annotations are suppressed using the `dont-require-annotations` directive.

Closes https://github.com/rust-lang/compiler-team/issues/862.
Previous attempt - #139427.
r? @jieyouxu 