### PR TITLE
Add option for stable backport poll

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -659,6 +659,7 @@ message_on_add = [
     """\
 /poll Approve stable backport of #{number}?
 approve
+approve (but does not justify new dot release on its own)
 decline
 don't know
 """,


### PR DESCRIPTION
When creating polls on Zulip about stable backport ("Do we approve the backport of `#12345`"?), stable backports should have the option of "approving, but only is a dot release is planned" (this is a hint to t-release about how the team think important - or not - is backporting some patch).

Discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc/topic/stable-nominated.3A.20.23139328/near/510037866)[#t-rustdoc > stable-nominated: #139328 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/266220-t-rustdoc/topic/stable-nominated.3A.20.23139328/near/510037866)

r? @aDotInTheVoid  (feel free to adjust the wording!)