### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,7 +4520,6 @@ dependencies = [
  "itertools",
  "rustc_abi",
  "rustc_ast",
- "rustc_attr_parsing",
  "rustc_data_structures",
  "rustc_errors",
  "rustc_fluent_macro",

--- a/compiler/rustc_trait_selection/Cargo.toml
+++ b/compiler/rustc_trait_selection/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 itertools = "0.12"
 rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }
-rustc_attr_parsing = { path = "../rustc_attr_parsing" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_fluent_macro = { path = "../rustc_fluent_macro" }

--- a/compiler/rustc_trait_selection/messages.ftl
+++ b/compiler/rustc_trait_selection/messages.ftl
@@ -148,9 +148,6 @@ trait_selection_dtcs_has_req_note = the used `impl` has a `'static` requirement
 trait_selection_dtcs_introduces_requirement = calling this method introduces the `impl`'s `'static` requirement
 trait_selection_dtcs_suggestion = consider relaxing the implicit `'static` requirement
 
-trait_selection_empty_on_clause_in_rustc_on_unimplemented = empty `on`-clause in `#[rustc_on_unimplemented]`
-    .label = empty on-clause here
-
 trait_selection_explicit_lifetime_required_sugg_with_ident = add explicit lifetime `{$named}` to the type of `{$simple_ident}`
 
 trait_selection_explicit_lifetime_required_sugg_with_param_type = add explicit lifetime `{$named}` to type
@@ -186,9 +183,6 @@ trait_selection_inherent_projection_normalization_overflow = overflow evaluating
 
 trait_selection_invalid_format_specifier = invalid format specifier
     .help = no format specifier are supported in this position
-
-trait_selection_invalid_on_clause_in_rustc_on_unimplemented = invalid `on`-clause in `#[rustc_on_unimplemented]`
-    .label = invalid on-clause here
 
 trait_selection_label_bad = {$bad_kind ->
     *[other] cannot infer type
@@ -236,10 +230,6 @@ trait_selection_negative_positive_conflict = found both positive and negative im
     .negative_implementation_in_crate = negative implementation in crate `{$negative_impl_cname}`
     .positive_implementation_here = positive implementation here
     .positive_implementation_in_crate = positive implementation in crate `{$positive_impl_cname}`
-
-trait_selection_no_value_in_rustc_on_unimplemented = this attribute must have a valid value
-    .label = expected value here
-    .note = eg `#[rustc_on_unimplemented(message="foo")]`
 
 trait_selection_nothing = {""}
 
@@ -338,6 +328,22 @@ trait_selection_ril_because_of = because of this returned expression
 trait_selection_ril_introduced_by = requirement introduced by this return type
 trait_selection_ril_introduced_here = `'static` requirement introduced here
 trait_selection_ril_static_introduced_by = "`'static` lifetime requirement introduced by the return type
+
+trait_selection_rustc_on_unimplemented_empty_on_clause = empty `on`-clause in `#[rustc_on_unimplemented]`
+    .label = empty `on`-clause here
+trait_selection_rustc_on_unimplemented_expected_identifier = expected an identifier inside this `on`-clause
+    .label = expected an identifier here, not `{$path}`
+trait_selection_rustc_on_unimplemented_expected_one_predicate_in_not = expected a single predicate in `not(..)`
+    .label = unexpected quantity of predicates here
+trait_selection_rustc_on_unimplemented_invalid_flag = invalid flag in `on`-clause
+    .label = expected one of the `crate_local`, `direct` or `from_desugaring` flags, not `{$invalid_flag}`
+trait_selection_rustc_on_unimplemented_invalid_predicate = this predicate is invalid
+    .label = expected one of `any`, `all` or `not` here, not `{$invalid_pred}`
+trait_selection_rustc_on_unimplemented_missing_value = this attribute must have a value
+    .label = expected value here
+    .note = e.g. `#[rustc_on_unimplemented(message="foo")]`
+trait_selection_rustc_on_unimplemented_unsupported_literal_in_on = literals inside `on`-clauses are not supported
+    .label = unexpected literal here
 
 trait_selection_source_kind_closure_return =
     try giving this closure an explicit return type

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use rustc_ast::Path;
 use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_errors::codes::*;
 use rustc_errors::{
@@ -31,23 +32,50 @@ pub struct UnableToConstructConstantValue<'a> {
 }
 
 #[derive(Diagnostic)]
-#[diag(trait_selection_empty_on_clause_in_rustc_on_unimplemented, code = E0232)]
-pub struct EmptyOnClauseInOnUnimplemented {
-    #[primary_span]
-    #[label]
-    pub span: Span,
+pub enum InvalidOnClause {
+    #[diag(trait_selection_rustc_on_unimplemented_empty_on_clause, code = E0232)]
+    Empty {
+        #[primary_span]
+        #[label]
+        span: Span,
+    },
+    #[diag(trait_selection_rustc_on_unimplemented_expected_one_predicate_in_not, code = E0232)]
+    ExpectedOnePredInNot {
+        #[primary_span]
+        #[label]
+        span: Span,
+    },
+    #[diag(trait_selection_rustc_on_unimplemented_unsupported_literal_in_on, code = E0232)]
+    UnsupportedLiteral {
+        #[primary_span]
+        #[label]
+        span: Span,
+    },
+    #[diag(trait_selection_rustc_on_unimplemented_expected_identifier, code = E0232)]
+    ExpectedIdentifier {
+        #[primary_span]
+        #[label]
+        span: Span,
+        path: Path,
+    },
+    #[diag(trait_selection_rustc_on_unimplemented_invalid_predicate, code = E0232)]
+    InvalidPredicate {
+        #[primary_span]
+        #[label]
+        span: Span,
+        invalid_pred: Symbol,
+    },
+    #[diag(trait_selection_rustc_on_unimplemented_invalid_flag, code = E0232)]
+    InvalidFlag {
+        #[primary_span]
+        #[label]
+        span: Span,
+        invalid_flag: Symbol,
+    },
 }
 
 #[derive(Diagnostic)]
-#[diag(trait_selection_invalid_on_clause_in_rustc_on_unimplemented, code = E0232)]
-pub struct InvalidOnClauseInOnUnimplemented {
-    #[primary_span]
-    #[label]
-    pub span: Span,
-}
-
-#[derive(Diagnostic)]
-#[diag(trait_selection_no_value_in_rustc_on_unimplemented, code = E0232)]
+#[diag(trait_selection_rustc_on_unimplemented_missing_value, code = E0232)]
 #[note]
 pub struct NoValueInOnUnimplemented {
     #[primary_span]

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.156"
+version = "0.1.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ffbd2789fe5bb95b96a2e22cbe3128239dc46ff0374e0d38e9f102062d7055"
+checksum = "74f103f5a97b25e3ed7134dee586e90bbb0496b33ba41816f0e7274e5bb73b50"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 
 [dependencies]
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.156", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "=0.1.157", features = ['rustc-dep-of-std'] }
 
 [features]
 compiler-builtins-mem = ['compiler_builtins/mem']

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3666,21 +3666,27 @@ impl<T, A: Allocator> Vec<T, A> {
     /// Using this method is equivalent to the following code:
     ///
     /// ```
-    /// # use std::cmp::min;
-    /// # let some_predicate = |x: &mut i32| { *x == 2 || *x == 3 || *x == 6 };
-    /// # let mut vec = vec![1, 2, 3, 4, 5, 6];
-    /// # let range = 1..4;
+    /// # let some_predicate = |x: &mut i32| { *x % 2 == 1 };
+    /// # let mut vec = vec![0, 1, 2, 3, 4, 5, 6];
+    /// # let mut vec2 = vec.clone();
+    /// # let range = 1..5;
     /// let mut i = range.start;
-    /// while i < min(vec.len(), range.end) {
+    /// let end_items = vec.len() - range.end;
+    /// # let mut extracted = vec![];
+    ///
+    /// while i < vec.len() - end_items {
     ///     if some_predicate(&mut vec[i]) {
     ///         let val = vec.remove(i);
+    /// #         extracted.push(val);
     ///         // your code here
     ///     } else {
     ///         i += 1;
     ///     }
     /// }
     ///
-    /// # assert_eq!(vec, vec![1, 4, 5]);
+    /// # let extracted2: Vec<_> = vec2.extract_if(range, some_predicate).collect();
+    /// # assert_eq!(vec, vec2);
+    /// # assert_eq!(extracted, extracted2);
     /// ```
     ///
     /// But `extract_if` is easier to use. `extract_if` is also more efficient,

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -1,6 +1,5 @@
 use core::num::NonZero;
 
-use crate::cmp::Ordering;
 use crate::iter::adapters::zip::try_get_unchecked;
 use crate::iter::adapters::{SourceIter, TrustedRandomAccess, TrustedRandomAccessNoCoerce};
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedLen, UncheckedIterator};
@@ -42,31 +41,13 @@ where
         self.it.next().cloned()
     }
 
-    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.it.size_hint()
     }
 
-    #[inline]
-    fn count(self) -> usize {
-        self.it.count()
-    }
-
-    fn last(self) -> Option<T> {
-        self.it.last().cloned()
-    }
-
-    #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
-        self.it.advance_by(n)
-    }
-
-    fn nth(&mut self, n: usize) -> Option<T> {
-        self.it.nth(n).cloned()
-    }
-
     fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
+        Self: Sized,
         F: FnMut(B, Self::Item) -> R,
         R: Try<Output = B>,
     {
@@ -78,58 +59,6 @@ where
         F: FnMut(Acc, Self::Item) -> Acc,
     {
         self.it.map(T::clone).fold(init, f)
-    }
-
-    fn find<P>(&mut self, mut predicate: P) -> Option<Self::Item>
-    where
-        P: FnMut(&Self::Item) -> bool,
-    {
-        self.it.find(move |x| predicate(&x)).cloned()
-    }
-
-    fn max_by<F>(self, mut compare: F) -> Option<Self::Item>
-    where
-        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
-    {
-        self.it.max_by(move |&x, &y| compare(x, y)).cloned()
-    }
-
-    fn min_by<F>(self, mut compare: F) -> Option<Self::Item>
-    where
-        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
-    {
-        self.it.min_by(move |&x, &y| compare(x, y)).cloned()
-    }
-
-    fn cmp<O>(self, other: O) -> Ordering
-    where
-        O: IntoIterator<Item = Self::Item>,
-        Self::Item: Ord,
-    {
-        self.it.cmp_by(other, |x, y| x.cmp(&y))
-    }
-
-    fn partial_cmp<O>(self, other: O) -> Option<Ordering>
-    where
-        O: IntoIterator,
-        Self::Item: PartialOrd<O::Item>,
-    {
-        self.it.partial_cmp_by(other, |x, y| x.partial_cmp(&y))
-    }
-
-    fn eq<O>(self, other: O) -> bool
-    where
-        O: IntoIterator,
-        Self::Item: PartialEq<O::Item>,
-    {
-        self.it.eq_by(other, |x, y| x == &y)
-    }
-
-    fn is_sorted_by<F>(self, mut compare: F) -> bool
-    where
-        F: FnMut(&Self::Item, &Self::Item) -> bool,
-    {
-        self.it.is_sorted_by(move |&x, &y| compare(x, y))
     }
 
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
@@ -152,13 +81,9 @@ where
         self.it.next_back().cloned()
     }
 
-    #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
-        self.it.advance_back_by(n)
-    }
-
     fn try_rfold<B, F, R>(&mut self, init: B, f: F) -> R
     where
