### PR TITLE
Add `is_inner` information to `rustdoc-json-types`

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -206,8 +206,8 @@ impl AttributeExt for Attribute {
         }
     }
 
-    fn style(&self) -> AttrStyle {
-        self.style
+    fn opt_style(&self) -> Option<AttrStyle> {
+        Some(self.style)
     }
 }
 
@@ -806,7 +806,14 @@ pub trait AttributeExt: Debug {
     /// * `#[doc(...)]` returns `None`.
     fn doc_str_and_comment_kind(&self) -> Option<(Symbol, CommentKind)>;
 
-    fn style(&self) -> AttrStyle;
+    fn style(&self) -> AttrStyle {
+        match self.opt_style() {
+            Some(style) => style,
+            None => panic!("AttributeExt::style: `{self:?}` has no style"),
+        }
+    }
+
+    fn opt_style(&self) -> Option<AttrStyle>;
 }
 
 // FIXME(fn_delegation): use function delegation instead of manually forwarding

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1245,11 +1245,11 @@ impl AttributeExt for Attribute {
     }
 
     #[inline]
-    fn style(&self) -> AttrStyle {
+    fn opt_style(&self) -> Option<AttrStyle> {
         match &self {
-            Attribute::Unparsed(u) => u.style,
-            Attribute::Parsed(AttributeKind::DocComment { style, .. }) => *style,
-            _ => panic!(),
+            Attribute::Unparsed(u) => Some(u.style),
+            Attribute::Parsed(AttributeKind::DocComment { style, .. }) => Some(*style),
+            _ => None,
         }
     }
 }
