### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -276,7 +276,7 @@ impl<'a> StripUnconfigured<'a> {
     pub(crate) fn expand_cfg_attr(&self, cfg_attr: &Attribute, recursive: bool) -> Vec<Attribute> {
         validate_attr::check_attribute_safety(
             &self.sess.psess,
-            AttributeSafety::Normal,
+            Some(AttributeSafety::Normal),
             &cfg_attr,
             ast::CRATE_NODE_ID,
         );

--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -37,6 +37,7 @@ use std::env::{self, VarError};
 use std::fmt::{self, Display};
 use std::io::{self, IsTerminal};
 
+use tracing::dispatcher::SetGlobalDefaultError;
 use tracing_core::{Event, Subscriber};
 use tracing_subscriber::filter::{Directive, EnvFilter, LevelFilter};
 use tracing_subscriber::fmt::FmtContext;
@@ -131,10 +132,10 @@ pub fn init_logger(cfg: LoggerConfig) -> Result<(), Error> {
                 .without_time()
                 .event_format(BacktraceFormatter { backtrace_target });
             let subscriber = subscriber.with(fmt_layer);
-            tracing::subscriber::set_global_default(subscriber).unwrap();
+            tracing::subscriber::set_global_default(subscriber)?;
         }
         Err(_) => {
-            tracing::subscriber::set_global_default(subscriber).unwrap();
+            tracing::subscriber::set_global_default(subscriber)?;
         }
     };
 
@@ -180,6 +181,7 @@ pub enum Error {
     InvalidColorValue(String),
     NonUnicodeColorValue,
     InvalidWraptree(String),
+    AlreadyInit(SetGlobalDefaultError),
 }
 
 impl std::error::Error for Error {}
@@ -199,6 +201,13 @@ impl Display for Error {
                 formatter,
                 "invalid log WRAPTREE value '{value}': expected a non-negative integer",
             ),
+            Error::AlreadyInit(tracing_error) => Display::fmt(tracing_error, formatter),
         }
