### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -55,8 +55,6 @@ bitflags::bitflags! {
         const IS_UNSAFE_CELL              = 1 << 9;
         /// Indicates whether the type is `UnsafePinned`.
         const IS_UNSAFE_PINNED              = 1 << 10;
-        /// Indicates whether the type is anonymous.
-        const IS_ANONYMOUS                = 1 << 11;
     }
 }
 rustc_data_structures::external_bitflags_debug! { AdtFlags }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1859,13 +1859,15 @@ impl<'a> Parser<'a> {
             let mut expr = self.parse_expr_opt()?;
             if let Some(expr) = &mut expr {
                 if label.is_some()
-                    && matches!(
-                        expr.kind,
+                    && match &expr.kind {
                         ExprKind::While(_, _, None)
-                            | ExprKind::ForLoop { label: None, .. }
-                            | ExprKind::Loop(_, None, _)
-                            | ExprKind::Block(_, None)
-                    )
+                        | ExprKind::ForLoop { label: None, .. }
+                        | ExprKind::Loop(_, None, _) => true,
+                        ExprKind::Block(block, None) => {
+                            matches!(block.rules, BlockCheckMode::Default)
+                        }
+                        _ => false,
+                    }
                 {
                     self.psess.buffer_lint(
                         BREAK_WITH_LABEL_AND_LOOP,

--- a/compiler/rustc_target/src/spec/targets/i686_win7_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/targets/i686_win7_windows_msvc.rs
@@ -7,6 +7,12 @@ pub(crate) fn target() -> Target {
     base.cpu = "pentium4".into();
     base.max_atomic_width = Some(64);
     base.supported_sanitizers = SanitizerSet::ADDRESS;
+    // On Windows 7 32-bit, the alignment characteristic of the TLS Directory
+    // don't appear to be respected by the PE Loader, leading to crashes. As
+    // a result, let's disable has_thread_local to make sure TLS goes through
+    // the emulation layer.
+    // See https://github.com/rust-lang/rust/issues/138903
+    base.has_thread_local = false;
 
     base.add_pre_link_args(
         LinkerFlavor::Msvc(Lld::No),

--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -1116,7 +1116,7 @@ impl CStr {
     /// with the corresponding <code>&[str]</code> slice. Otherwise, it will
     /// replace any invalid UTF-8 sequences with
     /// [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD] and return a
-    /// <code>[Cow]::[Owned]\(&[str])</code> with the result.
+    /// <code>[Cow]::[Owned]\([String])</code> with the result.
     ///
     /// [str]: prim@str "str"
     /// [Borrowed]: Cow::Borrowed

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1739,3 +1739,11 @@ impl<T: ?Sized> PartialOrd for *const T {
         *self >= *other
     }
 }
+
+#[stable(feature = "raw_ptr_default", since = "CURRENT_RUSTC_VERSION")]
+impl<T: ?Sized + Thin> Default for *const T {
+    /// Returns the default value of [`null()`][crate::ptr::null].
+    fn default() -> Self {
+        crate::ptr::null()
+    }
+}

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -2156,3 +2156,11 @@ impl<T: ?Sized> PartialOrd for *mut T {
         *self >= *other
     }
 }
+
+#[stable(feature = "raw_ptr_default", since = "CURRENT_RUSTC_VERSION")]
+impl<T: ?Sized + Thin> Default for *mut T {
+    /// Returns the default value of [`null_mut()`][crate::ptr::null_mut].
+    fn default() -> Self {
+        crate::ptr::null_mut()
+    }
+}

--- a/library/coretests/tests/ptr.rs
+++ b/library/coretests/tests/ptr.rs
@@ -1020,3 +1020,20 @@ fn test_ptr_swap_nonoverlapping_is_untyped() {
     ptr_swap_nonoverlapping_is_untyped_inner();
     const { ptr_swap_nonoverlapping_is_untyped_inner() };
 }
+
+#[test]
+fn test_ptr_default() {
+    #[derive(Default)]
+    struct PtrDefaultTest {
+        ptr: *const u64,
+    }
+    let default = PtrDefaultTest::default();
+    assert!(default.ptr.is_null());
+
+    #[derive(Default)]
+    struct PtrMutDefaultTest {
+        ptr: *mut u64,
+    }
+    let default = PtrMutDefaultTest::default();
+    assert!(default.ptr.is_null());
+}

--- a/library/std/src/sys/fs/unix.rs
+++ b/library/std/src/sys/fs/unix.rs
@@ -12,10 +12,11 @@ use libc::c_char;
     all(target_os = "linux", not(target_env = "musl")),
     target_os = "android",
     target_os = "fuchsia",
-    target_os = "hurd"
+    target_os = "hurd",
+    target_os = "illumos",
 ))]
 use libc::dirfd;
-#[cfg(target_os = "fuchsia")]
+#[cfg(any(target_os = "fuchsia", target_os = "illumos"))]
 use libc::fstatat as fstatat64;
 #[cfg(any(all(target_os = "linux", not(target_env = "musl")), target_os = "hurd"))]
 use libc::fstatat64;
@@ -892,7 +893,8 @@ impl DirEntry {
             all(target_os = "linux", not(target_env = "musl")),
             target_os = "android",
             target_os = "fuchsia",
-            target_os = "hurd"
+            target_os = "hurd",
+            target_os = "illumos",
         ),
         not(miri) // no dirfd on Miri
     ))]
