### PR TITLE
rustdoc-json: Improve test for auto-trait impls

### DIFF
--- a/tests/rustdoc-json/impls/auto.rs
+++ b/tests/rustdoc-json/impls/auto.rs
@@ -17,6 +17,8 @@ impl Foo {
 // Testing spans, so all tests below code
 //@ is "$.index[?(@.docs=='has span')].span.begin" "[13, 1]"
 //@ is "$.index[?(@.docs=='has span')].span.end" "[15, 2]"
-// FIXME: this doesn't work due to https://github.com/freestrings/jsonpath/issues/91
-// is "$.index[?(@.inner.impl.is_synthetic==true)].span" null
+//@ is "$.index[?(@.docs=='has span')].inner.impl.is_synthetic" false
+//@ is "$.index[?(@.inner.impl.is_synthetic==true)].span" null
+//@ is "$.index[?(@.inner.impl.is_synthetic==true)].inner.impl.for.resolved_path.path" '"Foo"'
+//@ is "$.index[?(@.inner.impl.is_synthetic==true)].inner.impl.trait.path" '"Bar"'
 pub struct Foo;


### PR DESCRIPTION
The TODO is fixable now due-to #138763. While I was here I realized there's probably a a few more things we should also test.

r? @GuillaumeGomez 