### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -2954,12 +2954,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
             }
         }
 
-        let name = if borrow_span.in_external_macro(self.infcx.tcx.sess.source_map()) {
-            // Don't name local variables in external macros.
-            "value".to_string()
-        } else {
-            format!("`{name}`")
-        };
+        let name = format!("`{name}`");
 
         let mut err = self.path_does_not_live_long_enough(borrow_span, &name);
 

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -317,6 +317,14 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         opt: DescribePlaceOpt,
     ) -> Option<String> {
         let local = place.local;
+        if self.body.local_decls[local]
+            .source_info
+            .span
+            .in_external_macro(self.infcx.tcx.sess.source_map())
+        {
+            return None;
+        }
+
         let mut autoderef_index = None;
         let mut buf = String::new();
         let mut ok = self.append_local_to_string(local, &mut buf);

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1929,13 +1929,17 @@ impl<'tcx> TyCtxt<'tcx> {
             if arg_cor_ty.is_coroutine() {
                 let span = self.def_span(def_id);
                 let source_info = SourceInfo::outermost(span);
+                // Even minimal, empty coroutine has 3 states (RESERVED_VARIANTS),
+                // so variant_fields and variant_source_info should have 3 elements.
                 let variant_fields: IndexVec<VariantIdx, IndexVec<FieldIdx, CoroutineSavedLocal>> =
                     iter::repeat(IndexVec::new()).take(CoroutineArgs::RESERVED_VARIANTS).collect();
+                let variant_source_info: IndexVec<VariantIdx, SourceInfo> =
+                    iter::repeat(source_info).take(CoroutineArgs::RESERVED_VARIANTS).collect();
                 let proxy_layout = CoroutineLayout {
                     field_tys: [].into(),
                     field_names: [].into(),
                     variant_fields,
-                    variant_source_info: [source_info].into(),
+                    variant_source_info,
                     storage_conflicts: BitMatrix::new(0, 0),
                 };
                 return Some(self.arena.alloc(proxy_layout));

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -112,8 +112,7 @@ impl Cargo {
         let mut cargo = builder.cargo(compiler, mode, source_type, target, cmd_kind);
 
         match cmd_kind {
-            // No need to configure the target linker for these command types,
-            // as they don't invoke rustc at all.
+            // No need to configure the target linker for these command types.
             Kind::Clean | Kind::Check | Kind::Suggest | Kind::Format | Kind::Setup => {}
             _ => {
                 cargo.configure_linker(builder);
@@ -205,6 +204,8 @@ impl Cargo {
         self
     }
 
+    // FIXME(onur-ozkan): Add coverage to make sure modifications to this function
+    // doesn't cause cache invalidations (e.g., #130108).
     fn configure_linker(&mut self, builder: &Builder<'_>) -> &mut Cargo {
         let target = self.target;
         let compiler = self.compiler;

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -114,7 +114,7 @@ impl Cargo {
         match cmd_kind {
             // No need to configure the target linker for these command types,
             // as they don't invoke rustc at all.
-            Kind::Clean | Kind::Suggest | Kind::Format | Kind::Setup => {}
+            Kind::Clean | Kind::Check | Kind::Suggest | Kind::Format | Kind::Setup => {}
             _ => {
                 cargo.configure_linker(builder);
             }

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -96,6 +96,7 @@ pub fn find(build: &Build) {
     let targets: HashSet<_> = match build.config.cmd {
         // We don't need to check cross targets for these commands.
         crate::Subcommand::Clean { .. }
+        | crate::Subcommand::Check { .. }
         | crate::Subcommand::Suggest { .. }
         | crate::Subcommand::Format { .. }
         | crate::Subcommand::Setup { .. } => {

--- a/tests/ui/derives/deriving-with-repr-packed-move-errors.rs
+++ b/tests/ui/derives/deriving-with-repr-packed-move-errors.rs
@@ -11,15 +11,15 @@ use std::cmp::Ordering;
 #[repr(packed)]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
 struct StructA(String);
-//~^ ERROR: cannot move out of `self` which is behind a shared reference
-//~| ERROR: cannot move out of `self` which is behind a shared reference
-//~| ERROR: cannot move out of `other` which is behind a shared reference
-//~| ERROR: cannot move out of `self` which is behind a shared reference
-//~| ERROR: cannot move out of `other` which is behind a shared reference
-//~| ERROR: cannot move out of `self` which is behind a shared reference
-//~| ERROR: cannot move out of `other` which is behind a shared reference
-//~| ERROR: cannot move out of `self` which is behind a shared reference
-//~| ERROR: cannot move out of `self` which is behind a shared reference
+//~^ ERROR: cannot move out of a shared reference [E0507]
+//~| ERROR: cannot move out of a shared reference [E0507]
+//~| ERROR: cannot move out of a shared reference [E0507]
+//~| ERROR: cannot move out of a shared reference [E0507]
+//~| ERROR: cannot move out of a shared reference [E0507]
+//~| ERROR: cannot move out of a shared reference [E0507]
+//~| ERROR: cannot move out of a shared reference [E0507]
+//~| ERROR: cannot move out of a shared reference [E0507]
+//~| ERROR: cannot move out of a shared reference [E0507]
 
 
 // Unrelated impl: additinal diagnostic should NOT be emitted

--- a/tests/ui/derives/deriving-with-repr-packed-move-errors.stderr
+++ b/tests/ui/derives/deriving-with-repr-packed-move-errors.stderr
@@ -1,10 +1,10 @@
-error[E0507]: cannot move out of `self` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed-move-errors.rs:13:16
    |
 LL | #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
    |          ----- in this derive macro expansion
 LL | struct StructA(String);
-   |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
+   |                ^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Debug)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
 help: consider cloning the value if the performance cost is acceptable
@@ -12,13 +12,13 @@ help: consider cloning the value if the performance cost is acceptable
 LL | struct StructA(String.clone());
    |                      ++++++++
 
-error[E0507]: cannot move out of `self` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed-move-errors.rs:13:16
    |
 LL | #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
    |                 --------- in this derive macro expansion
 LL | struct StructA(String);
-   |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
+   |                ^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(PartialEq)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
 help: consider cloning the value if the performance cost is acceptable
@@ -26,27 +26,28 @@ help: consider cloning the value if the performance cost is acceptable
 LL | struct StructA(String.clone());
    |                      ++++++++
 
-error[E0507]: cannot move out of `other` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed-move-errors.rs:13:16
    |
 LL | #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
    |                 --------- in this derive macro expansion
 LL | struct StructA(String);
-   |                ^^^^^^ move occurs because `other.0` has type `String`, which does not implement the `Copy` trait
+   |                ^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(PartialEq)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
    |                      ++++++++
 
-error[E0507]: cannot move out of `self` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed-move-errors.rs:13:16
    |
 LL | #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
    |                                ---------- in this derive macro expansion
 LL | struct StructA(String);
-   |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
+   |                ^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(PartialOrd)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
 help: consider cloning the value if the performance cost is acceptable
@@ -54,27 +55,28 @@ help: consider cloning the value if the performance cost is acceptable
 LL | struct StructA(String.clone());
    |                      ++++++++
 
-error[E0507]: cannot move out of `other` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed-move-errors.rs:13:16
    |
 LL | #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
    |                                ---------- in this derive macro expansion
 LL | struct StructA(String);
-   |                ^^^^^^ move occurs because `other.0` has type `String`, which does not implement the `Copy` trait
+   |                ^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(PartialOrd)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
    |                      ++++++++
 
-error[E0507]: cannot move out of `self` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed-move-errors.rs:13:16
    |
 LL | #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
    |                                            --- in this derive macro expansion
 LL | struct StructA(String);
-   |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
+   |                ^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Ord)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
 help: consider cloning the value if the performance cost is acceptable
@@ -82,27 +84,28 @@ help: consider cloning the value if the performance cost is acceptable
 LL | struct StructA(String.clone());
    |                      ++++++++
 
-error[E0507]: cannot move out of `other` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed-move-errors.rs:13:16
    |
 LL | #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
    |                                            --- in this derive macro expansion
 LL | struct StructA(String);
-   |                ^^^^^^ move occurs because `other.0` has type `String`, which does not implement the `Copy` trait
+   |                ^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Ord)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: consider cloning the value if the performance cost is acceptable
    |
 LL | struct StructA(String.clone());
    |                      ++++++++
 
-error[E0507]: cannot move out of `self` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed-move-errors.rs:13:16
    |
 LL | #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
    |                                                 ---- in this derive macro expansion
 LL | struct StructA(String);
-   |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
+   |                ^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Hash)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
 help: consider cloning the value if the performance cost is acceptable
@@ -110,13 +113,13 @@ help: consider cloning the value if the performance cost is acceptable
 LL | struct StructA(String.clone());
    |                      ++++++++
 
-error[E0507]: cannot move out of `self` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed-move-errors.rs:13:16
    |
 LL | #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default)]
    |                                                       ----- in this derive macro expansion
 LL | struct StructA(String);
-   |                ^^^^^^ move occurs because `self.0` has type `String`, which does not implement the `Copy` trait
+   |                ^^^^^^ move occurs because value has type `String`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Clone)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
 help: consider cloning the value if the performance cost is acceptable

--- a/tests/ui/derives/deriving-with-repr-packed.rs
+++ b/tests/ui/derives/deriving-with-repr-packed.rs
@@ -20,7 +20,7 @@ struct Y(usize);
 #[derive(Debug, Default)]
 #[repr(packed)]
 struct X(Y);
-//~^ ERROR cannot move out of `self` which is behind a shared reference
+//~^ ERROR cannot move out of a shared reference [E0507]
 
 #[derive(Debug)]
 #[repr(packed)]

--- a/tests/ui/derives/deriving-with-repr-packed.stderr
+++ b/tests/ui/derives/deriving-with-repr-packed.stderr
@@ -1,11 +1,11 @@
-error[E0507]: cannot move out of `self` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed.rs:22:10
    |
 LL | #[derive(Debug, Default)]
    |          ----- in this derive macro expansion
 LL | #[repr(packed)]
 LL | struct X(Y);
-   |          ^ move occurs because `self.0` has type `Y`, which does not implement the `Copy` trait
+   |          ^ move occurs because value has type `Y`, which does not implement the `Copy` trait
    |
 note: if `Y` implemented `Clone`, you could clone the value
   --> $DIR/deriving-with-repr-packed.rs:16:1
@@ -23,14 +23,14 @@ error[E0161]: cannot move a value of type `[u8]`
 LL |     data: [u8],
    |     ^^^^^^^^^^ the size of `[u8]` cannot be statically determined
 
-error[E0507]: cannot move out of `self.data` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed.rs:29:5
    |
 LL | #[derive(Debug)]
    |          ----- in this derive macro expansion
 ...
 LL |     data: [u8],
-   |     ^^^^^^^^^^ move occurs because `self.data` has type `[u8]`, which does not implement the `Copy` trait
+   |     ^^^^^^^^^^ move occurs because value has type `[u8]`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Debug)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
 
@@ -40,14 +40,14 @@ error[E0161]: cannot move a value of type `str`
 LL |     data: str,
    |     ^^^^^^^^^ the size of `str` cannot be statically determined
 
-error[E0507]: cannot move out of `self.data` which is behind a shared reference
+error[E0507]: cannot move out of a shared reference
   --> $DIR/deriving-with-repr-packed.rs:38:5
    |
 LL | #[derive(Debug)]
    |          ----- in this derive macro expansion
 ...
 LL |     data: str,
-   |     ^^^^^^^^^ move occurs because `self.data` has type `str`, which does not implement the `Copy` trait
+   |     ^^^^^^^^^ move occurs because value has type `str`, which does not implement the `Copy` trait
    |
    = note: `#[derive(Debug)]` triggers a move because taking references to the fields of a packed struct is undefined behaviour
 

--- a/tests/ui/macros/auxiliary/return_from_external_macro.rs
+++ b/tests/ui/macros/auxiliary/return_from_external_macro.rs
@@ -1,0 +1,11 @@
+#![feature(super_let)]
+
+#[macro_export]
+macro_rules! foo {
+    () => {
+        {
+            super let args = 1;
+            &args
+        }
+    };
+}

--- a/tests/ui/macros/return_from_external_macro.rs
+++ b/tests/ui/macros/return_from_external_macro.rs
@@ -1,0 +1,17 @@
+//@ aux-crate: ret_from_ext=return_from_external_macro.rs
+
+#![feature(super_let)]
+extern crate ret_from_ext;
+
+fn foo() -> impl Sized {
+    drop(|| ret_from_ext::foo!());
+    //~^ ERROR cannot return reference to local binding
+
+    ret_from_ext::foo!()
+    //~^ ERROR temporary value dropped while borrowed
+}
+//~^ NOTE temporary value is freed at the end of this statement
+
+fn main() {
+    foo();
+}

--- a/tests/ui/macros/return_from_external_macro.stderr
+++ b/tests/ui/macros/return_from_external_macro.stderr
@@ -1,0 +1,29 @@
+error[E0515]: cannot return reference to local binding
+  --> $DIR/return_from_external_macro.rs:7:13
+   |
+LL |     drop(|| ret_from_ext::foo!());
+   |             ^^^^^^^^^^^^^^^^^^^^
+   |             |
+   |             returns a reference to data owned by the current function
+   |             local binding introduced here
+   |
+   = note: this error originates in the macro `ret_from_ext::foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/return_from_external_macro.rs:10:5
+   |
+LL |     ret_from_ext::foo!()
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     creates a temporary value which is freed while still in use
+   |     opaque type requires that borrow lasts for `'static`
+LL |
+LL | }
+   | - temporary value is freed at the end of this statement
+   |
+   = note: this error originates in the macro `ret_from_ext::foo` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0515, E0716.
+For more information about an error, try `rustc --explain E0515`.

--- a/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.rs
+++ b/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.rs
@@ -9,14 +9,14 @@ use core::{
 
 fn function_call_stops_borrow_extension() {
     let phantom_pinned = identity(pin!(PhantomPinned));
-    //~^ ERROR does not live long enough
+    //~^ ERROR temporary value dropped while borrowed [E0716]
     stuff(phantom_pinned)
 }
 
 fn promotion_only_works_for_the_innermost_block() {
     let phantom_pinned = {
         let phantom_pinned = pin!(PhantomPinned);
-        //~^ ERROR does not live long enough
+        //~^ ERROR temporary value dropped while borrowed [E0716]
         phantom_pinned
     };
     stuff(phantom_pinned)

--- a/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.stderr
+++ b/tests/ui/pin-macro/lifetime_errors_on_promotion_misusage.stderr
@@ -1,29 +1,31 @@
-error[E0597]: value does not live long enough
+error[E0716]: temporary value dropped while borrowed
   --> $DIR/lifetime_errors_on_promotion_misusage.rs:11:35
    |
 LL |     let phantom_pinned = identity(pin!(PhantomPinned));
-   |                                   ^^^^^^^^^^^^^^^^^^^ - value dropped here while still borrowed
+   |                                   ^^^^^^^^^^^^^^^^^^^ - temporary value is freed at the end of this statement
    |                                   |
-   |                                   borrowed value does not live long enough
+   |                                   creates a temporary value which is freed while still in use
 LL |
 LL |     stuff(phantom_pinned)
    |           -------------- borrow later used here
    |
+   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0597]: value does not live long enough
+error[E0716]: temporary value dropped while borrowed
   --> $DIR/lifetime_errors_on_promotion_misusage.rs:18:30
    |
 LL |     let phantom_pinned = {
    |         -------------- borrow later stored here
 LL |         let phantom_pinned = pin!(PhantomPinned);
-   |                              ^^^^^^^^^^^^^^^^^^^ borrowed value does not live long enough
+   |                              ^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
 ...
 LL |     };
-   |     - value dropped here while still borrowed
+   |     - temporary value is freed at the end of this statement
    |
+   = note: consider using a `let` binding to create a longer lived value
    = note: this error originates in the macro `pin` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0597`.
+For more information about this error, try `rustc --explain E0716`.


### PR DESCRIPTION
Successful merges:

 - #140357 (bypass linker configuration and cross target check on `x check`)
 - #140580 (Don't name variables from external macros in borrow errors.)
 - #140630 (Async drop source info fix for proxy-drop-coroutine)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=140357,140580,140630)
<!-- homu-ignore:end -->