### PR TITLE
Fix for async drop ice with partly dropped tuple

### DIFF
--- a/compiler/rustc_mir_transform/src/elaborate_drop.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drop.rs
@@ -376,7 +376,7 @@ where
         if self.tcx().features().async_drop()
             && self.elaborator.body().coroutine.is_some()
             && self.elaborator.allow_async_drops()
-            && !self.elaborator.body()[bb].is_cleanup
+            && !self.elaborator.patch_ref().block(self.elaborator.body(), bb).is_cleanup
             && drop_ty.needs_async_drop(self.tcx(), self.elaborator.typing_env())
         {
             self.build_async_drop(

--- a/compiler/rustc_mir_transform/src/patch.rs
+++ b/compiler/rustc_mir_transform/src/patch.rs
@@ -148,11 +148,20 @@ impl<'tcx> MirPatch<'tcx> {
         self.term_patch_map[bb].is_some()
     }
 
+    /// Universal getter for block data, either it is in 'old' blocks or in patched ones
+    pub(crate) fn block<'a>(
+        &'a self,
+        body: &'a Body<'tcx>,
+        bb: BasicBlock,
+    ) -> &'a BasicBlockData<'tcx> {
+        match bb.index().checked_sub(body.basic_blocks.len()) {
+            Some(new) => &self.new_blocks[new],
+            None => &body[bb],
+        }
+    }
+
     pub(crate) fn terminator_loc(&self, body: &Body<'tcx>, bb: BasicBlock) -> Location {
-        let offset = match bb.index().checked_sub(body.basic_blocks.len()) {
-            Some(index) => self.new_blocks[index].statements.len(),
-            None => body[bb].statements.len(),
-        };
+        let offset = self.block(body, bb).statements.len();
         Location { block: bb, statement_index: offset }
     }
 
@@ -284,10 +293,7 @@ impl<'tcx> MirPatch<'tcx> {
     }
 
     pub(crate) fn source_info_for_location(&self, body: &Body<'tcx>, loc: Location) -> SourceInfo {
-        let data = match loc.block.index().checked_sub(body.basic_blocks.len()) {
-            Some(new) => &self.new_blocks[new],
-            None => &body[loc.block],
-        };
+        let data = self.block(body, loc.block);
         Self::source_info_for_index(data, loc)
     }
 }

--- a/tests/ui/async-await/async-drop/partly-dropped-tuple.rs
+++ b/tests/ui/async-await/async-drop/partly-dropped-tuple.rs
@@ -1,0 +1,11 @@
+//@ edition: 2024
+//@ build-pass
+#![crate_type = "lib"]
+#![allow(incomplete_features)]
+#![feature(async_drop)]
+async fn move_part_await_return_rest_tuple() -> Vec<usize> {
+    let x = (vec![3], vec![4, 4]);
+    drop(x.1);
+
+    x.0
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
https://github.com/rust-lang/rust/issues/126482
https://github.com/rust-lang/rust/issues/140427

    r? oli-obk
-->
<!-- homu-ignore:end -->

Fixes https://github.com/rust-lang/rust/issues/140427.
Problem was with block data access with block id from new added blocks in patch.