### PR TITLE
hir: Don't allocate for intrinsic inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,6 +3740,7 @@ dependencies = [
 name = "rustc_hir_analysis"
 version = "0.0.0"
 dependencies = [
+ "arrayvec",
  "itertools",
  "rustc_abi",
  "rustc_arena",

--- a/compiler/rustc_hir_analysis/Cargo.toml
+++ b/compiler/rustc_hir_analysis/Cargo.toml
@@ -9,6 +9,7 @@ doctest = false
 
 [dependencies]
 # tidy-alphabetical-start
+arrayvec = { version = "0.7", default-features = false }
 itertools = "0.12"
 rustc_abi = { path = "../rustc_abi" }
 rustc_arena = { path = "../rustc_arena" }

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -1,5 +1,6 @@
 //! Type-checking for the `#[rustc_intrinsic]` intrinsics that the compiler exposes.
 
+use arrayvec::ArrayVec;
 use rustc_abi::ExternAbi;
 use rustc_errors::DiagMessage;
 use rustc_hir::{self as hir, LangItem};
@@ -154,6 +155,12 @@ pub(crate) fn check_intrinsic_type(
     span: Span,
     intrinsic_name: Symbol,
 ) {
+    /// Shorthand to construct an `ArrayVec` with length 10.
+    fn invec<T, const N: usize>(x: [T; N]) -> ArrayVec<T, 4> {
+        const { assert!(N <= 4, "need to expand ArrayVec len") };
+        ArrayVec::from_iter(x)
+    }
+
     let generics = tcx.generics_of(intrinsic_id);
     let param = |n| {
         if let &ty::GenericParamDef { name, kind: ty::GenericParamDefKind::Type { .. }, .. } =
@@ -199,15 +206,15 @@ pub(crate) fn check_intrinsic_type(
         let (n_tps, inputs, output) = match split[1] {
             "cxchg" | "cxchgweak" => (
                 1,
-                vec![Ty::new_mut_ptr(tcx, param(0)), param(0), param(0)],
+                invec([Ty::new_mut_ptr(tcx, param(0)), param(0), param(0)]),
                 Ty::new_tup(tcx, &[param(0), tcx.types.bool]),
             ),
-            "load" => (1, vec![Ty::new_imm_ptr(tcx, param(0))], param(0)),
-            "store" => (1, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit),
+            "load" => (1, invec([Ty::new_imm_ptr(tcx, param(0))]), param(0)),
+            "store" => (1, invec([Ty::new_mut_ptr(tcx, param(0)), param(0)]), tcx.types.unit),
 
             "xchg" | "xadd" | "xsub" | "and" | "nand" | "or" | "xor" | "max" | "min" | "umax"
-            | "umin" => (1, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], param(0)),
-            "fence" | "singlethreadfence" => (0, Vec::new(), tcx.types.unit),
+            | "umin" => (1, invec([Ty::new_mut_ptr(tcx, param(0)), param(0)]), param(0)),
+            "fence" | "singlethreadfence" => (0, ArrayVec::new(), tcx.types.unit),
             op => {
                 tcx.dcx().emit_err(UnrecognizedAtomicOperation { span, op });
                 return;
@@ -219,283 +226,300 @@ pub(crate) fn check_intrinsic_type(
         // where C: for<'a> Fn(&'a Ret) -> bool,
         //
         // so: two type params, 0 lifetime param, 0 const params, two inputs, no return
-        (2, 0, 0, vec![param(0), param(1)], param(1), hir::Safety::Safe)
+        (2, 0, 0, invec([param(0), param(1)]), param(1), hir::Safety::Safe)
     } else {
         let safety = intrinsic_operation_unsafety(tcx, intrinsic_id);
         let (n_tps, n_cts, inputs, output) = match intrinsic_name {
-            sym::abort => (0, 0, vec![], tcx.types.never),
-            sym::unreachable => (0, 0, vec![], tcx.types.never),
-            sym::breakpoint => (0, 0, vec![], tcx.types.unit),
+            sym::abort => (0, 0, invec([]), tcx.types.never),
+            sym::unreachable => (0, 0, invec([]), tcx.types.never),
+            sym::breakpoint => (0, 0, invec([]), tcx.types.unit),
             sym::size_of | sym::pref_align_of | sym::min_align_of | sym::variant_count => {
-                (1, 0, vec![], tcx.types.usize)
+                (1, 0, invec([]), tcx.types.usize)
             }
             sym::size_of_val | sym::min_align_of_val => {
-                (1, 0, vec![Ty::new_imm_ptr(tcx, param(0))], tcx.types.usize)
+                (1, 0, invec([Ty::new_imm_ptr(tcx, param(0))]), tcx.types.usize)
             }
-            sym::rustc_peek => (1, 0, vec![param(0)], param(0)),
-            sym::caller_location => (0, 0, vec![], tcx.caller_location_ty()),
+            sym::rustc_peek => (1, 0, invec([param(0)]), param(0)),
+            sym::caller_location => (0, 0, invec([]), tcx.caller_location_ty()),
             sym::assert_inhabited
             | sym::assert_zero_valid
-            | sym::assert_mem_uninitialized_valid => (1, 0, vec![], tcx.types.unit),
-            sym::forget => (1, 0, vec![param(0)], tcx.types.unit),
-            sym::transmute | sym::transmute_unchecked => (2, 0, vec![param(0)], param(1)),
+            | sym::assert_mem_uninitialized_valid => (1, 0, invec([]), tcx.types.unit),
+            sym::forget => (1, 0, invec([param(0)]), tcx.types.unit),
+            sym::transmute | sym::transmute_unchecked => (2, 0, invec([param(0)]), param(1)),
             sym::prefetch_read_data
             | sym::prefetch_write_data
             | sym::prefetch_read_instruction
             | sym::prefetch_write_instruction => {
-                (1, 0, vec![Ty::new_imm_ptr(tcx, param(0)), tcx.types.i32], tcx.types.unit)
+                (1, 0, invec([Ty::new_imm_ptr(tcx, param(0)), tcx.types.i32]), tcx.types.unit)
             }
-            sym::needs_drop => (1, 0, vec![], tcx.types.bool),
+            sym::needs_drop => (1, 0, invec([]), tcx.types.bool),
 
-            sym::type_name => (1, 0, vec![], Ty::new_static_str(tcx)),
-            sym::type_id => (1, 0, vec![], tcx.types.u128),
-            sym::offset => (2, 0, vec![param(0), param(1)], param(0)),
+            sym::type_name => (1, 0, invec([]), Ty::new_static_str(tcx)),
+            sym::type_id => (1, 0, invec([]), tcx.types.u128),
+            sym::offset => (2, 0, invec([param(0), param(1)]), param(0)),
             sym::arith_offset => (
                 1,
                 0,
-                vec![Ty::new_imm_ptr(tcx, param(0)), tcx.types.isize],
+                invec([Ty::new_imm_ptr(tcx, param(0)), tcx.types.isize]),
                 Ty::new_imm_ptr(tcx, param(0)),
             ),
             sym::ptr_mask => (
                 1,
                 0,
-                vec![Ty::new_imm_ptr(tcx, param(0)), tcx.types.usize],
+                invec([Ty::new_imm_ptr(tcx, param(0)), tcx.types.usize]),
                 Ty::new_imm_ptr(tcx, param(0)),
             ),
 
             sym::copy | sym::copy_nonoverlapping => (
                 1,
                 0,
-                vec![
+                invec([
                     Ty::new_imm_ptr(tcx, param(0)),
                     Ty::new_mut_ptr(tcx, param(0)),
                     tcx.types.usize,
-                ],
+                ]),
                 tcx.types.unit,
             ),
             sym::volatile_copy_memory | sym::volatile_copy_nonoverlapping_memory => (
                 1,
                 0,
-                vec![
+                invec([
                     Ty::new_mut_ptr(tcx, param(0)),
                     Ty::new_imm_ptr(tcx, param(0)),
                     tcx.types.usize,
-                ],
+                ]),
                 tcx.types.unit,
             ),
             sym::compare_bytes => {
                 let byte_ptr = Ty::new_imm_ptr(tcx, tcx.types.u8);
-                (0, 0, vec![byte_ptr, byte_ptr, tcx.types.usize], tcx.types.i32)
+                (0, 0, invec([byte_ptr, byte_ptr, tcx.types.usize]), tcx.types.i32)
             }
             sym::write_bytes | sym::volatile_set_memory => (
                 1,
                 0,
-                vec![Ty::new_mut_ptr(tcx, param(0)), tcx.types.u8, tcx.types.usize],
+                invec([Ty::new_mut_ptr(tcx, param(0)), tcx.types.u8, tcx.types.usize]),
                 tcx.types.unit,
             ),
 
-            sym::sqrtf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::sqrtf32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::sqrtf64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::sqrtf128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::sqrtf16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::sqrtf32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::sqrtf64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::sqrtf128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::powif16 => (0, 0, vec![tcx.types.f16, tcx.types.i32], tcx.types.f16),
-            sym::powif32 => (0, 0, vec![tcx.types.f32, tcx.types.i32], tcx.types.f32),
-            sym::powif64 => (0, 0, vec![tcx.types.f64, tcx.types.i32], tcx.types.f64),
-            sym::powif128 => (0, 0, vec![tcx.types.f128, tcx.types.i32], tcx.types.f128),
+            sym::powif16 => (0, 0, invec([tcx.types.f16, tcx.types.i32]), tcx.types.f16),
+            sym::powif32 => (0, 0, invec([tcx.types.f32, tcx.types.i32]), tcx.types.f32),
+            sym::powif64 => (0, 0, invec([tcx.types.f64, tcx.types.i32]), tcx.types.f64),
+            sym::powif128 => (0, 0, invec([tcx.types.f128, tcx.types.i32]), tcx.types.f128),
 
-            sym::sinf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::sinf32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::sinf64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::sinf128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::sinf16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::sinf32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::sinf64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::sinf128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::cosf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::cosf32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::cosf64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::cosf128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::cosf16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::cosf32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::cosf64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::cosf128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::powf16 => (0, 0, vec![tcx.types.f16, tcx.types.f16], tcx.types.f16),
-            sym::powf32 => (0, 0, vec![tcx.types.f32, tcx.types.f32], tcx.types.f32),
-            sym::powf64 => (0, 0, vec![tcx.types.f64, tcx.types.f64], tcx.types.f64),
-            sym::powf128 => (0, 0, vec![tcx.types.f128, tcx.types.f128], tcx.types.f128),
+            sym::powf16 => (0, 0, invec([tcx.types.f16, tcx.types.f16]), tcx.types.f16),
+            sym::powf32 => (0, 0, invec([tcx.types.f32, tcx.types.f32]), tcx.types.f32),
+            sym::powf64 => (0, 0, invec([tcx.types.f64, tcx.types.f64]), tcx.types.f64),
+            sym::powf128 => (0, 0, invec([tcx.types.f128, tcx.types.f128]), tcx.types.f128),
 
-            sym::expf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::expf32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::expf64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::expf128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::expf16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::expf32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::expf64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::expf128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::exp2f16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::exp2f32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::exp2f64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::exp2f128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::exp2f16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::exp2f32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::exp2f64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::exp2f128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::logf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::logf32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::logf64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::logf128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::logf16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::logf32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::logf64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::logf128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::log10f16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::log10f32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::log10f64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::log10f128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::log10f16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::log10f32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::log10f64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::log10f128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::log2f16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::log2f32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::log2f64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::log2f128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::log2f16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::log2f32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::log2f64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::log2f128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::fmaf16 => (0, 0, vec![tcx.types.f16, tcx.types.f16, tcx.types.f16], tcx.types.f16),
-            sym::fmaf32 => (0, 0, vec![tcx.types.f32, tcx.types.f32, tcx.types.f32], tcx.types.f32),
-            sym::fmaf64 => (0, 0, vec![tcx.types.f64, tcx.types.f64, tcx.types.f64], tcx.types.f64),
+            sym::fmaf16 => {
+                (0, 0, invec([tcx.types.f16, tcx.types.f16, tcx.types.f16]), tcx.types.f16)
+            }
+            sym::fmaf32 => {
+                (0, 0, invec([tcx.types.f32, tcx.types.f32, tcx.types.f32]), tcx.types.f32)
+            }
+            sym::fmaf64 => {
+                (0, 0, invec([tcx.types.f64, tcx.types.f64, tcx.types.f64]), tcx.types.f64)
+            }
             sym::fmaf128 => {
-                (0, 0, vec![tcx.types.f128, tcx.types.f128, tcx.types.f128], tcx.types.f128)
+                (0, 0, invec([tcx.types.f128, tcx.types.f128, tcx.types.f128]), tcx.types.f128)
             }
 
             sym::fmuladdf16 => {
-                (0, 0, vec![tcx.types.f16, tcx.types.f16, tcx.types.f16], tcx.types.f16)
+                (0, 0, invec([tcx.types.f16, tcx.types.f16, tcx.types.f16]), tcx.types.f16)
             }
             sym::fmuladdf32 => {
-                (0, 0, vec![tcx.types.f32, tcx.types.f32, tcx.types.f32], tcx.types.f32)
+                (0, 0, invec([tcx.types.f32, tcx.types.f32, tcx.types.f32]), tcx.types.f32)
             }
             sym::fmuladdf64 => {
-                (0, 0, vec![tcx.types.f64, tcx.types.f64, tcx.types.f64], tcx.types.f64)
+                (0, 0, invec([tcx.types.f64, tcx.types.f64, tcx.types.f64]), tcx.types.f64)
             }
             sym::fmuladdf128 => {
-                (0, 0, vec![tcx.types.f128, tcx.types.f128, tcx.types.f128], tcx.types.f128)
+                (0, 0, invec([tcx.types.f128, tcx.types.f128, tcx.types.f128]), tcx.types.f128)
             }
 
-            sym::fabsf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::fabsf32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::fabsf64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::fabsf128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::fabsf16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::fabsf32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::fabsf64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::fabsf128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::minnumf16 => (0, 0, vec![tcx.types.f16, tcx.types.f16], tcx.types.f16),
-            sym::minnumf32 => (0, 0, vec![tcx.types.f32, tcx.types.f32], tcx.types.f32),
-            sym::minnumf64 => (0, 0, vec![tcx.types.f64, tcx.types.f64], tcx.types.f64),
-            sym::minnumf128 => (0, 0, vec![tcx.types.f128, tcx.types.f128], tcx.types.f128),
+            sym::minnumf16 => (0, 0, invec([tcx.types.f16, tcx.types.f16]), tcx.types.f16),
+            sym::minnumf32 => (0, 0, invec([tcx.types.f32, tcx.types.f32]), tcx.types.f32),
+            sym::minnumf64 => (0, 0, invec([tcx.types.f64, tcx.types.f64]), tcx.types.f64),
+            sym::minnumf128 => (0, 0, invec([tcx.types.f128, tcx.types.f128]), tcx.types.f128),
 
-            sym::maxnumf16 => (0, 0, vec![tcx.types.f16, tcx.types.f16], tcx.types.f16),
-            sym::maxnumf32 => (0, 0, vec![tcx.types.f32, tcx.types.f32], tcx.types.f32),
-            sym::maxnumf64 => (0, 0, vec![tcx.types.f64, tcx.types.f64], tcx.types.f64),
-            sym::maxnumf128 => (0, 0, vec![tcx.types.f128, tcx.types.f128], tcx.types.f128),
+            sym::maxnumf16 => (0, 0, invec([tcx.types.f16, tcx.types.f16]), tcx.types.f16),
+            sym::maxnumf32 => (0, 0, invec([tcx.types.f32, tcx.types.f32]), tcx.types.f32),
+            sym::maxnumf64 => (0, 0, invec([tcx.types.f64, tcx.types.f64]), tcx.types.f64),
+            sym::maxnumf128 => (0, 0, invec([tcx.types.f128, tcx.types.f128]), tcx.types.f128),
 
-            sym::copysignf16 => (0, 0, vec![tcx.types.f16, tcx.types.f16], tcx.types.f16),
-            sym::copysignf32 => (0, 0, vec![tcx.types.f32, tcx.types.f32], tcx.types.f32),
-            sym::copysignf64 => (0, 0, vec![tcx.types.f64, tcx.types.f64], tcx.types.f64),
-            sym::copysignf128 => (0, 0, vec![tcx.types.f128, tcx.types.f128], tcx.types.f128),
+            sym::copysignf16 => (0, 0, invec([tcx.types.f16, tcx.types.f16]), tcx.types.f16),
+            sym::copysignf32 => (0, 0, invec([tcx.types.f32, tcx.types.f32]), tcx.types.f32),
+            sym::copysignf64 => (0, 0, invec([tcx.types.f64, tcx.types.f64]), tcx.types.f64),
+            sym::copysignf128 => (0, 0, invec([tcx.types.f128, tcx.types.f128]), tcx.types.f128),
 
-            sym::floorf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::floorf32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::floorf64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::floorf128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::floorf16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::floorf32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::floorf64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::floorf128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::ceilf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::ceilf32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::ceilf64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::ceilf128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::ceilf16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::ceilf32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::ceilf64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::ceilf128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::truncf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::truncf32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::truncf64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::truncf128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::truncf16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::truncf32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::truncf64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::truncf128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::round_ties_even_f16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::round_ties_even_f32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::round_ties_even_f64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::round_ties_even_f128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::round_ties_even_f16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::round_ties_even_f32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::round_ties_even_f64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::round_ties_even_f128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
-            sym::roundf16 => (0, 0, vec![tcx.types.f16], tcx.types.f16),
-            sym::roundf32 => (0, 0, vec![tcx.types.f32], tcx.types.f32),
-            sym::roundf64 => (0, 0, vec![tcx.types.f64], tcx.types.f64),
-            sym::roundf128 => (0, 0, vec![tcx.types.f128], tcx.types.f128),
+            sym::roundf16 => (0, 0, invec([tcx.types.f16]), tcx.types.f16),
+            sym::roundf32 => (0, 0, invec([tcx.types.f32]), tcx.types.f32),
+            sym::roundf64 => (0, 0, invec([tcx.types.f64]), tcx.types.f64),
+            sym::roundf128 => (0, 0, invec([tcx.types.f128]), tcx.types.f128),
 
             sym::volatile_load | sym::unaligned_volatile_load => {
-                (1, 0, vec![Ty::new_imm_ptr(tcx, param(0))], param(0))
+                (1, 0, invec([Ty::new_imm_ptr(tcx, param(0))]), param(0))
             }
             sym::volatile_store | sym::unaligned_volatile_store => {
-                (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit)
+                (1, 0, invec([Ty::new_mut_ptr(tcx, param(0)), param(0)]), tcx.types.unit)
             }
 
             sym::ctpop | sym::ctlz | sym::ctlz_nonzero | sym::cttz | sym::cttz_nonzero => {
-                (1, 0, vec![param(0)], tcx.types.u32)
+                (1, 0, invec([param(0)]), tcx.types.u32)
             }
 
-            sym::bswap | sym::bitreverse => (1, 0, vec![param(0)], param(0)),
+            sym::bswap | sym::bitreverse => (1, 0, invec([param(0)]), param(0)),
 
             sym::three_way_compare => {
-                (1, 0, vec![param(0), param(0)], tcx.ty_ordering_enum(Some(span)))
+                (1, 0, invec([param(0), param(0)]), tcx.ty_ordering_enum(Some(span)))
             }
 
             sym::add_with_overflow | sym::sub_with_overflow | sym::mul_with_overflow => {
-                (1, 0, vec![param(0), param(0)], Ty::new_tup(tcx, &[param(0), tcx.types.bool]))
+                (1, 0, invec([param(0), param(0)]), Ty::new_tup(tcx, &[param(0), tcx.types.bool]))
             }
 
             sym::carrying_mul_add => {
-                (2, 0, vec![param(0); 4], Ty::new_tup(tcx, &[param(1), param(0)]))
+                (2, 0, invec([param(0); 4]), Ty::new_tup(tcx, &[param(1), param(0)]))
             }
 
             sym::ptr_guaranteed_cmp => (
                 1,
                 0,
-                vec![Ty::new_imm_ptr(tcx, param(0)), Ty::new_imm_ptr(tcx, param(0))],
+                invec([Ty::new_imm_ptr(tcx, param(0)), Ty::new_imm_ptr(tcx, param(0))]),
                 tcx.types.u8,
             ),
 
-            sym::const_allocate => {
-                (0, 0, vec![tcx.types.usize, tcx.types.usize], Ty::new_mut_ptr(tcx, tcx.types.u8))
-            }
+            sym::const_allocate => (
+                0,
+                0,
+                invec([tcx.types.usize, tcx.types.usize]),
+                Ty::new_mut_ptr(tcx, tcx.types.u8),
+            ),
             sym::const_deallocate => (
                 0,
                 0,
-                vec![Ty::new_mut_ptr(tcx, tcx.types.u8), tcx.types.usize, tcx.types.usize],
+                invec([Ty::new_mut_ptr(tcx, tcx.types.u8), tcx.types.usize, tcx.types.usize]),
                 tcx.types.unit,
             ),
 
             sym::ptr_offset_from => (
                 1,
                 0,
-                vec![Ty::new_imm_ptr(tcx, param(0)), Ty::new_imm_ptr(tcx, param(0))],
+                invec([Ty::new_imm_ptr(tcx, param(0)), Ty::new_imm_ptr(tcx, param(0))]),
                 tcx.types.isize,
             ),
             sym::ptr_offset_from_unsigned => (
                 1,
                 0,
-                vec![Ty::new_imm_ptr(tcx, param(0)), Ty::new_imm_ptr(tcx, param(0))],
+                invec([Ty::new_imm_ptr(tcx, param(0)), Ty::new_imm_ptr(tcx, param(0))]),
                 tcx.types.usize,
             ),
             sym::unchecked_div | sym::unchecked_rem | sym::exact_div | sym::disjoint_bitor => {
-                (1, 0, vec![param(0), param(0)], param(0))
+                (1, 0, invec([param(0), param(0)]), param(0))
             }
-            sym::unchecked_shl | sym::unchecked_shr => (2, 0, vec![param(0), param(1)], param(0)),
-            sym::rotate_left | sym::rotate_right => (1, 0, vec![param(0), tcx.types.u32], param(0)),
+            sym::unchecked_shl | sym::unchecked_shr => {
+                (2, 0, invec([param(0), param(1)]), param(0))
+            }
+            sym::rotate_left | sym::rotate_right => {
+                (1, 0, invec([param(0), tcx.types.u32]), param(0))
+            }
             sym::unchecked_add | sym::unchecked_sub | sym::unchecked_mul => {
-                (1, 0, vec![param(0), param(0)], param(0))
+                (1, 0, invec([param(0), param(0)]), param(0))
             }
             sym::wrapping_add | sym::wrapping_sub | sym::wrapping_mul => {
-                (1, 0, vec![param(0), param(0)], param(0))
+                (1, 0, invec([param(0), param(0)]), param(0))
             }
-            sym::saturating_add | sym::saturating_sub => (1, 0, vec![param(0), param(0)], param(0)),
+            sym::saturating_add | sym::saturating_sub => {
+                (1, 0, invec([param(0), param(0)]), param(0))
+            }
             sym::fadd_fast | sym::fsub_fast | sym::fmul_fast | sym::fdiv_fast | sym::frem_fast => {
-                (1, 0, vec![param(0), param(0)], param(0))
+                (1, 0, invec([param(0), param(0)]), param(0))
             }
             sym::fadd_algebraic
             | sym::fsub_algebraic
             | sym::fmul_algebraic
             | sym::fdiv_algebraic
-            | sym::frem_algebraic => (1, 0, vec![param(0), param(0)], param(0)),
-            sym::float_to_int_unchecked => (2, 0, vec![param(0)], param(1)),
+            | sym::frem_algebraic => (1, 0, invec([param(0), param(0)]), param(0)),
+            sym::float_to_int_unchecked => (2, 0, invec([param(0)]), param(1)),
 
-            sym::assume => (0, 0, vec![tcx.types.bool], tcx.types.unit),
-            sym::select_unpredictable => (1, 0, vec![tcx.types.bool, param(0), param(0)], param(0)),
-            sym::cold_path => (0, 0, vec![], tcx.types.unit),
+            sym::assume => (0, 0, invec([tcx.types.bool]), tcx.types.unit),
+            sym::select_unpredictable => {
+                (1, 0, invec([tcx.types.bool, param(0), param(0)]), param(0))
+            }
+            sym::cold_path => (0, 0, invec([]), tcx.types.unit),
 
-            sym::read_via_copy => (1, 0, vec![Ty::new_imm_ptr(tcx, param(0))], param(0)),
+            sym::read_via_copy => (1, 0, invec([Ty::new_imm_ptr(tcx, param(0))]), param(0)),
             sym::write_via_move => {
-                (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit)
+                (1, 0, invec([Ty::new_mut_ptr(tcx, param(0)), param(0)]), tcx.types.unit)
             }
 
             sym::typed_swap_nonoverlapping => {
-                (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)); 2], tcx.types.unit)
+                (1, 0, invec([Ty::new_mut_ptr(tcx, param(0)); 2]), tcx.types.unit)
             }
 
             sym::discriminant_value => {
@@ -509,11 +533,11 @@ pub(crate) fn check_intrinsic_type(
                 (
                     1,
                     0,
-                    vec![Ty::new_imm_ref(
+                    invec([Ty::new_imm_ref(
                         tcx,
                         ty::Region::new_bound(tcx, ty::INNERMOST, br),
                         param(0),
-                    )],
+                    )]),
                     Ty::new_projection_from_args(
                         tcx,
                         discriminant_def_id,
@@ -541,25 +565,29 @@ pub(crate) fn check_intrinsic_type(
                 (
                     0,
                     0,
-                    vec![Ty::new_fn_ptr(tcx, try_fn_ty), mut_u8, Ty::new_fn_ptr(tcx, catch_fn_ty)],
+                    invec([
+                        Ty::new_fn_ptr(tcx, try_fn_ty),
+                        mut_u8,
+                        Ty::new_fn_ptr(tcx, catch_fn_ty),
+                    ]),
                     tcx.types.i32,
                 )
             }
 
             sym::va_start | sym::va_end => {
-                (0, 0, vec![mk_va_list_ty(hir::Mutability::Mut).0], tcx.types.unit)
+                (0, 0, invec([mk_va_list_ty(hir::Mutability::Mut).0]), tcx.types.unit)
             }
 
             sym::va_copy => {
                 let (va_list_ref_ty, va_list_ty) = mk_va_list_ty(hir::Mutability::Not);
                 let va_list_ptr_ty = Ty::new_mut_ptr(tcx, va_list_ty);
-                (0, 0, vec![va_list_ptr_ty, va_list_ref_ty], tcx.types.unit)
+                (0, 0, invec([va_list_ptr_ty, va_list_ref_ty]), tcx.types.unit)
             }
 
-            sym::va_arg => (1, 0, vec![mk_va_list_ty(hir::Mutability::Mut).0], param(0)),
+            sym::va_arg => (1, 0, invec([mk_va_list_ty(hir::Mutability::Mut).0]), param(0)),
 
             sym::nontemporal_store => {
-                (1, 0, vec![Ty::new_mut_ptr(tcx, param(0)), param(0)], tcx.types.unit)
+                (1, 0, invec([Ty::new_mut_ptr(tcx, param(0)), param(0)]), tcx.types.unit)
             }
 
             sym::raw_eq => {
@@ -573,39 +601,39 @@ pub(crate) fn check_intrinsic_type(
                 };
                 let param_ty_rhs =
                     Ty::new_imm_ref(tcx, ty::Region::new_bound(tcx, ty::INNERMOST, br), param(0));
-                (1, 0, vec![param_ty_lhs, param_ty_rhs], tcx.types.bool)
+                (1, 0, invec([param_ty_lhs, param_ty_rhs]), tcx.types.bool)
             }
 
-            sym::black_box => (1, 0, vec![param(0)], param(0)),
+            sym::black_box => (1, 0, invec([param(0)]), param(0)),
 
-            sym::is_val_statically_known => (1, 0, vec![param(0)], tcx.types.bool),
+            sym::is_val_statically_known => (1, 0, invec([param(0)]), tcx.types.bool),
 
-            sym::const_eval_select => (4, 0, vec![param(0), param(1), param(2)], param(3)),
+            sym::const_eval_select => (4, 0, invec([param(0), param(1), param(2)]), param(3)),
 
             sym::vtable_size | sym::vtable_align => {
-                (0, 0, vec![Ty::new_imm_ptr(tcx, tcx.types.unit)], tcx.types.usize)
+                (0, 0, invec([Ty::new_imm_ptr(tcx, tcx.types.unit)]), tcx.types.usize)
             }
 
             // This type check is not particularly useful, but the `where` bounds
             // on the definition in `core` do the heavy lifting for checking it.
-            sym::aggregate_raw_ptr => (3, 0, vec![param(1), param(2)], param(0)),
-            sym::ptr_metadata => (2, 0, vec![Ty::new_imm_ptr(tcx, param(0))], param(1)),
+            sym::aggregate_raw_ptr => (3, 0, invec([param(1), param(2)]), param(0)),
+            sym::ptr_metadata => (2, 0, invec([Ty::new_imm_ptr(tcx, param(0))]), param(1)),
 
-            sym::ub_checks => (0, 0, Vec::new(), tcx.types.bool),
+            sym::ub_checks => (0, 0, ArrayVec::new(), tcx.types.bool),
 
-            sym::box_new => (1, 0, vec![param(0)], Ty::new_box(tcx, param(0))),
+            sym::box_new => (1, 0, invec([param(0)]), Ty::new_box(tcx, param(0))),
 
             // contract_checks() -> bool
-            sym::contract_checks => (0, 0, Vec::new(), tcx.types.bool),
+            sym::contract_checks => (0, 0, ArrayVec::new(), tcx.types.bool),
             // contract_check_requires::<C>(C) -> bool, where C: impl Fn() -> bool
-            sym::contract_check_requires => (1, 0, vec![param(0)], tcx.types.unit),
+            sym::contract_check_requires => (1, 0, invec([param(0)]), tcx.types.unit),
 
             sym::simd_eq
             | sym::simd_ne
             | sym::simd_lt
             | sym::simd_le
             | sym::simd_gt
-            | sym::simd_ge => (2, 0, vec![param(0), param(0)], param(1)),
+            | sym::simd_ge => (2, 0, invec([param(0), param(0)]), param(1)),
             sym::simd_add
             | sym::simd_sub
             | sym::simd_mul
@@ -619,8 +647,8 @@ pub(crate) fn check_intrinsic_type(
             | sym::simd_fmin
             | sym::simd_fmax
             | sym::simd_saturating_add
-            | sym::simd_saturating_sub => (1, 0, vec![param(0), param(0)], param(0)),
-            sym::simd_arith_offset => (2, 0, vec![param(0), param(1)], param(0)),
+            | sym::simd_saturating_sub => (1, 0, invec([param(0), param(0)]), param(0)),
+            sym::simd_arith_offset => (2, 0, invec([param(0), param(1)]), param(0)),
             sym::simd_neg
             | sym::simd_bswap
             | sym::simd_bitreverse
@@ -639,32 +667,34 @@ pub(crate) fn check_intrinsic_type(
             | sym::simd_ceil
             | sym::simd_floor
             | sym::simd_round
-            | sym::simd_trunc => (1, 0, vec![param(0)], param(0)),
+            | sym::simd_trunc => (1, 0, invec([param(0)]), param(0)),
             sym::simd_fma | sym::simd_relaxed_fma => {
-                (1, 0, vec![param(0), param(0), param(0)], param(0))
+                (1, 0, invec([param(0), param(0), param(0)]), param(0))
             }
-            sym::simd_gather => (3, 0, vec![param(0), param(1), param(2)], param(0)),
-            sym::simd_masked_load => (3, 0, vec![param(0), param(1), param(2)], param(2)),
-            sym::simd_masked_store => (3, 0, vec![param(0), param(1), param(2)], tcx.types.unit),
-            sym::simd_scatter => (3, 0, vec![param(0), param(1), param(2)], tcx.types.unit),
+            sym::simd_gather => (3, 0, invec([param(0), param(1), param(2)]), param(0)),
+            sym::simd_masked_load => (3, 0, invec([param(0), param(1), param(2)]), param(2)),
+            sym::simd_masked_store => (3, 0, invec([param(0), param(1), param(2)]), tcx.types.unit),
+            sym::simd_scatter => (3, 0, invec([param(0), param(1), param(2)]), tcx.types.unit),
             sym::simd_insert | sym::simd_insert_dyn => {
-                (2, 0, vec![param(0), tcx.types.u32, param(1)], param(0))
+                (2, 0, invec([param(0), tcx.types.u32, param(1)]), param(0))
             }
             sym::simd_extract | sym::simd_extract_dyn => {
-                (2, 0, vec![param(0), tcx.types.u32], param(1))
+                (2, 0, invec([param(0), tcx.types.u32]), param(1))
             }
             sym::simd_cast
             | sym::simd_as
             | sym::simd_cast_ptr
             | sym::simd_expose_provenance
-            | sym::simd_with_exposed_provenance => (2, 0, vec![param(0)], param(1)),
-            sym::simd_bitmask => (2, 0, vec![param(0)], param(1)),
+            | sym::simd_with_exposed_provenance => (2, 0, invec([param(0)]), param(1)),
+            sym::simd_bitmask => (2, 0, invec([param(0)]), param(1)),
             sym::simd_select | sym::simd_select_bitmask => {
-                (2, 0, vec![param(0), param(1), param(1)], param(1))
+                (2, 0, invec([param(0), param(1), param(1)]), param(1))
             }
-            sym::simd_reduce_all | sym::simd_reduce_any => (1, 0, vec![param(0)], tcx.types.bool),
+            sym::simd_reduce_all | sym::simd_reduce_any => {
+                (1, 0, invec([param(0)]), tcx.types.bool)
+            }
             sym::simd_reduce_add_ordered | sym::simd_reduce_mul_ordered => {
-                (2, 0, vec![param(0), param(1)], param(1))
+                (2, 0, invec([param(0), param(1)]), param(1))
             }
             sym::simd_reduce_add_unordered
             | sym::simd_reduce_mul_unordered
@@ -672,9 +702,9 @@ pub(crate) fn check_intrinsic_type(
             | sym::simd_reduce_or
             | sym::simd_reduce_xor
             | sym::simd_reduce_min
-            | sym::simd_reduce_max => (2, 0, vec![param(0)], param(1)),
-            sym::simd_shuffle => (3, 0, vec![param(0), param(0), param(1)], param(2)),
-            sym::simd_shuffle_const_generic => (2, 1, vec![param(0), param(0)], param(1)),
+            | sym::simd_reduce_max => (2, 0, invec([param(0)]), param(1)),
+            sym::simd_shuffle => (3, 0, invec([param(0), param(0), param(1)]), param(2)),
+            sym::simd_shuffle_const_generic => (2, 1, invec([param(0), param(0)]), param(1)),
 
             other => {
                 tcx.dcx().emit_err(UnrecognizedIntrinsicFunction { span, name: other });


### PR DESCRIPTION
This isn't exactly a hot path, but it does allocate for data with a statically known length. `arrayvec` is already in the crate graph, so use it here to avoid any allocation.

r? @ghost