### PR TITLE
Refactor rustc_on_unimplemented's filter parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,7 +4520,6 @@ dependencies = [
  "itertools",
  "rustc_abi",
  "rustc_ast",
- "rustc_attr_parsing",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_fluent_macro",

--- a/compiler/rustc_trait_selection/Cargo.toml
+++ b/compiler/rustc_trait_selection/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 itertools = "0.12"
 rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }
-rustc_attr_parsing = { path = "../rustc_attr_parsing" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_fluent_macro = { path = "../rustc_fluent_macro" }

--- a/compiler/rustc_trait_selection/messages.ftl
+++ b/compiler/rustc_trait_selection/messages.ftl
@@ -148,9 +148,6 @@ trait_selection_dtcs_has_req_note = the used `impl` has a `'static` requirement
 trait_selection_dtcs_introduces_requirement = calling this method introduces the `impl`'s `'static` requirement
 trait_selection_dtcs_suggestion = consider relaxing the implicit `'static` requirement
 
-trait_selection_empty_on_clause_in_rustc_on_unimplemented = empty `on`-clause in `#[rustc_on_unimplemented]`
-    .label = empty on-clause here
-
 trait_selection_explicit_lifetime_required_sugg_with_ident = add explicit lifetime `{$named}` to the type of `{$simple_ident}`
 
 trait_selection_explicit_lifetime_required_sugg_with_param_type = add explicit lifetime `{$named}` to type
@@ -186,9 +183,6 @@ trait_selection_inherent_projection_normalization_overflow = overflow evaluating
 
 trait_selection_invalid_format_specifier = invalid format specifier
     .help = no format specifier are supported in this position
-
-trait_selection_invalid_on_clause_in_rustc_on_unimplemented = invalid `on`-clause in `#[rustc_on_unimplemented]`
-    .label = invalid on-clause here
 
 trait_selection_label_bad = {$bad_kind ->
     *[other] cannot infer type
@@ -236,10 +230,6 @@ trait_selection_negative_positive_conflict = found both positive and negative im
     .negative_implementation_in_crate = negative implementation in crate `{$negative_impl_cname}`
     .positive_implementation_here = positive implementation here
     .positive_implementation_in_crate = positive implementation in crate `{$positive_impl_cname}`
-
-trait_selection_no_value_in_rustc_on_unimplemented = this attribute must have a valid value
-    .label = expected value here
-    .note = eg `#[rustc_on_unimplemented(message="foo")]`
 
 trait_selection_nothing = {""}
 
@@ -338,6 +328,22 @@ trait_selection_ril_because_of = because of this returned expression
 trait_selection_ril_introduced_by = requirement introduced by this return type
 trait_selection_ril_introduced_here = `'static` requirement introduced here
 trait_selection_ril_static_introduced_by = "`'static` lifetime requirement introduced by the return type
+
+trait_selection_rustc_on_unimplemented_empty_on_clause = empty `on`-clause in `#[rustc_on_unimplemented]`
+    .label = empty `on`-clause here
+trait_selection_rustc_on_unimplemented_expected_identifier = expected an identifier inside this `on`-clause
+    .label = expected an identifier here, not `{$path}`
+trait_selection_rustc_on_unimplemented_expected_one_predicate_in_not = expected a single predicate in `not(..)`
+    .label = unexpected quantity of predicates here
+trait_selection_rustc_on_unimplemented_invalid_flag = invalid flag in `on`-clause
+    .label = expected one of the `crate_local`, `direct` or `from_desugaring` flags, not `{$invalid_flag}`
+trait_selection_rustc_on_unimplemented_invalid_predicate = this predicate is invalid
+    .label = expected one of `any`, `all` or `not` here, not `{$invalid_pred}`
+trait_selection_rustc_on_unimplemented_missing_value = this attribute must have a value
+    .label = expected value here
+    .note = e.g. `#[rustc_on_unimplemented(message="foo")]`
+trait_selection_rustc_on_unimplemented_unsupported_literal_in_on = literals inside `on`-clauses are not supported
+    .label = unexpected literal here
 
 trait_selection_source_kind_closure_return =
     try giving this closure an explicit return type

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use rustc_ast::Path;
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_errors::codes::*;
 use rustc_errors::{
@@ -31,23 +32,50 @@ pub struct UnableToConstructConstantValue<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(trait_selection_empty_on_clause_in_rustc_on_unimplemented, code = E0232)]
-pub struct EmptyOnClauseInOnUnimplemented {
-    #[primary_span]
-    #[label]
-    pub span: Span,
+pub enum InvalidOnClause {
+    #[diag(trait_selection_rustc_on_unimplemented_empty_on_clause, code = E0232)]
+    Empty {
+        #[primary_span]
+        #[label]
+        span: Span,
+    },
+    #[diag(trait_selection_rustc_on_unimplemented_expected_one_predicate_in_not, code = E0232)]
+    ExpectedOnePredInNot {
+        #[primary_span]
+        #[label]
+        span: Span,
+    },
+    #[diag(trait_selection_rustc_on_unimplemented_unsupported_literal_in_on, code = E0232)]
+    UnsupportedLiteral {
+        #[primary_span]
+        #[label]
+        span: Span,
+    },
+    #[diag(trait_selection_rustc_on_unimplemented_expected_identifier, code = E0232)]
+    ExpectedIdentifier {
+        #[primary_span]
+        #[label]
+        span: Span,
+        path: Path,
+    },
+    #[diag(trait_selection_rustc_on_unimplemented_invalid_predicate, code = E0232)]
+    InvalidPredicate {
+        #[primary_span]
+        #[label]
+        span: Span,
+        invalid_pred: Symbol,
+    },
+    #[diag(trait_selection_rustc_on_unimplemented_invalid_flag, code = E0232)]
+    InvalidFlag {
+        #[primary_span]
+        #[label]
+        span: Span,
+        invalid_flag: Symbol,
+    },
 }
 
 #[derive(Diagnostic)]
-#[diag(trait_selection_invalid_on_clause_in_rustc_on_unimplemented, code = E0232)]
-pub struct InvalidOnClauseInOnUnimplemented {
-    #[primary_span]
-    #[label]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag(trait_selection_no_value_in_rustc_on_unimplemented, code = E0232)]
+#[diag(trait_selection_rustc_on_unimplemented_missing_value, code = E0232)]
 #[note]
 pub struct NoValueInOnUnimplemented {
     #[primary_span]

--- a/tests/ui/on-unimplemented/bad-annotation.rs
+++ b/tests/ui/on-unimplemented/bad-annotation.rs
@@ -1,64 +1,73 @@
-// ignore-tidy-linelength
-
+#![crate_type = "lib"]
 #![feature(rustc_attrs)]
-
 #![allow(unused)]
 
 #[rustc_on_unimplemented = "test error `{Self}` with `{Bar}` `{Baz}` `{Quux}`"]
-trait Foo<Bar, Baz, Quux>
-{}
+trait Foo<Bar, Baz, Quux> {}
 
-#[rustc_on_unimplemented="a collection of type `{Self}` cannot be built from an iterator over elements of type `{A}`"]
+#[rustc_on_unimplemented = "a collection of type `{Self}` cannot \
+ be built from an iterator over elements of type `{A}`"]
 trait MyFromIterator<A> {
     /// Builds a container with elements from an external iterator.
-    fn my_from_iter<T: Iterator<Item=A>>(iterator: T) -> Self;
+    fn my_from_iter<T: Iterator<Item = A>>(iterator: T) -> Self;
 }
 
 #[rustc_on_unimplemented]
 //~^ ERROR malformed `rustc_on_unimplemented` attribute
-trait BadAnnotation1
-{}
+trait NoContent {}
 
 #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{C}>`"]
 //~^ ERROR cannot find parameter C on this trait
-trait BadAnnotation2<A,B>
-{}
+trait ParameterNotPresent<A, B> {}
 
 #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{}>`"]
 //~^ ERROR positional format arguments are not allowed here
-trait BadAnnotation3<A,B>
-{}
+trait NoPositionalArgs<A, B> {}
 
-#[rustc_on_unimplemented(lorem="")]
+#[rustc_on_unimplemented(lorem = "")]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation4 {}
+trait EmptyMessage {}
 
 #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation5 {}
+trait Invalid {}
 
-#[rustc_on_unimplemented(message="x", message="y")]
+#[rustc_on_unimplemented(message = "x", message = "y")]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation6 {}
+trait DuplicateMessage {}
 
-#[rustc_on_unimplemented(message="x", on(desugared, message="y"))]
+#[rustc_on_unimplemented(message = "x", on(desugared, message = "y"))]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation7 {}
+trait OnInWrongPosition {}
 
-#[rustc_on_unimplemented(on(), message="y")]
+#[rustc_on_unimplemented(on(), message = "y")]
 //~^ ERROR empty `on`-clause
-trait BadAnnotation8 {}
+trait NoEmptyOn {}
 
-#[rustc_on_unimplemented(on="x", message="y")]
+#[rustc_on_unimplemented(on = "x", message = "y")]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation9 {}
+trait ExpectedPredicateInOn {}
 
-#[rustc_on_unimplemented(on(x="y"), message="y")]
-trait BadAnnotation10 {}
+#[rustc_on_unimplemented(on(x = "y"), message = "y")]
+trait OnWithoutDirectives {}
 
-#[rustc_on_unimplemented(on(desugared, on(desugared, message="x")), message="y")]
+#[rustc_on_unimplemented(on(desugared, on(desugared, message = "x")), message = "y")]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation11 {}
+trait NoNestedOn {}
 
-pub fn main() {
-}
+// caught by `OnUnimplementedDirective::parse`, *not* `eval_condition`
+#[rustc_on_unimplemented(on("y", message = "y"))]
+//~^ ERROR invalid `on`-clause
+trait UnsupportedLiteral {}
+
+#[rustc_on_unimplemented(on(not(a, b), message = "y"))]
+//~^ ERROR expected 1 cfg-pattern
+trait ExpectedOnePattern {}
+
+#[rustc_on_unimplemented(on(thing::What, message = "y"))]
+//~^ ERROR `cfg` predicate key must be an identifier
+trait KeyMustBeIdentifier {}
+
+#[rustc_on_unimplemented(on(thing::What = "value", message = "y"))]
+//~^ ERROR `cfg` predicate key must be an identifier
+trait KeyMustBeIdentifier2 {}

--- a/tests/ui/on-unimplemented/bad-annotation.rs
+++ b/tests/ui/on-unimplemented/bad-annotation.rs
@@ -25,49 +25,85 @@ trait ParameterNotPresent<A, B> {}
 trait NoPositionalArgs<A, B> {}
 
 #[rustc_on_unimplemented(lorem = "")]
-//~^ ERROR this attribute must have a valid
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
 trait EmptyMessage {}
 
 #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
-//~^ ERROR this attribute must have a valid
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
 trait Invalid {}
 
 #[rustc_on_unimplemented(message = "x", message = "y")]
-//~^ ERROR this attribute must have a valid
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
 trait DuplicateMessage {}
 
 #[rustc_on_unimplemented(message = "x", on(desugared, message = "y"))]
-//~^ ERROR this attribute must have a valid
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
 trait OnInWrongPosition {}
 
 #[rustc_on_unimplemented(on(), message = "y")]
 //~^ ERROR empty `on`-clause
-trait NoEmptyOn {}
+//~^^ NOTE empty `on`-clause here
+trait EmptyOn {}
 
 #[rustc_on_unimplemented(on = "x", message = "y")]
-//~^ ERROR this attribute must have a valid
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
 trait ExpectedPredicateInOn {}
 
 #[rustc_on_unimplemented(on(x = "y"), message = "y")]
 trait OnWithoutDirectives {}
 
-#[rustc_on_unimplemented(on(desugared, on(desugared, message = "x")), message = "y")]
-//~^ ERROR this attribute must have a valid
-trait NoNestedOn {}
+#[rustc_on_unimplemented(on(from_desugaring, on(from_desugaring, message = "x")), message = "y")]
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
+trait NestedOn {}
 
-// caught by `OnUnimplementedDirective::parse`, *not* `eval_condition`
 #[rustc_on_unimplemented(on("y", message = "y"))]
-//~^ ERROR invalid `on`-clause
+//~^ ERROR literals inside `on`-clauses are not supported
+//~^^ NOTE unexpected literal here
 trait UnsupportedLiteral {}
 
+#[rustc_on_unimplemented(on(42, message = "y"))]
+//~^ ERROR literals inside `on`-clauses are not supported
+//~^^ NOTE unexpected literal here
+trait UnsupportedLiteral2 {}
+
 #[rustc_on_unimplemented(on(not(a, b), message = "y"))]
-//~^ ERROR expected 1 cfg-pattern
+//~^ ERROR expected a single predicate in `not(..)` [E0232]
+//~^^ NOTE unexpected quantity of predicates here
 trait ExpectedOnePattern {}
 
+#[rustc_on_unimplemented(on(not(), message = "y"))]
+//~^ ERROR expected a single predicate in `not(..)` [E0232]
+//~^^ NOTE unexpected quantity of predicates here
+trait ExpectedOnePattern2 {}
+
 #[rustc_on_unimplemented(on(thing::What, message = "y"))]
-//~^ ERROR `cfg` predicate key must be an identifier
+//~^ ERROR expected an identifier inside this `on`-clause
+//~^^ NOTE expected an identifier here, not `thing::What`
 trait KeyMustBeIdentifier {}
 
 #[rustc_on_unimplemented(on(thing::What = "value", message = "y"))]
-//~^ ERROR `cfg` predicate key must be an identifier
+//~^ ERROR  expected an identifier inside this `on`-clause
+//~^^ NOTE expected an identifier here, not `thing::What`
 trait KeyMustBeIdentifier2 {}
+
+#[rustc_on_unimplemented(on(aaaaaaaaaaaaaa(a, b), message = "y"))]
+//~^ ERROR this predicate is invalid
+//~^^ NOTE expected one of `any`, `all` or `not` here, not `aaaaaaaaaaaaaa`
+trait InvalidPredicate {}
+
+#[rustc_on_unimplemented(on(something, message = "y"))]
+//~^ ERROR invalid flag in `on`-clause
+//~^^ NOTE expected one of the `crate_local`, `direct` or `from_desugaring` flags, not `something`
+trait InvalidFlag {}

--- a/tests/ui/on-unimplemented/bad-annotation.stderr
+++ b/tests/ui/on-unimplemented/bad-annotation.stderr
@@ -1,5 +1,5 @@
 error: malformed `rustc_on_unimplemented` attribute input
-  --> $DIR/bad-annotation.rs:17:1
+  --> $DIR/bad-annotation.rs:15:1
    |
 LL | #[rustc_on_unimplemented]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,27 +12,27 @@ LL | #[rustc_on_unimplemented(/*opt*/ message = "...", /*opt*/ label = "...", /*
    |                         ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0230]: cannot find parameter C on this trait
-  --> $DIR/bad-annotation.rs:22:90
+  --> $DIR/bad-annotation.rs:19:90
    |
 LL | #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{C}>`"]
    |                                                                                          ^
 
 error[E0231]: positional format arguments are not allowed here
-  --> $DIR/bad-annotation.rs:27:90
+  --> $DIR/bad-annotation.rs:23:90
    |
 LL | #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{}>`"]
    |                                                                                          ^
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:32:26
+  --> $DIR/bad-annotation.rs:27:26
    |
-LL | #[rustc_on_unimplemented(lorem="")]
-   |                          ^^^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(lorem = "")]
+   |                          ^^^^^^^^^^ expected value here
    |
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:36:26
+  --> $DIR/bad-annotation.rs:31:26
    |
 LL | #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
    |                          ^^^^^^^^^^^^^^^^^^^ expected value here
@@ -40,44 +40,68 @@ LL | #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:40:39
+  --> $DIR/bad-annotation.rs:35:41
    |
-LL | #[rustc_on_unimplemented(message="x", message="y")]
-   |                                       ^^^^^^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(message = "x", message = "y")]
+   |                                         ^^^^^^^^^^^^^ expected value here
    |
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:44:39
+  --> $DIR/bad-annotation.rs:39:41
    |
-LL | #[rustc_on_unimplemented(message="x", on(desugared, message="y"))]
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(message = "x", on(desugared, message = "y"))]
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
    |
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: empty `on`-clause in `#[rustc_on_unimplemented]`
-  --> $DIR/bad-annotation.rs:48:26
+  --> $DIR/bad-annotation.rs:43:26
    |
-LL | #[rustc_on_unimplemented(on(), message="y")]
+LL | #[rustc_on_unimplemented(on(), message = "y")]
    |                          ^^^^ empty on-clause here
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:52:26
+  --> $DIR/bad-annotation.rs:47:26
    |
-LL | #[rustc_on_unimplemented(on="x", message="y")]
-   |                          ^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(on = "x", message = "y")]
+   |                          ^^^^^^^^ expected value here
    |
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:59:40
+  --> $DIR/bad-annotation.rs:54:40
    |
