### PR TITLE
Add XtensaAsmPrinter

### DIFF
--- a/compiler/rustc_llvm/src/lib.rs
+++ b/compiler/rustc_llvm/src/lib.rs
@@ -229,6 +229,7 @@ pub fn initialize_available_targets() {
         LLVMInitializeXtensaTargetInfo,
         LLVMInitializeXtensaTarget,
         LLVMInitializeXtensaTargetMC,
+        LLVMInitializeXtensaAsmPrinter,
         LLVMInitializeXtensaAsmParser
     );
     init_target!(


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/133601. The PR was closed because it required LLVM 19 in CI added with (https://github.com/rust-lang/rust/commit/12167d7064597993355e41d3a8c20654bccaf0be)
