### PR TITLE
Fix accidental type inference in array coercion

### DIFF
--- a/tests/ui/coercion/closure-in-array.rs
+++ b/tests/ui/coercion/closure-in-array.rs
@@ -1,0 +1,7 @@
+// Weakened closure sig inference by #140283.
+fn foo<F: FnOnce(&str) -> usize, const N: usize>(x: [F; N]) {}
+
+fn main() {
+    foo([|s| s.len()])
+    //~^ ERROR: type annotations needed
+}

--- a/tests/ui/coercion/closure-in-array.stderr
+++ b/tests/ui/coercion/closure-in-array.stderr
@@ -1,0 +1,14 @@
+error[E0282]: type annotations needed
+  --> $DIR/closure-in-array.rs:5:11
+   |
+LL |     foo([|s| s.len()])
+   |           ^  - type must be known at this point
+   |
+help: consider giving this closure parameter an explicit type
+   |
+LL |     foo([|s: /* Type */| s.len()])
+   |            ++++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/tests/ui/coercion/coerce-many-with-ty-var.rs
+++ b/tests/ui/coercion/coerce-many-with-ty-var.rs
@@ -1,0 +1,36 @@
+//@ run-pass
+// Check that least upper bound coercions don't resolve type variable merely based on the first
+// coercion. Check issue #136420.
+
+fn foo() {}
+fn bar() {}
+
+fn infer<T>(_: T) {}
+
+fn infer_array_element<T>(_: [T; 2]) {}
+
+fn main() {
+    // Previously the element type's ty var will be unified with `foo`.
+    let _: [_; 2] = [foo, bar];
+    infer_array_element([foo, bar]);
+
+    let _ = if false {
+        foo
+    } else {
+        bar
+    };
+    infer(if false {
+        foo
+    } else {
+        bar
+    });
+
+    let _ = match false {
+        true => foo,
+        false => bar,
+    };
+    infer(match false {
+        true => foo,
+        false => bar,
+    });
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
Fixes rust-lang/rust#136420.

If the expectation of array element is a type variable, we should avoid resolving it to the first element's type and wait until LUB coercion is completed.
We create a free type variable instead which is only used in this `CoerceMany`.

[`check_expr_match`](https://github.com/rust-lang/rust/blob/847e3ee6b0e614937eee4e6d8f61094411eadcc0/compiler/rustc_hir_typeck/src/_match.rs#L72) and [`check_expr_if`](https://github.com/rust-lang/rust/blob/847e3ee6b0e614937eee4e6d8f61094411eadcc0/compiler/rustc_hir_typeck/src/expr.rs#L1329) where `CoerceMany` is also used do the [same](https://github.com/rust-lang/rust/blob/847e3ee6b0e614937eee4e6d8f61094411eadcc0/compiler/rustc_hir_typeck/src/expectation.rs#L50). 

### [FCP Proposal](https://github.com/rust-lang/rust/pull/140283#issuecomment-2933771068):
> Array expressions normally lub their element expressions' types to ensure that things like `[5, 5_u8]` work and don't result in type mismatches. When invoking a generic function `fn foo<T>(_: [T; N])` with an array expression, we end up with an infer var for the element type of the array in the signature. So when typecking the first array element we compare its type with the infer var and thus subsequently require all other elements to be the same type.
> 
> This PR changes that to instead fall back to "not knowing" that the argument type is array of infer var, but just having an infer var for the entire argument. Thus we typeck the array expression normally, lubbing the element expressions, and then in the end comparing the array expression's type with the array of infer var type.
> 
> Things like
> 
> ```rust
> fn foo() {}
> fn bar() {} 
> fn f<T>(_: [T; 2]) {}
> 
> f([foo, bar]);
> ```
> 
> and
> 
> ```rust
> struct Foo;
> struct Bar;
> trait Trait {}
> impl Trait for Foo {}
> impl Trait for Bar {} 
> fn f<T>(_: [T; 2]) {}
> 
> f([&Foo, &Bar as &dyn Trait]);
> ```

### Remaining inconsistency with `if` and `match`(rust-lang/rust#145048):
The typeck of array always uses the element coercion target type as the expectation of element exprs while `if` and `match` use `NoExpectation` if the expected type is an infer var.
This causes that array doesn't support nested coercion. 
```rust
fn foo() {}
fn bar() {}
fn main() {
    let _ =  [foo, if false { bar } else { foo }]; // type mismatch when trying to coerce `bar` into `foo` in if-then branch coercion.
}
```
But we can't simply change this behavior to be the same as `if` and `match` since [many code](https://github.com/rust-lang/rust/pull/140283#issuecomment-3190564399) depends on using the first element's type as expectation.