### PR TITLE
Fix Box's doc for aliasing rules

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1011,6 +1011,8 @@ impl<T: ?Sized> Box<T> {
     /// function is called twice on the same raw pointer.
     ///
     /// The raw pointer must point to a block of memory allocated by the global allocator.
+    /// And you should enforce the aliasing rule by ensuring nothing else uses the
+    /// raw pointer after calling this function.
     ///
     /// The safety conditions are described in the [memory layout] section.
     ///
@@ -1060,6 +1062,8 @@ impl<T: ?Sized> Box<T> {
     /// function is called twice on the same `NonNull` pointer.
     ///
     /// The non-null pointer must point to a block of memory allocated by the global allocator.
+    /// And you should enforce the aliasing rule by ensuring nothing else uses the
+    /// non-null pointer after calling this function.
     ///
     /// The safety conditions are described in the [memory layout] section.
     ///
@@ -1116,6 +1120,8 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// function is called twice on the same raw pointer.
     ///
     /// The raw pointer must point to a block of memory allocated by `alloc`.
+    /// If the `alloc` is a global allocator, you should enforce the aliasing rule
+    /// by ensuring nothing else uses the raw pointer after calling this function.
     ///
     /// # Examples
     ///
@@ -1169,6 +1175,8 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// function is called twice on the same raw pointer.
     ///
     /// The non-null pointer must point to a block of memory allocated by `alloc`.
+    /// If the `alloc` is a global allocator, you should enforce the aliasing rule
+    /// by ensuring nothing else uses the non-null pointer after calling this function.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
We noticed there are four spots in `Box`'s documentation where the safety notes are incomplete. According to Rust's stacked borrows rules, when APIs like `from_raw` take ownership of a pointer's memory, that original pointer shouldn't be touched anymore. Other similar APIs make this clear, like [Vec::from_raw_parts](https://doc.rust-lang.org/nightly/alloc/vec/struct.Vec.html#method.from_raw_parts) specifically says:

```
The ownership of ptr is effectively transferred to the Vec<T> which may then deallocate, 
reallocate or change the contents of memory pointed to by the pointer at will. 
Ensure that nothing else uses the pointer after calling this function.
```

But Box's docs are currently missing this important warning.