### PR TITLE
Hide unstable print kinds within emit_unknown_print_request_help in stable channel

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2069,7 +2069,8 @@ fn collect_print_requests(
             check_print_request_stability(early_dcx, unstable_opts, (print_name, *print_kind));
             *print_kind
         } else {
-            emit_unknown_print_request_help(early_dcx, req)
+            let is_nightly = nightly_options::match_is_nightly_build(matches);
+            emit_unknown_print_request_help(early_dcx, req, is_nightly)
         };
 
         let out = out.unwrap_or(OutFileName::Stdout);
@@ -2093,25 +2094,37 @@ fn check_print_request_stability(
     unstable_opts: &UnstableOptions,
     (print_name, print_kind): (&str, PrintKind),
 ) {
+    if !is_print_request_stable(print_kind) && !unstable_opts.unstable_options {
+        early_dcx.early_fatal(format!(
+            "the `-Z unstable-options` flag must also be passed to enable the `{print_name}` \
+                print option"
+        ));
+    }
+}
+
+fn is_print_request_stable(print_kind: PrintKind) -> bool {
     match print_kind {
         PrintKind::AllTargetSpecsJson
         | PrintKind::CheckCfg
         | PrintKind::CrateRootLintLevels
         | PrintKind::SupportedCrateTypes
-        | PrintKind::TargetSpecJson
-            if !unstable_opts.unstable_options =>
-        {
-            early_dcx.early_fatal(format!(
-                "the `-Z unstable-options` flag must also be passed to enable the `{print_name}` \
-                print option"
-            ));
-        }
-        _ => {}
+        | PrintKind::TargetSpecJson => false,
+        _ => true,
     }
 }
 
