### PR TITLE
Explicitly annotate edition for `unpretty=expanded` and `unpretty=hir` tests

### DIFF
--- a/tests/ui/asm/unpretty-expanded.rs
+++ b/tests/ui/asm/unpretty-expanded.rs
@@ -1,4 +1,5 @@
 //@ needs-asm-support
 //@ check-pass
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 core::arch::global_asm!("x: .byte 42");

--- a/tests/ui/asm/unpretty-expanded.stdout
+++ b/tests/ui/asm/unpretty-expanded.stdout
@@ -7,4 +7,5 @@ extern crate std;
 //@ needs-asm-support
 //@ check-pass
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 global_asm! ("x: .byte 42");

--- a/tests/ui/codemap_tests/unicode.expanded.stdout
+++ b/tests/ui/codemap_tests/unicode.expanded.stdout
@@ -7,6 +7,7 @@ extern crate std;
 //@ revisions: normal expanded
 //@[expanded] check-pass
 //@[expanded]compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 
 extern "路濫狼á́́" fn foo() {}
 

--- a/tests/ui/codemap_tests/unicode.normal.stderr
+++ b/tests/ui/codemap_tests/unicode.normal.stderr
@@ -1,5 +1,5 @@
 error[E0703]: invalid ABI: found `路濫狼á́́`
-  --> $DIR/unicode.rs:5:8
+  --> $DIR/unicode.rs:6:8
    |
 LL | extern "路濫狼á́́" fn foo() {}
    |        ^^^^^^^^^ invalid ABI

--- a/tests/ui/codemap_tests/unicode.rs
+++ b/tests/ui/codemap_tests/unicode.rs
@@ -1,6 +1,7 @@
 //@ revisions: normal expanded
 //@[expanded] check-pass
 //@[expanded]compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 
 extern "路濫狼á́́" fn foo() {} //[normal]~ ERROR invalid ABI
 

--- a/tests/ui/const-generics/defaults/pretty-printing-ast.rs
+++ b/tests/ui/const-generics/defaults/pretty-printing-ast.rs
@@ -1,6 +1,7 @@
 // Test the AST pretty printer correctly handles default values for const generics
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
+//@ edition: 2015
 
 #![crate_type = "lib"]
 

--- a/tests/ui/const-generics/defaults/pretty-printing-ast.stdout
+++ b/tests/ui/const-generics/defaults/pretty-printing-ast.stdout
@@ -3,6 +3,7 @@
 // Test the AST pretty printer correctly handles default values for const generics
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
+//@ edition: 2015
 
 #![crate_type = "lib"]
 #[prelude_import]

--- a/tests/ui/deriving/built-in-proc-macro-scope.rs
+++ b/tests/ui/deriving/built-in-proc-macro-scope.rs
@@ -1,6 +1,7 @@
 //@ check-pass
 //@ proc-macro: another-proc-macro.rs
 //@ compile-flags: -Zunpretty=expanded
+//@ edition:2015
 
 #![feature(derive_coerce_pointee)]
 

--- a/tests/ui/deriving/built-in-proc-macro-scope.stdout
+++ b/tests/ui/deriving/built-in-proc-macro-scope.stdout
@@ -3,6 +3,7 @@
 //@ check-pass
 //@ proc-macro: another-proc-macro.rs
 //@ compile-flags: -Zunpretty=expanded
+//@ edition:2015
 
 #![feature(derive_coerce_pointee)]
 #[prelude_import]

--- a/tests/ui/deriving/deriving-coerce-pointee-expanded.rs
+++ b/tests/ui/deriving/deriving-coerce-pointee-expanded.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 #![feature(derive_coerce_pointee)]
 use std::marker::CoercePointee;
 

--- a/tests/ui/deriving/deriving-coerce-pointee-expanded.stdout
+++ b/tests/ui/deriving/deriving-coerce-pointee-expanded.stdout
@@ -2,6 +2,7 @@
 #![no_std]
 //@ check-pass
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 #![feature(derive_coerce_pointee)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;

--- a/tests/ui/deriving/proc-macro-attribute-mixing.rs
+++ b/tests/ui/deriving/proc-macro-attribute-mixing.rs
@@ -7,6 +7,7 @@
 //@ check-pass
 //@ proc-macro: another-proc-macro.rs
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 
 #![feature(derive_coerce_pointee)]
 