@@ -1344,6 +1344,11 @@ impl Attribute {
     #[inline]
     pub fn style(&self) -> AttrStyle {
         AttributeExt::style(self)
+    }
+
+    #[inline]
+    pub fn opt_style(&self) -> Option<AttrStyle> {
+        AttributeExt::opt_style(self)
     }
 }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1194,7 +1194,7 @@ fn render_assoc_item(
 // a whitespace prefix and newline.
 fn render_attributes_in_pre(it: &clean::Item, prefix: &str, cx: &Context<'_>) -> impl fmt::Display {
     fmt::from_fn(move |f| {
-        for a in it.attributes(cx.tcx(), cx.cache(), false) {
+        for (_, a) in it.attributes(cx.tcx(), cx.cache(), false) {
             writeln!(f, "{prefix}{a}")?;
         }
         Ok(())
@@ -1204,7 +1204,7 @@ fn render_attributes_in_pre(it: &clean::Item, prefix: &str, cx: &Context<'_>) ->
 // When an attribute is rendered inside a <code> tag, it is formatted using
 // a div to produce a newline after it.
 fn render_attributes_in_code(w: &mut impl fmt::Write, it: &clean::Item, cx: &Context<'_>) {
-    for attr in it.attributes(cx.tcx(), cx.cache(), false) {
+    for (_, attr) in it.attributes(cx.tcx(), cx.cache(), false) {
         write!(w, "<div class=\"code-attribute\">{attr}</div>").unwrap();
     }
 }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -40,7 +40,11 @@ impl JsonRenderer<'_> {
             })
             .collect();
         let docs = item.opt_doc_value();
-        let attrs = item.attributes(self.tcx, self.cache(), true);
+        let attrs = item
+            .attributes(self.tcx, self.cache(), true)
+            .into_iter()
+            .map(|(is_inner, content)| Attribute { is_inner, content })
+            .collect::<Vec<_>>();
         let span = item.span(self.tcx);
         let visibility = item.visibility(self.tcx);
         let clean::ItemInner { name, item_id, .. } = *item.inner;
@@ -767,7 +771,11 @@ impl FromClean<clean::ProcMacro> for ProcMacro {
     fn from_clean(mac: clean::ProcMacro, _renderer: &JsonRenderer<'_>) -> Self {
         ProcMacro {
             kind: from_macro_kind(mac.kind),
-            helpers: mac.helpers.iter().map(|x| x.to_string()).collect(),
+            helpers: mac
+                .helpers
+                .iter()
+                .map(|x| Attribute { is_inner: false, content: x.to_string() })
+                .collect(),
         }
     }
 }

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -30,7 +30,7 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 /// This integer is incremented with every breaking change to the API,
 /// and is returned along with the JSON blob as [`Crate::format_version`].
 /// Consuming code should assert that this value matches the format version(s) that it supports.
-pub const FORMAT_VERSION: u32 = 45;
+pub const FORMAT_VERSION: u32 = 46;
 
 /// The root of the emitted JSON blob.
 ///

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -152,6 +152,15 @@ pub struct ItemSummary {
     pub kind: ItemKind,
 }
 
+/// An attribute (like `#[inline]`).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct Attribute {
+    /// Whether it is an inner (`#![]`) or an outer attribute (`#[]`).
+    pub is_inner: bool,
+    /// The content of the attribute.
+    pub content: String,
+}
+
 /// Anything that can hold documentation - modules, structs, enums, functions, traits, etc.
 ///
 /// The `Item` data type holds fields that can apply to any of these,
@@ -193,7 +202,7 @@ pub struct Item {
     ///
     /// As an internal implementation detail subject to change, this debug-printing format
     /// is currently equivalent to the HIR pretty-printing of parsed attributes.
-    pub attrs: Vec<String>,
+    pub attrs: Vec<Attribute>,
     /// Information about the item’s deprecation, if present.
     pub deprecation: Option<Deprecation>,
     /// The type-specific fields describing this item.
@@ -1301,7 +1310,7 @@ pub struct ProcMacro {
     ///     Some(T),
     /// }
     /// ```
-    pub helpers: Vec<String>,
+    pub helpers: Vec<Attribute>,
 }
 
 /// The way a [`ProcMacro`] is declared to be used.

--- a/tests/rustdoc-json/attrs/automatically_derived.rs
+++ b/tests/rustdoc-json/attrs/automatically_derived.rs
@@ -9,5 +9,5 @@ impl Default for Manual {
     }
 }
 
-//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Derive" && @.inner.impl.trait.path == "Default")].attrs' '["#[automatically_derived]"]'
+//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Derive" && @.inner.impl.trait.path == "Default")].attrs' '[{"content": "#[automatically_derived]", "is_inner": false}]'
 //@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Manual" && @.inner.impl.trait.path == "Default")].attrs' '[]'

--- a/tests/rustdoc-json/attrs/export_name_2021.rs
+++ b/tests/rustdoc-json/attrs/export_name_2021.rs
@@ -1,6 +1,6 @@
 //@ edition: 2021
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[export_name = \"altered\"]"]'
+//@ is "$.index[?(@.name=='example')].attrs" '[{"content": "#[export_name = \"altered\"]", "is_inner": false}]'
 #[export_name = "altered"]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/export_name_2024.rs
+++ b/tests/rustdoc-json/attrs/export_name_2024.rs
@@ -4,6 +4,6 @@
 // The representation of `#[unsafe(export_name = ..)]` in rustdoc in edition 2024
 // is still `#[export_name = ..]` without the `unsafe` attribute wrapper.
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[export_name = \"altered\"]"]'
+//@ is "$.index[?(@.name=='example')].attrs" '[{"content": "#[export_name = \"altered\"]", "is_inner": false}]'
 #[unsafe(export_name = "altered")]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/inner_vs_outer.rs
+++ b/tests/rustdoc-json/attrs/inner_vs_outer.rs
@@ -1,0 +1,7 @@
+#![no_std]
+
+//@ is "$.index[?(@.name=='foo')].attrs" '[{"content": "#[allow(unused)]", "is_inner": false}, {"content": "#[allow(dead_code)]", "is_inner": true}]'
+#[allow(unused)]
+pub mod foo {
+    #![allow(dead_code)]
+}

--- a/tests/rustdoc-json/attrs/must_use.rs
+++ b/tests/rustdoc-json/attrs/must_use.rs
@@ -1,9 +1,9 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[must_use]"]'
+//@ is "$.index[?(@.name=='example')].attrs" '[{"content": "#[must_use]", "is_inner": false}]'
 #[must_use]
 pub fn example() -> impl Iterator<Item = i64> {}
 
-//@ is "$.index[?(@.name=='explicit_message')].attrs" '["#[must_use = \"does nothing if you do not use it\"]"]'
+//@ is "$.index[?(@.name=='explicit_message')].attrs" '[{"content": "#[must_use = \"does nothing if you do not use it\"]", "is_inner": false}]'
 #[must_use = "does nothing if you do not use it"]
 pub fn explicit_message() -> impl Iterator<Item = i64> {}

--- a/tests/rustdoc-json/attrs/no_mangle_2021.rs
+++ b/tests/rustdoc-json/attrs/no_mangle_2021.rs
@@ -1,6 +1,6 @@
 //@ edition: 2021
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[no_mangle]"]'
+//@ is "$.index[?(@.name=='example')].attrs" '[{"content": "#[no_mangle]", "is_inner": false}]'
 #[no_mangle]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/no_mangle_2024.rs
+++ b/tests/rustdoc-json/attrs/no_mangle_2024.rs
@@ -4,6 +4,6 @@
 // The representation of `#[unsafe(no_mangle)]` in rustdoc in edition 2024
 // is still `#[no_mangle]` without the `unsafe` attribute wrapper.
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[no_mangle]"]'
+//@ is "$.index[?(@.name=='example')].attrs" '[{"content": "#[no_mangle]", "is_inner": false}]'
 #[unsafe(no_mangle)]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/non_exhaustive.rs
+++ b/tests/rustdoc-json/attrs/non_exhaustive.rs
@@ -1,18 +1,18 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='MyEnum')].attrs" '["#[non_exhaustive]"]'
+//@ is "$.index[?(@.name=='MyEnum')].attrs" '[{"content": "#[non_exhaustive]", "is_inner": false}]'
 #[non_exhaustive]
 pub enum MyEnum {
     First,
 }
 
 pub enum NonExhaustiveVariant {
-    //@ is "$.index[?(@.name=='Variant')].attrs" '["#[non_exhaustive]"]'
+    //@ is "$.index[?(@.name=='Variant')].attrs" '[{"content": "#[non_exhaustive]", "is_inner": false}]'
     #[non_exhaustive]
     Variant(i64),
 }
 
-//@ is "$.index[?(@.name=='MyStruct')].attrs" '["#[non_exhaustive]"]'
+//@ is "$.index[?(@.name=='MyStruct')].attrs" '[{"content": "#[non_exhaustive]", "is_inner": false}]'
 #[non_exhaustive]
 pub struct MyStruct {
     pub x: i64,

--- a/tests/rustdoc-json/attrs/repr_align.rs
+++ b/tests/rustdoc-json/attrs/repr_align.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='Aligned')].attrs" '["#[repr(align(4))]"]'
+//@ is "$.index[?(@.name=='Aligned')].attrs" '[{"content": "#[repr(align(4))]", "is_inner": false}]'
 #[repr(align(4))]
 pub struct Aligned {
     a: i8,

--- a/tests/rustdoc-json/attrs/repr_c.rs
+++ b/tests/rustdoc-json/attrs/repr_c.rs
@@ -1,16 +1,16 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='ReprCStruct')].attrs" '["#[repr(C)]"]'
+//@ is "$.index[?(@.name=='ReprCStruct')].attrs" '[{"content": "#[repr(C)]", "is_inner": false}]'
 #[repr(C)]
 pub struct ReprCStruct(pub i64);
 