+    }
+}
+
+impl From<SetGlobalDefaultError> for Error {
+    fn from(tracing_error: SetGlobalDefaultError) -> Self {
+        Error::AlreadyInit(tracing_error)
     }
 }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1929,13 +1929,17 @@ impl<'tcx> TyCtxt<'tcx> {
             if arg_cor_ty.is_coroutine() {
                 let span = self.def_span(def_id);
                 let source_info = SourceInfo::outermost(span);
+                // Even minimal, empty coroutine has 3 states (RESERVED_VARIANTS),
+                // so variant_fields and variant_source_info should have 3 elements.
                 let variant_fields: IndexVec<VariantIdx, IndexVec<FieldIdx, CoroutineSavedLocal>> =
                     iter::repeat(IndexVec::new()).take(CoroutineArgs::RESERVED_VARIANTS).collect();
+                let variant_source_info: IndexVec<VariantIdx, SourceInfo> =
+                    iter::repeat(source_info).take(CoroutineArgs::RESERVED_VARIANTS).collect();
                 let proxy_layout = CoroutineLayout {
                     field_tys: [].into(),
                     field_names: [].into(),
                     variant_fields,
-                    variant_source_info: [source_info].into(),
+                    variant_source_info,
                     storage_conflicts: BitMatrix::new(0, 0),
                 };
                 return Some(self.arena.alloc(proxy_layout));

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3659,9 +3659,9 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// If the returned `ExtractIf` is not exhausted, e.g. because it is dropped without iterating
     /// or the iteration short-circuits, then the remaining elements will be retained.
-    /// Use [`retain`] with a negated predicate if you do not need the returned iterator.
+    /// Use [`retain_mut`] with a negated predicate if you do not need the returned iterator.
     ///
-    /// [`retain`]: Vec::retain
+    /// [`retain_mut`]: Vec::retain_mut
     ///
     /// Using this method is equivalent to the following code:
     ///

--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3320,7 +3320,6 @@ pub const fn is_val_statically_known<T: Copy>(_arg: T) -> bool {
 #[inline]
 #[rustc_intrinsic]
 #[rustc_intrinsic_const_stable_indirect]
-#[rustc_allow_const_fn_unstable(const_swap_nonoverlapping)] // this is anyway not called since CTFE implements the intrinsic
 pub const unsafe fn typed_swap_nonoverlapping<T>(x: *mut T, y: *mut T) {
     // SAFETY: The caller provided single non-overlapping items behind
     // pointers, so swapping them with `count: 1` is fine.

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -15,7 +15,6 @@
 #![feature(char_max_len)]
 #![feature(clone_to_uninit)]
 #![feature(const_eval_select)]
-#![feature(const_swap_nonoverlapping)]
 #![feature(const_trait_impl)]
 #![feature(core_intrinsics)]
 #![feature(core_intrinsics_fallbacks)]

--- a/library/coretests/tests/ptr.rs
+++ b/library/coretests/tests/ptr.rs
@@ -949,6 +949,10 @@ fn test_const_swap_ptr() {
         // Make sure they still work.
         assert!(*s1.0.ptr == 1);
         assert!(*s2.0.ptr == 666);
+
+        // This is where we'd swap again using a `u8` type and a `count` of `size_of::<T>()` if it
+        // were not for the limitation of `swap_nonoverlapping` around pointers crossing multiple
+        // elements.
     };
 }
 

--- a/tests/codegen/const-vector.rs
+++ b/tests/codegen/const-vector.rs
@@ -1,4 +1,8 @@
-//@ compile-flags: -C no-prepopulate-passes -Copt-level=0
+//@ revisions: OPT0 OPT0_S390X
+//@ [OPT0] ignore-s390x
+//@ [OPT0_S390X] only-s390x
+//@ [OPT0] compile-flags: -C no-prepopulate-passes -Copt-level=0
+//@ [OPT0_S390X] compile-flags: -C no-prepopulate-passes -Copt-level=0 -C target-cpu=z13
 
 // This test checks that constants of SIMD type are passed as immediate vectors.
 // We ensure that both vector representations (struct with fields and struct wrapping array) work.

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -1,7 +1,5 @@
 //@ compile-flags: -Z ui-testing=no
 
-
-#![feature(const_swap_nonoverlapping)]
 use std::{
     mem::{self, MaybeUninit},
     ptr,

--- a/tests/ui/consts/missing_span_in_backtrace.stderr
+++ b/tests/ui/consts/missing_span_in_backtrace.stderr
@@ -1,11 +1,11 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/missing_span_in_backtrace.rs:16:9
+  --> $DIR/missing_span_in_backtrace.rs:14:9
    |
-16 | /         ptr::swap_nonoverlapping(
-17 | |             &mut ptr1 as *mut _ as *mut MaybeUninit<u8>,
-18 | |             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
-19 | |             mem::size_of::<&i32>(),
-20 | |         );
+14 | /         ptr::swap_nonoverlapping(
+15 | |             &mut ptr1 as *mut _ as *mut MaybeUninit<u8>,
+16 | |             &mut ptr2 as *mut _ as *mut MaybeUninit<u8>,
+17 | |             mem::size_of::<&i32>(),
+18 | |         );
    | |_________^ unable to copy parts of a pointer from memory at ALLOC0
    |
 note: inside `swap_nonoverlapping::<MaybeUninit<u8>>`

--- a/tests/ui/rust-2024/unsafe-attributes/auxiliary/safe_attr.rs
+++ b/tests/ui/rust-2024/unsafe-attributes/auxiliary/safe_attr.rs
@@ -1,0 +1,7 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn safe(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}

--- a/tests/ui/rust-2024/unsafe-attributes/safe-proc-macro-attribute.rs
+++ b/tests/ui/rust-2024/unsafe-attributes/safe-proc-macro-attribute.rs
@@ -1,0 +1,22 @@
+//! Anti-regression test for `#[safe]` proc-macro attribute.
+
+//@ revisions: unknown_attr proc_macro_attr
+//@[proc_macro_attr] proc-macro: safe_attr.rs
+//@[proc_macro_attr] check-pass
+
+#![warn(unsafe_attr_outside_unsafe)]
+
+#[cfg(proc_macro_attr)]
+extern crate safe_attr;
+#[cfg(proc_macro_attr)]
+use safe_attr::safe;
+
+#[safe]
+//[unknown_attr]~^ ERROR cannot find attribute `safe` in this scope
+fn foo() {}
+
+#[safe(no_mangle)]
+//[unknown_attr]~^ ERROR cannot find attribute `safe` in this scope
+fn bar() {}
+
+fn main() {}

--- a/tests/ui/rust-2024/unsafe-attributes/safe-proc-macro-attribute.unknown_attr.stderr
+++ b/tests/ui/rust-2024/unsafe-attributes/safe-proc-macro-attribute.unknown_attr.stderr
@@ -1,0 +1,14 @@
+error: cannot find attribute `safe` in this scope
+  --> $DIR/safe-proc-macro-attribute.rs:18:3
+   |
+LL | #[safe(no_mangle)]
+   |   ^^^^
+
+error: cannot find attribute `safe` in this scope
+  --> $DIR/safe-proc-macro-attribute.rs:14:3
+   |
+LL | #[safe]
+   |   ^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #137280 (stabilize ptr::swap_nonoverlapping in const)
 - #140457 (Use target-cpu=z13 on s390x codegen const vector test)
 - #140619 (Small adjustments to `check_attribute_safety` to make the logic more obvious)
 - #140625 (Suggest `retain_mut` over `retain` as `Vec::extract_if` alternative)
 - #140627 (Allow linking rustc and rustdoc against the same single tracing crate)
 - #140630 (Async drop source info fix for proxy-drop-coroutine)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=137280,140457,140619,140625,140627,140630)
<!-- homu-ignore:end -->