--- a/tests/ui/deriving/proc-macro-attribute-mixing.stdout
+++ b/tests/ui/deriving/proc-macro-attribute-mixing.stdout
@@ -9,6 +9,7 @@
 //@ check-pass
 //@ proc-macro: another-proc-macro.rs
 //@ compile-flags: -Zunpretty=expanded
+//@ edition: 2015
 
 #![feature(derive_coerce_pointee)]
 #[prelude_import]

--- a/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.rs
@@ -1,6 +1,7 @@
 // This ensures that ICEs like rust#94953 don't happen
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
+//@ edition: 2015
 
 // This `expect` will create an expectation with an unstable expectation id
 #[expect(while_true)]

--- a/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.stdout
+++ b/tests/ui/lint/rfc-2383-lint-reason/no_ice_for_partial_compiler_runs.stdout
@@ -7,6 +7,7 @@ extern crate std;
 // This ensures that ICEs like rust#94953 don't happen
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
+//@ edition: 2015
 
 // This `expect` will create an expectation with an unstable expectation id
 #[expect(while_true)]

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.rs
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.rs
@@ -1,4 +1,5 @@
 //@ compile-flags: -Zunpretty=hir
+//@ edition: 2015
 
 // issue#97006
 

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.stderr
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.stderr
@@ -1,5 +1,5 @@
 error: unexpected generic arguments in path
-  --> $DIR/genercs-in-path-with-prettry-hir.rs:12:10
+  --> $DIR/genercs-in-path-with-prettry-hir.rs:13:10
    |
 LL | m!(inline<u8>);
    |          ^^^^

--- a/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
+++ b/tests/ui/macros/genercs-in-path-with-prettry-hir.stdout
@@ -3,6 +3,7 @@ use ::std::prelude::rust_2015::*;
 #[macro_use]
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
+//@ edition: 2015
 
 // issue#97006
 

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/non-consuming-methods-have-optimized-codegen.rs
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/non-consuming-methods-have-optimized-codegen.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
+//@ edition: 2015
 
 #![feature(core_intrinsics, generic_assert)]
 

--- a/tests/ui/macros/rfc-2011-nicer-assert-messages/non-consuming-methods-have-optimized-codegen.stdout
+++ b/tests/ui/macros/rfc-2011-nicer-assert-messages/non-consuming-methods-have-optimized-codegen.stdout
@@ -2,6 +2,7 @@
 #![no_std]
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
+//@ edition: 2015
 
 #![feature(core_intrinsics, generic_assert)]
 #[prelude_import]

--- a/tests/ui/match/issue-82392.rs
+++ b/tests/ui/match/issue-82392.rs
@@ -1,6 +1,7 @@
 // https://github.com/rust-lang/rust/issues/82329
 //@ compile-flags: -Zunpretty=hir,typed
 //@ check-pass
