### PR TITLE
skip llvm-config in autodiff check builds, when its unavailable

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1194,8 +1194,7 @@ pub fn rustc_cargo(
         let enzyme_dir = builder.build.out.join(arch).join("enzyme").join("lib");
         cargo.rustflag("-L").rustflag(enzyme_dir.to_str().expect("Invalid path"));
 
-        if !builder.config.dry_run() {
-            let llvm_config = builder.llvm_config(builder.config.build).unwrap();
+        if let Some(llvm_config) = builder.llvm_config(builder.config.build) {
             let llvm_version_major = llvm::get_llvm_version_major(builder, &llvm_config);
             cargo.rustflag("-l").rustflag(&format!("Enzyme-{llvm_version_major}"));
         }


### PR DESCRIPTION
As you suggested, this indeed fixes `./x.py check` builds when autodiff is enabled.

r? @onur-ozkan 

closes #139936

Tracking:

- https://github.com/rust-lang/rust/issues/124509