### PR TITLE
minicore: Have `//@ add-core-stubs` also imply `-Cforce-unwind-tables=yes`

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/minicore.md
+++ b/src/doc/rustc-dev-guide/src/tests/minicore.md
@@ -6,24 +6,36 @@
 ui/codegen/assembly test suites. It provides `core` stubs for tests that need to
 build for cross-compiled targets but do not need/want to run.
 
-A test can use [`minicore`] by specifying the `//@ add-core-stubs` directive.
-Then, mark the test with `#![feature(no_core)]` + `#![no_std]` + `#![no_core]`.
-Due to Edition 2015 extern prelude rules, you will probably need to declare
-`minicore` as an extern crate.
-
-Due to the `no_std` + `no_core` nature of these tests, `//@ add-core-stubs`
-implies and requires that the test will be built with `-C panic=abort`.
-Unwinding panics are not supported.
-
-If you find a `core` item to be missing from the [`minicore`] stub, consider
-adding it to the test auxiliary if it's likely to be used or is already needed
-by more than one test.
-
 <div class="warning">
 Please note that [`minicore`] is only intended for `core` items, and explicitly
 **not** `std` or `alloc` items because `core` items are applicable to a wider
 range of tests.
 </div>
+
+A test can use [`minicore`] by specifying the `//@ add-core-stubs` directive.
+Then, mark the test with `#![feature(no_core)]` + `#![no_std]` + `#![no_core]`.
+Due to Edition 2015 extern prelude rules, you will probably need to declare
+`minicore` as an extern crate.
+
+## Implied compiler flags
+
+Due to the `no_std` + `no_core` nature of these tests, `//@ add-core-stubs`
+implies and requires that the test will be built with `-C panic=abort`.
+**Unwinding panics are not supported.**
+
+Tests will also be built with `-C force-unwind-tables=yes` to preserve CFI
+directives in assembly tests.
+
+TL;DR: `//@ add-core-stubs` implies two compiler flags:
+
+1. `-C panic=abort`
+2. `-C force-unwind-tables=yes`
+
+## Adding more `core` stubs
+
+If you find a `core` item to be missing from the [`minicore`] stub, consider
+adding it to the test auxiliary if it's likely to be used or is already needed
+by more than one test.
 
 ## Example codegen test that uses `minicore`
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1710,12 +1710,16 @@ impl<'test> TestCx<'test> {
         rustc.args(&self.props.compile_flags);
 
         // FIXME(jieyouxu): we should report a fatal error or warning if user wrote `-Cpanic=` with
-        // something that's not `abort`, however, by moving this last we should override previous
-        // `-Cpanic=`s
+        // something that's not `abort` and `-Cforce-unwind-tables` with a value that is not `yes`,
+        // however, by moving this last we should override previous `-Cpanic`s and
+        // `-Cforce-unwind-tables`s. Note that checking here is very fragile, because we'd have to
+        // account for all possible compile flag splittings (they have some... intricacies and are
+        // not yet normalized).
         //
         // `minicore` requires `#![no_std]` and `#![no_core]`, which means no unwinding panics.
         if self.props.add_core_stubs {
             rustc.arg("-Cpanic=abort");
+            rustc.arg("-Cforce-unwind-tables=yes");
         }
 
         rustc

--- a/tests/assembly/x86-return-float.rs
+++ b/tests/assembly/x86-return-float.rs
@@ -35,6 +35,7 @@ use minicore::*;
 pub fn return_f32(x: f32) -> f32 {
     // CHECK: movss {{.*}}(%ebp), %xmm0
     // CHECK-NEXT: popl %ebp
+    // linux-NEXT: .cfi_def_cfa
     // CHECK-NEXT: retl
     x
 }
@@ -44,6 +45,7 @@ pub fn return_f32(x: f32) -> f32 {
 pub fn return_f64(x: f64) -> f64 {
     // CHECK: movsd {{.*}}(%ebp), %xmm0
     // CHECK-NEXT: popl %ebp
+    // linux-NEXT: .cfi_def_cfa
     // CHECK-NEXT: retl
     x
 }
@@ -313,9 +315,13 @@ pub unsafe fn call_other_f64(x: &mut (usize, f64)) {
 #[no_mangle]
 pub fn return_f16(x: f16) -> f16 {
     // CHECK: pushl %ebp
+    // linux-NEXT: .cfi_def_cfa_offset
+    // linux-NEXT: .cfi_offset
     // CHECK-NEXT: movl %esp, %ebp
+    // linux-NEXT: .cfi_def_cfa_register
     // CHECK-NEXT: pinsrw $0, 8(%ebp), %xmm0
     // CHECK-NEXT: popl %ebp
+    // linux-NEXT: .cfi_def_cfa
     // CHECK-NEXT: retl
     x
 }
@@ -324,10 +330,14 @@ pub fn return_f16(x: f16) -> f16 {
 #[no_mangle]
 pub fn return_f128(x: f128) -> f128 {
     // CHECK: pushl %ebp
+    // linux-NEXT: .cfi_def_cfa_offset
+    // linux-NEXT: .cfi_offset
     // CHECK-NEXT: movl %esp, %ebp
+    // linux-NEXT: .cfi_def_cfa_register
     // linux-NEXT: movaps 8(%ebp), %xmm0
     // win-NEXT: movups 8(%ebp), %xmm0
     // CHECK-NEXT: popl %ebp
+    // linux-NEXT: .cfi_def_cfa
     // CHECK-NEXT: retl
     x
 }


### PR DESCRIPTION
To preserve CFI directives in assembly tests, as `//@ add-core-stubs` already imply `-C panic=abort`.

This is a blocker for https://github.com/rust-lang/rust/pull/140037#issuecomment-2816665358.

cc @RalfJung 
r? @bjorn3 