### PR TITLE
Let CStrings be either 1 or 2 byte aligned.

### DIFF
--- a/tests/assembly/cstring-merging.rs
+++ b/tests/assembly/cstring-merging.rs
@@ -5,7 +5,7 @@
 
 use std::ffi::CStr;
 
-// CHECK: .section .rodata.str1.1,"aMS"
+// CHECK: .section .rodata.str1.{{[12]}},"aMS"
 // CHECK: .Lanon.{{.+}}:
 // CHECK-NEXT: .asciz "foo"
 #[unsafe(no_mangle)]


### PR DESCRIPTION
We see a regression on the `tests/assembly/cstring-merging.rs` test on s390x.

Some architectures (like s390x) require strings to be 2 byte aligned. Therefor the section name will be marked with a .2  postfix on this architectures.

Allowing a section name with a .1 or .2 postfix will make the test pass on either platform.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
