### PR TITLE
add `CStr::display`

### DIFF
--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -659,6 +659,30 @@ impl CStr {
         // instead of doing it afterwards.
         str::from_utf8(self.to_bytes())
     }
+
+    /// Returns an object that implements [`Display`] for safely printing a [`CStr`] that may
+    /// contain non-Unicode data.
+    ///
+    /// Behaves as if `self` were first lossily converted to a `str`, with invalid UTF-8 presented
+    /// as the Unicode replacement character: �.
+    ///
+    /// [`Display`]: fmt::Display
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(cstr_display)]
+    ///
+    /// let cstr = c"Hello, world!";
+    /// println!("{}", cstr.display());
+    /// ```
+    #[unstable(feature = "cstr_display", issue = "139984")]
+    #[must_use = "this does not display the `CStr`; \
+                  it returns an object that can be displayed"]
+    #[inline]
+    pub fn display(&self) -> impl fmt::Display {
+        crate::bstr::ByteStr::from_bytes(self.to_bytes())
+    }
 }
 
 // `.to_bytes()` representations are compared instead of the inner `[c_char]`s,

--- a/library/coretests/tests/ffi/cstr.rs
+++ b/library/coretests/tests/ffi/cstr.rs
@@ -19,3 +19,9 @@ fn debug() {
     let s = c"abc\x01\x02\n\xE2\x80\xA6\xFF";
     assert_eq!(format!("{s:?}"), r#""abc\x01\x02\n\xe2\x80\xa6\xff""#);
 }
+
+#[test]
+fn display() {
+    let s = c"\xf0\x28\x8c\xbc";
+    assert_eq!(format!("{}", s.display()), "�(��");
+}

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -23,6 +23,7 @@
 #![feature(core_io_borrowed_buf)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]
+#![feature(cstr_display)]
 #![feature(dec2flt)]
 #![feature(duration_constants)]
 #![feature(duration_constructors)]


### PR DESCRIPTION
The implementation delegates to `<ByteStr as Display>::fmt`.

Link: https://github.com/rust-lang/libs-team/issues/550
Link: https://github.com/rust-lang/rust/issues/139984.

r? @BurntSushi
cc @Darksonn @tgross35 @ojeda @joshtriplett

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
