### PR TITLE
Replace the \01__gnu_mcount_nc to LLVM intrinsic for additional ARM targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_gnueabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv5te_unknown_linux_gnueabi.rs
@@ -20,6 +20,7 @@ pub(crate) fn target() -> Target {
             max_atomic_width: Some(32),
             mcount: "\u{1}__gnu_mcount_nc".into(),
             has_thumb_interworking: true,
+            llvm_mcount_intrinsic: Some("llvm.arm.gnu.eabi.mcount".into()),
             ..base::linux_gnu::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_gnueabihf.rs
@@ -22,6 +22,7 @@ pub(crate) fn target() -> Target {
             features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
             max_atomic_width: Some(64),
             mcount: "\u{1}__gnu_mcount_nc".into(),
+            llvm_mcount_intrinsic: Some("llvm.arm.gnu.eabi.mcount".into()),
             ..base::linux_gnu::opts()
         },
     }


### PR DESCRIPTION
This is an extension to #113814 which seems to have missed two targets which also need this patch for instrumentation with `-Z instrument-mcount` to work correctly.

For anyone who might stumble over this issue again in the future: As a workaround one can dump the current target configuration using

```
rustc +nightly -Z unstable-options --target armv7-unknown-linux-gnueabihf --print target-spec-json
```

(assuming `armv7-unknown-linux-gnueabihf` is the target to build for) add the line

```
    "llvm-mcount-intrinsic": "llvm.arm.gnu.eabi.mcount",
```

and compile with

```
RUSTFLAGS="-Z instrument-mcount -C passes=ee-instrument<post-inline>" cargo +nightly build -Z build-std --target <path to directory with modified target config>/armv7-unknown-linux-gnueabihf.json
```

It might be necessary to set the compiler for cross compiling using something like

```
export TARGET_CC=arm-linux-gnueabihf-gcc
```