### PR TITLE
rustfmt: Also allow bool literals as first item of let chain

### DIFF
--- a/src/tools/rustfmt/tests/source/let_chains.rs
+++ b/src/tools/rustfmt/tests/source/let_chains.rs
@@ -20,6 +20,11 @@ fn test_single_line_let_chain() {
     if a && let Some(b) = foo() {
     }
 
+    // first item in let-chain is a bool literal
+    if true && let Some(x) = y {
+
+    }
+
     // first item in let-chain is a unary ! with an ident
     let unary_not = if !from_hir_call
         && let Some(p) = parent
@@ -91,11 +96,6 @@ fn test_multi_line_let_chain() {
 
     // function call
     if a() && let Some(x) = y {
-
-    }
-
-    // bool literal
-    if true && let Some(x) = y {
 
     }
 

--- a/src/tools/rustfmt/tests/target/let_chains.rs
+++ b/src/tools/rustfmt/tests/target/let_chains.rs
@@ -50,6 +50,9 @@ fn test_single_line_let_chain() {
     // first item in let-chain is an ident
     if a && let Some(b) = foo() {}
 
+    // first item in let-chain is a bool literal
+    if true && let Some(x) = y {}
+
     // first item in let-chain is a unary ! with an ident
     let unary_not = if !from_hir_call && let Some(p) = parent {};
 
@@ -99,11 +102,6 @@ fn test_multi_line_let_chain() {
 
     // function call
     if a()
-        && let Some(x) = y
-    {}
-
-    // bool literal
-    if true
         && let Some(x) = y
     {}
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

This is a functional cherry-pick of https://github.com/rust-lang/rustfmt/pull/6492 

I'm bringing this change over directly as the subtree sync is taking more effort than anticipated (some unrelated r-l/rustfmt changes need to be reverted before we perform the full sync) and we need to ensure that rustfmt behavior accounts with the final style guide rules as part of let chain stabilization.

r? @ghost
