### PR TITLE
Fix some grammar errors and hyperlinks in doc for `trait Allocator`

### DIFF
--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -90,7 +90,7 @@ impl fmt::Display for AllocError {
 /// # Safety
 ///
 /// Memory blocks that are [*currently allocated*] by an allocator,
-/// must point to valid memory, and retain their validity while until either:
+/// must point to valid memory, and retain their validity until either:
 ///  - the memory block is deallocated, or
 ///  - the allocator is dropped.
 ///
@@ -112,7 +112,9 @@ pub unsafe trait Allocator {
     ///
     /// The returned block of memory remains valid as long as it is [*currently allocated*] and the shorter of:
     ///   - the borrow-checker lifetime of the allocator type itself.
-    ///   - as long as at the allocator and all its clones has not been dropped.
+    ///   - as long as the allocator and all its clones have not been dropped.
+    ///
+    /// [*currently allocated*]: #currently-allocated-memory
     ///
     /// # Errors
     ///


### PR DESCRIPTION
I was reading the allocator docs and noticed some weird sentences and missing hyperlink, so I fixed them and made this small PR.

* "while until either" could also be changed to "for a while until either", but I just deleted "while".
* fixed sentence with incorrect "at" and "has/have".
* linked [*currently allocated*] similar to other methods. All other hyperlinks are fine.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
