### PR TITLE
Clarify black_box warning a bit

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -320,6 +320,10 @@ pub fn spin_loop() {
 /// This also means that this function does not offer any guarantees for cryptographic or security
 /// purposes.
 ///
+/// This limitation is not specific to `black_box`; there is no mechanism in the entire Rust
+/// language that can provide the guarantees required for constant-time cryptography.
+/// (There is also no such mechanism in LLVM, so the same is true for every other LLVM-based compiler.)
+///
 /// </div>
 ///
 /// [`std::convert::identity`]: crate::convert::identity


### PR DESCRIPTION
Trying to bring the docs on black_box more in line with the advice that we have discussed in Zulip.

https://github.com/rust-lang/rust/pull/140341#issuecomment-2832592382