### PR TITLE
rustdoc: Allow multiple references to a single footnote

### DIFF
--- a/src/librustdoc/html/markdown/footnotes.rs
+++ b/src/librustdoc/html/markdown/footnotes.rs
@@ -23,6 +23,8 @@ struct FootnoteDef<'a> {
     content: Vec<Event<'a>>,
     /// The number that appears in the footnote reference and list.
     id: usize,
+    /// The number of footnote references.
+    num_refs: usize,
 }
 
 impl<'a, I: Iterator<Item = SpannedEvent<'a>>> Footnotes<'a, I> {
@@ -33,21 +35,25 @@ impl<'a, I: Iterator<Item = SpannedEvent<'a>>> Footnotes<'a, I> {
         Footnotes { inner: iter, footnotes: FxIndexMap::default(), existing_footnotes, start_id }
     }
 
-    fn get_entry(&mut self, key: &str) -> (&mut Vec<Event<'a>>, usize) {
+    fn get_entry(&mut self, key: &str) -> (&mut Vec<Event<'a>>, usize, &mut usize) {
         let new_id = self.footnotes.len() + 1 + self.start_id;
         let key = key.to_owned();
-        let FootnoteDef { content, id } =
-            self.footnotes.entry(key).or_insert(FootnoteDef { content: Vec::new(), id: new_id });
+        let FootnoteDef { content, id, num_refs } = self
+            .footnotes
+            .entry(key)
+            .or_insert(FootnoteDef { content: Vec::new(), id: new_id, num_refs: 0 });
         // Don't allow changing the ID of existing entries, but allow changing the contents.
-        (content, *id)
+        (content, *id, num_refs)
     }
 
     fn handle_footnote_reference(&mut self, reference: &CowStr<'a>) -> Event<'a> {
         // When we see a reference (to a footnote we may not know) the definition of,
         // reserve a number for it, and emit a link to that number.
-        let (_, id) = self.get_entry(reference);
+        let (_, id, num_refs) = self.get_entry(reference);
+        *num_refs += 1;
+        let fnref_suffix = if *num_refs <= 1 { "".to_owned() } else { format!("-{num_refs}") };
         let reference = format!(
-            "<sup id=\"fnref{0}\"><a href=\"#fn{0}\">{1}</a></sup>",
+            "<sup id=\"fnref{0}{fnref_suffix}\"><a href=\"#fn{0}\">{1}</a></sup>",
             id,
             // Although the ID count is for the whole page, the footnote reference
             // are local to the item so we make this ID "local" when displayed.
@@ -85,7 +91,7 @@ impl<'a, I: Iterator<Item = SpannedEvent<'a>>> Iterator for Footnotes<'a, I> {
                     // When we see a footnote definition, collect the associated content, and store
                     // that for rendering later.
                     let content = self.collect_footnote_def();
-                    let (entry_content, _) = self.get_entry(&def);
+                    let (entry_content, _, _) = self.get_entry(&def);
                     *entry_content = content;
                 }
                 Some(e) => return Some(e),
@@ -113,7 +119,7 @@ fn render_footnotes_defs(mut footnotes: Vec<FootnoteDef<'_>>) -> String {
     // browser generated for <li> are right.
     footnotes.sort_by_key(|x| x.id);
 
-    for FootnoteDef { mut content, id } in footnotes {
+    for FootnoteDef { mut content, id, num_refs } in footnotes {
         write!(ret, "<li id=\"fn{id}\">").unwrap();
         let mut is_paragraph = false;
         if let Some(&Event::End(TagEnd::Paragraph)) = content.last() {
@@ -121,7 +127,16 @@ fn render_footnotes_defs(mut footnotes: Vec<FootnoteDef<'_>>) -> String {
             is_paragraph = true;
         }
         html::push_html(&mut ret, content.into_iter());
-        write!(ret, "&nbsp;<a href=\"#fnref{id}\">↩</a>").unwrap();
+        if num_refs <= 1 {
+            write!(ret, "&nbsp;<a href=\"#fnref{id}\">↩</a>").unwrap();
+        } else {
+            // There are multiple references to single footnote. Make the first
+            // back link a single "a" element to make touch region larger.
+            write!(ret, "&nbsp;<a href=\"#fnref{id}\">↩&nbsp;<sup>1</sup></a>").unwrap();
+            for refid in 2..=num_refs {
+                write!(ret, "&nbsp;<sup><a href=\"#fnref{id}-{refid}\">{refid}</a></sup>").unwrap();
+            }
+        }
         if is_paragraph {
             ret.push_str("</p>");
         }

--- a/tests/rustdoc/footnote-reference-ids.rs
+++ b/tests/rustdoc/footnote-reference-ids.rs
@@ -1,0 +1,23 @@
+// This test ensures that multiple references to a single footnote and
+// corresponding back links work as expected.
+
+#![crate_name = "foo"]
+
+//@ has 'foo/index.html'
+//@ has - '//*[@class="docblock"]/p/sup[@id="fnref1"]/a[@href="#fn1"]' '1'
+//@ has - '//*[@class="docblock"]/p/sup[@id="fnref2"]/a[@href="#fn2"]' '2'
+//@ has - '//*[@class="docblock"]/p/sup[@id="fnref2-2"]/a[@href="#fn2"]' '2'
+//@ has - '//li[@id="fn1"]/p' 'meow'
+//@ has - '//li[@id="fn1"]/p/a[@href="#fnref1"]' '↩'
+//@ has - '//li[@id="fn2"]/p' 'uwu'
+//@ has - '//li[@id="fn2"]/p/a[@href="#fnref2"]/sup' '1'
+//@ has - '//li[@id="fn2"]/p/sup/a[@href="#fnref2-2"]' '2'
+
+//! # Footnote, references and back links
+//!
+//! Single: [^a].
+//!
+//! Double: [^b] [^b].
+//!
+//! [^a]: meow
+//! [^b]: uwu

--- a/tests/rustdoc/footnote-reference-in-footnote-def.rs
+++ b/tests/rustdoc/footnote-reference-in-footnote-def.rs
@@ -9,7 +9,7 @@
 //@ has - '//li[@id="fn1"]/p/sup[@id="fnref2"]/a[@href="#fn2"]' '2'
 //@ has - '//li[@id="fn1"]//a[@href="#fn2"]' '2'
 //@ has - '//li[@id="fn2"]/p' 'uwu'
-//@ has - '//li[@id="fn2"]/p/sup[@id="fnref1"]/a[@href="#fn1"]' '1'
+//@ has - '//li[@id="fn2"]/p/sup[@id="fnref1-2"]/a[@href="#fn1"]' '1'
 //@ has - '//li[@id="fn2"]//a[@href="#fn1"]' '1'
 
 //! # footnote-hell


### PR DESCRIPTION
Multiple references to a single footnote is a part of GitHub Flavored Markdown syntax (although not explicitly documented as well as regular footnotes, it is implemented in GitHub's fork of CommonMark) and not prohibited by rustdoc.

cf. <https://github.com/github/cmark-gfm/blob/587a12bb54d95ac37241377e6ddc93ea0e45439b/test/extensions.txt#L762-L780>

However, using it makes multiple `sup` elements with the same `id` attribute, which is invalid per the HTML specification.

Still, not only this is a valid GitHub Flavored Markdown syntax, this is helpful on certain cases and actually tested (accidentally) in `tests/rustdoc/footnote-reference-in-footnote-def.rs`.

This commit keeps track of the number of references per footnote and gives unique ID to each reference.
It also emits *all* back links from a footnote to its references as "↩" (return symbol) plus a numeric list in superscript.

As a known limitation, it assumes that all references to a footnote are rendered (this is not always true if a dangling footnote has one or more references but considered a reasonable compromise).

Also note that, this commit is designed so that no HTML changes will occur unless multiple references to a single footnote is actually used.

<!-- homu-ignore:start -->

# Background

A failure is detected on the CI process of rust-lang/rust#140389, which adopted `stdarch` submodule with PR rust-lang/stdarch#1779.

As you see in the screenshot of that stdarch PR, it uses multiple references to a single footnote to simplify showing various platform/version-specific notes (this is far more important than x86 because there are no architectural, fine-grained feature detection methods on RISC-V and hence feature detection is highly platform/version-specific).

And I thought this kind of references are allowed because:

1.  `rustdoc` does not reject such links and
2.  One of the tests `tests/rustdoc/footnote-reference-in-footnote-def.rs` contains multiple references to a single footnote `[^a]`.

...until I encounter a linkchecker failure (ran on CI).

# Proposal

Of course, rejecting such references might be an option but this PR attempts to resolve the issue by explicitly allowing multiple references to a single footnote by:

1.  Generating unique `id` attribute per a reference to a footnote and
2.  Emitting *all* back links from a footnote as a return symbol plus a numeric list in superscript.

Note that, this PR is designed so that no HTML changes will occur unless multiple references to a single footnote is *actually used*.

# Known Limitation

To simplify the implementation, it just keeps track of the number of references per footnote and *assumes* that all references to footnotes are rendered.  This is usually true but may not be *always* true if a reference is inside a footnote and that footnote is dangling (in this case, broken links (that won't cause any action when clicked/touched) will be generated but otherwise fine).

I also didn't use atomics but was it necessary?

# Screenshot

This is a screenshot of this PR plus rust-lang/stdarch#1779, showing how back links are rendered.
You can see the differences in the footnotes 1, 2 and 5.

![Screenshot of stdarch PR 1779 with this PR (footnote part)](https://github.com/user-attachments/assets/06795963-36d4-493e-ba5c-1756f6240ade)

# Design Considerations / Options

I just used 1-origin numbers for back links from a footnote but if this is confusing, using alphabet-based list "a", "b"..."z", "aa", "ab"... might be an option like in Wikipedia.  The reason I didn't do this (in the first proposal) is because back links are visually distinct than Wikipedia and seems easy to make distinction between regular references to footnotes due to the return symbol "↩" (Wikipedia: caret "^" is used).

# History

## Version 1 (2025-04-29)

The initial proposal.

## Version 2 and 3 (2025-04-30)

Excluding the rebase, they only change the commit message (mainly grammar fixes)
and the code is unchanged from the version 1.

## Version 4 (2025-05-06)

No changes in the source code.

*   Commit Message: Added minor adjustments
*   Commit Message: Added references to GitHub Flavored Markdown syntax and GitHub's fork of CommonMark
*   Commit Message: Clarified that multiple references in `tests/rustdoc/footnote-reference-in-footnote-def.rs` are (most likely) not to test such references themselves.

## Version 5 (2025-08-14)

*   Reflect the feedback by @fmease.
*   Commit Message: "cause" → "make"

<!-- homu-ignore:end -->
