### PR TITLE
docs(library/core/src/pin): fix typo "necessarily" -> "necessary"

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -12,11 +12,11 @@
 //! "pinned," in that it has been permanently (until the end of its lifespan) attached to its
 //! location in memory, as though pinned to a pinboard. Pinning a value is an incredibly useful
 //! building block for [`unsafe`] code to be able to reason about whether a raw pointer to the
-//! pinned value is still valid. [As we'll see later][drop-guarantee], this is necessary from the
-//! time the value is first pinned until the end of its lifespan. This concept of "pinning" is
-//! necessary to implement safe interfaces on top of things like self-referential types and
-//! intrusive data structures which cannot currently be modeled in fully safe Rust using only
-//! borrow-checked [references][reference].
+//! pinned value is still valid. [As we'll see later][drop-guarantee], once a value is pinned,
+//! it is necessarily valid at its memory location until the end of its lifespan. This concept
+//! of "pinning" is necessary to implement safe interfaces on top of things like self-referential
+//! types and intrusive data structures which cannot currently be modeled in fully safe Rust using
+//! only borrow-checked [references][reference].
 //!
 //! "Pinning" allows us to put a *value* which exists at some location in memory into a state where
 //! safe code cannot *move* that value to a different location in memory or otherwise invalidate it

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -12,7 +12,7 @@
 //! "pinned," in that it has been permanently (until the end of its lifespan) attached to its
 //! location in memory, as though pinned to a pinboard. Pinning a value is an incredibly useful
 //! building block for [`unsafe`] code to be able to reason about whether a raw pointer to the
-//! pinned value is still valid. [As we'll see later][drop-guarantee], this is necessarily from the
+//! pinned value is still valid. [As we'll see later][drop-guarantee], this is necessary from the
 //! time the value is first pinned until the end of its lifespan. This concept of "pinning" is
 //! necessary to implement safe interfaces on top of things like self-referential types and
 //! intrusive data structures which cannot currently be modeled in fully safe Rust using only


### PR DESCRIPTION
Fix a typo in [`library/core/src/pin.rs`](https://github.com/ruancomelli/rust/blob/14662fabeb69fe5ab6c6e68051bf9f80d4aaaa35/library/core/src/pin.rs), from

> As we'll see later, this is **necessarily** from the time the value is first pinned until the end of its lifespan.

to

> As we'll see later, this is **necessary** from the time the value is first pinned until the end of its lifespan.

(my emphasis).