@@ -922,6 +924,7 @@ impl DirEntry {
             target_os = "android",
             target_os = "fuchsia",
             target_os = "hurd",
+            target_os = "illumos",
         )),
         miri
     ))]

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -84,8 +84,8 @@ impl JsonRenderer<'_> {
                     let lo = span.lo(self.sess());
                     Some(Span {
                         filename: local_path,
-                        begin: (lo.line, lo.col.to_usize()),
-                        end: (hi.line, hi.col.to_usize()),
+                        begin: (lo.line, lo.col.to_usize() + 1),
+                        end: (hi.line, hi.col.to_usize() + 1),
                     })
                 } else {
                     None

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -30,7 +30,7 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 /// This integer is incremented with every breaking change to the API,
 /// and is returned along with the JSON blob as [`Crate::format_version`].
 /// Consuming code should assert that this value matches the format version(s) that it supports.
-pub const FORMAT_VERSION: u32 = 44;
+pub const FORMAT_VERSION: u32 = 45;
 
 /// The root of the emitted JSON blob.
 ///

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -205,9 +205,9 @@ pub struct Item {
 pub struct Span {
     /// The path to the source file for this span relative to the path `rustdoc` was invoked with.
     pub filename: PathBuf,
-    /// Zero indexed Line and Column of the first character of the `Span`
+    /// One indexed Line and Column of the first character of the `Span`.
     pub begin: (usize, usize),
-    /// Zero indexed Line and Column of the last character of the `Span`
+    /// One indexed Line and Column of the last character of the `Span`.
     pub end: (usize, usize),
 }
 

--- a/src/tools/nix-dev-shell/flake.nix
+++ b/src/tools/nix-dev-shell/flake.nix
@@ -1,32 +1,24 @@
 {
   description = "rustc dev shell";
 
-  inputs = {
-    nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url  = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
-	flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        x = import ./x { inherit pkgs; };
-      in
-      {
-        devShells.default = with pkgs; mkShell {
-          name = "rustc-dev-shell";
-          nativeBuildInputs = with pkgs; [
-            binutils cmake ninja pkg-config python3 git curl cacert patchelf nix
-          ];
-          buildInputs = with pkgs; [
-            openssl glibc.out glibc.static x
-          ];
-          # Avoid creating text files for ICEs.
-          RUSTC_ICE = "0";
-          # Provide `libstdc++.so.6` for the self-contained lld.
-          # Provide `libz.so.1`.
-          LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [stdenv.cc.cc.lib zlib]}";
-        };
-      }
-    );
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      inherit (nixpkgs) lib;
+      forEachSystem = lib.genAttrs lib.systems.flakeExposed;
+    in
+    {
+      devShells = forEachSystem (system: {
+        default = nixpkgs.legacyPackages.${system}.callPackage ./shell.nix { };
+      });
+
+      packages = forEachSystem (system: {
+        default = nixpkgs.legacyPackages.${system}.callPackage ./x { };
+      });
+    };
 }

--- a/src/tools/nix-dev-shell/shell.nix
+++ b/src/tools/nix-dev-shell/shell.nix
@@ -1,18 +1,26 @@
-{ pkgs ? import <nixpkgs> {} }:
-let 
-  x = import ./x { inherit pkgs; };
+{
+  pkgs ? import <nixpkgs> { },
+}:
+let
+  inherit (pkgs.lib) lists attrsets;
+
+  x = pkgs.callPackage ./x { };
+  inherit (x.passthru) cacert env;
 in
 pkgs.mkShell {
-  name = "rustc";
-  nativeBuildInputs = with pkgs; [
-    binutils cmake ninja pkg-config python3 git curl cacert patchelf nix
-  ];
-  buildInputs = with pkgs; [
-    openssl glibc.out glibc.static x
-  ];
-  # Avoid creating text files for ICEs.
-  RUSTC_ICE = "0";
-  # Provide `libstdc++.so.6` for the self-contained lld.
-  # Provide `libz.so.1`
-  LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [stdenv.cc.cc.lib zlib]}";
+  name = "rustc-shell";
+
+  inputsFrom = [ x ];
+  packages = [
+    pkgs.git
+    pkgs.nix
+    x
+    # Get the runtime deps of the x wrapper
+  ] ++ lists.flatten (attrsets.attrValues env);
+
+  env = {
+    # Avoid creating text files for ICEs.
+    RUSTC_ICE = 0;
+    SSL_CERT_FILE = cacert;
+  };
 }

