### PR TITLE
Add regression test for #140545

### DIFF
--- a/tests/ui/impl-trait/non-defining-uses/double-wrap-with-defining-use.rs
+++ b/tests/ui/impl-trait/non-defining-uses/double-wrap-with-defining-use.rs
@@ -1,0 +1,12 @@
+// Regression test for ICE from issue #140545
+// The error message is confusing and wrong, but that's a different problem (#139350)
+//@ edition:2018
+
+trait Foo {}
+fn a(x: impl Foo) -> impl Foo {
+    if true { x } else { a(a(x)) }
+    //~^ ERROR: expected generic type parameter, found `impl Foo` [E0792]
+    //~| ERROR: type parameter `impl Foo` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+}
+
+fn main(){}

--- a/tests/ui/impl-trait/non-defining-uses/double-wrap-with-defining-use.stderr
+++ b/tests/ui/impl-trait/non-defining-uses/double-wrap-with-defining-use.stderr
@@ -1,0 +1,17 @@
+error[E0792]: expected generic type parameter, found `impl Foo`
+  --> $DIR/double-wrap-with-defining-use.rs:7:26
+   |
+LL | fn a(x: impl Foo) -> impl Foo {
+   |         -------- this generic parameter must be used with a generic type parameter
+LL |     if true { x } else { a(a(x)) }
+   |                          ^^^^^^^
+
+error: type parameter `impl Foo` is part of concrete type but not used in parameter list for the `impl Trait` type alias
+  --> $DIR/double-wrap-with-defining-use.rs:7:26
+   |
+LL |     if true { x } else { a(a(x)) }
+   |                          ^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0792`.


### PR DESCRIPTION
Closes #140545 

I am not very knowledgable about the typesystem internals, so I couldn't come up with a good name for the test. But I'm happy to move it to a more appropriate place if there is one (`tests/ui/impl-trait/non-defining-uses` maybe?)

r? types (or reroll as appropriate if this is not actually a T-types issue; i'm clueless)