### PR TITLE
Change File::try_lock() and try_lock_shared() to return io::Result<()>

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -359,6 +359,28 @@ fn file_lock_blocking_async() {
 }
 
 #[test]
+#[cfg(windows)]
+fn file_try_lock_async() {
+    const FILE_FLAG_OVERLAPPED: u32 = 0x40000000;
+
+    let tmpdir = tmpdir();
+    let filename = &tmpdir.join("file_try_lock_async.txt");
+    let f1 = check!(File::create(filename));
+    let f2 =
+        check!(OpenOptions::new().custom_flags(FILE_FLAG_OVERLAPPED).write(true).open(filename));
+
+    // Check that shared locks block exclusive locks
+    check!(f1.lock_shared());
+    assert_matches!(f2.try_lock().unwrap_err().kind(), ErrorKind::WouldBlock);
+    check!(f1.unlock());
+
+    // Check that exclusive locks block all locks
+    check!(f1.lock());
+    assert_matches!(f2.try_lock().unwrap_err().kind(), ErrorKind::WouldBlock);
+    assert_matches!(f2.try_lock_shared().unwrap_err().kind(), ErrorKind::WouldBlock);
+}
+
+#[test]
 fn file_test_io_seek_shakedown() {
     //                   01234567890123
     let initial_msg = "qwer-asdf-zxcv";

--- a/library/std/src/sys/fs/hermit.rs
+++ b/library/std/src/sys/fs/hermit.rs
@@ -1,5 +1,4 @@
 use crate::ffi::{CStr, OsStr, OsString, c_char};
-use crate::fs::TryLockError;
 use crate::io::{self, BorrowedCursor, Error, ErrorKind, IoSlice, IoSliceMut, SeekFrom};
 use crate::os::hermit::ffi::OsStringExt;
 use crate::os::hermit::hermit_abi::{
@@ -13,7 +12,7 @@ use crate::sys::common::small_c_string::run_path_with_cstr;
 use crate::sys::fd::FileDesc;
 pub use crate::sys::fs::common::{copy, exists};
 use crate::sys::time::SystemTime;
-use crate::sys::{cvt, unsupported, unsupported_err};
+use crate::sys::{cvt, unsupported};
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 use crate::{fmt, mem};
 
@@ -367,12 +366,12 @@ impl File {
         unsupported()
     }
 
-    pub fn try_lock(&self) -> Result<(), TryLockError> {
-        Err(TryLockError::Error(unsupported_err()))
+    pub fn try_lock(&self) -> io::Result<()> {
+        unsupported()
     }
 
-    pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
-        Err(TryLockError::Error(unsupported_err()))
+    pub fn try_lock_shared(&self) -> io::Result<()> {
+        unsupported()
     }
 
     pub fn unlock(&self) -> io::Result<()> {

--- a/library/std/src/sys/fs/solid.rs
+++ b/library/std/src/sys/fs/solid.rs
@@ -2,7 +2,6 @@
 
 use crate::ffi::{CStr, CString, OsStr, OsString};
 use crate::fmt;
-use crate::fs::TryLockError;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, SeekFrom};
 use crate::mem::MaybeUninit;
 use crate::os::raw::{c_int, c_short};
@@ -12,7 +11,7 @@ use crate::sync::Arc;
 pub use crate::sys::fs::common::exists;
 use crate::sys::pal::{abi, error};
 use crate::sys::time::SystemTime;
-use crate::sys::{unsupported, unsupported_err};
+use crate::sys::unsupported;
 use crate::sys_common::ignore_notfound;
 
 type CIntNotMinusOne = core::num::niche_types::NotAllOnes<c_int>;
@@ -353,12 +352,12 @@ impl File {
         unsupported()
     }
 
-    pub fn try_lock(&self) -> Result<(), TryLockError> {
-        Err(TryLockError::Error(unsupported_err()))
+    pub fn try_lock(&self) -> io::Result<()> {
+        unsupported()
     }
 
-    pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
-        Err(TryLockError::Error(unsupported_err()))
+    pub fn try_lock_shared(&self) -> io::Result<()> {
+        unsupported()
     }
 
     pub fn unlock(&self) -> io::Result<()> {

--- a/library/std/src/sys/fs/uefi.rs
+++ b/library/std/src/sys/fs/uefi.rs
@@ -2,7 +2,6 @@ use r_efi::protocols::file;
 
 use crate::ffi::OsString;
 use crate::fmt;
-use crate::fs::TryLockError;
 use crate::hash::Hash;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, SeekFrom};
 use crate::path::{Path, PathBuf};
@@ -228,11 +227,11 @@ impl File {
         self.0
     }
 
-    pub fn try_lock(&self) -> Result<(), TryLockError> {
+    pub fn try_lock(&self) -> io::Result<()> {
         self.0
     }
 
-    pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
+    pub fn try_lock_shared(&self) -> io::Result<()> {
         self.0
     }
 

--- a/library/std/src/sys/fs/unsupported.rs
+++ b/library/std/src/sys/fs/unsupported.rs
@@ -1,6 +1,5 @@
 use crate::ffi::OsString;
 use crate::fmt;
-use crate::fs::TryLockError;
 use crate::hash::{Hash, Hasher};
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, SeekFrom};
 use crate::path::{Path, PathBuf};
@@ -207,11 +206,11 @@ impl File {
         self.0
     }
 
-    pub fn try_lock(&self) -> Result<(), TryLockError> {
+    pub fn try_lock(&self) -> io::Result<()> {
         self.0
     }
 
-    pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
+    pub fn try_lock_shared(&self) -> io::Result<()> {
         self.0
     }
 

--- a/library/std/src/sys/fs/wasi.rs
+++ b/library/std/src/sys/fs/wasi.rs
@@ -1,5 +1,4 @@
 use crate::ffi::{CStr, OsStr, OsString};
-use crate::fs::TryLockError;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, SeekFrom};
 use crate::mem::{self, ManuallyDrop};
 use crate::os::raw::c_int;
@@ -11,7 +10,7 @@ use crate::sys::common::small_c_string::run_path_with_cstr;
 use crate::sys::fd::WasiFd;
 pub use crate::sys::fs::common::exists;
 use crate::sys::time::SystemTime;
-use crate::sys::{unsupported, unsupported_err};
+use crate::sys::unsupported;
 use crate::sys_common::{AsInner, FromInner, IntoInner, ignore_notfound};
 use crate::{fmt, iter, ptr};
 
@@ -462,12 +461,12 @@ impl File {
         unsupported()
     }
 
-    pub fn try_lock(&self) -> Result<(), TryLockError> {
-        Err(TryLockError::Error(unsupported_err()))
+    pub fn try_lock(&self) -> io::Result<()> {
+        unsupported()
     }
 
-    pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
-        Err(TryLockError::Error(unsupported_err()))
+    pub fn try_lock_shared(&self) -> io::Result<()> {
+        unsupported()
     }
 
     pub fn unlock(&self) -> io::Result<()> {

--- a/library/std/src/sys/fs/windows.rs
+++ b/library/std/src/sys/fs/windows.rs
@@ -414,10 +414,7 @@ impl File {
 
         match result {
             Ok(_) => Ok(()),
-            Err(err)
-                if err.raw_os_error() == Some(c::ERROR_IO_PENDING as i32)
-                    || err.raw_os_error() == Some(c::ERROR_LOCK_VIOLATION as i32) =>
-            {
+            Err(err) if err.raw_os_error() == Some(c::ERROR_LOCK_VIOLATION as i32) => {
                 Err(io::ErrorKind::WouldBlock.into())
             }
             Err(err) => Err(err),
@@ -439,10 +436,7 @@ impl File {
 
         match result {
             Ok(_) => Ok(()),
-            Err(err)
-                if err.raw_os_error() == Some(c::ERROR_IO_PENDING as i32)
-                    || err.raw_os_error() == Some(c::ERROR_LOCK_VIOLATION as i32) =>
-            {
+            Err(err) if err.raw_os_error() == Some(c::ERROR_LOCK_VIOLATION as i32) => {
                 Err(io::ErrorKind::WouldBlock.into())
             }
             Err(err) => Err(err),


### PR DESCRIPTION
This PR changes the signatures of `File::try_lock` and `File::try_lock_shared` as requested by @rust-lang/libs-api in this discussion: https://github.com/rust-lang/rust/issues/130994#issuecomment-2855657455

These methods are unstable under the "file_lock" feature. The related tracking issue is https://github.com/rust-lang/rust/issues/130994
