### PR TITLE
Correctly display stdout and stderr in case a doctest is failing

### DIFF
--- a/src/librustdoc/doctest/runner.rs
+++ b/src/librustdoc/doctest/runner.rs
@@ -131,7 +131,22 @@ mod __doctest_mod {{
             .output()
             .expect(\"failed to run command\");
         if !out.status.success() {{
-            eprint!(\"{{}}\", String::from_utf8_lossy(&out.stderr));
+            if let Some(code) = out.status.code() {{
+                eprintln!(\"Test executable failed (exit status: {{code}}).\");
+            }} else {{
+                eprintln!(\"Test executable failed (terminated by signal).\");
+            }}
+            if !out.stdout.is_empty() || !out.stderr.is_empty() {{
+                eprintln!();
+            }}
+            if !out.stdout.is_empty() {{
+                eprintln!(\"stdout:\");
+                eprintln!(\"{{}}\", String::from_utf8_lossy(&out.stdout));
+            }}
+            if !out.stderr.is_empty() {{
+                eprintln!(\"stderr:\");
+                eprintln!(\"{{}}\", String::from_utf8_lossy(&out.stderr));
+            }}
             ExitCode::FAILURE
         }} else {{
             ExitCode::SUCCESS

--- a/tests/rustdoc-ui/doctest/edition-2024-error-output.stdout
+++ b/tests/rustdoc-ui/doctest/edition-2024-error-output.stdout
@@ -5,12 +5,16 @@ test $DIR/edition-2024-error-output.rs - (line 12) ... FAILED
 failures:
 
 ---- $DIR/edition-2024-error-output.rs - (line 12) stdout ----
+Test executable failed (exit status: 101).
+
+stderr:
 
 thread 'main' panicked at $TMP:6:1:
 assertion `left == right` failed
   left: 4
  right: 5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
 
 
 failures:

--- a/tests/rustdoc-ui/doctest/stdout-and-stderr.rs
+++ b/tests/rustdoc-ui/doctest/stdout-and-stderr.rs
@@ -1,0 +1,26 @@
+// This test ensures that the output is correctly generated when the
+// doctest fails. It checks when there is stderr and stdout, no stdout
+// and no stderr/stdout.
+//
+// This is a regression test for <https://github.com/rust-lang/rust/issues/140289>.
+
+//@ edition: 2024
+//@ compile-flags:--test --test-args=--test-threads=1
+//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "panicked at .+rs:" -> "panicked at $$TMP:"
+//@ failure-status: 101
+//@ rustc-env:RUST_BACKTRACE=0
+
+//! ```
+//! println!("######## from a DOC TEST ########");
+//! assert_eq!("doc", "test");
+//! ```
+//!
+//! ```
+//! assert_eq!("doc", "test");
+//! ```
+//!
+//! ```
+//! std::process::exit(1);
+//! ```

--- a/tests/rustdoc-ui/doctest/stdout-and-stderr.stdout
+++ b/tests/rustdoc-ui/doctest/stdout-and-stderr.stdout
@@ -1,0 +1,46 @@
+
+running 3 tests
+test $DIR/stdout-and-stderr.rs - (line 15) ... FAILED
+test $DIR/stdout-and-stderr.rs - (line 20) ... FAILED
+test $DIR/stdout-and-stderr.rs - (line 24) ... FAILED
+
+failures:
+
+---- $DIR/stdout-and-stderr.rs - (line 15) stdout ----
+Test executable failed (exit status: 101).
+
+stdout:
+######## from a DOC TEST ########
+
+stderr:
+
+thread 'main' panicked at $TMP:7:1:
+assertion `left == right` failed
+  left: "doc"
+ right: "test"
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+---- $DIR/stdout-and-stderr.rs - (line 20) stdout ----
+Test executable failed (exit status: 101).
+
+stderr:
+
+thread 'main' panicked at $TMP:15:1:
+assertion `left == right` failed
+  left: "doc"
+ right: "test"
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+---- $DIR/stdout-and-stderr.rs - (line 24) stdout ----
+Test executable failed (exit status: 1).
+
+
+failures:
+    $DIR/stdout-and-stderr.rs - (line 15)
+    $DIR/stdout-and-stderr.rs - (line 20)
+    $DIR/stdout-and-stderr.rs - (line 24)
+
+test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/140289.

Since the doctest is actually running itself, we need to handle the output directly inside it.

cc @fmease
r? @notriddle 