### PR TITLE
parser: Remove old diagnostic notes for type ascription syntax

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -806,9 +806,6 @@ parse_trait_alias_cannot_be_unsafe = trait aliases cannot be `unsafe`
 parse_transpose_dyn_or_impl = `for<...>` expected after `{$kw}`, not before
     .suggestion = move `{$kw}` before the `for<...>`
 
-parse_type_ascription_removed =
-    if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
-
 parse_unclosed_unicode_escape = unterminated unicode escape
     .label = missing a closing `{"}"}`
     .terminate = terminate the unicode escape

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1598,9 +1598,6 @@ pub(crate) struct PathSingleColon {
 
     #[suggestion(applicability = "machine-applicable", code = ":", style = "verbose")]
     pub suggestion: Span,
-
-    #[note(parse_type_ascription_removed)]
-    pub type_ascription: bool,
 }
 
 #[derive(Diagnostic)]
@@ -1617,9 +1614,6 @@ pub(crate) struct ColonAsSemi {
     #[primary_span]
     #[suggestion(applicability = "machine-applicable", code = ";", style = "verbose")]
     pub span: Span,
-
-    #[note(parse_type_ascription_removed)]
-    pub type_ascription: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1943,10 +1943,7 @@ impl<'a> Parser<'a> {
             && self.token == token::Colon
             && self.look_ahead(1, |next| line_idx(self.token.span) < line_idx(next.span))
         {
-            self.dcx().emit_err(ColonAsSemi {
-                span: self.token.span,
-                type_ascription: self.psess.unstable_features.is_nightly_build(),
-            });
+            self.dcx().emit_err(ColonAsSemi { span: self.token.span });
             self.bump();
             return true;
         }

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -273,7 +273,6 @@ impl<'a> Parser<'a> {
                         self.dcx().emit_err(PathSingleColon {
                             span: self.prev_token.span,
                             suggestion: self.prev_token.span.shrink_to_hi(),
-                            type_ascription: self.psess.unstable_features.is_nightly_build(),
                         });
                     }
                     continue;
@@ -348,7 +347,6 @@ impl<'a> Parser<'a> {
                             err = self.dcx().create_err(PathSingleColon {
                                 span: self.token.span,
                                 suggestion: self.prev_token.span.shrink_to_hi(),
-                                type_ascription: self.psess.unstable_features.is_nightly_build(),
                             });
                         }
                         // Attempt to find places where a missing `>` might belong.

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -771,10 +771,6 @@ impl<'a> Parser<'a> {
                                     Applicability::MaybeIncorrect,
                                 );
                             }
-                            if self.psess.unstable_features.is_nightly_build() {
-                                // FIXME(Nilstrieb): Remove this again after a few months.
-                                err.note("type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>");
-                            }
                         }
                     }
 

