### PR TITLE
Removing rustc_type_ir in the rustc_infer codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4494,6 +4494,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_transmute",
+ "rustc_type_ir",
  "smallvec",
  "thin-vec",
  "tracing",

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -121,19 +121,19 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         self.enter_forall(value, f)
     }
 
-    fn equate_ty_vids_raw(&self, a: rustc_type_ir::TyVid, b: rustc_type_ir::TyVid) {
+    fn equate_ty_vids_raw(&self, a: ty::TyVid, b: ty::TyVid) {
         self.inner.borrow_mut().type_variables().equate(a, b);
     }
 
-    fn equate_int_vids_raw(&self, a: rustc_type_ir::IntVid, b: rustc_type_ir::IntVid) {
+    fn equate_int_vids_raw(&self, a: ty::IntVid, b: ty::IntVid) {
         self.inner.borrow_mut().int_unification_table().union(a, b);
     }
 
-    fn equate_float_vids_raw(&self, a: rustc_type_ir::FloatVid, b: rustc_type_ir::FloatVid) {
+    fn equate_float_vids_raw(&self, a: ty::FloatVid, b: ty::FloatVid) {
         self.inner.borrow_mut().float_unification_table().union(a, b);
     }
 
-    fn equate_const_vids_raw(&self, a: rustc_type_ir::ConstVid, b: rustc_type_ir::ConstVid) {
+    fn equate_const_vids_raw(&self, a: ty::ConstVid, b: ty::ConstVid) {
         self.inner.borrow_mut().const_unification_table().union(a, b);
     }
 
@@ -141,8 +141,8 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         &self,
         relation: &mut R,
         target_is_expected: bool,
-        target_vid: rustc_type_ir::TyVid,
-        instantiation_variance: rustc_type_ir::Variance,
+        target_vid: ty::TyVid,
+        instantiation_variance: ty::Variance,
         source_ty: Ty<'tcx>,
     ) -> RelateResult<'tcx, ()> {
         self.instantiate_ty_var(
@@ -154,19 +154,11 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         )
     }
 
-    fn instantiate_int_var_raw(
-        &self,
-        vid: rustc_type_ir::IntVid,
-        value: rustc_type_ir::IntVarValue,
-    ) {
+    fn instantiate_int_var_raw(&self, vid: ty::IntVid, value: ty::IntVarValue) {
         self.inner.borrow_mut().int_unification_table().union_value(vid, value);
     }
 
-    fn instantiate_float_var_raw(
-        &self,
-        vid: rustc_type_ir::FloatVid,
-        value: rustc_type_ir::FloatVarValue,
-    ) {
+    fn instantiate_float_var_raw(&self, vid: ty::FloatVid, value: ty::FloatVarValue) {
         self.inner.borrow_mut().float_unification_table().union_value(vid, value);
     }
 
@@ -174,7 +166,7 @@ impl<'tcx> rustc_type_ir::InferCtxtLike for InferCtxt<'tcx> {
         &self,
         relation: &mut R,
         target_is_expected: bool,
-        target_vid: rustc_type_ir::ConstVid,
+        target_vid: ty::ConstVid,
         source_ct: ty::Const<'tcx>,
     ) -> RelateResult<'tcx, ()> {
         self.instantiate_const_var(relation, target_is_expected, target_vid, source_ct)

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -63,11 +63,11 @@ use rustc_data_structures::undo_log::UndoLogs;
 use rustc_middle::bug;
 use rustc_middle::mir::ConstraintCategory;
 use rustc_middle::traits::query::NoSolution;
+use rustc_middle::ty::outlives::{Component, push_outlives_components};
 use rustc_middle::ty::{
     self, GenericArgKind, GenericArgsRef, PolyTypeOutlivesPredicate, Region, Ty, TyCtxt,
     TypeFoldable as _, TypeVisitableExt,
 };
-use rustc_type_ir::outlives::{Component, push_outlives_components};
 use smallvec::smallvec;
 use tracing::{debug, instrument};
 

--- a/compiler/rustc_infer/src/infer/outlives/verify.rs
+++ b/compiler/rustc_infer/src/infer/outlives/verify.rs
@@ -1,7 +1,7 @@
 use std::assert_matches::assert_matches;
 
+use rustc_middle::ty::outlives::{Component, compute_alias_components_recursive};
 use rustc_middle::ty::{self, OutlivesPredicate, Ty, TyCtxt};
-use rustc_type_ir::outlives::{Component, compute_alias_components_recursive};
 use smallvec::smallvec;
 use tracing::{debug, instrument, trace};
 

--- a/compiler/rustc_infer/src/infer/relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/relate/mod.rs
@@ -2,9 +2,8 @@
 //! (except for some relations used for diagnostics and heuristics in the compiler).
 //! As well as the implementation of `Relate` for interned things (`Ty`/`Const`/etc).
 
-pub use rustc_middle::ty::relate::RelateResult;
-pub use rustc_type_ir::relate::combine::PredicateEmittingRelation;
-pub use rustc_type_ir::relate::*;
+pub use rustc_middle::ty::relate::combine::PredicateEmittingRelation;
+pub use rustc_middle::ty::relate::{RelateResult, *};
 
 mod generalize;
 mod higher_ranked;

--- a/compiler/rustc_infer/src/infer/relate/type_relating.rs
+++ b/compiler/rustc_infer/src/infer/relate/type_relating.rs
@@ -3,9 +3,8 @@ use rustc_middle::ty::relate::combine::{super_combine_consts, super_combine_tys}
 use rustc_middle::ty::relate::{
     Relate, RelateResult, TypeRelation, relate_args_invariantly, relate_args_with_variances,
 };
-use rustc_middle::ty::{self, Ty, TyCtxt, TyVar};
+use rustc_middle::ty::{self, DelayedSet, Ty, TyCtxt, TyVar};
 use rustc_span::Span;
-use rustc_type_ir::data_structures::DelayedSet;
 use tracing::{debug, instrument};
 
 use crate::infer::BoundRegionConversionTime::HigherRankedType;

--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -1,9 +1,8 @@
 use rustc_middle::bug;
 use rustc_middle::ty::{
-    self, Const, FallibleTypeFolder, InferConst, Ty, TyCtxt, TypeFoldable, TypeFolder,
+    self, Const, DelayedMap, FallibleTypeFolder, InferConst, Ty, TyCtxt, TypeFoldable, TypeFolder,
     TypeSuperFoldable, TypeVisitableExt,
 };
-use rustc_type_ir::data_structures::DelayedMap;
 
 use super::{FixupError, FixupResult, InferCtxt};
 

--- a/compiler/rustc_infer/src/infer/snapshot/fudge.rs
+++ b/compiler/rustc_infer/src/infer/snapshot/fudge.rs
@@ -3,9 +3,8 @@ use std::ops::Range;
 use rustc_data_structures::{snapshot_vec as sv, unify as ut};
 use rustc_middle::ty::{
     self, ConstVid, FloatVid, IntVid, RegionVid, Ty, TyCtxt, TyVid, TypeFoldable, TypeFolder,
-    TypeSuperFoldable,
+    TypeSuperFoldable, TypeVisitableExt,
 };
-use rustc_type_ir::TypeVisitableExt;
 use tracing::instrument;
 use ut::UnifyKey;
 

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -1,7 +1,7 @@
 use rustc_data_structures::fx::FxHashSet;
+pub use rustc_middle::ty::elaborate::*;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::{Ident, Span};
-pub use rustc_type_ir::elaborate::*;
 
 use crate::traits::{self, Obligation, ObligationCauseCode, PredicateObligation};
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -50,9 +50,17 @@ use rustc_session::lint::LintBuffer;
 pub use rustc_session::lint::RegisteredTools;
 use rustc_span::hygiene::MacroKind;
 use rustc_span::{DUMMY_SP, ExpnId, ExpnKind, Ident, Span, Symbol, kw, sym};
-pub use rustc_type_ir::data_structures::DelayedSet;
+pub use rustc_type_ir::data_structures::{DelayedMap, DelayedSet};
+#[allow(
+    hidden_glob_reexports,
+    rustc::usage_of_type_ir_inherent,
+    rustc::non_glob_import_of_type_ir_inherent
+)]
+use rustc_type_ir::inherent;
 pub use rustc_type_ir::relate::VarianceDiagInfo;
 pub use rustc_type_ir::*;
+#[allow(hidden_glob_reexports, unused_imports)]
+use rustc_type_ir::{InferCtxtLike, Interner};
 use tracing::{debug, instrument};
 pub use vtable::*;
 use {rustc_ast as ast, rustc_attr_data_structures as attr, rustc_hir as hir};

--- a/compiler/rustc_trait_selection/Cargo.toml
+++ b/compiler/rustc_trait_selection/Cargo.toml
@@ -21,6 +21,7 @@ rustc_parse_format = { path = "../rustc_parse_format" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_transmute = { path = "../rustc_transmute", features = ["rustc"] }
+rustc_type_ir = { path = "../rustc_type_ir" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 thin-vec = "0.2"
 tracing = "0.1"

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -156,9 +156,9 @@ impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<
     fn register_hidden_type_in_storage(
         &self,
         opaque_type_key: ty::OpaqueTypeKey<'tcx>,
-        hidden_ty: <Self::Interner as ty::Interner>::Ty,
-        span: <Self::Interner as ty::Interner>::Span,
-    ) -> Option<<Self::Interner as ty::Interner>::Ty> {
+        hidden_ty: <Self::Interner as rustc_type_ir::Interner>::Ty,
+        span: <Self::Interner as rustc_type_ir::Interner>::Span,
+    ) -> Option<<Self::Interner as rustc_type_ir::Interner>::Ty> {
         self.0.register_hidden_type_in_storage(
             opaque_type_key,
             ty::OpaqueHiddenType { span, ty: hidden_ty },


### PR DESCRIPTION
cc #138449

This is a second refactoring of rustc_type_ir to use rustc_middle instead, this time that's for rustc_infer


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
