### PR TITLE
Emit user type annotations for free consts in pattern position

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -553,8 +553,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         let res = self.typeck_results.qpath_res(qpath, id);
 
         let (def_id, user_ty) = match res {
-            Res::Def(DefKind::Const, def_id) => (def_id, None),
-            Res::Def(DefKind::AssocConst, def_id) => {
+            Res::Def(DefKind::Const, def_id) | Res::Def(DefKind::AssocConst, def_id) => {
                 (def_id, self.typeck_results.user_provided_types().get(id))
             }
 

--- a/tests/ui/generic-const-items/user_type_annotations_pattern.rs
+++ b/tests/ui/generic-const-items/user_type_annotations_pattern.rs
@@ -1,0 +1,14 @@
+#![feature(generic_const_items)]
+#![expect(incomplete_features)]
+
+const FOO<'a: 'static>: usize = 10;
+
+fn bar<'a>() {
+    match 10_usize {
+        FOO::<'a> => todo!(),
+        //~^ ERROR: lifetime may not live long enough
+        _ => todo!(),
+    }
+}
+
+fn main() {}

--- a/tests/ui/generic-const-items/user_type_annotations_pattern.stderr
+++ b/tests/ui/generic-const-items/user_type_annotations_pattern.stderr
@@ -1,0 +1,11 @@
+error: lifetime may not live long enough
+  --> $DIR/user_type_annotations_pattern.rs:8:9
+   |
+LL | fn bar<'a>() {
+   |        -- lifetime `'a` defined here
+LL |     match 10_usize {
+LL |         FOO::<'a> => todo!(),
+   |         ^^^^^^^^^ requires that `'a` must outlive `'static`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This previously wasnt done because free consts couldn't have any generic parameters that need to be preserved for borrowck. This is no longer the case with `feature(generic_const_items)`

r? fmease