### PR TITLE
Report the `unsafe_attr_outside_unsafe` lint at the closest node

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -82,6 +82,8 @@ struct AstValidator<'a> {
     /// Used to ban explicit safety on foreign items when the extern block is not marked as unsafe.
     extern_mod_safety: Option<Safety>,
 
+    lint_node_id: NodeId,
+
     lint_buffer: &'a mut LintBuffer,
 }
 
@@ -839,6 +841,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             self.has_proc_macro_decls = true;
         }
 
+        let previous_lint_node_id = mem::replace(&mut self.lint_node_id, item.id);
+
         if let Some(ident) = item.kind.ident()
             && attr::contains_name(&item.attrs, sym::no_mangle)
         {
@@ -1128,6 +1132,8 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             }
             _ => visit::walk_item(self, item),
         }
+
+        self.lint_node_id = previous_lint_node_id;
     }
 
     fn visit_foreign_item(&mut self, fi: &'a ForeignItem) {
@@ -1694,6 +1700,7 @@ pub fn check_crate(
         outer_impl_trait_span: None,
         disallow_tilde_const: Some(TildeConstReason::Item),
         extern_mod_safety: None,
+        lint_node_id: CRATE_NODE_ID,
         lint_buffer: lints,
     };
     visit::walk_crate(&mut validator, krate);

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -828,7 +828,7 @@ fn validate_generic_param_order(dcx: DiagCtxtHandle<'_>, generics: &[GenericPara
 
 impl<'a> Visitor<'a> for AstValidator<'a> {
     fn visit_attribute(&mut self, attr: &Attribute) {
-        validate_attr::check_attr(&self.sess.psess, attr);
+        validate_attr::check_attr(&self.sess.psess, attr, self.lint_node_id);
     }
 
     fn visit_ty(&mut self, ty: &'a Ty) {

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -274,7 +274,12 @@ impl<'a> StripUnconfigured<'a> {
     /// is in the original source file. Gives a compiler error if the syntax of
     /// the attribute is incorrect.
     pub(crate) fn expand_cfg_attr(&self, cfg_attr: &Attribute, recursive: bool) -> Vec<Attribute> {
-        validate_attr::check_attribute_safety(&self.sess.psess, AttributeSafety::Normal, &cfg_attr);
+        validate_attr::check_attribute_safety(
+            &self.sess.psess,
+            AttributeSafety::Normal,
+            &cfg_attr,
+            ast::CRATE_NODE_ID,
+        );
 
         // A trace attribute left in AST in place of the original `cfg_attr` attribute.
         // It can later be used by lints or other diagnostics.

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1983,7 +1983,11 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
         let mut span: Option<Span> = None;
         while let Some(attr) = attrs.next() {
             rustc_ast_passes::feature_gate::check_attribute(attr, self.cx.sess, features);
-            validate_attr::check_attr(&self.cx.sess.psess, attr);
+            validate_attr::check_attr(
+                &self.cx.sess.psess,
+                attr,
+                self.cx.current_expansion.lint_node_id,
+            );
 
             let current_span = if let Some(sp) = span { sp.to(attr.span) } else { attr.span };
             span = Some(current_span);

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-allow.rs
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-allow.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+//@ edition: 2021
+//
+// Anti-regression test for https://github.com/rust-lang/rust/issues/140602
+// where the generated warning couldn't be allowed due too being attached to
+// the wrong AST node.
+
+#![deny(unsafe_attr_outside_unsafe)]
+
+#[allow(unsafe_attr_outside_unsafe)]
+mod generated {
+    #[no_mangle]
+    fn _generated_foo() {}
+}
+
+fn main() {}


### PR DESCRIPTION
This PR have `AstValidation` track a linting node id and then uses it when reporting the `unsafe_attr_outside_unsafe` lint, so that instead of being bound at the crate-root, `#[allow]` of the lint works at any node.

Fixes rust-lang/rust#140602
r? @jieyouxu 
