### PR TITLE
Don't compute name of associated item if it's an RPITIT

### DIFF
--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -486,15 +486,15 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
             let items: &AssocItems = self.tcx.associated_items(self.def_id);
             items
                 .in_definition_order()
-                .filter(|item| item.is_type())
                 .filter(|item| {
-                    !self
-                        .gen_args
-                        .constraints
-                        .iter()
-                        .any(|constraint| constraint.ident.name == item.name())
+                    item.is_type()
+                        && !item.is_impl_trait_in_trait()
+                        && !self
+                            .gen_args
+                            .constraints
+                            .iter()
+                            .any(|constraint| constraint.ident.name == item.name())
                 })
-                .filter(|item| !item.is_impl_trait_in_trait())
                 .map(|item| self.tcx.item_ident(item.def_id).to_string())
                 .collect()
         } else {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -29,7 +29,7 @@ use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, ErrorGuaranteed, FatalError, struct_span_code_err,
 };
-use rustc_hir::def::{CtorKind, CtorOf, DefKind, Namespace, Res};
+use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, AnonConst, GenericArg, GenericArgs, HirId};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
@@ -1731,9 +1731,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 tcx.associated_items(*trait_def_id)
                         .in_definition_order()
                         .any(|i| {
-                            i.namespace() == Namespace::TypeNS
+                            i.is_type()
+                                && !i.is_impl_trait_in_trait()
                                 && i.ident(tcx).normalize_to_macros_2_0() == assoc_ident
-                                && i.is_type()
                         })
                     // Consider only accessible traits
                     && tcx.visibility(*trait_def_id)

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-2.rs
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-2.rs
@@ -1,0 +1,12 @@
+trait Foo {
+    fn rpitit() -> impl Sized;
+}
+
+// Ensure that we don't try to probe the name of the RPITIT when looking for
+// fixes to suggest for the redundant generic below.
+
+fn test<T: Foo<i32, Assoc = i32>>() {}
+//~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
+//~| ERROR associated type `Assoc` not found for `Foo`
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-2.stderr
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-2.stderr
@@ -1,0 +1,24 @@
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/dont-probe-missing-item-name-2.rs:8:12
+   |
+LL | fn test<T: Foo<i32, Assoc = i32>>() {}
+   |            ^^^------------------ help: remove the unnecessary generics
+   |            |
+   |            expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/dont-probe-missing-item-name-2.rs:1:7
+   |
+LL | trait Foo {
+   |       ^^^
+
+error[E0220]: associated type `Assoc` not found for `Foo`
+  --> $DIR/dont-probe-missing-item-name-2.rs:8:21
+   |
+LL | fn test<T: Foo<i32, Assoc = i32>>() {}
+   |                     ^^^^^ associated type `Assoc` not found
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0220.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-3.rs
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-3.rs
@@ -1,0 +1,11 @@
+trait Trait {
+    fn method() -> impl Sized;
+}
+
+// Ensure that we don't try to probe the name of the RPITIT when looking for
+// fixes to suggest for the missing associated type's trait path below.
+
+fn foo() -> i32::Assoc {}
+//~^ ERROR ambiguous associated type
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-3.stderr
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-3.stderr
@@ -1,0 +1,15 @@
+error[E0223]: ambiguous associated type
+  --> $DIR/dont-probe-missing-item-name-3.rs:8:13
+   |
+LL | fn foo() -> i32::Assoc {}
+   |             ^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `Assoc` implemented for `i32`, you could use the fully-qualified path
+   |
+LL - fn foo() -> i32::Assoc {}
+LL + fn foo() -> <i32 as Example>::Assoc {}
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0223`.


### PR DESCRIPTION
Another simple fix for an RPITIT name ICE.

Fixes https://github.com/rust-lang/rust/issues/139941
Fixes #140084

r? nnethercote