### PR TITLE
Don't compute name of associated item if it's an RPITIT

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -204,8 +204,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             .iter()
             .flat_map(|trait_def_id| tcx.associated_items(*trait_def_id).in_definition_order())
             .filter_map(|item| {
-                (!item.is_impl_trait_in_trait() && item.as_tag() == assoc_tag)
-                    .then_some(item.name())
+                (!item.is_impl_trait_in_trait() && item.as_tag() == assoc_tag).then(|| item.name())
             })
             .collect();
 

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name.rs
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name.rs
@@ -1,0 +1,12 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/139873>.
+
+// Test that we don't try to get the (nonexistent) name of the RPITIT in `Trait::foo`
+// when emitting an error for a missing associated item `Trait::Output`.
+
+trait Trait {
+    fn foo() -> impl Sized;
+    fn bar() -> Self::Output;
+    //~^ ERROR associated type `Output` not found for `Self`
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name.stderr
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name.stderr
@@ -1,0 +1,9 @@
+error[E0220]: associated type `Output` not found for `Self`
+  --> $DIR/dont-probe-missing-item-name.rs:8:23
+   |
+LL |     fn bar() -> Self::Output;
+   |                       ^^^^^^ associated type `Output` not found
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0220`.


### PR DESCRIPTION
Use `Option::then` in favor of `Option::then_some` to not compute `AssocItem::name` if it fails the condition. Alternatively, I'd be open to changing this just to an `if`.

Fixes https://github.com/rust-lang/rust/issues/139873

r? @nnethercote 