### PR TITLE
Add `rust.debug-assertions-tools` option

### DIFF
--- a/bootstrap.example.toml
+++ b/bootstrap.example.toml
@@ -570,6 +570,12 @@
 # Defaults to rust.debug-assertions value
 #debug-assertions-std = rust.debug-assertions (boolean)
 
+# Whether or not debug assertions are enabled for the tools built by bootstrap.
+# Overrides the `debug-assertions` option, if defined.
+#
+# Defaults to rust.debug-assertions value
+#debug-assertions-tools = rust.debug-assertions (boolean)
+
 # Whether or not to leave debug! and trace! calls in the rust binary.
 #
 # Defaults to rust.debug-assertions value

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -872,11 +872,15 @@ impl Builder<'_> {
         }
         cargo.env(
             profile_var("DEBUG_ASSERTIONS"),
-            if mode == Mode::Std {
-                self.config.std_debug_assertions.to_string()
-            } else {
-                self.config.rustc_debug_assertions.to_string()
-            },
+            match mode {
+                Mode::Std => self.config.std_debug_assertions,
+                Mode::Rustc => self.config.rustc_debug_assertions,
+                Mode::Codegen => self.config.rustc_debug_assertions,
+                Mode::ToolBootstrap => self.config.tools_debug_assertions,
+                Mode::ToolStd => self.config.tools_debug_assertions,
+                Mode::ToolRustc => self.config.tools_debug_assertions,
+            }
+            .to_string(),
         );
         cargo.env(
             profile_var("OVERFLOW_CHECKS"),

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -306,6 +306,7 @@ pub struct Config {
 
     pub rustc_debug_assertions: bool,
     pub std_debug_assertions: bool,
+    pub tools_debug_assertions: bool,
 
     pub rust_overflow_checks: bool,
     pub rust_overflow_checks_std: bool,
@@ -1280,6 +1281,7 @@ define_config! {
         rustc_debug_assertions: Option<bool> = "debug-assertions",
         randomize_layout: Option<bool> = "randomize-layout",
         std_debug_assertions: Option<bool> = "debug-assertions-std",
+        tools_debug_assertions: Option<bool> = "debug-assertions-tools",
         overflow_checks: Option<bool> = "overflow-checks",
         overflow_checks_std: Option<bool> = "overflow-checks-std",
         debug_logging: Option<bool> = "debug-logging",
@@ -1937,6 +1939,7 @@ impl Config {
         let mut debug = None;
         let mut rustc_debug_assertions = None;
         let mut std_debug_assertions = None;
+        let mut tools_debug_assertions = None;
         let mut overflow_checks = None;
         let mut overflow_checks_std = None;
         let mut debug_logging = None;
@@ -2000,6 +2003,7 @@ impl Config {
                 codegen_units_std,
                 rustc_debug_assertions: rustc_debug_assertions_toml,
                 std_debug_assertions: std_debug_assertions_toml,
+                tools_debug_assertions: tools_debug_assertions_toml,
                 overflow_checks: overflow_checks_toml,
                 overflow_checks_std: overflow_checks_std_toml,
                 debug_logging: debug_logging_toml,
@@ -2084,6 +2088,7 @@ impl Config {
             debug = debug_toml;
             rustc_debug_assertions = rustc_debug_assertions_toml;
             std_debug_assertions = std_debug_assertions_toml;
+            tools_debug_assertions = tools_debug_assertions_toml;
             overflow_checks = overflow_checks_toml;
             overflow_checks_std = overflow_checks_std_toml;
             debug_logging = debug_logging_toml;
@@ -2509,6 +2514,8 @@ impl Config {
         let default = debug == Some(true);
         config.rustc_debug_assertions = rustc_debug_assertions.unwrap_or(default);
         config.std_debug_assertions = std_debug_assertions.unwrap_or(config.rustc_debug_assertions);
+        config.tools_debug_assertions =
+            tools_debug_assertions.unwrap_or(config.rustc_debug_assertions);
         config.rust_overflow_checks = overflow_checks.unwrap_or(default);
         config.rust_overflow_checks_std =
             overflow_checks_std.unwrap_or(config.rust_overflow_checks);
@@ -3568,6 +3575,7 @@ fn check_incompatible_options_for_ci_rustc(
         codegen_units_std: _,
         rustc_debug_assertions: _,
         std_debug_assertions: _,
+        tools_debug_assertions: _,
         overflow_checks: _,
         overflow_checks_std: _,
         debuginfo_level: _,

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -401,4 +401,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "Added new option `include` to create config extensions.",
     },
+    ChangeInfo {
+        change_id: 140438,
+        severity: ChangeSeverity::Info,
+        summary: "Added a new option `rust.debug-assertions-tools` to control debug asssertions for tools.",
+    },
 ];


### PR DESCRIPTION
Before this PR, the two only options to configure the presence of debug assertions were the `rust.debug-assertions` and `rust.debug-assertions-std` options. The former applied to everything, and the latter allowed to override the setting just for the standard library. This combination of settings doesn't allow to enable debug assertions for the std and the compiler but not tools.

Some tools (like Cargo) are not really meant to be executed with debug assertions enabled, and in Ferrocene we hit some debug assertions in it that are exclusively meant for its test suite. We'd thus like to enable debug assertions everywhere but in tools.

This PR adds a `rust.debug-assertions-tools` setting that does exactly this.