### PR TITLE
[win][arm64] Disable various DebugInfo tests that don't work on Arm64 Windows

### DIFF
--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -35,6 +35,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-32bit",
     "ignore-64bit",
     "ignore-aarch64",
+    "ignore-aarch64-pc-windows-msvc",
     "ignore-aarch64-unknown-linux-gnu",
     "ignore-aix",
     "ignore-android",

--- a/tests/debuginfo/step-into-match.rs
+++ b/tests/debuginfo/step-into-match.rs
@@ -1,6 +1,10 @@
 //@ compile-flags: -g
 //@ ignore-android: FIXME(#10381)
 
+// On Arm64 Windows, stepping at the end of a function on goes to the callsite, not the instruction
+// after it.
+//@ ignore-aarch64-pc-windows-msvc: Stepping out of functions behaves differently.
+
 // === GDB TESTS ==============================================================
 
 // gdb-command: r

--- a/tests/debuginfo/type-names.rs
+++ b/tests/debuginfo/type-names.rs
@@ -1,5 +1,7 @@
 //@ ignore-lldb
 
+//@ ignore-aarch64-pc-windows-msvc: Arm64 Windows cdb doesn't support JavaScript extensions.
+
 // GDB changed the way that it formatted Foreign types
 //@ min-gdb-version: 9.2
 

--- a/tests/ui/runtime/backtrace-debuginfo.rs
+++ b/tests/ui/runtime/backtrace-debuginfo.rs
@@ -42,9 +42,13 @@ macro_rules! dump_and_die {
         // there, even on i686-pc-windows-msvc. We do the best we can in
         // rust-lang/rust to test it as well, but sometimes we just gotta keep
         // landing PRs.
+        //
+        // aarch64-msvc is broken as its backtraces are truncated.
+        // See https://github.com/rust-lang/rust/issues/140489
         if cfg!(any(target_os = "android",
                     all(target_os = "linux", target_arch = "arm"),
                     all(target_env = "msvc", target_arch = "x86"),
+                    all(target_env = "msvc", target_arch = "aarch64"),
                     target_os = "freebsd",
                     target_os = "dragonfly",
                     target_os = "openbsd")) {


### PR DESCRIPTION
While trying to get the aarch64-msvc build working correctly (#140136), various DebugInfo related tests were failing.

I've added comments to each test to indicate why it is disabled and linked to appropriate bugs.

* `tests/debuginfo/step-into-match.rs`: Stepping at the end of a function on goes to the callsite, not the instruction after it.
* `tests/debuginfo/type-names.rs`: Arm64 Windows cdb doesn't support JavaScript extensions. Followed up with the Microsoft Debugger Tools team to fix this.
* `tests/ui/runtime/backtrace-debuginfo.rs`: Backtraces are truncated due to #140489