### PR TITLE
Add an aarch64-msvc build running on ARM64 Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
       - name: show the current environment
         run: src/ci/scripts/dump-environment.sh
 
+      - name: install rust
+        run: src/ci/scripts/install-rust.sh
+
       - name: install awscli
         run: src/ci/scripts/install-awscli.sh
 

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -46,6 +46,10 @@ runners:
     os: windows-2025-8core-32gb
     <<: *base-job
 
+  - &job-windows-aarch64
+    os: windows-11-arm
+    <<: *base-job
+
   - &job-aarch64-linux
     # Free some disk space to avoid running out of space during the build.
     free_disk: true
@@ -539,6 +543,19 @@ auto:
       SCRIPT: make ci-msvc-ps1
     <<: *job-windows
 
+  # aarch64-msvc is split into two jobs to run tests in parallel.
+  - name: aarch64-msvc-1
+    env:
+      RUST_CONFIGURE_ARGS: --build=aarch64-pc-windows-msvc
+      SCRIPT: make ci-msvc-py
+    <<: *job-windows-aarch64
+
+  - name: aarch64-msvc-2
+    env:
+      RUST_CONFIGURE_ARGS: --build=aarch64-pc-windows-msvc
+      SCRIPT: make ci-msvc-ps1
+    <<: *job-windows-aarch64
+
   # x86_64-msvc-ext is split into multiple jobs to run tests in parallel.
   - name: x86_64-msvc-ext1
     env:
@@ -634,14 +651,14 @@ auto:
   - name: dist-aarch64-msvc
     env:
       RUST_CONFIGURE_ARGS: >-
-        --build=x86_64-pc-windows-msvc
+        --build=aarch64-pc-windows-msvc
         --host=aarch64-pc-windows-msvc
         --target=aarch64-pc-windows-msvc,arm64ec-pc-windows-msvc
         --enable-full-tools
         --enable-profiler
       SCRIPT: python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
-    <<: *job-windows
+    <<: *job-windows-aarch64
 
   - name: dist-i686-mingw
     env:

--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -56,9 +56,19 @@ elif isWindows && ! isKnownToBeMingwBuild; then
 
     mkdir -p citools/clang-rust
     cd citools
-    retry curl -f "${MIRRORS_BASE}/LLVM-${LLVM_VERSION}-win64.exe" \
-        -o "LLVM-${LLVM_VERSION}-win64.exe"
-    7z x -oclang-rust/ "LLVM-${LLVM_VERSION}-win64.exe"
+
+    if [[ "${CI_JOB_NAME}" = *aarch64* ]]; then
+        suffix=woa64
+
+        # On Arm64, the Ring crate requires that Clang be on the PATH.
+        # https://github.com/briansmith/ring/blob/main/BUILDING.md
+        ciCommandAddPath "$(cygpath -m "$(pwd)/clang-rust/bin")"
+    else
+        suffix=win64
+    fi
+    retry curl -f "${MIRRORS_BASE}/LLVM-${LLVM_VERSION}-${suffix}.exe" \
+        -o "LLVM-${LLVM_VERSION}-${suffix}.exe"
+    7z x -oclang-rust/ "LLVM-${LLVM_VERSION}-${suffix}.exe"
     ciCommandSetEnv RUST_CONFIGURE_ARGS \
         "${RUST_CONFIGURE_ARGS} --set llvm.clang-cl=$(pwd)/clang-rust/bin/clang-cl.exe"
 

--- a/src/ci/scripts/install-rust.sh
+++ b/src/ci/scripts/install-rust.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# The Arm64 Windows Runner does not have Rust already installed
+# https://github.com/actions/partner-runner-images/issues/77
+
+set -euo pipefail
+IFS=$'\n\t'
+
+source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
+
+if [[ "${CI_JOB_NAME}" = *aarch64* ]] && isWindows; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y -q --default-host aarch64-pc-windows-msvc
+    ciCommandAddPath "${USERPROFILE}/.cargo/bin"
+fi


### PR DESCRIPTION
Resurrecting rust-lang/rust#126341

Per <https://github.com/rust-lang/rfcs/pull/3817> we intend to promote `aarch64-pc-windows-msvc` to Tier 1. As part of that work, we are adding a pre-merge CI job to validate that changes do not break this target.

Additionally, for consistency, the `dist-aarch64-msvc` job will also be run on Arm64 Windows runners.

r? @Kobzol

try-job: `*aarch64-msvc*`