### PR TITLE
Stabilize proc_macro::Span::{file, local_file}.

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -543,13 +543,13 @@ impl Span {
     /// The path to the source file in which this span occurs, for display purposes.
     ///
     /// This might not correspond to a valid file system path.
-    /// It might be remapped, or might be an artificial path such as `"<macro expansion>"`.
+    /// It might be remapped (e.g. `"/src/lib.rs"`) or an artificial path (e.g. `"<command line>"`).
     #[stable(feature = "proc_macro_span_file", since = "CURRENT_RUSTC_VERSION")]
     pub fn file(&self) -> String {
         self.0.file()
     }
 
-    /// The path to the source file in which this span occurs on disk.
+    /// The path to the source file in which this span occurs on the local file system.
     ///
     /// This is the actual path on disk. It is unaffected by path remapping.
     ///

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -544,7 +544,7 @@ impl Span {
     ///
     /// This might not correspond to a valid file system path.
     /// It might be remapped, or might be an artificial path such as `"<macro expansion>"`.
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[stable(feature = "proc_macro_span_file", since = "CURRENT_RUSTC_VERSION")]
     pub fn file(&self) -> String {
         self.0.file()
     }
@@ -554,7 +554,7 @@ impl Span {
     /// This is the actual path on disk. It is unaffected by path remapping.
     ///
     /// This path should not be embedded in the output of the macro; prefer `file()` instead.
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[stable(feature = "proc_macro_span_file", since = "CURRENT_RUSTC_VERSION")]
     pub fn local_file(&self) -> Option<PathBuf> {
         self.0.local_file().map(|s| PathBuf::from(s))
     }


### PR DESCRIPTION
Stabilizes this part of https://github.com/rust-lang/rust/issues/54725:

```rust
impl Span {
    pub fn file(&self) -> String; // Mapped/artificial file name, for display purposes.

    pub fn local_file(&self) -> Option<PathBuf>; // Real file name as it exists on the local file system.
}
```

See also the naming discussion in https://github.com/rust-lang/rust/issues/139903