### PR TITLE
Add test for issue 34834

### DIFF
--- a/tests/ui/traits/associated_type_bound/hrtb-associated.rs
+++ b/tests/ui/traits/associated_type_bound/hrtb-associated.rs
@@ -1,0 +1,30 @@
+//@ check-pass
+//! This test ensures that HRTB (higher-ranked trait bounds) on associated types
+//! compile correctly. This was previously rejected by the compiler.
+//! Related issue: <https://github.com/rust-lang/rust/issues/34834>
+
+pub trait Provides<'a> {
+    type Item;
+}
+
+pub trait Selector: for<'a> Provides<'a> {
+    type Namespace: PartialEq + for<'a> PartialEq<<Self as Provides<'a>>::Item>;
+
+    fn get_namespace(&self) -> <Self as Provides>::Item;
+}
+
+pub struct MySelector;
+
+impl<'a> Provides<'a> for MySelector {
+    type Item = &'a str;
+}
+
+impl Selector for MySelector {
+    type Namespace = String;
+
+    fn get_namespace(&self) -> &str {
+        unimplemented!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
closes: #34834 

This PR adds a UI test for a case where a trait with an associated type using a higher-ranked trait bound (HRTB) failed to compile in Rust 1.55.0 but succeeded starting from 1.56.0.

```rust
pub trait Provides<'a> {
    type Item;
}

pub trait Selector: for<'a> Provides<'a> {
    type Namespace: PartialEq + for<'a> PartialEq<<Self as Provides<'a>>::Item>;

    fn get_namespace(&self) -> <Self as Provides>::Item;
}

pub struct MySelector;

impl<'a> Provides<'a> for MySelector {
    type Item = &'a str;
}

impl Selector for MySelector {
    type Namespace = String;

    fn get_namespace(&self) -> &str {
        unimplemented!()
    }
}

fn main() {}
```

* ❌ [compile fail (rustc: 1.55.0)](https://godbolt.org/z/T1jY1Ebo6)
* ⭕ [compile pass (rustc: 1.56.0)](https://godbolt.org/z/e4jo11Ma7)