### PR TITLE
Check bare function idents for non snake-case name

### DIFF
--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -422,6 +422,16 @@ impl<'tcx> LateLintPass<'tcx> for NonSnakeCase {
         }
     }
 
+    fn check_ty(&mut self, cx: &LateContext<'_>, ty: &hir::Ty<'_, hir::AmbigArg>) {
+        if let hir::TyKind::BareFn(hir::BareFnTy { param_idents, .. }) = &ty.kind {
+            for param_ident in *param_idents {
+                if let Some(param_ident) = param_ident {
+                    self.check_snake_case(cx, "variable", param_ident);
+                }
+            }
+        }
+    }
+
     fn check_trait_item(&mut self, cx: &LateContext<'_>, item: &hir::TraitItem<'_>) {
         if let hir::TraitItemKind::Fn(_, hir::TraitFn::Required(param_idents)) = item.kind {
             self.check_snake_case(cx, "trait method", &item.ident);

--- a/tests/ui/lint/non-snake-case/lint-uppercase-variables.rs
+++ b/tests/ui/lint/non-snake-case/lint-uppercase-variables.rs
@@ -35,6 +35,9 @@ fn main() {
     //~^^ ERROR `Foo` is named the same as one of the variants of the type `foo::Foo`
     //~^^^ WARN unused variable: `Foo`
 
+    let _: fn(CamelCase: i32);
+    //~^ ERROR variable `CamelCase` should have a snake case name
+
     test(1);
 
     let _ = Something { X: 0 };

--- a/tests/ui/lint/non-snake-case/lint-uppercase-variables.stderr
+++ b/tests/ui/lint/non-snake-case/lint-uppercase-variables.stderr
@@ -85,6 +85,12 @@ error: variable `Foo` should have a snake case name
 LL |     fn in_param(Foo: foo::Foo) {}
    |                 ^^^ help: convert the identifier to snake case (notice the capitalization): `foo`
 
-error: aborting due to 9 previous errors; 3 warnings emitted
+error: variable `CamelCase` should have a snake case name
+  --> $DIR/lint-uppercase-variables.rs:38:15
+   |
+LL |     let _: fn(CamelCase: i32);
+   |               ^^^^^^^^^ help: convert the identifier to snake case: `camel_case`
+
+error: aborting due to 10 previous errors; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0170`.


### PR DESCRIPTION
This PR adds the check required to lint on bare function idents for non snake-case name.

Reported at #140089.
cc @theemathas
