### PR TITLE
Introduce and use specialized `//@ ignore-auxiliary` for test support files instead of using `//@ ignore-test`

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/best-practices.md
+++ b/src/doc/rustc-dev-guide/src/tests/best-practices.md
@@ -175,6 +175,8 @@ See [compiletest directives] for a listing of directives.
 - For `ignore-*`/`needs-*`/`only-*` directives, unless extremely obvious,
   provide a brief remark on why the directive is needed. E.g. `"//@ ignore-wasi
   (wasi codegens the main symbol differently)"`.
+- When using `//@ ignore-auxiliary`, specify the corresponding main test files,
+  e.g. ``//@ ignore-auxiliary (used by `./foo.rs`)``.
 
 ## FileCheck best practices
 

--- a/src/doc/rustc-dev-guide/src/tests/directives.md
+++ b/src/doc/rustc-dev-guide/src/tests/directives.md
@@ -124,6 +124,9 @@ means the test won't be compiled or run.
 * `ignore-X` where `X` is a target detail or other criteria on which to ignore the test (see below)
 * `only-X` is like `ignore-X`, but will *only* run the test on that target or
   stage
+* `ignore-auxiliary` is intended for files that *participate* in one or more other
+  main test files but that `compiletest` should not try to build the file itself.
+  Please backlink to which main test is actually using the auxiliary file.
 * `ignore-test` always ignores the test. This can be used to temporarily disable
   a test if it is currently not working, but you want to keep it in tree to
   re-enable it later.

--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -44,6 +44,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-arm-unknown-linux-gnueabihf",
     "ignore-arm-unknown-linux-musleabi",
     "ignore-arm-unknown-linux-musleabihf",
+    "ignore-auxiliary",
     "ignore-avr",
     "ignore-beta",
     "ignore-cdb",

--- a/src/tools/compiletest/src/header/cfg.rs
+++ b/src/tools/compiletest/src/header/cfg.rs
@@ -101,6 +101,10 @@ fn parse_cfg_name_directive<'a>(
         message: "always"
     }
     condition! {
+        name: "auxiliary",
+        message: "used by another main test file"
+    }
+    condition! {
         name: &config.target,
         allowed_names: &target_cfgs.all_targets,
         message: "when the target is {name}"

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -940,3 +940,9 @@ fn test_supported_crate_types() {
         "//@ needs-crate-type: bin, cdylib, dylib, lib, proc-macro, rlib, staticlib"
     ));
 }
+
+#[test]
+fn test_ignore_auxiliary() {
+    let config = cfg().build();
+    assert!(check_ignore(&config, "//@ ignore-auxiliary"));
+}

