### PR TITLE
Make rustdoc JSON Span column 1-based, just like line numbers

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -84,8 +84,8 @@ impl JsonRenderer<'_> {
                     let lo = span.lo(self.sess());
                     Some(Span {
                         filename: local_path,
-                        begin: (lo.line, lo.col.to_usize()),
-                        end: (hi.line, hi.col.to_usize()),
+                        begin: (lo.line, lo.col.to_usize() + 1),
+                        end: (hi.line, hi.col.to_usize() + 1),
                     })
                 } else {
                     None

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -30,7 +30,7 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 /// This integer is incremented with every breaking change to the API,
 /// and is returned along with the JSON blob as [`Crate::format_version`].
 /// Consuming code should assert that this value matches the format version(s) that it supports.
-pub const FORMAT_VERSION: u32 = 44;
+pub const FORMAT_VERSION: u32 = 45;
 
 /// The root of the emitted JSON blob.
 ///

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -205,9 +205,9 @@ pub struct Item {
 pub struct Span {
     /// The path to the source file for this span relative to the path `rustdoc` was invoked with.
     pub filename: PathBuf,
-    /// Zero indexed Line and Column of the first character of the `Span`
+    /// One indexed Line and Column of the first character of the `Span`.
     pub begin: (usize, usize),
-    /// Zero indexed Line and Column of the last character of the `Span`
+    /// One indexed Line and Column of the last character of the `Span`.
     pub end: (usize, usize),
 }
 

--- a/tests/rustdoc-json/impls/auto.rs
+++ b/tests/rustdoc-json/impls/auto.rs
@@ -15,8 +15,8 @@ impl Foo {
 }
 
 // Testing spans, so all tests below code
-//@ is "$.index[?(@.docs=='has span')].span.begin" "[13, 0]"
-//@ is "$.index[?(@.docs=='has span')].span.end" "[15, 1]"
+//@ is "$.index[?(@.docs=='has span')].span.begin" "[13, 1]"
+//@ is "$.index[?(@.docs=='has span')].span.end" "[15, 2]"
 // FIXME: this doesn't work due to https://github.com/freestrings/jsonpath/issues/91
 // is "$.index[?(@.inner.impl.is_synthetic==true)].span" null
 pub struct Foo;

--- a/tests/rustdoc-json/span.rs
+++ b/tests/rustdoc-json/span.rs
@@ -1,0 +1,4 @@
+pub mod bar {}
+// This test ensures that spans are 1-indexed.
+//@ is "$.index[?(@.name=='span')].span.begin" "[1, 1]"
+//@ is "$.index[?(@.name=='bar')].span.begin" "[1, 1]"


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/139906.

This PR does two things:
 1. It makes column 1-indexed as well, just like lines.
 2. It updates documentation about them to mention that they are 1-indexed.

I think it's better for coherency to have them both 1-indexed instead of the weird mix we used to have. Docs for `line` and `col` fields can be found [here](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_span/struct.Loc.html#structfield.line).

And finally: it adds a regression test to ensure they are indeed 1-indexed.

r? @aDotInTheVoid 