### PR TITLE
Fix bootstrap build failure on macOS due to DYLD_LIBRARY_PATH

### DIFF
--- a/src/bootstrap/src/utils/shared_helpers.rs
+++ b/src/bootstrap/src/utils/shared_helpers.rs
@@ -23,7 +23,9 @@ pub fn dylib_path_var() -> &'static str {
     if cfg!(target_os = "windows") {
         "PATH"
     } else if cfg!(target_vendor = "apple") {
-        "DYLD_LIBRARY_PATH"
+        // Use DYLD_FALLBACK_LIBRARY_PATH instead of DYLD_LIBRARY_PATH on macOS
+        // to avoid conflicts with system libraries, as discussed in #139400.
+        "DYLD_FALLBACK_LIBRARY_PATH"
     } else if cfg!(target_os = "haiku") {
         "LIBRARY_PATH"
     } else if cfg!(target_os = "aix") {


### PR DESCRIPTION
Fix bootstrap build failures on macOS due to DYLD_LIBRARY_PATH conflicts

Previously, the Rust bootstrap process set the `DYLD_LIBRARY_PATH` environment variable on macOS, sometimes including system paths like `/usr/local/lib`. Because `DYLD_LIBRARY_PATH` is searched *before* the default system library locations and uses stem matching, this could cause the dynamic linker to load incorrect library versions.

A specific example is when a system framework (like ImageIO) depends on a library (like libjpeg) that also exists in `/usr/local/lib`. The presence of `/usr/local/lib` in `DYLD_LIBRARY_PATH` would cause `/usr/local/lib/libjpeg.dylib` to be loaded instead of the version required by ImageIO, leading to runtime errors (as reported in #139400).

This PR fixes the issue by modifying the `dylib_path_var` helper function (`src/bootstrap/src/utils/shared_helpers.rs`) to return `"DYLD_FALLBACK_LIBRARY_PATH"` instead of `"DYLD_LIBRARY_PATH"` on Apple platforms. `DYLD_FALLBACK_LIBRARY_PATH` is searched *after* the standard system paths, resolving the loading conflict while still allowing the build process to find necessary libraries in bootstrap-specific directories.

Fixes #139400
