### PR TITLE
Comment on `Rc` abort-guard strategy without naming unrelated fn

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -3536,7 +3536,7 @@ impl<T> Default for Weak<T> {
     }
 }
 
-// NOTE: We checked_add here to deal with mem::forget safely. In particular
+// NOTE: We wrapping_add here to deal with mem::forget safely. In particular
 // if you mem::forget Rcs (or Weaks), the ref-count can overflow, and then
 // you can free the allocation while outstanding Rcs (or Weaks) exist.
 // We abort because this is such a degenerate scenario that we don't care about

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -3536,11 +3536,11 @@ impl<T> Default for Weak<T> {
     }
 }
 
-// NOTE: We wrapping_add here to deal with mem::forget safely. In particular
-// if you mem::forget Rcs (or Weaks), the ref-count can overflow, and then
-// you can free the allocation while outstanding Rcs (or Weaks) exist.
-// We abort because this is such a degenerate scenario that we don't care about
-// what happens -- no real program should ever experience this.
+// NOTE: If you mem::forget Rcs (or Weaks), drop is skipped and the ref-count
+// is not decremented, meaning the ref-count can overflow, and then you can
+// free the allocation while outstanding Rcs (or Weaks) exist, which would be
+// unsound. We abort because this is such a degenerate scenario that we don't
+// care about what happens -- no real program should ever experience this.
 //
 // This should have negligible overhead since you don't actually need to
 // clone these much in Rust thanks to ownership and move-semantics.


### PR DESCRIPTION
`wrapped_add` is used, not `checked_add`, so avoid mentioning specific fn calls that may vary slightly based on "whatever produces the best code" and focus on things that will remain constant into the future.