### PR TITLE
Update `compiler-builtins` to 0.1.155

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.153"
+version = "0.1.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926ef6a360c15a911023352fd6969c51605d70495406f735beb1ca0257448e59"
+checksum = "341e0830ca6170a4fcf02e92e57daf4b6f10142d48da32a547023867a6c8b35e"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 
 [dependencies]
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.153", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "=0.1.155", features = ['rustc-dep-of-std'] }
 
 [features]
 compiler-builtins-mem = ['compiler_builtins/mem']

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.153" }
+compiler_builtins = { version = "=0.1.155" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',


### PR DESCRIPTION
Includes the following changes:

* Replace `#[naked]` with `#[unsafe(naked)]` [1] [2]
* Replace `bl!` with `asm_sym` [3]

[1]: https://github.com/rust-lang/compiler-builtins/pull/817
[2]: https://github.com/rust-lang/compiler-builtins/pull/821
[3]: https://github.com/rust-lang/compiler-builtins/pull/820

try-job: armhf-gnu
try-job: aarch64-apple
try-job: dist-apple-various