### PR TITLE
linker: Quote symbol names in .def files

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -816,7 +816,9 @@ impl<'a> Linker for GccLinker<'a> {
                 writeln!(f, "EXPORTS")?;
                 for symbol in symbols {
                     debug!("  _{symbol}");
-                    writeln!(f, "  {symbol}")?;
+                    // Quote the name in case it's reserved by linker in some way
+                    // (this accounts for names with dots in particular).
+                    writeln!(f, "  \"{symbol}\"")?;
                 }
             };
             if let Err(error) = res {

--- a/tests/ui/linking/weird-export-names.rs
+++ b/tests/ui/linking/weird-export-names.rs
@@ -1,0 +1,10 @@
+//@ build-pass
+//@ needs-crate-type: cdylib
+
+#![crate_type = "cdylib"]
+
+#[export_name = "foo.0123"]
+pub extern "C" fn foo() {}
+
+#[export_name = "EXPORTS"]
+pub extern "C" fn bar() {}


### PR DESCRIPTION
To support weird symbol names, including dots in particular.

cc [#134767](https://github.com/rust-lang/rust/pull/134767#issuecomment-2839397610)