### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -500,7 +500,7 @@
 # building without optimizations takes much longer than optimizing. Further, some platforms
 # fail to build without this optimization (c.f. #65352).
 # The valid options are:
-# true - Enable optimizations.
+# true - Enable optimizations (same as 3).
 # false - Disable optimizations.
 # 0 - Disable optimizations.
 # 1 - Basic optimizations.

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1488,6 +1488,39 @@ fn check_where_clauses<'tcx>(wfcx: &WfCheckingCtxt<'_, 'tcx>, span: Span, def_id
                         .then(|| WellFormedLoc::Ty(param.def_id.expect_local())),
                     default,
                 );
+            } else {
+                // If we've got a generic const parameter we still want to check its
+                // type is correct in case both it and the param type are fully concrete.
+                let GenericArgKind::Const(ct) = default.unpack() else {
+                    continue;
+                };
+
+                let ct_ty = match ct.kind() {
+                    ty::ConstKind::Infer(_)
+                    | ty::ConstKind::Placeholder(_)
+                    | ty::ConstKind::Bound(_, _) => unreachable!(),
+                    ty::ConstKind::Error(_) | ty::ConstKind::Expr(_) => continue,
+                    ty::ConstKind::Value(cv) => cv.ty,
+                    ty::ConstKind::Unevaluated(uv) => {
+                        infcx.tcx.type_of(uv.def).instantiate(infcx.tcx, uv.args)
+                    }
+                    ty::ConstKind::Param(param_ct) => param_ct.find_ty_from_env(wfcx.param_env),
+                };
+
+                let param_ty = tcx.type_of(param.def_id).instantiate_identity();
+                if !ct_ty.has_param() && !param_ty.has_param() {
+                    let cause = traits::ObligationCause::new(
+                        tcx.def_span(param.def_id),
+                        wfcx.body_def_id,
+                        ObligationCauseCode::WellFormed(None),
+                    );
+                    wfcx.register_obligation(Obligation::new(
+                        tcx,
+                        cause,
+                        wfcx.param_env,
+                        ty::ClauseKind::ConstArgHasType(ct, param_ty),
+                    ));
+                }
             }
         }
     }

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "4.5.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e935efc5854715dfc0a4c9ef18dc69dee0ec3bf9cc3ab740db831c0fdd86a3"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-core",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi-alloc"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d6f09fe2b6ad044bc3d2c34ce4979796581afd2f1ebc185837e02421e02fd7"
+checksum = "e43c53ff1a01d423d1cb762fd991de07d32965ff0ca2e4f80444ac7804198203"
 dependencies = [
  "compiler_builtins",
  "r-efi",

--- a/library/alloc/src/ffi/c_str.rs
+++ b/library/alloc/src/ffi/c_str.rs
@@ -821,6 +821,7 @@ impl From<Vec<NonZero<u8>>> for CString {
     }
 }
 
+#[stable(feature = "c_string_from_str", since = "1.85.0")]
 impl FromStr for CString {
     type Err = NulError;
 
@@ -833,6 +834,7 @@ impl FromStr for CString {
     }
 }
 