-LL | #[rustc_on_unimplemented(on(desugared, on(desugared, message="x")), message="y")]
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(on(desugared, on(desugared, message = "x")), message = "y")]
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
    |
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
-error: aborting due to 10 previous errors
+error[E0232]: invalid `on`-clause in `#[rustc_on_unimplemented]`
+  --> $DIR/bad-annotation.rs:59:26
+   |
+LL | #[rustc_on_unimplemented(on("y", message = "y"))]
+   |                          ^^^^^^^^^^^^^^^^^^^^^^ invalid on-clause here
 
-Some errors have detailed explanations: E0230, E0231, E0232.
+error[E0536]: expected 1 cfg-pattern
+  --> $DIR/bad-annotation.rs:63:29
+   |
+LL | #[rustc_on_unimplemented(on(not(a, b), message = "y"))]
+   |                             ^^^^^^^^^
+
+error: `cfg` predicate key must be an identifier
+  --> $DIR/bad-annotation.rs:67:29
+   |
+LL | #[rustc_on_unimplemented(on(thing::What, message = "y"))]
+   |                             ^^^^^^^^^^^
+
+error: `cfg` predicate key must be an identifier
+  --> $DIR/bad-annotation.rs:71:29
+   |
+LL | #[rustc_on_unimplemented(on(thing::What = "value", message = "y"))]
+   |                             ^^^^^^^^^^^
+
+error: aborting due to 14 previous errors
+
+Some errors have detailed explanations: E0230, E0231, E0232, E0536.
 For more information about an error, try `rustc --explain E0230`.

