### PR TITLE
Stabilize proc_macro::Span::{start,end,line,column}.

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -513,13 +513,13 @@ impl Span {
     }
 
     /// Creates an empty span pointing to directly before this span.
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[stable(feature = "proc_macro_span_location", since = "CURRENT_RUSTC_VERSION")]
     pub fn start(&self) -> Span {
         Span(self.0.start())
     }
 
     /// Creates an empty span pointing to directly after this span.
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[stable(feature = "proc_macro_span_location", since = "CURRENT_RUSTC_VERSION")]
     pub fn end(&self) -> Span {
         Span(self.0.end())
     }
@@ -527,7 +527,7 @@ impl Span {
     /// The one-indexed line of the source file where the span starts.
     ///
     /// To obtain the line of the span's end, use `span.end().line()`.
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[stable(feature = "proc_macro_span_location", since = "CURRENT_RUSTC_VERSION")]
     pub fn line(&self) -> usize {
         self.0.line()
     }
@@ -535,7 +535,7 @@ impl Span {
     /// The one-indexed column of the source file where the span starts.
     ///
     /// To obtain the column of the span's end, use `span.end().column()`.
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[stable(feature = "proc_macro_span_location", since = "CURRENT_RUSTC_VERSION")]
     pub fn column(&self) -> usize {
         self.0.column()
     }


### PR DESCRIPTION
This stabilizes part of https://github.com/rust-lang/rust/issues/54725

Specifically, the part related to getting the location of a span:

```rust
impl Span {
    pub fn start(&self) -> Span; // Empty span at the start of this span
    pub fn end(&self) -> Span; // Empty span at the end of this span

    pub fn line(&self) -> usize; // Line where the span starts
    pub fn column(&self) -> usize; // Column where the span starts
}
```

History of this part of the API:

Originally, `start` and `end` returned a `LineColumn` struct (containing the line and column).

This has been simplified/changed:

- No more `LineColumn`: `Span` now directly has `.line()` and `.column()` methods. This means we can easily add `.byte_offset()` or `.byte_range()` in the future if we want to.
- `Span::start()` and `Span::end()` are now the equivalent of rustc's internal `shrink_to_lo()` and `shrink_to_hi()`. This means you can do e.g. `span.end().column()`, removing the need for a `span.end_column()` or similar.