### PR TITLE
[win][CI] Convert paths to Windows format before adding to PATH

### DIFF
--- a/src/ci/scripts/install-mingw.sh
+++ b/src/ci/scripts/install-mingw.sh
@@ -42,5 +42,5 @@ if isWindows && isKnownToBeMingwBuild; then
 
     curl -o mingw.7z "${MIRRORS_BASE}/${mingw_archive}"
     7z x -y mingw.7z > /dev/null
-    ciCommandAddPath "$(pwd)/${mingw_dir}/bin"
+    ciCommandAddPath "$(cygpath -m "$(pwd)/${mingw_dir}/bin")"
 fi

--- a/src/ci/scripts/install-ninja.sh
+++ b/src/ci/scripts/install-ninja.sh
@@ -12,7 +12,7 @@ if isWindows; then
     7z x -oninja ninja.zip
     rm ninja.zip
     ciCommandSetEnv "RUST_CONFIGURE_ARGS" "${RUST_CONFIGURE_ARGS} --enable-ninja"
-    ciCommandAddPath "$(pwd)/ninja"
+    ciCommandAddPath "$(cygpath -m "$(pwd)/ninja")"
 elif isMacOS; then
     brew install ninja
 fi

--- a/src/ci/scripts/install-sccache.sh
+++ b/src/ci/scripts/install-sccache.sh
@@ -15,7 +15,7 @@ elif isWindows; then
     mkdir -p sccache
     curl -fo sccache/sccache.exe \
       "${MIRRORS_BASE}/2025-02-24-sccache-v0.10.0-x86_64-pc-windows-msvc.exe"
-    ciCommandAddPath "$(pwd)/sccache"
+    ciCommandAddPath "$(cygpath -m "$(pwd)/sccache")"
 fi
 
 # FIXME: we should probably install sccache outside the containers and then


### PR DESCRIPTION
While trying to get the `aarch64-msvc` build working correctly (#140136), I noticed that the `PATH` observed during the Rust steps of the build on Windows builds had some entries still in MinGW format, which means that Windows would not be able to use them correctly:

From <https://github.com/rust-lang/rust/actions/runs/14606167901/job/40975555680#step:28:192> note the path for `ninja` and `sccache`.

```
PATH = Some(C:\a\rust\rust\src\ci\citool\../../../build/citool\debug\deps;C:\a\rust\rust\src\ci\citool\../../../build/citool\debug;C:\Users\runneradmin\.rustup\toolchains\stable-aarch64-pc-windows-msvc\lib\rustlib\aarch64-pc-windows-msvc\lib;C:\Program Files\Git\clangarm64/bin;C:\Program Files\Git\usr\bin;C:\Users\runneradmin\bin;/c/a/rust/rust/ninja;/c/a/rust/rust/sccache;C:\Users\runneradmin/.cargo/bin;C:\aliyun-cli;C:\vcpkg;C:\Program Files (x86)\NSIS\;C:\Program Files\Mercurial\;C:\hostedtoolcache\windows\stack\3.3.1\x64;C:\mingw64\bin;C:\Program Files\dotnet;C:\Program Files\MySQL\MySQL Server 8.0\bin;C:\Program Files (x86)\R\R-4.4.2\bin\x64;C:\SeleniumWebDrivers\GeckoDriver;C:\SeleniumWebDrivers\EdgeDriver\;C:\SeleniumWebDrivers\ChromeDriver;C:\Program Files (x86)\sbt\bin;C:\Program Files (x86)\GitHub CLI;C:\Program Files\Git\bin;C:\Program Files (x86)\pipx_bin;C:\npm\prefix;C:\hostedtoolcache\windows\go\1.21.13\arm64\bin;C:\hostedtoolcache\windows\Python\3.9.13\x64\Scripts;C:\hostedtoolcache\windows\Python\3.9.13\x64;C:\hostedtoolcache\windows\Ruby\3.0.7\x64\bin;C:\Program Files\OpenSSL\bin;C:\tools\kotlinc\bin;C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\8.0.442-6\x64\bin;C:\Program Files (x86)\ImageMagick-7.1.1-Q16-HDRI;C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin;C:\ProgramData\kind;C:\ProgramData\Chocolatey\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\PowerShell\7\;C:\Program Files\Microsoft\Web Platform Installer\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn\;C:\Program Files\Microsoft SQL Server\150\Tools\Binn\;C:\Program Files\dotnet\;C:\Program Files\Microsoft SQL Server\130\DTS\Binn\;C:\Program Files\Microsoft SQL Server\140\DTS\Binn\;C:\Program Files\Microsoft SQL Server\150\DTS\Binn\;C:\Program Files\Microsoft SQL Server\160\DTS\Binn\;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\ProgramData\chocolatey\lib\pulumi\tools\Pulumi\bin;C:\Program Files\CMake\bin;C:\ProgramData\chocolatey\lib\maven\apache-maven-3.9.9\bin;C:\Program Files\nodejs\;C:\Program Files\Git\cmd;C:\Program Files\Git\clangarm64\bin;C:\Program Files\Git\usr\bin;C:\Program Files\GitHub CLI\;c:\tools\php;C:\Program Files (x86)\sbt\bin;C:\Program Files\Amazon\AWSCLIV2\;C:\Program Files\Amazon\SessionManagerPlugin\bin\;C:\Program Files\Amazon\AWSSAMCLI\bin\;C:\Program Files\Microsoft SQL Server\130\Tools\Binn\;C:\Program Files\LLVM\bin;C:\Users\runneradmin\.dotnet\tools;C:\Users\runneradmin\AppData\Local\Microsoft\WindowsApps)
```
The fix for this is to use `cygpath` to convert from the Cygwin format back to native Windows format before adding to the `PATH`.

---
try-job: dist-aarch64-msvc
try-job: x86_64-msvc-1
try-job: x86_64-msvc-2
try-job: i686-msvc-1
try-job: i686-msvc-2
try-job: x86_64-mingw-1
try-job: x86_64-mingw-2
try-job: dist-i686-mingw