### PR TITLE
improve diagnostic for raw pointer field access with ->

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -3289,8 +3289,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         err.multipart_suggestion(
             format!("{val} is a raw pointer; try dereferencing it"),
             vec![
-                (base.span.shrink_to_lo(), "(*".to_string()),
-                (base.span.shrink_to_hi(), ")".to_string()),
+                (base.span.shrink_to_lo(), "(*".into()),
+                (base.span.between(field.span), format!(").")),
             ],
             Applicability::MaybeIncorrect,
         );

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -246,9 +246,9 @@ parse_expected_struct_field = expected one of `,`, `:`, or `{"}"}`, found `{$tok
 
 parse_expected_trait_in_trait_impl_found_type = expected a trait, found type
 
-parse_expr_rarrow_call = `->` used for field access or method call
+parse_expr_rarrow_call = `->` is not valid syntax for field accesses and method calls
     .suggestion = try using `.` instead
-    .help = the `.` operator will dereference the value if needed
+    .help = the `.` operator will automatically dereference the value, except if the value is a raw pointer
 
 parse_extern_crate_name_with_dashes = crate name using dashes are not valid in `extern crate` statements
     .label = dash-separated idents are not valid

--- a/tests/ui/parser/expr-rarrow-call-on-a-raw-pointer.rs
+++ b/tests/ui/parser/expr-rarrow-call-on-a-raw-pointer.rs
@@ -1,0 +1,22 @@
+#![allow(
+    dead_code,
+    unused_must_use
+)]
+
+struct Named {
+    foo: usize,
+}
+
+struct Unnamed(usize);
+
+unsafe fn named_struct_field_access(named: *mut Named) {
+    named->foo += 1; //~ ERROR `->` is not valid syntax for field accesses and method calls
+    //~^ ERROR no field `foo` on type `*mut Named`
+}
+
+unsafe fn unnamed_struct_field_access(unnamed: *mut Unnamed) {
+    unnamed->0 += 1; //~ ERROR `->` is not valid syntax for field accesses and method calls
+    //~^ ERROR no field `0` on type `*mut Unnamed`
+}
+
+fn main() {}

--- a/tests/ui/parser/expr-rarrow-call-on-a-raw-pointer.stderr
+++ b/tests/ui/parser/expr-rarrow-call-on-a-raw-pointer.stderr
@@ -1,0 +1,53 @@
+error: `->` is not valid syntax for field accesses and method calls
+  --> $DIR/expr-rarrow-call-on-a-raw-pointer.rs:13:10
+   |
+LL |     named->foo += 1;
+   |          ^^
+   |
+   = help: the `.` operator will automatically dereference the value, except if the value is a raw pointer
+help: try using `.` instead
+   |
+LL -     named->foo += 1;
+LL +     named.foo += 1;
+   |
+
+error: `->` is not valid syntax for field accesses and method calls
+  --> $DIR/expr-rarrow-call-on-a-raw-pointer.rs:18:12
+   |
+LL |     unnamed->0 += 1;
+   |            ^^
+   |
+   = help: the `.` operator will automatically dereference the value, except if the value is a raw pointer
+help: try using `.` instead
+   |
+LL -     unnamed->0 += 1;
+LL +     unnamed.0 += 1;
+   |
+
+error[E0609]: no field `foo` on type `*mut Named`
+  --> $DIR/expr-rarrow-call-on-a-raw-pointer.rs:13:12
+   |
+LL |     named->foo += 1;
+   |            ^^^ unknown field
+   |
+help: `named` is a raw pointer; try dereferencing it
+   |
+LL -     named->foo += 1;
+LL +     (*named).foo += 1;
+   |
+
+error[E0609]: no field `0` on type `*mut Unnamed`
+  --> $DIR/expr-rarrow-call-on-a-raw-pointer.rs:18:14
+   |
+LL |     unnamed->0 += 1;
+   |              ^ unknown field
+   |
+help: `unnamed` is a raw pointer; try dereferencing it
+   |
+LL -     unnamed->0 += 1;
+LL +     (*unnamed).0 += 1;
+   |
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0609`.

