### PR TITLE
Delegate to inner `vec::IntoIter` from `env::ArgsOs`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -301,6 +301,8 @@
 #![feature(formatting_options)]
 #![feature(if_let_guard)]
 #![feature(intra_doc_pointers)]
+#![feature(iter_advance_by)]
+#![feature(iter_next_chunk)]
 #![feature(lang_items)]
 #![feature(let_chains)]
 #![feature(link_cfg)]
@@ -321,6 +323,7 @@
 #![feature(strict_provenance_lints)]
 #![feature(thread_local)]
 #![feature(try_blocks)]
+#![feature(try_trait_v2)]
 #![feature(type_alias_impl_trait)]
 // tidy-alphabetical-end
 //

--- a/library/std/src/sys/args/common.rs
+++ b/library/std/src/sys/args/common.rs
@@ -1,5 +1,7 @@
 use crate::ffi::OsString;
-use crate::{fmt, vec};
+use crate::num::NonZero;
+use crate::ops::Try;
+use crate::{array, fmt, vec};
 
 pub struct Args {
     iter: vec::IntoIter<OsString>,
@@ -9,6 +11,7 @@ impl !Send for Args {}
 impl !Sync for Args {}
 
 impl Args {
+    #[inline]
     pub(super) fn new(args: Vec<OsString>) -> Self {
         Args { iter: args.into_iter() }
     }
@@ -22,22 +25,77 @@ impl fmt::Debug for Args {
 
 impl Iterator for Args {
     type Item = OsString;
+
+    #[inline]
     fn next(&mut self) -> Option<OsString> {
         self.iter.next()
     }
+
+    #[inline]
+    fn next_chunk<const N: usize>(
+        &mut self,
+    ) -> Result<[OsString; N], array::IntoIter<OsString, N>> {
+        self.iter.next_chunk()
+    }
+
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
-}
 
-impl ExactSizeIterator for Args {
-    fn len(&self) -> usize {
+    #[inline]
+    fn count(self) -> usize {
         self.iter.len()
+    }
+
+    #[inline]
+    fn last(mut self) -> Option<OsString> {
+        self.iter.next_back()
+    }
+
+    #[inline]
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        self.iter.advance_by(n)
+    }
+
+    #[inline]
+    fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
+    where
+        F: FnMut(B, Self::Item) -> R,
+        R: Try<Output = B>,
+    {
+        self.iter.try_fold(init, f)
+    }
+
+    #[inline]
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, f)
     }
 }
 
 impl DoubleEndedIterator for Args {
+    #[inline]
     fn next_back(&mut self) -> Option<OsString> {
         self.iter.next_back()
+    }
+
+    #[inline]
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        self.iter.advance_back_by(n)
+    }
+}
+
+impl ExactSizeIterator for Args {
+    #[inline]
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.iter.is_empty()
     }
 }

--- a/library/std/src/sys/args/unsupported.rs
+++ b/library/std/src/sys/args/unsupported.rs
@@ -15,22 +15,28 @@ impl fmt::Debug for Args {
 
 impl Iterator for Args {
     type Item = OsString;
+
+    #[inline]
     fn next(&mut self) -> Option<OsString> {
         None
     }
+
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, Some(0))
     }
 }
 
-impl ExactSizeIterator for Args {
-    fn len(&self) -> usize {
-        0
+impl DoubleEndedIterator for Args {
+    #[inline]
+    fn next_back(&mut self) -> Option<OsString> {
+        None
     }
 }
 
-impl DoubleEndedIterator for Args {
-    fn next_back(&mut self) -> Option<OsString> {
-        None
+impl ExactSizeIterator for Args {
+    #[inline]
+    fn len(&self) -> usize {
+        0
     }
 }


### PR DESCRIPTION
Delegate from `std::env::ArgsOs` to the methods of the inner platform-specific iterators, when it would be more efficient than just using the default methods of its own impl. Most platforms use `vec::IntoIter` as the inner type, so prioritize delegating to the methods it provides.

`std::env::Args` is implemented atop `std::env::ArgsOs` and performs UTF-8 validation with a panic for invalid data. This is a visible effect which users certainly rely on, so we can't skip any arguments. Any further iterator methods would skip some elements, so no change is needed for that type.

Add `#[inline]` for any methods which simply wrap the inner iterator.