+        Self: Sized,
         F: FnMut(B, Self::Item) -> R,
         R: Try<Output = B>,
     {
@@ -171,13 +96,6 @@ where
     {
         self.it.map(T::clone).rfold(init, f)
     }
-
-    fn rfind<P>(&mut self, mut predicate: P) -> Option<Self::Item>
-    where
-        P: FnMut(&Self::Item) -> bool,
-    {
-        self.it.rfind(move |x| predicate(&x)).cloned()
-    }
 }
 
 #[stable(feature = "iter_cloned", since = "1.1.0")]
@@ -186,12 +104,10 @@ where
     I: ExactSizeIterator<Item = &'a T>,
     T: Clone,
 {
-    #[inline]
     fn len(&self) -> usize {
         self.it.len()
     }
 
-    #[inline]
     fn is_empty(&self) -> bool {
         self.it.is_empty()
     }

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -1,4 +1,3 @@
-use crate::cmp::Ordering;
 use crate::iter::adapters::zip::try_get_unchecked;
 use crate::iter::adapters::{SourceIter, TrustedRandomAccess, TrustedRandomAccessNoCoerce};
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedLen};
@@ -49,35 +48,20 @@ where
 
     fn next_chunk<const N: usize>(
         &mut self,
-    ) -> Result<[Self::Item; N], array::IntoIter<Self::Item, N>> {
+    ) -> Result<[Self::Item; N], array::IntoIter<Self::Item, N>>
+    where
+        Self: Sized,
+    {
         <I as SpecNextChunk<'_, N, T>>::spec_next_chunk(&mut self.it)
     }
 