--- a/tests/ui/parser/expr-rarrow-call.fixed
+++ b/tests/ui/parser/expr-rarrow-call.fixed
@@ -11,23 +11,23 @@ struct Named {
 struct Unnamed(usize);
 
 fn named_struct_field_access(named: &Named) {
-    named.foo; //~ ERROR `->` used for field access or method call
+    named.foo; //~ ERROR `->` is not valid syntax for field accesses and method calls
 }
 
 fn unnamed_struct_field_access(unnamed: &Unnamed) {
-    unnamed.0; //~ ERROR `->` used for field access or method call
+    unnamed.0; //~ ERROR `->` is not valid syntax for field accesses and method calls
 }
 
 fn tuple_field_access(t: &(u8, u8)) {
-    t.0; //~ ERROR `->` used for field access or method call
-    t.1; //~ ERROR `->` used for field access or method call
+    t.0; //~ ERROR `->` is not valid syntax for field accesses and method calls
+    t.1; //~ ERROR `->` is not valid syntax for field accesses and method calls
 }
 
 #[derive(Clone)]
 struct Foo;
 
 fn method_call(foo: &Foo) {
-    foo.clone(); //~ ERROR `->` used for field access or method call
+    foo.clone(); //~ ERROR `->` is not valid syntax for field accesses and method calls
 }
 
 fn main() {}

--- a/tests/ui/parser/expr-rarrow-call.rs
+++ b/tests/ui/parser/expr-rarrow-call.rs
@@ -11,23 +11,23 @@ struct Named {
 struct Unnamed(usize);
 
 fn named_struct_field_access(named: &Named) {
-    named->foo; //~ ERROR `->` used for field access or method call
+    named->foo; //~ ERROR `->` is not valid syntax for field accesses and method calls
 }
 
 fn unnamed_struct_field_access(unnamed: &Unnamed) {
-    unnamed->0; //~ ERROR `->` used for field access or method call
+    unnamed->0; //~ ERROR `->` is not valid syntax for field accesses and method calls
 }
 
 fn tuple_field_access(t: &(u8, u8)) {
-    t->0; //~ ERROR `->` used for field access or method call
-    t->1; //~ ERROR `->` used for field access or method call
+    t->0; //~ ERROR `->` is not valid syntax for field accesses and method calls
+    t->1; //~ ERROR `->` is not valid syntax for field accesses and method calls
 }
 
 #[derive(Clone)]
 struct Foo;
 
 fn method_call(foo: &Foo) {
-    foo->clone(); //~ ERROR `->` used for field access or method call
+    foo->clone(); //~ ERROR `->` is not valid syntax for field accesses and method calls
 }
 
 fn main() {}

--- a/tests/ui/parser/expr-rarrow-call.stderr
+++ b/tests/ui/parser/expr-rarrow-call.stderr
@@ -1,62 +1,62 @@
-error: `->` used for field access or method call
+error: `->` is not valid syntax for field accesses and method calls
   --> $DIR/expr-rarrow-call.rs:14:10
    |
 LL |     named->foo;
    |          ^^
    |
-   = help: the `.` operator will dereference the value if needed
+   = help: the `.` operator will automatically dereference the value, except if the value is a raw pointer
 help: try using `.` instead
    |
 LL -     named->foo;
 LL +     named.foo;
    |
 
-error: `->` used for field access or method call
+error: `->` is not valid syntax for field accesses and method calls
   --> $DIR/expr-rarrow-call.rs:18:12
    |
 LL |     unnamed->0;
    |            ^^
    |
-   = help: the `.` operator will dereference the value if needed
+   = help: the `.` operator will automatically dereference the value, except if the value is a raw pointer
 help: try using `.` instead
    |
 LL -     unnamed->0;
 LL +     unnamed.0;
    |
 
-error: `->` used for field access or method call
+error: `->` is not valid syntax for field accesses and method calls
   --> $DIR/expr-rarrow-call.rs:22:6
    |
 LL |     t->0;
    |      ^^
    |
-   = help: the `.` operator will dereference the value if needed
+   = help: the `.` operator will automatically dereference the value, except if the value is a raw pointer
 help: try using `.` instead
    |
 LL -     t->0;
 LL +     t.0;
    |
 
-error: `->` used for field access or method call
+error: `->` is not valid syntax for field accesses and method calls
   --> $DIR/expr-rarrow-call.rs:23:6
    |
 LL |     t->1;
    |      ^^
    |
-   = help: the `.` operator will dereference the value if needed
+   = help: the `.` operator will automatically dereference the value, except if the value is a raw pointer
 help: try using `.` instead
    |
 LL -     t->1;
 LL +     t.1;
    |
 
-error: `->` used for field access or method call
+error: `->` is not valid syntax for field accesses and method calls
   --> $DIR/expr-rarrow-call.rs:30:8
    |
 LL |     foo->clone();
    |        ^^
    |
-   = help: the `.` operator will dereference the value if needed
+   = help: the `.` operator will automatically dereference the value, except if the value is a raw pointer
 help: try using `.` instead
    |
 LL -     foo->clone();

--- a/tests/ui/parser/issues/issue-118530-ice.rs
+++ b/tests/ui/parser/issues/issue-118530-ice.rs
@@ -5,7 +5,7 @@ fn bar() -> String {
     attr::fn bar() -> String { //~ ERROR expected identifier, found keyword `fn`
     //~^ ERROR expected one of `(`, `.`, `::`, `;`, `?`, `}`, or an operator, found `{`
     //~| ERROR expected `;`, found `bar`
-    //~| ERROR `->` used for field access or method call
+    //~| ERROR `->` is not valid syntax for field accesses and method calls
     #[attr]
     [1, 2, 3].iter().map().collect::<String>()
     #[attr]

--- a/tests/ui/parser/issues/issue-118530-ice.stderr
+++ b/tests/ui/parser/issues/issue-118530-ice.stderr
@@ -33,13 +33,13 @@ LL |     attr::fn bar() -> String {
    |             |
    |             help: add `;` here
 
-error: `->` used for field access or method call
+error: `->` is not valid syntax for field accesses and method calls
   --> $DIR/issue-118530-ice.rs:5:20
    |
 LL |     attr::fn bar() -> String {
    |                    ^^
    |
-   = help: the `.` operator will dereference the value if needed
+   = help: the `.` operator will automatically dereference the value, except if the value is a raw pointer
 help: try using `.` instead
    |
 LL -     attr::fn bar() -> String {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
No related tracking issue.

r? @rust-lang/compiler
-->
<!-- homu-ignore:end -->

This PR enhances the error messages emitted by the Rust compiler when users attempt to use the `->` operator for field access on raw pointers or when dereferencing is needed. The changes aim to provide clearer guidance, by suggesting the correct use of the `.` operator and explicit dereferencing.

**Before:**
```
help: `xs` is a raw pointer; try dereferencing it
   |
LL |         (*xs)->count += 1;
   |         ++  +
```



**Now:**
```
help: use `.` on a dereferenced raw pointer instead
   |
LL -         xs->count += 1;
LL +         (*xs).count += 1;
   |
```