### PR TITLE
[EXPERIMENTAL] `tests/mir-opt/strip_debuginfo.rs` failure investigation

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1513,6 +1513,14 @@ impl<'test> TestCx<'test> {
         let set_mir_dump_dir = |rustc: &mut Command| {
             let mir_dump_dir = self.get_mir_dump_dir();
             remove_and_create_dir_all(&mir_dump_dir).unwrap_or_else(|e| {
+                let mut remaining = vec![];
+                for entry in walkdir::WalkDir::new(mir_dump_dir.as_std_path()) {
+                    let entry =
+                        entry.unwrap_or_else(|e| panic!("failed to walk {mir_dump_dir}: {e}"));
+                    remaining.push(entry.path().to_path_buf());
+                }
+                eprintln!("mir_dump_dir = {mir_dump_dir}, remaining = {:#?}", remaining);
+
                 panic!("failed to remove and recreate output directory `{mir_dump_dir}`: {e}")
             });
             let mut dir_opt = "-Zdump-mir-dir=".to_string();


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/140096#issuecomment-2818282483, https://github.com/rust-lang/rust/pull/139727#issuecomment-2817039259.
cf. #134351.

(Yes this isn't robust, but just in case)

r? ghost

try-job: x86_64-apple-1
try-job: x86_64-msvc-1
try-job: dist-x86_64-msvc