### PR TITLE
RISC-V target feature B implies Zba, Zbb, Zbs

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -491,6 +491,7 @@ const MIPS_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
 static RISCV_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     // tidy-alphabetical-start
     ("a", Stable, &["zaamo", "zalrsc"]),
+    ("b", Stable, &["zba", "zbb", "zbs"]),
     ("c", Stable, &[]),
     ("d", Unstable(sym::riscv_target_feature), &["f"]),
     ("e", Unstable(sym::riscv_target_feature), &[]),

--- a/tests/ui/check-cfg/target_feature.stderr
+++ b/tests/ui/check-cfg/target_feature.stderr
@@ -49,6 +49,7 @@ LL |     cfg!(target_feature = "_UNEXPECTED_VALUE");
 `avxvnni`
 `avxvnniint16`
 `avxvnniint8`
+`b`
 `backchain`
 `bf16`
 `bmi1`


### PR DESCRIPTION
zba, zbb, and zbs are already stable, B is a convenient alias for all three, so it seems reasonable to stabilize it as well.  
This feature name is supported by our current LLVM version (and LLVM uses the same name).  

The fourth bitmanip extension, Zbc, is not implied by B.

For reference, the RISC-V unprivileged manual defines this in chapter 29 on the B extension: https://github.com/riscv/riscv-isa-manual/releases

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
