### PR TITLE
Fix error when an intra doc link is trying to resolve an empty associated item

### DIFF
--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -246,6 +246,8 @@ impl AssocItems {
     }
 
     /// Returns an iterator over all associated items with the given name, ignoring hygiene.
+    ///
+    /// Panics if `name.is_empty()` returns `true`.
     pub fn filter_by_name_unhygienic(
         &self,
         name: Symbol,

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -59,7 +59,12 @@ fn filter_assoc_items_by_name_and_namespace(
     ident: Ident,
     ns: Namespace,
 ) -> impl Iterator<Item = &ty::AssocItem> {
-    tcx.associated_items(assoc_items_of).filter_by_name_unhygienic(ident.name).filter(move |item| {
+    let iter: Box<dyn Iterator<Item = &ty::AssocItem>> = if !ident.name.is_empty() {
+        Box::new(tcx.associated_items(assoc_items_of).filter_by_name_unhygienic(ident.name))
+    } else {
+        Box::new([].iter())
+    };
+    iter.filter(move |item| {
         item.namespace() == ns && tcx.hygienic_eq(ident, item.ident(tcx), assoc_items_of)
     })
 }

--- a/tests/rustdoc-ui/intra-doc/empty-associated-items.rs
+++ b/tests/rustdoc-ui/intra-doc/empty-associated-items.rs
@@ -1,0 +1,8 @@
+// This test ensures that an empty associated item will not crash rustdoc.
+// This is a regression test for <https://github.com/rust-lang/rust/issues/140026>.
+
+#[deny(rustdoc::broken_intra_doc_links)]
+
+/// [`String::`]
+//~^ ERROR
+pub struct Foo;

--- a/tests/rustdoc-ui/intra-doc/empty-associated-items.stderr
+++ b/tests/rustdoc-ui/intra-doc/empty-associated-items.stderr
@@ -1,0 +1,14 @@
+error: unresolved link to `String::`
+  --> $DIR/empty-associated-items.rs:6:7
+   |
+LL | /// [`String::`]
+   |       ^^^^^^^^ the struct `String` has no field or associated item named ``
+   |
+note: the lint level is defined here
+  --> $DIR/empty-associated-items.rs:4:8
+   |
+LL | #[deny(rustdoc::broken_intra_doc_links)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/140026.

Assigning @nnethercote since they're the one who wrote the initial change.

I updated rustdoc code instead of compiler's because I think it makes more sense that the caller ensures on their side that the name they're looking for isn't empty.

r? @nnethercote 