### PR TITLE
Steer docs to `utf8_chunks` and `Iterator::take`

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1358,6 +1358,7 @@ pub trait Iterator {
     /// ```
     ///
     /// [`by_ref`]: Iterator::by_ref
+    #[doc(alias = "limit")]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn take(self, n: usize) -> Take<Self>

--- a/library/core/src/str/lossy.rs
+++ b/library/core/src/str/lossy.rs
@@ -147,12 +147,14 @@ impl fmt::Debug for Debug<'_> {
 /// An iterator used to decode a slice of mostly UTF-8 bytes to string slices
 /// ([`&str`]) and byte slices ([`&[u8]`][byteslice]).
 ///
+/// This struct is created by the [`utf8_chunks`] method on bytes slices.
 /// If you want a simple conversion from UTF-8 byte slices to string slices,
 /// [`from_utf8`] is easier to use.
 ///
 /// See the [`Utf8Chunk`] type for documentation of the items yielded by this iterator.
 ///
 /// [byteslice]: slice
+/// [`utf8_chunks`]: slice::utf8_chunks
 /// [`from_utf8`]: super::from_utf8
 ///
 /// # Examples


### PR DESCRIPTION
- Adds `limit` as an alias of `take` (as this is [what Java calls this operation](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#limit-long-));
- Says that [`Utf8Chunks`](https://doc.rust-lang.org/std/str/struct.Utf8Chunks.html) comes from [`[u8]::utf8_chunks`](https://doc.rust-lang.org/std/primitive.slice.html#method.utf8_chunks).

@rustbot label +A-docs