### PR TITLE
Improve `-Zremap-path-scope` tests with dependency

### DIFF
--- a/tests/ui/errors/auxiliary/file-debuginfo.rs
+++ b/tests/ui/errors/auxiliary/file-debuginfo.rs
@@ -1,0 +1,11 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=debuginfo
+
+#[macro_export]
+macro_rules! my_file {
+    () => { file!() }
+}
+
+pub fn file() -> &'static str {
+    file!()
+}

--- a/tests/ui/errors/auxiliary/file-diag.rs
+++ b/tests/ui/errors/auxiliary/file-diag.rs
@@ -1,0 +1,11 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=diagnostics
+
+#[macro_export]
+macro_rules! my_file {
+    () => { file!() }
+}
+
+pub fn file() -> &'static str {
+    file!()
+}

--- a/tests/ui/errors/auxiliary/file-macro.rs
+++ b/tests/ui/errors/auxiliary/file-macro.rs
@@ -1,0 +1,11 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=macro
+
+#[macro_export]
+macro_rules! my_file {
+    () => { file!() }
+}
+
+pub fn file() -> &'static str {
+    file!()
+}

--- a/tests/ui/errors/auxiliary/file.rs
+++ b/tests/ui/errors/auxiliary/file.rs
@@ -1,0 +1,8 @@
+#[macro_export]
+macro_rules! my_file {
+    () => { file!() }
+}
+
+pub fn file() -> &'static str {
+    file!()
+}

--- a/tests/ui/errors/auxiliary/trait-debuginfo.rs
+++ b/tests/ui/errors/auxiliary/trait-debuginfo.rs
@@ -1,0 +1,4 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=debuginfo
+
+pub trait Trait: std::fmt::Display {}

--- a/tests/ui/errors/auxiliary/trait-diag.rs
+++ b/tests/ui/errors/auxiliary/trait-diag.rs
@@ -1,0 +1,4 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=diagnostics
+
+pub trait Trait: std::fmt::Display {}

--- a/tests/ui/errors/auxiliary/trait-macro.rs
+++ b/tests/ui/errors/auxiliary/trait-macro.rs
@@ -1,0 +1,4 @@
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@ compile-flags: -Zremap-path-scope=macro
+
+pub trait Trait: std::fmt::Display {}

--- a/tests/ui/errors/auxiliary/trait.rs
+++ b/tests/ui/errors/auxiliary/trait.rs
@@ -1,0 +1,1 @@
+pub trait Trait: std::fmt::Display {}