-    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.it.size_hint()
     }
 
-    #[inline]
-    fn count(self) -> usize {
-        self.it.count()
-    }
-
-    fn last(self) -> Option<T> {
-        self.it.last().copied()
-    }
-
-    #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
-        self.it.advance_by(n)
-    }
-
-    fn nth(&mut self, n: usize) -> Option<T> {
-        self.it.nth(n).copied()
-    }
-
     fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
+        Self: Sized,
         F: FnMut(B, Self::Item) -> R,
         R: Try<Output = B>,
     {
@@ -91,56 +75,21 @@ where
         self.it.fold(init, copy_fold(f))
     }
 
-    fn find<P>(&mut self, mut predicate: P) -> Option<Self::Item>
-    where
-        P: FnMut(&Self::Item) -> bool,
-    {
-        self.it.find(move |x| predicate(&x)).copied()
+    fn nth(&mut self, n: usize) -> Option<T> {
+        self.it.nth(n).copied()
     }
 
-    fn max_by<F>(self, mut compare: F) -> Option<Self::Item>
-    where
-        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
-    {
-        self.it.max_by(move |&x, &y| compare(x, y)).copied()
+    fn last(self) -> Option<T> {
+        self.it.last().copied()
     }
 
-    fn min_by<F>(self, mut compare: F) -> Option<Self::Item>
-    where
-        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
-    {
-        self.it.min_by(move |&x, &y| compare(x, y)).copied()
+    fn count(self) -> usize {
+        self.it.count()
     }
 
-    fn cmp<O>(self, other: O) -> Ordering
-    where
-        O: IntoIterator<Item = Self::Item>,
-        Self::Item: Ord,
-    {
-        self.it.cmp_by(other, |x, y| x.cmp(&y))
-    }
-
-    fn partial_cmp<O>(self, other: O) -> Option<Ordering>
-    where
-        O: IntoIterator,
-        Self::Item: PartialOrd<O::Item>,
-    {
-        self.it.partial_cmp_by(other, |x, y| x.partial_cmp(&y))
-    }
-
-    fn eq<O>(self, other: O) -> bool
-    where
-        O: IntoIterator,
-        Self::Item: PartialEq<O::Item>,
-    {
-        self.it.eq_by(other, |x, y| x == &y)
-    }
-
-    fn is_sorted_by<F>(self, mut compare: F) -> bool
-    where
-        F: FnMut(&Self::Item, &Self::Item) -> bool,
-    {
-        self.it.is_sorted_by(move |&x, &y| compare(x, y))
+    #[inline]
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        self.it.advance_by(n)
     }
 
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
@@ -163,13 +112,9 @@ where
         self.it.next_back().copied()
     }
 
-    #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
-        self.it.advance_back_by(n)
-    }
-
     fn try_rfold<B, F, R>(&mut self, init: B, f: F) -> R
     where
+        Self: Sized,
         F: FnMut(B, Self::Item) -> R,
         R: Try<Output = B>,
     {
@@ -183,11 +128,9 @@ where
         self.it.rfold(init, copy_fold(f))
     }
 
-    fn rfind<P>(&mut self, mut predicate: P) -> Option<Self::Item>
-    where
-        P: FnMut(&Self::Item) -> bool,
-    {
-        self.it.rfind(move |x| predicate(&x)).copied()
+    #[inline]
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        self.it.advance_back_by(n)
     }
 }
 