+#[stable(feature = "c_string_from_str", since = "1.85.0")]
 impl TryFrom<CString> for String {
     type Error = IntoStringError;
 

--- a/library/alloc/src/ffi/mod.rs
+++ b/library/alloc/src/ffi/mod.rs
@@ -87,5 +87,5 @@ pub use self::c_str::CString;
 #[stable(feature = "alloc_c_string", since = "1.64.0")]
 pub use self::c_str::{FromVecWithNulError, IntoStringError, NulError};
 
-#[unstable(feature = "c_str_module", issue = "112134")]
+#[stable(feature = "c_str_module", since = "CURRENT_RUSTC_VERSION")]
 pub mod c_str;

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -79,8 +79,9 @@ use crate::{fmt, ops, slice, str};
 ///
 /// fn my_string_safe() -> String {
 ///     let cstr = unsafe { CStr::from_ptr(my_string()) };
-///     // Get copy-on-write Cow<'_, str>, then guarantee a freshly-owned String allocation
-///     String::from_utf8_lossy(cstr.to_bytes()).to_string()
+///     // Get a copy-on-write Cow<'_, str>, then extract the
+///     // allocated String (or allocate a fresh one if needed).
+///     cstr.to_string_lossy().into_owned()
 /// }
 ///
 /// println!("string: {}", my_string_safe());

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -20,7 +20,7 @@ pub use self::c_str::FromBytesUntilNulError;
 pub use self::c_str::FromBytesWithNulError;
 use crate::fmt;
 
-#[unstable(feature = "c_str_module", issue = "112134")]
+#[stable(feature = "c_str_module", since = "CURRENT_RUSTC_VERSION")]
 pub mod c_str;
 
 #[unstable(

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -83,8 +83,8 @@ wasi = { version = "0.11.0", features = [
 ], default-features = false }
 
 [target.'cfg(target_os = "uefi")'.dependencies]
-r-efi = { version = "4.5.0", features = ['rustc-dep-of-std'] }
-r-efi-alloc = { version = "1.0.0", features = ['rustc-dep-of-std'] }
+r-efi = { version = "5.2.0", features = ['rustc-dep-of-std'] }
+r-efi-alloc = { version = "2.0.0", features = ['rustc-dep-of-std'] }
 
 [features]
 backtrace = [

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -161,7 +161,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-#[unstable(feature = "c_str_module", issue = "112134")]
+#[stable(feature = "c_str_module", since = "CURRENT_RUSTC_VERSION")]
 pub mod c_str;
 
 #[stable(feature = "core_c_void", since = "1.30.0")]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -327,7 +327,6 @@
 #![feature(array_chunks)]
 #![feature(bstr)]
 #![feature(bstr_internals)]
-#![feature(c_str_module)]
 #![feature(char_internals)]
 #![feature(clone_to_uninit)]
 #![feature(core_intrinsics)]

--- a/src/librustdoc/doctest/make.rs
+++ b/src/librustdoc/doctest/make.rs
@@ -444,8 +444,6 @@ fn parse_source(source: &str, crate_name: &Option<&str>) -> Result<ParseSourceIn
                             }
                         }
                     }
-                    // We do nothing in this case. Not marking it as `non_module_items` either.
-                    StmtKind::Empty => {}
                     _ => {
                         has_non_items = true;
                     }

--- a/src/librustdoc/doctest/make.rs
+++ b/src/librustdoc/doctest/make.rs
@@ -407,15 +407,19 @@ fn parse_source(source: &str, crate_name: &Option<&str>) -> Result<ParseSourceIn
                     push_to_s(&mut info.crate_attrs, source, attr.span, &mut prev_span_hi);
                 }
             }
+            let mut has_non_module_items = false;
             for stmt in &body.stmts {
                 let mut is_extern_crate = false;
                 match stmt.kind {
                     StmtKind::Item(ref item) => {
                         is_extern_crate = check_item(&item, &mut info, crate_name);
                     }
-                    StmtKind::Expr(ref expr) if matches!(expr.kind, ast::ExprKind::Err(_)) => {
-                        reset_error_count(&psess);
-                        return Err(());
+                    StmtKind::Expr(ref expr) => {
+                        if matches!(expr.kind, ast::ExprKind::Err(_)) {
+                            reset_error_count(&psess);
+                            return Err(());
+                        }
+                        has_non_module_items = true;
                     }
                     StmtKind::MacCall(ref mac_call) if !info.has_main_fn => {
                         let mut iter = mac_call.mac.args.tokens.iter();
@@ -437,7 +441,11 @@ fn parse_source(source: &str, crate_name: &Option<&str>) -> Result<ParseSourceIn
                             }
                         }
                     }
-                    _ => {}
+                    // We do nothing in this case. Not marking it as `non_module_items` either.
+                    StmtKind::Empty => {}
+                    _ => {
+                        has_non_module_items = true;
+                    }
                 }
 
                 // Weirdly enough, the `Stmt` span doesn't include its attributes, so we need to