--- a/tests/ui/errors/remap-path-prefix-diagnostics.not-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.not-diag-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> remapped/errors/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.only-debuginfo-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.only-debuginfo-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait-debuginfo.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.only-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.only-diag-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait-diag.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.only-macro-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.only-macro-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait-macro.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.rs
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.rs
@@ -1,0 +1,57 @@
+// This test exercises `-Zremap-path-scope`, diagnostics printing paths and dependency.
+//
+// We test different combinations with/without remap in deps, with/without remap in this
+// crate but always in deps and always here but never in deps.
+
+//@ revisions: with-diag-in-deps with-macro-in-deps with-debuginfo-in-deps
+//@ revisions: only-diag-in-deps only-macro-in-deps only-debuginfo-in-deps
+//@ revisions: not-diag-in-deps
+
+//@[with-diag-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-macro-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-debuginfo-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[not-diag-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+
+//@[with-diag-in-deps] compile-flags: -Zremap-path-scope=diagnostics
+//@[with-macro-in-deps] compile-flags: -Zremap-path-scope=macro
+//@[with-debuginfo-in-deps] compile-flags: -Zremap-path-scope=debuginfo
+//@[not-diag-in-deps] compile-flags: -Zremap-path-scope=diagnostics
+
+//@[with-diag-in-deps] aux-build:trait-diag.rs
+//@[with-macro-in-deps] aux-build:trait-macro.rs
+//@[with-debuginfo-in-deps] aux-build:trait-debuginfo.rs
+//@[only-diag-in-deps] aux-build:trait-diag.rs
+//@[only-macro-in-deps] aux-build:trait-macro.rs
+//@[only-debuginfo-in-deps] aux-build:trait-debuginfo.rs
+//@[not-diag-in-deps] aux-build:trait.rs
+
+// The $SRC_DIR*.rs:LL:COL normalisation doesn't kick in automatically
+// as the remapped revision will not begin with $SRC_DIR_REAL,
+// so we have to do it ourselves.
+//@ normalize-stderr: ".rs:\d+:\d+" -> ".rs:LL:COL"
+
+#[cfg(any(with_diag_in_deps, only_diag_in_deps))]
+extern crate trait_diag as r#trait;
+
+#[cfg(any(with_macro_in_deps, only_macro_in_deps))]
+extern crate trait_macro as r#trait;
+
+#[cfg(any(with_debuginfo_in_deps, only_debuginfo_in_deps))]
+extern crate trait_debuginfo as r#trait;
+
+#[cfg(not_diag_in_deps)]
+extern crate r#trait as r#trait;
+
+struct A;
+
+impl r#trait::Trait for A {}
+//[with-macro-in-deps]~^ ERROR `A` doesn't implement `std::fmt::Display`
+//[with-debuginfo-in-deps]~^^ ERROR `A` doesn't implement `std::fmt::Display`
+//[only-diag-in-deps]~^^^ ERROR `A` doesn't implement `std::fmt::Display`
+//[only-macro-in-deps]~^^^^ ERROR `A` doesn't implement `std::fmt::Display`
+//[only-debuginfo-in-deps]~^^^^^ ERROR `A` doesn't implement `std::fmt::Display`
+
+//[with-diag-in-deps]~? ERROR `A` doesn't implement `std::fmt::Display`
+//[not-diag-in-deps]~? ERROR `A` doesn't implement `std::fmt::Display`
+
+fn main() {}

