### PR TITLE
compiletest: Support optional error annotations

### DIFF
--- a/src/doc/rustc-dev-guide/src/tests/ui.md
+++ b/src/doc/rustc-dev-guide/src/tests/ui.md
@@ -218,6 +218,9 @@ fn meow(_: [u8]) {}
 //~| ERROR anonymous parameters
 ```
 
+A question mark after the error kind (`//~ ERROR?`) means that the annotation error is not actually
+required to be produced by the compiler, this is useful for target-dependent errors.
+
 The space character between `//~` (or other variants) and the subsequent text is
 negligible (i.e. there is no semantic difference between `//~ ERROR` and
 `//~ERROR` although the former is more common in the codebase).
@@ -335,7 +338,9 @@ Use of `error-pattern` is not recommended in general.
 For strict testing of compile time output, try to use the line annotations `//~` as much as
 possible, including `//~?` annotations for diagnostics without spans.
 
-If the compile time output is target dependent or too verbose, use directive
+If the compile time output is target dependent, use optional annotations `//~ ERROR?`.
+
+If the compile time output is too verbose, use directive
 `//@ dont-require-annotations: <diagnostic-kind>` to make the line annotation checking
 non-exhaustive.
 Some of the compiler messages can stay uncovered by annotations in this mode.

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -753,7 +753,7 @@ impl<'test> TestCx<'test> {
         let mut not_found = Vec::new();
         // anything not yet found is a problem
         for (index, expected_error) in expected_errors.iter().enumerate() {
-            if !found[index] {
+            if expected_error.require_annotation && !found[index] {
                 self.error(&format!(
                     "{}:{}: expected {} not found: {}",
                     file_name,

--- a/tests/ui/cfg/cfg_false_no_std-2.rs
+++ b/tests/ui/cfg/cfg_false_no_std-2.rs
@@ -1,6 +1,5 @@
 // Error, the linked empty library is `no_std` and doesn't provide a panic handler.
 
-//@ dont-require-annotations: ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build: cfg_false_lib_no_std_before.rs
 
@@ -11,6 +10,4 @@ extern crate cfg_false_lib_no_std_before as _;
 fn main() {}
 
 //~? ERROR `#[panic_handler]` function required, but not found
-// FIXME: This error is target-dependent, could be served by some "optional error" annotation
-// instead of `dont-require-annotations`.
-//FIXME~? ERROR unwinding panics are not supported without std
+//~? ERROR? unwinding panics are not supported without std

--- a/tests/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.rs
+++ b/tests/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.rs
@@ -1,12 +1,11 @@
-//FIXME~ ERROR values of the type `[u8; usize::MAX]` are too big for the target architecture
+//~ ERROR? values of the type `[u8; usize::MAX]` are too big for the target architecture
 // Make sure the compiler does not ICE when trying to generate the debuginfo name of a type that
 // causes a layout error.
 // This version of the test already ICE'd before the commit that introduce the ICE described in
 // https://github.com/rust-lang/rust/issues/94961.
 
-//@ compile-flags:-C debuginfo=2 --error-format=human
+//@ compile-flags:-C debuginfo=2
 //@ build-fail
-//@ error-pattern: values of the type `[u8; usize::MAX]` are too big for the target architecture
 
 #![crate_type = "rlib"]
 
@@ -18,5 +17,5 @@ pub fn foo() -> usize {
     std::mem::size_of::<Foo<u8>>()
 }
 
-// FIXME: the error is reported on different lines on different targets
-//FIXME~? ERROR values of the type `[u8; usize::MAX]` are too big for the target architecture
+// The error is reported on different lines on different targets
+//~? ERROR? values of the type `[u8; usize::MAX]` are too big for the target architecture

--- a/tests/ui/panic-runtime/two-panic-runtimes.rs
+++ b/tests/ui/panic-runtime/two-panic-runtimes.rs
@@ -1,6 +1,4 @@
-// ignore-tidy-linelength
 //@ build-fail
-//@ dont-require-annotations: ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build:panic-runtime-unwind.rs
 //@ aux-build:panic-runtime-unwind2.rs
@@ -16,7 +14,5 @@ extern crate panic_runtime_lang_items;
 fn main() {}
 
 //~? ERROR cannot link together two panic runtimes: panic_runtime_unwind and panic_runtime_unwind2
-// FIXME: These errors are target-dependent, could be served by some "optional error" annotation
-// instead of `dont-require-annotations`.
-//FIXME~? ERROR the linked panic runtime `panic_runtime_unwind2` is not compiled with this crate's panic strategy `abort`
-//FIXME~? ERROR the crate `panic_runtime_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`
+//~? ERROR? the linked panic runtime `panic_runtime_unwind2` is not compiled with this crate's panic strategy `abort`
+//~? ERROR? the crate `panic_runtime_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`

--- a/tests/ui/panic-runtime/want-abort-got-unwind.rs
+++ b/tests/ui/panic-runtime/want-abort-got-unwind.rs
@@ -1,6 +1,4 @@
-// ignore-tidy-linelength
 //@ build-fail
-//@ dont-require-annotations: ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build:panic-runtime-unwind.rs
 //@ compile-flags:-C panic=abort
@@ -10,7 +8,5 @@ extern crate panic_runtime_unwind;
 fn main() {}
 
 //~? ERROR the linked panic runtime `panic_runtime_unwind` is not compiled with this crate's panic strategy `abort`
-// FIXME: These errors are target-dependent, could be served by some "optional error" annotation
-// instead of `dont-require-annotations`.
-//FIXME~? ERROR cannot link together two panic runtimes: panic_unwind and panic_runtime_unwind
-//FIXME~? ERROR the crate `panic_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`
+//~? ERROR? cannot link together two panic runtimes: panic_unwind and panic_runtime_unwind
+//~? ERROR? the crate `panic_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`

--- a/tests/ui/panic-runtime/want-abort-got-unwind2.rs
+++ b/tests/ui/panic-runtime/want-abort-got-unwind2.rs
@@ -1,6 +1,4 @@
-// ignore-tidy-linelength
 //@ build-fail
-//@ dont-require-annotations: ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build:panic-runtime-unwind.rs
 //@ aux-build:wants-panic-runtime-unwind.rs
@@ -11,7 +9,5 @@ extern crate wants_panic_runtime_unwind;
 fn main() {}
 
 //~? ERROR the linked panic runtime `panic_runtime_unwind` is not compiled with this crate's panic strategy `abort`
-// FIXME: These errors are target-dependent, could be served by some "optional error" annotation
-// instead of `dont-require-annotations`.
-//FIXME~? ERROR cannot link together two panic runtimes: panic_unwind and panic_runtime_unwind
-//FIXME~? ERROR the crate `panic_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`
+//~? ERROR? cannot link together two panic runtimes: panic_unwind and panic_runtime_unwind
+//~? ERROR? the crate `panic_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`


### PR DESCRIPTION
that are not required to annotate an actual error, which is sometimes useful for target-dependent errors.

The syntax is `//~ ERROR? message`.

This is sort of a low cost low benefit feature, that is useful in specific cases.
I think it's better to have it, but not having it would also be ok.
The specific syntax is also up to debate.

r? @jieyouxu 