### PR TITLE
Generate obligations when possible instead of rejecting with ambiguity

### DIFF
--- a/tests/ui/associated-types/associated-type-projection-nonambig-supertrait.rs
+++ b/tests/ui/associated-types/associated-type-projection-nonambig-supertrait.rs
@@ -1,0 +1,48 @@
+//@ revisions: traditional next_solver
+//@ [next_solver] compile-flags: -Znext-solver
+//@ check-pass
+
+use std::marker::PhantomData;
+
+pub trait Receiver {
+    type Target: ?Sized;
+}
+
+pub trait Deref: Receiver<Target = <Self as Deref>::Target> {
+    type Target: ?Sized;
+    fn deref(&self) -> &<Self as Deref>::Target;
+}
+
+impl<T: Deref> Receiver for T {
+    type Target = <T as Deref>::Target;
+}
+
+// ===
+pub struct Type<Id, T>(PhantomData<(Id, T)>);
+pub struct AliasRef<Id, T: TypePtr<Id = Id>>(PhantomData<(Id, T)>);
+
+pub trait TypePtr: Deref<Target = Type<<Self as TypePtr>::Id, Self>> + Sized {
+    // ^ the impl head here provides the first candidate
+    // <T as Deref>::Target := Type<<T as TypePtr>::Id>
+    type Id;
+}
+
+pub struct Alias<Id, T>(PhantomData<(Id, T)>);
+
+impl<Id, T> Deref for Alias<Id, T>
+where
+    T: TypePtr<Id = Id> + Deref<Target = Type<Id, T>>,
+    // ^ the impl head here provides the second candidate
+    // <T as Deref>::Target := Type<Id, T>
+    // and additionally a normalisation is mandatory due to
+    // the following supertrait relation trait
+    // Deref: Receiver<Target = <Self as Deref>::Target>
+{
+    type Target = AliasRef<Id, T>;
+
+    fn deref(&self) -> &<Self as Deref>::Target {
+        todo!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
A new mode of type relating is introduced so that obligations are generated instead of outright rejecting projection clauses. This allows project candidates that are sourced from more than one predicates, such as supertrait bounds, provided that they do not conflict each other.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
