### PR TITLE
rustdoc: on mobile, make the sidebar full width and linewrap

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2527,9 +2527,12 @@ in src-script.js and main.js
 		z-index: 11;
 		/* Reduce height slightly to account for mobile topbar. */
 		height: calc(100vh - 45px);
-		width: 200px;
 		/* resize indicator: hide this when on touch or mobile */
 		border-right: none;
+		width: 100%;
+	}
+	.sidebar-elems .block li a {
+		white-space: wrap;
 	}
 
 	/* The source view uses a different design for the sidebar toggle, and doesn't have a topbar,

--- a/tests/rustdoc-gui/notable-trait.goml
+++ b/tests/rustdoc-gui/notable-trait.goml
@@ -244,10 +244,6 @@ click: ".sidebar-menu-toggle"
 assert: "//*[@class='sidebar shown']"
 assert-count: ("//*[@class='tooltip popover']", 0)
 assert-false: "#method\.create_an_iterator_from_read .tooltip:focus"
-// Clicking a notable trait tooltip popover should close the sidebar.
-click: "//*[@id='method.create_an_iterator_from_read']//*[@class='tooltip']"
-assert-count: ("//*[@class='tooltip popover']", 1)
-assert-false: "//*[@class='sidebar shown']"
 
 // Also check the focus handling for the settings button.
 set-window-size: (1100, 600)

--- a/tests/rustdoc-gui/pocket-menu.goml
+++ b/tests/rustdoc-gui/pocket-menu.goml
@@ -68,16 +68,3 @@ assert-css: ("#settings-menu .popover", {"display": "block"})
 click: ".sidebar-menu-toggle"
 assert: "//*[@class='sidebar shown']"
 assert-css: ("#settings-menu .popover", {"display": "none"})
-// Opening the settings popover should close the sidebar.
-click: "#settings-menu a"
-assert-css: ("#settings-menu .popover", {"display": "block"})
-assert-false: "//*[@class='sidebar shown']"
-
-// Opening the settings popover at start (which async loads stuff) should also close.
-reload:
-click: ".sidebar-menu-toggle"
-assert: "//*[@class='sidebar shown']"
-assert-false: "#settings-menu .popover"
-click: "#settings-menu a"
-assert-false: "//*[@class='sidebar shown']"
-wait-for: "#settings-menu .popover"

--- a/tests/rustdoc-gui/sidebar-mobile.goml
+++ b/tests/rustdoc-gui/sidebar-mobile.goml
@@ -32,8 +32,8 @@ assert-css: (
     {"display": "block"}
 )
 
-// Click elsewhere.
-click: "body"
+// Click the toggle to close it
+click: ".sidebar-menu-toggle"
 assert-css: (".sidebar", {"display": "block", "left": "-1000px"})
 
 // Open the sidebar menu, and make sure pressing Escape closes it.
@@ -57,6 +57,7 @@ scroll-to: ".block.keyword li:nth-child(1)"
 compare-elements-position-near: (".block.keyword li:nth-child(1)", ".mobile-topbar", {"y": 544})
 
 // Now checking the background color of the sidebar.
+reload:
 show-text: true
 
 define-function: (
@@ -72,6 +73,8 @@ define-function: (
             "background-color": |background|,
             "color": |color|,
         })
+        // Close the sidebar menu.
+        press-key: "Escape"
     },
 )
 

--- a/tests/rustdoc-gui/sidebar-mobile.goml
+++ b/tests/rustdoc-gui/sidebar-mobile.goml
@@ -57,7 +57,8 @@ scroll-to: ".block.keyword li:nth-child(1)"
 compare-elements-position-near: (".block.keyword li:nth-child(1)", ".mobile-topbar", {"y": 544})
 
 // Now checking the background color of the sidebar.
-reload:
+// Close the sidebar menu.
+press-key: "Escape"
 show-text: true
 
 define-function: (
@@ -73,6 +74,8 @@ define-function: (
             "background-color": |background|,
             "color": |color|,
         })
+        // Make sure the sidebar is full width
+        compare-elements-size: (".sidebar", "body", ["width"])
         // Close the sidebar menu.
         press-key: "Escape"
     },


### PR DESCRIPTION
this is because the mobile sidebar cannot be resized, unlike on desktop.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
