### PR TITLE
Remove estebank from automated review assignment

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1161,7 +1161,6 @@ compiler = [
     "@BoxyUwU",
     "@compiler-errors",
     "@davidtwco",
-    "@estebank",
     "@fee1-dead",
     "@fmease",
     "@jieyouxu",
@@ -1221,14 +1220,12 @@ incremental = [
 diagnostics = [
     "@compiler-errors",
     "@davidtwco",
-    "@estebank",
     "@oli-obk",
     "@chenyukang",
 ]
 parser = [
     "@compiler-errors",
     "@davidtwco",
-    "@estebank",
     "@nnethercote",
     "@petrochenkov",
     "@spastorino",
@@ -1236,7 +1233,6 @@ parser = [
 lexer = [
     "@nnethercote",
     "@petrochenkov",
-    "@estebank",
     "@chenyukang",
 ]
 arena = [
@@ -1268,7 +1264,6 @@ borrowck = [
 ]
 ast_lowering = [
     "@compiler-errors",
-    "@estebank",
     "@spastorino",
 ]
 debuginfo = [


### PR DESCRIPTION
First of all, Esteban thanks for all the reviews 💙

I think you've been quite busy IRL recently, so I'm proposing to remove you from the *automated* review assignment to prevent randomly rolling compiler PRs to you until you have more availability. If this is just temporary, please close this PR!

This is [just a way to improve our fairness when assigning reviews, trying to find a balance between leaving time to Rust contributors review on their terms and availability and avoid having PRs waiting for too long](https://github.com/rust-lang/compiler-team/issues/856).

> [!NOTE]
>
> This only prevents randomly-rolled compiler PRs from being auto assigned to you, it does not prevent explicit `r?` assignments.

**Please feel free to re-add yourself back to the active review rotation once you have more availability (if you feel like it).**

- If you want, it's also possible to only opt-out of the *general* compiler review rotation (`r? compiler`) but keep e.g. `r? diagnostics` rolls.

r? compiler_leads
