### PR TITLE
style: Never break within a nullary function call `func()` or a unit literal `()`

### DIFF
--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -26,6 +26,10 @@ edition).
 Not all Rust editions have corresponding changes to the Rust style. For
 instance, Rust 2015, Rust 2018, and Rust 2021 all use the same style edition.
 
+## Rust next style edition
+
+- Never break within a nullary function call `func()` or a unit literal `()`.
+
 ## Rust 2024 style edition
 
 This style guide describes the Rust 2024 style edition. The Rust 2024 style

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -183,6 +183,10 @@ let f = Foo {
 };
 ```
 
+## Unit literals
+
+Never break between the opening and closing parentheses of the `()` unit literal.
+
 ## Tuple literals
 
 Use a single-line form where possible. Do not put spaces between the opening
@@ -376,6 +380,11 @@ Do not put a space between an argument, and the comma which follows.
 Do put a space between an argument, and the comma which precedes it.
 
 Prefer not to break a line in the callee expression.
+
+For a function call with no arguments (a nullary function call like `func()`),
+never break within the parentheses, and never put a space between the
+parentheses. Always write a nullary function call as a single-line call, never
+a multi-line call.
 
 ### Single-line calls
 


### PR DESCRIPTION
Implements https://github.com/rust-lang/rust/issues/152761