### PR TITLE
handle function alignment in miri

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -872,8 +872,20 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
         // # Function pointers
         // (both global from `alloc_map` and local from `extra_fn_ptr_map`)
-        if self.get_fn_alloc(id).is_some() {
-            return AllocInfo::new(Size::ZERO, Align::ONE, AllocKind::Function, Mutability::Not);
+        if let Some(fn_val) = self.get_fn_alloc(id) {
+            let align = match fn_val {
+                FnVal::Instance(instance) => {
+                    // Function alignment can be set globally with the `-Zmin-function-alignment=<n>` flag;
+                    // the alignment from a `#[repr(align(<n>))]` is used if it specifies a higher alignment.
+                    let fn_align = self.tcx.codegen_fn_attrs(instance.def_id()).alignment;
+                    let global_align = self.tcx.sess.opts.unstable_opts.min_function_alignment;
+
+                    Ord::max(global_align, fn_align).unwrap_or(Align::ONE)
+                }
+                FnVal::Other(_) => Align::ONE,
+            };
+
+            return AllocInfo::new(Size::ZERO, align, AllocKind::Function, Mutability::Not);
         }
 
         // # Global allocations

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -882,6 +882,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
 
                     Ord::max(global_align, fn_align).unwrap_or(Align::ONE)
                 }
+                // Machine-specific extra functions currently do not support alignment restrictions.
                 FnVal::Other(_) => Align::ONE,
             };
 

--- a/src/tools/miri/tests/pass/fn_align.rs
+++ b/src/tools/miri/tests/pass/fn_align.rs
@@ -1,0 +1,21 @@
+//@compile-flags: -Zmin-function-alignment=8
+#![feature(fn_align)]
+
+// When a function uses `repr(align(N))`, the function address should be a multiple of `N`.
+
+#[repr(align(256))]
+fn foo() {}
+
+#[repr(align(16))]
+fn bar() {}
+
+#[repr(align(4))]
+fn baz() {}
+
+fn main() {
+    assert!((foo as usize).is_multiple_of(256));
+    assert!((bar as usize).is_multiple_of(16));
+
+    // The maximum of `repr(align(N))` and `-Zmin-function-alignment=N` is used.
+    assert!((baz as usize).is_multiple_of(8));
+}


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/82232
Fixes https://github.com/rust-lang/miri/issues/4282

The `#[repr(align(N))]` attribute on functions was ignored when using miri. For such a function, its address should be a multiple of `N`.

There is some further discussion in the thread [#t-compiler/const-eval > function address alignment](https://rust-lang.zulipchat.com/#narrow/channel/146212-t-compiler.2Fconst-eval/topic/function.20address.20alignment) on how `dyn Fn` should be handled. The behavior there appears to be consistent between miri and nightly, though both may be incorrect. In any case, that can be resolved separately.