--- a/tests/codegen/remap_path_prefix/aux_mod.rs
+++ b/tests/codegen/remap_path_prefix/aux_mod.rs
@@ -1,4 +1,4 @@
-//@ ignore-test: this is not a test
+//@ ignore-auxiliary (used by `./main.rs`)
 
 #[inline]
 pub fn some_aux_mod_function() -> i32 {

--- a/tests/debuginfo/drop-locations.rs
+++ b/tests/debuginfo/drop-locations.rs
@@ -1,5 +1,7 @@
 //@ ignore-android
-//@ ignore-test: #128971
+
+// FIXME: stepping with "next" in a debugger skips past end-of-scope drops
+//@ ignore-test (broken, see #128971)
 
 #![allow(unused)]
 

--- a/tests/ui/borrowck/move-error-snippets-ext.rs
+++ b/tests/ui/borrowck/move-error-snippets-ext.rs
@@ -1,4 +1,4 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `./move-error-snippets.rs`)
 
 macro_rules! aaa {
     ($c:ident) => {{

--- a/tests/ui/codemap_tests/two_files_data.rs
+++ b/tests/ui/codemap_tests/two_files_data.rs
@@ -1,4 +1,4 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `./two_files.rs`)
 
 trait Foo { }
 

--- a/tests/ui/conditional-compilation/module_with_cfg.rs
+++ b/tests/ui/conditional-compilation/module_with_cfg.rs
@@ -1,3 +1,3 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `./inner-cfg-non-inline-mod.rs`)
 
 #![cfg_attr(all(), cfg(FALSE))]

--- a/tests/ui/cross/cross-file-errors/underscore.rs
+++ b/tests/ui/cross/cross-file-errors/underscore.rs
@@ -1,4 +1,4 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `./main.rs`)
 #![crate_type = "lib"]
 
 macro_rules! underscore {

--- a/tests/ui/directory_ownership/macro_expanded_mod_helper/foo/bar.rs
+++ b/tests/ui/directory_ownership/macro_expanded_mod_helper/foo/bar.rs
@@ -1,1 +1,1 @@
-//@ ignore-test not a test, auxiliary
+//@ ignore-auxiliary (used by `../../macro-expanded-mod.rs`)

--- a/tests/ui/directory_ownership/macro_expanded_mod_helper/foo/mod.rs
+++ b/tests/ui/directory_ownership/macro_expanded_mod_helper/foo/mod.rs
@@ -1,3 +1,3 @@
-//@ ignore-test not a test, auxiliary
+//@ ignore-auxiliary (used by `../../macro-expanded-mod.rs`)
 
 mod_decl!(bar);

--- a/tests/ui/directory_ownership/mod_file_not_owning_aux1.rs
+++ b/tests/ui/directory_ownership/mod_file_not_owning_aux1.rs
@@ -1,6 +1,0 @@
-//@ ignore-test this is not a test
-
-macro_rules! m {
-    () => { mod mod_file_not_owning_aux2; }
-}
-m!();

--- a/tests/ui/directory_ownership/mod_file_not_owning_aux2.rs
+++ b/tests/ui/directory_ownership/mod_file_not_owning_aux2.rs
@@ -1,1 +1,0 @@
-//@ ignore-test this is not a test

--- a/tests/ui/directory_ownership/mod_file_not_owning_aux3.rs
+++ b/tests/ui/directory_ownership/mod_file_not_owning_aux3.rs
@@ -1,3 +1,0 @@
-//@ ignore-test this is not a test
-
-mod mod_file_not_owning_aux2;

--- a/tests/ui/lint/expansion-time-include.rs
+++ b/tests/ui/lint/expansion-time-include.rs
@@ -1,4 +1,4 @@
-//@ ignore-test auxiliary file for expansion-time.rs
+//@ ignore-auxiliary (used by `./expansion-time.rs`)
 
 1
 2

--- a/tests/ui/lint/known-tool-in-submodule/submodule.rs
+++ b/tests/ui/lint/known-tool-in-submodule/submodule.rs
@@ -1,4 +1,4 @@
-//@ ignore-test: not a test
+//@ ignore-auxiliary (used by `./root.rs`)
 
 #[allow(tool::lint)]
 pub fn foo() {}

--- a/tests/ui/lint/lint_pre_expansion_extern_module_aux.rs
+++ b/tests/ui/lint/lint_pre_expansion_extern_module_aux.rs
@@ -1,3 +1,3 @@
-//@ ignore-test: not a test
+//@ ignore-auxiliary (used by `./lint-pre-expansion-extern-module.rs`)
 
 pub fn try() {}

--- a/tests/ui/lint/unknown-lints/other.rs
+++ b/tests/ui/lint/unknown-lints/other.rs
@@ -1,6 +1,4 @@
-//@ ignore-test (auxiliary)
-
-// Companion to allow-in-other-module.rs
+//@ ignore-auxiliary (used by `./allow-in-other-module.rs`)
 
 // This should not warn.
 #![allow(not_a_real_lint)]

--- a/tests/ui/macros/auxiliary/macro-include-items-expr.rs
+++ b/tests/ui/macros/auxiliary/macro-include-items-expr.rs
@@ -1,3 +1,1 @@
-// ignore-test: this is not a test
-
 1

--- a/tests/ui/macros/auxiliary/macro-include-items-item.rs
+++ b/tests/ui/macros/auxiliary/macro-include-items-item.rs
@@ -1,3 +1,1 @@
-// ignore-test: this is not a test
-
 fn foo() { bar() }

--- a/tests/ui/macros/include-single-expr-helper-1.rs
+++ b/tests/ui/macros/include-single-expr-helper-1.rs
@@ -1,4 +1,4 @@
-//@ ignore-test auxiliary file for include-single-expr.rs
+//@ ignore-auxiliary (used by `./include-single-expr.rs`)
 
 0
 

--- a/tests/ui/macros/include-single-expr-helper.rs
+++ b/tests/ui/macros/include-single-expr-helper.rs
@@ -1,4 +1,4 @@
-//@ ignore-test auxiliary file for include-single-expr.rs
+//@ ignore-auxiliary (used by `./include-single-expr.rs`)
 
 0
 10

--- a/tests/ui/macros/issue-69838-dir/bar.rs
+++ b/tests/ui/macros/issue-69838-dir/bar.rs
@@ -1,3 +1,3 @@
-//@ ignore-test -- this is an auxiliary file as part of another test.
+//@ ignore-auxiliary (used by `../issue-69838-mods-relative-to-included-path.rs`)
 
 pub fn i_am_in_bar() {}

--- a/tests/ui/macros/issue-69838-dir/included.rs
+++ b/tests/ui/macros/issue-69838-dir/included.rs
@@ -1,3 +1,3 @@
-//@ ignore-test -- this is an auxiliary file as part of another test.
+//@ ignore-auxiliary (used by `../issue-69838-mods-relative-to-included-path.rs`)
 
 pub mod bar;

--- a/tests/ui/macros/macro-expanded-include/foo/mod.rs
+++ b/tests/ui/macros/macro-expanded-include/foo/mod.rs
@@ -1,4 +1,4 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `../test.rs`)
 
 macro_rules! m {
     () => { include!("file.txt"); }

--- a/tests/ui/missing_non_modrs_mod/foo.rs
+++ b/tests/ui/missing_non_modrs_mod/foo.rs
@@ -1,4 +1,3 @@
-//
-//@ ignore-test this is just a helper for the real test in this dir
+//@ ignore-auxiliary (used by `./missing_non_modrs_mod.rs`)
 
 mod missing;

--- a/tests/ui/missing_non_modrs_mod/foo_inline.rs
+++ b/tests/ui/missing_non_modrs_mod/foo_inline.rs
@@ -1,4 +1,4 @@
-//@ ignore-test this is just a helper for the real test in this dir
+//@ ignore-auxiliary (used by `./missing_non_modrs_mod_inline.rs`)
 
 mod inline {
     mod missing;

--- a/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod.stderr
+++ b/tests/ui/missing_non_modrs_mod/missing_non_modrs_mod.stderr
@@ -1,5 +1,5 @@
 error[E0583]: file not found for module `missing`
-  --> $DIR/foo.rs:4:1
+  --> $DIR/foo.rs:3:1
    |
 LL | mod missing;
    | ^^^^^^^^^^^^

--- a/tests/ui/modules/mod_file_aux.rs
+++ b/tests/ui/modules/mod_file_aux.rs
@@ -1,4 +1,3 @@
-//@ run-pass
-//@ ignore-test Not a test. Used by other tests
+//@ ignore-auxiliary (used by `./mod_file_with_path_attr.rs` and `mod_file.rs`)
 
 pub fn foo() -> isize { 10 }

--- a/tests/ui/modules_and_files_visibility/mod_file_aux.rs
+++ b/tests/ui/modules_and_files_visibility/mod_file_aux.rs
@@ -1,3 +1,3 @@
-//@ ignore-test Not a test. Used by other tests
+//@ ignore-auxiliary (used by `./mod_file_correct_spans.rs`)
 
 pub fn foo() -> isize { 10 }

--- a/tests/ui/modules_and_files_visibility/mod_file_disambig_aux.rs
+++ b/tests/ui/modules_and_files_visibility/mod_file_disambig_aux.rs
@@ -1,1 +1,1 @@
-//@ ignore-test not a test. aux file
+//@ ignore-auxiliary (used by `./mod_file_disambig.rs`)

--- a/tests/ui/modules_and_files_visibility/mod_file_disambig_aux/mod.rs
+++ b/tests/ui/modules_and_files_visibility/mod_file_disambig_aux/mod.rs
@@ -1,1 +1,1 @@
-//@ ignore-test not a test. aux file
+//@ ignore-auxiliary (used by `../mod_file_disambig.rs`)

--- a/tests/ui/non_modrs_mods/foors_mod.rs
+++ b/tests/ui/non_modrs_mods/foors_mod.rs
@@ -1,6 +1,4 @@
-//@ run-pass
-//
-//@ ignore-test: not a test, used by non_modrs_mods.rs
+//@ ignore-auxiliary (used by `./non_modrs_mods.rs`)
 
 pub mod inner_modrs_mod;
 pub mod inner_foors_mod;

--- a/tests/ui/non_modrs_mods_and_inline_mods/x.rs
+++ b/tests/ui/non_modrs_mods_and_inline_mods/x.rs
@@ -1,4 +1,4 @@
-//@ ignore-test: not a test
+//@ ignore-auxiliary (used by `./non_modrs_mods_and_inline_mods.rs`)
 
 pub mod y {
     pub mod z;

--- a/tests/ui/non_modrs_mods_and_inline_mods/x/y/z/mod.rs
+++ b/tests/ui/non_modrs_mods_and_inline_mods/x/y/z/mod.rs
@@ -1,1 +1,1 @@
-//@ ignore-test: not a test
+//@ ignore-auxiliary (used by `../../../non_modrs_mods_and_inline_mods.rs`)

--- a/tests/ui/numbers-arithmetic/saturating-float-casts-impl.rs
+++ b/tests/ui/numbers-arithmetic/saturating-float-casts-impl.rs
@@ -1,4 +1,4 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `./saturating-float-casts.rs` and `./saturating-float-casts-wasm.rs`)
 
 // Tests saturating float->int casts. See u128-as-f32.rs for the opposite direction.
 //

--- a/tests/ui/parser/circular_modules_hello.rs
+++ b/tests/ui/parser/circular_modules_hello.rs
@@ -1,4 +1,4 @@
-//@ ignore-test: this is an auxiliary file for circular-modules-main.rs
+//@ ignore-auxiliary (used by `./circular-modules-main.rs`)
 
 #[path = "circular_modules_main.rs"]
 mod circular_modules_main;

--- a/tests/ui/parser/issues/circular-module-with-doc-comment-issue-97589/recursive.rs
+++ b/tests/ui/parser/issues/circular-module-with-doc-comment-issue-97589/recursive.rs
@@ -1,4 +1,4 @@
-//@ ignore-test: this is an auxiliary file for circular-module-with-doc-comment-issue-97589.rs
+//@ ignore-auxiliary (used by `./circular-module-with-doc-comment-issue-97589.rs`)
 
 //! this comment caused the circular dependency checker to break
 

--- a/tests/ui/parser/issues/issue-48508-aux.rs
+++ b/tests/ui/parser/issues/issue-48508-aux.rs
@@ -1,5 +1,4 @@
-//@ run-pass
-//@ ignore-test Not a test. Used by issue-48508.rs
+//@ ignore-auxiliary (used by `./issue-48508.rs`)
 
 pub fn other() -> f64 {
     let µ = 1.0;

--- a/tests/ui/proc-macro/module.rs
+++ b/tests/ui/proc-macro/module.rs
@@ -1,1 +1,1 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `./attributes-on-modules-fail.rs`)

--- a/tests/ui/proc-macro/module_with_attrs.rs
+++ b/tests/ui/proc-macro/module_with_attrs.rs
@@ -1,4 +1,4 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `../inner-attr-non-inline-mod.rs`)
 
 #![rustfmt::skip]
 #![print_attr]

--- a/tests/ui/proc-macro/outer/inner.rs
+++ b/tests/ui/proc-macro/outer/inner.rs
@@ -1,1 +1,1 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `../attributes-on-modules-fail.rs`)

