### PR TITLE
allow `#[rustfmt::skip]` in combination with `#[naked]`

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -683,7 +683,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         }
                     }
 
-                    if !other_attr.has_any_name(ALLOW_LIST) {
+                    if !other_attr.has_any_name(ALLOW_LIST)
+                        && !matches!(other_attr.path().as_slice(), [sym::rustfmt, ..])
+                    {
                         let path = other_attr.path();
                         let path: Vec<_> = path.iter().map(|s| s.as_str()).collect();
                         let other_attr_name = path.join("::");

--- a/tests/ui/asm/naked-functions.rs
+++ b/tests/ui/asm/naked-functions.rs
@@ -231,3 +231,9 @@ pub extern "C" fn compatible_linkage() {
 pub extern "C" fn rustc_std_internal_symbol() {
     naked_asm!("", options(raw));
 }
+
+#[rustfmt::skip]
+#[unsafe(naked)]
+pub extern "C" fn rustfmt_skip() {
+    naked_asm!("", options(raw));
+}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/140623

We very deliberately use an allowlist to prevent weird interactions with `#[naked]`, hopefully we've now found all of the useful combinations.

cc @Amanieu 