### PR TITLE
Streamline the `format` macro.

### DIFF
--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -105,8 +105,7 @@ macro_rules! vec {
 macro_rules! format {
     ($($arg:tt)*) => {
         $crate::__export::must_use({
-            let res = $crate::fmt::format($crate::__export::format_args!($($arg)*));
-            res
+            $crate::fmt::format($crate::__export::format_args!($($arg)*))
         })
     }
 }

--- a/tests/pretty/issue-4264.pp
+++ b/tests/pretty/issue-4264.pp
@@ -31,14 +31,12 @@ fn bar() ({
 
     ((::alloc::__export::must_use as
             fn(String) -> String {must_use::<String>})(({
-            let res =
-                ((::alloc::fmt::format as
-                        for<'a> fn(Arguments<'a>) -> String {format})(((format_arguments::new_const
-                            as
-                            fn(&[&'static str; 1]) -> Arguments<'_> {Arguments::<'_>::new_const::<1>})((&([("test"
-                                        as &str)] as [&str; 1]) as &[&str; 1])) as Arguments<'_>))
-                    as String);
-            (res as String)
+            ((::alloc::fmt::format as
+                    for<'a> fn(Arguments<'a>) -> String {format})(((format_arguments::new_const
+                        as
+                        fn(&[&'static str; 1]) -> Arguments<'_> {Arguments::<'_>::new_const::<1>})((&([("test"
+                                    as &str)] as [&str; 1]) as &[&str; 1])) as Arguments<'_>))
+                as String)
         } as String)) as String);
 } as ())
 type Foo = [i32; (3 as usize)];


### PR DESCRIPTION
Removing the unnecessary local variable speeds up compilation a little.

r? @cuviper