### PR TITLE
remove intrinsics::drop_in_place

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -74,15 +74,6 @@ pub mod simd;
 #[cfg(all(target_has_atomic = "8", target_has_atomic = "32", target_has_atomic = "ptr"))]
 use crate::sync::atomic::{self, AtomicBool, AtomicI32, AtomicIsize, AtomicU32, Ordering};
 
-#[stable(feature = "drop_in_place", since = "1.8.0")]
-#[rustc_allowed_through_unstable_modules = "import this function via `std::ptr` instead"]
-#[deprecated(note = "no longer an intrinsic - use `ptr::drop_in_place` directly", since = "1.52.0")]
-#[inline]
-pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
-    // SAFETY: see `ptr::drop_in_place`
-    unsafe { crate::ptr::drop_in_place(to_drop) }
-}
-
 // N.B., these intrinsics take raw pointers because they mutate aliased
 // memory, which is not valid for either `&` or `&mut`.
 

--- a/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
@@ -8,7 +8,7 @@
       let _3: ();
       let mut _4: *mut std::vec::Vec<A>;
       let mut _5: *mut std::option::Option<B>;
-+     scope 1 (inlined std::ptr::drop_in_place::<Vec<A>> - shim(Some(Vec<A>))) {
++     scope 1 (inlined drop_in_place::<Vec<A>> - shim(Some(Vec<A>))) {
 +         let mut _6: &mut std::vec::Vec<A>;
 +         let mut _7: ();
 +         scope 2 (inlined <Vec<A> as Drop>::drop) {
@@ -38,14 +38,14 @@
 +                 scope 13 (inlined std::ptr::from_raw_parts_mut::<[A], A>) {
 +                 }
 +             }
-+             scope 14 (inlined std::ptr::drop_in_place::<[A]> - shim(Some([A]))) {
++             scope 14 (inlined drop_in_place::<[A]> - shim(Some([A]))) {
 +                 let mut _12: usize;
 +                 let mut _13: *mut A;
 +                 let mut _14: bool;
 +             }
 +         }
 +     }
-+     scope 15 (inlined std::ptr::drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
++     scope 15 (inlined drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
 +         let mut _15: isize;
 +         let mut _16: isize;
 +     }
@@ -54,7 +54,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = copy _1;
--         _3 = std::ptr::drop_in_place::<Vec<A>>(move _4) -> [return: bb1, unwind unreachable];
+-         _3 = drop_in_place::<Vec<A>>(move _4) -> [return: bb1, unwind unreachable];
 +         StorageLive(_6);
 +         StorageLive(_7);
 +         _6 = &mut (*_4);
@@ -82,7 +82,7 @@
           StorageDead(_3);
           StorageLive(_5);
           _5 = copy _2;
--         _0 = std::ptr::drop_in_place::<Option<B>>(move _5) -> [return: bb2, unwind unreachable];
+-         _0 = drop_in_place::<Option<B>>(move _5) -> [return: bb2, unwind unreachable];
 +         StorageLive(_15);
 +         StorageLive(_16);
 +         _15 = discriminant((*_5));

--- a/tests/mir-opt/inline/inline_shims.drop.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_shims.drop.Inline.panic-unwind.diff
@@ -8,7 +8,7 @@
       let _3: ();
       let mut _4: *mut std::vec::Vec<A>;
       let mut _5: *mut std::option::Option<B>;
-+     scope 1 (inlined std::ptr::drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
++     scope 1 (inlined drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
 +         let mut _6: isize;
 +         let mut _7: isize;
 +     }
@@ -17,7 +17,7 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = copy _1;
-          _3 = std::ptr::drop_in_place::<Vec<A>>(move _4) -> [return: bb1, unwind continue];
+          _3 = drop_in_place::<Vec<A>>(move _4) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -25,7 +25,7 @@
           StorageDead(_3);
           StorageLive(_5);
           _5 = copy _2;
--         _0 = std::ptr::drop_in_place::<Option<B>>(move _5) -> [return: bb2, unwind continue];
+-         _0 = drop_in_place::<Option<B>>(move _5) -> [return: bb2, unwind continue];
 +         StorageLive(_6);
 +         StorageLive(_7);
 +         _6 = discriminant((*_5));

--- a/tests/mir-opt/inline/inline_shims.rs
+++ b/tests/mir-opt/inline/inline_shims.rs
@@ -11,7 +11,7 @@ pub fn clone<A, B>(f: fn(A, B)) -> fn(A, B) {
 // EMIT_MIR inline_shims.drop.Inline.diff
 pub fn drop<A, B>(a: *mut Vec<A>, b: *mut Option<B>) {
     // CHECK-LABEL: fn drop(
-    // CHECK: (inlined std::ptr::drop_in_place::<Option<B>> - shim(Some(Option<B>)))
+    // CHECK: (inlined drop_in_place::<Option<B>> - shim(Some(Option<B>)))
     unsafe { std::ptr::drop_in_place(a) }
     unsafe { std::ptr::drop_in_place(b) }
 }

--- a/tests/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.panic-abort.mir
+++ b/tests/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.panic-abort.mir
@@ -1,6 +1,6 @@
-// MIR for `std::ptr::drop_in_place` after SimplifyCfg-make_shim
+// MIR for `drop_in_place` after SimplifyCfg-make_shim
 
-fn std::ptr::drop_in_place(_1: *mut Test) -> () {
+fn drop_in_place(_1: *mut Test) -> () {
     let mut _0: ();
     let mut _2: &mut Test;
     let mut _3: &mut Test;

--- a/tests/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.panic-unwind.mir
+++ b/tests/mir-opt/retag.core.ptr-drop_in_place.Test.SimplifyCfg-make_shim.after.panic-unwind.mir
@@ -1,6 +1,6 @@
-// MIR for `std::ptr::drop_in_place` after SimplifyCfg-make_shim
+// MIR for `drop_in_place` after SimplifyCfg-make_shim
 
-fn std::ptr::drop_in_place(_1: *mut Test) -> () {
+fn drop_in_place(_1: *mut Test) -> () {
     let mut _0: ();
     let mut _2: &mut Test;
     let mut _3: &mut Test;

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
@@ -1,6 +1,6 @@
-// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
+// MIR for `drop_in_place` before AddMovesForPackedDrops
 
-fn std::ptr::drop_in_place(_1: *mut [String; 42]) -> () {
+fn drop_in_place(_1: *mut [String; 42]) -> () {
     let mut _0: ();
     let mut _2: *mut [std::string::String; 42];
     let mut _3: *mut [std::string::String];

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
@@ -1,6 +1,6 @@
-// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
+// MIR for `drop_in_place` before AddMovesForPackedDrops
 
-fn std::ptr::drop_in_place(_1: *mut [String]) -> () {
+fn drop_in_place(_1: *mut [String]) -> () {
     let mut _0: ();
     let mut _2: usize;
     let mut _3: usize;

--- a/tests/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/unusual_item_types.core.ptr-drop_in_place.Vec_i32_.AddMovesForPackedDrops.before.mir
@@ -1,6 +1,6 @@
-// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
+// MIR for `drop_in_place` before AddMovesForPackedDrops
 
-fn std::ptr::drop_in_place(_1: *mut Vec<i32>) -> () {
+fn drop_in_place(_1: *mut Vec<i32>) -> () {
     let mut _0: ();
     let mut _2: &mut std::vec::Vec<i32>;
     let mut _3: ();

--- a/tests/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/tests/ui/consts/miri_unleashed/assoc_const.stderr
@@ -1,12 +1,12 @@
-error[E0080]: evaluation of `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))` failed
+error[E0080]: evaluation of `drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))` failed
   --> $DIR/assoc_const.rs:12:31
    |
 LL |     const F: u32 = (U::X, 42).1;
    |                               ^ calling non-const function `<Vec<u32> as Drop>::drop`
    |
-note: inside `std::ptr::drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
+note: inside `drop_in_place::<(Vec<u32>, u32)> - shim(Some((Vec<u32>, u32)))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))`
+note: inside `drop_in_place::<Vec<u32>> - shim(Some(Vec<u32>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 note: erroneous constant encountered

--- a/tests/ui/consts/miri_unleashed/drop.rs
+++ b/tests/ui/consts/miri_unleashed/drop.rs
@@ -15,6 +15,6 @@ static TEST_BAD: () = {
     let _v: Vec<i32> = Vec::new();
 }; //~ ERROR could not evaluate static initializer
    //~| NOTE calling non-const function `<Vec<i32> as Drop>::drop`
-   //~| NOTE inside `std::ptr::drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
+   //~| NOTE inside `drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
 
 //~? WARN skipping const checks

--- a/tests/ui/consts/miri_unleashed/drop.stderr
+++ b/tests/ui/consts/miri_unleashed/drop.stderr
@@ -4,7 +4,7 @@ error[E0080]: could not evaluate static initializer
 LL | };
    | ^ calling non-const function `<Vec<i32> as Drop>::drop`
    |
-note: inside `std::ptr::drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
+note: inside `drop_in_place::<Vec<i32>> - shim(Some(Vec<i32>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 warning: skipping const checks

--- a/tests/ui/consts/qualif-indirect-mutation-fail.stderr
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.stderr
@@ -13,11 +13,11 @@ error[E0080]: evaluation of constant value failed
 LL | };
    | ^ calling non-const function `<Vec<u8> as Drop>::drop`
    |
-note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+note: inside `drop_in_place::<Option<String>> - shim(Some(Option<String>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
+note: inside `drop_in_place::<String> - shim(Some(String))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+note: inside `drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
@@ -34,11 +34,11 @@ error[E0080]: evaluation of constant value failed
 LL | };
    | ^ calling non-const function `<Vec<u8> as Drop>::drop`
    |
-note: inside `std::ptr::drop_in_place::<Option<String>> - shim(Some(Option<String>))`
+note: inside `drop_in_place::<Option<String>> - shim(Some(Option<String>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<String> - shim(Some(String))`
+note: inside `drop_in_place::<String> - shim(Some(String))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
-note: inside `std::ptr::drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
+note: inside `drop_in_place::<Vec<u8>> - shim(Some(Vec<u8>))`
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 
 error[E0493]: destructor of `(u32, Option<String>)` cannot be evaluated at compile-time

--- a/tests/ui/stability-attribute/issue-99286-stable-intrinsics.rs
+++ b/tests/ui/stability-attribute/issue-99286-stable-intrinsics.rs
@@ -8,10 +8,9 @@
 #![allow(unused_imports)]
 #![allow(deprecated)]
 
-use std::intrinsics::drop_in_place as _;
 use std::intrinsics::copy_nonoverlapping as _;
 use std::intrinsics::copy as _;
 use std::intrinsics::write_bytes as _;
-use std::intrinsics::{drop_in_place, copy_nonoverlapping, copy, write_bytes};
+use std::intrinsics::{copy_nonoverlapping, copy, write_bytes};
 
 fn main() {}


### PR DESCRIPTION
This was only ever accidentally stable, and has been marked as deprecated since Rust 1.52, released almost 4 years ago. We've removed the old serialization `derive`s, maybe we can remove this one as well?

As suggested by @jhpratt, let's see what crater says for this one.