### PR TITLE
Issue an error when using `no_mangle` on language items

### DIFF
--- a/tests/ui/codegen/no-mangle-on-internal-lang-items.rs
+++ b/tests/ui/codegen/no-mangle-on-internal-lang-items.rs
@@ -1,0 +1,14 @@
+// Issue a error when the user uses #[no_mangle] on internal language items
+//@ edition:2024
+
+#![feature(rustc_attrs)]
+
+#[rustc_std_internal_symbol]
+#[unsafe(no_mangle)] //~ERROR `#[no_mangle]` cannot be used on internal language items
+fn internal_lang_function () {
+
+}
+
+fn main() {
+
+}

--- a/tests/ui/codegen/no-mangle-on-internal-lang-items.stderr
+++ b/tests/ui/codegen/no-mangle-on-internal-lang-items.stderr
@@ -1,0 +1,12 @@
+error: `#[no_mangle]` cannot be used on internal language items
+  --> $DIR/no-mangle-on-internal-lang-items.rs:7:1
+   |
+LL | #[unsafe(no_mangle)]
+   | ^^^^^^^^^^^^^^^^^^^^
+LL | fn internal_lang_function () {
+   | ---------------------------- should be the internal language item
+   |
+   = note: Rustc requires this item to have a specific mangled name.
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/codegen/no-mangle-on-panic-handler.rs
+++ b/tests/ui/codegen/no-mangle-on-panic-handler.rs
@@ -1,0 +1,14 @@
+// Issue an error when the user uses #[no_mangle] on the panic handler
+//@ edition:2024
+
+#![crate_type="lib"]
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+#[unsafe(no_mangle)] //~ ERROR `#[no_mangle]` cannot be used on internal language items
+#[panic_handler]
+pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+    loop {}
+}

--- a/tests/ui/codegen/no-mangle-on-panic-handler.stderr
+++ b/tests/ui/codegen/no-mangle-on-panic-handler.stderr
@@ -1,0 +1,16 @@
+error: `#[no_mangle]` cannot be used on internal language items
+  --> $DIR/no-mangle-on-panic-handler.rs:10:1
+   |
+LL | #[unsafe(no_mangle)]
+   | ^^^^^^^^^^^^^^^^^^^^
+LL | #[panic_handler]
+LL | pub unsafe fn panic_fmt(pi: &PanicInfo) -> ! {
+   | -------------------------------------------- should be the internal language item
+   |
+   = note: Rustc requires this item to have a specific mangled name.
+   = note: If you are trying to prevent mangling to ease debugging, many
+   = note: debuggers support a command such as `rbreak rust_begin_unwind` to
+   = note: match `.*rust_begin_unwind.*` instead of `break rust_begin_unwind` on a specific name
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/panic-handler/panic-handler-wrong-location.rs
+++ b/tests/ui/panic-handler/panic-handler-wrong-location.rs
@@ -4,7 +4,6 @@
 #![no_main]
 
 #[panic_handler] //~ ERROR `panic_impl` lang item must be applied to a function
-#[no_mangle]
 static X: u32 = 42;
 
 //~? ERROR `#[panic_handler]` function required, but not found


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This is related to https://github.com/rust-lang/rust/issues/139923
    r? @bjorn3
-->
<!-- homu-ignore:end -->

This pull requests adds the code to issue an error or a warning when using `no_mangle` on language items. This should detail why the `undefined symbol` error is issued for the code described in #139923.

The pull request adds two ui tests, one testing the error and the other one the warning.

I would love some feedback here, as I am not sure that the error and warning are issues using the right API.