--- a/tests/ui/proc-macro/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs
+++ b/tests/ui/proc-macro/pretty-print-hack/allsorts-rental-0.5.6/src/lib.rs
@@ -1,4 +1,4 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `../../../pretty-print-hack-show.rs`)
 
 #[derive(Print)]
 enum ProceduralMasqueradeDummyType {

--- a/tests/ui/proc-macro/pretty-print-hack/rental-0.5.5/src/lib.rs
+++ b/tests/ui/proc-macro/pretty-print-hack/rental-0.5.5/src/lib.rs
@@ -1,4 +1,4 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `../../../pretty-print-hack-show.rs`)
 
 #[derive(Print)]
 enum ProceduralMasqueradeDummyType {

--- a/tests/ui/proc-macro/pretty-print-hack/rental-0.5.6/src/lib.rs
+++ b/tests/ui/proc-macro/pretty-print-hack/rental-0.5.6/src/lib.rs
@@ -1,4 +1,4 @@
-//@ ignore-test (auxiliary, used by other tests)
+//@ ignore-auxiliary (used by `../../../pretty-print-hack/hide.rs`)
 
 #[derive(Print)]
 enum ProceduralMasqueradeDummyType {

--- a/tests/ui/runtime/backtrace-debuginfo-aux.rs
+++ b/tests/ui/runtime/backtrace-debuginfo-aux.rs
@@ -1,5 +1,4 @@
-//@ run-pass
-//@ ignore-test: not a test, used by backtrace-debuginfo.rs to test file!()
+//@ ignore-auxiliary (used by `./backtrace-debuginfo.rs` to test `file!()`)
 
 #[inline(never)]
 pub fn callback<F>(f: F) where F: FnOnce((&'static str, u32)) {


### PR DESCRIPTION
### Summary

Add a semantically meaningful directive for ignoring test *auxiliary* files. This is for auxiliary files that *participate* in actual tests but should not be built by `compiletest` (i.e. these files are involved through `mod xxx;` or `include!()` or `#[path = "xxx"]`, etc.).

### Motivation

A specialized directive like `//@ ignore-auxiliary` makes it way easier to audit disabled tests via `//@ ignore-test`.
  - These support files cannot use the canonical `auxiliary/` dir because they participate in module resolution or are included, or their relative paths can be important for test intention otherwise.

Follow-up to:
- #139705
- #139783
- #139740

See also discussions in:

- [#t-compiler > Directive name for non-test aux files?](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Directive.20name.20for.20non-test.20aux.20files.3F/with/512773817)
- [#t-compiler > Handling disabled &#96;//@ ignore-test&#96; tests](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/Handling.20disabled.20.60.2F.2F.40.20ignore-test.60.20tests/with/512005974)
- [#t-compiler/meetings > &#91;steering&#93; 2025-04-11 Dealing with disabled tests](https://rust-lang.zulipchat.com/#narrow/channel/238009-t-compiler.2Fmeetings/topic/.5Bsteering.5D.202025-04-11.20Dealing.20with.20disabled.20tests/with/511717981)

### Remarks on remaining unconditionally disabled tests under `tests/`

After this PR, against commit 79a272c6402, only **14** remaining test files are disabled through `//@ ignore-test`:

<details>
<summary>Remaining `//@ ignore-test` files under `tests/`</summary>

```
tests/debuginfo/drop-locations.rs
4://@ ignore-test (broken, see #128971)

tests/rustdoc/macro-document-private-duplicate.rs
1://@ ignore-test (fails spuriously, see issue #89228)

tests/rustdoc/inline_cross/assoc-const-equality.rs
3://@ ignore-test (FIXME: #125092)

tests/ui/match/issue-27021.rs
7://@ ignore-test (#54987)

tests/ui/match/issue-26996.rs
7://@ ignore-test (#54987)

tests/ui/issues/issue-49298.rs
9://@ ignore-test (#54987)

tests/ui/issues/issue-59756.rs
2://@ ignore-test (rustfix needs multiple suggestions)

tests/ui/precondition-checks/write.rs
5://@ ignore-test (unimplemented)

tests/ui/precondition-checks/read.rs
5://@ ignore-test (unimplemented)

tests/ui/precondition-checks/write_bytes.rs
5://@ ignore-test (unimplemented)

tests/ui/explicit-tail-calls/drop-order.rs
2://@ ignore-test: tail calls are not implemented in rustc_codegen_ssa yet, so this causes 🧊

tests/ui/panics/panic-short-backtrace-windows-x86_64.rs
3://@ ignore-test (#92000)

tests/ui/json/json-bom-plus-crlf-multifile-aux.rs
3://@ ignore-test Not a test. Used by other tests

tests/ui/traits/next-solver/object-soundness-requires-generalization.rs
2://@ ignore-test (see #114196)
```
</details>

Of these, most are either **unimplemented**, or **spurious**, or **known-broken**. The outstanding one is `tests/ui/json/json-bom-plus-crlf-multifile-aux.rs` which I did not want to touch in *this* PR -- that aux file has load-bearing BOM and carriage returns and byte offset matters. I think those test files that require special encoding / BOM probably are better off as `run-make` tests. See #139968 for that aux file.

### Review advice

- Best reviewed commit-by-commit.
- The directive name diverged from the most voted `//@ auxiliary` because I think that's easy to confuse with `//@ aux-{crate,dir}`.

r? compiler