### PR TITLE
fix typo in autorefs lint doc example

### DIFF
--- a/compiler/rustc_lint/src/autorefs.rs
+++ b/compiler/rustc_lint/src/autorefs.rs
@@ -15,9 +15,9 @@ declare_lint! {
     ///
     /// ```rust
     /// unsafe fn fun(ptr: *mut [u8]) -> *mut [u8] {
-    ///     &raw mut (*ptr)[..16]
-    ///     //             ^^^^^^ this calls `IndexMut::index_mut(&mut ..., ..16)`,
-    ///     //                    implicitly creating a reference
+    ///     unsafe { &raw mut (*ptr)[..16] }
+    ///     //                      ^^^^^^ this calls `IndexMut::index_mut(&mut ..., ..16)`,
+    ///     //                             implicitly creating a reference
     /// }
     /// ```
     ///
@@ -34,17 +34,17 @@ declare_lint! {
     ///
     /// ```rust
     /// unsafe fn fun(ptr: *mut [u8]) -> *mut [u8] {
-    ///     &raw mut (&mut *ptr)[..16]
+    ///     unsafe { &raw mut (&mut *ptr)[..16] }
     /// }
     /// ```
     ///
     /// Otherwise try to find an alternative way to achive your goals using only raw pointers:
     ///
     /// ```rust
-    /// use std::slice;
+    /// use std::ptr;
     ///
-    /// unsafe fn fun(ptr: *mut [u8]) -> *mut [u8] {
-    ///     slice::from_raw_parts_mut(ptr.cast(), 16)
+    /// fn fun(ptr: *mut [u8]) -> *mut [u8] {
+    ///     ptr::slice_from_raw_parts_mut(ptr.cast(), 16)
     /// }
     /// ```
     pub DANGEROUS_IMPLICIT_AUTOREFS,


### PR DESCRIPTION
The documentation is talking about other way using only raw pointers, but the example was use `std::slice::from_raw_parts_mut` which also create a reference. `std::ptr::slice_from_raw_parts_mut` should be used instead, and it also highlights the benefit of raw pointer manipulation compared to dereference, as the function doesn't need to be unsafe anymore.

Moreover, [`unsafe_op_in_unsafe_fn`](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html) warning has been enabled since Edition 2024, so I've updated the examples to use unsafe blocks.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
