### PR TITLE
Move zkVM constants into `sys::env_consts`

### DIFF
--- a/library/std/src/sys/env_consts.rs
+++ b/library/std/src/sys/env_consts.rs
@@ -389,6 +389,17 @@ pub mod os {
     pub const EXE_EXTENSION: &str = "exe";
 }
 
+#[cfg(target_os = "zkvm")]
+pub mod os {
+    pub const FAMILY: &str = "";
+    pub const OS: &str = "";
+    pub const DLL_PREFIX: &str = "";
+    pub const DLL_SUFFIX: &str = ".elf";
+    pub const DLL_EXTENSION: &str = "elf";
+    pub const EXE_SUFFIX: &str = ".elf";
+    pub const EXE_EXTENSION: &str = "elf";
+}
+
 // The fallback when none of the other gates match.
 #[else]
 pub mod os {

--- a/library/std/src/sys/pal/zkvm/env.rs
+++ b/library/std/src/sys/pal/zkvm/env.rs
@@ -1,9 +1,0 @@
-pub mod os {
-    pub const FAMILY: &str = "";
-    pub const OS: &str = "";
-    pub const DLL_PREFIX: &str = "";
-    pub const DLL_SUFFIX: &str = ".elf";
-    pub const DLL_EXTENSION: &str = "elf";
-    pub const EXE_SUFFIX: &str = ".elf";
-    pub const EXE_EXTENSION: &str = "elf";
-}


### PR DESCRIPTION
I missed this in #139868. Its `mod` declaration was removed, but the contents were not moved.

r? joboet