@@ -197,12 +140,10 @@ where
     I: ExactSizeIterator<Item = &'a T>,
     T: Copy,
 {
-    #[inline]
     fn len(&self) -> usize {
         self.it.len()
     }
 
-    #[inline]
     fn is_empty(&self) -> bool {
         self.it.is_empty()
     }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.156" }
+compiler_builtins = { version = "=0.1.157" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',

--- a/tests/ui/on-unimplemented/bad-annotation.rs
+++ b/tests/ui/on-unimplemented/bad-annotation.rs
@@ -1,64 +1,73 @@
-// ignore-tidy-linelength
-
+#![crate_type = "lib"]
 #![feature(rustc_attrs)]
-
 #![allow(unused)]
 
 #[rustc_on_unimplemented = "test error `{Self}` with `{Bar}` `{Baz}` `{Quux}`"]
-trait Foo<Bar, Baz, Quux>
-{}
+trait Foo<Bar, Baz, Quux> {}
 
-#[rustc_on_unimplemented="a collection of type `{Self}` cannot be built from an iterator over elements of type `{A}`"]
+#[rustc_on_unimplemented = "a collection of type `{Self}` cannot \
+ be built from an iterator over elements of type `{A}`"]
 trait MyFromIterator<A> {
     /// Builds a container with elements from an external iterator.
-    fn my_from_iter<T: Iterator<Item=A>>(iterator: T) -> Self;
+    fn my_from_iter<T: Iterator<Item = A>>(iterator: T) -> Self;
 }
 
 #[rustc_on_unimplemented]
 //~^ ERROR malformed `rustc_on_unimplemented` attribute
-trait BadAnnotation1
-{}
+trait NoContent {}
 
 #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{C}>`"]
 //~^ ERROR cannot find parameter C on this trait
-trait BadAnnotation2<A,B>
-{}
+trait ParameterNotPresent<A, B> {}
 
 #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{}>`"]
 //~^ ERROR positional format arguments are not allowed here
-trait BadAnnotation3<A,B>
-{}
+trait NoPositionalArgs<A, B> {}
 
-#[rustc_on_unimplemented(lorem="")]
+#[rustc_on_unimplemented(lorem = "")]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation4 {}
+trait EmptyMessage {}
 
 #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation5 {}
+trait Invalid {}
 
-#[rustc_on_unimplemented(message="x", message="y")]
+#[rustc_on_unimplemented(message = "x", message = "y")]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation6 {}
+trait DuplicateMessage {}
 
-#[rustc_on_unimplemented(message="x", on(desugared, message="y"))]
+#[rustc_on_unimplemented(message = "x", on(desugared, message = "y"))]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation7 {}
+trait OnInWrongPosition {}
 
-#[rustc_on_unimplemented(on(), message="y")]
+#[rustc_on_unimplemented(on(), message = "y")]
 //~^ ERROR empty `on`-clause
-trait BadAnnotation8 {}
+trait NoEmptyOn {}
 
-#[rustc_on_unimplemented(on="x", message="y")]
+#[rustc_on_unimplemented(on = "x", message = "y")]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation9 {}
+trait ExpectedPredicateInOn {}
 
-#[rustc_on_unimplemented(on(x="y"), message="y")]
-trait BadAnnotation10 {}
+#[rustc_on_unimplemented(on(x = "y"), message = "y")]
+trait OnWithoutDirectives {}
 
-#[rustc_on_unimplemented(on(desugared, on(desugared, message="x")), message="y")]
+#[rustc_on_unimplemented(on(desugared, on(desugared, message = "x")), message = "y")]
 //~^ ERROR this attribute must have a valid
-trait BadAnnotation11 {}
+trait NoNestedOn {}
 
-pub fn main() {
-}
+// caught by `OnUnimplementedDirective::parse`, *not* `eval_condition`
+#[rustc_on_unimplemented(on("y", message = "y"))]
+//~^ ERROR invalid `on`-clause
+trait UnsupportedLiteral {}
+
+#[rustc_on_unimplemented(on(not(a, b), message = "y"))]
+//~^ ERROR expected 1 cfg-pattern
+trait ExpectedOnePattern {}
+
+#[rustc_on_unimplemented(on(thing::What, message = "y"))]
+//~^ ERROR `cfg` predicate key must be an identifier
+trait KeyMustBeIdentifier {}
+
+#[rustc_on_unimplemented(on(thing::What = "value", message = "y"))]
+//~^ ERROR `cfg` predicate key must be an identifier
+trait KeyMustBeIdentifier2 {}

--- a/tests/ui/on-unimplemented/bad-annotation.rs
+++ b/tests/ui/on-unimplemented/bad-annotation.rs
@@ -25,49 +25,85 @@ trait ParameterNotPresent<A, B> {}
 trait NoPositionalArgs<A, B> {}
 
 #[rustc_on_unimplemented(lorem = "")]
-//~^ ERROR this attribute must have a valid
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
 trait EmptyMessage {}
 
 #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
-//~^ ERROR this attribute must have a valid
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
 trait Invalid {}
 
 #[rustc_on_unimplemented(message = "x", message = "y")]
-//~^ ERROR this attribute must have a valid
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
 trait DuplicateMessage {}
 
 #[rustc_on_unimplemented(message = "x", on(desugared, message = "y"))]
-//~^ ERROR this attribute must have a valid
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
 trait OnInWrongPosition {}
 
 #[rustc_on_unimplemented(on(), message = "y")]
 //~^ ERROR empty `on`-clause
-trait NoEmptyOn {}
+//~^^ NOTE empty `on`-clause here
+trait EmptyOn {}
 
 #[rustc_on_unimplemented(on = "x", message = "y")]
-//~^ ERROR this attribute must have a valid
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
 trait ExpectedPredicateInOn {}
 
 #[rustc_on_unimplemented(on(x = "y"), message = "y")]
 trait OnWithoutDirectives {}
 
-#[rustc_on_unimplemented(on(desugared, on(desugared, message = "x")), message = "y")]
-//~^ ERROR this attribute must have a valid
-trait NoNestedOn {}
+#[rustc_on_unimplemented(on(from_desugaring, on(from_desugaring, message = "x")), message = "y")]
+//~^ ERROR this attribute must have a value
+//~^^ NOTE e.g. `#[rustc_on_unimplemented(message="foo")]`
+//~^^^ NOTE expected value here
+trait NestedOn {}
 
-// caught by `OnUnimplementedDirective::parse`, *not* `eval_condition`
 #[rustc_on_unimplemented(on("y", message = "y"))]
-//~^ ERROR invalid `on`-clause
+//~^ ERROR literals inside `on`-clauses are not supported
+//~^^ NOTE unexpected literal here
 trait UnsupportedLiteral {}
 
+#[rustc_on_unimplemented(on(42, message = "y"))]
+//~^ ERROR literals inside `on`-clauses are not supported
+//~^^ NOTE unexpected literal here
+trait UnsupportedLiteral2 {}
+
 #[rustc_on_unimplemented(on(not(a, b), message = "y"))]
-//~^ ERROR expected 1 cfg-pattern
+//~^ ERROR expected a single predicate in `not(..)` [E0232]
+//~^^ NOTE unexpected quantity of predicates here
 trait ExpectedOnePattern {}
 
+#[rustc_on_unimplemented(on(not(), message = "y"))]
+//~^ ERROR expected a single predicate in `not(..)` [E0232]
+//~^^ NOTE unexpected quantity of predicates here
+trait ExpectedOnePattern2 {}
+
 #[rustc_on_unimplemented(on(thing::What, message = "y"))]
-//~^ ERROR `cfg` predicate key must be an identifier
+//~^ ERROR expected an identifier inside this `on`-clause
+//~^^ NOTE expected an identifier here, not `thing::What`
 trait KeyMustBeIdentifier {}
 
 #[rustc_on_unimplemented(on(thing::What = "value", message = "y"))]
-//~^ ERROR `cfg` predicate key must be an identifier
+//~^ ERROR  expected an identifier inside this `on`-clause
+//~^^ NOTE expected an identifier here, not `thing::What`
 trait KeyMustBeIdentifier2 {}
+
+#[rustc_on_unimplemented(on(aaaaaaaaaaaaaa(a, b), message = "y"))]
+//~^ ERROR this predicate is invalid
+//~^^ NOTE expected one of `any`, `all` or `not` here, not `aaaaaaaaaaaaaa`
+trait InvalidPredicate {}
+
+#[rustc_on_unimplemented(on(something, message = "y"))]
+//~^ ERROR invalid flag in `on`-clause
+//~^^ NOTE expected one of the `crate_local`, `direct` or `from_desugaring` flags, not `something`
+trait InvalidFlag {}

--- a/tests/ui/on-unimplemented/bad-annotation.stderr
+++ b/tests/ui/on-unimplemented/bad-annotation.stderr
@@ -1,5 +1,5 @@
 error: malformed `rustc_on_unimplemented` attribute input
-  --> $DIR/bad-annotation.rs:17:1
+  --> $DIR/bad-annotation.rs:15:1
    |
 LL | #[rustc_on_unimplemented]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,27 +12,27 @@ LL | #[rustc_on_unimplemented(/*opt*/ message = "...", /*opt*/ label = "...", /*
    |                         ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0230]: cannot find parameter C on this trait
-  --> $DIR/bad-annotation.rs:22:90
+  --> $DIR/bad-annotation.rs:19:90
    |
 LL | #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{C}>`"]
    |                                                                                          ^
 
 error[E0231]: positional format arguments are not allowed here
-  --> $DIR/bad-annotation.rs:27:90
+  --> $DIR/bad-annotation.rs:23:90
    |
 LL | #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{}>`"]
    |                                                                                          ^
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:32:26
+  --> $DIR/bad-annotation.rs:27:26
    |
-LL | #[rustc_on_unimplemented(lorem="")]
-   |                          ^^^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(lorem = "")]
+   |                          ^^^^^^^^^^ expected value here
    |
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:36:26
+  --> $DIR/bad-annotation.rs:31:26
    |
 LL | #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
    |                          ^^^^^^^^^^^^^^^^^^^ expected value here
