### PR TITLE
[arm64] Pointer auth test should link with C static library statically

### DIFF
--- a/tests/run-make/pointer-auth-link-with-c/test.rs
+++ b/tests/run-make/pointer-auth-link-with-c/test.rs
@@ -1,4 +1,4 @@
-#[link(name = "test")]
+#[link(name = "test", kind = "static")]
 extern "C" {
     fn foo() -> i32;
 }


### PR DESCRIPTION
While trying to get the aarch64-msvc build working correctly (#140136), the `pointer-auth-link-with-c` test was failing.

The pointer auth test builds its C library statically:
https://github.com/rust-lang/rust/blob/3ef8e64ce9f72ee8d600d55bc43b36eed069b252/tests/run-make/pointer-auth-link-with-c/rmake.rs#L15

However, the Rust code did not indicate the link kind, so it defaulted to dynamic which then fails on Windows.