### PR TITLE
Remove `define_debug_via_print` for `ExistentialProjection`, use regular structural debug impl

### DIFF
--- a/compiler/rustc_type_ir/src/ir_print.rs
+++ b/compiler/rustc_type_ir/src/ir_print.rs
@@ -60,7 +60,7 @@ define_display_via_print!(
     PatternKind,
 );
 
-define_debug_via_print!(TraitRef, ExistentialTraitRef, ExistentialProjection, PatternKind);
+define_debug_via_print!(TraitRef, ExistentialTraitRef, PatternKind);
 
 impl<I: Interner, T> fmt::Display for OutlivesPredicate<I, T>
 where

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -374,7 +374,7 @@ impl<I: Interner> ty::Binder<I, ExistentialTraitRef<I>> {
 }
 
 /// A `ProjectionPredicate` for an `ExistentialTraitRef`.
-#[derive_where(Clone, Copy, Hash, PartialEq, Eq; I: Interner)]
+#[derive_where(Clone, Copy, Hash, PartialEq, Eq, Debug; I: Interner)]
 #[derive(TypeVisitable_Generic, TypeFoldable_Generic, Lift_Generic)]
 #[cfg_attr(
     feature = "nightly",


### PR DESCRIPTION
The pretty print impl for `ExistentialProjection` always prints `AssocItem = Ty`:

https://github.com/rust-lang/rust/blob/6e830462330a9e34d8176e86d4580dd0820c6fd5/compiler/rustc_middle/src/ty/print/pretty.rs#L3293-L3299

We can't change this, b/c it's used for both pretty printing dyn types and for legacy symbol mangling.

Unfortunately, we also use this printing procedure for `Debug` impls. That means that it leaves out the *trait name* and *trait args* when debug printing an `ExistentialProjection` (or an `ExistentialPredicate` which has a variant for `ExistentialProjection`). This leads to awkward situations, like the two seemingly identical existential projection predicates present in a `dyn Trait` type using the definition below:

```rust
trait Super { type Assoc; }

trait Foo: Super<A, Assoc = i32> + Super<B, Assoc = i32> {}
```

Namely, they both just render as `Projection(Assoc = i32)`! This makes debugging `dyn Trait` type system bugs really hard, so let's use the *regular* debug impl for `ExistentialProjection`.