### PR TITLE
Add test for issue 125668

### DIFF
--- a/tests/ui/consts/const-blocks/const-block-in-array-size.rs
+++ b/tests/ui/consts/const-blocks/const-block-in-array-size.rs
@@ -1,0 +1,5 @@
+//@ check-pass
+
+type A = [u32; const { 2 }];
+
+fn main() {}


### PR DESCRIPTION
closes: #125668 

The issue stemmed from improper handling of const {} blocks used in array length expressions. As of rustc 1.80.0-nightly (804421dff 2024-06-07), this ICE no longer occurs and the code compiles successfully 😀