### PR TITLE
jsondocck: Require command is at start of line

### DIFF
--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -154,6 +154,7 @@ impl CommandKind {
 static LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     RegexBuilder::new(
         r#"
+        ^\s*
         //@\s+
         (?P<negated>!?)
         (?P<cmd>[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*)

--- a/tests/rustdoc-json/fns/return_type_alias.rs
+++ b/tests/rustdoc-json/fns/return_type_alias.rs
@@ -1,6 +1,6 @@
 // Regression test for <https://github.com/rust-lang/rust/issues/104851>
 
-///@ set foo = "$.index[?(@.name=='Foo')].id"
+//@ set foo = "$.index[?(@.name=='Foo')].id"
 pub type Foo = i32;
 
 //@ is "$.index[?(@.name=='demo')].inner.function.sig.output.resolved_path.id" $foo


### PR DESCRIPTION
In one place we use `///@` instead of `//@`. The test-runner allowed it, but it probably shouldn't. Ran into by @lolbinarycat in https://github.com/rust-lang/rust/pull/132748#issuecomment-2816469322:


```
error: unknown disambiguator `?(`
##[error] --> /checkout/tests/rustdoc-json/fns/return_type_alias.rs:3:25
  |
3 | ///@ set foo = "$.index[?(@.name=='Foo')].id"
  |                         ^^
  |
```

Maybe it's also worth erroring on this like we added in #137103

r? @GuillaumeGomez 