### PR TITLE
Change proc_macro::Span::byte_range -> byte_offset.

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -1,4 +1,4 @@
-use std::ops::{Bound, Range};
+use std::ops::Bound;
 
 use ast::token::IdentIsRaw;
 use pm::bridge::{
@@ -704,14 +704,12 @@ impl server::Span for Rustc<'_, '_> {
         span.source_callsite()
     }
 
-    fn byte_range(&mut self, span: Self::Span) -> Range<usize> {
+    fn byte_offset(&mut self, span: Self::Span) -> usize {
         let source_map = self.psess().source_map();
 
-        let relative_start_pos = source_map.lookup_byte_offset(span.lo()).pos;
-        let relative_end_pos = source_map.lookup_byte_offset(span.hi()).pos;
-
-        Range { start: relative_start_pos.0 as usize, end: relative_end_pos.0 as usize }
+        source_map.lookup_byte_offset(span.lo()).pos.0 as usize
     }
+
     fn start(&mut self, span: Self::Span) -> Self::Span {
         span.shrink_to_lo()
     }

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -12,7 +12,7 @@
 #![allow(wasm_c_abi)]
 
 use std::hash::Hash;
-use std::ops::{Bound, Range};
+use std::ops::Bound;
 use std::sync::Once;
 use std::{fmt, marker, mem, panic, thread};
 
@@ -85,7 +85,7 @@ macro_rules! with_api {
                 fn debug($self: $S::Span) -> String;
                 fn parent($self: $S::Span) -> Option<$S::Span>;
                 fn source($self: $S::Span) -> $S::Span;
-                fn byte_range($self: $S::Span) -> Range<usize>;
+                fn byte_offset($self: $S::Span) -> usize;
                 fn start($self: $S::Span) -> $S::Span;
                 fn end($self: $S::Span) -> $S::Span;
                 fn line($self: $S::Span) -> usize;
@@ -533,8 +533,4 @@ pub struct ExpnGlobals<Span> {
 
 compound_traits!(
     struct ExpnGlobals<Span> { def_site, call_site, mixed_site }
-);
-
-compound_traits!(
-    struct Range<T> { start, end }
 );

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -45,7 +45,7 @@ mod escape;
 mod to_tokens;
 
 use std::ffi::CStr;
-use std::ops::{Range, RangeBounds};
+use std::ops::RangeBounds;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::{error, fmt};
@@ -506,12 +506,6 @@ impl Span {
         Span(self.0.source())
     }
 
-    /// Returns the span's byte position range in the source file.
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
-    pub fn byte_range(&self) -> Range<usize> {
-        self.0.byte_range()
-    }
-
     /// Creates an empty span pointing to directly before this span.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn start(&self) -> Span {
@@ -538,6 +532,14 @@ impl Span {
     #[unstable(feature = "proc_macro_span", issue = "54725")]
     pub fn column(&self) -> usize {
         self.0.column()
+    }
+
+    /// The span's byte position in the source file.
+    ///
+    /// To obtain the byte position of the end of the span, use `span.end().byte_offset()`.
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    pub fn byte_offset(&self) -> usize {
+        self.0.byte_offset()
     }
 
     /// The path to the source file in which this span occurs, for display purposes.

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/rust_analyzer_span.rs
@@ -6,7 +6,7 @@
 //! change their representation to be compatible with rust-analyzer's.
 use std::{
     collections::{HashMap, HashSet},
-    ops::{Bound, Range},
+    ops::Bound,
 };
 
 use intern::Symbol;
@@ -281,10 +281,6 @@ impl server::Span for RaSpanServer {
         // FIXME requires db, returns the top level call site
         span
     }
-    fn byte_range(&mut self, span: Self::Span) -> Range<usize> {
-        // FIXME requires db to resolve the ast id, THIS IS NOT INCREMENTAL
-        Range { start: span.range.start().into(), end: span.range.end().into() }
-    }
     fn join(&mut self, first: Self::Span, second: Self::Span) -> Option<Self::Span> {
         // We can't modify the span range for fixup spans, those are meaningful to fixup, so just
         // prefer the non-fixup span.
@@ -385,6 +381,10 @@ impl server::Span for RaSpanServer {
     fn column(&mut self, _span: Self::Span) -> usize {
         // FIXME requires db to resolve line index, THIS IS NOT INCREMENTAL
         1
+    }
+    fn byte_offset(&mut self, span: Self::Span) -> usize {
+        // FIXME requires db to resolve the ast id, THIS IS NOT INCREMENTAL
+        span.range.start().into()
     }
 }
 

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/token_id.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/server_impl/token_id.rs
@@ -1,6 +1,6 @@
 //! proc-macro server backend based on [`proc_macro_api::msg::TokenId`] as the backing span.
 //! This backend is rather inflexible, used by RustRover and older rust-analyzer versions.
-use std::ops::{Bound, Range};
+use std::ops::Bound;
 
 use intern::Symbol;
 use proc_macro::bridge::{self, server};
@@ -250,9 +250,6 @@ impl server::Span for TokenIdServer {
     fn source(&mut self, span: Self::Span) -> Self::Span {
         span
     }
-    fn byte_range(&mut self, _span: Self::Span) -> Range<usize> {
-        Range { start: 0, end: 0 }
-    }
     fn join(&mut self, first: Self::Span, _second: Self::Span) -> Option<Self::Span> {
         // Just return the first span again, because some macros will unwrap the result.
         Some(first)
@@ -284,6 +281,10 @@ impl server::Span for TokenIdServer {
 
     fn column(&mut self, _span: Self::Span) -> usize {
         1
+    }
+
+    fn byte_offset(&mut self, _span: Self::Span) -> usize {
+        0
     }
 }
 


### PR DESCRIPTION
This is about #54725's open question on byte offsets:

Next to `span.line()` and `span.column()`, we also want a way to get the byte offset into the file.

We have basically two competing options to expose this:

## Option 1 (merge this PR)

```rust
impl Span {
    pub fn byte_offset(&self) -> usize;
}
```

This is consistent with the `line` and `column` methods on `Span`.
To get the offset of the end of the span, you use `span.end().byte_offset()`, just like how you use `span.end().column()` for the end column.

## Option 2 (close this PR)

```rust
impl Span {
    pub fn byte_range(&self) -> Range<usize>;
}
```

This gives you both ends of the range at once, and uses the `Range` type (which is usable to index a slice), but is arguably less consistent with the `line` and `column` methods.

---

Curious to hear what y'all think.

:+1: for option 1 (merge this PR)
:-1: for option 2 (close this PR)

(The decision is still up to the libs-api team. Votes are just useful as input, not as the final decision.)