### PR TITLE
ci: use aws codebuild for the `dist-x86_64-linux` job

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -2,7 +2,7 @@
 # CentOS 7 has headers for kernel 3.10, but that's fine as long as we don't
 # actually use newer APIs in rustc or std without a fallback. It's more
 # important that we match glibc for ELF symbol versioning.
-FROM centos:7
+FROM ghcr.io/rust-lang/centos:7
 
 WORKDIR /build
 

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -213,7 +213,7 @@ auto:
   - name: dist-x86_64-linux
     env:
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-linux-16c
+    <<: *job-linux-36c-codebuild
 
   - name: dist-x86_64-linux-alt
     env:


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
r? @ghost

We want to use aws credits for linux runners.
<!-- homu-ignore:end -->
try-job: dist-x86_64-linux