### PR TITLE
Remove outdated comment in integer signum

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -3566,11 +3566,6 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline(always)]
         pub const fn signum(self) -> Self {
-            // Picking the right way to phrase this is complicated
-            // (<https://graphics.stanford.edu/~seander/bithacks.html#CopyIntegerSign>)
-            // so delegate it to `Ord` which is already producing -1/0/+1
-            // exactly like we need and can be the place to deal with the complexity.
-
             crate::intrinsics::three_way_compare(self, 0) as Self
         }
 


### PR DESCRIPTION
Obsoleted by https://github.com/rust-lang/rust/pull/137835/

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
