### PR TITLE
Add T-compiler backports Zulip notifications

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -606,9 +606,6 @@ message_on_remove = "Issue #{number}'s prioritization request has been removed."
 message_on_close = "Issue #{number} has been closed while requested for prioritization."
 message_on_reopen = "Issue #{number} has been reopened."
 
-# FIXME: Patch triagebot to support `notify-zulip.<label>` getting mapped to an array of actions.
-#        At the moment, the beta-nominated+T-rustdoc action fully occupies the beta-nominated slot
-#        preventing others from adding more beta-nominated actions.
 [notify-zulip."beta-nominated"]
 required_labels = ["T-rustdoc"]
 zulip_stream = 266220 # #t-rustdoc
@@ -630,9 +627,6 @@ message_on_remove = "PR #{number}'s beta-nomination has been removed."
 message_on_close = "PR #{number} has been closed. Thanks for participating!"
 message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
 
-# FIXME: Patch triagebot to support `notify-zulip.<label>` getting mapped to an array of actions.
-#        At the moment, the beta-accepted+T-rustdoc action fully occupies the beta-accepted slot
-#        preventing others from adding more beta-accepted actions.
 [notify-zulip."beta-accepted"]
 required_labels = ["T-rustdoc"]
 zulip_stream = 266220 # #t-rustdoc
@@ -643,9 +637,6 @@ message_on_remove = "PR #{number}'s beta-acceptance has been **removed**."
 message_on_close = "PR #{number} has been closed. Thanks for participating!"
 message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
 
-# FIXME: Patch triagebot to support `notify-zulip.<label>` getting mapped to an array of actions.
-#        At the moment, the stable-nominated+T-rustdoc action fully occupies the stable-nominated slot
-#        preventing others from adding more stable-nominated actions.
 [notify-zulip."stable-nominated"]
 required_labels = ["T-rustdoc"]
 zulip_stream = 266220 # #t-rustdoc
@@ -668,9 +659,6 @@ message_on_remove = "PR #{number}'s stable-nomination has been removed."
 message_on_close = "PR #{number} has been closed. Thanks for participating!"
 message_on_reopen = "PR #{number} has been reopened. Pinging @*T-rustdoc*."
 
-# FIXME: Patch triagebot to support `notify-zulip.<label>` getting mapped to an array of actions.
-#        At the moment, the stable-accepted+T-rustdoc action fully occupies the stable-accepted slot
-#        preventing others from adding more stable-accepted actions.
 [notify-zulip."stable-accepted"]
 required_labels = ["T-rustdoc"]
 zulip_stream = 266220 # #t-rustdoc
@@ -690,6 +678,41 @@ message_on_add = """\
 message_on_remove = "Issue #{number}'s nomination has been removed. Thanks all for participating!"
 message_on_close = "Issue #{number} has been closed. Thanks for participating!"
 message_on_reopen = "Issue #{number} has been reopened. Pinging @*T-types*."
+
+[notify-zulip."beta-nominated".compiler]
+required_labels = ["T-compiler"]
+zulip_stream = 474880 # #t-compiler/backports
+topic = "#{number}: beta-nominated"
+message_on_add = [
+    """\
+@**channel** PR #{number} "{title}" has been nominated for beta backport.
+""",
+    """\
+/poll Approve beta backport of #{number}?
+approve
+decline
+don't know
+""",
+]
+message_on_remove = "PR #{number}'s beta-nomination has been removed."
+
+[notify-zulip."stable-nominated".compiler]
+required_labels = ["T-compiler"]
+zulip_stream = 474880 # #t-compiler/backports
+topic = "#{number}: stable-nominated"
+message_on_add = [
+    """\
+@**channel** PR #{number} "{title}" has been nominated for stable backport.
+""",
+    """\
+/poll Approve stable backport of #{number}?
+approve
+approve (but does not justify new dot release on its own)
+decline
+don't know
+""",
+]
+message_on_remove = "PR #{number}'s stable-nomination has been removed."
 
 [notify-zulip."A-edition-2021"]
 required_labels = ["C-bug"]


### PR DESCRIPTION
This patch make it so, that the triagebot willl send notifications to the Zulip channel [#t-compiler/backports](https://rust-lang.zulipchat.com/#narrow/channel/474880-t-compiler.2Fbackports) when a label `{stable-beta}-nominated` is added to beta or stable backport pull request. Requirement to trigger this notification is that the pull request be labeled `T-compiler`.

Note: Zulip notifications can send notifications also on other events (`message_on_close` and `message_on_reopen`) but I omitted them for now, I am not yet sure we need them.

r? @davidtwco 