### PR TITLE
WIP | Improve type parameter suggestion heuristic for missing types

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2764,7 +2764,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
                     let (msg, sugg) = match source {
                         PathSource::Type | PathSource::PreciseCapturingArg(TypeNS) => {
-                            ("you might be missing a type parameter", ident)
+                            ("you might be missing a type parameter", ident.clone())
                         }
                         PathSource::Expr(_) | PathSource::PreciseCapturingArg(ValueNS) => (
                             "you might be missing a const parameter",
@@ -2772,6 +2772,31 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                         ),
                         _ => return None,
                     };
+
+                    // Heuristically determine whether a type name is likely intended to be a generic.
+                    //
+                    // We apply three rules:
+                    // 1. Short names (like `T`, `U`, `E`) are common for generics.
+                    // 2. Certain well-known names (e.g., `Item`, `Output`, `Error`) are commonly used as generics.
+                    // 3. Names in UpperCamelCase are more likely to be concrete types.
+                    //
+                    // This approach may produce false positives or negatives, but works well in most cases.
+
+                    let common_generic_names: &[&str] = &[
+                        "Item", "Output", "Error", "Target", "Value", "Args",
+                        "Res", "Ret", "This", "Iter", "Type",
+                    ];
+                    let is_common_generic = common_generic_names.contains(&&*ident);
+                    let looks_like_camel_case = ident
+                        .chars()
+                        .next()
+                        .is_some_and(|c| c.is_uppercase())
+                        && ident.chars().skip(1).any(|c| c.is_lowercase());
+
+                    // If it's not a known generic name and looks like a concrete type, skip the suggestion.
+                    if !is_common_generic && looks_like_camel_case && ident.len() > 3 {
+                        return None;
+                    }
                     let (span, sugg) = if let [.., param] = &generics.params[..] {
                         let span = if let [.., bound] = &param.bounds[..] {
                             bound.span()

--- a/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-109141.stderr
@@ -3,11 +3,6 @@ error[E0425]: cannot find value `HashesEntryLEN` in this scope
    |
 LL | struct EntriesBuffer(Box<[[u8; HashesEntryLEN]; 5]>);
    |                                ^^^^^^^^^^^^^^ not found in this scope
-   |
-help: you might be missing a const parameter
-   |
-LL | struct EntriesBuffer<const HashesEntryLEN: /* Type */>(Box<[[u8; HashesEntryLEN]; 5]>);
-   |                     ++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/error-is-freeze.stderr
+++ b/tests/ui/consts/error-is-freeze.stderr
@@ -3,11 +3,6 @@ error[E0412]: cannot find type `UndefinedType` in this scope
    |
 LL |     foo: Option<UndefinedType>,
    |                 ^^^^^^^^^^^^^ not found in this scope
-   |
-help: you might be missing a type parameter
-   |
-LL | struct MyStruct<UndefinedType> {
-   |                +++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-58712.stderr
+++ b/tests/ui/issues/issue-58712.stderr
@@ -3,11 +3,6 @@ error[E0412]: cannot find type `DeviceId` in this scope
    |
 LL | impl<H> AddrVec<H, DeviceId> {
    |                    ^^^^^^^^ not found in this scope
-   |
-help: you might be missing a type parameter
-   |
-LL | impl<H, DeviceId> AddrVec<H, DeviceId> {
-   |       ++++++++++
 
 error[E0412]: cannot find type `DeviceId` in this scope
   --> $DIR/issue-58712.rs:8:29

--- a/tests/ui/layout/thaw-transmute-invalid-enum.stderr
+++ b/tests/ui/layout/thaw-transmute-invalid-enum.stderr
@@ -3,11 +3,6 @@ error[E0412]: cannot find type `Subset` in this scope
    |
 LL |     assert::is_transmutable::<Superset, Subset>();
    |                                         ^^^^^^ not found in this scope
-   |
-help: you might be missing a type parameter
-   |
-LL | fn test<Subset>() {
-   |        ++++++++
 
 error[E0517]: attribute should be applied to a struct or union
   --> $DIR/thaw-transmute-invalid-enum.rs:21:11

--- a/tests/ui/missing/missing-items/missing-type-parameter.rs
+++ b/tests/ui/missing/missing-items/missing-type-parameter.rs
@@ -1,4 +1,19 @@
-fn foo<X>() { }
+fn foo<X>() {}
+
+fn do_something() -> Option<ForgotToImport> {
+    //~^ cannot find type `ForgotToImport` in this scope [E0412]
+    None
+}
+
+fn do_something_T() -> Option<T> {
+    //~^ cannot find type `T` in this scope [E0412]
+    None
+}
+
+fn do_something_Type() -> Option<Type> {
+    //~^ cannot find type `Type` in this scope [E0412]
+    None
+}
 
 fn main() {
     foo(); //~ ERROR type annotations needed

--- a/tests/ui/missing/missing-items/missing-type-parameter.stderr
+++ b/tests/ui/missing/missing-items/missing-type-parameter.stderr
@@ -1,5 +1,33 @@
+error[E0412]: cannot find type `ForgotToImport` in this scope
+  --> $DIR/missing-type-parameter.rs:3:29
+   |
+LL | fn do_something() -> Option<ForgotToImport> {
+   |                             ^^^^^^^^^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/missing-type-parameter.rs:8:31
+   |
+LL | fn do_something_T() -> Option<T> {
+   |                               ^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | fn do_something_T<T>() -> Option<T> {
+   |                  +++
+
+error[E0412]: cannot find type `Type` in this scope
+  --> $DIR/missing-type-parameter.rs:13:34
+   |
+LL | fn do_something_Type() -> Option<Type> {
+   |                                  ^^^^ not found in this scope
+   |
+help: you might be missing a type parameter
+   |
+LL | fn do_something_Type<Type>() -> Option<Type> {
+   |                     ++++++
+
 error[E0282]: type annotations needed
-  --> $DIR/missing-type-parameter.rs:4:5
+  --> $DIR/missing-type-parameter.rs:19:5
    |
 LL |     foo();
    |     ^^^ cannot infer type of the type parameter `X` declared on the function `foo`
@@ -9,6 +37,7 @@ help: consider specifying the generic argument
 LL |     foo::<X>();
    |        +++++
 
-error: aborting due to 1 previous error
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0282`.
+Some errors have detailed explanations: E0282, E0412.
+For more information about an error, try `rustc --explain E0282`.

--- a/tests/ui/pattern/usefulness/issue-119493-type-error-ice.stderr
+++ b/tests/ui/pattern/usefulness/issue-119493-type-error-ice.stderr
@@ -10,10 +10,7 @@ error[E0412]: cannot find type `NonExistent` in this scope
 LL |     struct Foo(NonExistent);
    |                ^^^^^^^^^^^ not found in this scope
    |
-help: you might be missing a type parameter
-   |
-LL |     struct Foo<NonExistent>(NonExistent);
-   |               +++++++++++++
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0658]: `impl Trait` in type aliases is unstable
   --> $DIR/issue-119493-type-error-ice.rs:9:14

--- a/tests/ui/traits/issue-50480.stderr
+++ b/tests/ui/traits/issue-50480.stderr
@@ -32,10 +32,7 @@ error[E0412]: cannot find type `NotDefined` in this scope
 LL | struct Foo(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |               ^^^^^^^^^^ not found in this scope
    |
-help: you might be missing a type parameter
-   |
-LL | struct Foo<NotDefined>(N, NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
-   |           ++++++++++++
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0412]: cannot find type `N` in this scope
   --> $DIR/issue-50480.rs:14:18

--- a/tests/ui/traits/trait-selection-ice-84727.stderr
+++ b/tests/ui/traits/trait-selection-ice-84727.stderr
@@ -21,11 +21,6 @@ error[E0412]: cannot find type `NewBg` in this scope
    |
 LL |     fn over(self) -> Cell<NewBg> {
    |                           ^^^^^ not found in this scope
-   |
-help: you might be missing a type parameter
-   |
-LL | impl<'b, TopFg, TopBg, BottomFg, BottomBg, NewBg> Over<&Cell<BottomFg, BottomBg>, ()>
-   |                                          +++++++
 
 error[E0308]: mismatched types
   --> $DIR/trait-selection-ice-84727.rs:21:22


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/140073)*
<!-- homu-ignore:end -->

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? @jieyouxu 
-->
<!-- homu-ignore:end -->

I consider this solution a starting point and not final. I'm open to your ideas and suggestions for further improvements to the heuristic or implementation.

### Summary

This PR improves the heuristic used by `rustc` to suggest type parameters for missing types, addressing issue rust-lang/rust#139999. The issue occurs when `rustc` mistakenly suggests adding a type parameter for a missing type (e.g., `ForgotToImport`) that is likely a concrete type rather than a generic. This can lead to confusing error messages, as shown in the example:

```rust
pub fn do_stuff() -> Option<ForgotToImport> {
    None
}
```

Current output suggests adding a type parameter:

```
help: you might be missing a type parameter
  |
1 | pub fn do_stuff<ForgotToImport>() -> Option<ForgotToImport> {
  |                ++++++++++++++++
```

This PR refines the heuristic to avoid such suggestions for names that are likely concrete types.

### Changes

The fix modifies the logic in the type suggestion code to skip type parameter suggestions when the missing type name:

1. Is not a common generic name (e.g., `Item`, `Output`, `Error`).
2. Uses UpperCamelCase, which is typical for concrete types.
3. Is longer than 3 characters, as type parameters are often short (e.g., `T`, `U`).

### Example

With this change, the example code above will no longer suggest a type parameter for `ForgotToImport`, resulting in a cleaner error message:

```
error[E0412]: cannot find type `ForgotToImport` in this scope
 --> src/lib.rs:1:29
  |
1 | pub fn do_stuff() -> Option<ForgotToImport> {
  |                             ^^^^^^^^^^^^^^ not found in this scope
```

### Rationale

This approach balances precision and simplicity:

- UpperCamelCase is a strong indicator of concrete types in Rust, as type parameters are often single letters or specific generic names.
- The length check (&gt;3) reduces false positives for longer names, which are less common for generics.
- Preserving suggestions for well-known generic names ensures backward compatibility and avoids breaking valid cases.

### Related Issue

fixes rust-lang/rust#139999

cc @Wilfred (issue reporter)