--- a/tests/ui/on-unimplemented/bad-annotation.stderr
+++ b/tests/ui/on-unimplemented/bad-annotation.stderr
@@ -23,85 +23,109 @@ error[E0231]: positional format arguments are not allowed here
 LL | #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{}>`"]
    |                                                                                          ^
 
-error[E0232]: this attribute must have a valid value
+error[E0232]: this attribute must have a value
   --> $DIR/bad-annotation.rs:27:26
    |
 LL | #[rustc_on_unimplemented(lorem = "")]
    |                          ^^^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
-error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:31:26
+error[E0232]: this attribute must have a value
+  --> $DIR/bad-annotation.rs:33:26
    |
 LL | #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
    |                          ^^^^^^^^^^^^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
-error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:35:41
+error[E0232]: this attribute must have a value
+  --> $DIR/bad-annotation.rs:39:41
    |
 LL | #[rustc_on_unimplemented(message = "x", message = "y")]
    |                                         ^^^^^^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
-error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:39:41
+error[E0232]: this attribute must have a value
+  --> $DIR/bad-annotation.rs:45:41
    |
 LL | #[rustc_on_unimplemented(message = "x", on(desugared, message = "y"))]
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: empty `on`-clause in `#[rustc_on_unimplemented]`
-  --> $DIR/bad-annotation.rs:43:26
+  --> $DIR/bad-annotation.rs:51:26
    |
 LL | #[rustc_on_unimplemented(on(), message = "y")]
