### PR TITLE
Remove git repository from git config

### DIFF
--- a/src/bootstrap/src/core/build_steps/suggest.rs
+++ b/src/bootstrap/src/core/build_steps/suggest.rs
@@ -13,7 +13,6 @@ pub fn suggest(builder: &Builder<'_>, run: bool) {
     let git_config = builder.config.git_config();
     let suggestions = builder
         .tool_cmd(Tool::SuggestTests)
-        .env("SUGGEST_TESTS_GIT_REPOSITORY", git_config.git_repository)
         .env("SUGGEST_TESTS_NIGHTLY_BRANCH", git_config.nightly_branch)
         .env("SUGGEST_TESTS_MERGE_COMMIT_EMAIL", git_config.git_merge_commit_email)
         .run_capture_stdout(builder)

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2064,7 +2064,6 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         }
 
         let git_config = builder.config.git_config();
-        cmd.arg("--git-repository").arg(git_config.git_repository);
         cmd.arg("--nightly-branch").arg(git_config.nightly_branch);
         cmd.arg("--git-merge-commit-email").arg(git_config.git_merge_commit_email);
         cmd.force_coloring_in_ci();

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2963,7 +2963,6 @@ impl Config {
 
     pub fn git_config(&self) -> GitConfig<'_> {
         GitConfig {
-            git_repository: &self.stage0_metadata.config.git_repository,
             nightly_branch: &self.stage0_metadata.config.nightly_branch,
             git_merge_commit_email: &self.stage0_metadata.config.git_merge_commit_email,
         }

--- a/src/bootstrap/src/utils/tests/git.rs
+++ b/src/bootstrap/src/utils/tests/git.rs
@@ -135,7 +135,6 @@ impl GitCtx {
 
     fn git_config(&self) -> GitConfig<'_> {
         GitConfig {
-            git_repository: &self.git_repo,
             nightly_branch: &self.nightly_branch,
             git_merge_commit_email: &self.merge_bot_email,
         }

--- a/src/build_helper/src/git.rs
+++ b/src/build_helper/src/git.rs
@@ -5,7 +5,6 @@ use crate::ci::CiEnv;
 
 #[derive(Debug)]
 pub struct GitConfig<'a> {
-    pub git_repository: &'a str,
     pub nightly_branch: &'a str,
     pub git_merge_commit_email: &'a str,
 }

--- a/src/build_helper/src/stage0_parser.rs
+++ b/src/build_helper/src/stage0_parser.rs
@@ -20,7 +20,6 @@ pub struct Stage0Config {
     pub artifacts_server: String,
     pub artifacts_with_llvm_assertions_server: String,
     pub git_merge_commit_email: String,
-    pub git_repository: String,
     pub nightly_branch: String,
 }
 
@@ -49,7 +48,6 @@ pub fn parse_stage0_file() -> Stage0 {
                 stage0.config.artifacts_with_llvm_assertions_server = value.to_owned()
             }
             "git_merge_commit_email" => stage0.config.git_merge_commit_email = value.to_owned(),
-            "git_repository" => stage0.config.git_repository = value.to_owned(),
             "nightly_branch" => stage0.config.nightly_branch = value.to_owned(),
 
             "compiler_date" => stage0.compiler.date = value.to_owned(),

--- a/src/stage0
+++ b/src/stage0
@@ -2,7 +2,6 @@ dist_server=https://static.rust-lang.org
 artifacts_server=https://ci-artifacts.rust-lang.org/rustc-builds
 artifacts_with_llvm_assertions_server=https://ci-artifacts.rust-lang.org/rustc-builds-alt
 git_merge_commit_email=bors@rust-lang.org
-git_repository=rust-lang/rust
 nightly_branch=master
 
 # The configuration above this comment is editable, and can be changed

--- a/src/tools/bump-stage0/src/main.rs
+++ b/src/tools/bump-stage0/src/main.rs
@@ -61,7 +61,6 @@ impl Tool {
             artifacts_server,
             artifacts_with_llvm_assertions_server,
             git_merge_commit_email,
-            git_repository,
             nightly_branch,
         } = &self.config;
 
@@ -72,7 +71,6 @@ impl Tool {
             artifacts_with_llvm_assertions_server
         ));
         file_content.push_str(&format!("git_merge_commit_email={}\n", git_merge_commit_email));
-        file_content.push_str(&format!("git_repository={}\n", git_repository));
         file_content.push_str(&format!("nightly_branch={}\n", nightly_branch));
 
         file_content.push_str("\n");

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -399,7 +399,6 @@ pub struct Config {
     pub nocapture: bool,
 
     // Needed both to construct build_helper::git::GitConfig
-    pub git_repository: String,
     pub nightly_branch: String,
     pub git_merge_commit_email: String,
 
@@ -511,7 +510,6 @@ impl Config {
 
     pub fn git_config(&self) -> GitConfig<'_> {
         GitConfig {
-            git_repository: &self.git_repository,
             nightly_branch: &self.nightly_branch,
             git_merge_commit_email: &self.git_merge_commit_email,
         }

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -175,7 +175,6 @@ impl ConfigBuilder {
             self.host.as_deref().unwrap_or("x86_64-unknown-linux-gnu"),
             "--target",
             self.target.as_deref().unwrap_or("x86_64-unknown-linux-gnu"),
-            "--git-repository=",
             "--nightly-branch=",
             "--git-merge-commit-email=",
             "--minicore-path=",

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -188,7 +188,6 @@ pub fn parse_config(args: Vec<String>) -> Config {
             "run tests which rely on commit version being compiled into the binaries",
         )
         .optopt("", "edition", "default Rust edition", "EDITION")
-        .reqopt("", "git-repository", "name of the git repository", "ORG/REPO")
         .reqopt("", "nightly-branch", "name of the git branch for nightly", "BRANCH")
         .reqopt(
             "",
@@ -440,7 +439,6 @@ pub fn parse_config(args: Vec<String>) -> Config {
 
         nocapture: matches.opt_present("no-capture"),
 
-        git_repository: matches.opt_str("git-repository").unwrap(),
         nightly_branch: matches.opt_str("nightly-branch").unwrap(),
         git_merge_commit_email: matches.opt_str("git-merge-commit-email").unwrap(),
 

--- a/src/tools/suggest-tests/src/main.rs
+++ b/src/tools/suggest-tests/src/main.rs
@@ -6,7 +6,6 @@ use suggest_tests::get_suggestions;
 fn main() -> ExitCode {
     let modified_files = get_git_modified_files(
         &GitConfig {
-            git_repository: &env("SUGGEST_TESTS_GIT_REPOSITORY"),
             nightly_branch: &env("SUGGEST_TESTS_NIGHTLY_BRANCH"),
             git_merge_commit_email: &env("SUGGEST_TESTS_MERGE_COMMIT_EMAIL"),
         },


### PR DESCRIPTION
It is no longer needed after https://github.com/rust-lang/rust/pull/138591. We could even remove the `nightly_branch` field, but it still has one usage.

r? @jieyouxu