### PR TITLE
use `realpath` in `bootstrap.py` when creating build-dir

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1298,7 +1298,7 @@ def bootstrap(args):
     build.check_vendored_status()
 
     if not os.path.exists(build.build_dir):
-        os.makedirs(build.build_dir)
+        os.makedirs(os.path.realpath(build.build_dir))
 
     # Fetch/build the bootstrap
     build.download_toolchain()


### PR DESCRIPTION
Fixes #139800
r? @jieyouxu 

My use case for `./build` being a symlink is this: my "default" ~~partition~~ btrfs subvolume is snapshotted/backed up. I don't want to backup target-likes, so I move them to a special subvolume which isn't backed up. `./build` is a symlink into that subvolume. (`build.build-dir` configuration is not fully sufficient, it is still nice to be able to check build files with `ls ./build` or call tools from there)