### PR TITLE
allow `#[rustc_std_internal_symbol]` in combination with `#[naked]`

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -625,6 +625,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             sym::naked,
             sym::instruction_set,
             sym::repr,
+            sym::rustc_std_internal_symbol,
             // code generation
             sym::cold,
             // documentation

--- a/tests/ui/asm/naked-functions.rs
+++ b/tests/ui/asm/naked-functions.rs
@@ -2,7 +2,7 @@
 //@ ignore-nvptx64
 //@ ignore-spirv
 
-#![feature(asm_unwind, linkage)]
+#![feature(asm_unwind, linkage, rustc_attrs)]
 #![crate_type = "lib"]
 
 use std::arch::{asm, naked_asm};
@@ -223,5 +223,11 @@ pub extern "C" fn compatible_doc_attributes() {
 #[linkage = "external"]
 #[unsafe(naked)]
 pub extern "C" fn compatible_linkage() {
+    naked_asm!("", options(raw));
+}
+
+#[rustc_std_internal_symbol]
+#[unsafe(naked)]
+pub extern "C" fn rustc_std_internal_symbol() {
     naked_asm!("", options(raw));
 }


### PR DESCRIPTION
The need for this came up in https://github.com/rust-lang/compiler-builtins/pull/897, but in general this seems useful and valid to allow.

Based on a quick scan, I don't think changes to the generated assembly are needed. 

cc @bjorn3 
