### PR TITLE
Implement `Debug` for `EncodeWide`

### DIFF
--- a/library/alloc/src/wtf8/tests.rs
+++ b/library/alloc/src/wtf8/tests.rs
@@ -580,6 +580,17 @@ fn wtf8_encode_wide_size_hint() {
 }
 
 #[test]
+fn wtf8_encode_wide_debug() {
+    let mut string = Wtf8Buf::from_str("aé ");
+    string.push(CodePoint::from_u32(0xD83D).unwrap());
+    string.push_char('💩');
+    assert_eq!(
+        format!("{:?}", string.encode_wide()),
+        r#"EncodeWide(['a', 'é', ' ', 0xD83D, 0xD83D, 0xDCA9])"#
+    );
+}
+
+#[test]
 fn wtf8_clone_into() {
     let mut string = Wtf8Buf::new();
     clone_into(Wtf8::from_str("green"), &mut string);

--- a/library/std/src/sys_common/mod.rs
+++ b/library/std/src/sys_common/mod.rs
@@ -15,7 +15,6 @@
 //! Progress on this is tracked in #84187.
 
 #![allow(missing_docs)]
-#![allow(missing_debug_implementations)]
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
Since `std::os::windows::ffi::EncodeWide` was reexported from `std::sys_common::wtf8::EncodeWide`, which has `#![allow(missing_debug_implementations)]` in the parent module, it did not implement `Debug`. When it was moved to `core`, a placeholder impl was added; fill it in.

This becomes insta-stable.

r? libs-api