### PR TITLE
Improved diagnostics for non-primitive cast on non-primitive types (`Arc`, `Option`)

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -501,12 +501,25 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                             .must_apply_modulo_regions()
                         {
                             label = false;
-                            err.span_suggestion(
-                                self.span,
-                                "consider using the `From` trait instead",
-                                format!("{}::from({})", self.cast_ty, snippet),
-                                Applicability::MaybeIncorrect,
-                            );
+                            if let ty::Adt(def, args) = self.cast_ty.kind() {
+                                err.span_suggestion_verbose(
+                                    self.span,
+                                    "consider using the `From` trait instead",
+                                    format!(
+                                        "{}::from({})",
+                                        fcx.tcx.value_path_str_with_args(def.did(), args),
+                                        snippet
+                                    ),
+                                    Applicability::MaybeIncorrect,
+                                );
+                            } else {
+                                err.span_suggestion(
+                                    self.span,
+                                    "consider using the `From` trait instead",
+                                    format!("{}::from({})", self.cast_ty, snippet),
+                                    Applicability::MaybeIncorrect,
+                                );
+                            };
                         }
                     }
 

--- a/tests/ui/coercion/non-primitive-cast-135412.fixed
+++ b/tests/ui/coercion/non-primitive-cast-135412.fixed
@@ -1,0 +1,10 @@
+//@ run-rustfix
+
+use std::sync::Arc;
+
+fn main() {
+    let _ = Option::<_>::from(7u32);
+    //~^ ERROR non-primitive cast: `u32` as `Option<_>`
+    let _ = Arc::<str>::from("String");
+    //~^ ERROR non-primitive cast: `&'static str` as `Arc<str>`
+}

--- a/tests/ui/coercion/non-primitive-cast-135412.rs
+++ b/tests/ui/coercion/non-primitive-cast-135412.rs
@@ -1,0 +1,10 @@
+//@ run-rustfix
+
+use std::sync::Arc;
+
+fn main() {
+    let _ = 7u32 as Option<_>;
+    //~^ ERROR non-primitive cast: `u32` as `Option<_>`
+    let _ = "String" as Arc<str>;
+    //~^ ERROR non-primitive cast: `&'static str` as `Arc<str>`
+}

--- a/tests/ui/coercion/non-primitive-cast-135412.stderr
+++ b/tests/ui/coercion/non-primitive-cast-135412.stderr
@@ -1,11 +1,5 @@
-error[E0605]: non-primitive cast: `&&[i32; 1]` as `&[_]`
-  --> $DIR/issue-73886.rs:2:13
-   |
-LL |     let _ = &&[0] as &[_];
-   |             ^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
-
 error[E0605]: non-primitive cast: `u32` as `Option<_>`
-  --> $DIR/issue-73886.rs:4:13
+  --> $DIR/non-primitive-cast-135412.rs:6:13
    |
 LL |     let _ = 7u32 as Option<_>;
    |             ^^^^^^^^^^^^^^^^^
@@ -15,6 +9,19 @@ help: consider using the `From` trait instead
    |
 LL -     let _ = 7u32 as Option<_>;
 LL +     let _ = Option::<_>::from(7u32);
+   |
+
+error[E0605]: non-primitive cast: `&'static str` as `Arc<str>`
+  --> $DIR/non-primitive-cast-135412.rs:8:13
+   |
+LL |     let _ = "String" as Arc<str>;
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+help: consider using the `From` trait instead
+   |
+LL -     let _ = "String" as Arc<str>;
+LL +     let _ = Arc::<str>::from("String");
    |
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

here is a small fix that improving error messaging when user is trying to do something like this
```rust
let _ = "x" as Arc<str>;
let _ = 2 as Option<i32>;
```

before it looks like this
```rust
error[E0605]: non-primitive cast: `&'static str` as `Arc<str>`
 --> src\main.rs:3:13
  |
3 |     let _ = "x" as Arc<str>;
  |             ^^^^^^^^^^^^^^^ help: consider using the `From` trait instead: `Arc<str>::from("x")`

error[E0605]: non-primitive cast: `i32` as `Option<i32>`
 --> src\main.rs:4:13
  |
4 |     let _ = 2 as Option<i32>;
``` 
which looks horrible to be honest
so i made a small fix that make errors looks like this
```rust
error[E0605]: non-primitive cast: `&'static str` as `Arc<str>`
  |
3 |     let _ = "x" as Arc<str>;
  |             ^^^^^^^^^^^^^^^
  |
  = note: an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
help: consider using the `From` trait instead
  |
3 -     let _ = "x" as Arc<str>;
3 +     let _ = Arc::<str>::from("x");
  |

error[E0605]: non-primitive cast: `i32` as `Option<i32>`
  |
4 |     let _ = 2 as Option<i32>;
  |             ^^^^^^^^^^^^^^^^
  |
  = note: an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
help: consider using the `From` trait instead
  |
4 -     let _ = 2 as Option<i32>;
4 +     let _ = Option::<i32>::from(2);
```

**What improves?**
1) `Arc<str>::from("x")` which makes no sense because of missing `::`
2) readability

**Related Issue**
fixes #135412