### PR TITLE
Don't use item name to look up associated item from trait item

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1523,19 +1523,17 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     return None;
                 };
 
-                let trait_assoc_item = self.tcx.opt_associated_item(proj.projection_term.def_id)?;
-                let trait_assoc_ident = trait_assoc_item.ident(self.tcx);
-
                 let mut associated_items = vec![];
                 self.tcx.for_each_relevant_impl(
                     self.tcx.trait_of_item(proj.projection_term.def_id)?,
                     proj.projection_term.self_ty(),
                     |impl_def_id| {
                         associated_items.extend(
-                            self.tcx
-                                .associated_items(impl_def_id)
-                                .in_definition_order()
-                                .find(|assoc| assoc.ident(self.tcx) == trait_assoc_ident),
+                            self.tcx.associated_items(impl_def_id).in_definition_order().find(
+                                |assoc| {
+                                    assoc.trait_item_def_id == Some(proj.projection_term.def_id)
+                                },
+                            ),
                         );
                     },
                 );

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-4.rs
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-4.rs
@@ -1,0 +1,23 @@
+trait ServerFn {
+    type Output;
+    fn run_body() -> impl Sized;
+}
+struct MyServerFn {}
+
+macro_rules! f {
+    () => {
+        impl ServerFn for MyServerFn {
+            type Output = ();
+            fn run_body() -> impl Sized {}
+        }
+    };
+}
+
+f! {}
+
+fn problem<T: ServerFn<Output = i64>>(_: T) {}
+
+fn main() {
+    problem(MyServerFn {});
+    //~^ ERROR type mismatch resolving `<MyServerFn as ServerFn>::Output == i64`
+}

--- a/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-4.stderr
+++ b/tests/ui/impl-trait/in-trait/dont-probe-missing-item-name-4.stderr
@@ -1,0 +1,26 @@
+error[E0271]: type mismatch resolving `<MyServerFn as ServerFn>::Output == i64`
+  --> $DIR/dont-probe-missing-item-name-4.rs:21:13
+   |
+LL |     problem(MyServerFn {});
+   |     ------- ^^^^^^^^^^^^^ type mismatch resolving `<MyServerFn as ServerFn>::Output == i64`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: expected this to be `i64`
+  --> $DIR/dont-probe-missing-item-name-4.rs:10:27
+   |
+LL |             type Output = ();
+   |                           ^^
+...
+LL | f! {}
+   | ----- in this macro invocation
+note: required by a bound in `problem`
+  --> $DIR/dont-probe-missing-item-name-4.rs:18:24
+   |
+LL | fn problem<T: ServerFn<Output = i64>>(_: T) {}
+   |                        ^^^^^^^^^^^^ required by this bound in `problem`
+   = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
This fix should be self-justifying b/c the fact that we were using identifiers here was kinda sus anyways, esp b/c we have a failproof way of doing the comparison :) I'll leave some info about why this repro needs a macro.

Fixes https://github.com/rust-lang/rust/issues/140259

r? @nnethercote