### PR TITLE
Check if format argument is identifier to avoid error err-emit

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -918,73 +918,57 @@ impl<'a> Parser<'a> {
     }
 
     fn suggest_positional_arg_instead_of_captured_arg(&mut self, arg: Argument<'a>) {
-        // If the argument is an identifier, it may be a field access.
-        if arg.is_identifier() {
-            if let Some(end) = self.consume_pos('.') {
-                let byte_pos = self.to_span_index(end);
-                let start = InnerOffset(byte_pos.0 + 1);
-                let field = self.argument(start);
-                // We can only parse simple `foo.bar` field access or `foo.0` tuple index access, any
-                // deeper nesting, or another type of expression, like method calls, are not supported
-                if !self.consume('}') {
-                    return;
-                }
-                if let ArgumentNamed(_) = arg.position {
-                    match field.position {
-                        ArgumentNamed(_) => {
-                            self.errors.insert(
-                                0,
-                                ParseError {
-                                    description: "field access isn't supported".to_string(),
-                                    note: None,
-                                    label: "not supported".to_string(),
-                                    span: InnerSpan::new(
-                                        arg.position_span.start,
-                                        field.position_span.end,
-                                    ),
-                                    secondary_label: None,
-                                    suggestion: Suggestion::UsePositional,
-                                },
-                            );
-                        }
-                        ArgumentIs(_) => {
-                            self.errors.insert(
-                                0,
-                                ParseError {
-                                    description: "tuple index access isn't supported".to_string(),
-                                    note: None,
-                                    label: "not supported".to_string(),
-                                    span: InnerSpan::new(
-                                        arg.position_span.start,
-                                        field.position_span.end,
-                                    ),
-                                    secondary_label: None,
-                                    suggestion: Suggestion::UsePositional,
-                                },
-                            );
-                        }
-                        _ => {}
-                    };
-                }
-            }
-        } else if matches!(arg.position, ArgumentNamed(_) | ArgumentIs(_)) {
-            let arg_name = match arg.position {
-                ArgumentNamed(arg_name) => &format!("`{arg_name}`"),
-                ArgumentIs(arg_index) => &format!("at index `{arg_index}`"),
-                _ => unreachable!(),
-            };
+        // If the argument is not an identifier, it is not a field access.
+        if !arg.is_identifier() {
+            return;
+        }
 
-            self.errors.insert(
-                0,
-                ParseError {
-                    description: format!("invalid format string for argument {}", arg_name),
-                    note: None,
-                    label: format!("invalid format specifier for this argument"),
-                    span: InnerSpan::new(arg.position_span.start, arg.position_span.end),
-                    secondary_label: None,
-                    suggestion: Suggestion::None,
-                },
-            );
+        if let Some(end) = self.consume_pos('.') {
+            let byte_pos = self.to_span_index(end);
+            let start = InnerOffset(byte_pos.0 + 1);
+            let field = self.argument(start);
+            // We can only parse simple `foo.bar` field access or `foo.0` tuple index access, any
+            // deeper nesting, or another type of expression, like method calls, are not supported
+            if !self.consume('}') {
+                return;
+            }
+            if let ArgumentNamed(_) = arg.position {
+                match field.position {
+                    ArgumentNamed(_) => {
+                        self.errors.insert(
+                            0,
+                            ParseError {
+                                description: "field access isn't supported".to_string(),
+                                note: None,
+                                label: "not supported".to_string(),
+                                span: InnerSpan::new(
+                                    arg.position_span.start,
+                                    field.position_span.end,
+                                ),
+                                secondary_label: None,
+                                suggestion: Suggestion::UsePositional,
+                            },
+                        );
+                    }
+                    ArgumentIs(_) => {
+                        self.errors.insert(
+                            0,
+                            ParseError {
+                                description: "tuple index access isn't supported".to_string(),
+                                note: None,
+                                label: "not supported".to_string(),
+                                span: InnerSpan::new(
+                                    arg.position_span.start,
+                                    field.position_span.end,
+                                ),
+                                secondary_label: None,
+                                suggestion: Suggestion::UsePositional,
+                            },
+                        );
+                    }
+                    _ => {}
+                };
+            }
         }
     }
 

--- a/tests/ui/parser/issues/invalid-parse-format-issue-139104.rs
+++ b/tests/ui/parser/issues/invalid-parse-format-issue-139104.rs
@@ -1,8 +1,8 @@
 fn main() {
-    println!("{foo:_1.4}", foo = 3.14); //~ ERROR invalid format string: tuple index access isn't supported
-    println!("{foo:1.4_1.4}", foo = 3.14); //~ ERROR invalid format string: tuple index access isn't supported
-    println!("xxx{0:_1.4", 1.11); //~ ERROR invalid format string: expected `}`, found `.`
-    println!("{foo:_1.4", foo = 3.14); //~ ERROR invalid format string: expected `}`, found `.`
-    println!("xxx{0:_1.4", 1.11); //~ ERROR invalid format string: expected `}`, found `.`
+    println!("{foo:_1.4}", foo = 3.14); //~ ERROR invalid format string: invalid format string for argument `foo`
+    println!("{foo:1.4_1.4}", foo = 3.14); //~ ERROR invalid format string: invalid format string for argument `foo`
+    println!("xxx{0:_1.4}", 1.11); //~ ERROR invalid format string: invalid format string for argument at index `0`
+    println!("{foo:_1.4", foo = 3.14); //~ ERROR invalid format string: invalid format string for argument `foo`
+    println!("xxx{0:_1.4", 1.11); //~ ERROR invalid format string: invalid format string for argument at index `0`
     println!("xxx{  0", 1.11); //~ ERROR invalid format string: expected `}`, found `0`
 }

--- a/tests/ui/parser/issues/invalid-parse-format-issue-139104.rs
+++ b/tests/ui/parser/issues/invalid-parse-format-issue-139104.rs
@@ -1,0 +1,8 @@
+fn main() {
+    println!("{foo:_1.4}", foo = 3.14); //~ ERROR invalid format string: tuple index access isn't supported
+    println!("{foo:1.4_1.4}", foo = 3.14); //~ ERROR invalid format string: tuple index access isn't supported
+    println!("xxx{0:_1.4", 1.11); //~ ERROR invalid format string: expected `}`, found `.`
+    println!("{foo:_1.4", foo = 3.14); //~ ERROR invalid format string: expected `}`, found `.`
+    println!("xxx{0:_1.4", 1.11); //~ ERROR invalid format string: expected `}`, found `.`
+    println!("xxx{  0", 1.11); //~ ERROR invalid format string: expected `}`, found `0`
+}

--- a/tests/ui/parser/issues/invalid-parse-format-issue-139104.rs
+++ b/tests/ui/parser/issues/invalid-parse-format-issue-139104.rs
@@ -1,8 +1,13 @@
 fn main() {
-    println!("{foo:_1.4}", foo = 3.14); //~ ERROR invalid format string: invalid format string for argument `foo`
-    println!("{foo:1.4_1.4}", foo = 3.14); //~ ERROR invalid format string: invalid format string for argument `foo`
-    println!("xxx{0:_1.4}", 1.11); //~ ERROR invalid format string: invalid format string for argument at index `0`
-    println!("{foo:_1.4", foo = 3.14); //~ ERROR invalid format string: invalid format string for argument `foo`
-    println!("xxx{0:_1.4", 1.11); //~ ERROR invalid format string: invalid format string for argument at index `0`
-    println!("xxx{  0", 1.11); //~ ERROR invalid format string: expected `}`, found `0`
+    println!("{foo:_1.4}", foo = 3.14); //~ ERROR invalid format string: expected `}`, found `.`
+    println!("{0:_1.4}", 1.11); //~ ERROR invalid format string: expected `}`, found `.`
+    println!("{:_1.4}", 3.14); //~ ERROR invalid format string: expected `}`, found `.`
+
+    println!("{foo:_1.4", foo = 3.14); //~ ERROR invalid format string: expected `}`, found `.`
+    println!("{0:_1.4", 1.11); //~ ERROR invalid format string: expected `}`, found `.`
+    println!("{:_1.4", 3.14); //~ ERROR invalid format string: expected `}`, found `.`
+
+    println!("{  0", 1.11); //~ ERROR invalid format string: expected `}`, found `0`
+    println!("{foo:1.4_1.4}", foo = 3.14); //~ ERROR invalid format string: expected `}`, found `.`
+    println!("{0:1.4_1.4}", 3.14); //~ ERROR invalid format string: expected `}`, found `.`
 }

--- a/tests/ui/parser/issues/invalid-parse-format-issue-139104.stderr
+++ b/tests/ui/parser/issues/invalid-parse-format-issue-139104.stderr
@@ -1,0 +1,66 @@
+error: invalid format string: tuple index access isn't supported
+  --> $DIR/invalid-parse-format-issue-139104.rs:2:16
+   |
+LL |     println!("{foo:_1.4}", foo = 3.14);
+   |                ^^^^^^^^ not supported in format string
+   |
+help: consider using a positional formatting argument instead
+   |
+LL -     println!("{foo:_1.4}", foo = 3.14);
+LL +     println!("{0}", foo:_1.4, foo = 3.14);
+   |
+
+error: invalid format string: tuple index access isn't supported
+  --> $DIR/invalid-parse-format-issue-139104.rs:3:16
+   |
+LL |     println!("{foo:1.4_1.4}", foo = 3.14);
+   |                ^^^^^^^^^^^ not supported in format string
+   |
+help: consider using a positional formatting argument instead
+   |
+LL -     println!("{foo:1.4_1.4}", foo = 3.14);
+LL +     println!("{0}", foo:1.4_1.4, foo = 3.14);
+   |
+
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:4:23
+   |
+LL |     println!("xxx{0:_1.4", 1.11);
+   |                  -    ^ expected `}` in format string
+   |                  |
+   |                  because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:5:22
+   |
+LL |     println!("{foo:_1.4", foo = 3.14);
+   |               -      ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:6:23
+   |
+LL |     println!("xxx{0:_1.4", 1.11);
+   |                  -    ^ expected `}` in format string
+   |                  |
+   |                  because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `}`, found `0`
+  --> $DIR/invalid-parse-format-issue-139104.rs:7:21
+   |
+LL |     println!("xxx{  0", 1.11);
+   |                  -  ^ expected `}` in format string
+   |                  |
+   |                  because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/parser/issues/invalid-parse-format-issue-139104.stderr
+++ b/tests/ui/parser/issues/invalid-parse-format-issue-139104.stderr
@@ -1,56 +1,32 @@
-error: invalid format string: tuple index access isn't supported
+error: invalid format string: invalid format string for argument `foo`
   --> $DIR/invalid-parse-format-issue-139104.rs:2:16
    |
 LL |     println!("{foo:_1.4}", foo = 3.14);
-   |                ^^^^^^^^ not supported in format string
-   |
-help: consider using a positional formatting argument instead
-   |
-LL -     println!("{foo:_1.4}", foo = 3.14);
-LL +     println!("{0}", foo:_1.4, foo = 3.14);
-   |
+   |                ^^^ invalid format specifier for this argument in format string
 
-error: invalid format string: tuple index access isn't supported
+error: invalid format string: invalid format string for argument `foo`
   --> $DIR/invalid-parse-format-issue-139104.rs:3:16
    |
 LL |     println!("{foo:1.4_1.4}", foo = 3.14);
-   |                ^^^^^^^^^^^ not supported in format string
-   |
-help: consider using a positional formatting argument instead
-   |
-LL -     println!("{foo:1.4_1.4}", foo = 3.14);
-LL +     println!("{0}", foo:1.4_1.4, foo = 3.14);
-   |
+   |                ^^^ invalid format specifier for this argument in format string
 
-error: invalid format string: expected `}`, found `.`
-  --> $DIR/invalid-parse-format-issue-139104.rs:4:23
+error: invalid format string: invalid format string for argument at index `0`
+  --> $DIR/invalid-parse-format-issue-139104.rs:4:19
    |
-LL |     println!("xxx{0:_1.4", 1.11);
-   |                  -    ^ expected `}` in format string
-   |                  |
-   |                  because of this opening brace
-   |
-   = note: if you intended to print `{`, you can escape it using `{{`
+LL |     println!("xxx{0:_1.4}", 1.11);
+   |                   ^ invalid format specifier for this argument in format string
 
-error: invalid format string: expected `}`, found `.`
-  --> $DIR/invalid-parse-format-issue-139104.rs:5:22
+error: invalid format string: invalid format string for argument `foo`
+  --> $DIR/invalid-parse-format-issue-139104.rs:5:16
    |
 LL |     println!("{foo:_1.4", foo = 3.14);
-   |               -      ^ expected `}` in format string
-   |               |
-   |               because of this opening brace
-   |
-   = note: if you intended to print `{`, you can escape it using `{{`
+   |                ^^^ invalid format specifier for this argument in format string
 
-error: invalid format string: expected `}`, found `.`
-  --> $DIR/invalid-parse-format-issue-139104.rs:6:23
+error: invalid format string: invalid format string for argument at index `0`
+  --> $DIR/invalid-parse-format-issue-139104.rs:6:19
    |
 LL |     println!("xxx{0:_1.4", 1.11);
-   |                  -    ^ expected `}` in format string
-   |                  |
-   |                  because of this opening brace
-   |
-   = note: if you intended to print `{`, you can escape it using `{{`
+   |                   ^ invalid format specifier for this argument in format string
 
 error: invalid format string: expected `}`, found `0`
   --> $DIR/invalid-parse-format-issue-139104.rs:7:21

--- a/tests/ui/parser/issues/invalid-parse-format-issue-139104.stderr
+++ b/tests/ui/parser/issues/invalid-parse-format-issue-139104.stderr
@@ -1,42 +1,92 @@
-error: invalid format string: invalid format string for argument `foo`
-  --> $DIR/invalid-parse-format-issue-139104.rs:2:16
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:2:22
    |
 LL |     println!("{foo:_1.4}", foo = 3.14);
-   |                ^^^ invalid format specifier for this argument in format string
-
-error: invalid format string: invalid format string for argument `foo`
-  --> $DIR/invalid-parse-format-issue-139104.rs:3:16
-   |
-LL |     println!("{foo:1.4_1.4}", foo = 3.14);
-   |                ^^^ invalid format specifier for this argument in format string
-
-error: invalid format string: invalid format string for argument at index `0`
-  --> $DIR/invalid-parse-format-issue-139104.rs:4:19
-   |
-LL |     println!("xxx{0:_1.4}", 1.11);
-   |                   ^ invalid format specifier for this argument in format string
-
-error: invalid format string: invalid format string for argument `foo`
-  --> $DIR/invalid-parse-format-issue-139104.rs:5:16
-   |
-LL |     println!("{foo:_1.4", foo = 3.14);
-   |                ^^^ invalid format specifier for this argument in format string
-
-error: invalid format string: invalid format string for argument at index `0`
-  --> $DIR/invalid-parse-format-issue-139104.rs:6:19
-   |
-LL |     println!("xxx{0:_1.4", 1.11);
-   |                   ^ invalid format specifier for this argument in format string
-
-error: invalid format string: expected `}`, found `0`
-  --> $DIR/invalid-parse-format-issue-139104.rs:7:21
-   |
-LL |     println!("xxx{  0", 1.11);
-   |                  -  ^ expected `}` in format string
-   |                  |
-   |                  because of this opening brace
+   |               -      ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: aborting due to 6 previous errors
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:3:20
+   |
+LL |     println!("{0:_1.4}", 1.11);
+   |               -    ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:4:19
+   |
+LL |     println!("{:_1.4}", 3.14);
+   |               -   ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:6:22
+   |
+LL |     println!("{foo:_1.4", foo = 3.14);
+   |               -      ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:7:20
+   |
+LL |     println!("{0:_1.4", 1.11);
+   |               -    ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:8:19
+   |
+LL |     println!("{:_1.4", 3.14);
+   |               -   ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `}`, found `0`
+  --> $DIR/invalid-parse-format-issue-139104.rs:10:18
+   |
+LL |     println!("{  0", 1.11);
+   |               -  ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:11:25
+   |
+LL |     println!("{foo:1.4_1.4}", foo = 3.14);
+   |               -         ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: expected `}`, found `.`
+  --> $DIR/invalid-parse-format-issue-139104.rs:12:23
+   |
+LL |     println!("{0:1.4_1.4}", 3.14);
+   |               -       ^ expected `}` in format string
+   |               |
+   |               because of this opening brace
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: aborting due to 9 previous errors
 


### PR DESCRIPTION
Fixes #139104

When `argument` is not an identifier, it should not be considered a field access. I checked this and if not emit an invalid format string error. I think we could do with a little finer error handling, I'll open an issue to track this down later.

The first commit submits the ui test, the second commits the code and the changes to the test output.

r? compiler