### PR TITLE
Improve error message for `||` (or) in let chains

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -675,6 +675,8 @@ parse_note_pattern_alternatives_use_single_vert = alternatives in or-patterns ar
 
 parse_nul_in_c_str = null characters in C string literals are not supported
 
+parse_or_in_let_chain = `||` operators are not supported in let chain conditions
+
 parse_or_pattern_not_allowed_in_fn_parameters = top-level or-patterns are not allowed in function parameters
 parse_or_pattern_not_allowed_in_let_binding = top-level or-patterns are not allowed in `let` bindings
 parse_out_of_range_hex_escape = out of range hex escape

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -478,6 +478,13 @@ pub(crate) struct ExpectedExpressionFoundLet {
     pub comparison: Option<MaybeComparison>,
 }
 
+#[derive(Diagnostic)]
+#[diag(parse_or_in_let_chain)]
+pub(crate) struct OrInLetChain {
+    #[primary_span]
+    pub span: Span,
+}
+
 #[derive(Subdiagnostic, Clone, Copy)]
 #[multipart_suggestion(
     parse_maybe_missing_let,

--- a/tests/ui/parser/or-in-let-chain.edition2021.stderr
+++ b/tests/ui/parser/or-in-let-chain.edition2021.stderr
@@ -1,0 +1,28 @@
+error: `||` operators are not supported in let chain conditions
+  --> $DIR/or-in-let-chain.rs:6:24
+   |
+LL |     if let true = true || false {}
+   |                        ^^
+
+error: expected expression, found `let` statement
+  --> $DIR/or-in-let-chain.rs:9:9
+   |
+LL |     if (let true = true) || false {}
+   |         ^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+
+error: `||` operators are not supported in let chain conditions
+  --> $DIR/or-in-let-chain.rs:12:24
+   |
+LL |     if let true = true || false || true {}
+   |                        ^^
+
+error: `||` operators are not supported in let chain conditions
+  --> $DIR/or-in-let-chain.rs:15:33
+   |
+LL |     if let true = true && false || true {}
+   |                                 ^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/parser/or-in-let-chain.edition2024.stderr
+++ b/tests/ui/parser/or-in-let-chain.edition2024.stderr
@@ -1,0 +1,28 @@
+error: `||` operators are not supported in let chain conditions
+  --> $DIR/or-in-let-chain.rs:6:24
+   |
+LL |     if let true = true || false {}
+   |                        ^^
+
+error: expected expression, found `let` statement
+  --> $DIR/or-in-let-chain.rs:9:9
+   |
+LL |     if (let true = true) || false {}
+   |         ^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if` and `while` expressions
+
+error: `||` operators are not supported in let chain conditions
+  --> $DIR/or-in-let-chain.rs:12:24
+   |
+LL |     if let true = true || false || true {}
+   |                        ^^
+
+error: `||` operators are not supported in let chain conditions
+  --> $DIR/or-in-let-chain.rs:15:33
+   |
+LL |     if let true = true && false || true {}
+   |                                 ^^
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/parser/or-in-let-chain.rs
+++ b/tests/ui/parser/or-in-let-chain.rs
@@ -1,0 +1,17 @@
+//@ revisions: edition2021 edition2024
+//@ [edition2021] edition: 2021
+//@ [edition2024] edition: 2024
+
+fn main() {
+    if let true = true || false {}
+    //~^ ERROR `||` operators are not supported in let chain conditions
+    // With parentheses
+    if (let true = true) || false {}
+    //~^ ERROR expected expression, found `let` statement
+    // Multiple || operators
+    if let true = true || false || true {}
+    //~^ ERROR `||` operators are not supported in let chain conditions
+    // Mixed operators (should still show error for ||)
+    if let true = true && false || true {}
+    //~^ ERROR `||` operators are not supported in let chain conditions
+}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.rs
@@ -3,7 +3,7 @@
 fn let_or_guard(x: Result<Option<i32>, ()>) {
     match x {
         Ok(opt) if let Some(4) = opt || false  => {}
-        //~^ ERROR expected expression, found `let` statement
+        //~^ ERROR `||` operators are not supported in let chain conditions
         _ => {}
     }
 }

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.stderr
@@ -1,11 +1,4 @@
-error: expected expression, found `let` statement
-  --> $DIR/ast-validate-guards.rs:5:20
-   |
-LL |         Ok(opt) if let Some(4) = opt || false  => {}
-   |                    ^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
+error: `||` operators are not supported in let chain conditions
   --> $DIR/ast-validate-guards.rs:5:38
    |
 LL |         Ok(opt) if let Some(4) = opt || false  => {}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.feature.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.feature.stderr
@@ -272,14 +272,7 @@ LL |     if (let 0 = 0)? {}
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:121:16
-   |
-LL |     if true || let 0 = 0 {}
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
+error: `||` operators are not supported in let chain conditions
   --> $DIR/disallowed-positions.rs:121:13
    |
 LL |     if true || let 0 = 0 {}
@@ -485,14 +478,7 @@ LL |     while (let 0 = 0)? {}
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:212:19
-   |
-LL |     while true || let 0 = 0 {}
-   |                   ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
+error: `||` operators are not supported in let chain conditions
   --> $DIR/disallowed-positions.rs:212:16
    |
 LL |     while true || let 0 = 0 {}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.no_feature.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.no_feature.stderr
@@ -272,14 +272,7 @@ LL |     if (let 0 = 0)? {}
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:121:16
-   |
-LL |     if true || let 0 = 0 {}
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
+error: `||` operators are not supported in let chain conditions
   --> $DIR/disallowed-positions.rs:121:13
    |
 LL |     if true || let 0 = 0 {}
@@ -485,14 +478,7 @@ LL |     while (let 0 = 0)? {}
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:212:19
-   |
-LL |     while true || let 0 = 0 {}
-   |                   ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
+error: `||` operators are not supported in let chain conditions
   --> $DIR/disallowed-positions.rs:212:16
    |
 LL |     while true || let 0 = 0 {}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.nothing.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.nothing.stderr
@@ -272,14 +272,7 @@ LL |     if (let 0 = 0)? {}
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:121:16
-   |
-LL |     if true || let 0 = 0 {}
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
+error: `||` operators are not supported in let chain conditions
   --> $DIR/disallowed-positions.rs:121:13
    |
 LL |     if true || let 0 = 0 {}
@@ -485,14 +478,7 @@ LL |     while (let 0 = 0)? {}
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
-error: expected expression, found `let` statement
-  --> $DIR/disallowed-positions.rs:212:19
-   |
-LL |     while true || let 0 = 0 {}
-   |                   ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if` and `while` expressions
-note: `||` operators are not supported in let chain expressions
+error: `||` operators are not supported in let chain conditions
   --> $DIR/disallowed-positions.rs:212:16
    |
 LL |     while true || let 0 = 0 {}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.rs
