### PR TITLE
Construct OutputType using macro and print [=FILENAME] help info

### DIFF
--- a/tests/run-make/metadata-dep-info/dash-separated_something-extra.expected.d
+++ b/tests/run-make/metadata-dep-info/dash-separated_something-extra.expected.d
@@ -1,5 +1,5 @@
-libdash_separated_something-extra.rmeta: dash-separated.rs
-
 dash-separated_something-extra.d: dash-separated.rs
+
+libdash_separated_something-extra.rmeta: dash-separated.rs
 
 dash-separated.rs:

--- a/tests/run-make/rustc-help/help-v.diff
+++ b/tests/run-make/rustc-help/help-v.diff
@@ -1,4 +1,4 @@
-@@ -53,10 +53,27 @@
+@@ -63,10 +63,27 @@
                          Set a codegen option
      -V, --version       Print version info and exit
      -v, --verbose       Use verbose output

--- a/tests/run-make/rustc-help/help-v.stdout
+++ b/tests/run-make/rustc-help/help-v.stdout
@@ -26,9 +26,19 @@ Options:
                         Specify which edition of the compiler to use when
                         compiling code. The default is 2015 and the latest
                         stable edition is 2024.
-        --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
+        --emit TYPE[=FILE]
                         Comma separated list of types of output for the
-                        compiler to emit
+                        compiler to emit.
+                        Each TYPE has the default FILE name:
+                        * asm - CRATE_NAME.s
+                        * llvm-bc - CRATE_NAME.bc
+                        * dep-info - CRATE_NAME.d
+                        * link - (platform and crate-type dependent)
+                        * llvm-ir - CRATE_NAME.ll
+                        * metadata - libCRATE_NAME.rmeta
+                        * mir - CRATE_NAME.mir
+                        * obj - CRATE_NAME.o
+                        * thin-link-bitcode - CRATE_NAME.indexing.o
         --print INFO[=FILE]
                         Compiler information to print on stdout (or to a file)
                         INFO may be one of

--- a/tests/run-make/rustc-help/help.stdout
+++ b/tests/run-make/rustc-help/help.stdout
@@ -26,9 +26,19 @@ Options:
                         Specify which edition of the compiler to use when
                         compiling code. The default is 2015 and the latest
                         stable edition is 2024.
-        --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
+        --emit TYPE[=FILE]
                         Comma separated list of types of output for the
-                        compiler to emit
+                        compiler to emit.
+                        Each TYPE has the default FILE name:
+                        * asm - CRATE_NAME.s
+                        * llvm-bc - CRATE_NAME.bc
+                        * dep-info - CRATE_NAME.d
+                        * link - (platform and crate-type dependent)
+                        * llvm-ir - CRATE_NAME.ll
+                        * metadata - libCRATE_NAME.rmeta
+                        * mir - CRATE_NAME.mir
+                        * obj - CRATE_NAME.o
+                        * thin-link-bitcode - CRATE_NAME.indexing.o
         --print INFO[=FILE]
                         Compiler information to print on stdout (or to a file)
                         INFO may be one of

--- a/tests/ui/invalid-compile-flags/emit-output-types-without-args.rs
+++ b/tests/ui/invalid-compile-flags/emit-output-types-without-args.rs
@@ -1,0 +1,1 @@
+//@ compile-flags: --emit

--- a/tests/ui/invalid-compile-flags/emit-output-types-without-args.rs
+++ b/tests/ui/invalid-compile-flags/emit-output-types-without-args.rs
@@ -1,1 +1,2 @@
 //@ compile-flags: --emit
+//@ error-pattern: Argument to option 'emit' missing

--- a/tests/ui/invalid-compile-flags/emit-output-types-without-args.stderr
+++ b/tests/ui/invalid-compile-flags/emit-output-types-without-args.stderr
@@ -1,0 +1,6 @@
+error: Argument to option 'emit' missing
+       Usage:
+           --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
+                               Comma separated list of types of output for the
+                               compiler to emit
+

--- a/tests/ui/invalid-compile-flags/emit-output-types-without-args.stderr
+++ b/tests/ui/invalid-compile-flags/emit-output-types-without-args.stderr
@@ -1,6 +1,15 @@
 error: Argument to option 'emit' missing
        Usage:
-           --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
-                               Comma separated list of types of output for the
-                               compiler to emit
+           --emit TYPE[=FILE]  Comma separated list of types of output for the
+                               compiler to emit.
+                               Each TYPE has the default FILE name:
+                               * asm - CRATE_NAME.s
+                               * llvm-bc - CRATE_NAME.bc
+                               * dep-info - CRATE_NAME.d
+                               * link - (platform and crate-type dependent)
+                               * llvm-ir - CRATE_NAME.ll
+                               * metadata - libCRATE_NAME.rmeta
+                               * mir - CRATE_NAME.mir
+                               * obj - CRATE_NAME.o
+                               * thin-link-bitcode - CRATE_NAME.indexing.o
 


### PR DESCRIPTION
Closes #139805 

Use define_output_types to define variants of OutputType, as well as refactor all of its methods for clarity. This way no variant is missed when pattern matching or output help messages.

On top of that, I optimized for `emit` help messages.

r? @jieyouxu 