### PR TITLE
[AIX] Handle AIX dynamic library extensions within c-link-to-rust-dylib run-make test

### DIFF
--- a/tests/run-make/c-link-to-rust-dylib/rmake.rs
+++ b/tests/run-make/c-link-to-rust-dylib/rmake.rs
@@ -23,7 +23,11 @@ fn main() {
         if path.is_file()
             && path.extension().is_some_and(|ext| ext == expected_extension)
             && path.file_name().and_then(|name| name.to_str()).is_some_and(|name| {
-                name.ends_with(".so") || name.ends_with(".dll") || name.ends_with(".dylib")
+                if cfg!(target_os = "aix") {
+                    name.ends_with(".a")
+                } else {
+                    name.ends_with(".so") || name.ends_with(".dll") || name.ends_with(".dylib")
+                }
             })
         {
             rfs::remove_file(path);


### PR DESCRIPTION


Dynamic libraries on AIX have the ".a" extension. The c-link-to-rust-dylib run-make test checks for the extension explicitly, so the extension for AIX is also added to accommodate the test case on AIX.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
