### PR TITLE
Adjust some ui tests re. target-dependent errors

### DIFF
--- a/tests/ui/cfg/cfg_false_no_std-2.rs
+++ b/tests/ui/cfg/cfg_false_no_std-2.rs
@@ -1,7 +1,11 @@
 // Error, the linked empty library is `no_std` and doesn't provide a panic handler.
 
-//@ dont-require-annotations: ERROR
 //@ dont-check-compiler-stderr
+
+// NOTE: fix a panic strategy to prevent differing errors subject to target's default panic strategy
+// which changes between targets. The specific panic strategy doesn't matter for test intention.
+//@ compile-flags: -Cpanic=abort
+
 //@ aux-build: cfg_false_lib_no_std_before.rs
 
 #![no_std]
@@ -11,6 +15,3 @@ extern crate cfg_false_lib_no_std_before as _;
 fn main() {}
 
 //~? ERROR `#[panic_handler]` function required, but not found
-// FIXME: This error is target-dependent, could be served by some "optional error" annotation
-// instead of `dont-require-annotations`.
-//FIXME~? ERROR unwinding panics are not supported without std

--- a/tests/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.rs
+++ b/tests/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.rs
@@ -1,4 +1,6 @@
-//FIXME~ ERROR values of the type `[u8; usize::MAX]` are too big for the target architecture
+// ignore-tidy-linelength
+// FIXME(#140620)~ ERROR values of the type `[u8; usize::MAX]` are too big for the target architecture
+
 // Make sure the compiler does not ICE when trying to generate the debuginfo name of a type that
 // causes a layout error.
 // This version of the test already ICE'd before the commit that introduce the ICE described in
@@ -18,5 +20,5 @@ pub fn foo() -> usize {
     std::mem::size_of::<Foo<u8>>()
 }
 
-// FIXME: the error is reported on different lines on different targets
-//FIXME~? ERROR values of the type `[u8; usize::MAX]` are too big for the target architecture
+// FIXME(#140620): the error is reported on different lines on different targets
+//FIXME(#140620)~? ERROR values of the type `[u8; usize::MAX]` are too big for the target architecture

--- a/tests/ui/panic-runtime/two-panic-runtimes.rs
+++ b/tests/ui/panic-runtime/two-panic-runtimes.rs
@@ -1,10 +1,18 @@
 // ignore-tidy-linelength
 //@ build-fail
-//@ dont-require-annotations: ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build:panic-runtime-unwind.rs
 //@ aux-build:panic-runtime-unwind2.rs
 //@ aux-build:panic-runtime-lang-items.rs
+
+// NOTE: there can be additional errors regarding trying to mix this crate if the precompiled target
+// (such as `wasm32-unknown-unknown` currently unconditionally defaulting to panic=abort) panic
+// strategy differs to abort, then involving a potentially-unwinding `panic_runtime_unwind` that
+// uses a different panic strategy. These errors are important but not to the test intention, which
+// is to check that trying to bring two panic runtimes (`panic_runtime_unwind`) and
+// (`panic_runtime_unwind2`) is prohibited. As such, the additional errors are not checked in this
+// test.
+//@ dont-require-annotations: ERROR
 
 #![no_std]
 #![no_main]
@@ -16,7 +24,3 @@ extern crate panic_runtime_lang_items;
 fn main() {}
 
 //~? ERROR cannot link together two panic runtimes: panic_runtime_unwind and panic_runtime_unwind2
-// FIXME: These errors are target-dependent, could be served by some "optional error" annotation
-// instead of `dont-require-annotations`.
-//FIXME~? ERROR the linked panic runtime `panic_runtime_unwind2` is not compiled with this crate's panic strategy `abort`
-//FIXME~? ERROR the crate `panic_runtime_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`

--- a/tests/ui/panic-runtime/want-abort-got-unwind.rs
+++ b/tests/ui/panic-runtime/want-abort-got-unwind.rs
@@ -1,16 +1,18 @@
 // ignore-tidy-linelength
 //@ build-fail
-//@ dont-require-annotations: ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build:panic-runtime-unwind.rs
 //@ compile-flags:-C panic=abort
+
+// NOTE: depending on the target's default panic strategy, there can be additional errors that
+// complain about linking two panic runtimes (e.g. precompiled `panic_unwind` if target default
+// panic strategy is unwind, in addition to `panic_runtime_unwind`). These additional errors will
+// not be observed on targets whose default panic strategy is abort, where `panic_abort` is linked
+// in instead.
+//@ dont-require-annotations: ERROR
 
 extern crate panic_runtime_unwind;
 
 fn main() {}
 
 //~? ERROR the linked panic runtime `panic_runtime_unwind` is not compiled with this crate's panic strategy `abort`
-// FIXME: These errors are target-dependent, could be served by some "optional error" annotation
-// instead of `dont-require-annotations`.
-//FIXME~? ERROR cannot link together two panic runtimes: panic_unwind and panic_runtime_unwind
-//FIXME~? ERROR the crate `panic_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`

--- a/tests/ui/panic-runtime/want-abort-got-unwind2.rs
+++ b/tests/ui/panic-runtime/want-abort-got-unwind2.rs
@@ -1,17 +1,23 @@
 // ignore-tidy-linelength
 //@ build-fail
-//@ dont-require-annotations: ERROR
 //@ dont-check-compiler-stderr
 //@ aux-build:panic-runtime-unwind.rs
 //@ aux-build:wants-panic-runtime-unwind.rs
 //@ compile-flags:-C panic=abort
+
+// Like `want-abort-got-unwind.rs`, this version checks that if the root binary wants abort panic
+// runtime, that the compiler rejects a setup where a dependency crate in the dependency DAG
+// transitively provides an unwind panic runtime (which also is built with `-Cpanic=unwind`, making
+// that potentially-unwinding).
+
+// NOTE: similar to `want-abort-got-unwind.rs`, there can be additional errors if the target default
+// panic strategy is unwind, because then the precompiled `panic_unwind` would also be linked in,
+// duplicating `panic_runtime_unwind` (transitively). But those additional errors are not important
+// to test intention.
+//@ dont-require-annotations: ERROR
 
 extern crate wants_panic_runtime_unwind;
 
 fn main() {}
 
 //~? ERROR the linked panic runtime `panic_runtime_unwind` is not compiled with this crate's panic strategy `abort`
-// FIXME: These errors are target-dependent, could be served by some "optional error" annotation
-// instead of `dont-require-annotations`.
-//FIXME~? ERROR cannot link together two panic runtimes: panic_unwind and panic_runtime_unwind
-//FIXME~? ERROR the crate `panic_unwind` requires panic strategy `unwind` which is incompatible with this crate's strategy of `abort`


### PR DESCRIPTION
Alternatives to optional error annotations in #140586:

- Continue to ignore target-dependent additional errors in `tests/ui/panic-runtime/{two-panic-runtimes.rs,tests/ui/panic-runtime/want-abort-got-unwind.rs,tests/ui/panic-runtime/want-abort-got-unwind2.rs}` -- but explain why some targets have more errors than others.
- Use `-Cpanic=abort` for `tests/ui/cfg/cfg_false_no_std-2.rs`. In that test, the panic strategy does not matter w.r.t. test intention.
- Adjust FIXMEs in `tests/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.rs` to track it in #140620.

---

try-job: armhf-gnu
try-job: test-various
try-job: x86_64-msvc-1
try-job: i686-msvc-1
try-job: x86_64-mingw-1
try-job: aarch64-apple
try-job: x86_64-apple-1