### PR TITLE
Fix backtrace for cygwin

### DIFF
--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -57,7 +57,7 @@ object = { version = "0.36.0", default-features = false, optional = true, featur
     'archive',
 ] }
 
-[target.'cfg(windows)'.dependencies.windows-targets]
+[target.'cfg(any(windows, target_os = "cygwin"))'.dependencies.windows-targets]
 path = "../windows_targets"
 
 [dev-dependencies]

--- a/library/windows_targets/src/lib.rs
+++ b/library/windows_targets/src/lib.rs
@@ -34,6 +34,7 @@ pub macro link {
 }
 
 #[cfg(not(feature = "windows_raw_dylib"))]
+#[cfg(not(target_os = "cygwin"))] // Cygwin doesn't need these libs
 #[cfg_attr(target_vendor = "win7", link(name = "advapi32"))]
 #[link(name = "ntdll")]
 #[link(name = "userenv")]


### PR DESCRIPTION
Closes #140304 

Depends on:
- [x] https://github.com/rust-lang/backtrace-rs/pull/704 

This PR could not be merged until the above PR is merged. I'll update the submodule then.

EDIT: submodule updated.