-   |                          ^^^^ empty on-clause here
+   |                          ^^^^ empty `on`-clause here
 
-error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:47:26
+error[E0232]: this attribute must have a value
+  --> $DIR/bad-annotation.rs:56:26
    |
 LL | #[rustc_on_unimplemented(on = "x", message = "y")]
    |                          ^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
-error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:54:40
+error[E0232]: this attribute must have a value
+  --> $DIR/bad-annotation.rs:65:46
    |
-LL | #[rustc_on_unimplemented(on(desugared, on(desugared, message = "x")), message = "y")]
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(on(from_desugaring, on(from_desugaring, message = "x")), message = "y")]
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
-error[E0232]: invalid `on`-clause in `#[rustc_on_unimplemented]`
-  --> $DIR/bad-annotation.rs:59:26
-   |
-LL | #[rustc_on_unimplemented(on("y", message = "y"))]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^ invalid on-clause here
-
-error[E0536]: expected 1 cfg-pattern
-  --> $DIR/bad-annotation.rs:63:29
-   |
-LL | #[rustc_on_unimplemented(on(not(a, b), message = "y"))]
-   |                             ^^^^^^^^^
-
-error: `cfg` predicate key must be an identifier
-  --> $DIR/bad-annotation.rs:67:29
-   |
-LL | #[rustc_on_unimplemented(on(thing::What, message = "y"))]
-   |                             ^^^^^^^^^^^
-
-error: `cfg` predicate key must be an identifier
+error[E0232]: literals inside `on`-clauses are not supported
   --> $DIR/bad-annotation.rs:71:29
    |
