### PR TITLE
Use `output_base_dir` for `mir_dump_dir`

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1395,14 +1395,6 @@ impl<'test> TestCx<'test> {
         matches!(self.config.suite.as_str(), "rustdoc-ui" | "rustdoc-js" | "rustdoc-json")
     }
 
-    fn get_mir_dump_dir(&self) -> Utf8PathBuf {
-        let mut mir_dump_dir = self.config.build_test_suite_root.clone();
-        debug!("input_file: {}", self.testpaths.file);
-        mir_dump_dir.push(&self.testpaths.relative_dir);
-        mir_dump_dir.push(self.testpaths.file.file_stem().unwrap());
-        mir_dump_dir
-    }
-
     fn make_compile_args(
         &self,
         input_file: &Utf8Path,
@@ -1511,10 +1503,7 @@ impl<'test> TestCx<'test> {
         }
 
         let set_mir_dump_dir = |rustc: &mut Command| {
-            let mir_dump_dir = self.get_mir_dump_dir();
-            remove_and_create_dir_all(&mir_dump_dir).unwrap_or_else(|e| {
-                panic!("failed to remove and recreate output directory `{mir_dump_dir}`: {e}")
-            });
+            let mir_dump_dir = self.output_base_dir();
             let mut dir_opt = "-Zdump-mir-dir=".to_string();
             dir_opt.push_str(mir_dump_dir.as_str());
             debug!("dir_opt: {:?}", dir_opt);

--- a/src/tools/compiletest/src/runtest/mir_opt.rs
+++ b/src/tools/compiletest/src/runtest/mir_opt.rs
@@ -56,7 +56,7 @@ impl TestCx<'_> {
                 self.diff_mir_files(from_file.into(), after.into())
             } else {
                 let mut output_file = Utf8PathBuf::new();
-                output_file.push(self.get_mir_dump_dir());
+                output_file.push(self.output_base_dir());
                 output_file.push(&from_file);
                 debug!("comparing the contents of: {} with {:?}", output_file, expected_file);
                 if !output_file.exists() {
@@ -100,7 +100,7 @@ impl TestCx<'_> {
 
     fn diff_mir_files(&self, before: Utf8PathBuf, after: Utf8PathBuf) -> String {
         let to_full_path = |path: Utf8PathBuf| {
-            let full = self.get_mir_dump_dir().join(&path);
+            let full = self.output_base_dir().join(&path);
             if !full.exists() {
                 panic!(
                     "the mir dump file for {} does not exist (requested in {})",


### PR DESCRIPTION
It just occurred to me that the problem might be due to multiple revisions using the same dump directory (and therefore deleting the other revision's dir). This fixes that by simply using the normal per-test output directory, which is revision safe.