### PR TITLE
unwind: bump `unwinding` dependency to 0.2.6

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "unwinding"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f06a05848f650946acef3bf525fe96612226b61f74ae23ffa4e98bfbb8ab3c"
+checksum = "8393f2782b6060a807337ff353780c1ca15206f9ba2424df18cb6e733bd7b345"
 dependencies = [
  "compiler_builtins",
  "gimli",

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 libc = { version = "0.2.140", features = ['rustc-dep-of-std'], default-features = false }
 
 [target.'cfg(target_os = "xous")'.dependencies]
-unwinding = { version = "0.2.5", features = ['rustc-dep-of-std', 'unwinder', 'fde-custom'], default-features = false }
+unwinding = { version = "0.2.6", features = ['rustc-dep-of-std', 'unwinder', 'fde-custom'], default-features = false }
 
 [features]
 


### PR DESCRIPTION
Xous now fails to compile under nightly, due to the recent change where `#[naked]` must now be wrapped in `unsafe(...)`. The `unwinding` crate was updated to account for this.

With the following `bootstrap.toml`:

```
profile = "library"
change-id = 138934

[build]
build-stage = 2
target = ["riscv32imac-unknown-xous-elf"]

[rust]
std-features = ["panic-unwind"]
download-rustc = false
```

The build fails when trying unwinding v0.2.5:
```
$ ./x.py build
[...]
   Compiling unwinding v0.2.5
error: unsafe attribute used without unsafe
   --> /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/unwinding-0.2.5/src/unwinder/arch/riscv32.rs:176:3
    |
176 | #[naked]
    |   ^^^^^ usage of unsafe attribute
    |
help: wrap the attribute in `unsafe(...)`
    |
176 | #[unsafe(naked)]
    |   +++++++     +

error: could not compile `unwinding` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Build completed unsuccessfully in 0:06:26
$
```

This patch updates `unwinding` to v0.2.6, which now wraps all issues of `naked` in `unsafe()`.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
