### PR TITLE
fix ICE in `#[naked]` attribute validation

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -680,10 +680,14 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     }
 
                     if !other_attr.has_any_name(ALLOW_LIST) {
+                        let path = other_attr.path();
+                        let path: Vec<_> = path.iter().map(|s| s.as_str()).collect();
+                        let other_attr_name = path.join("::");
+
                         self.dcx().emit_err(errors::NakedFunctionIncompatibleAttribute {
                             span: other_attr.span(),
                             naked_span: attr.span(),
-                            attr: other_attr.name().unwrap(),
+                            attr: other_attr_name,
                         });
 
                         return;

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1249,7 +1249,7 @@ pub(crate) struct NakedFunctionIncompatibleAttribute {
     pub span: Span,
     #[label(passes_naked_attribute)]
     pub naked_span: Span,
-    pub attr: Symbol,
+    pub attr: String,
 }
 
 #[derive(Diagnostic)]

--- a/tests/ui/asm/naked-invalid-attr.rs
+++ b/tests/ui/asm/naked-invalid-attr.rs
@@ -51,3 +51,12 @@ fn main() {
     #[unsafe(naked)] //~ ERROR should be applied to a function definition
     || {};
 }
+
+// Check that the path of an attribute without a name is printed correctly (issue #140082)
+#[::a]
+//~^ ERROR attribute incompatible with `#[unsafe(naked)]`
+//~| ERROR failed to resolve: use of unresolved module or unlinked crate `a`
+#[unsafe(naked)]
+extern "C" fn issue_140082() {
+    naked_asm!("")
+}

--- a/tests/ui/asm/naked-invalid-attr.stderr
+++ b/tests/ui/asm/naked-invalid-attr.stderr
@@ -1,3 +1,9 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `a`
+  --> $DIR/naked-invalid-attr.rs:56:5
+   |
+LL | #[::a]
+   |     ^ use of unresolved module or unlinked crate `a`
+
 error: attribute should be applied to a function definition
   --> $DIR/naked-invalid-attr.rs:13:1
    |
@@ -27,6 +33,15 @@ LL |     #[unsafe(naked)]
 LL |     || {};
    |     ----- not a function definition
 
+error[E0736]: attribute incompatible with `#[unsafe(naked)]`
+  --> $DIR/naked-invalid-attr.rs:56:1
+   |
+LL | #[::a]
+   | ^^^^^^ the `{{root}}::a` attribute is incompatible with `#[unsafe(naked)]`
+...
+LL | #[unsafe(naked)]
+   | ---------------- function marked with `#[unsafe(naked)]` here
+
 error: attribute should be applied to a function definition
   --> $DIR/naked-invalid-attr.rs:22:5
    |
@@ -49,5 +64,7 @@ error: attribute should be applied to a function definition
 LL | #![unsafe(naked)]
    | ^^^^^^^^^^^^^^^^^ cannot be applied to crates
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 
+Some errors have detailed explanations: E0433, E0736.
+For more information about an error, try `rustc --explain E0433`.


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/140082

The comment here https://github.com/rust-lang/rust/pull/139615/files#r2040684192 is relevant, a better way to print the full path would be nice. If there's an issue I should `FIXME` this with let me know.

r? @jdonszelmann 
cc @nnethercote https://github.com/rust-lang/rust/pull/139615
