### PR TITLE
rustdoc-json: Remove newlines from attributes

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -786,7 +786,11 @@ impl Item {
                             // because it isn't public API.
                             None
                         }
-                        _ => Some(rustc_hir_pretty::attribute_to_string(&tcx, attr)),
+                        _ => Some({
+                            let mut s = rustc_hir_pretty::attribute_to_string(&tcx, attr);
+                            assert_eq!(s.pop(), Some('\n'));
+                            s
+                        }),
                     }
                 } else if attr.has_any_name(ALLOWED_ATTRIBUTES) {
                     Some(

--- a/tests/rustdoc-json/attrs/automatically_derived.rs
+++ b/tests/rustdoc-json/attrs/automatically_derived.rs
@@ -9,5 +9,5 @@ impl Default for Manual {
     }
 }
 
-//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Derive" && @.inner.impl.trait.path == "Default")].attrs' '["#[automatically_derived]\n"]'
+//@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Derive" && @.inner.impl.trait.path == "Default")].attrs' '["#[automatically_derived]"]'
 //@ is '$.index[?(@.inner.impl.for.resolved_path.path == "Manual" && @.inner.impl.trait.path == "Default")].attrs' '[]'

--- a/tests/rustdoc-json/attrs/export_name_2021.rs
+++ b/tests/rustdoc-json/attrs/export_name_2021.rs
@@ -1,6 +1,6 @@
 //@ edition: 2021
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[export_name = \"altered\"]\n"]'
+//@ is "$.index[?(@.name=='example')].attrs" '["#[export_name = \"altered\"]"]'
 #[export_name = "altered"]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/export_name_2024.rs
+++ b/tests/rustdoc-json/attrs/export_name_2024.rs
@@ -4,6 +4,6 @@
 // The representation of `#[unsafe(export_name = ..)]` in rustdoc in edition 2024
 // is still `#[export_name = ..]` without the `unsafe` attribute wrapper.
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[export_name = \"altered\"]\n"]'
+//@ is "$.index[?(@.name=='example')].attrs" '["#[export_name = \"altered\"]"]'
 #[unsafe(export_name = "altered")]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/must_use.rs
+++ b/tests/rustdoc-json/attrs/must_use.rs
@@ -1,9 +1,9 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[must_use]\n"]'
+//@ is "$.index[?(@.name=='example')].attrs" '["#[must_use]"]'
 #[must_use]
 pub fn example() -> impl Iterator<Item = i64> {}
 
-//@ is "$.index[?(@.name=='explicit_message')].attrs" '["#[must_use = \"does nothing if you do not use it\"]\n"]'
+//@ is "$.index[?(@.name=='explicit_message')].attrs" '["#[must_use = \"does nothing if you do not use it\"]"]'
 #[must_use = "does nothing if you do not use it"]
 pub fn explicit_message() -> impl Iterator<Item = i64> {}

--- a/tests/rustdoc-json/attrs/no_mangle_2021.rs
+++ b/tests/rustdoc-json/attrs/no_mangle_2021.rs
@@ -1,6 +1,6 @@
 //@ edition: 2021
 #![no_std]
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[no_mangle]\n"]'
+//@ is "$.index[?(@.name=='example')].attrs" '["#[no_mangle]"]'
 #[no_mangle]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/no_mangle_2024.rs
+++ b/tests/rustdoc-json/attrs/no_mangle_2024.rs
@@ -4,6 +4,6 @@
 // The representation of `#[unsafe(no_mangle)]` in rustdoc in edition 2024
 // is still `#[no_mangle]` without the `unsafe` attribute wrapper.
 
-//@ is "$.index[?(@.name=='example')].attrs" '["#[no_mangle]\n"]'
+//@ is "$.index[?(@.name=='example')].attrs" '["#[no_mangle]"]'
 #[unsafe(no_mangle)]
 pub extern "C" fn example() {}

--- a/tests/rustdoc-json/attrs/non_exhaustive.rs
+++ b/tests/rustdoc-json/attrs/non_exhaustive.rs
@@ -1,18 +1,18 @@
 #![no_std]
 
-//@ is "$.index[?(@.name=='MyEnum')].attrs" '["#[non_exhaustive]\n"]'
+//@ is "$.index[?(@.name=='MyEnum')].attrs" '["#[non_exhaustive]"]'
 #[non_exhaustive]
 pub enum MyEnum {
     First,
 }
 
 pub enum NonExhaustiveVariant {
-    //@ is "$.index[?(@.name=='Variant')].attrs" '["#[non_exhaustive]\n"]'
+    //@ is "$.index[?(@.name=='Variant')].attrs" '["#[non_exhaustive]"]'
     #[non_exhaustive]
     Variant(i64),
 }
 
-//@ is "$.index[?(@.name=='MyStruct')].attrs" '["#[non_exhaustive]\n"]'
+//@ is "$.index[?(@.name=='MyStruct')].attrs" '["#[non_exhaustive]"]'
 #[non_exhaustive]
 pub struct MyStruct {
     pub x: i64,

--- a/tests/rustdoc-json/keyword_private.rs
+++ b/tests/rustdoc-json/keyword_private.rs
@@ -5,7 +5,7 @@
 
 //@ !has "$.index[?(@.name=='match')]"
 //@ has  "$.index[?(@.name=='foo')]"
-//@ is   "$.index[?(@.name=='foo')].attrs" '["#[doc(keyword = \"match\")]\n"]'
+//@ is   "$.index[?(@.name=='foo')].attrs" '["#[doc(keyword = \"match\")]"]'
 //@ is   "$.index[?(@.name=='foo')].docs" '"this is a test!"'
 #[doc(keyword = "match")]
 /// this is a test!
@@ -13,7 +13,7 @@ pub mod foo {}
 
 //@ !has "$.index[?(@.name=='break')]"
 //@ has "$.index[?(@.name=='bar')]"
-//@ is   "$.index[?(@.name=='bar')].attrs" '["#[doc(keyword = \"break\")]\n"]'
+//@ is   "$.index[?(@.name=='bar')].attrs" '["#[doc(keyword = \"break\")]"]'
 //@ is   "$.index[?(@.name=='bar')].docs" '"hello"'
 #[doc(keyword = "break")]
 /// hello


### PR DESCRIPTION
Fixes #140689

Not sure if this needs to bump `FORMAT_VERSION` or not.

r? @GuillaumeGomez 

cc @obi1kenobi 