-//@ is "$.index[?(@.name=='ReprCEnum')].attrs" '["#[repr(C)]"]'
+//@ is "$.index[?(@.name=='ReprCEnum')].attrs" '[{"content": "#[repr(C)]", "is_inner": false}]'
 #[repr(C)]
 pub enum ReprCEnum {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReprCUnion')].attrs" '["#[repr(C)]"]'
+//@ is "$.index[?(@.name=='ReprCUnion')].attrs" '[{"content": "#[repr(C)]", "is_inner": false}]'
 #[repr(C)]
 pub union ReprCUnion {
     pub left: i64,

--- a/tests/rustdoc-json/attrs/repr_combination.rs
+++ b/tests/rustdoc-json/attrs/repr_combination.rs
@@ -3,33 +3,33 @@
 // Combinations of `#[repr(..)]` attributes.
 // Rustdoc JSON emits normalized output, regardless of the original source.
 
-//@ is "$.index[?(@.name=='ReprCI8')].attrs" '["#[repr(C, i8)]"]'
+//@ is "$.index[?(@.name=='ReprCI8')].attrs" '[{"content": "#[repr(C, i8)]", "is_inner": false}]'
 #[repr(C, i8)]
 pub enum ReprCI8 {
     First,
 }
 
-//@ is "$.index[?(@.name=='SeparateReprCI16')].attrs" '["#[repr(C, i16)]"]'
+//@ is "$.index[?(@.name=='SeparateReprCI16')].attrs" '[{"content": "#[repr(C, i16)]", "is_inner": false}]'
 #[repr(C)]
 #[repr(i16)]
 pub enum SeparateReprCI16 {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReversedReprCUsize')].attrs" '["#[repr(C, usize)]"]'
+//@ is "$.index[?(@.name=='ReversedReprCUsize')].attrs" '[{"content": "#[repr(C, usize)]", "is_inner": false}]'
 #[repr(usize, C)]
 pub enum ReversedReprCUsize {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReprCPacked')].attrs" '["#[repr(C, packed(1))]"]'
+//@ is "$.index[?(@.name=='ReprCPacked')].attrs" '[{"content": "#[repr(C, packed(1))]", "is_inner": false}]'
 #[repr(C, packed)]
 pub struct ReprCPacked {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='SeparateReprCPacked')].attrs" '["#[repr(C, packed(2))]"]'
+//@ is "$.index[?(@.name=='SeparateReprCPacked')].attrs" '[{"content": "#[repr(C, packed(2))]", "is_inner": false}]'
 #[repr(C)]
 #[repr(packed(2))]
 pub struct SeparateReprCPacked {
@@ -37,21 +37,21 @@ pub struct SeparateReprCPacked {
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='ReversedReprCPacked')].attrs" '["#[repr(C, packed(2))]"]'
+//@ is "$.index[?(@.name=='ReversedReprCPacked')].attrs" '[{"content": "#[repr(C, packed(2))]", "is_inner": false}]'
 #[repr(packed(2), C)]
 pub struct ReversedReprCPacked {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='ReprCAlign')].attrs" '["#[repr(C, align(16))]"]'
+//@ is "$.index[?(@.name=='ReprCAlign')].attrs" '[{"content": "#[repr(C, align(16))]", "is_inner": false}]'
 #[repr(C, align(16))]
 pub struct ReprCAlign {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='SeparateReprCAlign')].attrs" '["#[repr(C, align(2))]"]'
+//@ is "$.index[?(@.name=='SeparateReprCAlign')].attrs" '[{"content": "#[repr(C, align(2))]", "is_inner": false}]'
 #[repr(C)]
 #[repr(align(2))]
 pub struct SeparateReprCAlign {
@@ -59,20 +59,20 @@ pub struct SeparateReprCAlign {
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='ReversedReprCAlign')].attrs" '["#[repr(C, align(2))]"]'
+//@ is "$.index[?(@.name=='ReversedReprCAlign')].attrs" '[{"content": "#[repr(C, align(2))]", "is_inner": false}]'
 #[repr(align(2), C)]
 pub struct ReversedReprCAlign {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='AlignedExplicitRepr')].attrs" '["#[repr(C, align(16), isize)]"]'
