### PR TITLE
Add LLDB providers for BTreeMap and BTreeSet

### DIFF
--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -42,6 +42,11 @@ def summary_lookup(valobj: lldb.SBValue, _dict: LLDBOpaque) -> str:
     if rust_type == RustType.STD_HASH_SET:
         return SizeSummaryProvider(valobj, _dict)
 
+    if rust_type == RustType.STD_BTREE_MAP:
+        return SizeSummaryProvider(valobj, _dict)
+    if rust_type == RustType.STD_BTREE_SET:
+        return SizeSummaryProvider(valobj, _dict)
+
     if rust_type == RustType.STD_RC:
         return StdRcSummaryProvider(valobj, _dict)
     if rust_type == RustType.STD_ARC:
@@ -104,6 +109,12 @@ def synthetic_lookup(valobj: lldb.SBValue, _dict: LLDBOpaque) -> object:
             return StdHashMapSyntheticProvider(valobj, _dict, show_values=False)
         else:
             return StdOldHashMapSyntheticProvider(hash_map, _dict, show_values=False)
+
+    if rust_type == RustType.STD_BTREE_MAP:
+        return StdBTreeMapSyntheticProvider(valobj, _dict)
+    if rust_type == RustType.STD_BTREE_SET:
+        btree_map = valobj.GetChildAtIndex(0)
+        return StdBTreeMapSyntheticProvider(btree_map, _dict, show_values=False)
 
     if rust_type == RustType.STD_RC:
         return StdRcSyntheticProvider(valobj, _dict)

--- a/src/tools/compiletest/src/runtest/debugger.rs
+++ b/src/tools/compiletest/src/runtest/debugger.rs
@@ -111,6 +111,9 @@ impl DebuggerCommands {
 }
 
 /// Check that the pattern in `check_line` applies to `line`. Returns `true` if they do match.
+/// Note that this matching is lazy, i.e. matches as little as possible and thus might leave
+/// stuff unparsed, failing the check.
+/// This is different to usual regex or global matching that is typically eager.
 fn check_single_line(line: &str, check_line: &str) -> bool {
     // Allow check lines to leave parts unspecified (e.g., uninitialized
     // bits in the  wrong case of an enum) with the notation "[...]".

--- a/tests/debuginfo/pretty-std-collections.rs
+++ b/tests/debuginfo/pretty-std-collections.rs
@@ -51,6 +51,33 @@
 
 // lldb-command:run
 
+// lldb-command: v btree_set
+// lldb-check:[...] size=15 { [0] = 0 [1] = 1 [2] = 2 [3] = 3 [4] = 4 [5] = 5 [6] = 6 [7] = 7 [8] = 8 [9] = 9 [10] = 10 [11] = 11 [12] = 12 [13] = 13 [14] = 14 }
+
+// lldb-command: v empty_btree_set
+// lldb-check:[...] size=0
+
+// lldb-command: v btree_map
+// lldb-check:[...] size=15 { [0] = { 0 = 0 1 = 0 } [1] = { 0 = 1 1 = 1 } [2] = { 0 = 2 1 = 2 } [3] = { 0 = 3 1 = 3 } [4] = { 0 = 4 1 = 4 } [5] = { 0 = 5 1 = 5 } [6] = { 0 = 6 1 = 6 } [7] = { 0 = 7 1 = 7 } [8] = { 0 = 8 1 = 8 } [9] = { 0 = 9 1 = 9 } [10] = { 0 = 10 1 = 10 } [11] = { 0 = 11 1 = 11 } [12] = { 0 = 12 1 = 12 } [13] = { 0 = 13 1 = 13 } [14] = { 0 = 14 1 = 14 } }
+
+// lldb-command: v option_btree_map
+// lldb-check:[...] size=2 { [0] = { 0 = false 1 = [...] } [1] = { 0 = true 1 = [...]
+// (The matching here is lazy, so we cannot add braces at the end because they would match
+// intermediate braces and fail because not the entire input was consumed.)
+
+// lldb-command: v nasty_btree_map
+// lldb-check:[...] size=15 { [0] = { 0 = 0 1 = { 0 = 0 } } [1] = { 0 = 1 1 = { 0 = 1 } } [2] = { 0 = 2 1 = { 0 = 2 } } [3] = { 0 = 3 1 = { 0 = 3 } } [4] = { 0 = 4 1 = { 0 = 4 } } [5] = { 0 = 5 1 = { 0 = 5 } } [6] = { 0 = 6 1 = { 0 = 6 } } [7] = { 0 = 7 1 = { 0 = 7 } } [8] = { 0 = 8 1 = { 0 = 8 } } [9] = { 0 = 9 1 = { 0 = 9 } } [10] = { 0 = 10 1 = { 0 = 10 } } [11] = { 0 = 11 1 = { 0 = 11 } } [12] = { 0 = 12 1 = { 0 = 12 } } [13] = { 0 = 13 1 = { 0 = 13 } } [14] = { 0 = 14 1 = { 0 = 14 } } }
+// (Does not print out the type name in lldb)
+
+// lldb-command: v zst_key_btree_map
+// lldb-check:[...] size=1 { [0] = { 1 = 1 } }
+
+// lldb-command: v zst_val_btree_map
+// lldb-check:[...] size=1 { [0] = { 0 = 1 } }
+
+// lldb-command: v zst_key_val_btree_map
+// lldb-check:[...] size=1 { [0] = {} }
+
 // lldb-command:v vec_deque
 // lldb-check:[...] size=3 { [0] = 5 [1] = 3 [2] = 7 }
 


### PR DESCRIPTION
Fixes #111868.

I'm unsure what the supported LLDB versions for `rust-lldb` are. I tested with LLDB 18 and 19 and it works with those but I know that it does not work with LLDB 14 which was picked by my `codelldb` extension for some reason (even though it packages LLDB 19).

I also had to work around what seems like an LLDB bug to me. Otherwise, I'd have kept the code more similar to the GDB provider.
`SBTarget.FindFirstType()` does not find the types that I'm searching for (`LeafNode<i32, i32>*`):

```
target = node.GetTarget()
print("leaf type:", node.GetType())
internal_type = target.FindFirstType(node.GetType().GetName())
print("Actual type:", internal_type)
```

which prints

```
leaf type: struct alloc::collections::btree::node::LeafNode<int, int> *
Actual type: No value
```

All in all, my experience with LLDB debug provider was very fiddly/they seem to break easily but I think it would be better to have `BTreeMap`/`BTreeSet` providers than not have them.

Getting to run the `debuginfo` tests was a pain too because of #126092 and errors with `import _lldb` (#123621).
I ended up re-compling lldb from source against python 3.10 because the tests don't work if lldb is compiled against python 3.12.

Also, it seems like the tests are not run in CI? At least I had a test commit in the PR before to trigger a `debuginfo` test failure which I didn't see here in my PR.