### PR TITLE
run-make-support: set rustc dylib path for cargo wrapper

### DIFF
--- a/src/tools/run-make-support/src/external_deps/cargo.rs
+++ b/src/tools/run-make-support/src/external_deps/cargo.rs
@@ -1,8 +1,11 @@
 use crate::command::Command;
 use crate::env_var;
+use crate::util::set_host_compiler_dylib_path;
 
 /// Returns a command that can be used to invoke cargo. The cargo is provided by compiletest
 /// through the `CARGO` env var.
 pub fn cargo() -> Command {
-    Command::new(env_var("CARGO"))
+    let mut cmd = Command::new(env_var("CARGO"));
+    set_host_compiler_dylib_path(&mut cmd);
+    cmd
 }


### PR DESCRIPTION
Some run-make tests invoke Cargo via run_make_support::cargo(), but fail to execute correctly when rustc is built without rpath. In these setups, runtime loading of rustc’s shared libraries fails unless the appropriate dynamic library path is set manually.

This commit updates the cargo() wrapper to call set_host_compiler_dylib_path(), aligning its behavior with the existing rustc() wrapper: https://github.com/rust-lang/rust/blob/f76c7367c6363d33ddb5a93b5de0d158b2d827f6/src/tools/run-make-support/src/external_deps/rustc.rs#L39-L43

This ensures that Cargo invocations during tests inherit the necessary dylib paths, avoiding errors related to missing shared libraries in rpath-less builds.

Fixes part of #140738

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->
