### PR TITLE
`deref_patterns`: support string and byte string literals in explicit `deref!("...")` patterns

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -759,19 +759,40 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Byte string patterns behave the same way as array patterns
         // They can denote both statically and dynamically-sized byte arrays.
+        // Additionally, when `deref_patterns` is enabled, byte string literal patterns may have
+        // types `[u8]` or `[u8; N]`, in order to type, e.g., `deref!(b"..."): Vec<u8>`.
         let mut pat_ty = ty;
         if let hir::PatExprKind::Lit {
             lit: Spanned { node: ast::LitKind::ByteStr(..), .. }, ..
         } = lt.kind
         {
+            let tcx = self.tcx;
             let expected = self.structurally_resolve_type(span, expected);
-            if let ty::Ref(_, inner_ty, _) = *expected.kind()
-                && self.try_structurally_resolve_type(span, inner_ty).is_slice()
-            {
-                let tcx = self.tcx;
-                trace!(?lt.hir_id.local_id, "polymorphic byte string lit");
-                pat_ty =
-                    Ty::new_imm_ref(tcx, tcx.lifetimes.re_static, Ty::new_slice(tcx, tcx.types.u8));
+            match *expected.kind() {
+                // Allow `b"...": &[u8]`
+                ty::Ref(_, inner_ty, _)
+                    if self.try_structurally_resolve_type(span, inner_ty).is_slice() =>
+                {
+                    trace!(?lt.hir_id.local_id, "polymorphic byte string lit");
+                    pat_ty = Ty::new_imm_ref(
+                        tcx,
+                        tcx.lifetimes.re_static,
+                        Ty::new_slice(tcx, tcx.types.u8),
+                    );
+                }
+                // Allow `b"...": [u8; 3]` for `deref_patterns`
+                ty::Array(..) if tcx.features().deref_patterns() => {
+                    pat_ty = match *ty.kind() {
+                        ty::Ref(_, inner_ty, _) => inner_ty,
+                        _ => span_bug!(span, "found byte string literal with non-ref type {ty:?}"),
+                    }
+                }
+                // Allow `b"...": [u8]` for `deref_patterns`
+                ty::Slice(..) if tcx.features().deref_patterns() => {
+                    pat_ty = Ty::new_slice(tcx, tcx.types.u8);
+                }
+                // Otherwise, `b"...": &[u8; 3]`
+                _ => {}
             }
         }
 

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -775,6 +775,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
+        // When `deref_patterns` is enabled, in order to allow `deref!("..."): String`, we allow
+        // string literal patterns to have type `str`. This is accounted for when lowering to MIR.
+        if self.tcx.features().deref_patterns()
+            && let hir::PatExprKind::Lit {
+                lit: Spanned { node: ast::LitKind::Str(..), .. }, ..
+            } = lt.kind
+            && self.try_structurally_resolve_type(span, expected).is_str()
+        {
+            pat_ty = self.tcx.types.str_;
+        }
+
         if self.tcx.features().string_deref_patterns()
             && let hir::PatExprKind::Lit {
                 lit: Spanned { node: ast::LitKind::Str(..), .. }, ..

--- a/compiler/rustc_mir_build/src/thir/constant.rs
+++ b/compiler/rustc_mir_build/src/thir/constant.rs
@@ -44,12 +44,16 @@ pub(crate) fn lit_to_const<'tcx>(
             ty::ValTree::from_raw_bytes(tcx, str_bytes)
         }
         (ast::LitKind::ByteStr(data, _), ty::Ref(_, inner_ty, _))
-            if matches!(inner_ty.kind(), ty::Slice(_)) =>
+            if matches!(inner_ty.kind(), ty::Slice(_) | ty::Array(..)) =>
         {
             let bytes = data as &[u8];
             ty::ValTree::from_raw_bytes(tcx, bytes)
         }
-        (ast::LitKind::ByteStr(data, _), ty::Ref(_, inner_ty, _)) if inner_ty.is_array() => {
+        (ast::LitKind::ByteStr(data, _), ty::Slice(_) | ty::Array(..))
+            if tcx.features().deref_patterns() =>
+        {
+            // Byte string literal patterns may have type `[u8]` or `[u8; N]` if `deref_patterns` is
+            // enabled, in order to allow, e.g., `deref!(b"..."): Vec<u8>`.
             let bytes = data as &[u8];
             ty::ValTree::from_raw_bytes(tcx, bytes)
         }

--- a/compiler/rustc_mir_build/src/thir/constant.rs
+++ b/compiler/rustc_mir_build/src/thir/constant.rs
@@ -37,6 +37,12 @@ pub(crate) fn lit_to_const<'tcx>(
             let str_bytes = s.as_str().as_bytes();
             ty::ValTree::from_raw_bytes(tcx, str_bytes)
         }
+        (ast::LitKind::Str(s, _), ty::Str) if tcx.features().deref_patterns() => {
+            // String literal patterns may have type `str` if `deref_patterns` is enabled, in order
+            // to allow `deref!("..."): String`.
+            let str_bytes = s.as_str().as_bytes();
+            ty::ValTree::from_raw_bytes(tcx, str_bytes)
+        }
         (ast::LitKind::ByteStr(data, _), ty::Ref(_, inner_ty, _))
             if matches!(inner_ty.kind(), ty::Slice(_)) =>
         {

--- a/src/doc/unstable-book/src/language-features/deref-patterns.md
+++ b/src/doc/unstable-book/src/language-features/deref-patterns.md
@@ -54,4 +54,25 @@ if let [b] = &mut *v {
 assert_eq!(v, [Box::new(Some(2))]);
 ```
 
+Additionally, when `deref_patterns` is enabled, string literal patterns may be written where `str`
+is expected. Likewise, byte string literal patterns may be written where `[u8]` or `[u8; _]` is
+expected. This lets them be used in `deref!(_)` patterns:
+
+```rust
+# #![feature(deref_patterns)]
+# #![allow(incomplete_features)]
+match ("test".to_string(), b"test".to_vec()) {
+    (deref!("test"), deref!(b"test")) => {}
+    _ => panic!(),
+}
+
+// Matching on slices and arrays using literals is possible elsewhere as well:
+match *"test" {
+    "test" => {}
+    _ => panic!(),
+}
+```
+
+Implicit deref pattern syntax is not yet supported for string or byte string literals.
+
 [smart pointers in the standard library]: https://doc.rust-lang.org/std/ops/trait.DerefPure.html#implementors

--- a/tests/ui/pattern/byte-string-mutability-mismatch.rs
+++ b/tests/ui/pattern/byte-string-mutability-mismatch.rs
@@ -1,0 +1,19 @@
+//! Byte string literal patterns use the mutability of the literal, rather than the mutability of
+//! the pattern's scrutinee. Since byte string literals are always shared references, it's a
+//! mismatch to use a byte string literal pattern to match on a mutable array or slice reference.
+
+fn main() {
+    let mut val = [97u8, 10u8];
+    match &mut val {
+        b"a\n" => {},
+        //~^ ERROR mismatched types
+        //~| types differ in mutability
+        _ => {},
+    }
+    match &mut val[..] {
+         b"a\n" => {},
+        //~^ ERROR mismatched types
+        //~| types differ in mutability
+         _ => {},
+    }
+}

--- a/tests/ui/pattern/byte-string-mutability-mismatch.stderr
+++ b/tests/ui/pattern/byte-string-mutability-mismatch.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/byte-string-mutability-mismatch.rs:8:9
+   |
+LL |     match &mut val {
+   |           -------- this expression has type `&mut [u8; 2]`
+LL |         b"a\n" => {},
+   |         ^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut _`
+                      found reference `&'static _`
+
+error[E0308]: mismatched types
+  --> $DIR/byte-string-mutability-mismatch.rs:14:10
+   |
+LL |     match &mut val[..] {
+   |           ------------ this expression has type `&mut [u8]`
+LL |          b"a\n" => {},
+   |          ^^^^^^ types differ in mutability
+   |
+   = note: expected mutable reference `&mut _`
+                      found reference `&'static _`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/pattern/deref-patterns/byte-string-type-errors.rs
+++ b/tests/ui/pattern/deref-patterns/byte-string-type-errors.rs
@@ -1,0 +1,34 @@
+//! Test type errors for byte string literal patterns. `deref_patterns` allows byte string literal
+//! patterns to have type `[u8]` or `[u8; N]` when matching on a slice or array; this can affect the
+//! "found" type reported in error messages when matching on a slice or array of the wrong type.
+
+#![feature(deref_patterns)]
+#![expect(incomplete_features)]
+
+fn main() {
+    // Baseline 1: under normal circumstances, byte string literal patterns have type `&[u8; N]`,
+    // the same as byte string literals.
+    if let b"test" = () {}
+    //~^ ERROR mismatched types
+    //~| expected `()`, found `&[u8; 4]`
+
+    // Baseline 2: there's a special case for byte string patterns in stable rust, allowing them to
+    // match on slice references. This affects the error when matching on a non-`&[u8]` slice ref,
+    // reporting the "found" type as `&[u8]`.
+    if let b"test" = &[] as &[i8] {}
+    //~^ ERROR mismatched types
+    //~| expected `&[i8]`, found `&[u8]`
+
+    // Test matching on a non-`[u8]` slice: the pattern has type `[u8]` if a slice is expected.
+    if let b"test" = *(&[] as &[i8]) {}
+    //~^ ERROR mismatched types
+    //~| expected `[i8]`, found `[u8]`
+
+    // Test matching on a non-`[u8;4]` array: the pattern has type `[u8;4]` if an array is expected.
+    if let b"test" = [()] {}
+    //~^ ERROR mismatched types
+    //~| expected `[(); 1]`, found `[u8; 4]`
+    if let b"test" = *b"this array is too long" {}
+    //~^ ERROR mismatched types
+    //~| expected an array with a size of 22, found one with a size of 4
+}

--- a/tests/ui/pattern/deref-patterns/byte-string-type-errors.stderr
+++ b/tests/ui/pattern/deref-patterns/byte-string-type-errors.stderr
@@ -1,0 +1,52 @@
+error[E0308]: mismatched types
+  --> $DIR/byte-string-type-errors.rs:11:12
+   |
+LL |     if let b"test" = () {}
+   |            ^^^^^^^   -- this expression has type `()`
+   |            |
+   |            expected `()`, found `&[u8; 4]`
+
+error[E0308]: mismatched types
+  --> $DIR/byte-string-type-errors.rs:18:12
+   |
+LL |     if let b"test" = &[] as &[i8] {}
+   |            ^^^^^^^   ------------ this expression has type `&[i8]`
+   |            |
+   |            expected `&[i8]`, found `&[u8]`
+   |
+   = note: expected reference `&[i8]`
+              found reference `&'static [u8]`
+
+error[E0308]: mismatched types
+  --> $DIR/byte-string-type-errors.rs:23:12
+   |
+LL |     if let b"test" = *(&[] as &[i8]) {}
+   |            ^^^^^^^   --------------- this expression has type `[i8]`
+   |            |
+   |            expected `[i8]`, found `[u8]`
+   |
+   = note: expected slice `[i8]`
+              found slice `[u8]`
+
+error[E0308]: mismatched types
+  --> $DIR/byte-string-type-errors.rs:28:12
+   |
+LL |     if let b"test" = [()] {}
+   |            ^^^^^^^   ---- this expression has type `[(); 1]`
+   |            |
+   |            expected `[(); 1]`, found `[u8; 4]`
+   |
+   = note: expected array `[(); 1]`
+              found array `[u8; 4]`
+
+error[E0308]: mismatched types
+  --> $DIR/byte-string-type-errors.rs:31:12
+   |
+LL |     if let b"test" = *b"this array is too long" {}
+   |            ^^^^^^^   -------------------------- this expression has type `[u8; 22]`
+   |            |
+   |            expected an array with a size of 22, found one with a size of 4
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/pattern/deref-patterns/needs-gate.rs
+++ b/tests/ui/pattern/deref-patterns/needs-gate.rs
@@ -19,4 +19,14 @@ fn main() {
         //~^ ERROR: mismatched types
         _ => {}
     }
+    match *b"test" {
+        b"test" => {}
+        //~^ ERROR: mismatched types
+        _ => {}
+    }
+    match *(b"test" as &[u8]) {
+        b"test" => {}
+        //~^ ERROR: mismatched types
+        _ => {}
+    }
 }

--- a/tests/ui/pattern/deref-patterns/needs-gate.rs
+++ b/tests/ui/pattern/deref-patterns/needs-gate.rs
@@ -12,4 +12,11 @@ fn main() {
         //~^ ERROR: mismatched types
         _ => {}
     }
+
+    // `deref_patterns` allows string and byte string literals to have non-ref types.
+    match *"test" {
+        "test" => {}
+        //~^ ERROR: mismatched types
+        _ => {}
+    }
 }

--- a/tests/ui/pattern/deref-patterns/needs-gate.stderr
+++ b/tests/ui/pattern/deref-patterns/needs-gate.stderr
@@ -23,7 +23,15 @@ help: consider dereferencing to access the inner value using the Deref trait
 LL |     match *Box::new(0) {
    |           +
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/needs-gate.rs:18:9
+   |
+LL |     match *"test" {
+   |           ------- this expression has type `str`
+LL |         "test" => {}
+   |         ^^^^^^ expected `str`, found `&str`
+
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0308, E0658.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/pattern/deref-patterns/needs-gate.stderr
+++ b/tests/ui/pattern/deref-patterns/needs-gate.stderr
@@ -31,7 +31,23 @@ LL |     match *"test" {
 LL |         "test" => {}
    |         ^^^^^^ expected `str`, found `&str`
 
-error: aborting due to 3 previous errors
+error[E0308]: mismatched types
+  --> $DIR/needs-gate.rs:23:9
+   |
+LL |     match *b"test" {
+   |           -------- this expression has type `[u8; 4]`
+LL |         b"test" => {}
+   |         ^^^^^^^ expected `[u8; 4]`, found `&[u8; 4]`
+
+error[E0308]: mismatched types
+  --> $DIR/needs-gate.rs:28:9
+   |
+LL |     match *(b"test" as &[u8]) {
+   |           ------------------- this expression has type `[u8]`
+LL |         b"test" => {}
+   |         ^^^^^^^ expected `[u8]`, found `&[u8; 4]`
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0308, E0658.
 For more information about an error, try `rustc --explain E0308`.

--- a/tests/ui/pattern/deref-patterns/strings.rs
+++ b/tests/ui/pattern/deref-patterns/strings.rs
@@ -29,4 +29,38 @@ fn main() {
         s.make_ascii_uppercase();
     }
     assert_eq!(test, "TEST");
+
+    for (test_in, test_expect) in [(b"0", 0), (b"1", 1), (b"2", 2)] {
+        // Test byte string literal patterns having type `[u8; N]`
+        let test_actual = match *test_in {
+            b"0" => 0,
+            b"1" => 1,
+            _ => 2,
+        };
+        assert_eq!(test_actual, test_expect);
+
+        // Test byte string literal patterns having type `[u8]`
+        let test_actual = match *(test_in as &[u8]) {
+            b"0" => 0,
+            b"1" => 1,
+            _ => 2,
+        };
+        assert_eq!(test_actual, test_expect);
+
+        // Test byte string literals used as arrays in explicit `deref!(_)` patterns.
+        let test_actual = match Box::new(*test_in) {
+            deref!(b"0") => 0,
+            deref!(b"1") => 1,
+            _ => 2,
+        };
+        assert_eq!(test_actual, test_expect);
+
+        // Test byte string literals used as slices in explicit `deref!(_)` patterns.
+        let test_actual = match test_in.to_vec() {
+            deref!(b"0") => 0,
+            deref!(b"1") => 1,
+            _ => 2,
+        };
+        assert_eq!(test_actual, test_expect);
+    }
 }

--- a/tests/ui/pattern/deref-patterns/strings.rs
+++ b/tests/ui/pattern/deref-patterns/strings.rs
@@ -1,0 +1,32 @@
+//@ run-pass
+//! Test deref patterns using string and bytestring literals.
+
+#![feature(deref_patterns)]
+#![allow(incomplete_features)]
+
+fn main() {
+    for (test_in, test_expect) in [("zero", 0), ("one", 1), ("two", 2)] {
+        // Test string literal patterns having type `str`.
+        let test_actual = match *test_in {
+            "zero" => 0,
+            "one" => 1,
+            _ => 2,
+        };
+        assert_eq!(test_actual, test_expect);
+
+        // Test string literals in explicit `deref!(_)` patterns.
+        let test_actual = match test_in.to_string() {
+            deref!("zero") => 0,
+            deref!("one") => 1,
+            _ => 2,
+        };
+        assert_eq!(test_actual, test_expect);
+    }
+
+    // Test that we can still mutate in the match arm after using a literal to test equality:
+    let mut test = "test".to_string();
+    if let deref!(s @ "test") = &mut test {
+        s.make_ascii_uppercase();
+    }
+    assert_eq!(test, "TEST");
+}

--- a/tests/ui/pattern/deref-patterns/typeck_fail.rs
+++ b/tests/ui/pattern/deref-patterns/typeck_fail.rs
@@ -2,18 +2,14 @@
 #![allow(incomplete_features)]
 
 fn main() {
-    // FIXME(deref_patterns): fails to typecheck because `"foo"` has type &str but deref creates a
-    // place of type `str`.
+    // FIXME(deref_patterns): fails to typecheck because string literal patterns don't peel
+    // references from the scrutinee.
     match "foo".to_string() {
-        deref!("foo") => {}
-        //~^ ERROR: mismatched types
         "foo" => {}
         //~^ ERROR: mismatched types
         _ => {}
     }
     match &"foo".to_string() {
-        deref!("foo") => {}
-        //~^ ERROR: mismatched types
         "foo" => {}
         //~^ ERROR: mismatched types
         _ => {}

--- a/tests/ui/pattern/deref-patterns/typeck_fail.stderr
+++ b/tests/ui/pattern/deref-patterns/typeck_fail.stderr
@@ -1,34 +1,16 @@
 error[E0308]: mismatched types
-  --> $DIR/typeck_fail.rs:8:16
+  --> $DIR/typeck_fail.rs:8:9
    |
 LL |     match "foo".to_string() {
    |           ----------------- this expression has type `String`
-LL |         deref!("foo") => {}
-   |                ^^^^^ expected `str`, found `&str`
-
-error[E0308]: mismatched types
-  --> $DIR/typeck_fail.rs:10:9
-   |
-LL |     match "foo".to_string() {
-   |           ----------------- this expression has type `String`
-...
 LL |         "foo" => {}
    |         ^^^^^ expected `String`, found `&str`
 
 error[E0308]: mismatched types
-  --> $DIR/typeck_fail.rs:15:16
+  --> $DIR/typeck_fail.rs:13:9
    |
 LL |     match &"foo".to_string() {
    |           ------------------ this expression has type `&String`
-LL |         deref!("foo") => {}
-   |                ^^^^^ expected `str`, found `&str`
-
-error[E0308]: mismatched types
-  --> $DIR/typeck_fail.rs:17:9
-   |
-LL |     match &"foo".to_string() {
-   |           ------------------ this expression has type `&String`
-...
 LL |         "foo" => {}
    |         ^^^^^ expected `&String`, found `&str`
    |
@@ -36,7 +18,7 @@ LL |         "foo" => {}
               found reference `&'static str`
 
 error[E0308]: mismatched types
-  --> $DIR/typeck_fail.rs:24:9
+  --> $DIR/typeck_fail.rs:20:9
    |
 LL |     match Some(0) {
    |           ------- this expression has type `Option<{integer}>`
@@ -46,6 +28,6 @@ LL |         Ok(0) => {}
    = note: expected enum `Option<{integer}>`
               found enum `Result<_, _>`
 
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
When `deref_patterns` is enabled, this allows string literal patterns to be used where `str` is expected and byte string literal patterns to be used where `[u8]` or `[u8; N]` is expected. This lets them be used in explicit `deref!("...")` patterns to match on `String`, `Box<str>`, `Vec<u8>`, `Box<[u8;N]>`, etc. (as well as to match on slices and arrays obtained through other means). Implementation-wise, this follows up on #138992: similar to how byte string literals matching on `&[u8]` is implemented, this changes the type of the patterns as determined by HIR typeck, which informs const-to-pat on how to translate them to THIR (though strings needed a bit of extra work since we need references to call `<str as PartialEq>::eq` in the MIR lowering for string equality tests).

This PR does not add support for implicit deref pattern syntax (e.g. `"..."` matching on `String`, as `string_deref_patterns` allows). I have that implemented locally, but I'm saving it for a follow-up PR[^1].

This also does not add support for using named or associated constants of type `&str` where `str` is expected (nor likewise with named byte string constants). It'd be possible to add that if there's an appetite for it, but I figure it's simplest to start with literals.

This is gated by the `deref_patterns` feature since it's motivated by deref patterns. That said, its impact reaches outside of deref patterns; it may warrant a separate experiment and feature gate, particularly factoring in the follow-up[^1]. Even without deref patterns, I think there's probably motivation for these changes.

The update to the unstable book added by this will conflict with #140022, so they shouldn't be merged at the same time.

Tracking issue for deref patterns: #87121

r? @oli-obk
cc @Nadrieril 

[^1]: The piece missing from this PR to support implicit deref pattern syntax is to allow string literal patterns to implicitly dereference their scrutinees before matching (see #44849). As a consequence, it also makes examples like the one in that issue work (though it's still gated by `deref_patterns`). I can provide more information on how I've implemented it or open a draft if it'd help in reviewing this PR.