--- a/tests/ui/errors/remap-path-prefix-diagnostics.with-debuginfo-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.with-debuginfo-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait-debuginfo.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.with-diag-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.with-diag-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> remapped/errors/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> remapped/errors/auxiliary/trait-diag.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-diagnostics.with-macro-in-deps.stderr
+++ b/tests/ui/errors/remap-path-prefix-diagnostics.with-macro-in-deps.stderr
@@ -1,0 +1,17 @@
+error[E0277]: `A` doesn't implement `std::fmt::Display`
+  --> $DIR/remap-path-prefix-diagnostics.rs:LL:COL
+   |
+LL | impl r#trait::Trait for A {}
+   |                         ^ `A` cannot be formatted with the default formatter
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `A`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `Trait`
+  --> $DIR/auxiliary/trait-macro.rs:LL:COL
+   |
+LL | pub trait Trait: std::fmt::Display {}
+   |                  ^^^^^^^^^^^^^^^^^ required by this bound in `Trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/errors/remap-path-prefix-macro.normal.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.normal.run.stdout
@@ -1,1 +1,0 @@
-remapped/errors/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.not-macro-in-deps.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.not-macro-in-deps.run.stdout
@@ -1,0 +1,3 @@
+file::my_file!() = remapped/errors/remap-path-prefix-macro.rs
+file::file() = $DIR/auxiliary/file.rs
+file!() = remapped/errors/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.only-debuginfo-in-deps.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.only-debuginfo-in-deps.run.stdout
@@ -1,0 +1,3 @@
+file::my_file!() = $DIR/remap-path-prefix-macro.rs
+file::file() = $DIR/auxiliary/file-debuginfo.rs
+file!() = $DIR/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.only-diag-in-deps.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.only-diag-in-deps.run.stdout
@@ -1,0 +1,3 @@
+file::my_file!() = $DIR/remap-path-prefix-macro.rs
+file::file() = $DIR/auxiliary/file-diag.rs
+file!() = $DIR/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.only-macro-in-deps.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.only-macro-in-deps.run.stdout
@@ -1,0 +1,3 @@
+file::my_file!() = $DIR/remap-path-prefix-macro.rs
+file::file() = remapped/errors/auxiliary/file-macro.rs
+file!() = $DIR/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.rs
+++ b/tests/ui/errors/remap-path-prefix-macro.rs
@@ -1,12 +1,47 @@
+// This test exercises `-Zremap-path-scope`, macros (like file!()) and dependency.
+//
+// We test different combinations with/without remap in deps, with/without remap in
+// this crate but always in deps and always here but never in deps.
+
 //@ run-pass
 //@ check-run-results
 
-//@ revisions: normal with-macro-scope without-macro-scope
-//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
-//@ [with-macro-scope]compile-flags: -Zremap-path-scope=macro,diagnostics
-//@ [without-macro-scope]compile-flags: -Zremap-path-scope=diagnostics
-// no-remap-src-base: Manually remap, so the remapped path remains in .stderr file.
+//@ revisions: with-diag-in-deps with-macro-in-deps with-debuginfo-in-deps
+//@ revisions: only-diag-in-deps only-macro-in-deps only-debuginfo-in-deps
+//@ revisions: not-macro-in-deps
+
+//@[with-diag-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-macro-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[with-debuginfo-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+//@[not-macro-in-deps] compile-flags: --remap-path-prefix={{src-base}}=remapped
+
+//@[with-diag-in-deps] compile-flags: -Zremap-path-scope=diagnostics
+//@[with-macro-in-deps] compile-flags: -Zremap-path-scope=macro
+//@[with-debuginfo-in-deps] compile-flags: -Zremap-path-scope=debuginfo
+//@[not-macro-in-deps] compile-flags: -Zremap-path-scope=macro
+
+//@[with-diag-in-deps] aux-build:file-diag.rs
+//@[with-macro-in-deps] aux-build:file-macro.rs
+//@[with-debuginfo-in-deps] aux-build:file-debuginfo.rs
+//@[only-diag-in-deps] aux-build:file-diag.rs
+//@[only-macro-in-deps] aux-build:file-macro.rs
+//@[only-debuginfo-in-deps] aux-build:file-debuginfo.rs
+//@[not-macro-in-deps] aux-build:file.rs
+
+#[cfg(any(with_diag_in_deps, only_diag_in_deps))]
+extern crate file_diag as file;
+
+#[cfg(any(with_macro_in_deps, only_macro_in_deps))]
+extern crate file_macro as file;
+
+#[cfg(any(with_debuginfo_in_deps, only_debuginfo_in_deps))]
+extern crate file_debuginfo as file;
+
+#[cfg(not_macro_in_deps)]
+extern crate file;
 
 fn main() {
-    println!("{}", file!());
+    println!("file::my_file!() = {}", file::my_file!());
+    println!("file::file() = {}", file::file());
+    println!("file!() = {}", file!());
 }

--- a/tests/ui/errors/remap-path-prefix-macro.with-debuginfo-in-deps.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.with-debuginfo-in-deps.run.stdout
@@ -1,0 +1,3 @@
+file::my_file!() = $DIR/remap-path-prefix-macro.rs
+file::file() = $DIR/auxiliary/file-debuginfo.rs
+file!() = $DIR/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.with-diag-in-deps.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.with-diag-in-deps.run.stdout
@@ -1,0 +1,3 @@
+file::my_file!() = $DIR/remap-path-prefix-macro.rs
+file::file() = $DIR/auxiliary/file-diag.rs
+file!() = $DIR/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.with-macro-in-deps.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.with-macro-in-deps.run.stdout
@@ -1,0 +1,3 @@
+file::my_file!() = remapped/errors/remap-path-prefix-macro.rs
+file::file() = remapped/errors/auxiliary/file-macro.rs
+file!() = remapped/errors/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.with-macro-scope.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.with-macro-scope.run.stdout
@@ -1,1 +1,0 @@
-remapped/errors/remap-path-prefix-macro.rs

--- a/tests/ui/errors/remap-path-prefix-macro.without-macro-scope.run.stdout
+++ b/tests/ui/errors/remap-path-prefix-macro.without-macro-scope.run.stdout
@@ -1,1 +1,0 @@
-$DIR/remap-path-prefix-macro.rs


### PR DESCRIPTION
This PR greatly improves our coverage of `-Zremap-path-scope` for diagnostic paths and macros with dependencies.

r? @jieyouxu (since we talked about it)

try-job: x86_64-msvc-1