--- a/src/tools/nix-dev-shell/x/default.nix
+++ b/src/tools/nix-dev-shell/x/default.nix
@@ -1,22 +1,83 @@
 {
-  pkgs ? import <nixpkgs> { },
+  pkgs,
+  lib,
+  stdenv,
+  rustc,
+  python3,
+  makeBinaryWrapper,
+  # Bootstrap
+  curl,
+  pkg-config,
+  libiconv,
+  openssl,
+  patchelf,
+  cacert,
+  zlib,
+  # LLVM Deps
+  ninja,
+  cmake,
+  glibc,
 }:
-pkgs.stdenv.mkDerivation {
-  name = "x";
+stdenv.mkDerivation (self: {
+  strictDeps = true;
+  name = "x-none";
+
+  outputs = [
+    "out"
+    "unwrapped"
+  ];
 
   src = ./x.rs;
   dontUnpack = true;
 
-  nativeBuildInputs = with pkgs; [ rustc ];
+  nativeBuildInputs = [
+    rustc
+    makeBinaryWrapper
+  ];
 
+  env.PYTHON = python3.interpreter;
   buildPhase = ''
-    PYTHON=${pkgs.lib.getExe pkgs.python3} rustc -Copt-level=3 --crate-name x $src --out-dir $out/bin
+    rustc -Copt-level=3 --crate-name x $src --out-dir $unwrapped/bin
   '';
 
-  meta = with pkgs.lib; {
+  installPhase =
+    let
+      inherit (self.passthru) cacert env;
+    in
+    ''
+      makeWrapper $unwrapped/bin/x $out/bin/x \
+        --set-default SSL_CERT_FILE ${cacert} \
+        --prefix CPATH ";" "${lib.makeSearchPath "include" env.cpath}" \
+        --prefix PATH : ${lib.makeBinPath env.path} \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath env.ldLib}
+    '';
+
+  # For accessing them in the devshell
+  passthru = {
+    env = {
+      cpath = [ libiconv ];
+      path = [
+        python3
+        patchelf
+        curl
+        pkg-config
+        cmake
+        ninja
+        stdenv.cc
+      ];
+      ldLib = [
+        openssl
+        zlib
+        stdenv.cc.cc.lib
+      ];
+    };
+    cacert = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+  };
+
+  meta = {
     description = "Helper for rust-lang/rust x.py";
     homepage = "https://github.com/rust-lang/rust/blob/master/src/tools/x";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "x";
   };
-}
+})

--- a/tests/rustdoc-json/impls/auto.rs
+++ b/tests/rustdoc-json/impls/auto.rs
@@ -15,8 +15,8 @@ impl Foo {
 }
 
 // Testing spans, so all tests below code
-//@ is "$.index[?(@.docs=='has span')].span.begin" "[13, 0]"
-//@ is "$.index[?(@.docs=='has span')].span.end" "[15, 1]"
+//@ is "$.index[?(@.docs=='has span')].span.begin" "[13, 1]"
+//@ is "$.index[?(@.docs=='has span')].span.end" "[15, 2]"
 // FIXME: this doesn't work due to https://github.com/freestrings/jsonpath/issues/91
 // is "$.index[?(@.inner.impl.is_synthetic==true)].span" null
 pub struct Foo;

--- a/tests/rustdoc-json/span.rs
+++ b/tests/rustdoc-json/span.rs
@@ -1,0 +1,4 @@
+pub mod bar {}
+// This test ensures that spans are 1-indexed.
+//@ is "$.index[?(@.name=='span')].span.begin" "[1, 1]"
+//@ is "$.index[?(@.name=='bar')].span.begin" "[1, 1]"

--- a/tests/ui/lint/break-with-label-and-unsafe-block.rs
+++ b/tests/ui/lint/break-with-label-and-unsafe-block.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+
+#![deny(break_with_label_and_loop)]
+
+unsafe fn foo() -> i32 { 42 }
+
+fn main () {
+    'label: loop {
+        break 'label unsafe { foo() }
+    };
+}


### PR DESCRIPTION
Successful merges:

 - #137454 (not lint break with label and unsafe block)
 - #139297 (Deduplicate & clean up Nix shell)
 - #139535 (Implement `Default` for raw pointers)
 - #139919 (Make rustdoc JSON Span column 1-based, just like line numbers)
 - #139922 (fix incorrect type in cstr `to_string_lossy()` docs)
 - #140007 (Disable has_thread_local on i686-win7-windows-msvc)
 - #140016 (std: Use fstatat() on illumos)
 - #140025 (Re-remove `AdtFlags::IS_ANONYMOUS`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=137454,139297,139535,139919,139922,140007,140016,140025)
<!-- homu-ignore:end -->