### PR TITLE
replace some #[rustc_intrinsic] usage with use of the libcore declarations

### DIFF
--- a/tests/codegen/intrinsic-no-unnamed-attr.rs
+++ b/tests/codegen/intrinsic-no-unnamed-attr.rs
@@ -1,9 +1,8 @@
 //@ compile-flags: -C no-prepopulate-passes
 
-#![feature(intrinsics)]
+#![feature(core_intrinsics)]
 
-#[rustc_intrinsic]
-unsafe fn sqrtf32(x: f32) -> f32;
+use std::intrinsics::sqrtf32;
 
 // CHECK: @llvm.sqrt.f32(float) #{{[0-9]*}}
 

--- a/tests/ui/intrinsics/intrinsic-atomics.rs
+++ b/tests/ui/intrinsics/intrinsic-atomics.rs
@@ -1,53 +1,6 @@
 //@ run-pass
-#![feature(intrinsics)]
-
-mod rusti {
-
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_cxchg_seqcst_seqcst<T>(dst: *mut T, old: T, src: T) -> (T, bool);
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_cxchg_acquire_acquire<T>(dst: *mut T, old: T, src: T) -> (T, bool);
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_cxchg_release_relaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
-
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_cxchgweak_seqcst_seqcst<T>(dst: *mut T, old: T, src: T) -> (T, bool);
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_cxchgweak_acquire_acquire<T>(dst: *mut T, old: T, src: T) -> (T, bool);
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_cxchgweak_release_relaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
-
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_load_seqcst<T>(src: *const T) -> T;
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_load_acquire<T>(src: *const T) -> T;
-
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_store_seqcst<T>(dst: *mut T, val: T);
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_store_release<T>(dst: *mut T, val: T);
-
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_xchg_seqcst<T>(dst: *mut T, src: T) -> T;
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_xchg_acquire<T>(dst: *mut T, src: T) -> T;
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_xchg_release<T>(dst: *mut T, src: T) -> T;
-
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_xadd_seqcst<T>(dst: *mut T, src: T) -> T;
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_xadd_acquire<T>(dst: *mut T, src: T) -> T;
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_xadd_release<T>(dst: *mut T, src: T) -> T;
-
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_xsub_seqcst<T>(dst: *mut T, src: T) -> T;
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_xsub_acquire<T>(dst: *mut T, src: T) -> T;
-    #[rustc_intrinsic]
-    pub unsafe fn atomic_xsub_release<T>(dst: *mut T, src: T) -> T;
-}
+#![feature(core_intrinsics)]
+use std::intrinsics as rusti;
 
 pub fn main() {
     unsafe {


### PR DESCRIPTION
Better to centralize the `#[rustc_intrinsic]` declarations in libcore than have them spread across the test suite as well.