@@ -40,44 +40,68 @@ LL | #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:40:39
+  --> $DIR/bad-annotation.rs:35:41
    |
-LL | #[rustc_on_unimplemented(message="x", message="y")]
-   |                                       ^^^^^^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(message = "x", message = "y")]
+   |                                         ^^^^^^^^^^^^^ expected value here
    |
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:44:39
+  --> $DIR/bad-annotation.rs:39:41
    |
-LL | #[rustc_on_unimplemented(message="x", on(desugared, message="y"))]
-   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(message = "x", on(desugared, message = "y"))]
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
    |
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: empty `on`-clause in `#[rustc_on_unimplemented]`
-  --> $DIR/bad-annotation.rs:48:26
+  --> $DIR/bad-annotation.rs:43:26
    |
-LL | #[rustc_on_unimplemented(on(), message="y")]
+LL | #[rustc_on_unimplemented(on(), message = "y")]
    |                          ^^^^ empty on-clause here
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:52:26
+  --> $DIR/bad-annotation.rs:47:26
    |
-LL | #[rustc_on_unimplemented(on="x", message="y")]
-   |                          ^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(on = "x", message = "y")]
+   |                          ^^^^^^^^ expected value here
    |
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:59:40
+  --> $DIR/bad-annotation.rs:54:40
    |
