### PR TITLE
Make C string merging test work on MIPS

### DIFF
--- a/tests/assembly/cstring-merging.rs
+++ b/tests/assembly/cstring-merging.rs
@@ -1,3 +1,5 @@
+// MIPS assembler uses the label prefix `$anon.` for local anonymous variables
+// other architectures (including ARM and x86-64) use the prefix `.Lanon.`
 //@ only-linux
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -Copt-level=3
@@ -6,13 +8,13 @@
 use std::ffi::CStr;
 
 // CHECK: .section .rodata.str1.{{[12]}},"aMS"
-// CHECK: .Lanon.{{.+}}:
+// CHECK: {{(\.L|\$)}}anon.{{.+}}:
 // CHECK-NEXT: .asciz "foo"
 #[unsafe(no_mangle)]
 static CSTR: &[u8; 4] = b"foo\0";
 
 // CHECK-NOT: .section
-// CHECK: .Lanon.{{.+}}:
+// CHECK: {{(\.L|\$)}}anon.{{.+}}:
 // CHECK-NEXT: .asciz "bar"
 #[unsafe(no_mangle)]
 pub fn cstr() -> &'static CStr {
@@ -20,7 +22,7 @@ pub fn cstr() -> &'static CStr {
 }
 
 // CHECK-NOT: .section
-// CHECK: .Lanon.{{.+}}:
+// CHECK: {{(\.L|\$)}}anon.{{.+}}:
 // CHECK-NEXT: .asciz "baz"
 #[unsafe(no_mangle)]
 pub fn manual_cstr() -> &'static str {


### PR DESCRIPTION
Assembly for MIPS uses, by convention, a different prefix for local anonymous variables.