+LL | #[rustc_on_unimplemented(on("y", message = "y"))]
+   |                             ^^^ unexpected literal here
+
+error[E0232]: literals inside `on`-clauses are not supported
+  --> $DIR/bad-annotation.rs:76:29
+   |
+LL | #[rustc_on_unimplemented(on(42, message = "y"))]
+   |                             ^^ unexpected literal here
+
+error[E0232]: expected a single predicate in `not(..)`
+  --> $DIR/bad-annotation.rs:81:33
+   |
+LL | #[rustc_on_unimplemented(on(not(a, b), message = "y"))]
+   |                                 ^^^^ unexpected quantity of predicates here
+
+error[E0232]: expected a single predicate in `not(..)`
+  --> $DIR/bad-annotation.rs:86:29
+   |
+LL | #[rustc_on_unimplemented(on(not(), message = "y"))]
+   |                             ^^^^^ unexpected quantity of predicates here
+
+error[E0232]: expected an identifier inside this `on`-clause
+  --> $DIR/bad-annotation.rs:91:29
+   |
+LL | #[rustc_on_unimplemented(on(thing::What, message = "y"))]
+   |                             ^^^^^^^^^^^ expected an identifier here, not `thing::What`
+
+error[E0232]: expected an identifier inside this `on`-clause
+  --> $DIR/bad-annotation.rs:96:29
+   |
 LL | #[rustc_on_unimplemented(on(thing::What = "value", message = "y"))]
