### PR TITLE
Add `c_longdouble`

### DIFF
--- a/library/core/src/ffi/c_longdouble.md
+++ b/library/core/src/ffi/c_longdouble.md
@@ -1,0 +1,7 @@
+Equivalent to C's `long double` type.
+
+This type is [`f64`] on Apple and Windows targets, [`f128`] on most 64-bits unix
+targets, x87_f80 on x86, a randomly chosen type on powerpc, and usually the same
+as [`c_double`] on 32-bit targets.
+
+[`float`]: c_float

--- a/library/core/src/ffi/mod.rs
+++ b/library/core/src/ffi/mod.rs
@@ -38,6 +38,8 @@ pub use self::va_list::{VaList, VaListImpl};
 pub mod va_list;
 
 mod primitives;
+#[unstable(feature = "c_longdouble", issue = "none")]
+pub use self::primitives::c_longdouble;
 #[stable(feature = "core_ffi_c", since = "1.64.0")]
 pub use self::primitives::{
     c_char, c_double, c_float, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint,

--- a/library/core/src/ffi/primitives.rs
+++ b/library/core/src/ffi/primitives.rs
@@ -33,6 +33,7 @@ type_alias! { "c_ulonglong.md", c_ulonglong = u64; }
 
 type_alias! { "c_float.md", c_float = f32; }
 type_alias! { "c_double.md", c_double = f64; }
+type_alias! { "c_longdouble.md", c_longdouble = c_longdouble_definition::c_longdouble; #[doc(cfg(all()))] }
 
 mod c_char_definition {
     crate::cfg_match! {
@@ -180,6 +181,60 @@ mod c_int_definition {
         _ => {
             pub(super) type c_int = i32;
             pub(super) type c_uint = u32;
+        }
+    }
+}
+
+mod c_longdouble_definition {
+    crate::cfg_match! {
+        any(
+            // Windows and Apple use f64 across the board
+            target_family = "windows",
+            target_vendor = "apple",
+            // FreeBSD-like operating systems use f64 on mips
+            all(
+                target_arch = "mips64",
+                any(target_os = "freebsd", target_os = "dragonfly")
+            ),
+        ) => {
+            pub(super) type c_longdouble = f64;
+        }
+        any(target_arch = "powerpc", target_arch = "powerpc64") => {
+            // double-double or f128 based on config
+            compile_error!("who knows");
+        }
+        any(
+            target_arch = "aarch64",
+            // Not yet implemented
+            // target_arch = "loongarch32",
+            target_arch = "loongarch64",
+            target_arch = "mips64",
+            target_arch = "riscv32",
+            target_arch = "riscv64",
+            target_arch = "s390x",
+            target_arch = "wasm32",
+            target_arch = "wasm64",
+            // Note: mips32 with the N32 ABI is also f128 (?)
+
+            // Android and OpenHarmony use f128 on x86
+            all(
+                any(target_arch = "x86", target_arch = "x86_64"),
+                any(target_os = "android", target_env = "ohos")
+            ),
+            // Default to f128 for other 64-bit targets
+            all(not(target_arch = "x86_64"), target_pointer_width = "64")
+        ) => {
+            pub(super) type c_longdouble = f128;
+        }
+        // Most other operating systems use the x87 80-bit extended precision float
+        any(target_arch = "x86", target_arch = "x86_64") => {
+            // todo: obviously this isn't right
+            pub(super) type c_longdouble = ();
+        }
+        // Most 16- and 32-bit targets use the same size as `c_double`, usually `f64` but
+        // possibly `f32` on e.g. AVR.
+        _ => {
+            pub(super) type c_longdouble = c_double;
         }
     }
 }

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -164,6 +164,8 @@
 #[stable(feature = "c_str_module", since = "CURRENT_RUSTC_VERSION")]
 pub mod c_str;
 
+#[unstable(feature = "c_size_", issue = "none")]
+pub use core::ffi::c_longdouble;
 #[stable(feature = "core_c_void", since = "1.30.0")]
 pub use core::ffi::c_void;
 #[unstable(


### PR DESCRIPTION
We don't have all the types needed to actually provide this, so for now this is only a reference. Most of the links in the c_char definition apply here:

- f64 on Windows https://learn.microsoft.com/en-us/cpp/c-language/type-long-double?view=msvc-170
- f64 on Apple https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms#Handle-data-types-and-data-alignment-properly
- f128 on aarch64 https://github.com/ARM-software/abi-aa/blob/2024Q3/aapcs64/aapcs64.rst#arm-c-and-c-language-mappings
- f64 on arm32 https://github.com/ARM-software/abi-aa/blob/2024Q3/aapcs32/aapcs32.rst#arm-c-and-c-language-mappings
- f64 on csky https://github.com/c-sky/csky-doc/blob/9f7121f7d40970ba5cc0f15716da033db2bb9d07/C-SKY_V2_CPU_Applications_Binary_Interface_Standards_Manual.pdf Table 2.2: Mapping of C Fundamental Data Types to the C-SKY
- f64 on hexagon https://docs.qualcomm.com/bundle/publicresource/80-N2040-23_REV_K_Qualcomm_Hexagon_Application_Binary_Interface_User_Guide.pdf Table 3-1 Basic data type representation
- f64 on msp430 https://www.ti.com/lit/an/slaa534a/slaa534a.pdf Table 2-1. Data Sizes for Standard Types
- ppc_f128 or f128 on ppc https://gcc.gnu.org/wiki/Ieee128PowerPC
- f128 on riscv32 and riscv64 https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/draft-20240829-13bfa9f54634cb60d86b9b333e109f077805b4b3/riscv-cc.adoc#cc-type-sizes-and-alignments
- f128 on s390x https://linux.mainframe.blog/zarchitecture-principles-of-operation/ 
- f32 on xtensa  https://loboris.eu/ESP32/Xtensa_lx%20Overview%20handbook.pdf Table 59. Data Types and Alignment
- x87_f80 on x86 https://gitlab.com/x86-psABIs/x86-64-ABI/-/blob/master/x86-64-ABI/low-level-sys-info.tex#L198-199

For everything else, try to match Clang. 

Some scratch https://godbolt.org/z/YrYKshMMa

<!-- homu-ignore:start -->
r? @ghost
<!-- homu-ignore:end -->
