### PR TITLE
{B,C}Str: minor cleanup

### DIFF
--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -574,7 +574,7 @@ impl CString {
     #[stable(feature = "as_c_str", since = "1.20.0")]
     #[rustc_diagnostic_item = "cstring_as_c_str"]
     pub fn as_c_str(&self) -> &CStr {
-        &*self
+        unsafe { CStr::from_bytes_with_nul_unchecked(self.as_bytes_with_nul()) }
     }
 
     /// Converts this `CString` into a boxed [`CStr`].
@@ -705,14 +705,14 @@ impl ops::Deref for CString {
 
     #[inline]
     fn deref(&self) -> &CStr {
-        unsafe { CStr::from_bytes_with_nul_unchecked(self.as_bytes_with_nul()) }
+        self.as_c_str()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Debug for CString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
+        fmt::Debug::fmt(self.as_c_str(), f)
     }
 }
 

--- a/library/alloctests/tests/c_str2.rs
+++ b/library/alloctests/tests/c_str2.rs
@@ -34,12 +34,6 @@ fn build_with_zero2() {
 }
 
 #[test]
-fn formatted() {
-    let s = CString::new(&b"abc\x01\x02\n\xE2\x80\xA6\xFF"[..]).unwrap();
-    assert_eq!(format!("{s:?}"), r#""abc\x01\x02\n\xe2\x80\xa6\xff""#);
-}
-
-#[test]
 fn borrowed() {
     unsafe {
         let s = CStr::from_ptr(b"12\0".as_ptr() as *const _);

--- a/library/core/src/bstr/mod.rs
+++ b/library/core/src/bstr/mod.rs
@@ -37,7 +37,6 @@ use crate::ops::{Deref, DerefMut, DerefPure};
 ///
 /// The `Display` implementation behaves as if the `ByteStr` were first lossily converted to a
 /// `str`, with invalid UTF-8 presented as the Unicode replacement character: �
-///
 #[unstable(feature = "bstr", issue = "134915")]
 #[repr(transparent)]
 #[doc(alias = "BStr")]

--- a/library/core/src/bstr/mod.rs
+++ b/library/core/src/bstr/mod.rs
@@ -36,7 +36,7 @@ use crate::ops::{Deref, DerefMut, DerefPure};
 /// presented as hex escape sequences.
 ///
 /// The `Display` implementation behaves as if the `ByteStr` were first lossily converted to a
-/// `str`, with invalid UTF-8 presented as the Unicode replacement character: �
+/// `str`, with invalid UTF-8 presented as the Unicode replacement character (�).
 #[unstable(feature = "bstr", issue = "134915")]
 #[repr(transparent)]
 #[doc(alias = "BStr")]

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -150,7 +150,6 @@ impl Error for FromBytesWithNulError {
 /// within the slice.
 ///
 /// This error is created by the [`CStr::from_bytes_until_nul`] method.
-///
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[stable(feature = "cstr_from_bytes_until_nul", since = "1.69.0")]
 pub struct FromBytesUntilNulError(());

--- a/library/coretests/tests/ffi/cstr.rs
+++ b/library/coretests/tests/ffi/cstr.rs
@@ -13,3 +13,9 @@ fn compares_as_u8s() {
     assert_eq!(Ord::cmp(a, b), Ord::cmp(a_bytes, b_bytes));
     assert_eq!(PartialOrd::partial_cmp(a, b), PartialOrd::partial_cmp(a_bytes, b_bytes));
 }
+
+#[test]
+fn debug() {
+    let s = c"abc\x01\x02\n\xE2\x80\xA6\xFF";
+    assert_eq!(format!("{s:?}"), r#""abc\x01\x02\n\xe2\x80\xa6\xff""#);
+}


### PR DESCRIPTION
(hopefully) uncontroversial bits extracted from #139994.
