### PR TITLE
opt-dist: add a flag for running tests

### DIFF
--- a/src/tools/opt-dist/src/environment.rs
+++ b/src/tools/opt-dist/src/environment.rs
@@ -25,6 +25,7 @@ pub struct Environment {
     prebuilt_rustc_perf: Option<Utf8PathBuf>,
     use_bolt: bool,
     shared_llvm: bool,
+    run_tests: bool,
 }
 
 impl Environment {
@@ -100,6 +101,10 @@ impl Environment {
 
     pub fn benchmark_cargo_config(&self) -> &[String] {
         &self.benchmark_cargo_config
+    }
+
+    pub fn run_tests(&self) -> bool {
+        self.run_tests
     }
 }
 

--- a/src/tools/opt-dist/src/main.rs
+++ b/src/tools/opt-dist/src/main.rs
@@ -94,6 +94,10 @@ enum EnvironmentCmd {
         /// Arguments passed to `rustc-perf --cargo-config <value>` when running benchmarks.
         #[arg(long)]
         benchmark_cargo_config: Vec<String>,
+
+        /// Perform tests after final build if it's not a try build
+        #[arg(long)]
+        run_tests: bool,
     },
     /// Perform an optimized build on Linux CI, from inside Docker.
     LinuxCi {
@@ -125,6 +129,7 @@ fn create_environment(args: Args) -> anyhow::Result<(Environment, Vec<String>)> 
             skipped_tests,
             benchmark_cargo_config,
             shared,
+            run_tests,
         } => {
             let env = EnvironmentBuilder::default()
                 .host_tuple(target_triple)
@@ -138,6 +143,7 @@ fn create_environment(args: Args) -> anyhow::Result<(Environment, Vec<String>)> 
                 .use_bolt(use_bolt)
                 .skipped_tests(skipped_tests)
                 .benchmark_cargo_config(benchmark_cargo_config)
+                .run_tests(run_tests)
                 .build()?;
 
             (env, shared.build_args)
@@ -160,6 +166,7 @@ fn create_environment(args: Args) -> anyhow::Result<(Environment, Vec<String>)> 
                 // FIXME: Enable bolt for aarch64 once it's fixed upstream. Broken as of December 2024.
                 .use_bolt(!is_aarch64)
                 .skipped_tests(vec![])
+                .run_tests(true)
                 .build()?;
 
             (env, shared.build_args)
@@ -179,6 +186,7 @@ fn create_environment(args: Args) -> anyhow::Result<(Environment, Vec<String>)> 
                 .shared_llvm(false)
                 .use_bolt(false)
                 .skipped_tests(vec![])
+                .run_tests(true)
                 .build()?;
 
             (env, shared.build_args)
@@ -344,7 +352,7 @@ fn execute_pipeline(
     // possible regressions.
     // The tests are not executed for try builds, which can be in various broken states, so we don't
     // want to gatekeep them with tests.
-    if !is_try_build() {
+    if !is_try_build() && env.run_tests() {
         timer.section("Run tests", |_| run_tests(env))?;
     }
 


### PR DESCRIPTION
when using `opt-dist local` user probably won't need to run tests (for various reasons). currently the only way to disable them is to set `TRY_DIST_BUILD=1`, which is not obvious and can be bad for non-CI envronments (as I guess)

possibly the `run_tests` name can be confusing too...

r? Kobzol

try-job: dist-x86_64-linux
try-job: dist-x86_64-msvc

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
