### PR TITLE
Rename `*Guard::try_map` to `filter_map`.

### DIFF
--- a/library/std/src/sync/poison/mutex.rs
+++ b/library/std/src/sync/poison/mutex.rs
@@ -253,11 +253,11 @@ unsafe impl<T: ?Sized + Sync> Sync for MutexGuard<'_, T> {}
 /// The data protected by the mutex can be accessed through this guard via its
 /// [`Deref`] and [`DerefMut`] implementations.
 ///
-/// This structure is created by the [`map`] and [`try_map`] methods on
+/// This structure is created by the [`map`] and [`filter_map`] methods on
 /// [`MutexGuard`].
 ///
 /// [`map`]: MutexGuard::map
-/// [`try_map`]: MutexGuard::try_map
+/// [`filter_map`]: MutexGuard::filter_map
 /// [`Condvar`]: crate::sync::Condvar
 #[must_use = "if unused the Mutex will immediately unlock"]
 #[must_not_suspend = "holding a MappedMutexGuard across suspend \
@@ -718,7 +718,7 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
         U: ?Sized,
     {
         // SAFETY: the conditions of `MutexGuard::new` were satisfied when the original guard
-        // was created, and have been upheld throughout `map` and/or `try_map`.
+        // was created, and have been upheld throughout `map` and/or `filter_map`.
         // The signature of the closure guarantees that it will not "leak" the lifetime of the reference
         // passed to it. If the closure panics, the guard will be dropped.
         let data = NonNull::from(f(unsafe { &mut *orig.lock.data.get() }));
@@ -739,17 +739,16 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
     /// The `Mutex` is already locked, so this cannot fail.
     ///
     /// This is an associated function that needs to be used as
-    /// `MutexGuard::try_map(...)`. A method would interfere with methods of the
+    /// `MutexGuard::filter_map(...)`. A method would interfere with methods of the
     /// same name on the contents of the `MutexGuard` used through `Deref`.
-    #[doc(alias = "filter_map")]
     #[unstable(feature = "mapped_lock_guards", issue = "117108")]
-    pub fn try_map<U, F>(orig: Self, f: F) -> Result<MappedMutexGuard<'a, U>, Self>
+    pub fn filter_map<U, F>(orig: Self, f: F) -> Result<MappedMutexGuard<'a, U>, Self>
     where
         F: FnOnce(&mut T) -> Option<&mut U>,
         U: ?Sized,
     {
         // SAFETY: the conditions of `MutexGuard::new` were satisfied when the original guard
-        // was created, and have been upheld throughout `map` and/or `try_map`.
+        // was created, and have been upheld throughout `map` and/or `filter_map`.
         // The signature of the closure guarantees that it will not "leak" the lifetime of the reference
         // passed to it. If the closure panics, the guard will be dropped.
         match f(unsafe { &mut *orig.lock.data.get() }) {
@@ -826,7 +825,7 @@ impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
         U: ?Sized,
     {
         // SAFETY: the conditions of `MutexGuard::new` were satisfied when the original guard
-        // was created, and have been upheld throughout `map` and/or `try_map`.
+        // was created, and have been upheld throughout `map` and/or `filter_map`.
         // The signature of the closure guarantees that it will not "leak" the lifetime of the reference
         // passed to it. If the closure panics, the guard will be dropped.
         let data = NonNull::from(f(unsafe { orig.data.as_mut() }));
@@ -847,17 +846,16 @@ impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
     /// The `Mutex` is already locked, so this cannot fail.
     ///
     /// This is an associated function that needs to be used as
-    /// `MappedMutexGuard::try_map(...)`. A method would interfere with methods of the
+    /// `MappedMutexGuard::filter_map(...)`. A method would interfere with methods of the
     /// same name on the contents of the `MutexGuard` used through `Deref`.
-    #[doc(alias = "filter_map")]
     #[unstable(feature = "mapped_lock_guards", issue = "117108")]
-    pub fn try_map<U, F>(mut orig: Self, f: F) -> Result<MappedMutexGuard<'a, U>, Self>
+    pub fn filter_map<U, F>(mut orig: Self, f: F) -> Result<MappedMutexGuard<'a, U>, Self>
     where
         F: FnOnce(&mut T) -> Option<&mut U>,
         U: ?Sized,
     {
         // SAFETY: the conditions of `MutexGuard::new` were satisfied when the original guard
-        // was created, and have been upheld throughout `map` and/or `try_map`.
+        // was created, and have been upheld throughout `map` and/or `filter_map`.
         // The signature of the closure guarantees that it will not "leak" the lifetime of the reference
         // passed to it. If the closure panics, the guard will be dropped.
         match f(unsafe { orig.data.as_mut() }) {

--- a/library/std/tests/sync/mutex.rs
+++ b/library/std/tests/sync/mutex.rs
@@ -409,13 +409,13 @@ fn panic_while_mapping_unlocked_poison() {
 
     let _ = panic::catch_unwind(|| {
         let guard = lock.lock().unwrap();
-        let _guard = MutexGuard::try_map::<(), _>(guard, |_| panic!());
+        let _guard = MutexGuard::filter_map::<(), _>(guard, |_| panic!());
     });
 
     match lock.try_lock() {
-        Ok(_) => panic!("panicking in a MutexGuard::try_map closure should poison the Mutex"),
+        Ok(_) => panic!("panicking in a MutexGuard::filter_map closure should poison the Mutex"),
         Err(TryLockError::WouldBlock) => {
-            panic!("panicking in a MutexGuard::try_map closure should unlock the mutex")
+            panic!("panicking in a MutexGuard::filter_map closure should unlock the mutex")
         }
         Err(TryLockError::Poisoned(_)) => {}
     }
@@ -437,13 +437,15 @@ fn panic_while_mapping_unlocked_poison() {
     let _ = panic::catch_unwind(|| {
         let guard = lock.lock().unwrap();
         let guard = MutexGuard::map::<(), _>(guard, |val| val);
-        let _guard = MappedMutexGuard::try_map::<(), _>(guard, |_| panic!());
+        let _guard = MappedMutexGuard::filter_map::<(), _>(guard, |_| panic!());
     });
 
     match lock.try_lock() {
-        Ok(_) => panic!("panicking in a MappedMutexGuard::try_map closure should poison the Mutex"),
+        Ok(_) => {
+            panic!("panicking in a MappedMutexGuard::filter_map closure should poison the Mutex")
+        }
         Err(TryLockError::WouldBlock) => {
-            panic!("panicking in a MappedMutexGuard::try_map closure should unlock the mutex")
+            panic!("panicking in a MappedMutexGuard::filter_map closure should unlock the mutex")
         }
         Err(TryLockError::Poisoned(_)) => {}
     }

--- a/library/std/tests/sync/rwlock.rs
+++ b/library/std/tests/sync/rwlock.rs
@@ -517,16 +517,20 @@ fn panic_while_mapping_read_unlocked_no_poison() {
 
     let _ = panic::catch_unwind(|| {
         let guard = lock.read().unwrap();
-        let _guard = RwLockReadGuard::try_map::<(), _>(guard, |_| panic!());
+        let _guard = RwLockReadGuard::filter_map::<(), _>(guard, |_| panic!());
     });
 
     match lock.try_write() {
         Ok(_) => {}
         Err(TryLockError::WouldBlock) => {
-            panic!("panicking in a RwLockReadGuard::try_map closure should release the read lock")
+            panic!(
+                "panicking in a RwLockReadGuard::filter_map closure should release the read lock"
+            )
         }
         Err(TryLockError::Poisoned(_)) => {
-            panic!("panicking in a RwLockReadGuard::try_map closure should not poison the RwLock")
+            panic!(
+                "panicking in a RwLockReadGuard::filter_map closure should not poison the RwLock"
+            )
         }
     }
 
@@ -549,16 +553,16 @@ fn panic_while_mapping_read_unlocked_no_poison() {
     let _ = panic::catch_unwind(|| {
         let guard = lock.read().unwrap();
         let guard = RwLockReadGuard::map::<(), _>(guard, |val| val);
-        let _guard = MappedRwLockReadGuard::try_map::<(), _>(guard, |_| panic!());
+        let _guard = MappedRwLockReadGuard::filter_map::<(), _>(guard, |_| panic!());
     });
 
     match lock.try_write() {
         Ok(_) => {}
         Err(TryLockError::WouldBlock) => panic!(
-            "panicking in a MappedRwLockReadGuard::try_map closure should release the read lock"
+            "panicking in a MappedRwLockReadGuard::filter_map closure should release the read lock"
         ),
         Err(TryLockError::Poisoned(_)) => panic!(
-            "panicking in a MappedRwLockReadGuard::try_map closure should not poison the RwLock"
+            "panicking in a MappedRwLockReadGuard::filter_map closure should not poison the RwLock"
         ),
     }
 
@@ -585,15 +589,17 @@ fn panic_while_mapping_write_unlocked_poison() {
 
     let _ = panic::catch_unwind(|| {
         let guard = lock.write().unwrap();
-        let _guard = RwLockWriteGuard::try_map::<(), _>(guard, |_| panic!());
+        let _guard = RwLockWriteGuard::filter_map::<(), _>(guard, |_| panic!());
     });
 
     match lock.try_write() {
         Ok(_) => {
-            panic!("panicking in a RwLockWriteGuard::try_map closure should poison the RwLock")
+            panic!("panicking in a RwLockWriteGuard::filter_map closure should poison the RwLock")
         }
         Err(TryLockError::WouldBlock) => {
-            panic!("panicking in a RwLockWriteGuard::try_map closure should release the write lock")
+            panic!(
+                "panicking in a RwLockWriteGuard::filter_map closure should release the write lock"
+            )
         }
         Err(TryLockError::Poisoned(_)) => {}
     }
@@ -617,15 +623,15 @@ fn panic_while_mapping_write_unlocked_poison() {
     let _ = panic::catch_unwind(|| {
         let guard = lock.write().unwrap();
         let guard = RwLockWriteGuard::map::<(), _>(guard, |val| val);
-        let _guard = MappedRwLockWriteGuard::try_map::<(), _>(guard, |_| panic!());
+        let _guard = MappedRwLockWriteGuard::filter_map::<(), _>(guard, |_| panic!());
     });
 
     match lock.try_write() {
         Ok(_) => panic!(
-            "panicking in a MappedRwLockWriteGuard::try_map closure should poison the RwLock"
+            "panicking in a MappedRwLockWriteGuard::filter_map closure should poison the RwLock"
         ),
         Err(TryLockError::WouldBlock) => panic!(
-            "panicking in a MappedRwLockWriteGuard::try_map closure should release the write lock"
+            "panicking in a MappedRwLockWriteGuard::filter_map closure should release the write lock"
         ),
         Err(TryLockError::Poisoned(_)) => {}
     }


### PR DESCRIPTION
Rename `std::sync::*Guard::try_map` to `filter_map`.

1. Analogous to `std::cell::Ref(Mut)::filter_map`.
2. Doesn't imply `Try` genericizability.

r? @Amanieu (or other T-libs-api)

Tracking issue for `mapped_lock_guards`: https://github.com/rust-lang/rust/issues/117108

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
