### PR TITLE
Require sanitizers be enabled for asan_odr_windows.rs

### DIFF
--- a/tests/ui/sanitizer/asan_odr_windows.rs
+++ b/tests/ui/sanitizer/asan_odr_windows.rs
@@ -5,6 +5,8 @@
 //@ compile-flags:-Zsanitizer=address
 //@ aux-build: asan_odr_win-2.rs
 //@ only-windows-msvc
+//@ needs-sanitizer-support
+//@ needs-sanitizer-address
 
 extern crate othercrate;
 


### PR DESCRIPTION
Issue Details:
The `asan_odr_windows.rs` test is failing on AArch64 Windows, as sanitizers aren't supported on that platform.

Fix Details:
Apply the correct "need sanitizer" requirements to the test.