### PR TITLE
Remove `synstructure::Structure::underscore_const` calls.

### DIFF
--- a/compiler/rustc_macros/src/diagnostics/mod.rs
+++ b/compiler/rustc_macros/src/diagnostics/mod.rs
@@ -55,8 +55,7 @@ use synstructure::Structure;
 ///
 /// See rustc dev guide for more examples on using the `#[derive(Diagnostic)]`:
 /// <https://rustc-dev-guide.rust-lang.org/diagnostics/diagnostic-structs.html>
-pub(super) fn diagnostic_derive(mut s: Structure<'_>) -> TokenStream {
-    s.underscore_const(true);
+pub(super) fn diagnostic_derive(s: Structure<'_>) -> TokenStream {
     DiagnosticDerive::new(s).into_tokens()
 }
 
@@ -102,8 +101,7 @@ pub(super) fn diagnostic_derive(mut s: Structure<'_>) -> TokenStream {
 ///
 /// See rustc dev guide for more examples on using the `#[derive(LintDiagnostic)]`:
 /// <https://rustc-dev-guide.rust-lang.org/diagnostics/diagnostic-structs.html#reference>
-pub(super) fn lint_diagnostic_derive(mut s: Structure<'_>) -> TokenStream {
-    s.underscore_const(true);
+pub(super) fn lint_diagnostic_derive(s: Structure<'_>) -> TokenStream {
     LintDiagnosticDerive::new(s).into_tokens()
 }
 
@@ -153,7 +151,6 @@ pub(super) fn lint_diagnostic_derive(mut s: Structure<'_>) -> TokenStream {
 ///
 /// diag.subdiagnostic(RawIdentifierSuggestion { span, applicability, ident });
 /// ```
-pub(super) fn subdiagnostic_derive(mut s: Structure<'_>) -> TokenStream {
-    s.underscore_const(true);
+pub(super) fn subdiagnostic_derive(s: Structure<'_>) -> TokenStream {
     SubdiagnosticDerive::new().into_tokens(s)
 }

--- a/compiler/rustc_macros/src/hash_stable.rs
+++ b/compiler/rustc_macros/src/hash_stable.rs
@@ -74,8 +74,6 @@ fn hash_stable_derive_with_mode(
         HashStableMode::Generic | HashStableMode::NoContext => parse_quote!(__CTX),
     };
 
-    s.underscore_const(true);
-
     // no_context impl is able to derive by-field, which is closer to a perfect derive.
     s.add_bounds(match mode {
         HashStableMode::Normal | HashStableMode::Generic => synstructure::AddBounds::Generics,

--- a/compiler/rustc_macros/src/lift.rs
+++ b/compiler/rustc_macros/src/lift.rs
@@ -4,7 +4,6 @@ use syn::parse_quote;
 pub(super) fn lift_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::TokenStream {
     s.add_bounds(synstructure::AddBounds::Generics);
     s.bind_with(|_| synstructure::BindStyle::Move);
-    s.underscore_const(true);
 
     let tcx: syn::Lifetime = parse_quote!('tcx);
     let newtcx: syn::GenericParam = parse_quote!('__lifted);

--- a/compiler/rustc_macros/src/serialize.rs
+++ b/compiler/rustc_macros/src/serialize.rs
@@ -12,7 +12,6 @@ pub(super) fn type_decodable_derive(
     let decoder_ty = quote! { __D };
     s.add_impl_generic(parse_quote! { #decoder_ty: ::rustc_middle::ty::codec::TyDecoder<'tcx> });
     s.add_bounds(synstructure::AddBounds::Fields);
-    s.underscore_const(true);
 
     decodable_body(s, decoder_ty)
 }
@@ -26,7 +25,6 @@ pub(super) fn meta_decodable_derive(
     s.add_impl_generic(parse_quote! { '__a });
     let decoder_ty = quote! { DecodeContext<'__a, 'tcx> };
     s.add_bounds(synstructure::AddBounds::Generics);
-    s.underscore_const(true);
 
     decodable_body(s, decoder_ty)
 }
@@ -35,7 +33,6 @@ pub(super) fn decodable_derive(mut s: synstructure::Structure<'_>) -> proc_macro
     let decoder_ty = quote! { __D };
     s.add_impl_generic(parse_quote! { #decoder_ty: ::rustc_span::SpanDecoder });
     s.add_bounds(synstructure::AddBounds::Generics);
-    s.underscore_const(true);
 
     decodable_body(s, decoder_ty)
 }
@@ -46,13 +43,12 @@ pub(super) fn decodable_nocontext_derive(
     let decoder_ty = quote! { __D };
     s.add_impl_generic(parse_quote! { #decoder_ty: ::rustc_serialize::Decoder });
     s.add_bounds(synstructure::AddBounds::Fields);
-    s.underscore_const(true);
 
     decodable_body(s, decoder_ty)
 }
 
 fn decodable_body(
-    mut s: synstructure::Structure<'_>,
+    s: synstructure::Structure<'_>,
     decoder_ty: TokenStream,
 ) -> proc_macro2::TokenStream {
     if let syn::Data::Union(_) = s.ast().data {
@@ -98,7 +94,6 @@ fn decodable_body(
             }
         }
     };
-    s.underscore_const(true);
 
     s.bound_impl(
         quote!(::rustc_serialize::Decodable<#decoder_ty>),
@@ -133,7 +128,6 @@ pub(super) fn type_encodable_derive(
     }
     s.add_impl_generic(parse_quote! { #encoder_ty: ::rustc_middle::ty::codec::TyEncoder<'tcx> });
     s.add_bounds(synstructure::AddBounds::Fields);
-    s.underscore_const(true);
 
     encodable_body(s, encoder_ty, false)
 }
@@ -147,7 +141,6 @@ pub(super) fn meta_encodable_derive(
     s.add_impl_generic(parse_quote! { '__a });
     let encoder_ty = quote! { EncodeContext<'__a, 'tcx> };
     s.add_bounds(synstructure::AddBounds::Generics);
-    s.underscore_const(true);
 
     encodable_body(s, encoder_ty, true)
 }
@@ -156,7 +149,6 @@ pub(super) fn encodable_derive(mut s: synstructure::Structure<'_>) -> proc_macro
     let encoder_ty = quote! { __E };
     s.add_impl_generic(parse_quote! { #encoder_ty: ::rustc_span::SpanEncoder });
     s.add_bounds(synstructure::AddBounds::Generics);
-    s.underscore_const(true);
 
     encodable_body(s, encoder_ty, false)
 }
@@ -167,7 +159,6 @@ pub(super) fn encodable_nocontext_derive(
     let encoder_ty = quote! { __E };
     s.add_impl_generic(parse_quote! { #encoder_ty: ::rustc_serialize::Encoder });
     s.add_bounds(synstructure::AddBounds::Fields);
-    s.underscore_const(true);
 
     encodable_body(s, encoder_ty, false)
 }
@@ -181,7 +172,6 @@ fn encodable_body(
         panic!("cannot derive on union")
     }
 
-    s.underscore_const(true);
     s.bind_with(|binding| {
         // Handle the lack of a blanket reference impl.
         if let syn::Type::Reference(_) = binding.ast().ty {

--- a/compiler/rustc_macros/src/type_foldable.rs
+++ b/compiler/rustc_macros/src/type_foldable.rs
@@ -6,8 +6,6 @@ pub(super) fn type_foldable_derive(mut s: synstructure::Structure<'_>) -> proc_m
         panic!("cannot derive on union")
     }
 
-    s.underscore_const(true);
-
     if !s.ast().generics.lifetimes().any(|lt| lt.lifetime.ident == "tcx") {
         s.add_impl_generic(parse_quote! { 'tcx });
     }

--- a/compiler/rustc_macros/src/type_visitable.rs
+++ b/compiler/rustc_macros/src/type_visitable.rs
@@ -8,8 +8,6 @@ pub(super) fn type_visitable_derive(
         panic!("cannot derive on union")
     }
 
-    s.underscore_const(true);
-
     // ignore fields with #[type_visitable(ignore)]
     s.filter(|bi| {
         let mut ignored = false;


### PR DESCRIPTION
The `synstructure` docs say "This method is a no-op, underscore consts are used by default now." The behaviour change occurred going from `synstructure` version 0.13.0 to 0.13.1.

r? @SparrowLii 