### PR TITLE
Remove `avx512dq` and `avx512vl` implication for `avx512fp16`

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -398,7 +398,7 @@ static X86_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("avx512cd", Unstable(sym::avx512_target_feature), &["avx512f"]),
     ("avx512dq", Unstable(sym::avx512_target_feature), &["avx512f"]),
     ("avx512f", Unstable(sym::avx512_target_feature), &["avx2", "fma", "f16c"]),
-    ("avx512fp16", Unstable(sym::avx512_target_feature), &["avx512bw", "avx512vl", "avx512dq"]),
+    ("avx512fp16", Unstable(sym::avx512_target_feature), &["avx512bw"]),
     ("avx512ifma", Unstable(sym::avx512_target_feature), &["avx512f"]),
     ("avx512vbmi", Unstable(sym::avx512_target_feature), &["avx512bw"]),
     ("avx512vbmi2", Unstable(sym::avx512_target_feature), &["avx512bw"]),


### PR DESCRIPTION
According to Intel, `avx512fp16` requires only `avx512bw`, but LLVM also enables `avx512vl` and `avx512dq` when `avx512fp16` is active. This is relic code, and will be fixed in LLVM soon. We should remove this from Rust too asap, especially before the stabilization of AVX512

Related:
 - llvm/llvm-project#136209
 - #138940
 - rust-lang/stdarch#1781
 - #111137

@rustbot label O-x86_64 O-x86_32 A-SIMD A-target-feature T-compiler
r? @Amanieu