### PR TITLE
Do not insert duplicate SourceFile

### DIFF
--- a/compiler/rustc_span/src/source_map/tests.rs
+++ b/compiler/rustc_span/src/source_map/tests.rs
@@ -234,7 +234,7 @@ fn t10() {
         lines,
         multibyte_chars,
         normalized_pos,
-        stable_id,
+        stable_id: _,
         ..
     } = (*src_file).clone();
 
@@ -242,7 +242,9 @@ fn t10() {
         name,
         src_hash,
         checksum_hash,
-        stable_id,
+        StableSourceFileId::from_filename_in_current_crate(
+            &PathBuf::from("imported-blork.rs").into(),
+        ),
         source_len.to_u32(),
         CrateNum::ZERO,
         FreezeLock::new(lines.read().clone()),


### PR DESCRIPTION
This is a rebase of https://github.com/rust-lang/rust/pull/115572 which fixes a race by checking if a source file is already present before adding it.