### PR TITLE
[win][ci] Update LLVM toolchain used to build LLVM to 20

### DIFF
--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -10,8 +10,8 @@ IFS=$'\n\t'
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 # Update both macOS's and Windows's tarballs when bumping the version here.
-# Try to keep this in sync with src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
-LLVM_VERSION="18.1.4"
+# Try to keep this in sync with src/ci/docker/scripts/build-clang.sh
+LLVM_VERSION="20.1.3"
 
 if isMacOS; then
     # FIXME: This is the latest pre-built version of LLVM that's available for


### PR DESCRIPTION
While trying to get the aarch64-msvc build working correctly (#140136), I needed to update the version of LLVM used to build LLVM in Windows CI runners to 20 (as this has improved support for Arm64 and Arm64EC on Windows).

This catches Windows up to Linux which was updated to 20 by #137189

try-job: `x86_64-apple-*`
try-job: `aarch64-apple`
try-job: `x86_64-msvc-*`
try-job: `i686-msvc-*`
try-job: `x86_64-mingw-*`