### PR TITLE
rustdoc: fix typo change from equivelent to equivalent

### DIFF
--- a/src/doc/rustdoc/src/read-documentation/search.md
+++ b/src/doc/rustdoc/src/read-documentation/search.md
@@ -89,7 +89,7 @@ the standard library and functions that are included in the results list:
 
 ### Non-functions in type-based search
 Certain items that are not functions are treated as though they
-were a semantically equivelent function.
+were a semantically equivalent function.
 
 For example, struct fields are treated as though they were getter methods.
 This means that a search for `CpuidResult -> u32` will show


### PR DESCRIPTION
This PR fixes a typo in the search section in `rustdoc` book.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
