### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -486,15 +486,15 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
             let items: &AssocItems = self.tcx.associated_items(self.def_id);
             items
                 .in_definition_order()
-                .filter(|item| item.is_type())
                 .filter(|item| {
-                    !self
-                        .gen_args
-                        .constraints
-                        .iter()
-                        .any(|constraint| constraint.ident.name == item.name())
+                    item.is_type()
+                        && !item.is_impl_trait_in_trait()
+                        && !self
+                            .gen_args
+                            .constraints
+                            .iter()
+                            .any(|constraint| constraint.ident.name == item.name())
                 })
-                .filter(|item| !item.is_impl_trait_in_trait())
                 .map(|item| self.tcx.item_ident(item.def_id).to_string())
                 .collect()
         } else {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -29,7 +29,7 @@ use rustc_errors::codes::*;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, ErrorGuaranteed, FatalError, struct_span_code_err,
 };
-use rustc_hir::def::{CtorKind, CtorOf, DefKind, Namespace, Res};
+use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, AnonConst, GenericArg, GenericArgs, HirId};
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
@@ -1731,9 +1731,9 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 tcx.associated_items(*trait_def_id)
                         .in_definition_order()
                         .any(|i| {
-                            i.namespace() == Namespace::TypeNS
+                            i.is_type()
+                                && !i.is_impl_trait_in_trait()
                                 && i.ident(tcx).normalize_to_macros_2_0() == assoc_ident
-                                && i.is_type()
                         })
                     // Consider only accessible traits
                     && tcx.visibility(*trait_def_id)

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -35,7 +35,7 @@ miniz_oxide = { version = "0.8.0", optional = true, default-features = false }
 addr2line = { version = "0.24.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
-libc = { version = "0.2.171", default-features = false, features = [
+libc = { version = "0.2.172", default-features = false, features = [
     'rustc-dep-of-std',
 ], public = true }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -585,7 +585,7 @@ img {
 	margin-left: -140px;
 	border-left: none;
 }
-.sidebar-resizer.active:before {
+.sidebar-resizer.active::before {
 	border-left: solid 2px var(--sidebar-resizer-active);
 	display: block;
 	height: 100%;
@@ -2044,7 +2044,7 @@ button#toggle-all-docs:hover, button#toggle-all-docs:focus-visible {
 	text-decoration: none;
 }
 
-#settings-menu > a:before {
+#settings-menu > a::before {
 	/* Wheel <https://www.svgrepo.com/svg/384069/settings-cog-gear> */
 	content: url('data:image/svg+xml,<svg width="18" height="18" viewBox="0 0 12 12" \
 	enable-background="new 0 0 12 12" xmlns="http://www.w3.org/2000/svg">\
@@ -2064,7 +2064,7 @@ button#toggle-all-docs:hover, button#toggle-all-docs:focus-visible {
 	filter: var(--settings-menu-filter);
 }
 
-button#toggle-all-docs:before {
+button#toggle-all-docs::before {
 	/* Custom arrow icon */
 	content: url('data:image/svg+xml,<svg width="18" height="18" viewBox="0 0 12 12" \
 	enable-background="new 0 0 12 12" xmlns="http://www.w3.org/2000/svg">\
@@ -2074,14 +2074,14 @@ button#toggle-all-docs:before {
 	filter: var(--settings-menu-filter);
 }
 
-button#toggle-all-docs.will-expand:before {
+button#toggle-all-docs.will-expand::before {
 	/* Custom arrow icon */
 	content: url('data:image/svg+xml,<svg width="18" height="18" viewBox="0 0 12 12" \
 	enable-background="new 0 0 12 12" xmlns="http://www.w3.org/2000/svg">\
 	<path d="M2,5l4,-4l4,4M2,7l4,4l4,-4" stroke="black" fill="none" stroke-width="2px"/></svg>');
 }
 
-#help-button > a:before {
+#help-button > a::before {
 	/* Question mark with circle */
 	content: url('data:image/svg+xml,<svg width="18" height="18" viewBox="0 0 12 12" \
 	enable-background="new 0 0 12 12" xmlns="http://www.w3.org/2000/svg" fill="none">\
@@ -2093,17 +2093,17 @@ button#toggle-all-docs.will-expand:before {
 	filter: var(--settings-menu-filter);
 }
 
-button#toggle-all-docs:before,
-#help-button > a:before,
-#settings-menu > a:before {
+button#toggle-all-docs::before,
+#help-button > a::before,
+#settings-menu > a::before {
 	filter: var(--settings-menu-filter);
 	margin: 8px;
 }
 
 @media not (pointer: coarse) {
-	button#toggle-all-docs:hover:before,
-	#help-button > a:hover:before,
-	#settings-menu > a:hover:before {
+	button#toggle-all-docs:hover::before,
+	#help-button > a:hover::before,
+	#settings-menu > a:hover::before {
 		filter: var(--settings-menu-hover-filter);
 	}
 }
@@ -2125,7 +2125,7 @@ rustdoc-toolbar span.label {
 	padding-bottom: 4px;
 }
 
-#sidebar-button > a:before {
+#sidebar-button > a::before {
 	/* sidebar resizer image */
 	content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 22" \
 		fill="none" stroke="black">\
@@ -2400,21 +2400,21 @@ However, it's not needed with smaller screen width because the doc/code block is
 
 /* sidebar button opens modal
 	use hamburger button */
-.src #sidebar-button > a:before, .sidebar-menu-toggle:before {
+.src #sidebar-button > a::before, .sidebar-menu-toggle::before {
 	/* hamburger button image */
 	content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" \
 		viewBox="0 0 22 22" fill="none" stroke="black">\
 		<path d="M3,5h16M3,11h16M3,17h16" stroke-width="2.75"/></svg>');
 	opacity: 0.75;
 }
