### PR TITLE
bootstrap: Inhibit download-rustc in CI when tools are changed

### DIFF
--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -281,14 +281,27 @@ fn ci_rustc_if_unchanged_do_not_invalidate_on_library_changes_outside_ci() {
 }
 
 #[test]
-fn ci_rustc_if_unchanged_do_not_invalidate_on_tool_changes() {
+fn ci_rustc_if_unchanged_do_not_invalidate_on_tool_changes_in_ci() {
+    git_test(|ctx| {
+        prepare_rustc_checkout(ctx);
+        let sha = ctx.create_upstream_merge(&["compiler/bar"]);
+        // This change should invalidate download-ci-rustc
+        ctx.create_nonupstream_merge(&["src/tools/foo"]);
+
+        let config = parse_config_download_rustc_at(ctx.get_path(), "if-unchanged", true);
+        assert_eq!(config.download_rustc_commit, None);
+    });
+}
+
+#[test]
+fn ci_rustc_if_unchanged_do_not_invalidate_on_tool_changes_outside_ci() {
     git_test(|ctx| {
         prepare_rustc_checkout(ctx);
         let sha = ctx.create_upstream_merge(&["compiler/bar"]);
         // This change should not invalidate download-ci-rustc
         ctx.create_nonupstream_merge(&["src/tools/foo"]);
 
-        let config = parse_config_download_rustc_at(ctx.get_path(), "if-unchanged", true);
+        let config = parse_config_download_rustc_at(ctx.get_path(), "if-unchanged", false);
         assert_eq!(config.download_rustc_commit, Some(sha));
     });
 }

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -43,13 +43,13 @@ use crate::utils::helpers::{self, exe, output, t};
 /// is added here, it will cause bootstrap to skip necessary rebuilds, which may lead to risky results.
 /// For example, "src/bootstrap" should never be included in this list as it plays a crucial role in the
 /// final output/compiler, which can be significantly affected by changes made to the bootstrap sources.
-#[rustfmt::skip] // We don't want rustfmt to oneline this list
 pub(crate) const RUSTC_IF_UNCHANGED_ALLOWED_PATHS: &[&str] = &[
-    ":!src/tools",
+    // tidy-alphabetical-start
     ":!src/librustdoc",
     ":!src/rustdoc-json-types",
     ":!tests",
     ":!triagebot.toml",
+    // tidy-alphabetical-end
 ];
 
 /// Additional "allowed" paths for the `download-rustc="if-unchanged"` logic
@@ -64,6 +64,10 @@ pub(crate) const RUSTC_IF_UNCHANGED_EXTRA_ALLOWED_PATHS_OUTSIDE_CI: &[&str] = &[
     // functionality for library developers between `download-rustc=true` and `download-rustc="if-unchanged"`
     // options.
     ":!library",
+    // Tool changes should inhibit download-rustc in CI, to avoid situations like
+    // <https://github.com/rust-lang/rust/pull/139998#issuecomment-2824674661>
+    // where download-rustc interferes with test metrics for delicate compiletest changes.
+    ":!src/tools",
     // tidy-alphabetical-end
 ];
 

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -459,6 +459,7 @@ fn check_rustc_if_unchanged_paths() {
     let config = parse("");
     let normalised_allowed_paths: Vec<_> = RUSTC_IF_UNCHANGED_ALLOWED_PATHS
         .iter()
+        .chain(super::RUSTC_IF_UNCHANGED_EXTRA_ALLOWED_PATHS_OUTSIDE_CI)
         .map(|t| {
             t.strip_prefix(":!").expect(&format!("{t} doesn't have ':!' prefix, but it should."))
         })


### PR DESCRIPTION
This automatically avoids situations like https://github.com/rust-lang/rust/pull/139998#issuecomment-2824674661 and https://github.com/rust-lang/rust/pull/140177#issuecomment-2826968336, where a sensitive change to compiletest was eligible for download-rustc, preventing the collection of proper test metrics for comparison.

While the primary goal is to make *compiletest* changes inhibit download-rustc, this PR ends up making *any* change to `src/tools` inhibit download-rustc (but only in CI builds). With the current code, it's not clear how to “un-exempt” individual subdirectories that are covered by another exemption.

---

See https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Should.20tool.20changes.20inhibit.20download-rustc.20on.20CI.3F for associated discussion.