-   |                             ^^^^^^^^^^^
+   |                             ^^^^^^^^^^^ expected an identifier here, not `thing::What`
 
-error: aborting due to 14 previous errors
+error[E0232]: this predicate is invalid
+  --> $DIR/bad-annotation.rs:101:29
+   |
+LL | #[rustc_on_unimplemented(on(aaaaaaaaaaaaaa(a, b), message = "y"))]
+   |                             ^^^^^^^^^^^^^^ expected one of `any`, `all` or `not` here, not `aaaaaaaaaaaaaa`
 
-Some errors have detailed explanations: E0230, E0231, E0232, E0536.
+error[E0232]: invalid flag in `on`-clause
+  --> $DIR/bad-annotation.rs:106:29
+   |
+LL | #[rustc_on_unimplemented(on(something, message = "y"))]
+   |                             ^^^^^^^^^ expected one of the `crate_local`, `direct` or `from_desugaring` flags, not `something`
+
+error: aborting due to 18 previous errors
+
+Some errors have detailed explanations: E0230, E0231, E0232.
 For more information about an error, try `rustc --explain E0230`.


### PR DESCRIPTION
Followup to https://github.com/rust-lang/rust/pull/139091; I plan on moving most of this code into `rustc_attr_parsing` at some point, but want to land this separately first.

I have taken care to preserve the original behavior as much as I could:
- All but one of the new error variants are replacements for the ones originally emitted by the cfg parsing machinery; so these errors are not "new".
- the `InvalidFlag` variant is new, this PR turns this (from being ignored and silently doing nothing) into an error:
    ```rust
    #[rustc_on_unimplemented(on(something, message = "y"))]
    //~^ ERROR invalid boolean flag
    //~^^ NOTE expected one of `crate_local`, `direct` or `from_desugaring`, not `something`
    trait InvalidFlag {}
    ```
    This does not occur anywhere except in this test. I couldn't find a way that I liked to keep allowing this or to do nothing, erroring was the cleanest solution.
- There are a bunch of FIXME throughout this and the previous PR, I plan on addressing those in follow up prs..


Finally, this gets rid of the "longest" dependency in rustc:
![image](https://github.com/user-attachments/assets/3c3eb3a0-b7b3-40d9-aada-a752e28c8678)
