### PR TITLE
Fix drop handling in `hint::select_unpredictable`

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -1327,6 +1327,8 @@ pub const fn unlikely(b: bool) -> bool {
 /// any safety invariants.
 ///
 /// The public form of this instrinsic is [`core::hint::select_unpredictable`].
+/// However unlike the public form, the intrinsic will not drop the value that
+/// is not selected.
 #[unstable(feature = "core_intrinsics", issue = "none")]
 #[rustc_intrinsic]
 #[rustc_nounwind]

--- a/library/coretests/tests/hint.rs
+++ b/library/coretests/tests/hint.rs
@@ -1,0 +1,23 @@
+#[test]
+fn select_unpredictable_drop() {
+    use core::cell::Cell;
+    struct X<'a>(&'a Cell<bool>);
+    impl Drop for X<'_> {
+        fn drop(&mut self) {
+            self.0.set(true);
+        }
+    }
+
+    let a_dropped = Cell::new(false);
+    let b_dropped = Cell::new(false);
+    let a = X(&a_dropped);
+    let b = X(&b_dropped);
+    assert!(!a_dropped.get());
+    assert!(!b_dropped.get());
+    let selected = core::hint::select_unpredictable(core::hint::black_box(true), a, b);
+    assert!(!a_dropped.get());
+    assert!(b_dropped.get());
+    drop(selected);
+    assert!(a_dropped.get());
+    assert!(b_dropped.get());
+}

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -68,6 +68,7 @@
 #![feature(pointer_is_aligned_to)]
 #![feature(portable_simd)]
 #![feature(ptr_metadata)]
+#![feature(select_unpredictable)]
 #![feature(slice_from_ptr_range)]
 #![feature(slice_internals)]
 #![feature(slice_partition_dedup)]
@@ -147,6 +148,7 @@ mod ffi;
 mod fmt;
 mod future;
 mod hash;
+mod hint;
 mod intrinsics;
 mod io;
 mod iter;


### PR DESCRIPTION
This intrinsic doesn't drop the value that is not selected so this is manually done in the public function that wraps the intrinsic.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
