### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_lint/src/autorefs.rs
+++ b/compiler/rustc_lint/src/autorefs.rs
@@ -15,9 +15,9 @@ declare_lint! {
     ///
     /// ```rust
     /// unsafe fn fun(ptr: *mut [u8]) -> *mut [u8] {
-    ///     &raw mut (*ptr)[..16]
-    ///     //             ^^^^^^ this calls `IndexMut::index_mut(&mut ..., ..16)`,
-    ///     //                    implicitly creating a reference
+    ///     unsafe { &raw mut (*ptr)[..16] }
+    ///     //                      ^^^^^^ this calls `IndexMut::index_mut(&mut ..., ..16)`,
+    ///     //                             implicitly creating a reference
     /// }
     /// ```
     ///
@@ -34,17 +34,17 @@ declare_lint! {
     ///
     /// ```rust
     /// unsafe fn fun(ptr: *mut [u8]) -> *mut [u8] {
-    ///     &raw mut (&mut *ptr)[..16]
+    ///     unsafe { &raw mut (&mut *ptr)[..16] }
     /// }
     /// ```
     ///
     /// Otherwise try to find an alternative way to achive your goals using only raw pointers:
     ///
     /// ```rust
-    /// use std::slice;
+    /// use std::ptr;
     ///
-    /// unsafe fn fun(ptr: *mut [u8]) -> *mut [u8] {
-    ///     slice::from_raw_parts_mut(ptr.cast(), 16)
+    /// fn fun(ptr: *mut [u8]) -> *mut [u8] {
+    ///     ptr::slice_from_raw_parts_mut(ptr.cast(), 16)
     /// }
     /// ```
     pub DANGEROUS_IMPLICIT_AUTOREFS,

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.157"
+version = "0.1.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f103f5a97b25e3ed7134dee586e90bbb0496b33ba41816f0e7274e5bb73b50"
+checksum = "164cdc689e4c6d69417f77a5f48be240c291e84fbef0b1281755dc754b19c809"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 
 [dependencies]
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.157", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "=0.1.158", features = ['rustc-dep-of-std'] }
 
 [features]
 compiler-builtins-mem = ['compiler_builtins/mem']

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -57,7 +57,7 @@ object = { version = "0.36.0", default-features = false, optional = true, featur
     'archive',
 ] }
 
-[target.'cfg(windows)'.dependencies.windows-targets]
+[target.'cfg(any(windows, target_os = "cygwin"))'.dependencies.windows-targets]
 path = "../windows_targets"
 
 [dev-dependencies]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "=0.1.157" }
+compiler_builtins = { version = "=0.1.158" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',

--- a/library/windows_targets/src/lib.rs
+++ b/library/windows_targets/src/lib.rs
@@ -34,6 +34,7 @@ pub macro link {
 }
 
 #[cfg(not(feature = "windows_raw_dylib"))]
+#[cfg(not(target_os = "cygwin"))] // Cygwin doesn't need these libs
 #[cfg_attr(target_vendor = "win7", link(name = "advapi32"))]
 #[link(name = "ntdll")]
 #[link(name = "userenv")]

--- a/src/doc/style-guide/src/nightly.md
+++ b/src/doc/style-guide/src/nightly.md
@@ -5,15 +5,3 @@ This chapter documents style and formatting for nightly-only syntax. The rest of
 Style and formatting for nightly-only syntax should be removed from this chapter and integrated into the appropriate sections of the style guide at the time of stabilization.
 
 There is no guarantee of the stability of this chapter in contrast to the rest of the style guide. Refer to the style team policy for nightly formatting procedure regarding breaking changes to this chapter.
-
-### `feature(precise_capturing)`
-
-A `use<'a, T>` precise capturing bound is formatted as if it were a single path segment with non-turbofished angle-bracketed args, like a trait bound whose identifier is `use`.
-
-```
-fn foo() -> impl Sized + use<'a> {}
-
-// is formatted analogously to:
-
-fn foo() -> impl Sized + Use<'a> {}
-```

--- a/src/doc/style-guide/src/types.md
+++ b/src/doc/style-guide/src/types.md
@@ -59,3 +59,15 @@ Box<
     + Debug
 >
 ```
+
+## Precise capturing bounds
+
+A `use<'a, T>` precise capturing bound is formatted as if it were a single path segment with non-turbofished angle-bracketed args, like a trait bound whose identifier is `use`.
+
+```rust
+fn foo() -> impl Sized + use<'a> {}
+
+// is formatted analogously to:
+
+fn foo() -> impl Sized + Use<'a> {}
+```


### PR DESCRIPTION
Successful merges:

 - #139518 (Stabilize precise capture syntax in style guide)
 - #140398 (Fix backtrace for cygwin)
 - #140719 (fix typo in autorefs lint doc example)
 - #140724 (Update `compiler-builtins` to 0.1.158)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=139518,140398,140719,140724)
<!-- homu-ignore:end -->