### PR TITLE
Handle another negated literal in `eat_token_lit`.

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2148,6 +2148,17 @@ impl<'a> Parser<'a> {
     /// Keep this in sync with `Token::can_begin_literal_maybe_minus` and
     /// `Lit::from_token` (excluding unary negation).
     fn eat_token_lit(&mut self) -> Option<token::Lit> {
+        let check_expr = |expr: P<Expr>| {
+            if let ast::ExprKind::Lit(token_lit) = expr.kind {
+                Some(token_lit)
+            } else if let ast::ExprKind::Unary(UnOp::Neg, inner) = &expr.kind
+                && let ast::Expr { kind: ast::ExprKind::Lit(_), .. } = **inner
+            {
+                None
+            } else {
+                panic!("unexpected reparsed expr/literal: {:?}", expr.kind);
+            }
+        };
         match self.token.uninterpolate().kind {
             token::Ident(name, IdentIsRaw::No) if name.is_bool_lit() => {
                 self.bump();
@@ -2163,10 +2174,7 @@ impl<'a> Parser<'a> {
                 let lit = self
                     .eat_metavar_seq(MetaVarKind::Literal, |this| this.parse_literal_maybe_minus())
                     .expect("metavar seq literal");
-                let ast::ExprKind::Lit(token_lit) = lit.kind else {
-                    panic!("didn't reparse a literal");
-                };
-                Some(token_lit)
+                check_expr(lit)
             }
             token::OpenDelim(Delimiter::Invisible(InvisibleOrigin::MetaVar(
                 mv_kind @ MetaVarKind::Expr { can_begin_literal_maybe_minus: true, .. },
@@ -2174,15 +2182,7 @@ impl<'a> Parser<'a> {
                 let expr = self
                     .eat_metavar_seq(mv_kind, |this| this.parse_expr())
                     .expect("metavar seq expr");
-                if let ast::ExprKind::Lit(token_lit) = expr.kind {
-                    Some(token_lit)
-                } else if let ast::ExprKind::Unary(UnOp::Neg, inner) = &expr.kind
-                    && let ast::Expr { kind: ast::ExprKind::Lit(_), .. } = **inner
-                {
-                    None
-                } else {
-                    panic!("unexpected reparsed expr: {:?}", expr.kind);
-                }
+                check_expr(expr)
             }
             _ => None,
         }

--- a/tests/ui/macros/reparse-expr-issue-139495.rs
+++ b/tests/ui/macros/reparse-expr-issue-139495.rs
@@ -1,7 +1,15 @@
-macro_rules! m {
-  ($abi : expr) => { extern $abi } //~ ERROR expected expression, found keyword `extern`
+macro_rules! m1 {
+  ($abi: literal) => { extern $abi } //~ ERROR expected expression, found keyword `extern`
+}
+
+macro_rules! m2 {
+  ($abi: expr) => { extern $abi } //~ ERROR expected expression, found keyword `extern`
 }
 
 fn main() {
-    m!(-2)
+    m1!(-2)
+}
+
+fn f() {
+    m2!(-2)
 }

--- a/tests/ui/macros/reparse-expr-issue-139495.stderr
+++ b/tests/ui/macros/reparse-expr-issue-139495.stderr
@@ -1,13 +1,24 @@
 error: expected expression, found keyword `extern`
-  --> $DIR/reparse-expr-issue-139495.rs:2:22
+  --> $DIR/reparse-expr-issue-139495.rs:2:24
    |
-LL |   ($abi : expr) => { extern $abi }
-   |                      ^^^^^^ expected expression
+LL |   ($abi: literal) => { extern $abi }
+   |                        ^^^^^^ expected expression
 ...
-LL |     m!(-2)
-   |     ------ in this macro invocation
+LL |     m1!(-2)
+   |     ------- in this macro invocation
    |
-   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 1 previous error
+error: expected expression, found keyword `extern`
+  --> $DIR/reparse-expr-issue-139495.rs:6:21
+   |
+LL |   ($abi: expr) => { extern $abi }
+   |                     ^^^^^^ expected expression
+...
+LL |     m2!(-2)
+   |     ------- in this macro invocation
+   |
+   = note: this error originates in the macro `m2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Extends the change from #139653, which was on expressions, to literals.

Fixes #140098.

r? @petrochenkov 