-LL | #[rustc_on_unimplemented(on(desugared, on(desugared, message="x")), message="y")]
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(on(desugared, on(desugared, message = "x")), message = "y")]
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
    |
    = note: eg `#[rustc_on_unimplemented(message="foo")]`
 
-error: aborting due to 10 previous errors
+error[E0232]: invalid `on`-clause in `#[rustc_on_unimplemented]`
+  --> $DIR/bad-annotation.rs:59:26
+   |
+LL | #[rustc_on_unimplemented(on("y", message = "y"))]
+   |                          ^^^^^^^^^^^^^^^^^^^^^^ invalid on-clause here
 
-Some errors have detailed explanations: E0230, E0231, E0232.
+error[E0536]: expected 1 cfg-pattern
+  --> $DIR/bad-annotation.rs:63:29
+   |
+LL | #[rustc_on_unimplemented(on(not(a, b), message = "y"))]
+   |                             ^^^^^^^^^
+
+error: `cfg` predicate key must be an identifier
+  --> $DIR/bad-annotation.rs:67:29
+   |
+LL | #[rustc_on_unimplemented(on(thing::What, message = "y"))]
+   |                             ^^^^^^^^^^^
+
+error: `cfg` predicate key must be an identifier
+  --> $DIR/bad-annotation.rs:71:29
+   |
+LL | #[rustc_on_unimplemented(on(thing::What = "value", message = "y"))]
+   |                             ^^^^^^^^^^^
+
+error: aborting due to 14 previous errors
+
+Some errors have detailed explanations: E0230, E0231, E0232, E0536.
 For more information about an error, try `rustc --explain E0230`.

