### PR TITLE
Don't warn about `v128` in wasm ABI transition

### DIFF
--- a/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
+++ b/compiler/rustc_monomorphize/src/mono_checks/abi_check.rs
@@ -99,6 +99,12 @@ fn wasm_abi_safe<'tcx>(tcx: TyCtxt<'tcx>, arg: &ArgAbi<'tcx, Ty<'tcx>>) -> bool 
         return true;
     }
 
+    // Both the old and the new ABIs treat vector types like `v128` the same
+    // way.
+    if uses_vector_registers(&arg.mode, &arg.layout.backend_repr) {
+        return true;
+    }
+
     // This matches `unwrap_trivial_aggregate` in the wasm ABI logic.
     if arg.layout.is_aggregate() {
         let cx = LayoutCx::new(tcx, TypingEnv::fully_monomorphized());

--- a/tests/ui/lint/wasm_c_abi_transition.rs
+++ b/tests/ui/lint/wasm_c_abi_transition.rs
@@ -3,7 +3,7 @@
 //@ add-core-stubs
 //@ build-fail
 
-#![feature(no_core)]
+#![feature(no_core, repr_simd)]
 #![no_core]
 #![crate_type = "lib"]
 #![deny(wasm_c_abi)]
@@ -45,3 +45,13 @@ pub fn call_other_fun(x: MyType) {
 pub struct MyZstType;
 #[allow(improper_ctypes_definitions)]
 pub extern "C" fn zst_safe(_x: (), _y: MyZstType) {}
+
+// The old and new wasm ABI treats simd types like `v128` the same way, so no
+// wasm_c_abi warning should be emitted.
+#[repr(simd)]
+#[allow(non_camel_case_types)]
+pub struct v128([i32; 4]);
+#[target_feature(enable = "simd128")]
+pub extern "C" fn my_safe_simd(x: v128) -> v128 { x }
+//~^ WARN `extern` fn uses type `v128`, which is not FFI-safe
+//~| WARN `extern` fn uses type `v128`, which is not FFI-safe

--- a/tests/ui/lint/wasm_c_abi_transition.stderr
+++ b/tests/ui/lint/wasm_c_abi_transition.stderr
@@ -1,3 +1,32 @@
+warning: `extern` fn uses type `v128`, which is not FFI-safe
+  --> $DIR/wasm_c_abi_transition.rs:55:35
+   |
+LL | pub extern "C" fn my_safe_simd(x: v128) -> v128 { x }
+   |                                   ^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/wasm_c_abi_transition.rs:53:1
+   |
+LL | pub struct v128([i32; 4]);
+   | ^^^^^^^^^^^^^^^
+   = note: `#[warn(improper_ctypes_definitions)]` on by default
+
+warning: `extern` fn uses type `v128`, which is not FFI-safe
+  --> $DIR/wasm_c_abi_transition.rs:55:44
+   |
+LL | pub extern "C" fn my_safe_simd(x: v128) -> v128 { x }
+   |                                            ^^^^ not FFI-safe
+   |
+   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
+   = note: this struct has unspecified layout
+note: the type is defined here
+  --> $DIR/wasm_c_abi_transition.rs:53:1
+   |
+LL | pub struct v128([i32; 4]);
+   | ^^^^^^^^^^^^^^^
+
 error: this function definition involves an argument of type `MyType` which is affected by the wasm ABI transition
   --> $DIR/wasm_c_abi_transition.rs:18:1
    |
@@ -33,7 +62,7 @@ LL |     unsafe { other_fun(x) }
    = note: for more information, see issue #138762 <https://github.com/rust-lang/rust/issues/138762>
    = help: the "C" ABI Rust uses on wasm32-unknown-unknown will change to align with the standard "C" ABI for this target
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 2 warnings emitted
 
 Future incompatibility report: Future breakage diagnostic:
 error: this function definition involves an argument of type `MyType` which is affected by the wasm ABI transition


### PR DESCRIPTION
The `-Zwasm-c-abi=spec` mode of `extern "C"` does not actually change the meaning of `v128`  meaning that the FCW lint firing is a false positive. 

cc https://github.com/rust-lang/rust/issues/138762#issuecomment-2801709483