### PR TITLE
fix missing word in comment

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -772,8 +772,8 @@ impl hash::Hash for TypeId {
         //   (especially given the previous point about the lower 64 bits being
         //   high quality on their own).
         // - It is correct to do so -- only hashing a subset of `self` is still
-        //   with an `Eq` implementation that considers the entire value, as
-        //   ours does.
+        //   compatible with an `Eq` implementation that considers the entire
+        //   value, as ours does.
         self.t.1.hash(state);
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
a very simple fix, rectifying a situation in which a word was accidentally .