### PR TITLE
run-make: drop `os_pipe` workaround now that `anonymous_pipe` is stable on beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,16 +2573,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "os_pipe"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,7 +3132,6 @@ dependencies = [
  "gimli 0.31.1",
  "libc",
  "object 0.36.7",
- "os_pipe",
  "regex",
  "serde_json",
  "similar",

--- a/src/tools/run-make-support/Cargo.toml
+++ b/src/tools/run-make-support/Cargo.toml
@@ -14,9 +14,5 @@ build_helper = { path = "../../build_helper" }
 serde_json = "1.0"
 libc = "0.2"
 
-# FIXME(#137532): replace `os_pipe` with `anonymous_pipe` once it stabilizes and
-# reaches beta.
-os_pipe = "1.2.1"
-
 [lib]
 crate-type = ["lib", "dylib"]

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -41,8 +41,6 @@ pub use bstr;
 pub use gimli;
 pub use libc;
 pub use object;
-// FIXME(#137532): replace with std `anonymous_pipe` once it stabilizes and reaches beta.
-pub use os_pipe;
 pub use regex;
 pub use serde_json;
 pub use similar;

--- a/tests/run-make/broken-pipe-no-ice/rmake.rs
+++ b/tests/run-make/broken-pipe-no-ice/rmake.rs
@@ -14,9 +14,7 @@
 use std::io::Read;
 use std::process::{Command, Stdio};
 
-// FIXME(#137532): replace `os_pipe` dependency with std `anonymous_pipe` once that stabilizes and
-// reaches beta.
-use run_make_support::{env_var, os_pipe};
+use run_make_support::env_var;
 
 #[derive(Debug, PartialEq)]
 enum Binary {
@@ -25,7 +23,7 @@ enum Binary {
 }
 
 fn check_broken_pipe_handled_gracefully(bin: Binary, mut cmd: Command) {
-    let (reader, writer) = os_pipe::pipe().unwrap();
+    let (reader, writer) = std::io::pipe().unwrap();
     drop(reader); // close read-end
     cmd.stdout(writer).stderr(Stdio::piped());
 


### PR DESCRIPTION
Follow-up to #137537 where I had to include a temporary dep on `os_pipe` before `anonymous_pipe` was stabilized. Now that `anonymous_pipe` is stable on beta, we can get rid of this workaround.

Closes #137532. (Final cleanup item)

r? @Kobzol