### PR TITLE
Track per-obligation recursion depth only if there is inference in the new solver

### DIFF
--- a/tests/ui/traits/next-solver/coerce-depth.rs
+++ b/tests/ui/traits/next-solver/coerce-depth.rs
@@ -1,0 +1,31 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+// Ensure that a stack of coerce predicates doesn't end up overflowing when they get procesed
+// in *reverse* order, which may require O(N) iterations of the fulfillment loop.
+
+#![recursion_limit = "16"]
+
+fn main() {
+    match 0 {
+        0 => None,
+        1 => None,
+        2 => None,
+        3 => None,
+        4 => None,
+        5 => None,
+        6 => None,
+        7 => None,
+        8 => None,
+        9 => None,
+        10 => None,
+        11 => None,
+        12 => None,
+        13 => None,
+        14 => None,
+        15 => None,
+        16 => None,
+        17 => None,
+        _ => Some(1u32),
+    };
+}


### PR DESCRIPTION
Track how many times an obligation has been processed in the fulfillment context by reusing its recursion depth, and only overflow if a singular (root) goal hits the limit.

This also fixes a (probably theoretical at this point) problem where we don't detect pseudo-hangs across `select_where_possible` calls.

fixes https://github.com/rust-lang/trait-system-refactor-initiative/issues/186

r? lcnr