### PR TITLE
Async drop source info fix for proxy-drop-coroutine

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1929,13 +1929,17 @@ impl<'tcx> TyCtxt<'tcx> {
             if arg_cor_ty.is_coroutine() {
                 let span = self.def_span(def_id);
                 let source_info = SourceInfo::outermost(span);
+                // Even minimal, empty coroutine has 3 states (RESERVED_VARIANTS),
+                // so variant_fields and variant_source_info should have 3 elements.
                 let variant_fields: IndexVec<VariantIdx, IndexVec<FieldIdx, CoroutineSavedLocal>> =
                     iter::repeat(IndexVec::new()).take(CoroutineArgs::RESERVED_VARIANTS).collect();
+                let variant_source_info: IndexVec<VariantIdx, SourceInfo> =
+                    iter::repeat(source_info).take(CoroutineArgs::RESERVED_VARIANTS).collect();
                 let proxy_layout = CoroutineLayout {
                     field_tys: [].into(),
                     field_names: [].into(),
                     variant_fields,
-                    variant_source_info: [source_info].into(),
+                    variant_source_info,
                     storage_conflicts: BitMatrix::new(0, 0),
                 };
                 return Some(self.arena.alloc(proxy_layout));


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
https://github.com/rust-lang/rust/issues/126482
https://github.com/rust-lang/rust/issues/140426
    r? oli-obk
-->
<!-- homu-ignore:end -->

Fixes crash at debug info generation: https://github.com/rust-lang/rust/issues/140426 .
Also, the submitted example requires sync Drop implementation too.
Because sync version is required for unwind and when drop is performed in sync context (sync function).

Probably, it is also needed to add such a lint/error about missed `impl Drop`, when there is `impl AsyncDrop`.

Fix description: even minimal, empty coroutine (for proxy-coroutine) has 3 states and the source info array should have 3 elements too.

```
#![feature(async_drop)]

use std::future::AsyncDrop;
use std::pin::Pin;

#[tokio::main(flavor = "current_thread")]
async fn main() {
    let _st = St;
}

struct St;

impl AsyncDrop for St {
    async fn drop(self: Pin<&mut Self>) {
        println!("123");
    }
}
```