### PR TITLE
build_helper: Exponentially increase rm delay

### DIFF
--- a/src/build_helper/src/fs/mod.rs
+++ b/src/build_helper/src/fs/mod.rs
@@ -52,7 +52,7 @@ pub fn recursive_remove<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let is_dir_like = fs::Metadata::is_dir;
 
     const MAX_RETRIES: usize = 5;
-    const RETRY_DELAY_MS: u64 = 100;
+    const RETRY_MIN_DELAY_MS: u64 = 100;
 
     let try_remove = || {
         if is_dir_like(&metadata) {
@@ -72,7 +72,7 @@ pub fn recursive_remove<P: AsRef<Path>>(path: P) -> io::Result<()> {
             Ok(()) => return Ok(()),
             Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(_) if attempt < MAX_RETRIES - 1 => {
-                std::thread::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS));
+                std::thread::sleep(std::time::Duration::from_millis(RETRY_MIN_DELAY_MS << attempt));
                 continue;
             }
             Err(e) => return Err(e),


### PR DESCRIPTION
An alternative approach to working around the CI issues with removing a directory. In the worst case this means we may end up waiting a couple of seconds in total for the directory to be removed. Hopefully that will be more than sufficient.

While not my favourite approach, I'm posting this PR just in case my other workaround doesn't help. If it isn't needed then it can be closed.

r? jieyouxu 