### PR TITLE
Remove redundant check

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -730,7 +730,6 @@ pub(crate) fn check_item_type(tcx: TyCtxt<'_>, def_id: LocalDefId) {
                     .is_ok()
                 {
                     check_impl_items_against_trait(tcx, def_id, impl_trait_header);
-                    check_on_unimplemented(tcx, def_id);
                 }
             }
         }


### PR DESCRIPTION
We still check for `rustc_on_unimplemented` on implementations, but this functionality was removed in https://github.com/rust-lang/rust/pull/139091, since then it always returns `Ok` when called with a non-trait defid.

https://github.com/rust-lang/rust/blob/b4c8b0c3f0533bb342a4873ff59bdad3883ab8e3/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs#L557-L564
