### PR TITLE
do not emit `OpaqueCast` projections with `-Znext-solver`

### DIFF
--- a/compiler/rustc_middle/src/hir/place.rs
+++ b/compiler/rustc_middle/src/hir/place.rs
@@ -40,6 +40,8 @@ pub enum ProjectionKind {
 
     /// A conversion from an opaque type to its hidden type so we can
     /// do further projections on it.
+    ///
+    /// This is unused if `-Znext-solver` is enabled.
     OpaqueCast,
 }
 

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -1242,6 +1242,8 @@ pub enum ProjectionElem<V, T> {
 
     /// Like an explicit cast from an opaque type to a concrete type, but without
     /// requiring an intermediate variable.
+    ///
+    /// This is unused with `-Znext-solver`.
     OpaqueCast(T),
 
     /// A transmute from an unsafe binder to the type that it wraps. This is a projection

--- a/tests/ui/type-alias-impl-trait/cross_inference_pattern_bug_no_type.rs
+++ b/tests/ui/type-alias-impl-trait/cross_inference_pattern_bug_no_type.rs
@@ -1,6 +1,5 @@
 //@ compile-flags: --crate-type=lib
 //@ edition: 2021
-//@ rustc-env:RUST_BACKTRACE=0
 //@ check-pass
 
 // tracked in https://github.com/rust-lang/rust/issues/96572

--- a/tests/ui/type-alias-impl-trait/destructure_tait-ice-113594.rs
+++ b/tests/ui/type-alias-impl-trait/destructure_tait-ice-113594.rs
@@ -1,3 +1,5 @@
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
 //@ build-pass
 //@ edition: 2021
 

--- a/tests/ui/type-alias-impl-trait/tait-normalize.rs
+++ b/tests/ui/type-alias-impl-trait/tait-normalize.rs
@@ -1,3 +1,5 @@
+//@ revisions: current next
+//@ [next] compile-flags: -Znext-solver
 //@ check-pass
 
 #![feature(type_alias_impl_trait)]


### PR DESCRIPTION
We normalize opaque types in their defining scope if the new solver is enabled. This means projections do not contain any 'revealable' opaque types we need to worry about. We either have a type which has been normalized by writeback or we need to normalize it anyways.

r? @compiler-errors @oli-obk 