### PR TITLE
build_helper: try to rename dir before delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
 name = "build_helper"
 version = "0.1.0"
 dependencies = [
+ "fastrand",
  "serde",
  "serde_derive",
 ]

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
 name = "build_helper"
 version = "0.1.0"
 dependencies = [
+ "fastrand",
  "serde",
  "serde_derive",
 ]
@@ -232,6 +233,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fd-lock"

--- a/src/build_helper/Cargo.toml
+++ b/src/build_helper/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+fastrand = "2.3.0"
 serde = "1"
 serde_derive = "1"


### PR DESCRIPTION
This is aimed at working around "failed to remove and recreate output directory" errors in CI. Mostly coming from https://github.com/rust-lang/rust/blob/49e5e4e3a5610c240a717cb99003a5d5d3356679/src/tools/compiletest/src/runtest.rs#L1515-L1516

Essentially we want to create a new empty directory but an old directory with the same name exists. Ideally we'd remove the old directory but renaming it has (more or less) the same effect. Maybe a better strategy would be to use unique directory names to start with but I fear that will be a more invasive change.

r? jieyouxu