-.sidebar-menu-toggle:hover:before,
-.sidebar-menu-toggle:active:before,
-.sidebar-menu-toggle:focus:before {
+.sidebar-menu-toggle:hover::before,
+.sidebar-menu-toggle:active::before,
+.sidebar-menu-toggle:focus::before {
 	opacity: 1;
 }
 
 /* src sidebar button opens a folder view */
-.src #sidebar-button > a:before {
+.src #sidebar-button > a::before {
 	/* folder image */
 	content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" \
 		viewBox="0 0 22 22" fill="none" stroke="black">\
@@ -2599,7 +2599,7 @@ in src-script.js and main.js
 	}
 
 	/* sidebar button becomes topbar button */
-	#sidebar-button > a:before {
+	#sidebar-button > a::before {
 		content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" \
 			viewBox="0 0 22 22" fill="none" stroke="black">\
 			<rect x="1" y="1" width="20" height="20" ry="1.5" stroke-width="1.5" stroke="%23777"/>\
@@ -2608,7 +2608,7 @@ in src-script.js and main.js
 		width: 22px;
 		height: 22px;
 	}
-	.sidebar-menu-toggle:before {
+	.sidebar-menu-toggle::before {
 		filter: var(--mobile-sidebar-menu-filter);
 	}
 	.sidebar-menu-toggle:hover {
@@ -3287,7 +3287,7 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 }
 
 :root[data-theme="ayu"] #settings-menu > a img,
-:root[data-theme="ayu"] #sidebar-button > a:before {
+:root[data-theme="ayu"] #sidebar-button > a::before {
 	filter: invert(100);
 }
 /* End theme: ayu */

--- a/tests/run-make/metadata-dep-info/dash-separated_something-extra.expected.d
+++ b/tests/run-make/metadata-dep-info/dash-separated_something-extra.expected.d
@@ -1,5 +1,5 @@
-libdash_separated_something-extra.rmeta: dash-separated.rs
-
 dash-separated_something-extra.d: dash-separated.rs
+
+libdash_separated_something-extra.rmeta: dash-separated.rs
 
 dash-separated.rs:

--- a/tests/run-make/rustc-help/help-v.diff
+++ b/tests/run-make/rustc-help/help-v.diff
@@ -1,4 +1,4 @@
-@@ -53,10 +53,27 @@
+@@ -63,10 +63,27 @@
                          Set a codegen option
      -V, --version       Print version info and exit
      -v, --verbose       Use verbose output

--- a/tests/run-make/rustc-help/help-v.stdout
+++ b/tests/run-make/rustc-help/help-v.stdout
@@ -26,9 +26,19 @@ Options:
                         Specify which edition of the compiler to use when
                         compiling code. The default is 2015 and the latest
                         stable edition is 2024.
-        --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
+        --emit TYPE[=FILE]
                         Comma separated list of types of output for the
-                        compiler to emit
+                        compiler to emit.
+                        Each TYPE has the default FILE name:
+                        * asm - CRATE_NAME.s
+                        * llvm-bc - CRATE_NAME.bc
+                        * dep-info - CRATE_NAME.d
+                        * link - (platform and crate-type dependent)
+                        * llvm-ir - CRATE_NAME.ll
+                        * metadata - libCRATE_NAME.rmeta
+                        * mir - CRATE_NAME.mir
+                        * obj - CRATE_NAME.o
+                        * thin-link-bitcode - CRATE_NAME.indexing.o
         --print INFO[=FILE]
                         Compiler information to print on stdout (or to a file)
                         INFO may be one of

--- a/tests/run-make/rustc-help/help.stdout
+++ b/tests/run-make/rustc-help/help.stdout
@@ -26,9 +26,19 @@ Options:
                         Specify which edition of the compiler to use when
                         compiling code. The default is 2015 and the latest
                         stable edition is 2024.
-        --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
+        --emit TYPE[=FILE]
                         Comma separated list of types of output for the
