### PR TITLE
Use select in projection lookup in `report_projection_error`

### DIFF
--- a/tests/ui/associated-types/mismatch-two-relevant-impls.rs
+++ b/tests/ui/associated-types/mismatch-two-relevant-impls.rs
@@ -1,0 +1,20 @@
+trait Tr {
+    type Assoc;
+}
+
+struct W<T>(T);
+
+impl Tr for W<i32> {
+    type Assoc = u32;
+}
+
+impl Tr for W<u32> {
+    type Assoc = i32;
+}
+
+fn needs_unit<T: Tr<Assoc = ()>>() {}
+
+fn main() {
+    needs_unit::<W<i32>>();
+    //~^ ERROR type mismatch resolving `<W<i32> as Tr>::Assoc == ()`
+}

--- a/tests/ui/associated-types/mismatch-two-relevant-impls.stderr
+++ b/tests/ui/associated-types/mismatch-two-relevant-impls.stderr
@@ -1,0 +1,20 @@
+error[E0271]: type mismatch resolving `<W<i32> as Tr>::Assoc == ()`
+  --> $DIR/mismatch-two-relevant-impls.rs:18:18
+   |
+LL |     needs_unit::<W<i32>>();
+   |                  ^^^^^^ type mismatch resolving `<W<i32> as Tr>::Assoc == ()`
+   |
+note: expected this to be `()`
+  --> $DIR/mismatch-two-relevant-impls.rs:8:18
+   |
+LL |     type Assoc = u32;
+   |                  ^^^
+note: required by a bound in `needs_unit`
+  --> $DIR/mismatch-two-relevant-impls.rs:15:21
+   |
+LL | fn needs_unit<T: Tr<Assoc = ()>>() {}
+   |                     ^^^^^^^^^^ required by this bound in `needs_unit`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
Using `for_each_relevant_impl` doesn't actually select the correct impl; we can use `select` here to actually get the correct impl with certainty. Follow-up to https://github.com/rust-lang/rust/pull/140278.

r? oli-obk