### PR TITLE
docs(LocalKey<T>): clarify that T's Drop shouldn't panic

### DIFF
--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -46,7 +46,7 @@ macro_rules! rtprintpanic {
 macro_rules! rtabort {
     ($($t:tt)*) => {
         {
-            rtprintpanic!("fatal runtime error: {}\n", format_args!($($t)*));
+            rtprintpanic!("fatal runtime error: {}, aborting\n", format_args!($($t)*));
             crate::sys::abort_internal();
         }
     }

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -22,11 +22,15 @@ use crate::fmt;
 ///
 /// Initialization is dynamically performed on the first call to a setter (e.g.
 /// [`with`]) within a thread, and values that implement [`Drop`] get
-/// destructed when a thread exits. Some caveats apply, which are explained below.
+/// destructed when a thread exits. Some platform-specific caveats apply, which
+/// are explained below.
+/// Note that, should the destructor panics, the whole process will be [aborted].
 ///
 /// A `LocalKey`'s initializer cannot recursively depend on itself. Using a
 /// `LocalKey` in this way may cause panics, aborts or infinite recursion on
 /// the first call to `with`.
+///
+/// [aborted]: crate::process::abort
 ///
 /// # Single-thread Synchronization
 ///

--- a/src/tools/miri/tests/fail/panic/tls_macro_const_drop_panic.stderr
+++ b/src/tools/miri/tests/fail/panic/tls_macro_const_drop_panic.stderr
@@ -1,7 +1,7 @@
 
 thread $NAME panicked at tests/fail/panic/tls_macro_const_drop_panic.rs:LL:CC:
 ow
-fatal runtime error: thread local panicked on drop
+fatal runtime error: thread local panicked on drop, aborting
 error: abnormal termination: the program aborted execution
 
 error: aborting due to 1 previous error

--- a/src/tools/miri/tests/fail/panic/tls_macro_drop_panic.stderr
+++ b/src/tools/miri/tests/fail/panic/tls_macro_drop_panic.stderr
@@ -1,7 +1,7 @@
 
 thread $NAME panicked at tests/fail/panic/tls_macro_drop_panic.rs:LL:CC:
 ow
-fatal runtime error: thread local panicked on drop
+fatal runtime error: thread local panicked on drop, aborting
 error: abnormal termination: the program aborted execution
 
 error: aborting due to 1 previous error

--- a/tests/ui/runtime/rt-explody-panic-payloads.rs
+++ b/tests/ui/runtime/rt-explody-panic-payloads.rs
@@ -27,6 +27,6 @@ fn main() {
             // by QEMU in the stderr whenever a core dump happens. Remove it before the check.
             v.strip_suffix("qemu: uncaught target signal 6 (Aborted) - core dumped\n").unwrap_or(v)
         })
-        .map(|v| { v.ends_with("fatal runtime error: drop of the panic payload panicked\n") })
+        .map(|v| v.ends_with("fatal runtime error: drop of the panic payload panicked, aborting\n"))
         .unwrap_or(false));
 }


### PR DESCRIPTION
Clarify that should a TLS destructor panics, the process will abort.

Also, an abort may be obfuscated as the process can be terminated with `SIGSEGV` or [`STATUS_STACK_BUFFER_OVERRUN`](https://devblogs.microsoft.com/oldnewthing/20190108-00/?p=100655) (i.e., `SIGABRT` is not guaranteed), so explicitly prints that the process was aborted.

Context:
https://users.rust-lang.org/t/status-stack-buffer-overrun-on-windows-without-any-usage-of-unsafe/128417

@rustbot label -T-compiler