### PR TITLE
[beta] Delay `hash_extract_if` stabilization from 1.87 to 1.88

### DIFF
--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -668,6 +668,7 @@ impl<K, V, S> HashMap<K, V, S> {
     /// Splitting a map into even and odd keys, reusing the original map:
     ///
     /// ```
+    /// #![feature(hash_extract_if)]
     /// use std::collections::HashMap;
     ///
     /// let mut map: HashMap<i32, i32> = (0..8).map(|x| (x, x)).collect();
@@ -683,7 +684,7 @@ impl<K, V, S> HashMap<K, V, S> {
     /// ```
     #[inline]
     #[rustc_lint_query_instability]
-    #[stable(feature = "hash_extract_if", since = "1.87.0")]
+    #[unstable(feature = "hash_extract_if", issue = "59618")]
     pub fn extract_if<F>(&mut self, pred: F) -> ExtractIf<'_, K, V, F>
     where
         F: FnMut(&K, &mut V) -> bool,
@@ -1670,6 +1671,8 @@ impl<'a, K, V> Drain<'a, K, V> {
 /// # Example
 ///
 /// ```
+/// #![feature(hash_extract_if)]
+///
 /// use std::collections::HashMap;
 ///
 /// let mut map = HashMap::from([
@@ -1677,7 +1680,7 @@ impl<'a, K, V> Drain<'a, K, V> {
 /// ]);
 /// let iter = map.extract_if(|_k, v| *v % 2 == 0);
 /// ```
-#[stable(feature = "hash_extract_if", since = "1.87.0")]
+#[unstable(feature = "hash_extract_if", issue = "59618")]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct ExtractIf<'a, K, V, F>
 where
@@ -2294,7 +2297,7 @@ where
     }
 }
 
-#[stable(feature = "hash_extract_if", since = "1.87.0")]
+#[unstable(feature = "hash_extract_if", issue = "59618")]
 impl<K, V, F> Iterator for ExtractIf<'_, K, V, F>
 where
     F: FnMut(&K, &mut V) -> bool,
@@ -2311,10 +2314,10 @@ where
     }
 }
 
-#[stable(feature = "hash_extract_if", since = "1.87.0")]
+#[unstable(feature = "hash_extract_if", issue = "59618")]
 impl<K, V, F> FusedIterator for ExtractIf<'_, K, V, F> where F: FnMut(&K, &mut V) -> bool {}
 
-#[stable(feature = "hash_extract_if", since = "1.87.0")]
+#[unstable(feature = "hash_extract_if", issue = "59618")]
 impl<'a, K, V, F> fmt::Debug for ExtractIf<'a, K, V, F>
 where
     F: FnMut(&K, &mut V) -> bool,

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -293,6 +293,7 @@ impl<T, S> HashSet<T, S> {
     /// Splitting a set into even and odd values, reusing the original set:
     ///
     /// ```
+    /// #![feature(hash_extract_if)]
     /// use std::collections::HashSet;
     ///
     /// let mut set: HashSet<i32> = (0..8).collect();
@@ -308,7 +309,7 @@ impl<T, S> HashSet<T, S> {
     /// ```
     #[inline]
     #[rustc_lint_query_instability]
-    #[stable(feature = "hash_extract_if", since = "1.87.0")]
+    #[unstable(feature = "hash_extract_if", issue = "59618")]
     pub fn extract_if<F>(&mut self, pred: F) -> ExtractIf<'_, T, F>
     where
         F: FnMut(&T) -> bool,
@@ -1384,13 +1385,15 @@ pub struct Drain<'a, K: 'a> {
 /// # Examples
 ///
 /// ```
+/// #![feature(hash_extract_if)]
+///
 /// use std::collections::HashSet;
 ///
 /// let mut a = HashSet::from([1, 2, 3]);
 ///
 /// let mut extract_ifed = a.extract_if(|v| v % 2 == 0);
 /// ```
-#[stable(feature = "hash_extract_if", since = "1.87.0")]
+#[unstable(feature = "hash_extract_if", issue = "59618")]
 pub struct ExtractIf<'a, K, F>
 where
     F: FnMut(&K) -> bool,
@@ -1673,7 +1676,7 @@ impl<K: fmt::Debug> fmt::Debug for Drain<'_, K> {
     }
 }
 
-#[stable(feature = "hash_extract_if", since = "1.87.0")]
+#[unstable(feature = "hash_extract_if", issue = "59618")]
 impl<K, F> Iterator for ExtractIf<'_, K, F>
 where
     F: FnMut(&K) -> bool,
@@ -1690,10 +1693,10 @@ where
     }
 }
 
-#[stable(feature = "hash_extract_if", since = "1.87.0")]
+#[unstable(feature = "hash_extract_if", issue = "59618")]
 impl<K, F> FusedIterator for ExtractIf<'_, K, F> where F: FnMut(&K) -> bool {}
 
-#[stable(feature = "hash_extract_if", since = "1.87.0")]
+#[unstable(feature = "hash_extract_if", issue = "59618")]
 impl<'a, K, F> fmt::Debug for ExtractIf<'a, K, F>
 where
     F: FnMut(&K) -> bool,


### PR DESCRIPTION
This PR is a revert of:

- https://github.com/rust-lang/rust/pull/134655

for use in the event that we are unable to get https://github.com/rust-lang/rust/pull/139764 into 1.87 (current beta).