### PR TITLE
build_helper: temporarily swallow remove dir failure

### DIFF
--- a/src/build_helper/src/fs/mod.rs
+++ b/src/build_helper/src/fs/mod.rs
@@ -100,6 +100,10 @@ where
 
 pub fn remove_and_create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref();
-    recursive_remove(path)?;
+    // FIXME(#134351): for reasons that are not clear yet, `tests/mir-opt/strip_debuginfo.rs`
+    // triggers various permission denied and dir not empty failures too frequently. Temporarily
+    // swallow the remove dir failure to make CI failure rate tolerable, but this is mostly likely
+    // masking a genuine bug, possibly some kind of race condition.
+    let _ = recursive_remove(path);
     fs::create_dir_all(path)
 }


### PR DESCRIPTION
Due to very high failure rate of `tests/mir-opt/strip_debuginfo.rs` for unknown reasons, cf. <https://github.com/rust-lang/rust/issues/134351>. This restores the previous silently swallow remove dir behavior prior to #139870, but would mask genuine bugs.

Only merge this PR if `tests/mir-opt/strip_debuginfo.rs` failure rates become unbearably high.

Backlink to tracking issue: #134351

r? @ChrisDenton