### PR TITLE
Don't canonicalize crate paths

### DIFF
--- a/tests/run-make/crate-loading-multiple-candidates/crateresolve1-1.rs
+++ b/tests/run-make/crate-loading-multiple-candidates/crateresolve1-1.rs
@@ -1,0 +1,6 @@
+#![crate_name = "crateresolve1"]
+#![crate_type = "lib"]
+
+pub fn f() -> isize {
+    10
+}

--- a/tests/run-make/crate-loading-multiple-candidates/crateresolve1-2.rs
+++ b/tests/run-make/crate-loading-multiple-candidates/crateresolve1-2.rs
@@ -1,0 +1,6 @@
+#![crate_name = "crateresolve1"]
+#![crate_type = "lib"]
+
+pub fn f() -> isize {
+    20
+}

--- a/tests/run-make/crate-loading-multiple-candidates/multiple-candidates.rs
+++ b/tests/run-make/crate-loading-multiple-candidates/multiple-candidates.rs
@@ -1,0 +1,3 @@
+extern crate crateresolve1;
+
+fn main() {}

--- a/tests/run-make/crate-loading-multiple-candidates/multiple-candidates.stderr
+++ b/tests/run-make/crate-loading-multiple-candidates/multiple-candidates.stderr
@@ -1,0 +1,12 @@
+error[E0464]: multiple candidates for `rlib` dependency `crateresolve1` found
+  --> multiple-candidates.rs:1:1
+   |
+LL | extern crate crateresolve1;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: candidate #1: ./mylibs/libcrateresolve1-1.rlib
+   = note: candidate #2: ./mylibs/libcrateresolve1-2.rlib
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0464`.

--- a/tests/run-make/crate-loading-multiple-candidates/rmake.rs
+++ b/tests/run-make/crate-loading-multiple-candidates/rmake.rs
@@ -1,0 +1,34 @@
+//@ needs-symlink
+//@ ignore-cross-compile
+
+// Tests that the multiple candidate dependencies diagnostic prints relative
+// paths if a relative library path was passed in.
+
+use run_make_support::{bare_rustc, diff, rfs, rustc};
+
+fn main() {
+    // Check that relative paths are preserved in the diagnostic
+    rfs::create_dir("mylibs");
+    rustc().input("crateresolve1-1.rs").out_dir("mylibs").extra_filename("-1").run();
+    rustc().input("crateresolve1-2.rs").out_dir("mylibs").extra_filename("-2").run();
+    check("./mylibs");
+
+    // Check that symlinks aren't followed when printing the diagnostic
+    rfs::rename("mylibs", "original");
+    rfs::symlink_dir("original", "mylibs");
+    check("./mylibs");
+}
+
+fn check(library_path: &str) {
+    let out = rustc()
+        .input("multiple-candidates.rs")
+        .library_search_path(library_path)
+        .ui_testing()
+        .run_fail()
+        .stderr_utf8();
+    diff()
+        .expected_file("multiple-candidates.stderr")
+        .normalize(r"\\", "/")
+        .actual_text("(rustc)", &out)
+        .run();
+}


### PR DESCRIPTION
When printing paths in diagnostic we should favour printing the paths that were passed in rather than resolving all symlinks.

This PR changes the form of the crate path but it should only really affect diagnostics as filesystem functions won't care which path is used. The uncanonicalized path was already used as a fallback for when canonicalization failed.

This is a partial alternative to #139823.