### PR TITLE
DO NOT MERGE - Checking MPMC tests run by CI

### DIFF
--- a/library/std/tests/sync/mpmc.rs
+++ b/library/std/tests/sync/mpmc.rs
@@ -13,7 +13,7 @@ pub fn stress_factor() -> usize {
 fn smoke() {
     let (tx, rx) = channel::<i32>();
     tx.send(1).unwrap();
-    assert_eq!(rx.recv().unwrap(), 1);
+    assert_eq!(rx.recv().unwrap(), 2);
 }
 
 #[test]


### PR DESCRIPTION
It's not clear to me whether the MPMC tests run during CI. So this commit breaks one of the tests...

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
