### PR TITLE
Require `T: Copy` for `hint::select_unpredictable`

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -735,9 +735,9 @@ pub const fn cold_path() {
     crate::intrinsics::cold_path()
 }
 
-/// Returns either `true_val` or `false_val` depending on the value of `b`,
-/// with a hint to the compiler that `b` is unlikely to be correctly
-/// predicted by a CPU’s branch predictor.
+/// Returns either `true_val` or `false_val` depending on the value of
+/// `condition`, with a hint to the compiler that `condition` is unlikely to be
+/// correctly predicted by a CPU’s branch predictor.
 ///
 /// This method is functionally equivalent to
 /// ```ignore (this is just for illustrative purposes)
@@ -753,9 +753,9 @@ pub const fn cold_path() {
 /// search.
 ///
 /// Note however that this lowering is not guaranteed (on any platform) and
-/// should not be relied upon when trying to write constant-time code. Also
-/// be aware that this lowering might *decrease* performance if `condition`
-/// is well-predictable. It is advisable to perform benchmarks to tell if
+/// should not be relied upon when trying to write cryptographic constant-time
+/// code. Also be aware that this lowering might *decrease* performance if
+/// `condition` is well-predictable. It is advisable to perform benchmarks to tell if
 /// this function is useful.
 ///
 /// # Examples
@@ -780,6 +780,6 @@ pub const fn cold_path() {
 /// ```
 #[inline(always)]
 #[unstable(feature = "select_unpredictable", issue = "133962")]
-pub fn select_unpredictable<T>(b: bool, true_val: T, false_val: T) -> T {
-    crate::intrinsics::select_unpredictable(b, true_val, false_val)
+pub fn select_unpredictable<T: Copy>(condition: bool, true_val: T, false_val: T) -> T {
+    crate::intrinsics::select_unpredictable(condition, true_val, false_val)
 }

--- a/tests/codegen/intrinsics/select_unpredictable.rs
+++ b/tests/codegen/intrinsics/select_unpredictable.rs
@@ -20,6 +20,7 @@ pub fn test_pair(p: bool, a: (u64, u64), b: (u64, u64)) -> (u64, u64) {
     core::intrinsics::select_unpredictable(p, a, b)
 }
 
+#[derive(Copy)]
 struct Large {
     e: [u64; 100],
 }


### PR DESCRIPTION
The current implementation doesn't call the drop the value that is not selected. This could be fixed in the future but for now it is sufficient to limit this to `Copy` types.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
