### PR TITLE
Make time not inline on unsupported platforms

### DIFF
--- a/library/std/src/sys/pal/unsupported/time.rs
+++ b/library/std/src/sys/pal/unsupported/time.rs
@@ -9,6 +9,7 @@ pub struct SystemTime(Duration);
 pub const UNIX_EPOCH: SystemTime = SystemTime(Duration::from_secs(0));
 
 impl Instant {
+    #[inline(never)]
     pub fn now() -> Instant {
         panic!("time not implemented on this platform")
     }
@@ -27,6 +28,7 @@ impl Instant {
 }
 
 impl SystemTime {
+    #[inline(never)]
     pub fn now() -> SystemTime {
         panic!("time not implemented on this platform")
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

The PR main intention is to allow enable wasm support in std time (see https://github.com/rust-lang/rust/issues/48564) with minimal changes via binary patches. but since the `now` function is inlined, it is not work at the moment. this PR marks it as `#[inline(never)]` to make it patchable.

![image](https://github.com/user-attachments/assets/849dd37f-730f-4efd-a61f-82e2c3c4c7cc)

I have tested the patch and it works.




