### PR TITLE
SystemTime doc tweaks

### DIFF
--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -245,6 +245,7 @@ pub struct Instant(time::Instant);
 /// > structure cannot represent the new point in time.
 ///
 /// [`add`]: SystemTime::add
+/// [`UNIX_EPOCH`]: SystemTime::UNIX_EPOCH
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[stable(feature = "time2", since = "1.8.0")]
 pub struct SystemTime(time::SystemTime);

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -205,8 +205,8 @@ pub struct Instant(time::Instant);
 ///            println!("{}", elapsed.as_secs());
 ///        }
 ///        Err(e) => {
-///            // an error occurred!
-///            println!("Error: {e:?}");
+///            // the system clock went backwards!
+///            println!("Great Scott! {e:?}");
 ///        }
 ///    }
 /// }


### PR DESCRIPTION
* Change the `UNIX_EPOCH` link in the `SystemTime` docs to point to the associated constant, not the module level constant. The former seems to be the recommended way to access it, since aiui the only reason the module constant exists in the first place is that associated constants weren't stable yet at the time.
* Reword the comment in the `SystemTime` example - "an error occurred!" is a tad misleading; I feel like it implies a system error out of our control while `SystemTimeError` is more of a logic error.

I was originally just gonna do the first thing but I noticed the second and figured I may as well.

I'm also somewhat surprised that there aren't more in-depth module level docs for `std::time`; they don't even mention `SystemTime` at all. I might make another PR for that but mainly just wanted to flag it.