### PR TITLE
normalize: prefer `ParamEnv` over `AliasBound` candidates

### DIFF
--- a/tests/ui/traits/winnowing/norm-where-bound-gt-alias-bound.rs
+++ b/tests/ui/traits/winnowing/norm-where-bound-gt-alias-bound.rs
@@ -1,0 +1,29 @@
+//@ revisions: current next
+//@ ignore-compare-mode-next-solver (explicit revisions)
+//@[next] compile-flags: -Znext-solver
+//@ check-pass
+
+// Make sure we prefer the `I::IntoIterator: Iterator<Item = ()>`
+// where-bound over the `I::Intoiterator: Iterator<Item = I::Item>`
+// alias-bound.
+
+trait Iterator {
+    type Item;
+}
+
+trait IntoIterator {
+    type Item;
+    type IntoIter: Iterator<Item = Self::Item>;
+}
+
+fn normalize<I: Iterator<Item = ()>>() {}
+
+fn foo<I>()
+where
+    I: IntoIterator,
+    I::IntoIter: Iterator<Item = ()>,
+{
+    normalize::<I::IntoIter>();
+}
+
+fn main() {}


### PR DESCRIPTION
cc https://github.com/rust-lang/trait-system-refactor-initiative/issues/175 not the only issue affecting bevy sadly

r? @compiler-errors
