### PR TITLE
Ignore aix for tests/ui/erros/pic-linker.rs

### DIFF
--- a/tests/ui/errors/pic-linker.rs
+++ b/tests/ui/errors/pic-linker.rs
@@ -5,6 +5,7 @@
 //@ ignore-windows
 //@ ignore-macos
 //@ ignore-cross-compile
+//@ ignore-aix
 
 //@ compile-flags: -Clink-args=-Wl,-z,text
 //@ run-pass


### PR DESCRIPTION
This test case fails on AIX because of how the linker arguments are passed. Furthermore on AIX `-z text` only works in dynamic mode, making this test case irrelevant. 
