### PR TITLE
Introduce `BoxMarker` to improve pretty-printing correctness

### DIFF
--- a/compiler/rustc_ast_pretty/src/lib.rs
+++ b/compiler/rustc_ast_pretty/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(internal_features)]
 #![doc(rust_logo)]
 #![feature(box_patterns)]
+#![feature(negative_impls)]
 #![feature(rustdoc_internals)]
 // tidy-alphabetical-end
 

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -234,6 +234,38 @@ struct BufEntry {
     size: isize,
 }
 
+// Boxes opened with methods like `Printer::{cbox,ibox}` must be closed with
+// `Printer::end`. Failure to do so can result in bad indenting, or in extreme
+// cases, cause no output to be produced at all.
+//
+// Box opening and closing used to be entirely implicit, which was hard to
+// understand and easy to get wrong. This marker type is now returned from the
+// box opening methods and forgotten by `Printer::end`. Any marker that isn't
+// forgotten will trigger a panic in `drop`. (Closing a box more than once
+// isn't possible because `BoxMarker` doesn't implement `Copy` or `Clone`.)
+//
+// FIXME(nnethercote): the panic in `drop` is currently disabled because a few
+// places fail to close their boxes. It can be enabled once they are fixed.
+//
+// Note: it would be better to make open/close mismatching impossible and avoid
+// the need for this marker type altogether by having functions like
+// `with_ibox` that open a box, call a closure, and then close the box. That
+// would work for simple cases, but box lifetimes sometimes interact with
+// complex control flow and across function boundaries in ways that are
+// difficult to handle with such a technique.
+#[must_use]
+pub struct BoxMarker;
+
+impl !Clone for BoxMarker {}
+impl !Copy for BoxMarker {}
+
+impl Drop for BoxMarker {
+    fn drop(&mut self) {
+        // FIXME(nnethercote): enable once the bad cases are fixed
+        //panic!("BoxMarker not ended with `Printer::end()`");
+    }
+}
+
 impl Printer {
     pub fn new() -> Self {
         Printer {
@@ -270,7 +302,8 @@ impl Printer {
         }
     }
 
-    fn scan_begin(&mut self, token: BeginToken) {
+    // This is is where `BoxMarker`s are produced.
+    fn scan_begin(&mut self, token: BeginToken) -> BoxMarker {
         if self.scan_stack.is_empty() {
             self.left_total = 1;
             self.right_total = 1;
@@ -278,15 +311,18 @@ impl Printer {
         }
         let right = self.buf.push(BufEntry { token: Token::Begin(token), size: -self.right_total });
         self.scan_stack.push_back(right);
+        BoxMarker
     }
 
-    fn scan_end(&mut self) {
+    // This is is where `BoxMarker`s are consumed.
+    fn scan_end(&mut self, b: BoxMarker) {
         if self.scan_stack.is_empty() {
             self.print_end();
         } else {
             let right = self.buf.push(BufEntry { token: Token::End, size: -1 });
             self.scan_stack.push_back(right);
         }
+        std::mem::forget(b)
     }
 
     fn scan_break(&mut self, token: BreakToken) {

--- a/compiler/rustc_ast_pretty/src/pp/convenience.rs
+++ b/compiler/rustc_ast_pretty/src/pp/convenience.rs
@@ -1,25 +1,27 @@
 use std::borrow::Cow;
 
-use crate::pp::{BeginToken, BreakToken, Breaks, IndentStyle, Printer, SIZE_INFINITY, Token};
+use crate::pp::{
+    BeginToken, BoxMarker, BreakToken, Breaks, IndentStyle, Printer, SIZE_INFINITY, Token,
+};
 
 impl Printer {
     /// "raw box"
-    pub fn rbox(&mut self, indent: isize, breaks: Breaks) {
+    pub fn rbox(&mut self, indent: isize, breaks: Breaks) -> BoxMarker {
         self.scan_begin(BeginToken { indent: IndentStyle::Block { offset: indent }, breaks })
     }
 
     /// Inconsistent breaking box
-    pub fn ibox(&mut self, indent: isize) {
+    pub fn ibox(&mut self, indent: isize) -> BoxMarker {
         self.rbox(indent, Breaks::Inconsistent)
     }
 
     /// Consistent breaking box
-    pub fn cbox(&mut self, indent: isize) {
+    pub fn cbox(&mut self, indent: isize) -> BoxMarker {
         self.rbox(indent, Breaks::Consistent)
     }
 
-    pub fn visual_align(&mut self) {
-        self.scan_begin(BeginToken { indent: IndentStyle::Visual, breaks: Breaks::Consistent });
+    pub fn visual_align(&mut self) -> BoxMarker {
+        self.scan_begin(BeginToken { indent: IndentStyle::Visual, breaks: Breaks::Consistent })
     }
 
     pub fn break_offset(&mut self, n: usize, off: isize) {
@@ -30,8 +32,8 @@ impl Printer {
         });
     }
 
-    pub fn end(&mut self) {
-        self.scan_end()
+    pub fn end(&mut self, b: BoxMarker) {
+        self.scan_end(b)
     }
 
     pub fn eof(mut self) -> String {

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1013,10 +1013,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
 
     fn block_to_string(&self, blk: &ast::Block) -> String {
         Self::to_string(|s| {
-            // Containing cbox, will be closed by `print_block` at `}`.
-            let cb = s.cbox(INDENT_UNIT);
-            // Head-ibox, will be closed by `print_block` after `{`.
-            let ib = s.ibox(0);
+            let (cb, ib) = s.head("");
             s.print_block(blk, cb, ib)
         })
     }

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -26,7 +26,7 @@ use rustc_span::symbol::IdentPrinter;
 use rustc_span::{BytePos, CharPos, DUMMY_SP, FileName, Ident, Pos, Span, Symbol, kw, sym};
 
 use crate::pp::Breaks::{Consistent, Inconsistent};
-use crate::pp::{self, Breaks};
+use crate::pp::{self, BoxMarker, Breaks};
 use crate::pprust::state::fixup::FixupContext;
 
 pub enum MacHeader<'a> {
@@ -419,7 +419,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
     {
         let mut it = elts.into_iter();
 
-        self.rbox(0, b);
+        let rb = self.rbox(0, b);
         if let Some(first) = it.next() {
             op(self, first);
             for elt in it {
@@ -430,7 +430,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
                 op(self, elt);
             }
         }
-        self.end();
+        self.end(rb);
     }
 
     fn commasep<'x, T: 'x, F, I>(&mut self, b: Breaks, elts: I, op: F)
@@ -461,7 +461,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
                     self.zerobreak();
                 }
                 if let Some((last, lines)) = cmnt.lines.split_last() {
-                    self.ibox(0);
+                    let ib = self.ibox(0);
 
                     for line in lines {
                         self.word(line.clone());
@@ -471,7 +471,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
                     self.word(last.clone());
                     self.space();
 
-                    self.end();
+                    self.end(ib);
                 }
                 self.zerobreak()
             }
@@ -494,14 +494,14 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
                     self.word(line.clone());
                     self.hardbreak()
                 } else {
-                    self.visual_align();
+                    let vb = self.visual_align();
                     for line in &cmnt.lines {
                         if !line.is_empty() {
                             self.word(line.clone());
                         }
                         self.hardbreak();
                     }
-                    self.end();
+                    self.end(vb);
                 }
             }
             CommentStyle::BlankLine => {
@@ -620,7 +620,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
     }
 
     fn print_attr_item(&mut self, item: &ast::AttrItem, span: Span) {
-        self.ibox(0);
+        let ib = self.ibox(0);
         match item.unsafety {
             ast::Safety::Unsafe(_) => {
                 self.word("unsafe");
@@ -653,7 +653,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
             ast::Safety::Unsafe(_) => self.pclose(),
             ast::Safety::Default | ast::Safety::Safe(_) => {}
         }
-        self.end();
+        self.end(ib);
     }
 
     /// This doesn't deserve to be called "pretty" printing, but it should be
@@ -739,9 +739,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
         convert_dollar_crate: bool,
         span: Span,
     ) {
-        if delim == Delimiter::Brace {
-            self.cbox(INDENT_UNIT);
-        }
+        let cb = (delim == Delimiter::Brace).then(|| self.cbox(INDENT_UNIT));
         match header {
             Some(MacHeader::Path(path)) => self.print_path(path, false, 0),
             Some(MacHeader::Keyword(kw)) => self.word(kw),
@@ -763,18 +761,18 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
                 if !tts.is_empty() {
                     self.space();
                 }
-                self.ibox(0);
+                let ib = self.ibox(0);
                 self.print_tts(tts, convert_dollar_crate);
-                self.end();
+                self.end(ib);
                 let empty = tts.is_empty();
-                self.bclose(span, empty);
+                self.bclose(span, empty, cb.unwrap());
             }
             delim => {
                 let token_str = self.token_kind_to_string(&delim.as_open_token_kind());
                 self.word(token_str);
-                self.ibox(0);
+                let ib = self.ibox(0);
                 self.print_tts(tts, convert_dollar_crate);
-                self.end();
+                self.end(ib);
                 let token_str = self.token_kind_to_string(&delim.as_close_token_kind());
                 self.word(token_str);
             }
@@ -828,37 +826,38 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
         }
     }
 
-    fn head<S: Into<Cow<'static, str>>>(&mut self, w: S) {
+    fn head<S: Into<Cow<'static, str>>>(&mut self, w: S) -> (BoxMarker, BoxMarker) {
         let w = w.into();
         // Outer-box is consistent.
-        self.cbox(INDENT_UNIT);
+        let cb = self.cbox(INDENT_UNIT);
         // Head-box is inconsistent.
-        self.ibox(0);
+        let ib = self.ibox(0);
         // Keyword that starts the head.
         if !w.is_empty() {
             self.word_nbsp(w);
         }
+        (cb, ib)
     }
 
-    fn bopen(&mut self) {
+    fn bopen(&mut self, ib: BoxMarker) {
         self.word("{");
-        self.end(); // Close the head-box.
+        self.end(ib);
     }
 
-    fn bclose_maybe_open(&mut self, span: rustc_span::Span, empty: bool, close_box: bool) {
+    fn bclose_maybe_open(&mut self, span: rustc_span::Span, empty: bool, cb: Option<BoxMarker>) {
         let has_comment = self.maybe_print_comment(span.hi());
         if !empty || has_comment {
             self.break_offset_if_not_bol(1, -INDENT_UNIT);
         }
         self.word("}");
-        if close_box {
-            self.end(); // Close the outer-box.
+        if let Some(cb) = cb {
+            self.end(cb);
         }
     }
 
-    fn bclose(&mut self, span: rustc_span::Span, empty: bool) {
-        let close_box = true;
-        self.bclose_maybe_open(span, empty, close_box)
+    fn bclose(&mut self, span: rustc_span::Span, empty: bool, cb: BoxMarker) {
+        let cb = Some(cb);
+        self.bclose_maybe_open(span, empty, cb)
     }
 
     fn break_offset_if_not_bol(&mut self, n: usize, off: isize) {
@@ -1015,10 +1014,10 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
     fn block_to_string(&self, blk: &ast::Block) -> String {
         Self::to_string(|s| {
             // Containing cbox, will be closed by `print_block` at `}`.
-            s.cbox(INDENT_UNIT);
+            let cb = s.cbox(INDENT_UNIT);
             // Head-ibox, will be closed by `print_block` after `{`.
-            s.ibox(0);
-            s.print_block(blk)
+            let ib = s.ibox(0);
+            s.print_block(blk, cb, ib)
         })
     }
 
@@ -1090,7 +1089,7 @@ impl<'a> State<'a> {
         F: FnMut(&mut State<'_>, &T),
         G: FnMut(&T) -> rustc_span::Span,
     {
-        self.rbox(0, b);
+        let rb = self.rbox(0, b);
         let len = elts.len();
         let mut i = 0;
         for elt in elts {
@@ -1103,7 +1102,7 @@ impl<'a> State<'a> {
                 self.space_if_not_bol();
             }
         }
-        self.end();
+        self.end(rb);
     }
 
     fn commasep_exprs(&mut self, b: Breaks, exprs: &[P<ast::Expr>]) {
@@ -1172,7 +1171,7 @@ impl<'a> State<'a> {
 
     pub fn print_type(&mut self, ty: &ast::Ty) {
         self.maybe_print_comment(ty.span.lo());
-        self.ibox(0);
+        let ib = self.ibox(0);
         match &ty.kind {
             ast::TyKind::Slice(ty) => {
                 self.word("[");
@@ -1214,12 +1213,12 @@ impl<'a> State<'a> {
                 self.print_ty_fn(f.ext, f.safety, &f.decl, None, &f.generic_params);
             }
             ast::TyKind::UnsafeBinder(f) => {
-                self.ibox(INDENT_UNIT);
+                let ib = self.ibox(INDENT_UNIT);
                 self.word("unsafe");
                 self.print_generic_params(&f.generic_params);
                 self.nbsp();
                 self.print_type(&f.inner_ty);
-                self.end();
+                self.end(ib);
             }
             ast::TyKind::Path(None, path) => {
                 self.print_path(path, false, 0);
@@ -1277,7 +1276,7 @@ impl<'a> State<'a> {
                 self.print_ty_pat(pat);
             }
         }
-        self.end();
+        self.end(ib);
     }
 
     fn print_trait_ref(&mut self, t: &ast::TraitRef) {
@@ -1324,15 +1323,15 @@ impl<'a> State<'a> {
             ast::StmtKind::Let(loc) => {
                 self.print_outer_attributes(&loc.attrs);
                 self.space_if_not_bol();
-                self.ibox(INDENT_UNIT);
+                let ib1 = self.ibox(INDENT_UNIT);
                 if loc.super_.is_some() {
                     self.word_nbsp("super");
                 }
                 self.word_nbsp("let");
 
-                self.ibox(INDENT_UNIT);
+                let ib2 = self.ibox(INDENT_UNIT);
                 self.print_local_decl(loc);
-                self.end();
+                self.end(ib2);
                 if let Some((init, els)) = loc.kind.init_else_opt() {
                     self.nbsp();
                     self.word_space("=");
@@ -1342,14 +1341,14 @@ impl<'a> State<'a> {
                         FixupContext::default(),
                     );
                     if let Some(els) = els {
-                        self.cbox(INDENT_UNIT);
-                        self.ibox(INDENT_UNIT);
+                        let cb = self.cbox(INDENT_UNIT);
+                        let ib = self.ibox(INDENT_UNIT);
                         self.word(" else ");
-                        self.print_block(els);
+                        self.print_block(els, cb, ib);
                     }
                 }
                 self.word(";");
-                self.end(); // `let` ibox
+                self.end(ib1);
             }
             ast::StmtKind::Item(item) => self.print_item(item),
             ast::StmtKind::Expr(expr) => {
@@ -1380,23 +1379,30 @@ impl<'a> State<'a> {
         self.maybe_print_trailing_comment(st.span, None)
     }
 
-    fn print_block(&mut self, blk: &ast::Block) {
-        self.print_block_with_attrs(blk, &[])
+    fn print_block(&mut self, blk: &ast::Block, cb: BoxMarker, ib: BoxMarker) {
+        self.print_block_with_attrs(blk, &[], cb, ib)
     }
 
-    fn print_block_unclosed_indent(&mut self, blk: &ast::Block) {
-        self.print_block_maybe_unclosed(blk, &[], false)
+    fn print_block_unclosed_indent(&mut self, blk: &ast::Block, ib: BoxMarker) {
+        self.print_block_maybe_unclosed(blk, &[], None, ib)
     }
 
-    fn print_block_with_attrs(&mut self, blk: &ast::Block, attrs: &[ast::Attribute]) {
-        self.print_block_maybe_unclosed(blk, attrs, true)
+    fn print_block_with_attrs(
+        &mut self,
+        blk: &ast::Block,
+        attrs: &[ast::Attribute],
+        cb: BoxMarker,
+        ib: BoxMarker,
+    ) {
+        self.print_block_maybe_unclosed(blk, attrs, Some(cb), ib)
     }
 
     fn print_block_maybe_unclosed(
         &mut self,
         blk: &ast::Block,
         attrs: &[ast::Attribute],
-        close_box: bool,
+        cb: Option<BoxMarker>,
+        ib: BoxMarker,
     ) {
         match blk.rules {
             BlockCheckMode::Unsafe(..) => self.word_space("unsafe"),
@@ -1404,7 +1410,7 @@ impl<'a> State<'a> {
         }
         self.maybe_print_comment(blk.span.lo());
         self.ann.pre(self, AnnNode::Block(blk));
-        self.bopen();
+        self.bopen(ib);
 
         let has_attrs = self.print_inner_attributes(attrs);
 
@@ -1421,7 +1427,7 @@ impl<'a> State<'a> {
         }
 
         let empty = !has_attrs && blk.stmts.is_empty();
-        self.bclose_maybe_open(blk.span, empty, close_box);
+        self.bclose_maybe_open(blk.span, empty, cb);
         self.ann.post(self, AnnNode::Block(blk))
     }
 
@@ -1556,8 +1562,8 @@ impl<'a> State<'a> {
                         }
                     }
                     InlineAsmOperand::Label { block } => {
-                        s.head("label");
-                        s.print_block(block);
+                        let (cb, ib) = s.head("label");
+                        s.print_block(block, cb, ib);
                     }
                 }
             }
@@ -1671,13 +1677,13 @@ impl<'a> State<'a> {
                     Consistent,
                     fields,
                     |s, f| {
-                        s.cbox(INDENT_UNIT);
+                        let cb = s.cbox(INDENT_UNIT);
                         if !f.is_shorthand {
                             s.print_ident(f.ident);
                             s.word_nbsp(":");
                         }
                         s.print_pat(&f.pat);
-                        s.end();
+                        s.end(cb);
                     },
                     |f| f.pat.span,
                 );
@@ -1928,7 +1934,7 @@ impl<'a> State<'a> {
     }
 
     fn print_param(&mut self, input: &ast::Param, is_closure: bool) {
-        self.ibox(INDENT_UNIT);
+        let ib = self.ibox(INDENT_UNIT);
 
         self.print_outer_attributes_inline(&input.attrs);
 
@@ -1947,16 +1953,16 @@ impl<'a> State<'a> {
                 }
             }
         }
-        self.end();
+        self.end(ib);
     }
 
     fn print_fn_ret_ty(&mut self, fn_ret_ty: &ast::FnRetTy) {
         if let ast::FnRetTy::Ty(ty) = fn_ret_ty {
             self.space_if_not_bol();
-            self.ibox(INDENT_UNIT);
+            let ib = self.ibox(INDENT_UNIT);
             self.word_space("->");
             self.print_type(ty);
-            self.end();
+            self.end(ib);
             self.maybe_print_comment(ty.span.lo());
         }
     }
@@ -1969,12 +1975,12 @@ impl<'a> State<'a> {
         name: Option<Ident>,
         generic_params: &[ast::GenericParam],
     ) {
-        self.ibox(INDENT_UNIT);
+        let ib = self.ibox(INDENT_UNIT);
         self.print_formal_generic_params(generic_params);
         let generics = ast::Generics::default();
         let header = ast::FnHeader { safety, ext, ..ast::FnHeader::default() };
         self.print_fn(decl, header, name, &generics);
-        self.end();
+        self.end(ib);
     }
 
     fn print_fn_header_info(&mut self, header: ast::FnHeader) {
@@ -2052,7 +2058,7 @@ impl<'a> State<'a> {
     }
 
     fn print_meta_item(&mut self, item: &ast::MetaItem) {
-        self.ibox(INDENT_UNIT);
+        let ib = self.ibox(INDENT_UNIT);
         match &item.kind {
             ast::MetaItemKind::Word => self.print_path(&item.path, false, 0),
             ast::MetaItemKind::NameValue(value) => {
@@ -2068,7 +2074,7 @@ impl<'a> State<'a> {
                 self.pclose();
             }
         }
-        self.end();
+        self.end(ib);
     }
 
     pub(crate) fn bounds_to_string(&self, bounds: &[ast::GenericBound]) -> String {

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -439,18 +439,8 @@ impl<'a> State<'a> {
         self.print_generic_params(&generics.params);
         self.print_where_clause(&generics.where_clause);
         self.space();
-        self.print_variants(&enum_definition.variants, span, cb, ib)
-    }
-
-    fn print_variants(
-        &mut self,
-        variants: &[ast::Variant],
-        span: rustc_span::Span,
-        cb: BoxMarker,
-        ib: BoxMarker,
-    ) {
         self.bopen(ib);
-        for v in variants {
+        for v in enum_definition.variants.iter() {
             self.space_if_not_bol();
             self.maybe_print_comment(v.span.lo());
             self.print_outer_attributes(&v.attrs);
@@ -460,7 +450,7 @@ impl<'a> State<'a> {
             self.end(ib);
             self.maybe_print_trailing_comment(v.span, None);
         }
-        let empty = variants.is_empty();
+        let empty = enum_definition.variants.is_empty();
         self.bclose(span, empty, cb)
     }
 
@@ -483,35 +473,6 @@ impl<'a> State<'a> {
         if let ast::Defaultness::Default(_) = defaultness {
             self.word_nbsp("default");
         }
-    }
-
-    pub(crate) fn print_record_struct_body(
-        &mut self,
-        fields: &[ast::FieldDef],
-        span: rustc_span::Span,
-        cb: BoxMarker,
-        ib: BoxMarker,
-    ) {
-        self.nbsp();
-        self.bopen(ib);
-
-        let empty = fields.is_empty();
-        if !empty {
-            self.hardbreak_if_not_bol();
-
-            for field in fields {
-                self.hardbreak_if_not_bol();
-                self.maybe_print_comment(field.span.lo());
-                self.print_outer_attributes(&field.attrs);
-                self.print_visibility(&field.vis);
-                self.print_ident(field.ident.unwrap());
-                self.word_nbsp(":");
-                self.print_type(&field.ty);
-                self.word(",");
-            }
-        }
-
-        self.bclose(span, empty, cb);
     }
 
     fn print_struct(
@@ -547,7 +508,26 @@ impl<'a> State<'a> {
             }
             ast::VariantData::Struct { fields, .. } => {
                 self.print_where_clause(&generics.where_clause);
-                self.print_record_struct_body(fields, span, cb, ib);
+                self.nbsp();
+                self.bopen(ib);
+
+                let empty = fields.is_empty();
+                if !empty {
+                    self.hardbreak_if_not_bol();
+
+                    for field in fields {
+                        self.hardbreak_if_not_bol();
+                        self.maybe_print_comment(field.span.lo());
+                        self.print_outer_attributes(&field.attrs);
+                        self.print_visibility(&field.vis);
+                        self.print_ident(field.ident.unwrap());
+                        self.word_nbsp(":");
+                        self.print_type(&field.ty);
+                        self.word(",");
+                    }
+                }
+
+                self.bclose(span, empty, cb);
             }
         }
     }

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -5,6 +5,7 @@ use rustc_ast::ModKind;
 use rustc_ast::ptr::P;
 use rustc_span::Ident;
 
+use crate::pp::BoxMarker;
 use crate::pp::Breaks::Inconsistent;
 use crate::pprust::state::fixup::FixupContext;
 use crate::pprust::state::{AnnNode, INDENT_UNIT, PrintState, State};
@@ -96,7 +97,7 @@ impl<'a> State<'a> {
         define_opaque: Option<&[(ast::NodeId, ast::Path)]>,
     ) {
         self.print_define_opaques(define_opaque);
-        self.head("");
+        let (cb, ib) = self.head("");
         self.print_visibility(vis);
         self.print_safety(safety);
         self.print_defaultness(defaultness);
@@ -113,14 +114,14 @@ impl<'a> State<'a> {
         if body.is_some() {
             self.space();
         }
-        self.end(); // end the head-ibox
+        self.end(ib);
         if let Some(body) = body {
             self.word_space("=");
             self.print_expr(body, FixupContext::default());
         }
         self.print_where_clause(&generics.where_clause);
         self.word(";");
-        self.end(); // end the outer cbox
+        self.end(cb);
     }
 
     fn print_associated_type(
@@ -135,7 +136,7 @@ impl<'a> State<'a> {
     ) {
         let (before_predicates, after_predicates) =
             generics.where_clause.predicates.split_at(where_clauses.split);
-        self.head("");
+        let (cb, ib) = self.head("");
         self.print_visibility(vis);
         self.print_defaultness(defaultness);
         self.word_space("type");
@@ -153,8 +154,8 @@ impl<'a> State<'a> {
         }
         self.print_where_clause_parts(where_clauses.after.has_where_token, after_predicates);
         self.word(";");
-        self.end(); // end inner head-block
-        self.end(); // end outer head-block
+        self.end(ib);
+        self.end(cb);
     }
 
     /// Pretty-prints an item.
@@ -165,7 +166,7 @@ impl<'a> State<'a> {
         self.ann.pre(self, AnnNode::Item(item));
         match &item.kind {
             ast::ItemKind::ExternCrate(orig_name, ident) => {
-                self.head(visibility_qualified(&item.vis, "extern crate"));
+                let (cb, ib) = self.head(visibility_qualified(&item.vis, "extern crate"));
                 if let &Some(orig_name) = orig_name {
                     self.print_name(orig_name);
                     self.space();
@@ -174,8 +175,8 @@ impl<'a> State<'a> {
                 }
                 self.print_ident(*ident);
                 self.word(";");
-                self.end(); // end inner head-block
-                self.end(); // end outer head-block
+                self.end(ib);
+                self.end(cb);
             }
             ast::ItemKind::Use(tree) => {
                 self.print_visibility(&item.vis);
@@ -228,7 +229,7 @@ impl<'a> State<'a> {
                 self.print_fn_full(&item.vis, &item.attrs, &*func);
             }
             ast::ItemKind::Mod(safety, ident, mod_kind) => {
-                self.head(Self::to_string(|s| {
+                let (cb, ib) = self.head(Self::to_string(|s| {
                     s.print_visibility(&item.vis);
                     s.print_safety(*safety);
                     s.word("mod");
@@ -238,23 +239,23 @@ impl<'a> State<'a> {
                 match mod_kind {
                     ModKind::Loaded(items, ..) => {
                         self.nbsp();
-                        self.bopen();
+                        self.bopen(ib);
                         self.print_inner_attributes(&item.attrs);
                         for item in items {
                             self.print_item(item);
                         }
                         let empty = item.attrs.is_empty() && items.is_empty();
-                        self.bclose(item.span, empty);
+                        self.bclose(item.span, empty, cb);
                     }
                     ModKind::Unloaded => {
                         self.word(";");
-                        self.end(); // end inner head-block
-                        self.end(); // end outer head-block
+                        self.end(ib);
+                        self.end(cb);
                     }
                 }
             }
             ast::ItemKind::ForeignMod(nmod) => {
-                self.head(Self::to_string(|s| {
+                let (cb, ib) = self.head(Self::to_string(|s| {
                     s.print_safety(nmod.safety);
                     s.word("extern");
                 }));
@@ -262,18 +263,18 @@ impl<'a> State<'a> {
                     self.print_token_literal(abi.as_token_lit(), abi.span);
                     self.nbsp();
                 }
-                self.bopen();
+                self.bopen(ib);
                 self.print_foreign_mod(nmod, &item.attrs);
                 let empty = item.attrs.is_empty() && nmod.items.is_empty();
-                self.bclose(item.span, empty);
+                self.bclose(item.span, empty, cb);
             }
             ast::ItemKind::GlobalAsm(asm) => {
                 // FIXME: Print `builtin # global_asm` once macro `global_asm` uses `builtin_syntax`.
-                self.head(visibility_qualified(&item.vis, "global_asm!"));
+                let (cb, ib) = self.head(visibility_qualified(&item.vis, "global_asm!"));
                 self.print_inline_asm(asm);
                 self.word(";");
-                self.end();
-                self.end();
+                self.end(ib);
+                self.end(cb);
             }
             ast::ItemKind::TyAlias(box ast::TyAlias {
                 defaultness,
@@ -297,12 +298,12 @@ impl<'a> State<'a> {
                 self.print_enum_def(enum_definition, params, *ident, item.span, &item.vis);
             }
             ast::ItemKind::Struct(ident, struct_def, generics) => {
-                self.head(visibility_qualified(&item.vis, "struct"));
-                self.print_struct(struct_def, generics, *ident, item.span, true);
+                let (cb, ib) = self.head(visibility_qualified(&item.vis, "struct"));
+                self.print_struct(struct_def, generics, *ident, item.span, true, cb, ib);
             }
             ast::ItemKind::Union(ident, struct_def, generics) => {
-                self.head(visibility_qualified(&item.vis, "union"));
-                self.print_struct(struct_def, generics, *ident, item.span, true);
+                let (cb, ib) = self.head(visibility_qualified(&item.vis, "union"));
+                self.print_struct(struct_def, generics, *ident, item.span, true, cb, ib);
             }
             ast::ItemKind::Impl(box ast::Impl {
                 safety,
@@ -314,7 +315,7 @@ impl<'a> State<'a> {
                 self_ty,
                 items,
             }) => {
-                self.head("");
+                let (cb, ib) = self.head("");
                 self.print_visibility(&item.vis);
                 self.print_defaultness(*defaultness);
                 self.print_safety(*safety);
@@ -343,13 +344,13 @@ impl<'a> State<'a> {
                 self.print_where_clause(&generics.where_clause);
 
                 self.space();
-                self.bopen();
+                self.bopen(ib);
                 self.print_inner_attributes(&item.attrs);
                 for impl_item in items {
                     self.print_assoc_item(impl_item);
                 }
                 let empty = item.attrs.is_empty() && items.is_empty();
-                self.bclose(item.span, empty);
+                self.bclose(item.span, empty, cb);
             }
             ast::ItemKind::Trait(box ast::Trait {
                 safety,
@@ -359,7 +360,7 @@ impl<'a> State<'a> {
                 bounds,
                 items,
             }) => {
-                self.head("");
+                let (cb, ib) = self.head("");
                 self.print_visibility(&item.vis);
                 self.print_safety(*safety);
                 self.print_is_auto(*is_auto);
@@ -372,16 +373,16 @@ impl<'a> State<'a> {
                 }
                 self.print_where_clause(&generics.where_clause);
                 self.word(" ");
-                self.bopen();
+                self.bopen(ib);
                 self.print_inner_attributes(&item.attrs);
                 for trait_item in items {
                     self.print_assoc_item(trait_item);
                 }
                 let empty = item.attrs.is_empty() && items.is_empty();
-                self.bclose(item.span, empty);
+                self.bclose(item.span, empty, cb);
             }
             ast::ItemKind::TraitAlias(ident, generics, bounds) => {
-                self.head(visibility_qualified(&item.vis, "trait"));
+                let (cb, ib) = self.head(visibility_qualified(&item.vis, "trait"));
                 self.print_ident(*ident);
                 self.print_generic_params(&generics.params);
                 self.nbsp();
@@ -391,8 +392,8 @@ impl<'a> State<'a> {
                 }
                 self.print_where_clause(&generics.where_clause);
                 self.word(";");
-                self.end(); // end inner head-block
-                self.end(); // end outer head-block
+                self.end(ib);
+                self.end(cb);
             }
             ast::ItemKind::MacCall(mac) => {
                 self.print_mac(mac);
@@ -433,28 +434,34 @@ impl<'a> State<'a> {
         span: rustc_span::Span,
         visibility: &ast::Visibility,
     ) {
-        self.head(visibility_qualified(visibility, "enum"));
+        let (cb, ib) = self.head(visibility_qualified(visibility, "enum"));
         self.print_ident(ident);
         self.print_generic_params(&generics.params);
         self.print_where_clause(&generics.where_clause);
         self.space();
-        self.print_variants(&enum_definition.variants, span)
+        self.print_variants(&enum_definition.variants, span, cb, ib)
     }
 
-    fn print_variants(&mut self, variants: &[ast::Variant], span: rustc_span::Span) {
-        self.bopen();
+    fn print_variants(
+        &mut self,
+        variants: &[ast::Variant],
+        span: rustc_span::Span,
+        cb: BoxMarker,
+        ib: BoxMarker,
+    ) {
+        self.bopen(ib);
         for v in variants {
             self.space_if_not_bol();
             self.maybe_print_comment(v.span.lo());
             self.print_outer_attributes(&v.attrs);
-            self.ibox(0);
+            let ib = self.ibox(0);
             self.print_variant(v);
             self.word(",");
-            self.end();
+            self.end(ib);
             self.maybe_print_trailing_comment(v.span, None);
         }
         let empty = variants.is_empty();
-        self.bclose(span, empty)
+        self.bclose(span, empty, cb)
     }
 
     pub(crate) fn print_visibility(&mut self, vis: &ast::Visibility) {
@@ -482,9 +489,11 @@ impl<'a> State<'a> {
         &mut self,
         fields: &[ast::FieldDef],
         span: rustc_span::Span,
+        cb: BoxMarker,
+        ib: BoxMarker,
     ) {
         self.nbsp();
-        self.bopen();
+        self.bopen(ib);
 
         let empty = fields.is_empty();
         if !empty {
@@ -502,7 +511,7 @@ impl<'a> State<'a> {
             }
         }
 
-        self.bclose(span, empty);
+        self.bclose(span, empty, cb);
     }
 
     fn print_struct(
@@ -512,6 +521,8 @@ impl<'a> State<'a> {
         ident: Ident,
         span: rustc_span::Span,
         print_finalizer: bool,
+        cb: BoxMarker,
+        ib: BoxMarker,
     ) {
         self.print_ident(ident);
         self.print_generic_params(&generics.params);
@@ -531,21 +542,21 @@ impl<'a> State<'a> {
                 if print_finalizer {
                     self.word(";");
                 }
-                self.end();
-                self.end(); // Close the outer-box.
+                self.end(ib);
+                self.end(cb);
             }
             ast::VariantData::Struct { fields, .. } => {
                 self.print_where_clause(&generics.where_clause);
-                self.print_record_struct_body(fields, span);
+                self.print_record_struct_body(fields, span, cb, ib);
             }
         }
     }
 
     pub(crate) fn print_variant(&mut self, v: &ast::Variant) {
-        self.head("");
+        let (cb, ib) = self.head("");
         self.print_visibility(&v.vis);
         let generics = ast::Generics::default();
-        self.print_struct(&v.data, &generics, v.ident, v.span, false);
+        self.print_struct(&v.data, &generics, v.ident, v.span, false, cb, ib);
         if let Some(d) = &v.disr_expr {
             self.space();
             self.word_space("=");
@@ -636,9 +647,7 @@ impl<'a> State<'a> {
         kind: DelegationKind<'_>,
         body: &Option<P<ast::Block>>,
     ) {
-        if body.is_some() {
-            self.head("");
-        }
+        let body_cb_ib = body.as_ref().map(|body| (body, self.head("")));
         self.print_visibility(vis);
         self.word_nbsp("reuse");
 
@@ -670,9 +679,9 @@ impl<'a> State<'a> {
                 self.word("*");
             }
         }
-        if let Some(body) = body {
+        if let Some((body, (cb, ib))) = body_cb_ib {
             self.nbsp();
-            self.print_block_with_attrs(body, attrs);
+            self.print_block_with_attrs(body, attrs, cb, ib);
         } else {
             self.word(";");
         }
@@ -683,9 +692,8 @@ impl<'a> State<'a> {
 
         self.print_define_opaques(define_opaque.as_deref());
 
-        if body.is_some() {
-            self.head("");
-        }
+        let body_cb_ib = body.as_ref().map(|body| (body, self.head("")));
+
         self.print_visibility(vis);
         self.print_defaultness(*defaultness);
         self.print_fn(&sig.decl, sig.header, Some(*ident), generics);
@@ -693,9 +701,9 @@ impl<'a> State<'a> {
             self.nbsp();
             self.print_contract(contract);
         }
-        if let Some(body) = body {
+        if let Some((body, (cb, ib))) = body_cb_ib {
             self.nbsp();
-            self.print_block_with_attrs(body, attrs);
+            self.print_block_with_attrs(body, attrs, cb, ib);
         } else {
             self.word(";");
         }
@@ -851,10 +859,10 @@ impl<'a> State<'a> {
                 } else if let [(item, _)] = items.as_slice() {
                     self.print_use_tree(item);
                 } else {
-                    self.cbox(INDENT_UNIT);
+                    let cb = self.cbox(INDENT_UNIT);
                     self.word("{");
                     self.zerobreak();
-                    self.ibox(0);
+                    let ib = self.ibox(0);
                     for (pos, use_tree) in items.iter().with_position() {
                         let is_last = matches!(pos, Position::Last | Position::Only);
                         self.print_use_tree(&use_tree.0);
@@ -867,11 +875,11 @@ impl<'a> State<'a> {
                             }
                         }
                     }
-                    self.end();
+                    self.end(ib);
                     self.trailing_comma();
                     self.offset(-INDENT_UNIT);
                     self.word("}");
-                    self.end();
+                    self.end(cb);
                 }
             }
         }

--- a/compiler/rustc_ast_pretty/src/pprust/tests.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/tests.rs
@@ -11,10 +11,10 @@ fn fun_to_string(
     generics: &ast::Generics,
 ) -> String {
     to_string(|s| {
-        s.head("");
+        let (cb, ib) = s.head("");
         s.print_fn(decl, header, Some(ident), generics);
-        s.end(); // Close the head box.
-        s.end(); // Close the outer box.
+        s.end(ib);
+        s.end(cb);
     })
 }
 

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -870,33 +870,23 @@ impl<'a> State<'a> {
             }
             hir::VariantData::Struct { .. } => {
                 self.print_where_clause(generics);
-                self.print_variant_struct(span, struct_def.fields(), ib, cb)
+                self.nbsp();
+                self.bopen(ib);
+                self.hardbreak_if_not_bol();
+
+                for field in struct_def.fields() {
+                    self.hardbreak_if_not_bol();
+                    self.maybe_print_comment(field.span.lo());
+                    self.print_attrs_as_outer(self.attrs(field.hir_id));
+                    self.print_ident(field.ident);
+                    self.word_nbsp(":");
+                    self.print_type(field.ty);
+                    self.word(",");
+                }
+
+                self.bclose(span, cb)
             }
         }
-    }
-
-    fn print_variant_struct(
-        &mut self,
-        span: rustc_span::Span,
-        fields: &[hir::FieldDef<'_>],
-        cb: BoxMarker,
-        ib: BoxMarker,
-    ) {
-        self.nbsp();
-        self.bopen(ib);
-        self.hardbreak_if_not_bol();
-
-        for field in fields {
-            self.hardbreak_if_not_bol();
-            self.maybe_print_comment(field.span.lo());
-            self.print_attrs_as_outer(self.attrs(field.hir_id));
-            self.print_ident(field.ident);
-            self.word_nbsp(":");
-            self.print_type(field.ty);
-            self.word(",");
-        }
-
-        self.bclose(span, cb)
     }
 
     pub fn print_variant(&mut self, v: &hir::Variant<'_>) {

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -13,7 +13,7 @@ use rustc_abi::ExternAbi;
 use rustc_ast::util::parser::{self, ExprPrecedence, Fixity};
 use rustc_ast::{AttrStyle, DUMMY_NODE_ID, DelimArgs};
 use rustc_ast_pretty::pp::Breaks::{Consistent, Inconsistent};
-use rustc_ast_pretty::pp::{self, Breaks};
+use rustc_ast_pretty::pp::{self, BoxMarker, Breaks};
 use rustc_ast_pretty::pprust::state::MacHeader;
 use rustc_ast_pretty::pprust::{Comments, PrintState};
 use rustc_attr_data_structures::{AttributeKind, PrintAttribute};
@@ -127,7 +127,7 @@ impl<'a> State<'a> {
     }
 
     fn print_attr_item(&mut self, item: &hir::AttrItem, span: Span) {
-        self.ibox(0);
+        let ib = self.ibox(0);
         let path = ast::Path {
             span,
             segments: item
@@ -161,7 +161,7 @@ impl<'a> State<'a> {
                 self.word(token_str);
             }
         }
-        self.end();
+        self.end(ib);
     }
 
     fn print_node(&mut self, node: Node<'_>) {
@@ -192,10 +192,10 @@ impl<'a> State<'a> {
             Node::PreciseCapturingNonLifetimeArg(param) => self.print_ident(param.ident),
             Node::Block(a) => {
                 // Containing cbox, will be closed by print-block at `}`.
-                self.cbox(INDENT_UNIT);
+                let cb = self.cbox(INDENT_UNIT);
                 // Head-ibox, will be closed by print-block after `{`.
-                self.ibox(0);
-                self.print_block(a);
+                let ib = self.ibox(0);
+                self.print_block(a, cb, ib);
             }
             Node::Lifetime(a) => self.print_lifetime(a),
             Node::GenericParam(_) => panic!("cannot print Node::GenericParam"),
@@ -315,17 +315,17 @@ pub fn item_to_string(ann: &dyn PpAnn, pat: &hir::Item<'_>) -> String {
 }
 
 impl<'a> State<'a> {
-    fn bclose_maybe_open(&mut self, span: rustc_span::Span, close_box: bool) {
+    fn bclose_maybe_open(&mut self, span: rustc_span::Span, cb: Option<BoxMarker>) {
         self.maybe_print_comment(span.hi());
         self.break_offset_if_not_bol(1, -INDENT_UNIT);
         self.word("}");
-        if close_box {
-            self.end(); // close the outer-box
+        if let Some(cb) = cb {
+            self.end(cb);
         }
     }
 
-    fn bclose(&mut self, span: rustc_span::Span) {
-        self.bclose_maybe_open(span, true)
+    fn bclose(&mut self, span: rustc_span::Span, cb: BoxMarker) {
+        self.bclose_maybe_open(span, Some(cb))
     }
 
     fn commasep_cmnt<T, F, G>(&mut self, b: Breaks, elts: &[T], mut op: F, mut get_span: G)
@@ -333,7 +333,7 @@ impl<'a> State<'a> {
         F: FnMut(&mut State<'_>, &T),
         G: FnMut(&T) -> rustc_span::Span,
     {
-        self.rbox(0, b);
+        let rb = self.rbox(0, b);
         let len = elts.len();
         let mut i = 0;
         for elt in elts {
@@ -346,7 +346,7 @@ impl<'a> State<'a> {
                 self.space_if_not_bol();
             }
         }
-        self.end();
+        self.end(rb);
     }
 
     fn commasep_exprs(&mut self, b: Breaks, exprs: &[hir::Expr<'_>]) {
@@ -369,7 +369,7 @@ impl<'a> State<'a> {
 
     fn print_type(&mut self, ty: &hir::Ty<'_>) {
         self.maybe_print_comment(ty.span.lo());
-        self.ibox(0);
+        let ib = self.ibox(0);
         match ty.kind {
             hir::TyKind::Slice(ty) => {
                 self.word("[");
@@ -456,16 +456,16 @@ impl<'a> State<'a> {
                 self.print_ty_pat(pat);
             }
         }
-        self.end()
+        self.end(ib)
     }
 
     fn print_unsafe_binder(&mut self, unsafe_binder: &hir::UnsafeBinderTy<'_>) {
-        self.ibox(INDENT_UNIT);
+        let ib = self.ibox(INDENT_UNIT);
         self.word("unsafe");
         self.print_generic_params(unsafe_binder.generic_params);
         self.nbsp();
         self.print_type(unsafe_binder.inner_ty);
-        self.end();
+        self.end(ib);
     }
 
     fn print_foreign_item(&mut self, item: &hir::ForeignItem<'_>) {
@@ -474,7 +474,7 @@ impl<'a> State<'a> {
         self.print_attrs_as_outer(self.attrs(item.hir_id()));
         match item.kind {
             hir::ForeignItemKind::Fn(sig, arg_idents, generics) => {
-                self.head("");
+                let (cb, ib) = self.head("");
                 self.print_fn(
                     sig.decl,
                     sig.header,
@@ -483,13 +483,13 @@ impl<'a> State<'a> {
                     arg_idents,
                     None,
                 );
-                self.end(); // end head-ibox
+                self.end(ib);
                 self.word(";");
-                self.end() // end the outer fn box
+                self.end(cb)
             }
             hir::ForeignItemKind::Static(t, m, safety) => {
                 self.print_safety(safety);
-                self.head("static");
+                let (cb, ib) = self.head("static");
                 if m.is_mut() {
                     self.word_space("mut");
                 }
@@ -497,15 +497,15 @@ impl<'a> State<'a> {
                 self.word_space(":");
                 self.print_type(t);
                 self.word(";");
-                self.end(); // end the head-ibox
-                self.end() // end the outer cbox
+                self.end(ib);
+                self.end(cb)
             }
             hir::ForeignItemKind::Type => {
-                self.head("type");
+                let (cb, ib) = self.head("type");
                 self.print_ident(item.ident);
                 self.word(";");
-                self.end(); // end the head-ibox
-                self.end() // end the outer cbox
+                self.end(ib);
+                self.end(cb)
             }
         }
     }
@@ -561,7 +561,7 @@ impl<'a> State<'a> {
         self.ann.pre(self, AnnNode::Item(item));
         match item.kind {
             hir::ItemKind::ExternCrate(orig_name, ident) => {
-                self.head("extern crate");
+                let (cb, ib) = self.head("extern crate");
                 if let Some(orig_name) = orig_name {
                     self.print_name(orig_name);
                     self.space();
@@ -570,11 +570,11 @@ impl<'a> State<'a> {
                 }
                 self.print_ident(ident);
                 self.word(";");
-                self.end(); // end inner head-block
-                self.end(); // end outer head-block
+                self.end(ib);
+                self.end(cb);
             }
             hir::ItemKind::Use(path, kind) => {
-                self.head("use");
+                let (cb, ib) = self.head("use");
                 self.print_path(path, false);
 
                 match kind {
@@ -589,11 +589,11 @@ impl<'a> State<'a> {
                     hir::UseKind::Glob => self.word("::*;"),
                     hir::UseKind::ListStem => self.word("::{};"),
                 }
-                self.end(); // end inner head-block
-                self.end(); // end outer head-block
+                self.end(ib);
+                self.end(cb);
             }
             hir::ItemKind::Static(ident, ty, m, expr) => {
-                self.head("static");
+                let (cb, ib) = self.head("static");
                 if m.is_mut() {
                     self.word_space("mut");
                 }
@@ -601,85 +601,86 @@ impl<'a> State<'a> {
                 self.word_space(":");
                 self.print_type(ty);
                 self.space();
-                self.end(); // end the head-ibox
+                self.end(ib);
 
                 self.word_space("=");
                 self.ann.nested(self, Nested::Body(expr));
                 self.word(";");
-                self.end(); // end the outer cbox
+                self.end(cb);
             }
             hir::ItemKind::Const(ident, ty, generics, expr) => {
-                self.head("const");
+                let (cb, ib) = self.head("const");
                 self.print_ident(ident);
                 self.print_generic_params(generics.params);
                 self.word_space(":");
                 self.print_type(ty);
                 self.space();
-                self.end(); // end the head-ibox
+                self.end(ib);
 
                 self.word_space("=");
                 self.ann.nested(self, Nested::Body(expr));
                 self.print_where_clause(generics);
                 self.word(";");
-                self.end(); // end the outer cbox
+                self.end(cb);
             }
             hir::ItemKind::Fn { ident, sig, generics, body, .. } => {
-                self.head("");
+                let (cb, ib) = self.head("");
                 self.print_fn(sig.decl, sig.header, Some(ident.name), generics, &[], Some(body));
                 self.word(" ");
-                self.end(); // need to close a box
-                self.end(); // need to close a box
+                self.end(ib);
+                self.end(cb);
                 self.ann.nested(self, Nested::Body(body));
             }
             hir::ItemKind::Macro(ident, macro_def, _) => {
                 self.print_mac_def(macro_def, &ident, item.span, |_| {});
             }
             hir::ItemKind::Mod(ident, mod_) => {
-                self.head("mod");
+                let (cb, ib) = self.head("mod");
                 self.print_ident(ident);
                 self.nbsp();
-                self.bopen();
+                self.bopen(ib);
                 self.print_mod(mod_, attrs);
-                self.bclose(item.span);
+                self.bclose(item.span, cb);
             }
             hir::ItemKind::ForeignMod { abi, items } => {
-                self.head("extern");
+                let (cb, ib) = self.head("extern");
                 self.word_nbsp(abi.to_string());
-                self.bopen();
+                self.bopen(ib);
                 self.print_attrs_as_inner(self.attrs(item.hir_id()));
                 for item in items {
                     self.ann.nested(self, Nested::ForeignItem(item.id));
                 }
-                self.bclose(item.span);
+                self.bclose(item.span, cb);
             }
             hir::ItemKind::GlobalAsm { asm, .. } => {
-                self.head("global_asm!");
+                // FIXME(nnethercote): `ib` is unclosed
+                let (cb, _ib) = self.head("global_asm!");
                 self.print_inline_asm(asm);
-                self.end()
+                self.end(cb)
             }
             hir::ItemKind::TyAlias(ident, ty, generics) => {
-                self.head("type");
+                let (cb, ib) = self.head("type");
                 self.print_ident(ident);
                 self.print_generic_params(generics.params);
-                self.end(); // end the inner ibox
+                self.end(ib);
 
                 self.print_where_clause(generics);
                 self.space();
                 self.word_space("=");
                 self.print_type(ty);
                 self.word(";");
-                self.end(); // end the outer ibox
+                self.end(cb);
             }
             hir::ItemKind::Enum(ident, ref enum_definition, params) => {
                 self.print_enum_def(enum_definition, params, ident.name, item.span);
             }
             hir::ItemKind::Struct(ident, ref struct_def, generics) => {
-                self.head("struct");
-                self.print_struct(struct_def, generics, ident.name, item.span, true);
+                let (cb, ib) = self.head("struct");
+                self.print_struct(struct_def, generics, ident.name, item.span, true, cb, ib);
             }
             hir::ItemKind::Union(ident, ref struct_def, generics) => {
-                self.head("union");
-                self.print_struct(struct_def, generics, ident.name, item.span, true);
+                let (cb, ib) = self.head("union");
+                self.print_struct(struct_def, generics, ident.name, item.span, true, cb, ib);
             }
             hir::ItemKind::Impl(&hir::Impl {
                 constness,
@@ -692,7 +693,7 @@ impl<'a> State<'a> {
                 self_ty,
                 items,
             }) => {
-                self.head("");
+                let (cb, ib) = self.head("");
                 self.print_defaultness(defaultness);
                 self.print_safety(safety);
                 self.word_nbsp("impl");
@@ -720,15 +721,15 @@ impl<'a> State<'a> {
                 self.print_where_clause(generics);
 
                 self.space();
-                self.bopen();
+                self.bopen(ib);
                 self.print_attrs_as_inner(attrs);
                 for impl_item in items {
                     self.ann.nested(self, Nested::ImplItem(impl_item.id));
                 }
-                self.bclose(item.span);
+                self.bclose(item.span, cb);
             }
             hir::ItemKind::Trait(is_auto, safety, ident, generics, bounds, trait_items) => {
-                self.head("");
+                let (cb, ib) = self.head("");
                 self.print_is_auto(is_auto);
                 self.print_safety(safety);
                 self.word_nbsp("trait");
@@ -737,22 +738,22 @@ impl<'a> State<'a> {
                 self.print_bounds(":", bounds);
                 self.print_where_clause(generics);
                 self.word(" ");
-                self.bopen();
+                self.bopen(ib);
                 for trait_item in trait_items {
                     self.ann.nested(self, Nested::TraitItem(trait_item.id));
                 }
-                self.bclose(item.span);
+                self.bclose(item.span, cb);
             }
             hir::ItemKind::TraitAlias(ident, generics, bounds) => {
-                self.head("trait");
+                let (cb, ib) = self.head("trait");
                 self.print_ident(ident);
                 self.print_generic_params(generics.params);
                 self.nbsp();
                 self.print_bounds("=", bounds);
                 self.print_where_clause(generics);
                 self.word(";");
-                self.end(); // end inner head-block
-                self.end(); // end outer head-block
+                self.end(ib);
+                self.end(cb);
             }
         }
         self.ann.post(self, AnnNode::Item(item))
@@ -763,7 +764,8 @@ impl<'a> State<'a> {
     }
 
     fn print_opaque_ty(&mut self, o: &hir::OpaqueTy<'_>) {
-        self.head("opaque");
+        // FIXME(nnethercote): `cb` and `ib` are unclosed
+        let (_cb, _ib) = self.head("opaque");
         self.word("{");
         self.print_bounds("impl", o.bounds);
         self.word("}");
@@ -800,27 +802,33 @@ impl<'a> State<'a> {
         name: Symbol,
         span: rustc_span::Span,
     ) {
-        self.head("enum");
+        let (cb, ib) = self.head("enum");
         self.print_name(name);
         self.print_generic_params(generics.params);
         self.print_where_clause(generics);
         self.space();
-        self.print_variants(enum_definition.variants, span);
+        self.print_variants(enum_definition.variants, span, cb, ib);
     }
 
-    fn print_variants(&mut self, variants: &[hir::Variant<'_>], span: rustc_span::Span) {
-        self.bopen();
+    fn print_variants(
+        &mut self,
+        variants: &[hir::Variant<'_>],
+        span: rustc_span::Span,
+        cb: BoxMarker,
+        ib: BoxMarker,
+    ) {
+        self.bopen(ib);
         for v in variants {
             self.space_if_not_bol();
             self.maybe_print_comment(v.span.lo());
             self.print_attrs_as_outer(self.attrs(v.hir_id));
-            self.ibox(INDENT_UNIT);
+            let ib = self.ibox(INDENT_UNIT);
             self.print_variant(v);
             self.word(",");
-            self.end();
+            self.end(ib);
             self.maybe_print_trailing_comment(v.span, None);
         }
-        self.bclose(span)
+        self.bclose(span, cb)
     }
 
     fn print_defaultness(&mut self, defaultness: hir::Defaultness) {
@@ -837,6 +845,8 @@ impl<'a> State<'a> {
         name: Symbol,
         span: rustc_span::Span,
         print_finalizer: bool,
+        cb: BoxMarker,
+        ib: BoxMarker,
     ) {
         self.print_name(name);
         self.print_generic_params(generics.params);
@@ -855,19 +865,25 @@ impl<'a> State<'a> {
                 if print_finalizer {
                     self.word(";");
                 }
-                self.end();
-                self.end() // close the outer-box
+                self.end(ib);
+                self.end(cb);
             }
             hir::VariantData::Struct { .. } => {
                 self.print_where_clause(generics);
-                self.print_variant_struct(span, struct_def.fields())
+                self.print_variant_struct(span, struct_def.fields(), ib, cb)
             }
         }
     }
 
-    fn print_variant_struct(&mut self, span: rustc_span::Span, fields: &[hir::FieldDef<'_>]) {
+    fn print_variant_struct(
+        &mut self,
+        span: rustc_span::Span,
+        fields: &[hir::FieldDef<'_>],
+        cb: BoxMarker,
+        ib: BoxMarker,
+    ) {
         self.nbsp();
-        self.bopen();
+        self.bopen(ib);
         self.hardbreak_if_not_bol();
 
         for field in fields {
@@ -880,13 +896,13 @@ impl<'a> State<'a> {
             self.word(",");
         }
 
-        self.bclose(span)
+        self.bclose(span, cb)
     }
 
     pub fn print_variant(&mut self, v: &hir::Variant<'_>) {
-        self.head("");
+        let (cb, ib) = self.head("");
         let generics = hir::Generics::empty();
-        self.print_struct(&v.data, generics, v.ident.name, v.span, false);
+        self.print_struct(&v.data, generics, v.ident.name, v.span, false, cb, ib);
         if let Some(ref d) = v.disr_expr {
             self.space();
             self.word_space("=");
@@ -919,11 +935,11 @@ impl<'a> State<'a> {
                 self.word(";");
             }
             hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Provided(body)) => {
-                self.head("");
+                let (cb, ib) = self.head("");
                 self.print_method_sig(ti.ident, sig, ti.generics, &[], Some(body));
                 self.nbsp();
-                self.end(); // need to close a box
-                self.end(); // need to close a box
+                self.end(ib);
+                self.end(cb);
                 self.ann.nested(self, Nested::Body(body));
             }
             hir::TraitItemKind::Type(bounds, default) => {
@@ -944,11 +960,11 @@ impl<'a> State<'a> {
                 self.print_associated_const(ii.ident, ii.generics, ty, Some(expr));
             }
             hir::ImplItemKind::Fn(ref sig, body) => {
-                self.head("");
+                let (cb, ib) = self.head("");
                 self.print_method_sig(ii.ident, sig, ii.generics, &[], Some(body));
                 self.nbsp();
-                self.end(); // need to close a box
-                self.end(); // need to close a box
+                self.end(ib);
+                self.end(cb);
                 self.ann.nested(self, Nested::Body(body));
             }
             hir::ImplItemKind::Type(ty) => {
@@ -966,15 +982,15 @@ impl<'a> State<'a> {
         decl: impl Fn(&mut Self),
     ) {
         self.space_if_not_bol();
-        self.ibox(INDENT_UNIT);
+        let ibm1 = self.ibox(INDENT_UNIT);
         if super_ {
             self.word_nbsp("super");
         }
         self.word_nbsp("let");
 
-        self.ibox(INDENT_UNIT);
+        let ibm2 = self.ibox(INDENT_UNIT);
         decl(self);
-        self.end();
+        self.end(ibm2);
 
         if let Some(init) = init {
             self.nbsp();
@@ -986,13 +1002,13 @@ impl<'a> State<'a> {
             self.nbsp();
             self.word_space("else");
             // containing cbox, will be closed by print-block at `}`
-            self.cbox(0);
+            let cb = self.cbox(0);
             // head-box, will be closed by print-block after `{`
-            self.ibox(0);
-            self.print_block(els);
+            let ib = self.ibox(0);
+            self.print_block(els, cb, ib);
         }
 
-        self.end()
+        self.end(ibm1)
     }
 
     fn print_stmt(&mut self, st: &hir::Stmt<'_>) {
@@ -1020,23 +1036,30 @@ impl<'a> State<'a> {
         self.maybe_print_trailing_comment(st.span, None)
     }
 
-    fn print_block(&mut self, blk: &hir::Block<'_>) {
-        self.print_block_with_attrs(blk, &[])
+    fn print_block(&mut self, blk: &hir::Block<'_>, cb: BoxMarker, ib: BoxMarker) {
+        self.print_block_with_attrs(blk, &[], cb, ib)
     }
 
-    fn print_block_unclosed(&mut self, blk: &hir::Block<'_>) {
-        self.print_block_maybe_unclosed(blk, &[], false)
+    fn print_block_unclosed(&mut self, blk: &hir::Block<'_>, ib: BoxMarker) {
+        self.print_block_maybe_unclosed(blk, &[], None, ib)
     }
 
-    fn print_block_with_attrs(&mut self, blk: &hir::Block<'_>, attrs: &[hir::Attribute]) {
-        self.print_block_maybe_unclosed(blk, attrs, true)
+    fn print_block_with_attrs(
+        &mut self,
+        blk: &hir::Block<'_>,
+        attrs: &[hir::Attribute],
+        cb: BoxMarker,
+        ib: BoxMarker,
+    ) {
+        self.print_block_maybe_unclosed(blk, attrs, Some(cb), ib)
     }
 
     fn print_block_maybe_unclosed(
         &mut self,
         blk: &hir::Block<'_>,
         attrs: &[hir::Attribute],
-        close_box: bool,
+        cb: Option<BoxMarker>,
+        ib: BoxMarker,
     ) {
         match blk.rules {
             hir::BlockCheckMode::UnsafeBlock(..) => self.word_space("unsafe"),
@@ -1044,7 +1067,7 @@ impl<'a> State<'a> {
         }
         self.maybe_print_comment(blk.span.lo());
         self.ann.pre(self, AnnNode::Block(blk));
-        self.bopen();
+        self.bopen(ib);
 
         self.print_attrs_as_inner(attrs);
 
@@ -1056,7 +1079,7 @@ impl<'a> State<'a> {
             self.print_expr(expr);
             self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi()));
         }
-        self.bclose_maybe_open(blk.span, close_box);
+        self.bclose_maybe_open(blk.span, cb);
         self.ann.post(self, AnnNode::Block(blk))
     }
 
@@ -1065,20 +1088,20 @@ impl<'a> State<'a> {
             match els_inner.kind {
                 // Another `else if` block.
                 hir::ExprKind::If(i, hir::Expr { kind: hir::ExprKind::Block(t, None), .. }, e) => {
-                    self.cbox(0);
-                    self.ibox(0);
+                    let cb = self.cbox(0);
+                    let ib = self.ibox(0);
                     self.word(" else if ");
                     self.print_expr_as_cond(i);
                     self.space();
-                    self.print_block(t);
+                    self.print_block(t, cb, ib);
                     self.print_else(e);
                 }
                 // Final `else` block.
                 hir::ExprKind::Block(b, None) => {
-                    self.cbox(0);
-                    self.ibox(0);
+                    let cb = self.cbox(0);
+                    let ib = self.ibox(0);
                     self.word(" else ");
-                    self.print_block(b);
+                    self.print_block(b, cb, ib);
                 }
                 // Constraints would be great here!
                 _ => {
@@ -1094,14 +1117,14 @@ impl<'a> State<'a> {
         blk: &hir::Expr<'_>,
         elseopt: Option<&hir::Expr<'_>>,
     ) {
-        self.cbox(0);
-        self.ibox(0);
-        self.word_nbsp("if");
-        self.print_expr_as_cond(test);
-        self.space();
         match blk.kind {
             hir::ExprKind::Block(blk, None) => {
-                self.print_block(blk);
+                let cb = self.cbox(0);
+                let ib = self.ibox(0);
+                self.word_nbsp("if");
+                self.print_expr_as_cond(test);
+                self.space();
+                self.print_block(blk, cb, ib);
                 self.print_else(elseopt)
             }
             _ => panic!("non-block then expr"),
@@ -1175,28 +1198,28 @@ impl<'a> State<'a> {
     }
 
     fn print_expr_vec(&mut self, exprs: &[hir::Expr<'_>]) {
-        self.ibox(INDENT_UNIT);
+        let ib = self.ibox(INDENT_UNIT);
         self.word("[");
         self.commasep_exprs(Inconsistent, exprs);
         self.word("]");
-        self.end()
+        self.end(ib)
     }
 
     fn print_inline_const(&mut self, constant: &hir::ConstBlock) {
-        self.ibox(INDENT_UNIT);
+        let ib = self.ibox(INDENT_UNIT);
         self.word_space("const");
         self.ann.nested(self, Nested::Body(constant.body));
-        self.end()
+        self.end(ib)
     }
 
     fn print_expr_repeat(&mut self, element: &hir::Expr<'_>, count: &hir::ConstArg<'_>) {
-        self.ibox(INDENT_UNIT);
+        let ib = self.ibox(INDENT_UNIT);
         self.word("[");
         self.print_expr(element);
         self.word_space(";");
         self.print_const_arg(count);
         self.word("]");
-        self.end()
+        self.end(ib)
     }
 
     fn print_expr_struct(
@@ -1211,23 +1234,23 @@ impl<'a> State<'a> {
         self.commasep_cmnt(Consistent, fields, |s, field| s.print_expr_field(field), |f| f.span);
         match wth {
             hir::StructTailExpr::Base(expr) => {
-                self.ibox(INDENT_UNIT);
+                let ib = self.ibox(INDENT_UNIT);
                 if !fields.is_empty() {
                     self.word(",");
                     self.space();
                 }
                 self.word("..");
                 self.print_expr(expr);
-                self.end();
+                self.end(ib);
             }
             hir::StructTailExpr::DefaultFields(_) => {
-                self.ibox(INDENT_UNIT);
+                let ib = self.ibox(INDENT_UNIT);
                 if !fields.is_empty() {
                     self.word(",");
                     self.space();
                 }
                 self.word("..");
-                self.end();
+                self.end(ib);
             }
             hir::StructTailExpr::None => {}
         }
@@ -1236,14 +1259,14 @@ impl<'a> State<'a> {
     }
 
     fn print_expr_field(&mut self, field: &hir::ExprField<'_>) {
-        self.cbox(INDENT_UNIT);
+        let cb = self.cbox(INDENT_UNIT);
         self.print_attrs_as_outer(self.attrs(field.hir_id));
         if !field.is_shorthand {
             self.print_ident(field.ident);
             self.word_space(":");
         }
         self.print_expr(field.expr);
-        self.end()
+        self.end(cb)
     }
 
     fn print_expr_tup(&mut self, exprs: &[hir::Expr<'_>]) {
@@ -1416,8 +1439,8 @@ impl<'a> State<'a> {
                     s.print_qpath(path, true);
                 }
                 hir::InlineAsmOperand::Label { block } => {
-                    s.head("label");
-                    s.print_block(block);
+                    let (cb, ib) = s.head("label");
+                    s.print_block(block, cb, ib);
                 }
             },
             AsmArg::Options(opts) => {
@@ -1435,7 +1458,7 @@ impl<'a> State<'a> {
     fn print_expr(&mut self, expr: &hir::Expr<'_>) {
         self.maybe_print_comment(expr.span.lo());
         self.print_attrs_as_outer(self.attrs(expr.hir_id));
-        self.ibox(INDENT_UNIT);
+        let ib = self.ibox(INDENT_UNIT);
         self.ann.pre(self, AnnNode::Expr(expr));
         match expr.kind {
             hir::ExprKind::Array(exprs) => {
@@ -1483,21 +1506,21 @@ impl<'a> State<'a> {
             }
             hir::ExprKind::Type(expr, ty) => {
                 self.word("type_ascribe!(");
-                self.ibox(0);
+                let ib = self.ibox(0);
                 self.print_expr(expr);
 
                 self.word(",");
                 self.space_if_not_bol();
                 self.print_type(ty);
 
-                self.end();
+                self.end(ib);
                 self.word(")");
             }
             hir::ExprKind::DropTemps(init) => {
                 // Print `{`:
-                self.cbox(INDENT_UNIT);
-                self.ibox(0);
-                self.bopen();
+                let cb = self.cbox(INDENT_UNIT);
+                let ib = self.ibox(0);
+                self.bopen(ib);
 
                 // Print `let _t = $init;`:
                 let temp = Ident::from_str("_t");
@@ -1509,7 +1532,7 @@ impl<'a> State<'a> {
                 self.print_ident(temp);
 
                 // Print `}`:
-                self.bclose_maybe_open(expr.span, true);
+                self.bclose_maybe_open(expr.span, Some(cb));
             }
             hir::ExprKind::Let(&hir::LetExpr { pat, ty, init, .. }) => {
                 self.print_let(pat, ty, init);
@@ -1522,20 +1545,20 @@ impl<'a> State<'a> {
                     self.print_ident(label.ident);
                     self.word_space(":");
                 }
-                self.head("loop");
-                self.print_block(blk);
+                let (cb, ib) = self.head("loop");
+                self.print_block(blk, cb, ib);
             }
             hir::ExprKind::Match(expr, arms, _) => {
-                self.cbox(INDENT_UNIT);
-                self.ibox(INDENT_UNIT);
+                let cb = self.cbox(INDENT_UNIT);
+                let ib = self.ibox(INDENT_UNIT);
                 self.word_nbsp("match");
                 self.print_expr_as_cond(expr);
                 self.space();
-                self.bopen();
+                self.bopen(ib);
                 for arm in arms {
                     self.print_arm(arm);
                 }
-                self.bclose(expr.span);
+                self.bclose(expr.span, cb);
             }
             hir::ExprKind::Closure(&hir::Closure {
                 binder,
@@ -1558,12 +1581,15 @@ impl<'a> State<'a> {
 
                 // This is a bare expression.
                 self.ann.nested(self, Nested::Body(body));
-                self.end(); // need to close a box
+                // FIXME(nnethercote): this is bogus
+                let fake_ib = BoxMarker;
+                self.end(fake_ib);
 
                 // A box will be closed by `print_expr`, but we didn't want an overall
                 // wrapper so we closed the corresponding opening. so create an
                 // empty box to satisfy the close.
-                self.ibox(0);
+                // FIXME(nnethercote): this is bogus, and `print_expr` is missing
+                let _ib = self.ibox(0);
             }
             hir::ExprKind::Block(blk, opt_label) => {
                 if let Some(label) = opt_label {
@@ -1571,10 +1597,10 @@ impl<'a> State<'a> {
                     self.word_space(":");
                 }
                 // containing cbox, will be closed by print-block at `}`
-                self.cbox(0);
+                let cb = self.cbox(0);
                 // head-box, will be closed by print-block after `{`
-                self.ibox(0);
-                self.print_block(blk);
+                let ib = self.ibox(0);
+                self.print_block(blk, cb, ib);
             }
             hir::ExprKind::Assign(lhs, rhs, _) => {
                 self.print_expr_cond_paren(lhs, lhs.precedence() <= ExprPrecedence::Assign);
@@ -1675,7 +1701,7 @@ impl<'a> State<'a> {
             }
         }
         self.ann.post(self, AnnNode::Expr(expr));
-        self.end()
+        self.end(ib)
     }
 
     fn print_local_decl(&mut self, loc: &hir::LetStmt<'_>) {
@@ -2043,14 +2069,14 @@ impl<'a> State<'a> {
         if self.attrs(field.hir_id).is_empty() {
             self.space();
         }
-        self.cbox(INDENT_UNIT);
+        let cb = self.cbox(INDENT_UNIT);
         self.print_attrs_as_outer(self.attrs(field.hir_id));
         if !field.is_shorthand {
             self.print_ident(field.ident);
             self.word_nbsp(":");
         }
         self.print_pat(field.pat);
-        self.end();
+        self.end(cb);
     }
 
     fn print_param(&mut self, arg: &hir::Param<'_>) {
@@ -2086,9 +2112,9 @@ impl<'a> State<'a> {
         if self.attrs(arm.hir_id).is_empty() {
             self.space();
         }
-        self.cbox(INDENT_UNIT);
+        let cb = self.cbox(INDENT_UNIT);
         self.ann.pre(self, AnnNode::Arm(arm));
-        self.ibox(0);
+        let ib = self.ibox(0);
         self.print_attrs_as_outer(self.attrs(arm.hir_id));
         self.print_pat(arm.pat);
         self.space();
@@ -2105,8 +2131,7 @@ impl<'a> State<'a> {
                     self.print_ident(label.ident);
                     self.word_space(":");
                 }
-                // the block will close the pattern's ibox
-                self.print_block_unclosed(blk);
+                self.print_block_unclosed(blk, ib);
 
                 // If it is a user-provided unsafe block, print a comma after it
                 if let hir::BlockCheckMode::UnsafeBlock(hir::UnsafeSource::UserProvided) = blk.rules
@@ -2115,13 +2140,13 @@ impl<'a> State<'a> {
                 }
             }
             _ => {
-                self.end(); // close the ibox for the pattern
+                self.end(ib);
                 self.print_expr(arm.body);
                 self.word(",");
             }
         }
         self.ann.post(self, AnnNode::Arm(arm));
-        self.end() // close enclosing cbox
+        self.end(cb)
     }
 
     fn print_fn(
@@ -2167,9 +2192,9 @@ impl<'a> State<'a> {
             i += 1;
         };
         self.commasep(Inconsistent, decl.inputs, |s, ty| {
-            s.ibox(INDENT_UNIT);
+            let ib = s.ibox(INDENT_UNIT);
             print_arg(s, Some(ty));
-            s.end();
+            s.end(ib);
         });
         if decl.c_variadic {
             if !decl.inputs.is_empty() {
@@ -2188,7 +2213,7 @@ impl<'a> State<'a> {
         self.word("|");
         let mut i = 0;
         self.commasep(Inconsistent, decl.inputs, |s, ty| {
-            s.ibox(INDENT_UNIT);
+            let ib = s.ibox(INDENT_UNIT);
 
             s.ann.nested(s, Nested::BodyParamPat(body_id, i));
             i += 1;
@@ -2200,7 +2225,7 @@ impl<'a> State<'a> {
                 s.space();
                 s.print_type(ty);
             }
-            s.end();
+            s.end(ib);
         });
         self.word("|");
 
@@ -2442,16 +2467,16 @@ impl<'a> State<'a> {
         match decl.output {
             hir::FnRetTy::Return(ty) => {
                 self.space_if_not_bol();
-                self.ibox(INDENT_UNIT);
+                let ib = self.ibox(INDENT_UNIT);
                 self.word_space("->");
                 self.print_type(ty);
-            }
-            hir::FnRetTy::DefaultReturn(..) => return,
-        }
-        self.end();
+                self.end(ib);
 
-        if let hir::FnRetTy::Return(output) = decl.output {
-            self.maybe_print_comment(output.span.lo());
+                if let hir::FnRetTy::Return(output) = decl.output {
+                    self.maybe_print_comment(output.span.lo());
+                }
+            }
+            hir::FnRetTy::DefaultReturn(..) => {}
         }
     }
 
@@ -2464,7 +2489,7 @@ impl<'a> State<'a> {
         generic_params: &[hir::GenericParam<'_>],
         arg_idents: &[Option<Ident>],
     ) {
-        self.ibox(INDENT_UNIT);
+        let ib = self.ibox(INDENT_UNIT);
         self.print_formal_generic_params(generic_params);
         let generics = hir::Generics::empty();
         self.print_fn(
@@ -2480,7 +2505,7 @@ impl<'a> State<'a> {
             arg_idents,
             None,
         );
-        self.end();
+        self.end(ib);
     }
 
     fn print_fn_header_info(&mut self, header: hir::FnHeader) {

--- a/src/librustdoc/clean/render_macro_matchers.rs
+++ b/src/librustdoc/clean/render_macro_matchers.rs
@@ -34,20 +34,20 @@ pub(super) fn render_macro_matcher(tcx: TyCtxt<'_>, matcher: &TokenTree) -> Stri
     //             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!
     //         ) => {...};
     //     }
-    printer.cbox(8);
+    let cb = printer.cbox(8);
     printer.word("(");
     printer.zerobreak();
-    printer.ibox(0);
+    let ib = printer.ibox(0);
     match matcher {
         TokenTree::Delimited(_span, _spacing, _delim, tts) => print_tts(&mut printer, tts),
         // Matcher which is not a Delimited is unexpected and should've failed
         // to compile, but we render whatever it is wrapped in parens.
         TokenTree::Token(..) => print_tt(&mut printer, matcher),
     }
-    printer.end();
+    printer.end(ib);
     printer.break_offset_if_not_bol(0, -4);
     printer.word(")");
-    printer.end();
+    printer.end(cb);
     printer.s.eof()
 }
 


### PR DESCRIPTION
Box opening/closing is really easy to get wrong in the pretty-printers. This PR makes it much harder to get wrong.

r? @Urgau