### PR TITLE
Cygwin support in rustc

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -255,6 +255,7 @@ fn main() {
     } else if target.contains("haiku")
         || target.contains("darwin")
         || (is_crossed && (target.contains("dragonfly") || target.contains("solaris")))
+        || target.contains("cygwin")
     {
         println!("cargo:rustc-link-lib=z");
     } else if target.contains("netbsd") {

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -1388,7 +1388,7 @@ impl<'a> Builder<'a> {
         // Windows doesn't need dylib path munging because the dlls for the
         // compiler live next to the compiler and the system will find them
         // automatically.
-        if cfg!(windows) {
+        if cfg!(any(windows, target_os = "cygwin")) {
             return;
         }
 

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -130,7 +130,7 @@ pub fn is_debug_info(name: &str) -> bool {
 /// Returns the corresponding relative library directory that the compiler's
 /// dylibs will be found in.
 pub fn libdir(target: TargetSelection) -> &'static str {
-    if target.is_windows() { "bin" } else { "lib" }
+    if target.is_windows() || target.contains("cygwin") { "bin" } else { "lib" }
 }
 
 /// Adds a list of lookup paths to `cmd`'s dynamic library lookup path.

--- a/src/bootstrap/src/utils/shared_helpers.rs
+++ b/src/bootstrap/src/utils/shared_helpers.rs
@@ -46,7 +46,7 @@ pub fn dylib_path() -> Vec<std::path::PathBuf> {
 /// Given an executable called `name`, return the filename for the
 /// executable for a particular target.
 pub fn exe(name: &str, target: &str) -> String {
-    if target.contains("windows") || target.contains("cygwin") {
+    if target.contains("windows") {
         format!("{name}.exe")
     } else if target.contains("uefi") {
         format!("{name}.efi")

--- a/src/bootstrap/src/utils/shared_helpers.rs
+++ b/src/bootstrap/src/utils/shared_helpers.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 /// Returns the environment variable which the dynamic library lookup path
 /// resides in for this platform.
 pub fn dylib_path_var() -> &'static str {
-    if cfg!(target_os = "windows") {
+    if cfg!(any(target_os = "windows", target_os = "cygwin")) {
         "PATH"
     } else if cfg!(target_vendor = "apple") {
         "DYLD_LIBRARY_PATH"
@@ -46,7 +46,7 @@ pub fn dylib_path() -> Vec<std::path::PathBuf> {
 /// Given an executable called `name`, return the filename for the
 /// executable for a particular target.
 pub fn exe(name: &str, target: &str) -> String {
-    if target.contains("windows") {
+    if target.contains("windows") || target.contains("cygwin") {
         format!("{name}.exe")
     } else if target.contains("uefi") {
         format!("{name}.efi")

--- a/src/tools/miri/src/shims/native_lib.rs
+++ b/src/tools/miri/src/shims/native_lib.rs
@@ -117,7 +117,12 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let mut info = std::mem::MaybeUninit::<libc::Dl_info>::uninit();
         unsafe {
             if libc::dladdr(*func.deref() as *const _, info.as_mut_ptr()) != 0 {
-                if std::ffi::CStr::from_ptr(info.assume_init().dli_fname).to_str().unwrap()
+                let info = info.assume_init();
+                #[cfg(target_os = "cygwin")]
+                let fname_ptr = info.dli_fname.as_ptr();
+                #[cfg(not(target_os = "cygwin"))]
+                let fname_ptr = info.dli_fname;
+                if std::ffi::CStr::from_ptr(fname_ptr).to_str().unwrap()
                     != _lib_path.to_str().unwrap()
                 {
                     return None;


### PR DESCRIPTION
This PR builds host rustc targeting cygwin.

- [x] https://github.com/rust-lang/stacker/pull/122
- [x] https://github.com/nagisa/rust_libloading/pull/173
- [x] https://github.com/Detegr/rust-ctrlc/pull/131
- [x] https://github.com/rust-random/getrandom/pull/654
- [x] https://github.com/msys2/MSYS2-packages/issues/5350
- [x] https://github.com/rust-lang/rust/pull/140886
- [x] https://github.com/rust-lang/rust/pull/140921
- [x] https://github.com/rust-lang/rust/pull/140973

Currently supported:
* rustc
* rustdoc
* rustfmt
* clippy

Blocking:
* cargo: blocked by https://github.com/rust-lang/socket2/pull/568
* rust-analyzer: needs `cargo update`, fixed upstream

```
$ rustc --version --verbose
rustc 1.88.0-dev
binary: rustc
commit-hash: unknown
commit-date: unknown
host: x86_64-pc-cygwin
release: 1.88.0-dev
LLVM version: 20.1.4
```