### PR TITLE
Small adjustments to `check_attribute_safety` to make the logic more obvious

### DIFF
--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -276,7 +276,7 @@ impl<'a> StripUnconfigured<'a> {
     pub(crate) fn expand_cfg_attr(&self, cfg_attr: &Attribute, recursive: bool) -> Vec<Attribute> {
         validate_attr::check_attribute_safety(
             &self.sess.psess,
-            AttributeSafety::Normal,
+            Some(AttributeSafety::Normal),
             &cfg_attr,
             ast::CRATE_NODE_ID,
         );

--- a/tests/ui/rust-2024/unsafe-attributes/auxiliary/safe_attr.rs
+++ b/tests/ui/rust-2024/unsafe-attributes/auxiliary/safe_attr.rs
@@ -1,0 +1,7 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn safe(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}

--- a/tests/ui/rust-2024/unsafe-attributes/safe-proc-macro-attribute.rs
+++ b/tests/ui/rust-2024/unsafe-attributes/safe-proc-macro-attribute.rs
@@ -1,0 +1,22 @@
+//! Anti-regression test for `#[safe]` proc-macro attribute.
+
+//@ revisions: unknown_attr proc_macro_attr
+//@[proc_macro_attr] proc-macro: safe_attr.rs
+//@[proc_macro_attr] check-pass
+
+#![warn(unsafe_attr_outside_unsafe)]
+
+#[cfg(proc_macro_attr)]
+extern crate safe_attr;
+#[cfg(proc_macro_attr)]
+use safe_attr::safe;
+
+#[safe]
+//[unknown_attr]~^ ERROR cannot find attribute `safe` in this scope
+fn foo() {}
+
+#[safe(no_mangle)]
+//[unknown_attr]~^ ERROR cannot find attribute `safe` in this scope
+fn bar() {}
+
+fn main() {}

--- a/tests/ui/rust-2024/unsafe-attributes/safe-proc-macro-attribute.unknown_attr.stderr
+++ b/tests/ui/rust-2024/unsafe-attributes/safe-proc-macro-attribute.unknown_attr.stderr
@@ -1,0 +1,14 @@
+error: cannot find attribute `safe` in this scope
+  --> $DIR/safe-proc-macro-attribute.rs:18:3
+   |
+LL | #[safe(no_mangle)]
+   |   ^^^^
+
+error: cannot find attribute `safe` in this scope
+  --> $DIR/safe-proc-macro-attribute.rs:14:3
+   |
+LL | #[safe]
+   |   ^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Follow-up to #140617.