--- a/tests/ui/on-unimplemented/bad-annotation.stderr
+++ b/tests/ui/on-unimplemented/bad-annotation.stderr
@@ -23,85 +23,109 @@ error[E0231]: positional format arguments are not allowed here
 LL | #[rustc_on_unimplemented = "Unimplemented trait error on `{Self}` with params `<{A},{B},{}>`"]
    |                                                                                          ^
 
-error[E0232]: this attribute must have a valid value
+error[E0232]: this attribute must have a value
   --> $DIR/bad-annotation.rs:27:26
    |
 LL | #[rustc_on_unimplemented(lorem = "")]
    |                          ^^^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
-error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:31:26
+error[E0232]: this attribute must have a value
+  --> $DIR/bad-annotation.rs:33:26
    |
 LL | #[rustc_on_unimplemented(lorem(ipsum(dolor)))]
    |                          ^^^^^^^^^^^^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
-error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:35:41
+error[E0232]: this attribute must have a value
+  --> $DIR/bad-annotation.rs:39:41
    |
 LL | #[rustc_on_unimplemented(message = "x", message = "y")]
    |                                         ^^^^^^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
-error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:39:41
+error[E0232]: this attribute must have a value
+  --> $DIR/bad-annotation.rs:45:41
    |
 LL | #[rustc_on_unimplemented(message = "x", on(desugared, message = "y"))]
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
 error[E0232]: empty `on`-clause in `#[rustc_on_unimplemented]`
-  --> $DIR/bad-annotation.rs:43:26
+  --> $DIR/bad-annotation.rs:51:26
    |
 LL | #[rustc_on_unimplemented(on(), message = "y")]
-   |                          ^^^^ empty on-clause here
+   |                          ^^^^ empty `on`-clause here
 
-error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:47:26
+error[E0232]: this attribute must have a value
+  --> $DIR/bad-annotation.rs:56:26
    |
 LL | #[rustc_on_unimplemented(on = "x", message = "y")]
    |                          ^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