@@ -119,7 +119,7 @@ fn nested_within_if_expr() {
     //~^ ERROR expected expression, found `let` statement
 
     if true || let 0 = 0 {}
-    //~^ ERROR expected expression, found `let` statement
+    //~^ ERROR `||` operators are not supported in let chain conditions
     if (true || let 0 = 0) {}
     //~^ ERROR expected expression, found `let` statement
     if true && (true || let 0 = 0) {}
@@ -210,7 +210,7 @@ fn nested_within_while_expr() {
     //~^ ERROR expected expression, found `let` statement
 
     while true || let 0 = 0 {}
-    //~^ ERROR expected expression, found `let` statement
+    //~^ ERROR `||` operators are not supported in let chain conditions
     while (true || let 0 = 0) {}
     //~^ ERROR expected expression, found `let` statement
     while true && (true || let 0 = 0) {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

**Description**

This PR improves the error message when using `||` in an if let chain expression, addressing #140263.

**Changes**

1. Creates a dedicated error message specifically for `||` usage in let chains
2. Points the primary span directly at the `||` operator
3. Removes confusing secondary notes about "let statements" and unsupported contexts
5. Adds UI tests verifying the new error message and valid cases

**Before**
```rust
error: expected expression, found let statement
 --> src/main.rs:2:8
  |
2 |     if let true = true || false {}
  |        ^^^^^^^^^^^^^^^
  |
  = note: only supported directly in conditions of if and while expressions
note: || operators are not supported in let chain expressions
 --> src/main.rs:2:24
  |
2 |     if let true = true || false {}
  |       
```

**After**
```rust
error: `||` operators are not supported in let chain conditions
 --> src/main.rs:2:24
  |
2 |     if let true = true || false {}
  |                        ^^
```

**Implementation details**
1. Added new `OrInLetChain` diagnostic in errors.rs

2. Modified `CondChecker` in expr.rs to prioritize the `||` error

3. Updated fluent message definitions to use clearer wording

**Related issue**
Fixes #140263

cc @ehuss (issue author)