### PR TITLE
Return an iterator instead of a `Vec` in rustdoc `Item::attributes`

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -40,7 +40,7 @@ impl JsonRenderer<'_> {
             })
             .collect();
         let docs = item.opt_doc_value();
-        let attrs = item.attributes(self.tcx, self.cache(), true);
+        let attrs = item.attributes(self.tcx, self.cache(), true).collect::<Vec<_>>();
         let span = item.span(self.tcx);
         let visibility = item.visibility(self.tcx);
         let clean::ItemInner { name, item_id, .. } = *item.inner;


### PR DESCRIPTION
Let's see if it has an impact on performance.

r? ghost