### PR TITLE
bootstrap: enable zlib for LLVM for Windows GNU

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/138784
+Last change is for: https://github.com/rust-lang/rust/pull/139931

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -370,8 +370,8 @@ impl Step for Llvm {
             cfg.define("LLVM_PROFDATA_FILE", path);
         }
 
-        // Libraries for ELF section compression.
-        if !target.is_windows() {
+        // Libraries for ELF section compression and profraw files merging.
+        if !target.is_msvc() {
             cfg.define("LLVM_ENABLE_ZLIB", "ON");
         } else {
             cfg.define("LLVM_ENABLE_ZLIB", "OFF");


### PR DESCRIPTION
when compiling target LLVM with `opt-dist local` on Windows/MinGW, profraw files are being compressed with zlib, so compiling without it will make `llvm-profdata` complain about lacking of zlib support. this error is shown:

`profile uses zlib compression but the profile reader was built without zlib support`

example from llvm test suite: https://github.com/llvm/llvm-project/blob/76b5fcbf975547251faaeed8b567ea09d139a607/llvm/test/tools/llvm-profdata/nocompress.test#L15.

implementation of step 3. from https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/experiment.20with.20.60opt-dist.20local.60.20in.20MSYS2/near/512393873

r? Kobzol
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
