### PR TITLE
Add warning comment to `Take::get_ref` and `Chain::get_ref`

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2658,6 +2658,10 @@ impl<T, U> Chain<T, U> {
 
     /// Gets references to the underlying readers in this `Chain`.
     ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying readers as doing so may corrupt the internal state of this
+    /// `Chain`.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -2914,6 +2918,10 @@ impl<T> Take<T> {
     }
 
     /// Gets a reference to the underlying reader.
+    ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying reader as doing so may corrupt the internal limit of this
+    /// `Take`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The methods `Take::get_mut` and `Chain::get_mut` include comments
warning about modifying the I/O state of the underlying reader. However,
many readers (e.g. `File`) allow I/O using a shared reference (e.g.
`&File`). So, add the same caveat to the `get_ref` methods.