--- a/tests/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
+++ b/tests/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
@@ -66,7 +66,6 @@ error: unexpected `,` in pattern
 LL |     let women, men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
    |              ^
    |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: try adding parentheses to match on a tuple
    |
 LL |     let (women, men): (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()

--- a/tests/ui/generics/single-colon-path-not-const-generics.stderr
+++ b/tests/ui/generics/single-colon-path-not-const-generics.stderr
@@ -4,7 +4,6 @@ error: path separator must be a double colon
 LL |   a: Vec<foo::bar:A>,
    |                  ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
 LL |   a: Vec<foo::bar::A>,

--- a/tests/ui/or-patterns/or-patterns-syntactic-fail.stderr
+++ b/tests/ui/or-patterns/or-patterns-syntactic-fail.stderr
@@ -6,7 +6,6 @@ LL |     let _ = |A | B: E| ();
    |             |
    |             while parsing the body of this closure
    |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: you might have meant to open the body of the closure
    |
 LL |     let _ = |A | { B: E| ();

--- a/tests/ui/parser/issues/issue-35813-postfix-after-cast.stderr
+++ b/tests/ui/parser/issues/issue-35813-postfix-after-cast.stderr
@@ -49,24 +49,18 @@ error: expected one of `.`, `;`, `?`, `else`, or an operator, found `:`
    |
 LL |     let _ = 0i32: i32: i32.count_ones();
    |                 ^ expected one of `.`, `;`, `?`, `else`, or an operator
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: expected one of `!`, `(`, `.`, `::`, `;`, `<`, `?`, or `else`, found `:`
   --> $DIR/issue-35813-postfix-after-cast.rs:43:21
    |
 LL |     let _ = 0 as i32: i32.count_ones();
    |                     ^ expected one of 8 possible tokens
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: expected one of `.`, `;`, `?`, `else`, or an operator, found `:`
   --> $DIR/issue-35813-postfix-after-cast.rs:47:17
    |
 LL |     let _ = 0i32: i32 as i32.count_ones();
    |                 ^ expected one of `.`, `;`, `?`, `else`, or an operator
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:51:13
@@ -84,16 +78,12 @@ error: expected one of `.`, `;`, `?`, `else`, or an operator, found `:`
    |
 LL |     let _ = 0i32: i32: i32 as u32 as i32.count_ones();
    |                 ^ expected one of `.`, `;`, `?`, `else`, or an operator
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: expected one of `.`, `;`, `?`, `else`, or an operator, found `:`
   --> $DIR/issue-35813-postfix-after-cast.rs:60:17
    |
 LL |     let _ = 0i32: i32.count_ones(): u32;
    |                 ^ expected one of `.`, `;`, `?`, `else`, or an operator
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:64:13
@@ -111,16 +101,12 @@ error: expected one of `.`, `;`, `?`, or `else`, found `:`
    |
 LL |     let _ = 0 as i32.count_ones(): u32;
    |                                  ^ expected one of `.`, `;`, `?`, or `else`
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: expected one of `.`, `;`, `?`, `else`, or an operator, found `:`
   --> $DIR/issue-35813-postfix-after-cast.rs:69:17
    |
 LL |     let _ = 0i32: i32.count_ones() as u32;
    |                 ^ expected one of `.`, `;`, `?`, `else`, or an operator
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:73:13
@@ -138,8 +124,6 @@ error: expected one of `.`, `;`, `?`, `else`, or an operator, found `:`
    |
 LL |     let _ = 0i32: i32: i32.count_ones() as u32 as i32;
    |                 ^ expected one of `.`, `;`, `?`, `else`, or an operator
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: cast cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:82:13
@@ -262,8 +246,6 @@ error: expected identifier, found `:`
    |
 LL |     drop_ptr: F();
    |             ^ expected identifier
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `:`
   --> $DIR/issue-35813-postfix-after-cast.rs:160:13

--- a/tests/ui/parser/recover/turbofish-arg-with-stray-colon.stderr
+++ b/tests/ui/parser/recover/turbofish-arg-with-stray-colon.stderr
@@ -4,7 +4,6 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, fo
 LL |     let x = Tr<A, A:>;
    |                 ^ expected one of 8 possible tokens
    |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: maybe write a path separator here
    |
 LL |     let x = Tr<A, A::>;

--- a/tests/ui/parser/ternary_operator.stderr
+++ b/tests/ui/parser/ternary_operator.stderr
@@ -33,8 +33,6 @@ error: expected one of `.`, `;`, `?`, `else`, or an operator, found `:`
    |
 LL |     let x = 5 > 2 ? { let x = vec![]: Vec<u16>; x } : { false };
    |                                     ^ expected one of `.`, `;`, `?`, `else`, or an operator
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: Rust has no ternary operator
   --> $DIR/ternary_operator.rs:26:19

--- a/tests/ui/pattern/bindings-after-at/nested-type-ascription-syntactically-invalid.stderr
+++ b/tests/ui/pattern/bindings-after-at/nested-type-ascription-syntactically-invalid.stderr
@@ -11,8 +11,6 @@ error: expected one of `)`, `,`, `@`, `if`, or `|`, found `:`
    |
 LL |     let a @ (b: u8);
    |               ^ expected one of `)`, `,`, `@`, `if`, or `|`
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: expected one of `!`, `(`, `+`, `::`, `;`, `<`, or `=`, found `@`
   --> $DIR/nested-type-ascription-syntactically-invalid.rs:30:15

--- a/tests/ui/suggestions/argument-list-from-path-sep-error-129273.stderr
+++ b/tests/ui/suggestions/argument-list-from-path-sep-error-129273.stderr
@@ -4,7 +4,6 @@ error: path separator must be a double colon
 LL |     fn fmt(&self, f: &mut fmt:Formatter) -> fmt::Result {
    |                              ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
 LL |     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/tests/ui/suggestions/many-type-ascription.stderr
+++ b/tests/ui/suggestions/many-type-ascription.stderr
@@ -3,8 +3,6 @@ error: expected one of `.`, `;`, `?`, `else`, or an operator, found `:`
    |
 LL |     let _ = 0: i32;
    |              ^ expected one of `.`, `;`, `?`, `else`, or an operator
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
+++ b/tests/ui/suggestions/struct-field-type-including-single-colon.stderr
@@ -4,7 +4,6 @@ error: path separator must be a double colon
 LL |     a: foo:A,
    |           ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
 LL |     a: foo::A,
@@ -16,7 +15,6 @@ error: path separator must be a double colon
 LL |     b: foo::bar:B,
    |                ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
 LL |     b: foo::bar::B,

--- a/tests/ui/suggestions/type-ascription-instead-of-method.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-method.stderr
@@ -4,7 +4,6 @@ error: path separator must be a double colon
 LL |     let _ = Box:new("foo".to_string());
    |                ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
 LL |     let _ = Box::new("foo".to_string());

--- a/tests/ui/suggestions/type-ascription-instead-of-path-2.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path-2.stderr
@@ -4,7 +4,6 @@ error: expected one of `(`, `.`, `::`, `;`, `?`, `else`, or an operator, found `
 LL |     let _ = vec![Ok(2)].into_iter().collect:<Result<Vec<_>,_>>()?;
    |                                            ^ expected one of 7 possible tokens
    |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: maybe write a path separator here
    |
 LL |     let _ = vec![Ok(2)].into_iter().collect::<Result<Vec<_>,_>>()?;

--- a/tests/ui/suggestions/type-ascription-instead-of-path.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-path.stderr
@@ -4,7 +4,6 @@ error: path separator must be a double colon
 LL |     std:io::stdin();
    |        ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
 LL |     std::io::stdin();

--- a/tests/ui/suggestions/type-ascription-instead-of-variant.stderr
+++ b/tests/ui/suggestions/type-ascription-instead-of-variant.stderr
@@ -4,7 +4,6 @@ error: path separator must be a double colon
 LL |     let _ = Option:Some("");
    |                   ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
 LL |     let _ = Option::Some("");

--- a/tests/ui/type/ascription/issue-47666.stderr
+++ b/tests/ui/type/ascription/issue-47666.stderr
@@ -4,7 +4,6 @@ error: path separator must be a double colon
 LL |     let _ = Option:Some(vec![0, 1]);
    |                   ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
 LL |     let _ = Option::Some(vec![0, 1]);

--- a/tests/ui/type/ascription/issue-54516.stderr
+++ b/tests/ui/type/ascription/issue-54516.stderr
@@ -4,7 +4,6 @@ error: path separator must be a double colon
 LL |     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
    |                            ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
 LL |     println!("{}", std::mem::size_of::<BTreeMap<u32, u32>>());

--- a/tests/ui/type/ascription/issue-60933.stderr
+++ b/tests/ui/type/ascription/issue-60933.stderr
@@ -4,7 +4,6 @@ error: path separator must be a double colon
 LL |     let _: usize = std::mem:size_of::<u32>();
    |                            ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a double colon instead
    |
 LL |     let _: usize = std::mem::size_of::<u32>();

--- a/tests/ui/type/missing-let-in-binding.stderr
+++ b/tests/ui/type/missing-let-in-binding.stderr
@@ -4,7 +4,6 @@ error: expected identifier, found `:`
 LL |     _foo: i32 = 4;
    |         ^ expected identifier
    |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: you might have meant to introduce a new binding
    |
 LL |     let _foo: i32 = 4;

--- a/tests/ui/type/type-ascription-instead-of-statement-end.stderr
+++ b/tests/ui/type/type-ascription-instead-of-statement-end.stderr
@@ -4,7 +4,6 @@ error: statements are terminated with a semicolon
 LL |     println!("test"):
    |                     ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a semicolon instead
    |
 LL -     println!("test"):

--- a/tests/ui/type/type-ascription-precedence.stderr
+++ b/tests/ui/type/type-ascription-precedence.stderr
@@ -33,8 +33,6 @@ error: expected identifier, found `:`
    |
 LL |     S .. S: S;
    |           ^ expected identifier
-   |
-   = note: type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `:`
   --> $DIR/type-ascription-precedence.rs:53:13

--- a/tests/ui/type/type-ascription-with-fn-call.stderr
+++ b/tests/ui/type/type-ascription-with-fn-call.stderr
@@ -4,7 +4,6 @@ error: statements are terminated with a semicolon
 LL |     f()  :
    |          ^
    |
-   = note: if you meant to annotate an expression with a type, the type ascription syntax has been removed, see issue #101728 <https://github.com/rust-lang/rust/issues/101728>
 help: use a semicolon instead
    |
 LL -     f()  :


### PR DESCRIPTION
Type ascription syntax was removed by #109128 in 2023, so “remove this again in a few months” is long overdue.

Happily, this also reduces the amount of parser diagnostic code that cares whether the compiler is unstable.

---

See also the recent #138898, which removed some other related dead code but declined to touch the diagnostics.

It's possible that some of these parser tests are no longer useful at all, but I haven't investigated them for this PR.