+//@ is "$.index[?(@.name=='AlignedExplicitRepr')].attrs" '[{"content": "#[repr(C, align(16), isize)]", "is_inner": false}]'
 #[repr(C, align(16), isize)]
 pub enum AlignedExplicitRepr {
     First,
 }
 
-//@ is "$.index[?(@.name=='ReorderedAlignedExplicitRepr')].attrs" '["#[repr(C, align(16), isize)]"]'
+//@ is "$.index[?(@.name=='ReorderedAlignedExplicitRepr')].attrs" '[{"content": "#[repr(C, align(16), isize)]", "is_inner": false}]'
 #[repr(isize, C, align(16))]
 pub enum ReorderedAlignedExplicitRepr {
     First,

--- a/tests/rustdoc-json/attrs/repr_int_enum.rs
+++ b/tests/rustdoc-json/attrs/repr_int_enum.rs
@@ -1,18 +1,18 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='I8')].attrs" '["#[repr(i8)]"]'
+//@ is "$.index[?(@.name=='I8')].attrs" '[{"content": "#[repr(i8)]", "is_inner": false}]'
 #[repr(i8)]
 pub enum I8 {
     First,
 }
 
-//@ is "$.index[?(@.name=='I32')].attrs" '["#[repr(i32)]"]'
+//@ is "$.index[?(@.name=='I32')].attrs" '[{"content": "#[repr(i32)]", "is_inner": false}]'
 #[repr(i32)]
 pub enum I32 {
     First,
 }
 
