### PR TITLE
Simply try to unpeel AsyncFnKindHelper goal in `emit_specialized_closure_kind_error`

### DIFF
--- a/tests/ui/async-await/async-closures/kind-due-to-arg-with-box-wrap.rs
+++ b/tests/ui/async-await/async-closures/kind-due-to-arg-with-box-wrap.rs
@@ -1,0 +1,22 @@
+//@ edition: 2024
+
+// Regression test for <https://github.com/rust-lang/rust/issues/140292>.
+
+struct Test;
+
+impl Test {
+    async fn an_async_fn(&mut self) {
+        todo!()
+    }
+
+    pub async fn uses_takes_asyncfn(&mut self) {
+        takes_asyncfn(Box::new(async || self.an_async_fn().await));
+        //~^ ERROR expected a closure that implements the `AsyncFn` trait, but this closure only implements `AsyncFnMut`
+    }
+}
+
+async fn takes_asyncfn(_: impl AsyncFn()) {
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-closures/kind-due-to-arg-with-box-wrap.stderr
+++ b/tests/ui/async-await/async-closures/kind-due-to-arg-with-box-wrap.stderr
@@ -1,0 +1,21 @@
+error[E0525]: expected a closure that implements the `AsyncFn` trait, but this closure only implements `AsyncFnMut`
+  --> $DIR/kind-due-to-arg-with-box-wrap.rs:13:32
+   |
+LL |         takes_asyncfn(Box::new(async || self.an_async_fn().await));
+   |         ------------- ---------^^^^^^^^--------------------------
+   |         |             |        |        |
+   |         |             |        |        closure is `AsyncFnMut` because it mutates the variable `*self` here
+   |         |             |        this closure implements `AsyncFnMut`, not `AsyncFn`
+   |         |             the requirement to implement `AsyncFn` derives from here
+   |         required by a bound introduced by this call
+   |
+   = note: required for `Box<{async closure@$DIR/kind-due-to-arg-with-box-wrap.rs:13:32: 13:40}>` to implement `AsyncFn()`
+note: required by a bound in `takes_asyncfn`
+  --> $DIR/kind-due-to-arg-with-box-wrap.rs:18:32
+   |
+LL | async fn takes_asyncfn(_: impl AsyncFn()) {
+   |                                ^^^^^^^^^ required by this bound in `takes_asyncfn`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0525`.


### PR DESCRIPTION
Tweak the handling of `AsyncFnKindHelper` goals in `emit_specialized_closure_kind_error` to not be so special-casey, and just try to unpeel one or two layers of obligation causes to get to their underlying `AsyncFn*` goal.

Fixes https://github.com/rust-lang/rust/issues/140292