### PR TITLE
Use `compiletest-ignore-dir` for bootstrap self-tests

### DIFF
--- a/tests/ui/bootstrap/self-test/a.rs
+++ b/tests/ui/bootstrap/self-test/a.rs
@@ -1,2 +1,1 @@
 //! Not used by compiler, this is used by bootstrap cli self-test.
-//@ ignore-test (used by bootstrap)

--- a/tests/ui/bootstrap/self-test/b.rs
+++ b/tests/ui/bootstrap/self-test/b.rs
@@ -1,2 +1,1 @@
 //! Not used by compiler, used by bootstrap cli self-test.
-//@ ignore-test (used by bootstrap)


### PR DESCRIPTION
Follow-up to #139705 and #139740.

I did another survey pass over `//@ ignore-test` under `tests/`, and this is the only 2 non-tests that should use `compiletest-ignore-dir`.

r? @Zalathar (or compiler/bootstrap)