### PR TITLE
Document why CodeStats::type_sizes is public

### DIFF
--- a/compiler/rustc_session/src/code_stats.rs
+++ b/compiler/rustc_session/src/code_stats.rs
@@ -72,6 +72,8 @@ pub struct TypeSizeInfo {
 
 #[derive(Default)]
 pub struct CodeStats {
+    /// The hash set that actually holds all the type size information.
+    /// The field is public for use in external tools. See #139876.
     pub type_sizes: Lock<FxHashSet<TypeSizeInfo>>,
 }
 


### PR DESCRIPTION
As indicated in [this comment](https://github.com/rust-lang/rust/pull/139876#issuecomment-2808932673) from #139876
> Need some comment, otherwise this pub can be eventually removed as unused.

r? @nnethercote