@@ -461,6 +469,11 @@ fn parse_source(source: &str, crate_name: &Option<&str>) -> Result<ParseSourceIn
                 } else {
                     push_to_s(&mut info.crates, source, span, &mut prev_span_hi);
                 }
+            }
+            if has_non_module_items {
+                // FIXME: if `info.has_main_fn` is `true`, emit a warning here to mention that
+                // this code will not be called.
+                info.has_main_fn = false;
             }
             Ok(info)
         }

--- a/src/librustdoc/doctest/make.rs
+++ b/src/librustdoc/doctest/make.rs
@@ -424,7 +424,10 @@ fn parse_source(source: &str, crate_name: &Option<&str>) -> Result<ParseSourceIn
                     // We assume that the macro calls will expand to item(s) even though they could
                     // expand to statements and expressions. And the simple fact that we're trying
                     // to retrieve a `main` function inside it is a terrible idea.
-                    StmtKind::MacCall(ref mac_call) if !info.has_main_fn => {
+                    StmtKind::MacCall(ref mac_call) => {
+                        if info.has_main_fn {
+                            continue;
+                        }
                         let mut iter = mac_call.mac.args.tokens.iter();
 
                         while let Some(token) = iter.next() {

--- a/src/librustdoc/doctest/runner.rs
+++ b/src/librustdoc/doctest/runner.rs
@@ -131,7 +131,22 @@ mod __doctest_mod {{
             .output()
             .expect(\"failed to run command\");
         if !out.status.success() {{
-            eprint!(\"{{}}\", String::from_utf8_lossy(&out.stderr));
+            if let Some(code) = out.status.code() {{
+                eprintln!(\"Test executable failed (exit status: {{code}}).\");
+            }} else {{
+                eprintln!(\"Test executable failed (terminated by signal).\");
+            }}
+            if !out.stdout.is_empty() || !out.stderr.is_empty() {{
+                eprintln!();
+            }}
+            if !out.stdout.is_empty() {{
+                eprintln!(\"stdout:\");
+                eprintln!(\"{{}}\", String::from_utf8_lossy(&out.stdout));
+            }}
+            if !out.stderr.is_empty() {{
+                eprintln!(\"stderr:\");
+                eprintln!(\"{{}}\", String::from_utf8_lossy(&out.stderr));
+            }}
             ExitCode::FAILURE
         }} else {{
             ExitCode::SUCCESS

--- a/tests/rustdoc-ui/doctest/auxiliary/macro-after-main.rs
+++ b/tests/rustdoc-ui/doctest/auxiliary/macro-after-main.rs
@@ -1,0 +1,1 @@
+use std::string::String;

--- a/tests/rustdoc-ui/doctest/edition-2024-error-output.stdout
+++ b/tests/rustdoc-ui/doctest/edition-2024-error-output.stdout
@@ -5,12 +5,16 @@ test $DIR/edition-2024-error-output.rs - (line 12) ... FAILED
 failures:
 
 ---- $DIR/edition-2024-error-output.rs - (line 12) stdout ----
+Test executable failed (exit status: 101).
+
+stderr:
 
 thread 'main' panicked at $TMP:6:1:
 assertion `left == right` failed
   left: 4
  right: 5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
 
 
 failures:

--- a/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.rs
@@ -4,12 +4,12 @@
 //@ compile-flags:--test
 //@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
-//@ failure-status: 101
+//@ check-pass
 
 /// <https://github.com/rust-lang/rust/issues/91014>
 ///
 /// ```rust
-/// struct S {}; // unexpected semicolon after struct def
+/// struct S {};
 ///
 /// fn main() {
 ///    assert_eq!(0, 1);

--- a/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-extra-semicolon-on-item.stdout
@@ -1,29 +1,6 @@
 
 running 1 test
-test $DIR/failed-doctest-extra-semicolon-on-item.rs - m (line 11) ... FAILED
+test $DIR/failed-doctest-extra-semicolon-on-item.rs - m (line 11) ... ok
 
-failures:
-
----- $DIR/failed-doctest-extra-semicolon-on-item.rs - m (line 11) stdout ----
-error: expected item, found `;`
-  --> $DIR/failed-doctest-extra-semicolon-on-item.rs:12:12
-   |
-LL | struct S {}; // unexpected semicolon after struct def
-   |            ^
-   |
-   = help: braced struct declarations are not followed by a semicolon
-help: remove this semicolon
-   |
-LL - struct S {}; // unexpected semicolon after struct def
-LL + struct S {} // unexpected semicolon after struct def
-   |
-
-error: aborting due to 1 previous error
-
-Couldn't compile the test.
-
-failures:
-    $DIR/failed-doctest-extra-semicolon-on-item.rs - m (line 11)
-
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/macro-after-main.rs
+++ b/tests/rustdoc-ui/doctest/macro-after-main.rs
@@ -1,0 +1,16 @@
+// This test checks a corner case where the macro calls used to be skipped,
+// making them considered as statement, and therefore some cases where
+// `include!` macro was then put into a function body, making the doctest
+// compilation fail.
+
+//@ compile-flags:--test
+//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ check-pass
+
+//! ```
+//! include!("./auxiliary/macro-after-main.rs");
+//!
+//! fn main() {}
+//! eprintln!();
+//! ```

--- a/tests/rustdoc-ui/doctest/macro-after-main.stdout
+++ b/tests/rustdoc-ui/doctest/macro-after-main.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/macro-after-main.rs - (line 11) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/stdout-and-stderr.rs
+++ b/tests/rustdoc-ui/doctest/stdout-and-stderr.rs
@@ -1,0 +1,26 @@
+// This test ensures that the output is correctly generated when the
+// doctest fails. It checks when there is stderr and stdout, no stdout
+// and no stderr/stdout.
+//
+// This is a regression test for <https://github.com/rust-lang/rust/issues/140289>.
+
+//@ edition: 2024
+//@ compile-flags:--test --test-args=--test-threads=1
+//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ normalize-stdout: "panicked at .+rs:" -> "panicked at $$TMP:"
+//@ failure-status: 101
+//@ rustc-env:RUST_BACKTRACE=0
+
+//! ```
+//! println!("######## from a DOC TEST ########");
+//! assert_eq!("doc", "test");
+//! ```
+//!
+//! ```
+//! assert_eq!("doc", "test");
+//! ```
+//!
+//! ```
+//! std::process::exit(1);
+//! ```

--- a/tests/rustdoc-ui/doctest/stdout-and-stderr.stdout
+++ b/tests/rustdoc-ui/doctest/stdout-and-stderr.stdout
@@ -1,0 +1,46 @@
+
+running 3 tests
+test $DIR/stdout-and-stderr.rs - (line 15) ... FAILED
+test $DIR/stdout-and-stderr.rs - (line 20) ... FAILED
+test $DIR/stdout-and-stderr.rs - (line 24) ... FAILED
+
+failures:
+
+---- $DIR/stdout-and-stderr.rs - (line 15) stdout ----
+Test executable failed (exit status: 101).
+
+stdout:
+######## from a DOC TEST ########
+
+stderr:
+
+thread 'main' panicked at $TMP:7:1:
+assertion `left == right` failed
+  left: "doc"
+ right: "test"
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+---- $DIR/stdout-and-stderr.rs - (line 20) stdout ----
+Test executable failed (exit status: 101).
+
+stderr:
+
+thread 'main' panicked at $TMP:15:1:
+assertion `left == right` failed
+  left: "doc"
+ right: "test"
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+---- $DIR/stdout-and-stderr.rs - (line 24) stdout ----
+Test executable failed (exit status: 1).
+
+
+failures:
+    $DIR/stdout-and-stderr.rs - (line 15)
+    $DIR/stdout-and-stderr.rs - (line 20)
+    $DIR/stdout-and-stderr.rs - (line 24)
+
+test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/test-main-alongside-exprs.rs
+++ b/tests/rustdoc-ui/doctest/test-main-alongside-exprs.rs
@@ -1,0 +1,22 @@
+// This test ensures that if there is an expression alongside a `main`
+// function, it will not consider the entire code to be part of the `main`
+// function and will generate its own function to wrap everything.
+//
+// This is a regression test for:
+// * <https://github.com/rust-lang/rust/issues/140162>
+// * <https://github.com/rust-lang/rust/issues/139651>
+//@ compile-flags:--test
+//@ normalize-stdout: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ check-pass
+
+#![crate_name = "foo"]
+
+//! ```
+//! # if cfg!(miri) { return; }
+//! use std::ops::Deref;
+//!
+//! fn main() {
+//!     println!("Hi!");
+//! }
+//! ```

--- a/tests/rustdoc-ui/doctest/test-main-alongside-exprs.stdout
+++ b/tests/rustdoc-ui/doctest/test-main-alongside-exprs.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/test-main-alongside-exprs.rs - (line 15) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/ui/const-generics/defaults/concrete-const-param-type.rs
+++ b/tests/ui/const-generics/defaults/concrete-const-param-type.rs
@@ -1,0 +1,13 @@
+#![feature(generic_const_parameter_types, unsized_const_params, adt_const_params)]
+//~^ WARN the feature `generic_const_parameter_types` is incomplete
+//~| WARN the feature `unsized_const_params` is incomplete
+// Make sure that we test the const param type of default const parameters
+// if both the type of the default and the type of the parameter are concrete.
+
+use std::marker::ConstParamTy_;
+
+struct Foo<const N: u32, const M: u64 = N>; //~ ERROR the constant `N` is not of type `u64`
+struct Bar<T: ConstParamTy_, const N: T, const M: u64 = N>(T); // ok
+struct Baz<T: ConstParamTy_, const N: u32, const M: T = N>(T); // ok
+
+fn main() {}

--- a/tests/ui/const-generics/defaults/concrete-const-param-type.stderr
+++ b/tests/ui/const-generics/defaults/concrete-const-param-type.stderr
@@ -1,0 +1,25 @@
+warning: the feature `generic_const_parameter_types` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/concrete-const-param-type.rs:1:12
+   |
+LL | #![feature(generic_const_parameter_types, unsized_const_params, adt_const_params)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #137626 <https://github.com/rust-lang/rust/issues/137626> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: the feature `unsized_const_params` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/concrete-const-param-type.rs:1:43
+   |
+LL | #![feature(generic_const_parameter_types, unsized_const_params, adt_const_params)]
+   |                                           ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
+
+error: the constant `N` is not of type `u64`
+  --> $DIR/concrete-const-param-type.rs:9:26
+   |
+LL | struct Foo<const N: u32, const M: u64 = N>;
+   |                          ^^^^^^^^^^^^^^^^ expected `u64`, found `u32`
+
+error: aborting due to 1 previous error; 2 warnings emitted
+


### PR DESCRIPTION
Successful merges:

 - #137439 (Stabilise `std::ffi::c_str`)
 - #138737 (uefi: Update r-efi)
 - #139646 (check types of const param defaults)
 - #140220 (Fix detection of main function if there are expressions around it)
 - #140291 (Correctly display stdout and stderr in case a doctest is failing)
 - #140297 (Update example to use CStr::to_string_lossy)
 - #140330 (Clarified bootstrap optimization "true" argument)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=137439,138737,139646,140220,140291,140297,140330)
<!-- homu-ignore:end -->