-error[E0232]: this attribute must have a valid value
-  --> $DIR/bad-annotation.rs:54:40
+error[E0232]: this attribute must have a value
+  --> $DIR/bad-annotation.rs:65:46
    |
-LL | #[rustc_on_unimplemented(on(desugared, on(desugared, message = "x")), message = "y")]
-   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
+LL | #[rustc_on_unimplemented(on(from_desugaring, on(from_desugaring, message = "x")), message = "y")]
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected value here
    |
-   = note: eg `#[rustc_on_unimplemented(message="foo")]`
+   = note: e.g. `#[rustc_on_unimplemented(message="foo")]`
 
-error[E0232]: invalid `on`-clause in `#[rustc_on_unimplemented]`
-  --> $DIR/bad-annotation.rs:59:26
-   |
-LL | #[rustc_on_unimplemented(on("y", message = "y"))]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^ invalid on-clause here
-
-error[E0536]: expected 1 cfg-pattern
-  --> $DIR/bad-annotation.rs:63:29
-   |
-LL | #[rustc_on_unimplemented(on(not(a, b), message = "y"))]
-   |                             ^^^^^^^^^
-
-error: `cfg` predicate key must be an identifier
-  --> $DIR/bad-annotation.rs:67:29
-   |
-LL | #[rustc_on_unimplemented(on(thing::What, message = "y"))]
-   |                             ^^^^^^^^^^^
-
-error: `cfg` predicate key must be an identifier
+error[E0232]: literals inside `on`-clauses are not supported
   --> $DIR/bad-annotation.rs:71:29
    |
+LL | #[rustc_on_unimplemented(on("y", message = "y"))]
+   |                             ^^^ unexpected literal here
+
+error[E0232]: literals inside `on`-clauses are not supported
+  --> $DIR/bad-annotation.rs:76:29
+   |
+LL | #[rustc_on_unimplemented(on(42, message = "y"))]
+   |                             ^^ unexpected literal here
+
+error[E0232]: expected a single predicate in `not(..)`
+  --> $DIR/bad-annotation.rs:81:33
+   |
+LL | #[rustc_on_unimplemented(on(not(a, b), message = "y"))]
+   |                                 ^^^^ unexpected quantity of predicates here
+
+error[E0232]: expected a single predicate in `not(..)`
+  --> $DIR/bad-annotation.rs:86:29
+   |
+LL | #[rustc_on_unimplemented(on(not(), message = "y"))]
+   |                             ^^^^^ unexpected quantity of predicates here
+
+error[E0232]: expected an identifier inside this `on`-clause
+  --> $DIR/bad-annotation.rs:91:29
+   |
+LL | #[rustc_on_unimplemented(on(thing::What, message = "y"))]
+   |                             ^^^^^^^^^^^ expected an identifier here, not `thing::What`
+
+error[E0232]: expected an identifier inside this `on`-clause
+  --> $DIR/bad-annotation.rs:96:29
+   |
 LL | #[rustc_on_unimplemented(on(thing::What = "value", message = "y"))]
-   |                             ^^^^^^^^^^^
+   |                             ^^^^^^^^^^^ expected an identifier here, not `thing::What`
 
-error: aborting due to 14 previous errors
+error[E0232]: this predicate is invalid
+  --> $DIR/bad-annotation.rs:101:29
+   |
+LL | #[rustc_on_unimplemented(on(aaaaaaaaaaaaaa(a, b), message = "y"))]
+   |                             ^^^^^^^^^^^^^^ expected one of `any`, `all` or `not` here, not `aaaaaaaaaaaaaa`
 
-Some errors have detailed explanations: E0230, E0231, E0232, E0536.
+error[E0232]: invalid flag in `on`-clause
+  --> $DIR/bad-annotation.rs:106:29
+   |
+LL | #[rustc_on_unimplemented(on(something, message = "y"))]
+   |                             ^^^^^^^^^ expected one of the `crate_local`, `direct` or `from_desugaring` flags, not `something`
+
+error: aborting due to 18 previous errors
+
+Some errors have detailed explanations: E0230, E0231, E0232.
 For more information about an error, try `rustc --explain E0230`.


### PR DESCRIPTION
Successful merges:

 - #135734 (Correct `extract_if` sample equivalent.)
 - #140307 (Refactor rustc_on_unimplemented's filter parser)
 - #140644 (Revert "Avoid unused clones in Cloned<I> and Copied<I>")
 - #140648 (Update `compiler-builtins` to 0.1.157)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=135734,140307,140644,140648)
<!-- homu-ignore:end -->