-                        compiler to emit
+                        compiler to emit.
+                        Each TYPE has the default FILE name:
+                        * asm - CRATE_NAME.s
+                        * llvm-bc - CRATE_NAME.bc
+                        * dep-info - CRATE_NAME.d
+                        * link - (platform and crate-type dependent)
+                        * llvm-ir - CRATE_NAME.ll
+                        * metadata - libCRATE_NAME.rmeta
+                        * mir - CRATE_NAME.mir
+                        * obj - CRATE_NAME.o
+                        * thin-link-bitcode - CRATE_NAME.indexing.o
         --print INFO[=FILE]
                         Compiler information to print on stdout (or to a file)
                         INFO may be one of

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-2.rs
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-2.rs
@@ -1,0 +1,12 @@
+trait Foo {
+    fn rpitit() -> impl Sized;
+}
+
+// Ensure that we don't try to probe the name of the RPITIT when looking for
+// fixes to suggest for the redundant generic below.
+
+fn test<T: Foo<i32, Assoc = i32>>() {}
+//~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
+//~| ERROR associated type `Assoc` not found for `Foo`
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-2.stderr
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-2.stderr
@@ -1,0 +1,24 @@
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/dont-probe-missing-item-name-2.rs:8:12
+   |
+LL | fn test<T: Foo<i32, Assoc = i32>>() {}
+   |            ^^^------------------ help: remove the unnecessary generics
+   |            |
+   |            expected 0 generic arguments
+   |
+note: trait defined here, with 0 generic parameters
+  --> $DIR/dont-probe-missing-item-name-2.rs:1:7
+   |
+LL | trait Foo {
+   |       ^^^
+
+error[E0220]: associated type `Assoc` not found for `Foo`
+  --> $DIR/dont-probe-missing-item-name-2.rs:8:21
+   |
+LL | fn test<T: Foo<i32, Assoc = i32>>() {}
+   |                     ^^^^^ associated type `Assoc` not found
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0220.
+For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-3.rs
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-3.rs
@@ -1,0 +1,11 @@
+trait Trait {
+    fn method() -> impl Sized;
+}
+
+// Ensure that we don't try to probe the name of the RPITIT when looking for
+// fixes to suggest for the missing associated type's trait path below.
+
+fn foo() -> i32::Assoc {}
+//~^ ERROR ambiguous associated type
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-3.stderr
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-3.stderr
@@ -1,0 +1,15 @@
+error[E0223]: ambiguous associated type
+  --> $DIR/dont-probe-missing-item-name-3.rs:8:13
+   |
+LL | fn foo() -> i32::Assoc {}
+   |             ^^^^^^^^^^
+   |
+help: if there were a trait named `Example` with associated type `Assoc` implemented for `i32`, you could use the fully-qualified path
+   |
+LL - fn foo() -> i32::Assoc {}
+LL + fn foo() -> <i32 as Example>::Assoc {}
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0223`.

--- a/tests/ui/invalid-compile-flags/emit-output-types-without-args.rs
+++ b/tests/ui/invalid-compile-flags/emit-output-types-without-args.rs
@@ -1,0 +1,1 @@
+//@ compile-flags: --emit

--- a/tests/ui/invalid-compile-flags/emit-output-types-without-args.rs
+++ b/tests/ui/invalid-compile-flags/emit-output-types-without-args.rs
@@ -1,1 +1,2 @@
 //@ compile-flags: --emit
+//@ error-pattern: Argument to option 'emit' missing

--- a/tests/ui/invalid-compile-flags/emit-output-types-without-args.stderr
+++ b/tests/ui/invalid-compile-flags/emit-output-types-without-args.stderr
@@ -1,0 +1,6 @@
+error: Argument to option 'emit' missing
+       Usage:
+           --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
+                               Comma separated list of types of output for the
+                               compiler to emit
+

--- a/tests/ui/invalid-compile-flags/emit-output-types-without-args.stderr
+++ b/tests/ui/invalid-compile-flags/emit-output-types-without-args.stderr
@@ -1,6 +1,15 @@
 error: Argument to option 'emit' missing
        Usage:
-           --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
-                               Comma separated list of types of output for the
-                               compiler to emit
+           --emit TYPE[=FILE]  Comma separated list of types of output for the
+                               compiler to emit.
+                               Each TYPE has the default FILE name:
+                               * asm - CRATE_NAME.s
+                               * llvm-bc - CRATE_NAME.bc
+                               * dep-info - CRATE_NAME.d
+                               * link - (platform and crate-type dependent)
+                               * llvm-ir - CRATE_NAME.ll
+                               * metadata - libCRATE_NAME.rmeta
+                               * mir - CRATE_NAME.mir
+                               * obj - CRATE_NAME.o
+                               * thin-link-bitcode - CRATE_NAME.indexing.o
 


### PR DESCRIPTION
Successful merges:

 - #139981 (Don't compute name of associated item if it's an RPITIT)
 - #140077 (Construct OutputType using macro and print [=FILENAME] help info)
 - #140081 (Update `libc` to 0.2.172)
 - #140128 (Use correct annotation for CSS pseudo elements)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=139981,140077,140081,140128)
<!-- homu-ignore:end -->