-//@ is "$.index[?(@.name=='Usize')].attrs" '["#[repr(usize)]"]'
+//@ is "$.index[?(@.name=='Usize')].attrs" '[{"content": "#[repr(usize)]", "is_inner": false}]'
 #[repr(usize)]
 pub enum Usize {
     First,

--- a/tests/rustdoc-json/attrs/repr_packed.rs
+++ b/tests/rustdoc-json/attrs/repr_packed.rs
@@ -3,14 +3,14 @@
 // Note the normalization:
 // `#[repr(packed)]` in source becomes `#[repr(packed(1))]` in rustdoc JSON.
 //
-//@ is "$.index[?(@.name=='Packed')].attrs" '["#[repr(packed(1))]"]'
+//@ is "$.index[?(@.name=='Packed')].attrs" '[{"content": "#[repr(packed(1))]", "is_inner": false}]'
 #[repr(packed)]
 pub struct Packed {
     a: i8,
     b: i64,
 }
 
-//@ is "$.index[?(@.name=='PackedAligned')].attrs" '["#[repr(packed(4))]"]'
+//@ is "$.index[?(@.name=='PackedAligned')].attrs" '[{"content": "#[repr(packed(4))]", "is_inner": false}]'
 #[repr(packed(4))]
 pub struct PackedAligned {
     a: i8,

--- a/tests/rustdoc-json/attrs/repr_transparent.rs
+++ b/tests/rustdoc-json/attrs/repr_transparent.rs
@@ -10,7 +10,7 @@
 // Here, the non-1-ZST field is public.
 // We expect `#[repr(transparent)]` in the attributes.
 //
-//@ is "$.index[?(@.name=='Transparent')].attrs" '["#[repr(transparent)]"]'
+//@ is "$.index[?(@.name=='Transparent')].attrs" '[{"content": "#[repr(transparent)]", "is_inner": false}]'
 #[repr(transparent)]
 pub struct Transparent(pub i64);
 
@@ -24,7 +24,7 @@ pub struct TransparentNonPub(i64);
 // Only 1-ZST fields here, and one of them is public.
 // We expect `#[repr(transparent)]` in the attributes.
 //
-//@ is "$.index[?(@.name=='AllZst')].attrs" '["#[repr(transparent)]"]'
+//@ is "$.index[?(@.name=='AllZst')].attrs" '[{"content": "#[repr(transparent)]", "is_inner": false}]'
 #[repr(transparent)]
 pub struct AllZst<'a>(pub core::marker::PhantomData<&'a ()>, ());
 

--- a/tests/rustdoc-json/enums/discriminant/struct.rs
+++ b/tests/rustdoc-json/enums/discriminant/struct.rs
@@ -1,5 +1,5 @@
 #[repr(i32)]
-//@ is "$.index[?(@.name=='Foo')].attrs" '["#[repr(i32)]"]'
+//@ is "$.index[?(@.name=='Foo')].attrs" '[{"content": "#[repr(i32)]", "is_inner": false}]'
 pub enum Foo {
     //@ is    "$.index[?(@.name=='Struct')].inner.variant.discriminant" null
     //@ count "$.index[?(@.name=='Struct')].inner.variant.kind.struct.fields[*]" 0

--- a/tests/rustdoc-json/enums/discriminant/tuple.rs
+++ b/tests/rustdoc-json/enums/discriminant/tuple.rs
@@ -1,5 +1,5 @@
 #[repr(u32)]
-//@ is "$.index[?(@.name=='Foo')].attrs" '["#[repr(u32)]"]'
+//@ is "$.index[?(@.name=='Foo')].attrs" '[{"content": "#[repr(u32)]", "is_inner": false}]'
 pub enum Foo {
     //@ is    "$.index[?(@.name=='Tuple')].inner.variant.discriminant" null
     //@ count "$.index[?(@.name=='Tuple')].inner.variant.kind.tuple[*]" 0

--- a/tests/rustdoc-json/keyword_private.rs
+++ b/tests/rustdoc-json/keyword_private.rs
@@ -5,7 +5,7 @@
 
 //@ !has "$.index[?(@.name=='match')]"
 //@ has  "$.index[?(@.name=='foo')]"
-//@ is   "$.index[?(@.name=='foo')].attrs" '["#[doc(keyword = \"match\")]"]'
+//@ is   "$.index[?(@.name=='foo')].attrs" '[{"content": "#[doc(keyword = \"match\")]", "is_inner": false}]'
 //@ is   "$.index[?(@.name=='foo')].docs" '"this is a test!"'
 #[doc(keyword = "match")]
 /// this is a test!
@@ -13,7 +13,7 @@ pub mod foo {}
 
 //@ !has "$.index[?(@.name=='break')]"
 //@ has "$.index[?(@.name=='bar')]"
-//@ is   "$.index[?(@.name=='bar')].attrs" '["#[doc(keyword = \"break\")]"]'
+//@ is   "$.index[?(@.name=='bar')].attrs" '[{"content": "#[doc(keyword = \"break\")]", "is_inner": false}]'
 //@ is   "$.index[?(@.name=='bar')].docs" '"hello"'
 #[doc(keyword = "break")]
 /// hello


### PR DESCRIPTION
Part of #137645.

Since it adds more information for attributes, I suppose the next step could be to add `span` on them as well.

cc @urgau for the compiler changes.
r? @aDotInTheVoid 