+//@ edition:2015
 
 pub fn main() {
     if true {

--- a/tests/ui/match/issue-82392.stdout
+++ b/tests/ui/match/issue-82392.stdout
@@ -5,6 +5,7 @@ extern crate std;
 // https://github.com/rust-lang/rust/issues/82329
 //@ compile-flags: -Zunpretty=hir,typed
 //@ check-pass
+//@ edition:2015
 
 fn main() ({
     (if (true as bool)

--- a/tests/ui/proc-macro/nonterminal-token-hygiene.rs
+++ b/tests/ui/proc-macro/nonterminal-token-hygiene.rs
@@ -8,6 +8,7 @@
 //@ normalize-stdout: "expn\d{3,}" -> "expnNNN"
 //@ normalize-stdout: "extern crate compiler_builtins /\* \d+ \*/" -> "extern crate compiler_builtins /* NNN */"
 //@ proc-macro: test-macros.rs
+//@ edition: 2015
 
 #![feature(decl_macro)]
 #![no_std] // Don't load unnecessary hygiene information from std

--- a/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
+++ b/tests/ui/proc-macro/nonterminal-token-hygiene.stdout
@@ -5,19 +5,19 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
         stream: TokenStream [
             Ident {
                 ident: "struct",
-                span: $DIR/nonterminal-token-hygiene.rs:32:5: 32:11 (#5),
+                span: $DIR/nonterminal-token-hygiene.rs:33:5: 33:11 (#5),
             },
             Ident {
                 ident: "S",
-                span: $DIR/nonterminal-token-hygiene.rs:32:12: 32:13 (#5),
+                span: $DIR/nonterminal-token-hygiene.rs:33:12: 33:13 (#5),
             },
             Punct {
                 ch: ';',
                 spacing: Alone,
-                span: $DIR/nonterminal-token-hygiene.rs:32:13: 32:14 (#5),
+                span: $DIR/nonterminal-token-hygiene.rs:33:13: 33:14 (#5),
             },
         ],
-        span: $DIR/nonterminal-token-hygiene.rs:22:27: 22:32 (#4),
+        span: $DIR/nonterminal-token-hygiene.rs:23:27: 23:32 (#4),
     },
 ]
 #![feature /* 0#0 */(prelude_import)]
@@ -32,6 +32,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
 //@ normalize-stdout: "expn\d{3,}" -> "expnNNN"
 //@ normalize-stdout: "extern crate compiler_builtins /\* \d+ \*/" -> "extern crate compiler_builtins /* NNN */"
 //@ proc-macro: test-macros.rs
+//@ edition: 2015
 
 #![feature /* 0#0 */(decl_macro)]
 #![no_std /* 0#0 */]

--- a/tests/ui/proc-macro/quote/debug.rs
+++ b/tests/ui/proc-macro/quote/debug.rs
@@ -3,6 +3,7 @@
 //@ no-prefer-dynamic
 //@ compile-flags: -Z unpretty=expanded
 //@ needs-unwind compiling proc macros with panic=abort causes a warning
+//@ edition: 2015
 //
 // This file is not actually used as a proc-macro - instead,
 // it's just used to show the output of the `quote!` macro

--- a/tests/ui/proc-macro/quote/debug.stdout
+++ b/tests/ui/proc-macro/quote/debug.stdout
@@ -5,6 +5,7 @@
 //@ no-prefer-dynamic
 //@ compile-flags: -Z unpretty=expanded
 //@ needs-unwind compiling proc macros with panic=abort causes a warning
+//@ edition: 2015
 //
 // This file is not actually used as a proc-macro - instead,
 // it's just used to show the output of the `quote!` macro

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-pretty-check.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-pretty-check.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
+//@ edition: 2015
 
 fn main() {
     if let 0 = 1 {}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-pretty-check.stdout
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-pretty-check.stdout
@@ -6,5 +6,6 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ check-pass
 //@ compile-flags: -Z unpretty=expanded
+//@ edition: 2015
 
 fn main() { if let 0 = 1 {} }

--- a/tests/ui/type-alias-impl-trait/issue-60662.rs
+++ b/tests/ui/type-alias-impl-trait/issue-60662.rs
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: -Z unpretty=hir
+//@ edition: 2015
 
 #![feature(type_alias_impl_trait)]
 

--- a/tests/ui/type-alias-impl-trait/issue-60662.stdout
+++ b/tests/ui/type-alias-impl-trait/issue-60662.stdout
@@ -1,5 +1,6 @@
 //@ check-pass
 //@ compile-flags: -Z unpretty=hir
+//@ edition: 2015
 
 #![feature(type_alias_impl_trait)]
 #[prelude_import]

--- a/tests/ui/unpretty/bad-literal.rs
+++ b/tests/ui/unpretty/bad-literal.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-fail
+//@ edition: 2015
 
 // In #100948 this caused an ICE with -Zunpretty=hir.
 fn main() {

--- a/tests/ui/unpretty/bad-literal.stderr
+++ b/tests/ui/unpretty/bad-literal.stderr
@@ -1,5 +1,5 @@
 error: invalid suffix `u` for number literal
-  --> $DIR/bad-literal.rs:6:5
+  --> $DIR/bad-literal.rs:7:5
    |
 LL |     1u;
    |     ^^ invalid suffix `u`

--- a/tests/ui/unpretty/bad-literal.stdout
+++ b/tests/ui/unpretty/bad-literal.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-fail
+//@ edition: 2015
 
 // In #100948 this caused an ICE with -Zunpretty=hir.
 fn main() {

--- a/tests/ui/unpretty/debug-fmt-hir.rs
+++ b/tests/ui/unpretty/debug-fmt-hir.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 use std::fmt;
 

--- a/tests/ui/unpretty/debug-fmt-hir.stdout
+++ b/tests/ui/unpretty/debug-fmt-hir.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 use std::fmt;
 

--- a/tests/ui/unpretty/deprecated-attr.rs
+++ b/tests/ui/unpretty/deprecated-attr.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 #[deprecated]
 pub struct PlainDeprecated;

--- a/tests/ui/unpretty/deprecated-attr.stdout
+++ b/tests/ui/unpretty/deprecated-attr.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 #[attr = Deprecation {deprecation: Deprecation {since: Unspecified}}]
 struct PlainDeprecated;

--- a/tests/ui/unpretty/diagnostic-attr.rs
+++ b/tests/ui/unpretty/diagnostic-attr.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 #[diagnostic::on_unimplemented(
     message = "My Message for `ImportantTrait<{A}>` implemented for `{Self}`",

--- a/tests/ui/unpretty/diagnostic-attr.stdout
+++ b/tests/ui/unpretty/diagnostic-attr.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 #[diagnostic::on_unimplemented(message =
 "My Message for `ImportantTrait<{A}>` implemented for `{Self}`", label =

--- a/tests/ui/unpretty/expanded-interpolation.rs
+++ b/tests/ui/unpretty/expanded-interpolation.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=expanded
 //@ check-pass
+//@ edition: 2015
 
 // This test covers the AST pretty-printer's insertion of parentheses in some
 // macro metavariable edge cases. Synthetic parentheses (i.e. not appearing in

--- a/tests/ui/unpretty/expanded-interpolation.stdout
+++ b/tests/ui/unpretty/expanded-interpolation.stdout
@@ -2,6 +2,7 @@
 #![no_std]
 //@ compile-flags: -Zunpretty=expanded
 //@ check-pass
+//@ edition: 2015
 
 // This test covers the AST pretty-printer's insertion of parentheses in some
 // macro metavariable edge cases. Synthetic parentheses (i.e. not appearing in

--- a/tests/ui/unpretty/flattened-format-args.rs
+++ b/tests/ui/unpretty/flattened-format-args.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir -Zflatten-format-args=yes
 //@ check-pass
+//@ edition: 2015
 
 fn main() {
     let x = 1;

--- a/tests/ui/unpretty/flattened-format-args.stdout
+++ b/tests/ui/unpretty/flattened-format-args.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir -Zflatten-format-args=yes
 //@ check-pass
+//@ edition: 2015
 
 fn main() {
     let x = 1;

--- a/tests/ui/unpretty/let-else-hir.rs
+++ b/tests/ui/unpretty/let-else-hir.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 
 

--- a/tests/ui/unpretty/let-else-hir.stdout
+++ b/tests/ui/unpretty/let-else-hir.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 
 

--- a/tests/ui/unpretty/self-hir.rs
+++ b/tests/ui/unpretty/self-hir.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 pub struct Bar {
     a: String,

--- a/tests/ui/unpretty/self-hir.stdout
+++ b/tests/ui/unpretty/self-hir.stdout
@@ -4,6 +4,7 @@ use ::std::prelude::rust_2015::*;
 extern crate std;
 //@ compile-flags: -Zunpretty=hir
 //@ check-pass
+//@ edition: 2015
 
 struct Bar {
     a: String,

--- a/tests/ui/unpretty/unpretty-expr-fn-arg.rs
+++ b/tests/ui/unpretty/unpretty-expr-fn-arg.rs
@@ -6,6 +6,7 @@
 
 //@ check-pass
 //@ compile-flags: -Zunpretty=hir,typed
+//@ edition: 2015
 #![allow(dead_code)]
 
 fn main() {}

--- a/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
+++ b/tests/ui/unpretty/unpretty-expr-fn-arg.stdout
@@ -6,6 +6,7 @@
 
 //@ check-pass
 //@ compile-flags: -Zunpretty=hir,typed
+//@ edition: 2015
 #![allow(dead_code)]
 #[prelude_import]
 use ::std::prelude::rust_2015::*;


### PR DESCRIPTION
These emit prelude imports which means they are always edition dependent and so running them with a different `--edition` will fail.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