-fn emit_unknown_print_request_help(early_dcx: &EarlyDiagCtxt, req: &str) -> ! {
-    let prints = PRINT_KINDS.iter().map(|(name, _)| format!("`{name}`")).collect::<Vec<_>>();
+fn emit_unknown_print_request_help(early_dcx: &EarlyDiagCtxt, req: &str, is_nightly: bool) -> ! {
+    let prints = PRINT_KINDS
+        .iter()
+        .filter_map(|(name, kind)| {
+            // If we're not on nightly, we don't want to print unstable options
+            if !is_nightly && !is_print_request_stable(*kind) {
+                None
+            } else {
+                Some(format!("`{name}`"))
+            }
+        })
+        .collect::<Vec<_>>();
     let prints = prints.join(", ");
 
     let mut diag = early_dcx.early_struct_fatal(format!("unknown print request: `{req}`"));

--- a/tests/run-make/print-request-help-stable-unstable/help-diff.diff
+++ b/tests/run-make/print-request-help-stable-unstable/help-diff.diff
@@ -1,0 +1,7 @@
+@@ -1,5 +1,5 @@
+ error: unknown print request: `xxx`
+   |
+-  = help: valid print requests are: `calling-conventions`, `cfg`, `code-models`, `crate-name`, `deployment-target`, `file-names`, `host-tuple`, `link-args`, `native-static-libs`, `relocation-models`, `split-debuginfo`, `stack-protector-strategies`, `sysroot`, `target-cpus`, `target-features`, `target-libdir`, `target-list`, `tls-models`
++  = help: valid print requests are: `all-target-specs-json`, `calling-conventions`, `cfg`, `check-cfg`, `code-models`, `crate-name`, `crate-root-lint-levels`, `deployment-target`, `file-names`, `host-tuple`, `link-args`, `native-static-libs`, `relocation-models`, `split-debuginfo`, `stack-protector-strategies`, `supported-crate-types`, `sysroot`, `target-cpus`, `target-features`, `target-libdir`, `target-list`, `target-spec-json`, `tls-models`
+   = help: for more information, see the rustc book: https://doc.rust-lang.org/rustc/command-line-arguments.html#--print-print-compiler-information
+ 

--- a/tests/run-make/print-request-help-stable-unstable/rmake.rs
+++ b/tests/run-make/print-request-help-stable-unstable/rmake.rs
@@ -1,0 +1,33 @@
+//! Check that unstable print requests are omitted from help if compiler is in stable channel.
+//!
+//! Issue: <https://github.com/rust-lang/rust/issues/138698>
+use run_make_support::{diff, rustc, similar};
+
+fn main() {
+    let stable_invalid_print_request_help = rustc()
+        .env("RUSTC_BOOTSTRAP", "-1")
+        .cfg("force_stable")
+        .print("xxx")
+        .run_fail()
+        .stderr_utf8();
+    assert!(!stable_invalid_print_request_help.contains("all-target-specs-json"));
+    diff()
+        .expected_file("stable-invalid-print-request-help.err")
+        .actual_text("stable_invalid_print_request_help", &stable_invalid_print_request_help)
+        .run();
+
+    let unstable_invalid_print_request_help = rustc().print("xxx").run_fail().stderr_utf8();
+    assert!(unstable_invalid_print_request_help.contains("all-target-specs-json"));
+    diff()
+        .expected_file("unstable-invalid-print-request-help.err")
+        .actual_text("unstable_invalid_print_request_help", &unstable_invalid_print_request_help)
+        .run();
+
+    let help_diff = similar::TextDiff::from_lines(
+        &stable_invalid_print_request_help,
+        &unstable_invalid_print_request_help,
+    )
+    .unified_diff()
+    .to_string();
+    diff().expected_file("help-diff.diff").actual_text("help_diff", help_diff).run();
+}

--- a/tests/run-make/print-request-help-stable-unstable/stable-invalid-print-request-help.err
+++ b/tests/run-make/print-request-help-stable-unstable/stable-invalid-print-request-help.err
@@ -1,0 +1,5 @@
+error: unknown print request: `xxx`
+  |
+  = help: valid print requests are: `calling-conventions`, `cfg`, `code-models`, `crate-name`, `deployment-target`, `file-names`, `host-tuple`, `link-args`, `native-static-libs`, `relocation-models`, `split-debuginfo`, `stack-protector-strategies`, `sysroot`, `target-cpus`, `target-features`, `target-libdir`, `target-list`, `tls-models`
+  = help: for more information, see the rustc book: https://doc.rust-lang.org/rustc/command-line-arguments.html#--print-print-compiler-information
+

--- a/tests/run-make/print-request-help-stable-unstable/unstable-invalid-print-request-help.err
+++ b/tests/run-make/print-request-help-stable-unstable/unstable-invalid-print-request-help.err
@@ -1,0 +1,5 @@
+error: unknown print request: `xxx`
+  |
+  = help: valid print requests are: `all-target-specs-json`, `calling-conventions`, `cfg`, `check-cfg`, `code-models`, `crate-name`, `crate-root-lint-levels`, `deployment-target`, `file-names`, `host-tuple`, `link-args`, `native-static-libs`, `relocation-models`, `split-debuginfo`, `stack-protector-strategies`, `supported-crate-types`, `sysroot`, `target-cpus`, `target-features`, `target-libdir`, `target-list`, `target-spec-json`, `tls-models`
+  = help: for more information, see the rustc book: https://doc.rust-lang.org/rustc/command-line-arguments.html#--print-print-compiler-information
+


### PR DESCRIPTION
Fixes #138698 

We need to get the channel from `matches`. However, since `matches`(Line 1169) is constructed after `rustc_optgroups` (Line1165, where `RustcOptGroup::value_hint` is generated, i.e. what `rustc --print print` prints), I've left it unchanged here for now.

https://github.com/rust-lang/rust/blob/2da29dbe8fe23df1c7c4ab1d8740ca3c32b15526/compiler/rustc_driver_impl/src/lib.rs#L1161-L1169


There is actually a way to manually parse the `--crate-name` parameter, but I'm afraid that's an unorthodox practice. So I conservatively just modified `emit_unknown_print_request_help` to print different parameters depending on whether they are nightly or not when passing the error parameter.

r? @jieyouxu 