### PR TITLE
Update hashbrown dependency to unblock ExtractIf improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",


### PR DESCRIPTION
Release notes: https://github.com/rust-lang/hashbrown/releases/tag/v0.15.3

Relevant to me, this release includes https://github.com/rust-lang/hashbrown/pull/616 which unblocks https://github.com/rust-lang/rust/pull/139764.