### PR TITLE
Add `-Zindirect-branch-cs-prefix`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -462,6 +462,15 @@ pub(crate) unsafe fn create_module<'ll>(
         }
     }
 
+    if sess.opts.unstable_opts.indirect_branch_cs_prefix {
+        llvm::add_module_flag_u32(
+            llmod,
+            llvm::ModuleFlagMergeBehavior::Override,
+            "indirect_branch_cs_prefix",
+            1,
+        );
+    }
+
     match (sess.opts.unstable_opts.small_data_threshold, sess.target.small_data_threshold_support())
     {
         // Set up the small-data optimization limit for architectures that use

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -807,6 +807,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(hint_mostly_unused, true);
     tracked!(human_readable_cgu_names, true);
     tracked!(incremental_ignore_spans, true);
+    tracked!(indirect_branch_cs_prefix, true);
     tracked!(inline_mir, Some(true));
     tracked!(inline_mir_hint_threshold, Some(123));
     tracked!(inline_mir_threshold, Some(123));

--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -49,6 +49,8 @@ session_hexadecimal_float_literal_not_supported = hexadecimal float literal is n
 session_incompatible_linker_flavor = linker flavor `{$flavor}` is incompatible with the current target
     .note = compatible flavors are: {$compatible_list}
 
+session_indirect_branch_cs_prefix_requires_x86_or_x86_64 = `-Zindirect-branch-cs-prefix` is only supported on x86 and x86_64
+
 session_instrumentation_not_supported = {$us} instrumentation is not supported for this target
 
 session_int_literal_too_large = integer literal is too large

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -472,6 +472,10 @@ pub(crate) struct FunctionReturnRequiresX86OrX8664;
 pub(crate) struct FunctionReturnThunkExternRequiresNonLargeCodeModel;
 
 #[derive(Diagnostic)]
+#[diag(session_indirect_branch_cs_prefix_requires_x86_or_x86_64)]
+pub(crate) struct IndirectBranchCsPrefixRequiresX86OrX8664;
+
+#[derive(Diagnostic)]
 #[diag(session_unsupported_regparm)]
 pub(crate) struct UnsupportedRegparm {
     pub(crate) regparm: u32,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2295,6 +2295,8 @@ options! {
         - hashes of green query instances
         - hash collisions of query keys
         - hash collisions when creating dep-nodes"),
+    indirect_branch_cs_prefix: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER],
+        "add cs prefix to call and jmp to indirect thunk (default: no)"),
     inline_llvm: bool = (true, parse_bool, [TRACKED],
         "enable LLVM inlining (default: yes)"),
     inline_mir: Option<bool> = (None, parse_opt_bool, [TRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2296,7 +2296,7 @@ options! {
         - hash collisions of query keys
         - hash collisions when creating dep-nodes"),
     indirect_branch_cs_prefix: bool = (false, parse_bool, [TRACKED TARGET_MODIFIER],
-        "add cs prefix to call and jmp to indirect thunk (default: no)"),
+        "add `cs` prefix to `call` and `jmp` to indirect thunks (default: no)"),
     inline_llvm: bool = (true, parse_bool, [TRACKED],
         "enable LLVM inlining (default: yes)"),
     inline_mir: Option<bool> = (None, parse_opt_bool, [TRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1368,6 +1368,12 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
         }
     }
 
+    if sess.opts.unstable_opts.indirect_branch_cs_prefix {
+        if sess.target.arch != "x86" && sess.target.arch != "x86_64" {
+            sess.dcx().emit_err(errors::IndirectBranchCsPrefixRequiresX86OrX8664);
+        }
+    }
+
     if let Some(regparm) = sess.opts.unstable_opts.regparm {
         if regparm > 3 {
             sess.dcx().emit_err(errors::UnsupportedRegparm { regparm });

--- a/src/doc/unstable-book/src/compiler-flags/indirect-branch-cs-prefix.md
+++ b/src/doc/unstable-book/src/compiler-flags/indirect-branch-cs-prefix.md
@@ -1,0 +1,19 @@
+# `indirect-branch-cs-prefix`
+
+The tracking issue for this feature is: https://github.com/rust-lang/rust/issues/116852.
+
+------------------------
+
+Option `-Zindirect-branch-cs-prefix` controls whether a `cs` prefix is added to
+`call` and `jmp` to indirect thunks.
+
+It is equivalent to [Clang]'s and [GCC]'s `-mindirect-branch-cs-prefix`. The
+Linux kernel uses it for RETPOLINE builds. For details, see
+[LLVM commit 6f867f910283] ("[X86] Support ``-mindirect-branch-cs-prefix`` for
+call and jmp to indirect thunk") which introduces the feature.
+
+Only x86 and x86_64 are supported.
+
+[Clang]: https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-mindirect-branch-cs-prefix
+[GCC]: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html#index-mindirect-branch-cs-prefix
+[LLVM commit 6f867f910283]: https://github.com/llvm/llvm-project/commit/6f867f9102838ebe314c1f3661fdf95700386e5a

--- a/tests/assembly-llvm/x86_64-indirect-branch-cs-prefix.rs
+++ b/tests/assembly-llvm/x86_64-indirect-branch-cs-prefix.rs
@@ -1,0 +1,27 @@
+// Test that the `cs` prefix is (not) added into a `call` and a `jmp` to the
+// indirect thunk when the `-Zindirect-branch-cs-prefix` flag is (not) set.
+
+//@ revisions: unset set
+//@ assembly-output: emit-asm
+//@ compile-flags: -Copt-level=3 -Cunsafe-allow-abi-mismatch=retpoline,retpoline-external-thunk,indirect-branch-cs-prefix -Zretpoline-external-thunk
+//@ [set] compile-flags: -Zindirect-branch-cs-prefix
+//@ only-x86_64
+//@ ignore-apple Symbol is called `___x86_indirect_thunk` (Darwin's extra underscore)
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: foo:
+#[no_mangle]
+pub fn foo(g: fn()) {
+    // unset-NOT: cs
+    // unset: callq {{__x86_indirect_thunk.*}}
+    // set: cs
+    // set-NEXT: callq {{__x86_indirect_thunk.*}}
+    g();
+
+    // unset-NOT: cs
+    // unset: jmp {{__x86_indirect_thunk.*}}
+    // set: cs
+    // set-NEXT: jmp {{__x86_indirect_thunk.*}}
+    g();
+}

--- a/tests/codegen-llvm/indirect-branch-cs-prefix.rs
+++ b/tests/codegen-llvm/indirect-branch-cs-prefix.rs
@@ -1,0 +1,18 @@
+// Test that the `indirect_branch_cs_prefix` module attribute is (not) emitted when the
+// `-Zindirect-branch-cs-prefix` flag is (not) set.
+
+//@ add-core-stubs
+//@ revisions: unset set
+//@ needs-llvm-components: x86
+//@ compile-flags: --target x86_64-unknown-linux-gnu
+//@ [set] compile-flags: -Zindirect-branch-cs-prefix
+
+#![crate_type = "lib"]
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+
+// unset-NOT: !{{[0-9]+}} = !{i32 4, !"indirect_branch_cs_prefix", i32 1}
+// set: !{{[0-9]+}} = !{i32 4, !"indirect_branch_cs_prefix", i32 1}

--- a/tests/codegen-llvm/indirect-branch-cs-prefix.rs
+++ b/tests/codegen-llvm/indirect-branch-cs-prefix.rs
@@ -1,5 +1,5 @@
-// Test that the `indirect_branch_cs_prefix` module attribute is (not) emitted when the
-// `-Zindirect-branch-cs-prefix` flag is (not) set.
+// Test that the `indirect_branch_cs_prefix` module attribute is (not)
+// emitted when the `-Zindirect-branch-cs-prefix` flag is (not) set.
 
 //@ add-core-stubs
 //@ revisions: unset set
@@ -11,8 +11,8 @@
 #![feature(no_core, lang_items)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // unset-NOT: !{{[0-9]+}} = !{i32 4, !"indirect_branch_cs_prefix", i32 1}
 // set: !{{[0-9]+}} = !{i32 4, !"indirect_branch_cs_prefix", i32 1}

--- a/tests/ui/invalid-compile-flags/indirect-branch-cs-prefix/requires-x86-or-x86_64.aarch64.stderr
+++ b/tests/ui/invalid-compile-flags/indirect-branch-cs-prefix/requires-x86-or-x86_64.aarch64.stderr
@@ -1,0 +1,4 @@
+error: `-Zindirect-branch-cs-prefix` is only supported on x86 and x86_64
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/invalid-compile-flags/indirect-branch-cs-prefix/requires-x86-or-x86_64.rs
+++ b/tests/ui/invalid-compile-flags/indirect-branch-cs-prefix/requires-x86-or-x86_64.rs
@@ -1,0 +1,21 @@
+//@ revisions: x86 x86_64 aarch64
+
+//@ compile-flags: -Zindirect-branch-cs-prefix
+
+//@[x86] check-pass
+//@[x86] needs-llvm-components: x86
+//@[x86] compile-flags: --target i686-unknown-linux-gnu
+
+//@[x86_64] check-pass
+//@[x86_64] needs-llvm-components: x86
+//@[x86_64] compile-flags: --target x86_64-unknown-linux-gnu
+
+//@[aarch64] check-fail
+//@[aarch64] needs-llvm-components: aarch64
+//@[aarch64] compile-flags: --target aarch64-unknown-linux-gnu
+
+#![feature(no_core)]
+#![no_core]
+#![no_main]
+
+//[aarch64]~? ERROR `-Zindirect-branch-cs-prefix` is only supported on x86 and x86_64


### PR DESCRIPTION
Cc: @azhogin @Darksonn

This goes on top of https://github.com/rust-lang/rust/pull/135927, i.e. please skip the first commit here. Please feel free to inherit it there.

In fact, I am not sure if there is any use case for the flag without `-Zretpoline*`. GCC and Clang allow it, though.

There is a `FIXME` for two `ignore`s in the test that I took from another test I did in the past -- they may be needed or not here since I didn't run the full CI. Either way, it is not critical.

Tracking issue: https://github.com/rust-lang/rust/issues/116852.
MCP: https://github.com/rust-lang/compiler-team/issues/899.